### PR TITLE
POC 'true megazord' .so build for android (includes fxa, openssl, sqlcipher, loginsapi_ffi)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "sync15-adapter",
     "sync15/passwords",
     "sync15/passwords/ffi",
+    "ffi-megazord"
 ]
 
 # For RSA keys cloning. Remove once openssl 0.10.8+ is released.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ members = [
     "sync15-adapter",
     "sync15/passwords",
     "sync15/passwords/ffi",
-    "ffi-megazord"
+    "ffi-megazord",
+    "megazord-symbol-checker"
 ]
 
 # For RSA keys cloning. Remove once openssl 0.10.8+ is released.

--- a/ffi-megazord/Cargo.toml
+++ b/ffi-megazord/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ffi-megazord"
+version = "0.1.0"
+authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
+
+[lib]
+name = "moz_as_megazord"
+crate-type = ["cdylib"]
+
+[features]
+default = ["loginsapi"]
+fxa_browserid = ["fxa-client-ffi/browserid"]
+loginsapi = ["loginsapi_ffi"]
+
+[dependencies]
+fxa-client-ffi = { path = "../fxa-client/ffi" }
+loginsapi_ffi = { path = "../sync15/passwords/ffi", optional = true }
+

--- a/ffi-megazord/src/lib.rs
+++ b/ffi-megazord/src/lib.rs
@@ -1,0 +1,86 @@
+
+extern crate fxa_client;
+pub use fxa_client::*;
+
+#[cfg(feature = "loginsapi")]
+extern crate loginsapi_ffi;
+
+#[cfg(feature = "loginsapi")]
+pub use loginsapi_ffi::*;
+
+/// A fake function that just reads the first byte of each of the functions
+/// exposed by the FFI, so that the compiler (or linker, or whoever is
+/// responsible for this) on android is forced to include them. AFAICT it's just
+/// android that has this problem. It seems similar to rustlang issue 36342,
+/// but maybe not the same? Dunno.
+///
+/// In either case, this works better than wrapping functions (despite being
+/// basically the grosest thing ever), because
+// 
+/// - it doesn't require all the types in the crate in question be public (in
+///   particular, the fxa_client ffi has some #[repr(C)] structs that are not
+///   reexported).
+/// - It also doesn't produce extra functions in the symbol table, nor does it require
+///   updating when the arguments in question change.
+///
+/// It's certainly a lot less pretty though, and I'd *love* to find a way around this.
+#[no_mangle]
+pub unsafe extern "C" fn NEVER_CALL_THIS_workaround_rustlang_36342() {
+    let mut functions = vec![
+        &fxa_client::fxa_get_release_config as *const _ as *const u8,
+        &fxa_client::fxa_get_custom_config as *const _ as *const u8,
+        &fxa_client::fxa_new as *const _ as *const u8,
+        &fxa_client::fxa_from_json as *const _ as *const u8,
+        &fxa_client::fxa_to_json as *const _ as *const u8,
+        &fxa_client::fxa_profile as *const _ as *const u8,
+        &fxa_client::fxa_get_token_server_endpoint_url as *const _ as *const u8,
+        &fxa_client::fxa_begin_oauth_flow as *const _ as *const u8,
+        &fxa_client::fxa_complete_oauth_flow as *const _ as *const u8,
+        &fxa_client::fxa_get_oauth_token as *const _ as *const u8,
+        &fxa_client::fxa_str_free as *const _ as *const u8,
+        &fxa_client::fxa_free as *const _ as *const u8,
+        &fxa_client::fxa_config_free as *const _ as *const u8,
+        &fxa_client::fxa_oauth_info_free as *const _ as *const u8,
+        &fxa_client::fxa_profile_free as *const _ as *const u8,
+        &fxa_client::fxa_sync_keys_free as *const _ as *const u8,
+        &fxa_client::fxa_register_persist_callback as *const _ as *const u8,
+        &fxa_client::fxa_unregister_persist_callback as *const _ as *const u8,
+    ];
+    // These are only present when fxa is built with the browserid feature.
+    #[cfg(feature = "fxa_browserid")]
+    {
+        functions.extend(&[
+            &fxa_client::fxa_from_credentials as *const _ as *const u8,
+            &fxa_client::fxa_assertion_new as *const _ as *const u8,
+            &fxa_client::fxa_get_sync_keys as *const _ as *const u8,
+        ]);
+    }
+    #[cfg(feature = "loginsapi")]
+    {
+        functions.extend(&[
+            &loginsapi_ffi::sync15_passwords_delete as *const _ as *const u8,
+            &loginsapi_ffi::sync15_passwords_get_all as *const _ as *const u8,
+            &loginsapi_ffi::sync15_passwords_get_by_id as *const _ as *const u8,
+            &loginsapi_ffi::sync15_passwords_reset as *const _ as *const u8,
+            &loginsapi_ffi::sync15_passwords_state_destroy as *const _ as *const u8,
+            &loginsapi_ffi::sync15_passwords_state_new as *const _ as *const u8,
+            &loginsapi_ffi::sync15_passwords_sync as *const _ as *const u8,
+            &loginsapi_ffi::sync15_passwords_touch as *const _ as *const u8,
+            &loginsapi_ffi::sync15_passwords_wipe as *const _ as *const u8,
+            &loginsapi_ffi::wtf_destroy_c_char as *const _ as *const u8,
+        ]);
+    }
+    for &i in functions.iter() {
+        ::std::ptr::read_volatile::<u8>(i);
+    }
+
+    // The next block would also work, but seems like it's asking for trouble...
+
+    // let mut p = functions.as_ptr();
+    // let e = p.offset(functions.len() as isize);
+    // while p != e {
+    //     let f = ::std::ptr::read_volatile(p) as *const fn();
+    //     p = p.offset(1);
+    //     (*f)();
+    // }
+}

