### PR TITLE
Enable gradle publish for the places component

### DIFF
--- a/components/places/android/library/build.gradle
+++ b/components/places/android/library/build.gradle
@@ -143,8 +143,8 @@ afterEvaluate {
 
 archivesBaseName = 'places'
 
-// apply from: '../../../../publish.gradle'
-// ext.configurePublish(
-//         'org.mozilla.places',
-//         'places',
-//         'Low level places storage implementation.')
+apply from: '../../../../publish.gradle'
+ext.configurePublish(
+        'org.mozilla.places',
+        'places',
+        'Low level places storage implementation.')


### PR DESCRIPTION
This allows `./gradlew service-sync-places:install` to publish to the local maven repo with a sane name.