### PR TITLE
Patch FxA soname (fixes #174)

### DIFF
--- a/libs/.gitignore
+++ b/libs/.gitignore
@@ -1,3 +1,4 @@
 openssl*
 *.tar.gz
 android-ndk-r*
+bin/patchelf

--- a/libs/build-patchelf.sh
+++ b/libs/build-patchelf.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -euvx
+
+if test -f bin/patchelf; then
+    echo "Already have patchelf."
+    return
+fi
+
+rm -f patchelf-master.zip bin/patchelf
+rm -rf patchelf-master
+
+mkdir -p bin
+
+PATCHELF_COMMIT_HASH=27ffe8ae871e7a186018d66020ef3f6162c12c69
+PATCHELF_ZIP_SHA256=efc301d64a34892f813b546754ddf63cc210b82292f34f74fde96cb29c1f76ee
+
+curl -o patchelf-src.zip -L "https://github.com/NixOS/patchelf/archive/$PATCHELF_COMMIT_HASH.zip"
+
+echo "${PATCHELF_ZIP_SHA256}  patchelf-src.zip" | shasum -a 256 -c - || exit 2
+unzip patchelf-src.zip
+# This is what's inside the zip
+PATCHELF_SRC_DIR="patchelf-$PATCHELF_COMMIT_HASH"
+
+cd $PATCHELF_SRC_DIR
+mkdir .install_prefix
+./bootstrap.sh
+./configure --prefix="$PWD/.install_prefix"
+# `patchelf` is just 1 C++ file so no need for -j6
+make && make install
+
+mv .install_prefix/bin/patchelf ../bin
+
+cd -
+
+rm -rf patchelf-src.zip $PATCHELF_SRC_DIR

--- a/scripts/taskcluster-android.sh
+++ b/scripts/taskcluster-android.sh
@@ -2,7 +2,10 @@
 
 set -euvx
 
-apt-get update -qq && apt-get install zip -y
+# libtool/automake/autoconf are needed for the patchelf build (The project is
+# small enough (one file) that this is probably not necessary, it's easy
+# enough to just do it the right way).
+apt-get update -qq && apt-get install zip libtool automake autoconf -y
 
 mkdir -p .cargo
 yes | cp -rf scripts/taskcluster-cargo-config .cargo/config

--- a/scripts/taskcluster-android.sh
+++ b/scripts/taskcluster-android.sh
@@ -3,7 +3,7 @@
 set -euvx
 
 # libtool/automake/autoconf are needed for the patchelf build (The project is
-# small enough (one file) that this is probably not necessary, it's easy
+# small enough (one file) that this is probably not necessary, but it's easy
 # enough to just do it the right way).
 apt-get update -qq && apt-get install zip libtool automake autoconf -y
 
@@ -42,6 +42,9 @@ do
     cargo +beta build -p fxa-client-ffi --target ${android_targets[$target]} --release
   mkdir -p fxa-client/$target
   cp target/${android_targets[$target]}/release/libfxa_client.so fxa-client/$target
+
+  # Patch the soname of this lib since rustc (currently) won't, but android's
+  # linker needs it: https://github.com/mozilla/application-services/issues/174
   ./libs/bin/patchelf --set-soname libfxa_client.so fxa-client/$target/libfxa_client.so
 done
 

--- a/scripts/taskcluster-android.sh
+++ b/scripts/taskcluster-android.sh
@@ -6,7 +6,7 @@ apt-get update -qq && apt-get install zip -y
 
 mkdir -p .cargo
 yes | cp -rf scripts/taskcluster-cargo-config .cargo/config
-pushd libs/ && ./build-all.sh android && popd
+pushd libs/ && ./build-all.sh android && ./build-patchelf.sh && popd
 
 declare -A android_targets
 android_targets=(
@@ -39,6 +39,7 @@ do
     cargo +beta build -p fxa-client-ffi --target ${android_targets[$target]} --release
   mkdir -p fxa-client/$target
   cp target/${android_targets[$target]}/release/libfxa_client.so fxa-client/$target
+  ./libs/bin/patchelf --set-soname libfxa_client.so fxa-client/$target/libfxa_client.so
 done
 
 # Because Android needs the lib to be in a armeabi-v7a dir.


### PR DESCRIPTION
This locally builds a version of patchelf and stores it in `libs/bin/patchelf`, which is gitignored. There's no stable release that is fixed to work with `strip` in this case, so it downloads what is currently the latest commit from github to do it.

Patchelf seems to be portable so this doesn't need to be done per-target.