### PR TITLE
logins-api: only require SyncUnlockInfo for `sync` calls (not `unlock`)

### DIFF
--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorage.kt
@@ -21,14 +21,14 @@ interface LoginsStorage : Closeable {
 
     fun lock(): SyncResult<Unit>
 
-    fun unlock(encryptionKey: String, syncInfo: SyncUnlockInfo): SyncResult<Unit>
+    fun unlock(encryptionKey: String): SyncResult<Unit>
 
     fun isLocked(): SyncResult<Boolean>
 
     /**
      * Synchronize the logins storage layer with a remote layer.
      */
-    fun sync(): SyncResult<Unit>
+    fun sync(syncInfo: SyncUnlockInfo): SyncResult<Unit>
 
     /**
      * Delete all locally stored login sync metadata.

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorage.kt
@@ -14,7 +14,7 @@ class SyncUnlockInfo (
         val kid: String,
         val fxaAccessToken: String,
         val syncKey: String,
-        val tokenserverBaseURL: String
+        val tokenserverURL: String
 )
 
 interface LoginsStorage : Closeable {

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorageException.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorageException.kt
@@ -11,5 +11,10 @@ package org.mozilla.sync15.logins
 // TODO: Get more descriptive errors here.
 open class LoginsStorageException(msg: String): Exception(msg)
 
+/** Indicates that the sync authentication is invalid, likely due to having
+ * expired.
+ */
+class SyncAuthInvalidException(msg: String): LoginsStorageException(msg)
+
 // This doesn't really belong in this file...
 class MismatchedLockException(msg: String): LoginsStorageException(msg)

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/MemoryLoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/MemoryLoginsStorage.kt
@@ -45,7 +45,7 @@ class MemoryLoginsStorage(private var list: List<ServerPassword>) : Closeable, L
         }
     }
 
-    override fun unlock(encryptionKey: String, syncInfo: SyncUnlockInfo): SyncResult<Unit> {
+    override fun unlock(encryptionKey: String): SyncResult<Unit> {
         return asyncResult {
             checkNotClosed()
             if (state == LoginsStorageState.Unlocked) {
@@ -61,7 +61,7 @@ class MemoryLoginsStorage(private var list: List<ServerPassword>) : Closeable, L
         }
     }
 
-    override fun sync(): SyncResult<Unit> {
+    override fun sync(syncInfo: SyncUnlockInfo): SyncResult<Unit> {
         return asyncResult {
             checkUnlocked()
             Log.w("MemoryLoginsStorage", "Not syncing because this implementation can not sync")

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/MentatLoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/MentatLoginsStorage.kt
@@ -64,7 +64,7 @@ class MentatLoginsStorage(private val dbPath: String) : Closeable, LoginsStorage
                     syncInfo.kid,
                     syncInfo.fxaAccessToken,
                     syncInfo.syncKey,
-                    syncInfo.tokenserverBaseURL,
+                    syncInfo.tokenserverURL,
                     error)
         }
     }

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/MentatLoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/MentatLoginsStorage.kt
@@ -43,7 +43,7 @@ class MentatLoginsStorage(private val dbPath: String) : Closeable, LoginsStorage
         }
     }
 
