### PR TITLE
Fix bustage in sample due to missing generic parameter for mutateStorage

### DIFF
--- a/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/MainActivity.kt
+++ b/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/MainActivity.kt
@@ -209,7 +209,7 @@ class LoginViewAdapter(private var logins: List<ServerPassword>) :
             // activity for a single item is overkill, and we should probably use LoginsStorage.get()
             // and RecyclerView.notifyItemChanged
 
-            fun mutateStorage(callback: (LoginsStorage) -> SyncResult<Unit>) {
+            fun <T> mutateStorage(callback: (LoginsStorage) -> SyncResult<T>) {
                 val activity = getContext() as MainActivity
                 activity.whenStoreReady().then(callback) { err ->
                     activity.dumpError("LoginViewAdapter", err);


### PR DESCRIPTION
Extremely my bad on this one, I ran tests after cleaning/splitting up my commits but must have messed this up.