### PR TITLE
Implement add/update support into android logins-api

### DIFF
--- a/logins-api/android/build.gradle
+++ b/logins-api/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.2.50'
 
     ext.library = [
-        version: '0.4.0'
+        version: '0.4.1'
     ]
 
     ext.build = [

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/DatabaseLoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/DatabaseLoginsStorage.kt
@@ -123,6 +123,22 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
         }
     }
 
+    override fun add(login: ServerPassword): SyncResult<String> {
+        return safeAsyncString {
+            val s = login.toJSON().toString()
+            PasswordSyncAdapter.INSTANCE.sync15_passwords_add(this.raw!!, s, it)
+        }.then {
+            SyncResult.fromValue(it!!)
+        }
+    }
+
+    override fun update(login: ServerPassword): SyncResult<Unit> {
+        return safeAsync {
+            val s = login.toJSON().toString()
+            PasswordSyncAdapter.INSTANCE.sync15_passwords_update(this.raw!!, s, it)
+        }
+    }
+
     override fun close() {
         synchronized(PasswordSyncAdapter.INSTANCE) {
             var raw = this.raw;

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorage.kt
@@ -41,7 +41,7 @@ interface LoginsStorage : Closeable {
     fun wipe(): SyncResult<Unit>
 
     /**
-     * Delete a password with the given ID. TODO: should be SyncResult<bool>!
+     * Delete a password with the given ID.
      */
     fun delete(id: String): SyncResult<Boolean>
 
@@ -59,4 +59,39 @@ interface LoginsStorage : Closeable {
      * Fetch the full list of passwords from the underlying storage layer.
      */
     fun list(): SyncResult<List<ServerPassword>>
+
+    /**
+     * Insert the provided login into the database.
+     *
+     * This function ignores values in metadata fields (`timesUsed`,
+     * `timeCreated`, `timeLastUsed`, and `timePasswordChanged`).
+     *
+     * If login has an empty id field, then a GUID will be
+     * generated automatically. The format of generated guids
+     * are left up to the implementation of LoginsStorage (in
+     * practice the [DatabaseLoginsStorage] generates 12-character
+     * base64url (RFC 4648) encoded strings, and [MemoryLoginsStorage]
+     * generates strings using [java.util.UUID.toString])
+     *
+     * This will return an error result if a GUID is provided but
+     * collides with an existing record, or if the provided record
+     * is invalid (missing password, hostname, or doesn't have exactly
+     * one of formSubmitURL and httpRealm).
+     */
+    fun add(login: ServerPassword): SyncResult<String>
+
+    /**
+     * Update the fields in the provided record.
+     *
+     * This will return an error if `login.id` does not refer to
+     * a record that exists in the database, or if the provided record
+     * is invalid (missing password, hostname, or doesn't have exactly
+     * one of formSubmitURL and httpRealm).
+     *
+     * Like `add`, this function will ignore values in metadata
+     * fields (`timesUsed`, `timeCreated`, `timeLastUsed`, and
+     * `timePasswordChanged`).
+     */
+    fun update(login: ServerPassword): SyncResult<Unit>
+
 }

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorageException.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorageException.kt
@@ -8,13 +8,37 @@
  * specific language governing permissions and limitations under the License. */
 package org.mozilla.sync15.logins
 
-// TODO: Get more descriptive errors here.
+// TODO: More descriptive errors would be nice here...
 open class LoginsStorageException(msg: String): Exception(msg)
 
-/** Indicates that the sync authentication is invalid, likely due to having
+/** This indicates that the sync authentication is invalid, likely due to having
  * expired.
  */
 class SyncAuthInvalidException(msg: String): LoginsStorageException(msg)
 
-// This doesn't really belong in this file...
+/**
+ * This is thrown if `lock()`/`unlock()` pairs don't match up.
+ */
 class MismatchedLockException(msg: String): LoginsStorageException(msg)
+
+/**
+ * This is thrown if `update()` is performed with a record whose ID
+ * does not exist.
+ */
+class NoSuchRecordException(msg: String): LoginsStorageException(msg)
+
+/**
+ * This is thrown if `add()` is given a record that has an ID, and
+ * that ID does not exist.
+ */
+class IdCollisionException(msg: String): LoginsStorageException(msg)
+
+/**
+ * This is thrown on attempts to insert or update a record so that it
+ * is no longer valid. Valid records have:
+ *
+ * - non-empty hostnames
+ * - non-empty passwords
+ * - and exactly one of `httpRealm` or `formSubmitUrl` is non-null.
+ */
+class InvalidRecordException(msg: String): LoginsStorageException(msg)

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/ServerPassword.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/ServerPassword.kt
@@ -14,7 +14,7 @@ import org.json.JSONObject;
 /**
  * Raw password data that is stored by the LoginsStorage implementation.
  */
-class ServerPassword (
+data class ServerPassword (
 
      /**
       * The unique ID associated with this login.
@@ -25,9 +25,18 @@ class ServerPassword (
       */
     val id: String,
 
+    /**
+     * The hostname this record corresponds to. It is an error to
+     * attempt to insert or update a record to have a blank hostname.
+     */
     val hostname: String,
+
     val username: String?,
 
+    /**
+     * The password field of this record. It is an error to attempt to insert or update
+     * a record to have a blank password.
+     */
     val password: String,
 
     /**
@@ -42,16 +51,56 @@ class ServerPassword (
      */
     val formSubmitURL: String? = null,
 
+    /**
+     * Number of times this password has been used.
+     */
     val timesUsed: Int,
 
+    /**
+     * Time of creation in milliseconds from the unix epoch.
+     */
     val timeCreated: Long,
+
+    /**
+     * Time of last use in milliseconds from the unix epoch.
+     */
     val timeLastUsed: Long,
+
+    /**
+     * Time of last password change in milliseconds from the unix epoch.
+     */
     val timePasswordChanged: Long,
 
     val usernameField: String? = null,
     val passwordField: String? = null
 ) {
 
+    fun toJSON(): JSONObject {
+        val o = JSONObject()
+        o.put("id", this.id)
+        o.put("hostname", this.hostname)
+        o.put("password", password)
+        o.put("timesUsed", timesUsed)
+        o.put("timeCreated", timeCreated)
+        o.put("timeLastUsed", timeLastUsed)
+        o.put("timePasswordChanged", timePasswordChanged)
+        if (username != null) {
+            o.put("username", username)
+        }
+        if (httpRealm != null) {
+            o.put("httpRealm", httpRealm)
+        }
+        if (formSubmitURL != null) {
+            o.put("formSubmitURL", formSubmitURL)
+        }
+        if (usernameField != null) {
+            o.put("usernameField", usernameField)
+        }
+        if (passwordField != null) {
+            o.put("passwordField", passwordField)
+        }
+        return o
+    }
 
     companion object {
         fun fromJSON(jsonObject: JSONObject): ServerPassword {
@@ -76,6 +125,7 @@ class ServerPassword (
                     timePasswordChanged = jsonObject.getLong("timePasswordChanged")
             )
         }
+
 
         fun fromJSON(jsonText: String): ServerPassword {
             return fromJSON(JSONObject(jsonText))

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/RustError.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/RustError.kt
@@ -10,7 +10,9 @@ package org.mozilla.sync15.logins.rust
 
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
+import org.mozilla.sync15.logins.IdCollisionException
 import org.mozilla.sync15.logins.LoginsStorageException
+import org.mozilla.sync15.logins.NoSuchRecordException
 import org.mozilla.sync15.logins.SyncAuthInvalidException
 import java.util.Arrays
 
@@ -47,6 +49,12 @@ open class RustError : Structure() {
             // It's probably a bad idea to throw here! We're probably leaking something if this is
             // ever hit! (But we shouldn't ever hit it?)
             throw RuntimeException("[Bug] intoException called on non-failure!");
+        }
+        if (code == 3) {
+            return IdCollisionException(this.consumeErrorMessage())
+        }
+        if (code == 2) {
+            return NoSuchRecordException(this.consumeErrorMessage())
         }
         if (code == 1) {
             return SyncAuthInvalidException(this.consumeErrorMessage());

--- a/logins-sql/ffi/src/error.rs
+++ b/logins-sql/ffi/src/error.rs
@@ -126,6 +126,16 @@ pub enum ExternErrorCode {
     /// Indicates the FxA credentials are invalid, and should be refreshed.
     AuthInvalidError = 1,
 
+    /// Returned from an `update()` call where the record ID did not exist.
+    NoSuchRecord = 2,
+
+    /// Returned from an `add()` call that was provided an ID, where the ID
+    /// already existed.
+    DuplicateGuid = 3,
+
+    /// Attempted to insert or update a record so that it is invalid
+    InvalidLogin = 4,
+
     // TODO: lockbox indicated that they would want to know when we fail to open
     // the DB due to invalid key.
     // https://github.com/mozilla/application-services/issues/231
@@ -182,6 +192,18 @@ fn get_code(err: &Error) -> ExternErrorCode {
                 }
                 _ => ExternErrorCode::OtherError,
             }
+        }
+        ErrorKind::DuplicateGuid(id) => {
+            error!("Guid already exists: {}", id);
+            ExternErrorCode::DuplicateGuid
+        }
+        ErrorKind::NoSuchRecord(id) => {
+            error!("No record exists with id {}", id);
+            ExternErrorCode::NoSuchRecord
+        }
+        ErrorKind::InvalidLogin(desc) => {
+            error!("Invalid login: {}", desc);
+            ExternErrorCode::InvalidLogin
         }
         err => {
             error!("Unexpected error: {:?}", err);


### PR DESCRIPTION
Not required for lockbox short term, but necessary long term. This also implements it in the in-memory version.

I also clarified some of the documentation slightly.