### PR TITLE
Cache (in memory)/ETag FxA profile requests

### DIFF
--- a/fxa-rust-client/ffi/src/lib.rs
+++ b/fxa-rust-client/ffi/src/lib.rs
@@ -211,9 +211,10 @@ pub extern "C" fn fxa_to_json(fxa: *mut FirefoxAccount) -> *mut ExternResult {
 pub extern "C" fn fxa_profile(
     fxa: *mut FirefoxAccount,
     profile_access_token: &str,
+    ignore_cache: bool,
 ) -> *mut ExternResult {
     let fxa = unsafe { &mut *fxa };
-    let profile: ProfileC = match fxa.get_profile(profile_access_token) {
+    let profile: ProfileC = match fxa.get_profile(profile_access_token, ignore_cache) {
         Ok(profile) => profile.into(),
         Err(err) => return ExternResult::from_internal(err),
     };

--- a/fxa-rust-client/sdks/swift/FxAClient/FxAClient/FirefoxAccount.swift
+++ b/fxa-rust-client/sdks/swift/FxAClient/FxAClient/FirefoxAccount.swift
@@ -50,7 +50,8 @@ class FirefoxAccount: RustOpaquePointer {
     }
 
     public func getProfile() throws -> Profile {
-        return Profile(raw: try fxa_profile(self.raw).pointee.unwrap())
+        let profileToken = try self.getOAuthToken(scopes: ["profile"]).accessToken;
+        return Profile(raw: try fxa_profile(self.raw, profileToken, false).pointee.unwrap())
     }
 
     public func getSyncKeys() throws -> SyncKeys {

--- a/fxa-rust-client/sdks/swift/FxAClient/FxAClient/fxa.h
+++ b/fxa-rust-client/sdks/swift/FxAClient/FxAClient/fxa.h
@@ -77,7 +77,7 @@ Result*_Nonnull fxa_get_oauth_token(FirefoxAccount *_Nonnull fxa, const char *_N
 Result*_Nonnull fxa_from_json(const char *_Nonnull json);
 Result*_Nonnull fxa_to_json(FirefoxAccount *_Nonnull fxa);
 Result*_Nonnull fxa_new(Config *config, const char *_Nonnull client_id);
-Result*_Nonnull fxa_profile(FirefoxAccount *_Nonnull fxa);
+Result*_Nonnull fxa_profile(FirefoxAccount *_Nonnull fxa, const char *_Nonnull profile_access_token, bool ignore_cache);
 Result*_Nonnull fxa_from_credentials(Config *_Nonnull config, const char *_Nonnull client_id, const char *_Nonnull json);
 Result*_Nonnull fxa_assertion_new(FirefoxAccount *_Nonnull fxa, const char *_Nonnull audience);
 char *_Nonnull fxa_get_token_server_endpoint_url(FirefoxAccount *_Nonnull fxa);


### PR DESCRIPTION
(Partialy?) Fi.xes https://github.com/mozilla/application-services/issues/36

Keep in mind that the caching code in this PR doesn't do anything if a network/parse error happens during a profile fetch.