### PR TITLE
Configure APK splits for logins sample

### DIFF
--- a/logins-api/android/sample/build.gradle
+++ b/logins-api/android/sample/build.gradle
@@ -18,6 +18,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'x86', 'arm64', 'armeabi-v7a'
+        }
+    }
+
     buildToolsVersion '27.0.3'
     productFlavors {
     }


### PR DESCRIPTION
@thomcc r?

Christian had to do this in the FxA sample over in android components, otherwise on ARM you will get `cannot find libfxaclient.so` and crash