### PR TITLE
Test logins kotlin FFI (and fix a bunch of bugs those tests uncovered)

### DIFF
--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -60,8 +60,8 @@ then
   ./build-all-android.sh "$OPENSSL_SRC_PATH" "$SQLCIPHER_SRC_PATH"
 elif [ "$PLATFORM" == "desktop" ]
 then
-  # TODO: "$SQLCIPHER_SRC_PATH"
-  ./build-all-desktop.sh "$OPENSSL_SRC_PATH"
+  ./build-openssl-desktop.sh "$OPENSSL_SRC_PATH"
+  ./build-sqlcipher-desktop.sh "$SQLCIPHER_SRC_PATH" $(abspath "desktop/openssl")
 else
   echo "Unrecognized platform"
   exit 1

--- a/libs/build-openssl-desktop.sh
+++ b/libs/build-openssl-desktop.sh
@@ -7,18 +7,12 @@ set -euvx
 if [ "$#" -ne 1 ]
 then
     echo "Usage:"
-    echo "./build-all-desktop.sh <OPENSSL_SRC_PATH>"
+    echo "./build-openssl-desktop.sh <OPENSSL_SRC_PATH>"
     exit 1
 fi
 
 OPENSSL_SRC_PATH=$1
 OPENSSL_DIR=$(abspath "desktop/openssl")
-
-if [ $(uname -s) == "Darwin" ]; then
-  LIB_EXTENSION=dylib
-else
-  LIB_EXTENSION=so
-fi
 
 if [ -d "$OPENSSL_DIR" ]; then
   echo "$OPENSSL_DIR"" folder already exists. Skipping build."
@@ -36,8 +30,8 @@ else
   make -j6 && make install
   mkdir -p "$OPENSSL_DIR""/include/openssl"
   mkdir -p "$OPENSSL_DIR""/lib"
