### PR TITLE
get_visited_urls fixes and improvements.

### DIFF
--- a/components/places/android/library/src/main/java/org/mozilla/places/PlacesConnection.kt
+++ b/components/places/android/library/src/main/java/org/mozilla/places/PlacesConnection.kt
@@ -60,7 +60,7 @@ open class PlacesConnection(path: String, encryption_key: String? = null) : Auto
     }
 
     /** NB: start and end are unix timestamps in milliseconds! */
-    fun getVisitedUrlsInRange(start: Long, end: Long, includeRemote: Boolean): List<String> {
+    fun getVisitedUrlsInRange(start: Long, end: Long = Long.MAX_VALUE, includeRemote: Boolean = true): List<String> {
         val urlsJson = rustCallForString { error ->
             val incRemoteArg: Byte = if (includeRemote) { 1 } else { 0 }
             LibPlacesFFI.INSTANCE.places_get_visited_urls_in_range(


### PR DESCRIPTION
- Fix `get_visited_urls` SQL (and a bug the test uncovered in `apply_observation`), fixing #332
- Don't require all args for getVisitedUrlsInRange in the android code, fixing #331.