### PR TITLE
Avoid initializing logger multiple times - Fixes #153

### DIFF
--- a/sync15/passwords/ffi/src/lib.rs
+++ b/sync15/passwords/ffi/src/lib.rs
@@ -35,6 +35,7 @@ use error::{
 use std::os::raw::{
     c_char,
 };
+use std::sync::{Once, ONCE_INIT};
 
 use ffi_toolkit::string::{
     c_char_to_string,
@@ -90,6 +91,7 @@ impl log::Log for DevLogger {
     }
     fn flush(&self) {}
 }
+static INIT_LOGGER: Once = ONCE_INIT;
 static DEV_LOGGER: &'static log::Log = &DevLogger;
 fn init_logger() {
     log::set_logger(DEV_LOGGER).unwrap();
@@ -114,7 +116,7 @@ pub unsafe extern "C" fn sync15_passwords_state_new(
 
     error: *mut ExternError
 ) -> *mut PasswordSyncState {
-    init_logger();
+    INIT_LOGGER.call_once(init_logger);
     with_translated_result(error, || {
         let client = Sync15StorageClient::new(Sync15StorageClientInit {
             key_id: c_char_to_string(key_id).into(),


### PR DESCRIPTION
As @ncalexan had guessed, this isn't safe to do multiple times. (I had attempted to test this by calling it twice in a row when setting up, and it seemed to work then -- but reading the `log` source tells me I must be mistaken, maybe it wasn't using the correct `.so` when I tested?).

Either way, this fixes the crash that occurred during my demo.