### PR TITLE
Pin failure version in sync15-adapter to 0.1.1 (fixes #150)

### DIFF
--- a/sync15-adapter/Cargo.toml
+++ b/sync15-adapter/Cargo.toml
@@ -16,8 +16,8 @@ hyper = "0.11"
 log = "0.4"
 lazy_static = "1.0"
 base16 = "0.1"
-failure = "0.1.1"
-failure_derive = "0.1.1"
+failure = "= 0.1.1"
+failure_derive = "= 0.1.1"
 
 [dev-dependencies]
 env_logger = "0.5"


### PR DESCRIPTION
This sucks, but seems the easiest/clearest path forward for #150. It's not exactly clear why this fails under the recently released 0.1.2, but we aren't really following the Error+ErrorKind pattern exactly (our ErrorKinds contain extra data), so it's possible it's because of this?
