### PR TITLE
fix(rss): Fix the 404's in the RSS/Atom feeds.

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -10,7 +10,7 @@ const users = [
 const siteConfig = {
   title: 'Firefox Application Services' /* title for your website */,
   tagline: 'Build the next thing...',
-  url: 'https://mozilla.github.io/application-services' /* your website url */,
+  url: 'https://mozilla.github.io' /* your website url */,
   baseUrl: '/application-services/' /* base url for your project */,
   projectName: 'application-services',
   headerLinks: [


### PR DESCRIPTION
The `url` config option had the `application-services` path, which caused
a double `application-services/application-services` in links in the
RSS and Atom feeds. This fixes that problem.

fixes #272 

@vladikoff - r?