-  cp -p "$OPENSSL_OUTPUT_PATH"/lib/libssl."$LIB_EXTENSION"* "$OPENSSL_DIR""/lib"
-  cp -p "$OPENSSL_OUTPUT_PATH"/lib/libcrypto."$LIB_EXTENSION"* "$OPENSSL_DIR""/lib"
+  cp -p "$OPENSSL_OUTPUT_PATH"/lib/libssl.a "$OPENSSL_DIR""/lib"
+  cp -p "$OPENSSL_OUTPUT_PATH"/lib/libcrypto.a "$OPENSSL_DIR""/lib"
   cp -L "$PWD"/include/openssl/*.h "${OPENSSL_DIR}/include/openssl"
   rm -rf "$OPENSSL_OUTPUT_PATH"
   cd ..

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euvx
+
+if [ "$#" -ne 2 ]
+then
+  echo "Usage:"
+  echo "./build-sqlcipher-desktop.sh <SQLCIPHER_SRC_PATH> <OPENSSL_DIR>"
+  exit 1
+fi
+
+SQLCIPHER_SRC_PATH=$1
+OPENSSL_DIR=$2
+SQLCIPHER_DIR=$(abspath "desktop/sqlcipher")
+
+if [ -d "$SQLCIPHER_DIR" ]; then
+  echo "$SQLCIPHER_DIR folder already exists. Skipping build."
+  exit 0
+fi
+
+echo "# Building sqlcipher"
+
+SQLCIPHER_CFLAGS=" \
+  -DSQLITE_HAS_CODEC \
+  -DSQLITE_SOUNDEX \
+  -DHAVE_USLEEP=1 \
+  -DSQLITE_MAX_VARIABLE_NUMBER=99999 \
+  -DSQLITE_TEMP_STORE=3 \
+  -DSQLITE_THREADSAFE=1 \
+  -DSQLITE_DEFAULT_JOURNAL_SIZE_LIMIT=1048576 \
+  -DNDEBUG=1 \
+  -DSQLITE_ENABLE_MEMORY_MANAGEMENT=1 \
+  -DSQLITE_ENABLE_LOAD_EXTENSION \
+  -DSQLITE_ENABLE_COLUMN_METADATA \
+  -DSQLITE_ENABLE_UNLOCK_NOTIFY \
+  -DSQLITE_ENABLE_RTREE \
+  -DSQLITE_ENABLE_STAT3 \
+  -DSQLITE_ENABLE_STAT4 \
+  -DSQLITE_ENABLE_JSON1 \
+  -DSQLITE_ENABLE_FTS3_PARENTHESIS \
+  -DSQLITE_ENABLE_FTS4 \
+  -DSQLITE_ENABLE_FTS5 \
+  -DSQLCIPHER_CRYPTO_OPENSSL \
+  -DSQLITE_ENABLE_DBSTAT_VTA \
+"
+
+rm -rf "$SQLCIPHER_SRC_PATH/build-desktop"
+mkdir -p "$SQLCIPHER_SRC_PATH/build-desktop/install-prefix"
+pushd "$SQLCIPHER_SRC_PATH/build-desktop"
+
+../configure --prefix="$PWD/install-prefix" \
+  --enable-tempstore=yes \
+  CFLAGS="$SQLCIPHER_CFLAGS -I$OPENSSL_DIR/include -L$OPENSSL_DIR/lib" \
+  LDFLAGS="-lcrypto -lm"
+
+make -j6 && make install
+
+mkdir -p "$SQLCIPHER_DIR/lib"
+cp -r "install-prefix/include" "$SQLCIPHER_DIR"
+cp -p "install-prefix/lib/libsqlcipher.a" "$SQLCIPHER_DIR/lib/libsqlcipher.a"
+
+chmod +w "$SQLCIPHER_DIR/lib/libsqlcipher.a"
+
+popd

--- a/logins-api/android/build.gradle
+++ b/logins-api/android/build.gradle
@@ -30,6 +30,10 @@ buildscript {
 
         classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.2.1'
 
+        // Yes, this is unusual.  We want to access some host-specific
+        // computation at build time.
+        classpath 'net.java.dev.jna:jna:4.5.2'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/logins-api/android/library/build.gradle
+++ b/logins-api/android/library/build.gradle
@@ -3,6 +3,10 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
+apply plugin: 'com.github.dcendents.android-maven'
+
+import com.sun.jna.Platform
+
 android {
     compileSdkVersion 27
 
@@ -21,6 +25,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    sourceSets {
+        test.resources.srcDirs += "$buildDir/rustResources"
     }
 
     // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
@@ -42,12 +50,12 @@ cargo {
     targetDirectory = '../../../target'
 
     // The Cargo outputs to include in the AAR.
-    targetIncludes = ['libloginsapi_ffi.so'] // TODO: for unit tests, include ['libloginsapi_ffi.dylib', 'libloginsapi_ffi.dll']
+    targetIncludes = ['libloginsapi_ffi.so', 'libloginsapi_ffi.dylib', 'libloginsapi_ffi.dll']
 
     // The Cargo targets to invoke.  The mapping from short name to target
     // triple is defined by the `rust-android-gradle` plugin.
     targets = [
-        // 'default', // TODO: For unit tests.
+        'default',
         'arm',
         'arm64',
         'x86',
@@ -62,10 +70,12 @@ cargo {
     // the `libs/` directory has been populated before invoking Gradle (or Cargo).
     exec = { spec, toolchain ->
         switch (toolchain.platform) {
-            // TODO: For unit tests.
-            // case 'default':
-            //     spec.environment("OPENSSL_DIR", file('../../../libs/desktop/openssl').absolutePath)
-            //     break;
+            case 'default':
+                 spec.environment("OPENSSL_STATIC", "1")
+                 spec.environment("OPENSSL_DIR",           file("../../../libs/desktop/openssl").absolutePath)
+                 spec.environment("SQLCIPHER_LIB_DIR",     file("../../../libs/desktop/sqlcipher/lib").absolutePath)
+                 spec.environment("SQLCIPHER_INCLUDE_DIR", file("../../../libs/desktop/sqlcipher/include").absolutePath)
+                 break;
             case 'arm':
             case 'arm64':
             case 'x86':
@@ -79,23 +89,46 @@ cargo {
         }
     }
 
-    // TODO: For unit tests.
+    // For unit tests.
     // This puts the output of `cargo build` (the "default" toolchain) into the correct directory
     // for JNA to find it.
-    // defaultToolchainBuildPrefixDir = Platform.RESOURCE_PREFIX
+    defaultToolchainBuildPrefixDir = Platform.RESOURCE_PREFIX
+}
+
+configurations {
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
 }
 
 dependencies {
+    jnaForTest 'net.java.dev.jna:jna:4.5.2@jar'
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'net.java.dev.jna:jna:4.5.2@aar'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:0.23.4'
 
+    testImplementation files(configurations.jnaForTest.files)
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'org.mockito:mockito-core:2.21.0'
 
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
+
 
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
@@ -107,8 +140,8 @@ afterEvaluate {
         def buildType = "${variant.buildType.name.capitalize()}"
         tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
 
-        // TODO: For unit tests.
-        // tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
+        // For unit tests.
+        tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
     }
 }
 

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/DatabaseLoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/DatabaseLoginsStorage.kt
@@ -88,7 +88,7 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
     override fun delete(id: String): SyncResult<Boolean> {
         return safeAsync { error ->
             Log.d("LoginsAPI", "delete by id")
-            PasswordSyncAdapter.INSTANCE.sync15_passwords_delete(this.raw!!, id, error)
+            PasswordSyncAdapter.INSTANCE.sync15_passwords_delete(this.raw!!, id, error).toInt() != 0
         }
     }
 

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/DatabaseLoginsStorage.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/DatabaseLoginsStorage.kt
@@ -30,6 +30,12 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
         }
     }
 
+    private fun checkUnlocked() {
+        if (raw == null) {
+            throw LoginsStorageException("Using DatabaseLoginsStorage without unlocking first");
+        }
+    }
+
     override fun lock(): SyncResult<Unit> {
         return safeAsync {
             Log.d("LoginsAPI", "locking!");
@@ -62,6 +68,7 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
     override fun sync(syncInfo: SyncUnlockInfo): SyncResult<Unit> {
         return safeAsync { error ->
             Log.d("LoginsAPI", "sync")
+            checkUnlocked()
             PasswordSyncAdapter.INSTANCE.sync15_passwords_sync(this.raw!!,
                     syncInfo.kid,
                     syncInfo.fxaAccessToken,
@@ -74,6 +81,7 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
     override fun reset(): SyncResult<Unit> {
         return safeAsync { error ->
             Log.d("LoginsAPI", "reset")
+            checkUnlocked()
             PasswordSyncAdapter.INSTANCE.sync15_passwords_reset(this.raw!!, error)
         }
     }
@@ -81,6 +89,7 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
     override fun wipe(): SyncResult<Unit> {
         return safeAsync { error ->
             Log.d("LoginsAPI", "wipe")
+            checkUnlocked()
             PasswordSyncAdapter.INSTANCE.sync15_passwords_wipe(this.raw!!, error)
         }
     }
@@ -88,12 +97,15 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
     override fun delete(id: String): SyncResult<Boolean> {
         return safeAsync { error ->
             Log.d("LoginsAPI", "delete by id")
-            PasswordSyncAdapter.INSTANCE.sync15_passwords_delete(this.raw!!, id, error).toInt() != 0
+            checkUnlocked()
+            val deleted = PasswordSyncAdapter.INSTANCE.sync15_passwords_delete(this.raw!!, id, error)
+            deleted.toInt() != 0
         }
     }
 
     override fun get(id: String): SyncResult<ServerPassword?> {
         return safeAsyncString { error ->
+            checkUnlocked()
             PasswordSyncAdapter.INSTANCE.sync15_passwords_get_by_id(this.raw!!, id, error)
         }.then { json ->
             SyncResult.fromValue(
@@ -109,6 +121,7 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
     override fun touch(id: String): SyncResult<Unit> {
         return safeAsync { error ->
             Log.d("LoginsAPI", "touch by id")
+            checkUnlocked()
             PasswordSyncAdapter.INSTANCE.sync15_passwords_touch(this.raw!!, id, error)
         }
     }
@@ -116,9 +129,11 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
     override fun list(): SyncResult<List<ServerPassword>> {
         return safeAsyncString {
             Log.d("LoginsAPI", "list all")
+            checkUnlocked()
             PasswordSyncAdapter.INSTANCE.sync15_passwords_get_all(this.raw!!, it)
         }.then { json ->
-            Log.d("Logins", "got list: " + json);
+            Log.d("Logins", "got list: " + json)
+            checkUnlocked()
             SyncResult.fromValue(ServerPassword.fromJSONArray(json!!))
         }
     }
@@ -126,6 +141,7 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
     override fun add(login: ServerPassword): SyncResult<String> {
         return safeAsyncString {
             val s = login.toJSON().toString()
+            checkUnlocked()
             PasswordSyncAdapter.INSTANCE.sync15_passwords_add(this.raw!!, s, it)
         }.then {
             SyncResult.fromValue(it!!)
@@ -135,6 +151,7 @@ class DatabaseLoginsStorage(private val dbPath: String) : Closeable, LoginsStora
     override fun update(login: ServerPassword): SyncResult<Unit> {
         return safeAsync {
             val s = login.toJSON().toString()
+            checkUnlocked()
             PasswordSyncAdapter.INSTANCE.sync15_passwords_update(this.raw!!, s, it)
         }
     }

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/ServerPassword.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/ServerPassword.kt
@@ -105,18 +105,26 @@ data class ServerPassword (
     companion object {
         fun fromJSON(jsonObject: JSONObject): ServerPassword {
 
+            fun stringOrNull(key: String): String? {
+                try {
+                    return jsonObject.getString(key)
+                } catch (e: JSONException) {
+                    return null
+                }
+            }
+
             return ServerPassword(
                     id = jsonObject.getString("id"),
 
                     hostname = jsonObject.getString("hostname"),
                     password = jsonObject.getString("password"),
-                    username = jsonObject.optString("username", null),
+                    username = stringOrNull("username"),
 
-                    httpRealm = jsonObject.optString("httpRealm", null),
-                    formSubmitURL = jsonObject.optString("formSubmitURL", null),
+                    httpRealm = stringOrNull("httpRealm"),
+                    formSubmitURL = stringOrNull("formSubmitURL"),
 
-                    usernameField = jsonObject.optString("usernameField", null),
-                    passwordField = jsonObject.optString("passwordField", null),
+                    usernameField = stringOrNull("usernameField"),
+                    passwordField = stringOrNull("passwordField"),
 
                     timesUsed = jsonObject.getInt("timesUsed"),
 

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/SyncResult.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/SyncResult.kt
@@ -123,11 +123,17 @@ class SyncResult<T> {
 
             override fun onException(exception: Exception) {
                 if (exceptionListener == null) {
-                    // Do not swallow thrown exceptions if a listener is not present
-                    throw exception
+                    // Let later handlers in the chain handle the exception.
+                    result.completeFrom(fromException(exception))
+                } else {
+                    try {
+                        result.completeFrom(exceptionListener.onException(exception))
+                    } catch (ex: Exception) {
+                        // Allow users to `throw err` instead of returning `SyncResult.fromException`
+                        // (similar to JavaScript promises).
+                        result.completeFrom(fromException(ex))
+                    }
                 }
-
-                result.completeFrom(exceptionListener.onException(exception))
             }
         }
 

--- a/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/PasswordSyncAdapter.kt
+++ b/logins-api/android/library/src/main/java/org/mozilla/sync15/logins/rust/PasswordSyncAdapter.kt
@@ -53,7 +53,9 @@ internal interface PasswordSyncAdapter : Library {
     fun sync15_passwords_reset(state: RawLoginSyncState, error: RustError.ByReference)
 
     fun sync15_passwords_touch(state: RawLoginSyncState, id: String, error: RustError.ByReference)
-    fun sync15_passwords_delete(state: RawLoginSyncState, id: String, error: RustError.ByReference): Boolean
+    // This is 1 for true and 0 for false, it would be a boolean but we need to return a value with
+    // a known size.
+    fun sync15_passwords_delete(state: RawLoginSyncState, id: String, error: RustError.ByReference): Byte
     // Note: returns guid of new login entry (unless one was specifically requested)
     fun sync15_passwords_add(state: RawLoginSyncState, new_login_json: String, error: RustError.ByReference): Pointer
     fun sync15_passwords_update(state: RawLoginSyncState, existing_login_json: String, error: RustError.ByReference)

--- a/logins-api/android/library/src/test/java/org/mozilla/sync15/logins/DatabaseLoginsStorageTest.kt
+++ b/logins-api/android/library/src/test/java/org/mozilla/sync15/logins/DatabaseLoginsStorageTest.kt
@@ -1,0 +1,25 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.sync15.logins
+
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class DatabaseLoginsStorageTest: LoginsStorageTest() {
+    @Rule
+    @JvmField
+    val dbFolder = TemporaryFolder()
+
+    override fun createTestStore(): LoginsStorage {
+        val dbPath = dbFolder.newFile()
+        return DatabaseLoginsStorage(dbPath = dbPath.absolutePath)
+    }
+
+}
+

--- a/logins-sql/ffi/src/lib.rs
+++ b/logins-sql/ffi/src/lib.rs
@@ -112,12 +112,13 @@ pub unsafe extern "C" fn sync15_passwords_delete(
     state: *const PasswordEngine,
     id: *const c_char,
     error: *mut ExternError
-) -> bool {
+) -> u8 {
     trace!("sync15_passwords_delete");
     with_translated_value_result(error, || {
         assert!(!state.is_null(), "Null state passed to sync15_passwords_delete");
         let state = &*state;
-        state.delete(c_str_to_str(id))
+        let deleted = state.delete(c_str_to_str(id))?;
+        Ok(if deleted { 1 } else { 0 })
     })
 }
 

--- a/logins-sql/src/login.rs
+++ b/logins-sql/src/login.rs
@@ -19,19 +19,24 @@ pub struct Login {
     // rename_all = "camelCase" by default will do formSubmitUrl, but we can just
     // override this one field.
     #[serde(rename = "formSubmitURL")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub form_submit_url: Option<String>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub http_realm: Option<String>,
 
     #[serde(default)]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub username: String,
 
     pub password: String,
 
     #[serde(default)]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub username_field: String,
 
     #[serde(default)]
+    #[serde(skip_serializing_if = "String::is_empty")]
     pub password_field: String,
 
     #[serde(default)]


### PR DESCRIPTION
This does a bunch of things:

1. Build SQLcipher on desktop
2. Build OpenSSL as a static library on desktop
3. Set gradle up so that it can run unit tests that call into rust code.
4. Implement a `DatabaseLoginsStorageTest`, similar to the `MemoryLoginsStorageTest`.
5. Fix all the bugs this uncovered!
    - We can't pass Boolean reliably over JNA
    - `someSyncResult.then({ foo }).then({ bar }, { handleErrors })` threws if the first result resolves to an error. I've made it behave like JS promises so that you can chain them without handling errors at each step.
    - `someJSONObject.optString("key", null)` apparently returns `"null"` if `"key"` is missing.
6. Throw LoginsStorageExceptions instead of NullPointerException in DatabaseLoginsStorage. Throwing NullPointerExceptions was just an accident of how it was implemented!