### PR TITLE
Set Make parallelism when building openssl/sqlcipher

### DIFF
--- a/libs/build-all-desktop.sh
+++ b/libs/build-all-desktop.sh
@@ -33,7 +33,7 @@ else
   else
     ./config shared --openssldir="$OPENSSL_OUTPUT_PATH"
   fi
-  make && make install
+  make -j6 && make install
   mkdir -p "$OPENSSL_DIR""/include/openssl"
   mkdir -p "$OPENSSL_DIR""/lib"
   cp -p "$OPENSSL_OUTPUT_PATH"/lib/libssl."$LIB_EXTENSION"* "$OPENSSL_DIR""/lib"

--- a/libs/build-openssl-android.sh
+++ b/libs/build-openssl-android.sh
@@ -51,7 +51,7 @@ fi
 
 make clean || true
 ./Configure "$CONFIGURE_ARCH" shared --openssldir="$OPENSSL_OUTPUT_PATH"
-make
+make -j6
 make install_sw
 mkdir -p "$DIST_DIR""/include/openssl"
 mkdir -p "$DIST_DIR""/lib"

--- a/libs/build-openssl-ios.sh
+++ b/libs/build-openssl-ios.sh
@@ -48,7 +48,7 @@ fi
 
 sed -ie "s!^CFLAG=!CFLAG=-isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} -miphoneos-version-min=${IOS_MIN_SDK_VERSION} !" "Makefile"
 
-make && make install
+make -j6 && make install
 mkdir -p "$DIST_DIR""/include/openssl"
 mkdir -p "$DIST_DIR""/lib"
 cp -p "$OPENSSL_OUTPUT_PATH"/lib/libssl.a "$DIST_DIR""/lib"

--- a/libs/build-sqlcipher-android.sh
+++ b/libs/build-sqlcipher-android.sh
@@ -54,7 +54,7 @@ SQLCIPHER_CFLAGS="-DSQLITE_HAS_CODEC -DSQLITE_SOUNDEX -DHAVE_USLEEP=1 -DSQLITE_M
 
 make clean || true
 ./configure --host="${HOST}" --enable-tempstore=yes CFLAGS="${CFLAGS} ${SQLCIPHER_CFLAGS} -I${OPENSSL_DIR}/include -L${OPENSSL_DIR}/lib" LDFLAGS="-lcrypto -llog -lm" --prefix="${SQLCIPHER_OUTPUT_PATH}"
-make
+make -j6
 make install
 
 mkdir -p "$DIST_DIR""/include/sqlcipher"


### PR DESCRIPTION
This speeds things up about 2-3x for me, at least for the android build (I've done the other builds to make sure they work, but I didn't run them twice to compare times).

6 was chosen arbitrarily.