### PR TITLE
Move from error_chain to failure

### DIFF
--- a/fxa-rust-client/Cargo.toml
+++ b/fxa-rust-client/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Edouard Oger <eoger@fastmail.com>"]
 
 [dependencies]
 base64 = "0.9.0"
-error-chain = "0.11.0"
+failure = "0.1.1"
+failure_derive = "0.1.1"
 hawk = { git = "https://github.com/eoger/rust-hawk", branch = "use-openssl" }
 hex = "0.3.1"
 hkdf = "0.4"

--- a/fxa-rust-client/ffi/src/lib.rs
+++ b/fxa-rust-client/ffi/src/lib.rs
@@ -12,7 +12,7 @@ use std::ptr;
 
 use ctypes::*;
 use fxa_client::errors::Error as InternalError;
-use fxa_client::errors::ErrorKind::*;
+use fxa_client::errors::ErrorKind as InternalErrorKind;
 use fxa_client::{Config, FirefoxAccount, WebChannelResponse};
 use libc::c_char;
 use util::*;
@@ -50,10 +50,10 @@ impl Default for ExternError {
 
 impl From<InternalError> for ExternError {
     fn from(err: InternalError) -> ExternError {
-        match err {
-            InternalError(RemoteError(401, ..), ..)
-            | InternalError(NotMarried, ..)
-            | InternalError(NeededTokenNotFound, ..) => ExternError {
+        match err.kind() {
+            InternalErrorKind::RemoteError { code: 401, .. }
+            | InternalErrorKind::NotMarried
+            | InternalErrorKind::NoCachedToken(_) => ExternError {
                 code: ErrorCode::AuthenticationError,
                 message: string_to_c_char(err.to_string()),
             },

--- a/fxa-rust-client/src/errors.rs
+++ b/fxa-rust-client/src/errors.rs
@@ -2,34 +2,194 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-error_chain! {
-    foreign_links {
-        BadCleartextUtf8(::std::string::FromUtf8Error);
-        BadUrl(::reqwest::UrlError);
-        Base64Decode(::base64::DecodeError);
-        HawkError(::hawk::Error);
-        HexError(::hex::FromHexError);
-        JWTError(::jose::error::Error);
-        JsonError(::serde_json::Error);
-        OpensslError(::openssl::error::ErrorStack);
-        RequestError(::reqwest::Error);
+use std::boxed::Box;
+use std::{fmt, result, string};
+
+use base64;
+use failure::{Backtrace, Context, Fail, SyncFailure};
+use hawk;
+use hex;
+use jose;
+use openssl;
+use reqwest;
+use serde_json;
+
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub struct Error(Box<Context<ErrorKind>>);
+
+impl Fail for Error {
+    #[inline]
+    fn cause(&self) -> Option<&Fail> {
+        self.0.cause()
     }
-    errors {
-        RemoteError(code: u64, errno: u64, error: String, message: String, info: String) {
-          description("FxA Remote Error")
-          display("Remote Error Description: '{}' '{}' '{}' '{}' '{}'", code, errno, error, message, info)
+
+    #[inline]
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.0.backtrace()
+    }
+}
+
+impl fmt::Display for Error {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&*self.0, f)
+    }
+}
+
+impl Error {
+    #[inline]
+    pub fn kind(&self) -> &ErrorKind {
+        &*self.0.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    #[inline]
+    fn from(kind: ErrorKind) -> Error {
+        Error(Box::new(Context::new(kind)))
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    #[inline]
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error(Box::new(inner))
+    }
+}
+
+#[derive(Debug, Fail)]
+pub enum ErrorKind {
+    #[fail(display = "Unknown OAuth State")]
+    UnknownOAuthState,
+
+    #[fail(display = "The client requested keys alongside the token but they were not included")]
+    TokenWithoutKeys,
+
+    #[fail(display = "Login state needs to be Married for the current operation")]
+    NotMarried,
+
+    #[fail(display = "No cached token for scope {}", _0)]
+    NoCachedToken(&'static str),
+
+    #[fail(display = "Unrecoverable server error")]
+    UnrecoverableServerError,
+
+    #[fail(display = "Invalid OAuth scope value {}", _0)]
+    InvalidOAuthScopeValue(String),
+
+    #[fail(display = "Empty names")]
+    EmptyOAuthScopeNames,
+
+    #[fail(display = "SHA256 HMAC Mismatch error")]
+    HmacMismatch,
+
+    #[fail(display = "Key {} had wrong length, got {}, expected {}", _0, _1, _2)]
+    BadKeyLength(&'static str, usize, usize),
+
+    #[fail(display = "Cannot xor arrays with different lengths: {} and {}", _0, _1)]
+    XorLengthMismatch(usize, usize),
+
+    #[fail(display = "Audience URL without a host")]
+    AudienceURLWithoutHost,
+
+    #[fail(display = "JWT signature validation failed")]
+    JWTSignatureValidationFailed,
+
+    #[fail(
+        display = "Remote server error: '{}' '{}' '{}' '{}' '{}'", code, errno, error, message, info
+    )]
+    RemoteError {
+        code: u64,
+        errno: u64,
+        error: String,
+        message: String,
+        info: String,
+    },
+
+    // Basically reimplement error_chain's foreign_links. (Ugh, this sucks)
+    #[fail(display = "Hex decode error: {}", _0)]
+    HexDecodeError(#[fail(cause)] hex::FromHexError),
+
+    #[fail(display = "OpenSSL error: {}", _0)]
+    OpensslError(#[fail(cause)] openssl::error::ErrorStack),
+
+    #[fail(display = "Base64 decode error: {}", _0)]
+    Base64Decode(#[fail(cause)] base64::DecodeError),
+
+    #[fail(display = "JSON parse error: {}", _0)]
+    JsonError(#[fail(cause)] serde_json::Error),
+
+    #[fail(display = "UTF8 decode error: {}", _0)]
+    UTF8DecodeError(#[fail(cause)] string::FromUtf8Error),
+
+    #[fail(display = "Network error: {}", _0)]
+    RequestError(#[fail(cause)] reqwest::Error),
+
+    #[fail(display = "Malformed URL error: {}", _0)]
+    MalformedUrl(#[fail(cause)] reqwest::UrlError),
+
+    #[fail(display = "HAWK error: {}", _0)]
+    HawkError(#[fail(cause)] SyncFailure<hawk::Error>),
+
+    #[fail(display = "JOSE error: {}", _0)]
+    JoseError(#[fail(cause)] SyncFailure<jose::error::Error>),
+}
+
+macro_rules! impl_from_error {
+    ($(($variant:ident, $type:ty)),+) => ($(
+        impl From<$type> for ErrorKind {
+            #[inline]
+            fn from(e: $type) -> ErrorKind {
+                ErrorKind::$variant(e)
+            }
         }
-        NeededTokenNotFound {
-            description("Required token needed for current operation not found.")
-            display("Required token needed for current operation not found.")
+
+        impl From<$type> for Error {
+            #[inline]
+            fn from(e: $type) -> Error {
+                ErrorKind::from(e).into()
+            }
         }
-        UnknownOAuthState {
-            description("Unknown OAuth state.")
-            display("Unknown OAuth state.")
-        }
-        NotMarried {
-            description("Not in a Married state.")
-            display("Not in a Married state.")
-        }
+    )*);
+}
+
+impl_from_error! {
+    (HexDecodeError, ::hex::FromHexError),
+    (OpensslError, ::openssl::error::ErrorStack),
+    (Base64Decode, ::base64::DecodeError),
+    (JsonError, ::serde_json::Error),
+    (UTF8DecodeError, ::std::string::FromUtf8Error),
+    (RequestError, ::reqwest::Error),
+    (MalformedUrl, ::reqwest::UrlError)
+}
+
+// ::hawk::Error and jose use error_chain, and so it's not trivially compatible with failure.
+// We have to box it inside a SyncError (which allows errors to be accessed from multiple
+// threads at the same time, which failure requires for some reason...).
+impl From<hawk::Error> for ErrorKind {
+    #[inline]
+    fn from(e: hawk::Error) -> ErrorKind {
+        ErrorKind::HawkError(SyncFailure::new(e))
+    }
+}
+impl From<hawk::Error> for Error {
+    #[inline]
+    fn from(e: hawk::Error) -> Error {
+        ErrorKind::from(e).into()
+    }
+}
+
+impl From<jose::error::Error> for ErrorKind {
+    #[inline]
+    fn from(e: jose::error::Error) -> ErrorKind {
+        ErrorKind::JoseError(SyncFailure::new(e))
+    }
+}
+impl From<jose::error::Error> for Error {
+    #[inline]
+    fn from(e: jose::error::Error) -> Error {
+        ErrorKind::from(e).into()
     }
 }

--- a/fxa-rust-client/src/http_client/browser_id/jwt_utils.rs
+++ b/fxa-rust-client/src/http_client/browser_id/jwt_utils.rs
@@ -97,7 +97,7 @@ impl<'keypair> SignedJWTBuilder<'keypair> {
         };
         let obj = match payload.as_object_mut() {
             Some(obj) => obj,
-            None => bail!("Invalid JSON"),
+            None => panic!("The supplied payload was not an object"),
         };
         if let Some(ref audience) = self.audience {
             obj.insert("aud".to_string(), json!(audience));
@@ -152,7 +152,7 @@ mod tests {
         let signature = base64::decode_config(&segments[2], base64::URL_SAFE_NO_PAD)?;
         let verified = key_pair.verify_message(&message_bytes, &signature)?;
         if !verified {
-            bail!("Could not verify token.")
+            return Err(ErrorKind::JWTSignatureValidationFailed.into());
         }
         let payload = base64::decode_config(&segments[1], base64::URL_SAFE_NO_PAD)?;
         String::from_utf8(payload).map_err(|e| e.into())

--- a/fxa-rust-client/src/util.rs
+++ b/fxa-rust-client/src/util.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use errors::*;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // Gets the unix epoch in ms.
@@ -20,13 +21,13 @@ pub fn now_secs() -> u64 {
 }
 
 pub trait Xorable {
-    fn xored_with(&self, other: &[u8]) -> Result<Vec<u8>, &'static str>;
+    fn xored_with(&self, other: &[u8]) -> Result<Vec<u8>>;
 }
 
 impl Xorable for [u8] {
-    fn xored_with(&self, other: &[u8]) -> Result<Vec<u8>, &'static str> {
+    fn xored_with(&self, other: &[u8]) -> Result<Vec<u8>> {
         if self.len() != other.len() {
-            Err("Slices have different sizes.")
+            Err(ErrorKind::XorLengthMismatch(self.len(), other.len()).into())
         } else {
             Ok(self
                 .iter()


### PR DESCRIPTION
Since everybody's moving to `failure` we might as well do the same and keep things compatible between crates.
This reuses most of the supporting code from #92.