### PR TITLE
Use base16 crate in sync adapter and improve HMAC verification

### DIFF
--- a/sync15-adapter/Cargo.toml
+++ b/sync15-adapter/Cargo.toml
@@ -16,6 +16,7 @@ hawk = { git = "https://github.com/eoger/rust-hawk", branch = "use-openssl" }
 hyper = "0.11"
 log = "0.4"
 lazy_static = "1.0"
+base16 = "0.1"
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/sync15-adapter/src/lib.rs
+++ b/sync15-adapter/src/lib.rs
@@ -30,6 +30,7 @@ extern crate serde_json;
 extern crate error_chain;
 
 extern crate url;
+extern crate base16;
 
 // TODO: Some of these don't need to be pub...
 pub mod key_bundle;

--- a/sync15-adapter/src/util.rs
+++ b/sync15-adapter/src/util.rs
@@ -9,21 +9,6 @@ use std::str::FromStr;
 use openssl;
 use base64;
 
-pub fn base16_encode(bytes: &[u8]) -> String {
-    // This seems to be the fastest way of doing this without using a bunch of unsafe:
-    // https://gist.github.com/thomcc/c4860d68cf31f9b0283c692f83a239f3
-    static HEX_CHARS: &'static [u8] = b"0123456789abcdef";
-    let mut result = vec![0u8; bytes.len() * 2];
-    let mut index = 0;
-    for &byte in bytes {
-        result[index + 0] = HEX_CHARS[(byte >> 4) as usize];
-        result[index + 1] = HEX_CHARS[(byte & 15) as usize];
-        index += 2;
-    }
-    // We know statically that this unwrap is safe, since we can only write ascii
-    String::from_utf8(result).unwrap()
-}
-
 pub fn random_guid() -> Result<String, openssl::error::ErrorStack> {
     let mut bytes = vec![0u8; 9];
     openssl::rand::rand_bytes(&mut bytes)?;
@@ -109,17 +94,6 @@ mod test {
         let dur = t0.duration_since(t1).unwrap();
         assert_eq!(dur.as_secs(), 200);
         assert_eq!(dur.subsec_nanos(), 100_000_000);
-    }
-
-    #[test]
-    fn test_base16_encode() {
-        assert_eq!(base16_encode(&[0x01, 0x10, 0x00, 0x00, 0xab, 0xbc, 0xde, 0xff]),
-                   "01100000abbcdeff");
-        assert_eq!(base16_encode(&[]), "");
-        assert_eq!(base16_encode(&[0, 0, 0, 0]), "00000000");
-        assert_eq!(base16_encode(&[0xff, 0xff, 0xff, 0xff]), "ffffffff");
-        assert_eq!(base16_encode(&[0x00, 0x01, 0x02, 0x03, 0x0a]), "000102030a");
-        assert_eq!(base16_encode(&[0x00, 0x10, 0x20, 0x30, 0xa0]), "00102030a0");
     }
 
     #[test]


### PR DESCRIPTION
Having a local base16_encode function is kind of dumb as noted during review, so now we use the base16 crate. I think this part should not be controversial at all.

Regarding the HMAC changes:

Previously we would compare directly against the bytes of the string that was in the `"hmac"` property of the encrypted record. This changes that for two reasons:

1. `openssl::memcmp::eq` [panics](https://github.com/sfackler/rust-openssl/blob/5b0a0e56921d94090d594cc75ca3792720f74b37/openssl/src/memcmp.rs#L65) if the lengths aren't the same. This probably means they expect you to check first. It's also very different behavior than desktop, so we avoid the panic by checking first and returning false, to behave as desktop does.

2. In theory a sync client could use uppercase base-16 for `"hmac"` when writing records to the server -- AFAICT none of the clients make specific effort to ensure it's lowercase, it just happens to work that way based on various toString implementations returning lowercase values (`Number.prototype.toString(16)` in JS, `Integer.toHexString` in Java, ...). The way the code was written initially this would fail (and it would fail on iOS and Desktop, but not Android), but IMO probably should work.

    To fix this we decode the HMAC key from base16 into bytes before comparing it (this is also how Sync on Android does it). If we see an invalid base16 character in the HMAC, we return false immediately (to behave the same as desktop and iOS).

    This also avoids an allocation compared to the previous code, which is nice but not really that important.

I think neither of the early returns for garbage `"hmac"` signatures compromise the (albeit small) amount of security gained by using a constant time comparison because they only leak information about the `"hmac"` property of the record, which is already stored on the server unencrypted (and AIUI the threat model for this is a compromised server).