--- a/ffi-megazord/src/lib.rs
+++ b/ffi-megazord/src/lib.rs
@@ -1,6 +1,6 @@
 
-extern crate fxa_client;
-pub use fxa_client::*;
+extern crate fxa_client_ffi;
+pub use fxa_client_ffi::*;
 
 #[cfg(feature = "loginsapi")]
 extern crate loginsapi_ffi;
@@ -18,7 +18,7 @@ pub use loginsapi_ffi::*;
 /// basically the grosest thing ever), because
 // 
 /// - it doesn't require all the types in the crate in question be public (in
-///   particular, the fxa_client ffi has some #[repr(C)] structs that are not
+///   particular, fxa_client_ffi has some #[repr(C)] structs that are not
 ///   reexported).
 /// - It also doesn't produce extra functions in the symbol table, nor does it require
 ///   updating when the arguments in question change.
@@ -27,32 +27,32 @@ pub use loginsapi_ffi::*;
 #[no_mangle]
 pub unsafe extern "C" fn NEVER_CALL_THIS_workaround_rustlang_36342() {
     let mut functions = vec![
-        &fxa_client::fxa_get_release_config as *const _ as *const u8,
-        &fxa_client::fxa_get_custom_config as *const _ as *const u8,
-        &fxa_client::fxa_new as *const _ as *const u8,
-        &fxa_client::fxa_from_json as *const _ as *const u8,
-        &fxa_client::fxa_to_json as *const _ as *const u8,
-        &fxa_client::fxa_profile as *const _ as *const u8,
-        &fxa_client::fxa_get_token_server_endpoint_url as *const _ as *const u8,
-        &fxa_client::fxa_begin_oauth_flow as *const _ as *const u8,
-        &fxa_client::fxa_complete_oauth_flow as *const _ as *const u8,
-        &fxa_client::fxa_get_oauth_token as *const _ as *const u8,
-        &fxa_client::fxa_str_free as *const _ as *const u8,
-        &fxa_client::fxa_free as *const _ as *const u8,
-        &fxa_client::fxa_config_free as *const _ as *const u8,
-        &fxa_client::fxa_oauth_info_free as *const _ as *const u8,
-        &fxa_client::fxa_profile_free as *const _ as *const u8,
-        &fxa_client::fxa_sync_keys_free as *const _ as *const u8,
-        &fxa_client::fxa_register_persist_callback as *const _ as *const u8,
-        &fxa_client::fxa_unregister_persist_callback as *const _ as *const u8,
+        &fxa_client_ffi::fxa_get_release_config as *const _ as *const u8,
+        &fxa_client_ffi::fxa_get_custom_config as *const _ as *const u8,
+        &fxa_client_ffi::fxa_new as *const _ as *const u8,
+        &fxa_client_ffi::fxa_from_json as *const _ as *const u8,
+        &fxa_client_ffi::fxa_to_json as *const _ as *const u8,
+        &fxa_client_ffi::fxa_profile as *const _ as *const u8,
+        &fxa_client_ffi::fxa_get_token_server_endpoint_url as *const _ as *const u8,
+        &fxa_client_ffi::fxa_begin_oauth_flow as *const _ as *const u8,
+        &fxa_client_ffi::fxa_complete_oauth_flow as *const _ as *const u8,
+        &fxa_client_ffi::fxa_get_oauth_token as *const _ as *const u8,
+        &fxa_client_ffi::fxa_str_free as *const _ as *const u8,
+        &fxa_client_ffi::fxa_free as *const _ as *const u8,
+        &fxa_client_ffi::fxa_config_free as *const _ as *const u8,
+        &fxa_client_ffi::fxa_oauth_info_free as *const _ as *const u8,
+        &fxa_client_ffi::fxa_profile_free as *const _ as *const u8,
+        &fxa_client_ffi::fxa_sync_keys_free as *const _ as *const u8,
+        &fxa_client_ffi::fxa_register_persist_callback as *const _ as *const u8,
+        &fxa_client_ffi::fxa_unregister_persist_callback as *const _ as *const u8,
     ];
     // These are only present when fxa is built with the browserid feature.
     #[cfg(feature = "fxa_browserid")]
     {
         functions.extend(&[
-            &fxa_client::fxa_from_credentials as *const _ as *const u8,
-            &fxa_client::fxa_assertion_new as *const _ as *const u8,
-            &fxa_client::fxa_get_sync_keys as *const _ as *const u8,
+            &fxa_client_ffi::fxa_from_credentials as *const _ as *const u8,
+            &fxa_client_ffi::fxa_assertion_new as *const _ as *const u8,
+            &fxa_client_ffi::fxa_get_sync_keys as *const _ as *const u8,
         ]);
     }
     #[cfg(feature = "loginsapi")]

--- a/fxa-client/ffi/Cargo.toml
+++ b/fxa-client/ffi/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Edouard Oger <eoger@fastmail.com>"]
 
 [lib]
-name = "fxa_client"
+name = "fxa_client_ffi"
 crate-type = ["staticlib", "cdylib", "lib"]
 
 [dependencies]

--- a/fxa-client/ffi/Cargo.toml
+++ b/fxa-client/ffi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Edouard Oger <eoger@fastmail.com>"]
 
 [lib]
 name = "fxa_client"
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["staticlib", "cdylib", "lib"]
 
 [dependencies]
 libc = "0.2"

--- a/logins-api/android/library/build.gradle
+++ b/logins-api/android/library/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'net.java.dev.jna:jna:4.5.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "net.zetetic:android-database-sqlcipher:3.5.9@aar"
+    //implementation "net.zetetic:android-database-sqlcipher:3.5.9@aar"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:0.23.4"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/PasswordSyncAdapter.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/PasswordSyncAdapter.kt
@@ -16,13 +16,10 @@ import com.sun.jna.PointerType
 @Suppress("FunctionNaming", "TooManyFunctions", "TooGenericExceptionThrown")
 internal interface PasswordSyncAdapter : Library {
     companion object {
-        private const val JNA_LIBRARY_NAME = "loginsapi_ffi"
+        private const val JNA_LIBRARY_NAME = "moz_as_megazord"
         internal var INSTANCE: PasswordSyncAdapter
 
         init {
-            System.loadLibrary("crypto")
-            System.loadLibrary("ssl")
-            System.loadLibrary("sqlcipher")
             INSTANCE = Native.loadLibrary(JNA_LIBRARY_NAME, PasswordSyncAdapter::class.java) as PasswordSyncAdapter
         }
     }

--- a/megazord-symbol-checker/Cargo.toml
+++ b/megazord-symbol-checker/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "megazord-symbol-checker"
+version = "0.1.0"
+authors = ["Thom Chiovoloni <chiovolonit@gmail.com>"]
+
+[dependencies]
+goblin = "0.0.17"
+failure = "0.1.1"
+toml = "0.4.6"
+log = "0.4.3"
+env_logger = "0.5.12"

--- a/megazord-symbol-checker/src/main.rs
+++ b/megazord-symbol-checker/src/main.rs
@@ -1,0 +1,221 @@
+#[macro_use]
+extern crate failure;
+extern crate goblin;
+extern crate toml;
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+use std::io::Read;
+use std::fs::File;
+use std::process::{self, Command};
+use std::env;
+use std::path::{Path, PathBuf};
+use std::collections::HashSet;
+
+use failure::{Error};
+
+use goblin::elf::Elf;
+
+type Result<T> = ::std::result::Result<T, Error>;
+
+fn get_workspace_root(args: &[String]) -> Result<PathBuf> {
+    if let Some(p) = args.get(1) {
+        Ok(Path::new(p).canonicalize()?)
+    } else {
+        let mut cur_dir = env::current_dir()?;
+        if cur_dir.ends_with("megazord-symbol-checker") {
+            cur_dir.pop();
+        }
+        Ok(cur_dir)
+    }
+}
+
+fn build_android_lib(name: &str) -> Result<()> {
+    // Do an android x86 release build. The arch shouldn't matter, and we use
+    // release to maximize the chance that something will screw up and fail to
+    // export the symbols.
+    info!("Building {} for android (release, x86). This may take a while...", name);
+    info!("  (run with RUST_LOG=trace for more verbose output)");
+    let mut cmd = Command::new("./scripts/android-megazord.sh");
+    cmd.args(&["x86", "release", name]);
+    if !log_enabled!(log::Level::Trace) {
+        cmd.stdout(process::Stdio::null()).stderr(process::Stdio::null());
+    }
+    let status = cmd.status()?;
+    if !status.success() {
+        eprintln!("Error: \
+Failed to run `./scripts/android-megazord x86 release \"{}\"` (status: {:?}).
+Things to try:
+- Make sure you have the NDK set up, and have set the `ANDROID_NDK_TOOLCHAIN_DIR`
+  and `ANDROID_NDK_API_VERSION` environment variables. We expect a standalone
+  android x86 toolchain to be available at `$ANDROID_NDK_TOOLCHAIN_DIR/x86-$ANDROID_NDK_API_VERSION`
+- Make sure you have your .cargo/config set for [target.i686-linux-android] 
+  (should have `linker` and `ar`
+- If these are correct you may need to run a `cargo clean` if you previously
+  performed builds with slightly different configurations
+", name, status);
+        bail!("Child process exited with error status {:?}", status);
+    }
+    Ok(())
+}
+
+fn read_file_bytes<P: AsRef<Path>>(path: P, buffer: &mut Vec<u8>) -> Result<()> {
+    let mut file = File::open(path)?;
+    buffer.reserve(
+        file.metadata().map(|m| m.len() as usize + 1).unwrap_or(0));
+    file.read_to_end(buffer)?;
+    Ok(())
+}
+
+fn read_toml<P: AsRef<Path>>(path: P) -> Result<toml::Value> {
+    let mut file = File::open(path)?;
+    let mut string = String::with_capacity(
+        file.metadata().map(|m| m.len() as usize + 1).unwrap_or(0));
+    file.read_to_string(&mut string)?;
+    let toml = string.parse::<toml::Value>()?;
+    Ok(toml)
+}
+
+fn get_table_key(toml: &toml::Value, table_name: &str, key: &str) -> Option<String> {
+    toml.get(table_name)
+        .and_then(|val| val.as_table())
+        .and_then(|tab| tab.get(key))
+        .and_then(|val| val.as_str())
+        .map(|s| s.to_string())
+}
+
+#[derive(Clone, Debug)]
+struct LibInfo {
+    path: String,
+    crate_name: String,
+    lib_name: String,
+}
+
+impl LibInfo {
+    pub fn new(path: &str) -> Result<LibInfo> {
+        let mut cargo_toml_path: PathBuf = Path::new(path).to_owned();
+        cargo_toml_path.push("Cargo.toml");
+
+        let toml = read_toml(&cargo_toml_path)?;
+
+        let crate_name = get_table_key(&toml, "package", "name").ok_or_else(||
+            format_err!("Failed to locate [package] name in {}/Cargo.toml!", path))?;
+
+        // [lib] name is "defaulted to the name of the package or project, with
+        // any dashes replaced with underscores" according to cargo docs. 
+        let lib_name = get_table_key(&toml, "lib", "name").unwrap_or_else(||
+            crate_name.replace("-", "_"));
+
+        Ok(LibInfo {
+            path: path.into(),
+            lib_name,
+            crate_name,
+        })
+    }
+
+    fn get_shared_object_path(&self) -> PathBuf {
+        let mut buf: PathBuf = Path::new("./target/i686-linux-android/release").to_owned();
+        buf.push(format!("lib{}.so", self.lib_name));
+        buf
+    }
+
+    fn get_shared_object_bytes(&self, buf: &mut Vec<u8>) -> Result<()> {
+        buf.clear();
+        let path = self.get_shared_object_path();
+        info!("Reading shared object from {:?}", path);
+        Ok(read_file_bytes(self.get_shared_object_path(), buf)?)
+    }
+
+    pub fn build(&self) -> Result<()> {
+        build_android_lib(&self.path)
+    }
+
+    pub fn parse_elf_symbols(&self, buf: &mut Vec<u8>) -> Result<HashSet<String>> {
+        self.get_shared_object_bytes(buf)?;
+        info!("Parsing lib{}.so", self.lib_name);
+        let sofile = Elf::parse(&buf)?;
+        let mut symbols: HashSet<String> = HashSet::new();
+
+        let sym_names = sofile.dynstrtab;
+        for sym in sofile.dynsyms.iter() {
+            if sym.st_name == 0 {
+                // first entry is always all 0s (probably should check this is the first...)
+                continue;
+            }
+            if sym.is_import() {
+                // We don't care about ELF imports, but log them at trace level.
+                trace!(" {}: Skipping imported symbol {} ({:?})", self.crate_name,
+                    sym_names.get(sym.st_name).unwrap_or(Ok("(unknown)"))
+                    .unwrap_or("(unknown)"), sym);
+                continue;
+            }
+            if !sym.is_function() {
+                // Not clear if this is the right choice, but I doubt anybody
+                // is exporting globals this way. Warn if they are because this
+                // seems like a bad idea.
+                warn!(" {}: Skipping non-function symbol {} ({:?})", self.crate_name,
+                    sym_names.get(sym.st_name).unwrap_or(Ok("(unknown)"))
+                    .unwrap_or("(unknown)"), sym);
+                continue;
+            }
+            match sym_names.get(sym.st_name) {
+                Some(Ok(s)) => {
+                    debug!("{}: FOUND SYM {} {:?}", self.crate_name, s, sym);
+                    symbols.insert(s.into());
+                },
+                other => {
+                    warn!("{}: Something went wrong finding symbol!: {:?}, {:?}",
+                          self.crate_name, other, sym)
+                }
+            }
+        }
+        info!("{}: Found {} symbols", self.crate_name, symbols.len());
+        Ok(symbols)
+    }
+}
+
+fn main() -> Result<()> {
+    // Default log level is info, since this is slow and we want to indicate
+    // what we're doing somewhat.
+    let env = env_logger::Env::default().filter_or("RUST_LOG", "info");
+    env_logger::init_from_env(env);
+    let args = env::args().collect::<Vec<_>>();
+    let root = get_workspace_root(&args)?;
+    info!("Using workspace root: {:?}", root);
+    env::set_current_dir(&root)?;
+
+    let megazord = LibInfo::new("ffi-megazord")?;
+    let components = &[
+        LibInfo::new("fxa-client/ffi")?,
+        LibInfo::new("sync15/passwords/ffi")?,
+    ];
+    // Build all required libs
+    megazord.build()?;
+    for lib in components {
+        lib.build()?;
+    }
+    let mut buf: Vec<u8> = vec![];
+
+    let preserved = megazord.parse_elf_symbols(&mut buf)?;
+    let mut missing: Vec<(String, &LibInfo)> = vec![];
+    for lib in components {
+        let from_this_lib = lib.parse_elf_symbols(&mut buf)?;
+        for sym in from_this_lib {
+            if !preserved.contains(&sym) {
+                eprintln!("Error: {} doesn't contain symbol from {}: {}!", megazord.crate_name, lib.crate_name, sym);
+                missing.push((sym.clone(), &lib));
+            }
+        }
+    }
+
+    if missing.len() != 0 { 
+        eprintln!("lib{}.so is missing {} symbols:", megazord.lib_name, missing.len());
+        for (symbol, lib) in missing {
+            eprintln!("  - from lib{}.so: {}", lib.lib_name, symbol);
+        }
+        process::exit(1);
+    }
+    println!("All expected symbols accounted for!");
+    Ok(())
+}

--- a/scripts/android-megazord.sh
+++ b/scripts/android-megazord.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+set -evx
+
+TARGET=$1
+TRIPLE=""
+if [ -z "$TARGET" ]; then
+    echo "Usage: $0 (x86|arm|arm64) [debug|release = debug]"
+    exit 1
+fi
+
+TRIPLE=""
+case $TARGET in
+x86)
+    TRIPLE="i686-linux-android"
+    ;;
+arm)
+    TRIPLE="armv7-linux-androideabi"
+    ;;
+arm64)
+    TRIPLE="aarch64-linux-android"
+    ;;
+*)
+    echo "Unknown Target: '$TARGET'. Must be x86/arm/arm64"
+    exit 1
+esac
+
+BUILD_TYPE=$2
+if [ -z "$BUILD_TYPE" ]; then
+    BUILD_TYPE=debug
+fi
+
+if [ ! -f libs/android/$TARGET/sqlcipher/lib/libsqlcipher.a ]; then
+    echo "Error: no static lib of libsqlcipher (or probably openssl)."
+    echo "  You probably want to erase libs/android and then run ./libs/build-all.sh android"
+    echo "  before trying this again."
+    exit 1
+fi
+
+APPSVC_ROOT="$PWD"
+
+cd ffi-megazord
+
+CARGO_ARGS="--target $TRIPLE --verbose"
+if [ "$BUILD_TYPE" = "release" ]; then
+    CARGO_ARGS="$CARGO_ARGS --release"
+fi
+
+env PATH="$PATH:$ANDROID_NDK_TOOLCHAIN_DIR/$TARGET-$ANDROID_NDK_API_VERSION/bin" \
+    SQLCIPHER_INCLUDE_DIR=$APPSVC_ROOT/libs/android/$TARGET/sqlcipher/include \
+    SQLCIPHER_LIB_DIR=$APPSVC_ROOT/libs/android/$TARGET/sqlcipher/lib \
+    OPENSSL_INCLUDE_DIR=$APPSVC_ROOT/libs/android/$TARGET/openssl/include \
+    OPENSSL_LIB_DIR=$APPSVC_ROOT/libs/android/$TARGET/openssl/lib \
+    OPENSSL_STATIC=1 \
+    cargo build $CARGO_ARGS
+
+cd -
+
+echo "Lib should be located at target/$TRIPLE/$BUILD_TYPE/libmoz_as_megazord.so"

