### PR TITLE
Change serde error string to not imply all errors are parsing errors

### DIFF
--- a/fxa-client/src/errors.rs
+++ b/fxa-client/src/errors.rs
@@ -143,7 +143,7 @@ pub enum ErrorKind {
     #[fail(display = "Base64 decode error: {}", _0)]
     Base64Decode(#[fail(cause)] base64::DecodeError),
 
-    #[fail(display = "JSON parse error: {}", _0)]
+    #[fail(display = "JSON error: {}", _0)]
     JsonError(#[fail(cause)] serde_json::Error),
 
     #[fail(display = "UTF8 decode error: {}", _0)]

--- a/sync15-adapter/src/error.rs
+++ b/sync15-adapter/src/error.rs
@@ -128,7 +128,7 @@ pub enum ErrorKind {
     #[fail(display = "Base64 decode error: {}", _0)]
     Base64Decode(#[fail(cause)] base64::DecodeError),
 
-    #[fail(display = "JSON parse error: {}", _0)]
+    #[fail(display = "JSON error: {}", _0)]
     JsonError(#[fail(cause)] serde_json::Error),
 
     #[fail(display = "Bad cleartext UTF8: {}", _0)]


### PR DESCRIPTION
This is a trivial patch which might help prevent some confusion - I saw a serde related error which wasn't related to JSON parsing - for a short time I went down a rabbit hole thinking some parsing code was involved, which it wasn't.

tl;dr - not all serde errors relate to parsing, so the error message shouldn't imply they are.