### PR TITLE
loginsapi: Expose RequestFailedException and InvalidKeyException to kotlin

### DIFF
--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorageException.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/LoginsStorageException.kt
@@ -42,3 +42,18 @@ class IdCollisionException(msg: String): LoginsStorageException(msg)
  * - and exactly one of `httpRealm` or `formSubmitUrl` is non-null.
  */
 class InvalidRecordException(msg: String): LoginsStorageException(msg)
+
+/**
+ * This error is emitted in two cases:
+ *
+ * 1. An incorrect key is used to to open the login database
+ * 2. The file at the path specified is not a sqlite database.
+ */
+class InvalidKeyException(msg: String): LoginsStorageException(msg)
+
+/**
+ * This error is emitted if a request to a sync server failed.
+ */
+class RequestFailedException(msg: String): LoginsStorageException(msg)
+
+

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/RustError.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/RustError.kt
@@ -10,10 +10,7 @@ package org.mozilla.sync15.logins.rust
 
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
-import org.mozilla.sync15.logins.IdCollisionException
-import org.mozilla.sync15.logins.LoginsStorageException
-import org.mozilla.sync15.logins.NoSuchRecordException
-import org.mozilla.sync15.logins.SyncAuthInvalidException
+import org.mozilla.sync15.logins.*
 import java.util.Arrays
 
 /**
@@ -50,16 +47,16 @@ open class RustError : Structure() {
             // ever hit! (But we shouldn't ever hit it?)
             throw RuntimeException("[Bug] intoException called on non-failure!");
         }
-        if (code == 3) {
-            return IdCollisionException(this.consumeErrorMessage())
+        val message = this.consumeErrorMessage();
+        when (code) {
+            1 -> return SyncAuthInvalidException(message)
+            2 -> return NoSuchRecordException(message)
+            3 -> return IdCollisionException(message)
+            4 -> return InvalidRecordException(message)
+            5 -> return InvalidKeyException(message)
+            6 -> return RequestFailedException(message)
+            else -> return LoginsStorageException(message)
         }
-        if (code == 2) {
-            return NoSuchRecordException(this.consumeErrorMessage())
-        }
-        if (code == 1) {
-            return SyncAuthInvalidException(this.consumeErrorMessage());
-        }
-        return LoginsStorageException(this.consumeErrorMessage());
     }
 
     /**

--- a/logins-sql/ffi/src/error.rs
+++ b/logins-sql/ffi/src/error.rs
@@ -5,6 +5,7 @@
 use std::{self, panic, thread, ptr, process};
 use std::os::raw::c_char;
 use std::ffi::CString;
+use rusqlite;
 
 use logins_sql::{
     Result,
@@ -136,9 +137,12 @@ pub enum ExternErrorCode {
     /// Attempted to insert or update a record so that it is invalid
     InvalidLogin = 4,
 
-    // TODO: lockbox indicated that they would want to know when we fail to open
-    // the DB due to invalid key.
-    // https://github.com/mozilla/application-services/issues/231
+    /// Either the file is not a database, or it is not encrypted with the
+    /// provided encryption key.
+    InvalidKeyError = 5,
+
+    /// A request to the sync server failed.
+    NetworkError = 6,
 }
 
 /// Represents an error that occurred on the rust side. Many rust FFI functions take a
@@ -189,6 +193,9 @@ fn get_code(err: &Error) -> ExternErrorCode {
             match e.kind() {
                 Sync15ErrorKind::TokenserverHttpError(401) => {
                     ExternErrorCode::AuthInvalidError
+                },
+                Sync15ErrorKind::RequestError(_) => {
+                    ExternErrorCode::NetworkError
                 }
                 _ => ExternErrorCode::OtherError,
             }
@@ -204,6 +211,13 @@ fn get_code(err: &Error) -> ExternErrorCode {
         ErrorKind::InvalidLogin(desc) => {
             error!("Invalid login: {}", desc);
             ExternErrorCode::InvalidLogin
+        }
+        // We can't destructure `err` without bringing in the libsqlite3_sys crate
+        // (and I'd really rather not) so we can't put this in the match.
+        ErrorKind::SqlError(rusqlite::Error::SqliteFailure(err, _))
+                if err.code == rusqlite::ErrorCode::NotADatabase => {
+            error!("Not a database / invalid key error");
+            ExternErrorCode::InvalidKeyError
         }
         err => {
             error!("Unexpected error: {:?}", err);


### PR DESCRIPTION
Fixes #231

I don't think there are any other errors we could emit that users could meaningfully handle.