### PR TITLE
Update dedupe/dependencies and remove obsolete temporary fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,6 @@ members = [
     "logins-sql/ffi"
 ]
 
-# For RSA keys cloning. Remove once openssl 0.10.8+ is released.
-[patch.crates-io]
-openssl = { git = 'https://github.com/sfackler/rust-openssl', rev = '5debc1ba5a78963acea2229fd9be5f0e5e0aaa99' }
-# Remove these two once https://github.com/carllerche/mio/pull/846 and https://github.com/rust-lang-nursery/net2-rs/pull/74 are merged.
-net2 = { git = 'https://github.com/mehcode/net2-rs', branch = 'master' }
-mio = { git = 'https://github.com/mehcode/mio', branch = 'master' }
-# Remove once a new version of rust-native-tls containing this commit is released.
-native-tls = { git = 'https://github.com/vladikoff/rust-native-tls', rev = '885617dbb827728e81650ba6785fcd25b33e7860' }
-
 [profile.release]
 opt-level = "z"
 debug = true

--- a/fxa-client/Cargo.toml
+++ b/fxa-client/Cargo.toml
@@ -6,8 +6,8 @@ authors = ["Edouard Oger <eoger@fastmail.com>"]
 [dependencies]
 base64 = "0.9.3"
 byteorder = "1.2.6"
-failure = "0.1.1"
-failure_derive = "0.1.1"
+failure = "0.1.2"
+failure_derive = "0.1.2"
 hawk = { git = "https://github.com/eoger/rust-hawk", branch = "use-ring-latest", optional = true }
 hex = "0.3.2"
 lazy_static = "1.0.0"

--- a/fxa-client/Cargo.toml
+++ b/fxa-client/Cargo.toml
@@ -4,23 +4,23 @@ version = "0.1.0"
 authors = ["Edouard Oger <eoger@fastmail.com>"]
 
 [dependencies]
-base64 = "0.9.0"
-byteorder = "1.2.3"
+base64 = "0.9.3"
+byteorder = "1.2.6"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 hawk = { git = "https://github.com/eoger/rust-hawk", branch = "use-ring-latest", optional = true }
-hex = "0.3.1"
+hex = "0.3.2"
 lazy_static = "1.0.0"
-log = "0.4"
-openssl = { version = "0.10.7", optional = true }
+log = "0.4.5"
+openssl = { version = "0.10.12", optional = true }
 regex = "1.0.0"
-reqwest = "0.8.2"
-ring = "0.13.0-alpha5"
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
+reqwest = "0.9.1"
+ring = "0.13.2"
+serde = "1.0.79"
+serde_derive = "1.0.79"
+serde_json = "1.0.28"
 untrusted = "0.6.2"
-url = "1.6.0"
+url = "1.7.1"
 
 [features]
 browserid = ["openssl", "hawk"]

--- a/fxa-client/ffi/Cargo.toml
+++ b/fxa-client/ffi/Cargo.toml
@@ -8,7 +8,7 @@ name = "fxa_client"
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-libc = "0.2"
+libc = "0.2.43"
 
 [dependencies.fxa-client]
 path = "../"