--- a/scripts/android-megazord.sh
+++ b/scripts/android-megazord.sh
@@ -5,7 +5,7 @@ set -evx
 TARGET=$1
 TRIPLE=""
 if [ -z "$TARGET" ]; then
-    echo "Usage: $0 (x86|arm|arm64) [debug|release = debug]"
+    echo "Usage: $0 (x86|arm|arm64) [debug|release = debug] [workspace-relative-crate-dir = ffi-megazord]"
     exit 1
 fi
 
@@ -30,6 +30,12 @@ if [ -z "$BUILD_TYPE" ]; then
     BUILD_TYPE=debug
 fi
 
+# XXX this script is abused by `
+ROOT_REL_LIB_PATH=$3
+if [ -z "$ROOT_REL_LIB_PATH" ]; then
+    ROOT_REL_LIB_PATH=ffi-megazord
+fi
+
 if [ ! -f libs/android/$TARGET/sqlcipher/lib/libsqlcipher.a ]; then
     echo "Error: no static lib of libsqlcipher (or probably openssl)."
     echo "  You probably want to erase libs/android and then run ./libs/build-all.sh android"
@@ -39,7 +45,7 @@ fi
 
 APPSVC_ROOT="$PWD"
 
-cd ffi-megazord
+cd $ROOT_REL_LIB_PATH
 
 CARGO_ARGS="--target $TRIPLE --verbose"
 if [ "$BUILD_TYPE" = "release" ]; then
