### PR TITLE
Make sure travis tests more than just `--all-features`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,12 @@ matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
-script: cargo test --all-features --verbose
+script:
+  # Test with 1. only default features on, 2. all features on, 3. no features on.
+  # This is not perfect (really we want the cartesian product), but is good enough in practice.
+  - cargo test --all --verbose
+  - cargo test --all --all-features --verbose
+  - cargo test --all --no-default-features --verbose
 
 jobs:
   include:


### PR DESCRIPTION
We don't actually test every package in travis at the moment, and we also only test them with features turned on and not both on and off.

This isn't that hard to do, and is probably just a mistake. Ideally we'd do the cartesian product of features but that's a big rats nest.