### PR TITLE
sync() takes a collection request builder rather than timestamps.

### DIFF
--- a/logins-sql/src/db.rs
+++ b/logins-sql/src/db.rs
@@ -633,6 +633,11 @@ impl LoginDb {
         self.put_meta(schema::LAST_SYNC_META_KEY, &last_sync_millis)
     }
 
+    fn get_last_sync(&self) -> Result<Option<ServerTimestamp>> {
+        Ok(self.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?
+               .map(|millis| ServerTimestamp(millis as f64 / 1000.0)))
+    }
+
     pub fn set_global_state(&self, global_state: &str) -> Result<()> {
         self.put_meta(schema::GLOBAL_STATE_META_KEY, &global_state)
     }
@@ -662,9 +667,7 @@ impl Store for LoginDb {
     }
 
     fn get_collection_request(&self) -> result::Result<CollectionRequest, failure::Error> {
-        let since = self.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?
-                        .map(|millis| ServerTimestamp(millis as f64 / 1000.0))
-                        .unwrap_or_default();
+        let since = self.get_last_sync()?.unwrap_or_default();
         Ok(CollectionRequest::new("passwords").full().newer_than(since))
     }
 }

--- a/logins-sql/src/db.rs
+++ b/logins-sql/src/db.rs
@@ -11,7 +11,15 @@ use std::result;
 use failure;
 use schema;
 use login::{LocalLogin, MirrorLogin, Login, SyncStatus, SyncLoginData};
-use sync::{self, ServerTimestamp, IncomingChangeset, Store, OutgoingChangeset, Payload};
+use sync::{
+    self,
+    CollectionRequest,
+    IncomingChangeset,
+    OutgoingChangeset,
+    Payload,
+    ServerTimestamp,
+    Store,
+};
 use update_plan::UpdatePlan;
 use sql_support::{self, ConnExt};
 use util;
@@ -619,7 +627,7 @@ impl LoginDb {
         )?)
     }
 