-    override fun unlock(encryptionKey: String, syncInfo: SyncUnlockInfo): SyncResult<Unit> {
+    override fun unlock(encryptionKey: String): SyncResult<Unit> {
         return safeAsync { error ->
             Log.d("LoginsAPI", "unlock");
             if (raw != null) {
@@ -52,19 +52,20 @@ class MentatLoginsStorage(private val dbPath: String) : Closeable, LoginsStorage
             raw = PasswordSyncAdapter.INSTANCE.sync15_passwords_state_new(
                     dbPath,
                     encryptionKey,
-                    syncInfo.kid,
-                    syncInfo.fxaAccessToken,
-                    syncInfo.syncKey,
-                    syncInfo.tokenserverBaseURL,
                     error
             )
         }
     }
 
-    override fun sync(): SyncResult<Unit> {
+    override fun sync(syncInfo: SyncUnlockInfo): SyncResult<Unit> {
         return safeAsync { error ->
             Log.d("LoginsAPI", "sync")
-            PasswordSyncAdapter.INSTANCE.sync15_passwords_sync(this.raw!!, error)
+            PasswordSyncAdapter.INSTANCE.sync15_passwords_sync(this.raw!!,
+                    syncInfo.kid,
+                    syncInfo.fxaAccessToken,
+                    syncInfo.syncKey,
+                    syncInfo.tokenserverBaseURL,
+                    error)
         }
     }
 

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/MentatLoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/MentatLoginsStorage.kt
@@ -163,7 +163,7 @@ class MentatLoginsStorage(private val dbPath: String) : Closeable, LoginsStorage
                         return@launch
                     }
                     if (e.isFailure()) {
-                        result.completeExceptionally(LoginsStorageException(e.consumeErrorMessage()))
+                        result.completeExceptionally(e.intoException())
                     } else {
                         result.complete(ret)
                     }

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/PasswordSyncAdapter.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/PasswordSyncAdapter.kt
@@ -30,10 +30,6 @@ internal interface PasswordSyncAdapter : Library {
     fun sync15_passwords_state_new(
             mentat_db_path: String,
             encryption_key: String,
-            key_id: String,
-            access_token: String,
-            sync_key: String,
-            token_server_base_url: String,
             error: RustError.ByReference
     ): RawLoginSyncState
 
@@ -49,7 +45,12 @@ internal interface PasswordSyncAdapter : Library {
     // return json array
     fun sync15_passwords_get_all(state: RawLoginSyncState, error: RustError.ByReference): Pointer
 
-    fun sync15_passwords_sync(state: RawLoginSyncState, error: RustError.ByReference)
+    fun sync15_passwords_sync(state: RawLoginSyncState,
+                              key_id: String,
+                              access_token: String,
+                              sync_key: String,
+                              token_server_base_url: String,
+                              error: RustError.ByReference)
 
     fun sync15_passwords_wipe(state: RawLoginSyncState, error: RustError.ByReference)
     fun sync15_passwords_reset(state: RawLoginSyncState, error: RustError.ByReference)

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/PasswordSyncAdapter.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/PasswordSyncAdapter.kt
@@ -49,7 +49,7 @@ internal interface PasswordSyncAdapter : Library {
                               key_id: String,
                               access_token: String,
                               sync_key: String,
-                              token_server_base_url: String,
+                              token_server_url: String,
                               error: RustError.ByReference)
 
     fun sync15_passwords_wipe(state: RawLoginSyncState, error: RustError.ByReference)

--- a/logins-api/android/library/src/test/java/org/mozilla/sync15/logins/MemoryLoginsTest.kt
+++ b/logins-api/android/library/src/test/java/org/mozilla/sync15/logins/MemoryLoginsTest.kt
@@ -133,10 +133,10 @@ class MemoryLoginsTest {
         waitForException(test.delete("aaaaaaaaaaaa"))
         waitForException(test.touch("bbbbbbbbbbbb"))
         waitForException(test.wipe())
-        waitForException(test.sync())
+        waitForException(test.sync(SyncUnlockInfo("", "", "", "")))
         waitForException(test.reset())
 
-        waitForResult(test.unlock("", SyncUnlockInfo("", "", "", "")))
+        waitForResult(test.unlock(""))
         assertEquals(waitForResult(test.isLocked()), false);
         // Make sure things didn't change despite being locked
         assertNotNull(waitForResult(test.get("aaaaaaaaaaaa")))
@@ -148,7 +148,7 @@ class MemoryLoginsTest {
     @Test
     fun testTouch() {
         val test = getTestStore()
-        waitForResult(test.unlock("", SyncUnlockInfo("", "", "", "")))
+        waitForResult(test.unlock(""))
         assertEquals(waitForResult(test.list())!!.size, 2)
         val b = waitForResult(test.get("bbbbbbbbbbbb"))!!
         assertEquals(0, b.timesUsed)
@@ -170,7 +170,7 @@ class MemoryLoginsTest {
     @Test
     fun testDelete() {
         val test = getTestStore();
-        waitForResult(test.unlock("", SyncUnlockInfo("", "", "", "")))
+        waitForResult(test.unlock(""))
 
         assertNotNull(waitForResult(test.get("aaaaaaaaaaaa")))
         assertTrue(waitForResult(test.delete("aaaaaaaaaaaa"))!!)
@@ -185,7 +185,7 @@ class MemoryLoginsTest {
     @Test
     fun testListWipe() {
         val test = getTestStore();
-        waitForResult(test.unlock("", SyncUnlockInfo("", "", "", "")))
+        waitForResult(test.unlock(""))
         assertEquals(2, waitForResult(test.list())!!.size);
 
         waitForResult(test.wipe())

--- a/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/MainActivity.kt
+++ b/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/MainActivity.kt
@@ -156,13 +156,13 @@ class MainActivity : AppCompatActivity() {
                 kid = info.string("kid")!!,
                 fxaAccessToken = creds.accessToken,
                 syncKey = info.string("k")!!,
-                tokenserverBaseURL = "https://token.services.mozilla.com"
+                tokenserverURL = creds.tokenServer
         )
     }
 
     fun initMentatStore(): SyncResult<MentatLoginsStorage> {
         val appFiles = this.applicationContext.getExternalFilesDir(null)
-        val storage = MentatLoginsStorage(appFiles.absolutePath + "/logins.mentatdb");
+        val storage = MentatLoginsStorage(appFiles.absolutePath + "/logins3.mentatdb");
         return storage.unlock("my_secret_key").then {
             SyncResult.fromValue(storage)
         }

--- a/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/MainActivity.kt
+++ b/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : AppCompatActivity() {
         return if (this.store != null) {
             SyncResult.fromValue(this.store as LoginsStorage)
         } else {
-            initFromCredentials(ExampleApp.instance.account?.creds!!).then({ store ->
+            initMentatStore().then({ store ->
                 this.store = store;
                 SyncResult.fromValue(store as LoginsStorage)
             }, { error ->
@@ -67,15 +67,17 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    fun refresh(sync: Boolean) {
+    fun refresh(sync: Boolean): SyncResult<Unit> {
         Log.d("TEST", "Refreshing logins...")
 
-        Snackbar.make(recyclerView!!, "Loading logins...", Snackbar.LENGTH_LONG)
-                .setAction("Action", null).show()
+        if (sync) {
+            Snackbar.make(recyclerView!!, "Loading logins...", Snackbar.LENGTH_LONG)
+                    .setAction("Action", null).show()
+        }
 
-        whenStoreReady().then { store ->
+        return whenStoreReady().then { store ->
             if (sync) {
-                store.sync().then { SyncResult.fromValue(store) }
+                store.sync(getUnlockInfo()).then { SyncResult.fromValue(store) }
             } else {
                 SyncResult.fromValue(store)
             }
@@ -84,10 +86,11 @@ class MainActivity : AppCompatActivity() {
         }.then({ SyncResult.fromValue(it) }) { err ->
             dumpError("LoginsMainActivity", err)
             SyncResult.fromException(err)
-        } .whenComplete { logins ->
+        }.then { logins ->
             runOnUiThread {
                 (this.recyclerView!!.adapter as LoginViewAdapter).setLogins(logins)
             }
+            SyncResult.fromValue(Unit)
         }
     }
 
@@ -116,7 +119,11 @@ class MainActivity : AppCompatActivity() {
         fab.setOnClickListener { _ ->
             refresh(true)
         }
-        refresh(true)
+        // Initially refresh without syncing to display the currently
+        // downloaded data, but start a sync as soon as that finishes.
+        refresh(false).whenComplete {
+            refresh(true)
+        }
     }
     fun refreshOnUiThread(sync: Boolean) {
         runOnUiThread {
@@ -134,23 +141,29 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    fun initFromCredentials(creds: Credentials): SyncResult<MentatLoginsStorage> {
+    private fun getUnlockInfo(): SyncUnlockInfo {
+        return credentialsToUnlockInfo(ExampleApp.instance.account?.creds!!)
+    }
+
+    private fun credentialsToUnlockInfo(creds: Credentials): SyncUnlockInfo {
         // The format is a bit weird so I'm not sure if I can map this make klaxon do the
         // deserializing for us...
         val stringBuilder: StringBuilder = StringBuilder(creds.keys)
         val o = Parser().parse(stringBuilder) as JsonObject
         val info = o.obj("https://identity.mozilla.com/apps/oldsync")!!
-        val appFiles = this.applicationContext.getExternalFilesDir(null)
 
-        val storage = MentatLoginsStorage(appFiles.absolutePath + "/logins.mentatdb");
-        val unlockInfo = SyncUnlockInfo(
+        return SyncUnlockInfo(
                 kid = info.string("kid")!!,
                 fxaAccessToken = creds.accessToken,
                 syncKey = info.string("k")!!,
                 tokenserverBaseURL = "https://token.services.mozilla.com"
         )
+    }
 
-        return storage.unlock("my_secret_key", unlockInfo).then {
+    fun initMentatStore(): SyncResult<MentatLoginsStorage> {
+        val appFiles = this.applicationContext.getExternalFilesDir(null)
+        val storage = MentatLoginsStorage(appFiles.absolutePath + "/logins.mentatdb");
+        return storage.unlock("my_secret_key").then {
             SyncResult.fromValue(storage)
         }
     }

--- a/sync15-adapter/src/client.rs
+++ b/sync15-adapter/src/client.rs
@@ -22,7 +22,7 @@ use util::ServerTimestamp;
 pub struct Sync15StorageClientInit {
     pub key_id: String,
     pub access_token: String,
-    pub tokenserver_base_url: String,
+    pub tokenserver_url: Url,
 }
 
 /// A trait containing the methods required to run through the setup state
@@ -100,9 +100,9 @@ impl Sync15StorageClient {
     pub fn new(init_params: Sync15StorageClientInit) -> error::Result<Sync15StorageClient> {
         let client = Client::builder().timeout(Duration::from_secs(30)).build()?;
         let tsc = token::TokenProvider::new(
-            init_params.tokenserver_base_url.clone(),
-            init_params.access_token.clone(),
-            init_params.key_id.clone(),
+            init_params.tokenserver_url,
+            init_params.access_token,
+            init_params.key_id,
         );
         let timestamp = ServerTimestamp(0f64);
         Ok(Sync15StorageClient {

--- a/sync15/passwords/Cargo.toml
+++ b/sync15/passwords/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = "1.0"
 [dev-dependencies]
 env_logger = "0.5"
 prettytable-rs = "0.6"
+url = "1.6.0"
 
 [dependencies.sync15-adapter]
 path = "../../sync15-adapter"

--- a/sync15/passwords/ffi/Cargo.toml
+++ b/sync15/passwords/ffi/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 serde_json = "1.0"
 failure = "0.1.1"
 log = "0.4"
+url = "1.6.0"
 
 [dependencies.ffi-toolkit]
 #path="../../../../ffi-toolkit"

--- a/sync15/passwords/ffi/Cargo.toml
+++ b/sync15/passwords/ffi/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = "1.0"
 failure = "0.1.1"
 log = "0.4"
 url = "1.6.0"
+reqwest = "0.8.2"
 
 [dependencies.ffi-toolkit]
 #path="../../../../ffi-toolkit"

--- a/sync15/passwords/ffi/src/lib.rs
+++ b/sync15/passwords/ffi/src/lib.rs
@@ -16,6 +16,7 @@
 extern crate failure;
 extern crate serde_json;
 extern crate url;
+extern crate reqwest;
 
 #[macro_use] extern crate ffi_toolkit;
 extern crate mentat;

--- a/sync15/passwords/tests/sync_pass_mentat.rs
+++ b/sync15/passwords/tests/sync_pass_mentat.rs
@@ -14,6 +14,7 @@ extern crate failure;
 extern crate serde;
 #[macro_use] extern crate serde_derive;
 extern crate serde_json;
+extern crate url;
 
 extern crate logins;
 extern crate mentat;
@@ -287,7 +288,7 @@ fn main() -> Result<(), Error> {
     let client = sync::Sync15StorageClient::new(sync::Sync15StorageClientInit {
         key_id: scope.kid.clone(),
         access_token: oauth_data.access_token.clone(),
-        tokenserver_base_url: "https://oauth-sync.dev.lcip.org/syncserver/token".into(),
+        tokenserver_url: url::Url::parse("https://oauth-sync.dev.lcip.org/syncserver/token/1.0/sync/1.5")?,
     })?;
     let mut sync_state = sync::GlobalState::default();
 


### PR DESCRIPTION
Based on the discussion we had today.

For future context: this simplifies error reporting (it doesn't conflate `bad encryption key` and `something went wrong when connecting to sync`) and the user of the API to fetch the current list of logins before we've finished doing the initial network requests for (or even if they have no network connection!).
