### PR TITLE
Test mio-uds cast fix on taskcluster

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ net2 = { git = 'https://github.com/mehcode/net2-rs', branch = 'master' }
 mio = { git = 'https://github.com/mehcode/mio', branch = 'master' }
 # Remove once a new version of rust-native-tls containing this commit is released.
 native-tls = { git = 'https://github.com/vladikoff/rust-native-tls', rev = '885617dbb827728e81650ba6785fcd25b33e7860' }
+# Testing if this fixes our android build issues on taskcluster
+mio-uds = { git = 'https://github.com/Txuritan/mio-uds', rev = '1fffb0e38183bf1faa2149cb18bbd0cf597dd348'  }
 
 [profile.release]
 opt-level = "z"


### PR DESCRIPTION
This PR exists just to trigger taskcluster, and test https://github.com/alexcrichton/mio-uds/pull/17. We probably don't want to merge this as is.