-    pub fn set_last_sync(&self, last_sync: ServerTimestamp) -> Result<()> {
+    fn set_last_sync(&self, last_sync: ServerTimestamp) -> Result<()> {
         debug!("Updating last sync to {}", last_sync);
         let last_sync_millis = last_sync.as_millis() as i64;
         self.put_meta(schema::LAST_SYNC_META_KEY, &last_sync_millis)
@@ -627,11 +635,6 @@ impl LoginDb {
 
     pub fn set_global_state(&self, global_state: &str) -> Result<()> {
         self.put_meta(schema::GLOBAL_STATE_META_KEY, &global_state)
-    }
-
-    pub fn get_last_sync(&self) -> Result<Option<ServerTimestamp>> {
-        Ok(self.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?
-            .map(|millis| ServerTimestamp(millis as f64 / 1000.0)))
     }
 
     pub fn get_global_state(&self) -> Result<Option<String>> {
@@ -656,6 +659,13 @@ impl Store for LoginDb {
             &records_synced.iter().map(|r| r.as_str()).collect::<Vec<_>>(),
             new_timestamp
         )?)
+    }
+
+    fn get_collection_request(&self) -> result::Result<CollectionRequest, failure::Error> {
+        let since = self.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?
+                        .map(|millis| ServerTimestamp(millis as f64 / 1000.0))
+                        .unwrap_or_default();
+        Ok(CollectionRequest::new("passwords").full().newer_than(since))
     }
 }
 

--- a/logins-sql/src/engine.rs
+++ b/logins-sql/src/engine.rs
@@ -160,8 +160,6 @@ impl PasswordEngine {
 
         info!("Syncing passwords engine!");
 
-        let ts = self.db.get_last_sync()?.unwrap_or_default();
-
         // We don't use `?` here so that we can restore the value of of
         // `self.sync` even if sync fails.
         let result = sync::synchronize(
@@ -169,7 +167,6 @@ impl PasswordEngine {
             &sync_info.state,
             &self.db,
             "passwords".into(),
-            ts,
             true
         );
 

--- a/sync15-adapter/src/changeset.rs
+++ b/sync15-adapter/src/changeset.rs
@@ -6,7 +6,7 @@ use bso_record::{EncryptedBso, Payload};
 use client::Sync15StorageClient;
 use error::{self, ErrorKind, Result};
 use key_bundle::KeyBundle;
-use request::{NormalResponseHandler, UploadInfo};
+use request::{NormalResponseHandler, UploadInfo, CollectionRequest};
 use state::GlobalState;
 use util::ServerTimestamp;
 
@@ -66,9 +66,9 @@ impl IncomingChangeset {
         client: &Sync15StorageClient,
         state: &GlobalState,
         collection: String,
-        since: ServerTimestamp,
+        collection_request: &CollectionRequest,
     ) -> Result<IncomingChangeset> {
-        let records = client.get_encrypted_records(&collection, since)?;
+        let records = client.get_encrypted_records(collection_request)?;
         let timestamp = state.last_modified_or_zero(&collection);
         let mut result = IncomingChangeset::new(collection, timestamp);
         result.changes.reserve(records.len());

--- a/sync15-adapter/src/client.rs
+++ b/sync15-adapter/src/client.rs
@@ -120,12 +120,11 @@ impl Sync15StorageClient {
 
     pub fn get_encrypted_records(
         &self,
-        collection: &str,
-        since: ServerTimestamp,
+        collection_request: &CollectionRequest,
     ) -> error::Result<Vec<EncryptedBso>> {
         let mut resp = self.collection_request(
             Method::GET,
-            CollectionRequest::new(collection).full().newer_than(since),
+            collection_request,
         )?;
         Ok(resp.json()?)
     }
@@ -165,7 +164,9 @@ impl Sync15StorageClient {
     }
 
     fn exec_request(&self, req: Request, require_success: bool) -> error::Result<Response> {
+        trace!("request: {} {}", req.method(), req.url().path());
         let resp = self.http_client.execute(req)?;
+        trace!("response: {}", resp.status());
 
         self.update_timestamp(resp.headers());
 

--- a/sync15-adapter/src/lib.rs
+++ b/sync15-adapter/src/lib.rs
@@ -52,3 +52,4 @@ pub use util::{ServerTimestamp, SERVER_EPOCH};
 pub use key_bundle::KeyBundle;
 pub use client::{Sync15StorageClientInit, Sync15StorageClient};
 pub use state::{GlobalState, SetupStateMachine};
+pub use request::{CollectionRequest};

--- a/sync15-adapter/src/request.rs
+++ b/sync15-adapter/src/request.rs
@@ -64,49 +64,49 @@ impl CollectionRequest {
     }
 
     #[inline]
-    pub fn ids<V>(&mut self, v: V) -> &mut CollectionRequest where V: Into<Vec<String>> {
+    pub fn ids<V>(mut self, v: V) -> CollectionRequest where V: Into<Vec<String>> {
         self.ids = Some(v.into());
         self
     }
 
     #[inline]
-    pub fn full(&mut self) -> &mut CollectionRequest {
+    pub fn full(mut self) -> CollectionRequest {
         self.full = true;
         self
     }
 
     #[inline]
-    pub fn older_than(&mut self, ts: ServerTimestamp) -> &mut CollectionRequest {
+    pub fn older_than(mut self, ts: ServerTimestamp) -> CollectionRequest {
         self.older = Some(ts);
         self
     }
 
     #[inline]
-    pub fn newer_than(&mut self, ts: ServerTimestamp) -> &mut CollectionRequest {
+    pub fn newer_than(mut self, ts: ServerTimestamp) -> CollectionRequest {
         self.newer = Some(ts);
         self
     }
 
     #[inline]
-    pub fn sort_by(&mut self, order: RequestOrder) -> &mut CollectionRequest {
+    pub fn sort_by(mut self, order: RequestOrder) -> CollectionRequest {
         self.order = Some(order);
         self
     }
 
     #[inline]
-    pub fn limit(&mut self, num: usize) -> &mut CollectionRequest {
+    pub fn limit(mut self, num: usize) -> CollectionRequest {
         self.limit = num;
         self
     }
 
     #[inline]
-    pub fn batch(&mut self, batch: Option<String>) -> &mut CollectionRequest {
+    pub fn batch(mut self, batch: Option<String>) -> CollectionRequest {
         self.batch = batch;
         self
     }
 
     #[inline]
-    pub fn commit(&mut self, v: bool) -> &mut CollectionRequest {
+    pub fn commit(mut self, v: bool) -> CollectionRequest {
         self.commit = v;
         self
     }

--- a/sync15-adapter/src/sync.rs
+++ b/sync15-adapter/src/sync.rs
@@ -26,11 +26,11 @@ pub trait Store {
         records_synced: &[String],
     ) -> Result<(), failure::Error>;
 
-    // The store is responsible for building the collection request. Engines
-    // typically will store a lastModified timestamp and use that to build
-    // a request saying "give me full records since that date" - however, other
-    // engines might do something fancier. This could even later be extended
-    // to handle "backfills" etc
+    /// The store is responsible for building the collection request. Engines
+    /// typically will store a lastModified timestamp and use that to build
+    /// a request saying "give me full records since that date" - however, other
+    /// engines might do something fancier. This could even later be extended
+    /// to handle "backfills" etc
     fn get_collection_request(&self) -> Result<CollectionRequest, failure::Error>;
 }
 


### PR DESCRIPTION
This gives more control to individual stores about what records are fetched
for a "normal" sync - history will use this to apply a limit