--- a/fxa-client/src/errors.rs
+++ b/fxa-client/src/errors.rs
@@ -153,6 +153,12 @@ pub enum ErrorKind {
     #[fail(display = "Malformed URL error: {}", _0)]
     MalformedUrl(#[fail(cause)] reqwest::UrlError),
 
+    #[fail(display = "Header parsing error: {}", _0)]
+    HeaderParseError(#[fail(cause)] reqwest::header::ToStrError),
+
+    #[fail(display = "Malformed header error: {}", _0)]
+    MalformedHeader(#[fail(cause)] reqwest::header::InvalidHeaderValue),
+
     #[cfg(feature = "browserid")]
     #[fail(display = "HAWK error: {}", _0)]
     HawkError(#[fail(cause)] SyncFailure<hawk::Error>),
@@ -182,7 +188,9 @@ impl_from_error! {
     (JsonError, ::serde_json::Error),
     (UTF8DecodeError, ::std::string::FromUtf8Error),
     (RequestError, ::reqwest::Error),
-    (MalformedUrl, ::reqwest::UrlError)
+    (MalformedUrl, ::reqwest::UrlError),
+    (HeaderParseError, ::reqwest::header::ToStrError),
+    (MalformedHeader, ::reqwest::header::InvalidHeaderValue)
 }
 
 #[cfg(feature = "browserid")]

--- a/fxa-client/src/http_client/hawk_request.rs
+++ b/fxa-client/src/http_client/hawk_request.rs
@@ -4,7 +4,7 @@
 
 use hawk::{Credentials, Key, PayloadHasher, RequestBuilder, SHA256};
 use hex;
-use reqwest::{header, Client, Method, Request};
+use reqwest::{header::{self, HeaderValue}, Client, Method, Request};
 use serde_json;
 use url::Url;
 
@@ -59,11 +59,11 @@ impl<'a> HAWKRequestBuilder<'a> {
         }
 
         let mut request_builder = Client::new().request(self.method, self.url);
-        request_builder.header(header::Authorization(hawk_header));
+        request_builder = request_builder.header(header::AUTHORIZATION, HeaderValue::from_str(&hawk_header)?);
 
         if let Some(body) = self.body {
-            request_builder.header(header::ContentType::json());
-            request_builder.body(body);
+            request_builder = request_builder.header(header::CONTENT_TYPE, "application/json");
+            request_builder = request_builder.body(body);
         }
 
         request_builder.build().map_err(|e| e.into())

--- a/fxa-client/src/lib.rs
+++ b/fxa-client/src/lib.rs
@@ -550,8 +550,7 @@ mod tests {
 
     #[test]
     fn test_serialize_deserialize() {
-        let mut fxa1 =
-            FirefoxAccount::new(Config::stable_dev().unwrap(), "12345678", "https://foo.bar");
+        let fxa1 = FirefoxAccount::new(Config::stable_dev().unwrap(), "12345678", "https://foo.bar");
         let fxa1_json = fxa1.to_json().unwrap();
         drop(fxa1);
         let fxa2 = FirefoxAccount::from_json(&fxa1_json).unwrap();

--- a/logins-sql/Cargo.toml
+++ b/logins-sql/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 
 [dependencies]
 sync15-adapter = { path = "../sync15-adapter" }
-serde = "1.0.75"
-serde_derive = "1.0.75"
-serde_json = "1.0.26"
-log = "0.4.4"
+serde = "1.0.79"
+serde_derive = "1.0.79"
+serde_json = "1.0.28"
+log = "0.4.5"
 lazy_static = "1.1.0"
 url = "1.7.1"
 failure = "0.1"

--- a/logins-sql/Cargo.toml
+++ b/logins-sql/Cargo.toml
@@ -11,8 +11,8 @@ serde_json = "1.0.28"
 log = "0.4.5"
 lazy_static = "1.1.0"
 url = "1.7.1"
-failure = "0.1"
-failure_derive = "0.1"
+failure = "0.1.2"
+failure_derive = "0.1.2"
 
 [dependencies.rusqlite]
 version = "0.14.0"

--- a/logins-sql/ffi/Cargo.toml
+++ b/logins-sql/ffi/Cargo.toml
@@ -8,8 +8,8 @@ name = "loginsapi_ffi"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-serde_json = "1.0.26"
-log = "0.4.4"
+serde_json = "1.0.28"
+log = "0.4.5"
 url = "1.7.1"
 
 [dependencies.rusqlite]

--- a/sync15-adapter/Cargo.toml
+++ b/sync15-adapter/Cargo.toml
@@ -4,18 +4,18 @@ version = "0.1.0"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 
 [dependencies]
-base64 = "0.9.0"
-serde = "^1.0.63"
-serde_derive = "^1.0.63"
-serde_json = "1.0"
-url = "1.6.0"
-reqwest = "0.8.2"
-openssl = "0.10.7"
+base64 = "0.9.3"
+serde = "1.0.79"
+serde_derive = "1.0.79"
+serde_json = "1.0.28"
+url = "1.7.1"
+reqwest = "0.9.1"
+openssl = "0.10.12"
 hawk = { git = "https://github.com/eoger/rust-hawk", branch = "use-openssl" }
-hyper = "0.11"
-log = "0.4"
+hyper = "0.12.10"
+log = "0.4.5"
 lazy_static = "1.0"
-base16 = "0.1"
+base16 = "0.1.1"
 failure = "0.1.2"
 failure_derive = "0.1.2"
 

--- a/sync15-adapter/src/client.rs
+++ b/sync15-adapter/src/client.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 use std::time::Duration;
 
 use hyper::{Method};
-use reqwest::{Client, Request, Response, Url, header::{self, Accept}};
+use reqwest::{Client, Request, Response, Url, header::{self, HeaderValue, ACCEPT, AUTHORIZATION}};
 use serde;
 use serde_json;
 
@@ -14,7 +14,8 @@ use bso_record::{BsoRecord, EncryptedBso};
 use error::{self, ErrorKind};
 use record_types::MetaGlobalRecord;
 use request::{BatchPoster, CollectionRequest, InfoConfiguration, PostQueue, PostResponse,
-              PostResponseHandler, XIfUnmodifiedSince, XWeaveTimestamp, InfoCollections};
+              PostResponseHandler, X_IF_UNMODIFIED_SINCE, X_WEAVE_TIMESTAMP, InfoCollections};
+use std::str::FromStr;
 use token;
 use util::ServerTimestamp;
 
@@ -58,7 +59,7 @@ impl SetupStorageClient for Sync15StorageClient {
     }
 
     fn fetch_meta_global(&self) -> error::Result<BsoRecord<MetaGlobalRecord>> {
-        let mut resp = match self.relative_storage_request(Method::Get, "storage/meta/global") {
+        let mut resp = match self.relative_storage_request(Method::GET, "storage/meta/global") {
             Ok(r) => Ok(r),
             Err(ref e) if e.is_not_found() => Err(ErrorKind::NoMetaGlobal.into()),
             Err(e) => Err(e)
@@ -74,7 +75,7 @@ impl SetupStorageClient for Sync15StorageClient {
     }
 
     fn fetch_crypto_keys(&self) -> error::Result<EncryptedBso> {
-        let mut keys_resp = self.relative_storage_request(Method::Get, "storage/crypto/keys")?;
+        let mut keys_resp = self.relative_storage_request(Method::GET, "storage/crypto/keys")?;
         let keys: EncryptedBso = keys_resp.json()?;
         Ok(keys)
     }
@@ -87,7 +88,7 @@ impl SetupStorageClient for Sync15StorageClient {
         let s = self.tsc.api_endpoint(&self.http_client)?;
         let url = Url::parse(&s)?;
 
-        let req = self.build_request(Method::Delete, url)?;
+        let req = self.build_request(Method::DELETE, url)?;
         match self.exec_request(req, true) {
             Ok(_) => Ok(()),
             Err(ref e) if e.is_not_found() => Ok(()),
@@ -123,7 +124,7 @@ impl Sync15StorageClient {
         since: ServerTimestamp,
     ) -> error::Result<Vec<EncryptedBso>> {
         let mut resp = self.collection_request(
-            Method::Get,
+            Method::GET,
             CollectionRequest::new(collection).full().newer_than(since),
         )?;
         Ok(resp.json()?)
@@ -131,8 +132,8 @@ impl Sync15StorageClient {
 
     #[inline]
     fn authorized(&self, mut req: Request) -> error::Result<Request> {
-        let header = self.tsc.authorization(&self.http_client, &req)?;
-        req.headers_mut().set(header);
+        let hawk_header_value = self.tsc.authorization(&self.http_client, &req)?;
+        req.headers_mut().insert(AUTHORIZATION, HeaderValue::from_str(&hawk_header_value)?);
         Ok(req)
     }
 
@@ -141,7 +142,7 @@ impl Sync15StorageClient {
     fn build_request(&self, method: Method, url: Url) -> error::Result<Request> {
         self.authorized(self.http_client
             .request(method, url)
-            .header(Accept::json())
+            .header(ACCEPT, "application/json")
             .build()?)
     }
 
@@ -200,13 +201,13 @@ impl Sync15StorageClient {
     where
         for<'a> T: serde::de::Deserialize<'a>,
     {
-        let mut resp = self.relative_storage_request(Method::Get, path)?;
+        let mut resp = self.relative_storage_request(Method::GET, path)?;
         let result: T = resp.json()?;
         Ok(result)
     }
 
-    fn update_timestamp(&self, hs: &header::Headers) {
-        if let Some(ts) = hs.get::<XWeaveTimestamp>().map(|h| **h) {
+    fn update_timestamp(&self, hm: &header::HeaderMap) {
+        if let Some(ts) = hm.get(X_WEAVE_TIMESTAMP).and_then(|v| v.to_str().ok()).and_then(|s| ServerTimestamp::from_str(s).ok()) {
             self.timestamp.set(ts);
         } else {
             // Should we complain more here?
@@ -243,10 +244,10 @@ impl Sync15StorageClient {
 
         let bytes = serde_json::to_vec(body)?;
 
-        let mut req = self.build_request(Method::Put, url)?;
-        req.headers_mut().set(header::ContentType::json());
+        let mut req = self.build_request(Method::PUT, url)?;
+        req.headers_mut().insert(header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
         if let Some(ts) = xius {
-            req.headers_mut().set(XIfUnmodifiedSince(ts));
+            req.headers_mut().insert(X_IF_UNMODIFIED_SINCE, HeaderValue::from_str(&format!("{}", ts))?);
         }
         *req.body_mut() = Some(bytes.into());
         let _ = self.exec_request(req, true)?;
@@ -276,9 +277,9 @@ impl<'a> BatchPoster for PostWrapper<'a> {
                 .tsc
                 .api_endpoint(&self.client.http_client)?)?)?;
 
-        let mut req = self.client.build_request(Method::Post, url)?;
-        req.headers_mut().set(header::ContentType::json());
-        req.headers_mut().set(XIfUnmodifiedSince(xius));
+        let mut req = self.client.build_request(Method::POST, url)?;
+        req.headers_mut().insert(header::CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        req.headers_mut().insert(X_IF_UNMODIFIED_SINCE, HeaderValue::from_str(&format!("{}", xius))?);
         // It's very annoying that we need to copy the body here, the request
         // shouldn't need to take ownership of it...
         *req.body_mut() = Some(Vec::from(bytes).into());

--- a/sync15-adapter/src/error.rs
+++ b/sync15-adapter/src/error.rs
@@ -142,6 +142,9 @@ pub enum ErrorKind {
 
     #[fail(display = "Malformed URL error: {}", _0)]
     MalformedUrl(#[fail(cause)] reqwest::UrlError),
+
+    #[fail(display = "Malformed header error: {}", _0)]
+    MalformedHeader(#[fail(cause)] reqwest::header::InvalidHeaderValue),
 }
 
 macro_rules! impl_from_error {
@@ -168,7 +171,8 @@ impl_from_error! {
     (JsonError, ::serde_json::Error),
     (BadCleartextUtf8, ::std::string::FromUtf8Error),
     (RequestError, ::reqwest::Error),
-    (MalformedUrl, ::reqwest::UrlError)
+    (MalformedUrl, ::reqwest::UrlError),
+    (MalformedHeader, ::reqwest::header::InvalidHeaderValue)
 }
 
 // ::hawk::Error uses error_chain, and so it's not trivially compatible with failure.

--- a/sync15-adapter/src/lib.rs
+++ b/sync15-adapter/src/lib.rs
@@ -7,14 +7,12 @@ extern crate base64;
 extern crate openssl;
 extern crate reqwest;
 extern crate hawk;
+extern crate hyper;
 
 extern crate failure;
 
 #[macro_use]
 extern crate failure_derive;
-
-#[macro_use]
-extern crate hyper;
 
 #[macro_use]
 extern crate lazy_static;

--- a/sync15-adapter/src/request.rs
+++ b/sync15-adapter/src/request.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::collections::HashMap;
 use std::default::Default;
 use std::ops::Deref;
+use std::str::FromStr;
 use url::{Url, UrlQuery, form_urlencoded::Serializer};
 use error::{self, Result, ErrorKind};
 use hyper::{StatusCode};
@@ -18,9 +19,9 @@ use reqwest::Response;
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum RequestOrder { Oldest, Newest, Index }
 
-header! { (XIfUnmodifiedSince, "X-If-Unmodified-Since") => [ServerTimestamp] }
-header! { (XLastModified, "X-Last-Modified") => [ServerTimestamp] }
-header! { (XWeaveTimestamp, "X-Weave-Timestamp") => [ServerTimestamp] }
+pub const X_IF_UNMODIFIED_SINCE: &str = "X-If-Unmodified-Since";
+pub const X_WEAVE_TIMESTAMP: &str = "X-Weave-Timestamp";
+const X_LAST_MODIFIED: &str = "X-Last-Modified";
 
 impl fmt::Display for RequestOrder {
     #[inline]
@@ -287,7 +288,7 @@ impl PostResponse {
     pub fn from_response(r: &mut Response) -> Result<PostResponse> {
         let result: UploadResult = r.json()?;
         // TODO Can this happen in error cases?
-        let last_modified = r.headers().get::<XLastModified>().map(|h| **h).ok_or_else(||
+        let last_modified = r.headers().get(X_LAST_MODIFIED).and_then(|v| v.to_str().ok()).and_then(|s| ServerTimestamp::from_str(s).ok()).ok_or_else(||
             ErrorKind::MissingServerTimestamp)?;
         let status = r.status();
         Ok(PostResponse { status, result, last_modified })
@@ -359,7 +360,7 @@ impl PostResponseHandler for NormalResponseHandler {
     fn handle_response(&mut self, r: PostResponse, mid_batch: bool) -> error::Result<()> {
         if !r.status.is_success() {
             warn!("Got failure status from server while posting: {}", r.status);
-            if r.status == StatusCode::PreconditionFailed {
+            if r.status == StatusCode::PRECONDITION_FAILED {
                 return Err(ErrorKind::BatchInterrupted.into());
             } else {
                 return Err(ErrorKind::StorageHttpError {
@@ -537,7 +538,7 @@ where
             return Ok(());
         }
 
-        if resp.status != StatusCode::Accepted {
+        if resp.status != StatusCode::ACCEPTED {
             if self.in_batch() {
                 return Err(ErrorKind::ServerBatchProblem(
                     "Server responded non-202 success code while a batch was in progress").into());
@@ -875,7 +876,7 @@ mod test {
         };
         let time = 11111111.0;
         let (mut pq, tester) = pq_test_setup(cfg, time, vec![
-            fake_response(StatusCode::Ok, time + 100.0, None),
+            fake_response(StatusCode::OK, time + 100.0, None),
         ]);
 
         pq.enqueue(&make_record(100)).unwrap();
@@ -900,8 +901,8 @@ mod test {
         };
         let time = 11111111.0;
         let (mut pq, tester) = pq_test_setup(cfg, time, vec![
-            fake_response(StatusCode::Ok, time + 100.0, None),
-            fake_response(StatusCode::Ok, time + 200.0, None),
+            fake_response(StatusCode::OK, time + 100.0, None),
+            fake_response(StatusCode::OK, time + 200.0, None),
         ]);
 
         // Note that the total record overhead is around 85 bytes
@@ -941,8 +942,8 @@ mod test {
         };
         let time = 11111111.0;
         let (mut pq, tester) = pq_test_setup(cfg, time, vec![
-            fake_response(StatusCode::Ok, time + 100.0, None),
-            fake_response(StatusCode::Ok, time + 200.0, None),
+            fake_response(StatusCode::OK, time + 100.0, None),
+            fake_response(StatusCode::OK, time + 200.0, None),
         ]);
 
         // Note that the total record overhead is around 85 bytes
@@ -969,7 +970,7 @@ mod test {
         let cfg = InfoConfiguration::default();
         let time = 11111111.0;
         let (mut pq, tester) = pq_test_setup(cfg, time, vec![
-            fake_response(StatusCode::Accepted, time + 100.0, Some("1234")),
+            fake_response(StatusCode::ACCEPTED, time + 100.0, Some("1234")),
         ]);
 
         let payload_size = 100 - *NON_PAYLOAD_OVERHEAD;
@@ -999,8 +1000,8 @@ mod test {
         };
         let time = 11111111.0;
         let (mut pq, tester) = pq_test_setup(cfg, time, vec![
-            fake_response(StatusCode::Accepted, time, Some("1234")),
-            fake_response(StatusCode::Accepted, time + 100.0, Some("1234")),
+            fake_response(StatusCode::ACCEPTED, time, Some("1234")),
+            fake_response(StatusCode::ACCEPTED, time + 100.0, Some("1234")),
         ]);
 
         pq.enqueue(&make_record(100)).unwrap();
@@ -1041,9 +1042,9 @@ mod test {
         };
         let time = 11111111.0;
         let (mut pq, tester) = pq_test_setup(cfg, time, vec![
-            fake_response(StatusCode::Accepted, time, Some("1234")),
-            fake_response(StatusCode::Accepted, time, Some("1234")),
-            fake_response(StatusCode::Accepted, time + 100.0, Some("1234")),
+            fake_response(StatusCode::ACCEPTED, time, Some("1234")),
+            fake_response(StatusCode::ACCEPTED, time, Some("1234")),
+            fake_response(StatusCode::ACCEPTED, time + 100.0, Some("1234")),
         ]);
 
         pq.enqueue(&make_record(100)).unwrap();
@@ -1096,10 +1097,10 @@ mod test {
         };
         let time = 11111111.0;
         let (mut pq, tester) = pq_test_setup(cfg, time, vec![
-            fake_response(StatusCode::Accepted, time, Some("1234")),
-            fake_response(StatusCode::Accepted, time + 100.0, Some("1234")),
-            fake_response(StatusCode::Accepted, time + 100.0, Some("abcd")),
-            fake_response(StatusCode::Accepted, time + 200.0, Some("abcd")),
+            fake_response(StatusCode::ACCEPTED, time, Some("1234")),
+            fake_response(StatusCode::ACCEPTED, time + 100.0, Some("1234")),
+            fake_response(StatusCode::ACCEPTED, time + 100.0, Some("abcd")),
+            fake_response(StatusCode::ACCEPTED, time + 200.0, Some("abcd")),
         ]);
 
         pq.enqueue(&make_record(100)).unwrap();
@@ -1168,10 +1169,10 @@ mod test {
         };
         let time = 11111111.0;
         let (mut pq, tester) = pq_test_setup(cfg, time, vec![
-            fake_response(StatusCode::Accepted, time, Some("1234")),
-            fake_response(StatusCode::Accepted, time + 100.0, Some("1234")), // should commit
-            fake_response(StatusCode::Accepted, time + 100.0, Some("abcd")),
-            fake_response(StatusCode::Accepted, time + 200.0, Some("abcd")), // should commit
+            fake_response(StatusCode::ACCEPTED, time, Some("1234")),
+            fake_response(StatusCode::ACCEPTED, time + 100.0, Some("1234")), // should commit
+            fake_response(StatusCode::ACCEPTED, time + 100.0, Some("abcd")),
+            fake_response(StatusCode::ACCEPTED, time + 200.0, Some("abcd")), // should commit
         ]);
 
         pq.enqueue(&make_record(100)).unwrap();


### PR DESCRIPTION
Fixes #201 and fixes #218.
Note that we do a bunch of `HeaderMap::get().and_then()[...]` which eats a bunch (UTF-8 parsing/number parsing) of errors, do we want to catch all of them?