### PR TITLE
Build loginsapi rust code from gradle as optimized+debuginfo. Fixes #207

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,5 @@ native-tls = { git = 'https://github.com/vladikoff/rust-native-tls', rev = '8856
 
 [profile.release]
 opt-level = "z"
-debug = false
+debug = true
 lto = true

--- a/logins-api/android/library/build.gradle
+++ b/logins-api/android/library/build.gradle
@@ -53,6 +53,10 @@ cargo {
         'x86',
     ]
 
+    // Perform release builds (which should have debug info, due to
+    // `debug = true` in Cargo.toml).
+    profile = "release"
+
     // Configure some environment variables, per toolchain, that will apply
     // during the Cargo build.  Paths are relative to this file.  We assume that
     // the `libs/` directory has been populated before invoking Gradle (or Cargo).


### PR DESCRIPTION
In practice this is less important with the current version than it was with the Mentat version, since less work is done in Rust, but it still seems worth doing.