### PR TITLE
Set ELF SONAME using `rust-android-gradle` plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
 
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.3.0'
+        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.4.0'
 
         // Yes, this is unusual.  We want to access some host-specific
         // computation at build time.

--- a/fxa-client/sdks/android/library/build.gradle
+++ b/fxa-client/sdks/android/library/build.gradle
@@ -41,8 +41,7 @@ cargo {
     // Where Cargo writes its outputs.
     targetDirectory = '../../../../target'
 
-    // The Cargo outputs to include in the AAR.
-    targetIncludes = ['libfxa_client.so'] // TODO: for unit tests, include ['libfxa_client.dylib', 'libfxa_client.dll']
+    libname = 'libfxa_client'
 
     // The Cargo targets to invoke.  The mapping from short name to target
     // triple is defined by the `rust-android-gradle` plugin.

--- a/logins-api/android/library/build.gradle
+++ b/logins-api/android/library/build.gradle
@@ -49,8 +49,7 @@ cargo {
     // Where Cargo writes its outputs.
     targetDirectory = '../../../target'
 
-    // The Cargo outputs to include in the AAR.
-    targetIncludes = ['libloginsapi_ffi.so', 'libloginsapi_ffi.dylib', 'libloginsapi_ffi.dll']
+    libname = 'libloginsapi_ffi'
 
     // The Cargo targets to invoke.  The mapping from short name to target
     // triple is defined by the `rust-android-gradle` plugin.


### PR DESCRIPTION
This follows-up on #248 and should address #197.