### PR TITLE
Support running with RUST_BACKTRACE

### DIFF
--- a/fxa-client/src/lib.rs
+++ b/fxa-client/src/lib.rs
@@ -653,7 +653,14 @@ mod tests {
         let url = fxa.begin_pairing_flow(&PAIRING_URL, &["https://identity.mozilla.com/apps/oldsync"]);
 
         assert!(url.is_err());
-        assert_eq!(format!("{:?}", url), "Err(Error(\n\nOrigin mismatch))")
+
+        match url {
+            Ok(_) => { panic!("should have error"); }
+            Err(err) => match err.kind() {
+                ErrorKind::OriginMismatch { .. } => {},
+                _ => panic!("error not OriginMismatch")
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #278 

Not sure if this is the ideal solution, but it does work as expected. When running `RUST_BACKTRACE=1 cargo test`, the test pass. Injecting an error does cause the stacktrace to be logged.