### PR TITLE
loginsapi: Fix wrong bounds in JSONArray conversion

### DIFF
--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/ServerPassword.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/ServerPassword.kt
@@ -84,7 +84,7 @@ class ServerPassword (
         fun fromJSONArray(jsonArrayText: String): List<ServerPassword> {
             val result: MutableList<ServerPassword> = mutableListOf();
             val array = JSONArray(jsonArrayText);
-            for (index in 0..array.length()) {
+            for (index in 0 until array.length()) {
                 result.add(fromJSON(array.getJSONObject(index)));
             }
             return result


### PR DESCRIPTION
Fix for bug introduced in #241, apparently .. is an inclusive range in kotlin :| (also, apparently I hadn't tested this? I thought I did when I wrote it initially...)