### PR TITLE
Use delete_credential in logins ffi so that the deletion is synced

### DIFF
--- a/sync15/passwords/ffi/src/lib.rs
+++ b/sync15/passwords/ffi/src/lib.rs
@@ -171,12 +171,8 @@ pub unsafe extern "C" fn sync15_passwords_delete(state: *mut PasswordSyncState, 
     with_translated_value_result(error, || {
         assert_pointer_not_null!(state);
         let state = &mut *state;
-        Ok({
-            let mut in_progress = state.engine.store.begin_transaction()?;
-            let deleted = passwords::delete_by_sync_uuid(&mut in_progress, c_char_to_string(id).into())?;
-            in_progress.commit()?;
-            deleted
-        })
+        let deleted = state.engine.delete_credential(c_char_to_string(id).into())?;
+        Ok(deleted)
     })
 }
 

--- a/sync15/passwords/src/engine.rs
+++ b/sync15/passwords/src/engine.rs
@@ -75,11 +75,11 @@ impl PasswordEngine {
         Ok(())
     }
 
-    pub fn delete_credential(&mut self, id: String) -> Result<()> {
+    pub fn delete_credential(&mut self, id: String) -> Result<bool> {
         let mut in_progress = self.store.begin_transaction()?;
-        credentials::delete_by_id(&mut in_progress, CredentialId(id))?;
+        let deleted = credentials::delete_by_id(&mut in_progress, CredentialId(id))?;
         in_progress.commit()?;
-        Ok(())
+        Ok(deleted)
     }
 
     pub fn update_credential(&mut self, id: &str, updater: impl FnMut(&mut Credential)) -> Result<bool> {


### PR DESCRIPTION
This requires making delete_credential return whether or not it deleted anything (like the earlier patch)