### PR TITLE
Rename MentatLoginsStorage -> DatabaseLoginsStorage

### DIFF
--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/DatabaseLoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/DatabaseLoginsStorage.kt
@@ -17,7 +17,10 @@ import org.mozilla.sync15.logins.rust.RawLoginSyncState
 import org.mozilla.sync15.logins.rust.RustError
 import java.io.Closeable
 
-class MentatLoginsStorage(private val dbPath: String) : Closeable, LoginsStorage {
+/**
+ * LoginsStorage implementation backed by a database.
+ */
+class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStorage {
 
     private var raw: RawLoginSyncState? = null;
 

--- a/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/App.kt
+++ b/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/App.kt
@@ -39,7 +39,7 @@ class ExampleApp: Application() {
     fun startNewIntent() {
         val acct = account
         val intent: Intent
-        if (acct == null || acct.creds == null) {
+        if (acct?.creds == null) {
             intent = Intent(baseContext, LoginActivity::class.java)
         } else {
             intent = Intent(baseContext, MainActivity::class.java)

--- a/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/LoginActivity.kt
+++ b/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/LoginActivity.kt
@@ -30,15 +30,6 @@ const val clientId = "98adfa37698f255b"
 const val redirectUri = "https://lockbox.firefox.com/fxa/ios-redirect.html"
 
 class LoginActivity : AppCompatActivity() {
-    companion object {
-        init {
-            // We need to pre-load some of these libraries or fxa_client tries to load them with strange
-            // names (eg, lib_sso.1.1.0.so or something...)
-            System.loadLibrary("crypto")
-            System.loadLibrary("ssl")
-            System.loadLibrary("fxa_client")
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,7 +37,7 @@ class LoginActivity : AppCompatActivity() {
         var fxa: FirefoxAccount? = null;
         Config.custom(contentBase).then({ value: Config ->
             fxa = FirefoxAccount(value, clientId, redirectUri)
-            var scopes = arrayOf(
+            val scopes = arrayOf(
                     "profile",
                     "https://identity.mozilla.com/apps/oldsync",
                     "https://identity.mozilla.com/apps/lockbox"

--- a/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/MainActivity.kt
+++ b/logins-api/android/sample/src/main/java/org/mozilla/sync15_logins_example/MainActivity.kt
@@ -39,7 +39,7 @@ import java.util.*
 import java.text.SimpleDateFormat
 
 class MainActivity : AppCompatActivity() {
-    private var store: MentatLoginsStorage? = null;
+    private var store: DatabaseLoginsStorage? = null;
     private var recyclerView: RecyclerView? = null;
 
     fun dumpError(tag: String, e: Exception) {
@@ -57,7 +57,7 @@ class MainActivity : AppCompatActivity() {
         return if (this.store != null) {
             SyncResult.fromValue(this.store as LoginsStorage)
         } else {
-            initMentatStore().then({ store ->
+            initStore().then({ store ->
                 this.store = store;
                 SyncResult.fromValue(store as LoginsStorage)
             }, { error ->
@@ -160,9 +160,9 @@ class MainActivity : AppCompatActivity() {
         )
     }
 
-    fun initMentatStore(): SyncResult<MentatLoginsStorage> {
+    fun initStore(): SyncResult<DatabaseLoginsStorage> {
         val appFiles = this.applicationContext.getExternalFilesDir(null)
-        val storage = MentatLoginsStorage(appFiles.absolutePath + "/logins3.mentatdb");
+        val storage = DatabaseLoginsStorage(appFiles.absolutePath + "/logins.db");
         return storage.unlock("my_secret_key").then {
             SyncResult.fromValue(storage)
         }


### PR DESCRIPTION
This also fixes some small warnings and deletes some code that isn't necessary (and I'm surprised doesn't cause any problems) in the LoginActivity (e.g. the loadLibrary calls).