### PR TITLE
Disable travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ matrix:
     - rust: nightly
   fast_finish: true
 script: cargo test --all-features --verbose
-cache: cargo
 
 jobs:
   include:

--- a/scripts/travis-ci-ios.sh
+++ b/scripts/travis-ci-ios.sh
@@ -6,7 +6,7 @@ rustup target add aarch64-apple-ios
 rustup target add armv7-apple-ios
 rustup target add i386-apple-ios
 rustup target add x86_64-apple-ios
-cargo install --git https://github.com/TimNN/cargo-lipo
+cargo install --force --git https://github.com/TimNN/cargo-lipo
 cd fxa-client/sdks
 carthage build --no-skip-current --verbose && carthage archive
 rm -rf Carthage


### PR DESCRIPTION
This fixes Travis CI release builds 2 ways:
- The sniper fix that adds `--force` to `cargo install lipo` so we don't fail if lipo is already present.
- The nuclear bomb fix that gets rid of cargo caching altogether that made the first issue described happen and will avoid future other problems.