@@ -55,5 +61,3 @@ env PATH="$PATH:$ANDROID_NDK_TOOLCHAIN_DIR/$TARGET-$ANDROID_NDK_API_VERSION/bin"
     cargo build $CARGO_ARGS
 
 cd -
-
-echo "Lib should be located at target/$TRIPLE/$BUILD_TYPE/libmoz_as_megazord.so"


### PR DESCRIPTION
I got really sidetracked this morning on build crap, and ended up doing this. It wasn't that bad (part had already been done).

The combined size of the release so file is around 11MB (unstripped). We might be able to get more by building the c code so that we can link with --gc-sections. Maybe. I also think we might be able to build the c code with clang and not GCC, and have both emit llvm bitcode, which should give us some degree of cross language LTO. That probably would not be very different than what this patch does.

That said, the idea is that different ffi apis would just be exposed as features in the megazord ffi crate. you'd use the set you actually want, and get a build with just those.

Anyway, I'm not sure if this is a thing we could ever merge? It does work at least for the logins portion. Hard to test the FxA portion but I have no reason to think it doesn't, it does export all the symbols expected (I still would very much like to test it, though).

The ffi-megazord/src/lib.rs is terrible. It's implementation is horrific, and ideally it would be either get generated automatically, or at a minimum detect and error if it's out of sync with the symbols exposed from the ffi libs.

CC @ncalexan @eoger @vladikoff 