### PR TITLE
Update taskcluster rust version so that `opt-level = "z"` is usable

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -58,7 +58,7 @@ tasks:
     payload:
       maxRunTime: 7200
       deadline: "{{ '4 hours' | $fromNow }}"
-      image: 'mozillamobile/rust-component:buildtools-27.0.3-ndk-r15c-ndk-version-21-rust-stable-rust-beta'
+      image: 'mozillamobile/rust-component:buildtools-27.0.3-ndk-r15c-ndk-version-21-rust-stable-1.28.0-rust-beta-1.29.0-beta.15'
       command:
         - /bin/bash
         - '-c'
@@ -99,7 +99,7 @@ tasks:
     payload:
       maxRunTime: 7200
       deadline: "{{ '4 hours' | $fromNow }}"
-      image: 'mozillamobile/rust-component:buildtools-27.0.3-ndk-r15c-ndk-version-21-rust-stable-rust-beta'
+      image: 'mozillamobile/rust-component:buildtools-27.0.3-ndk-r15c-ndk-version-21-rust-stable-1.28.0-rust-beta-1.29.0-beta.15'
       command:
         - /bin/bash
         - '-c'

--- a/logins-api/android/build.gradle
+++ b/logins-api/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.2.50'
 
     ext.library = [
-        version: '0.4.1'
+        version: '0.4.2'
     ]
 
     ext.build = [


### PR DESCRIPTION
Fixes issue with 0.4.1 release.