### PR TITLE
do not merge: Introduce the concept of a "stateful sync", which consumes state for a store managed externally.

### DIFF
--- a/logins-sql/examples/sync_pass_sql.rs
+++ b/logins-sql/examples/sync_pass_sql.rs
@@ -32,7 +32,7 @@ use failure::Fail;
 use std::{fs, io::{self, Read, Write}};
 use std::collections::HashMap;
 use fxa_client::{FirefoxAccount, Config, OAuthInfo};
-use sync::{Sync15StorageClientInit, KeyBundle};
+use sync::{Sync15StorageClientInit, KeyBundle, sync_stateful};
 use logins_sql::{PasswordEngine, Login};
 
 const CLIENT_ID: &str = "98adfa37698f255b";
@@ -362,16 +362,15 @@ fn main() -> Result<()> {
 
     // TODO: we should probably set a persist callback on acct?
     let mut acct = load_or_create_fxa_creds(cred_file, cfg.clone())?;
-    let token: OAuthInfo;
-    match acct.get_oauth_token(SCOPES)? {
-        Some(t) => token = t,
+    let token: OAuthInfo = match acct.get_oauth_token(SCOPES)? {
+        Some(t) => t,
         None => {
             // The cached credentials did not have appropriate scope, sign in again.
             warn!("Credentials do not have appropriate scope, launching OAuth flow.");
             acct = create_fxa_creds(cred_file, cfg.clone())?;
-            token = acct.get_oauth_token(SCOPES)?.unwrap();
+            acct.get_oauth_token(SCOPES)?.unwrap()
         }
-    }
+    };
 
     let keys: HashMap<String, ScopedKeyData> = serde_json::from_str(&token.keys.unwrap())?;
 
@@ -443,19 +442,19 @@ fn main() -> Result<()> {
             }
             'R' | 'r' => {
                 info!("Resetting client.");
-                if let Err(e) = engine.reset() {
+                if let Err(e) = engine.db.reset() {
                     warn!("Failed to reset! {}", e);
                 }
             }
             'W' | 'w' => {
                 info!("Wiping all data from client!");
-                if let Err(e) = engine.wipe() {
+                if let Err(e) = engine.db.wipe() {
                     warn!("Failed to wipe! {}", e);
                 }
             }
             'S' | 's' => {
                 info!("Syncing!");
-                if let Err(e) = engine.sync(&client_init, &root_sync_key) {
+                if let Err(e) = sync_stateful(&engine.db, &engine.db, &engine.client_info, &client_init, &root_sync_key) {
                     warn!("Sync failed! {}", e);
                     warn!("BT: {:?}", e.backtrace());
                 } else {

--- a/logins-sql/ffi/src/lib.rs
+++ b/logins-sql/ffi/src/lib.rs
@@ -29,6 +29,8 @@ use logins_sql::{
     PasswordEngine,
 };
 
+use sync15_adapter::sync_stateful;
+
 fn logging_init() {
     #[cfg(target_os = "android")]
     {
@@ -70,8 +72,11 @@ pub unsafe extern "C" fn sync15_passwords_sync(
 ) {
     trace!("sync15_passwords_sync");
     // TODO: Is there any way to convince rust that some `&mut T` is unwind safe?
-    call_with_result(error, || {
-        state.sync(
+    call_with_result(error, || -> Result<()> {
+        Ok(sync_stateful(
+            &state.db,
+            &state.db,
+            &state.client_info,
             &sync15_adapter::Sync15StorageClientInit {
                 key_id: rust_string_from_c(key_id),
                 access_token: rust_string_from_c(access_token),
@@ -80,7 +85,7 @@ pub unsafe extern "C" fn sync15_passwords_sync(
             &sync15_adapter::KeyBundle::from_ksync_base64(
                 rust_str_from_c(sync_key)
             )?
-        )
+        )?)
     })
 }
 

--- a/logins-sql/src/db.rs
+++ b/logins-sql/src/db.rs
@@ -11,7 +11,15 @@ use std::result;
 use failure;
 use schema;
 use login::{LocalLogin, MirrorLogin, Login, SyncStatus, SyncLoginData};
-use sync::{self, ServerTimestamp, IncomingChangeset, Store, OutgoingChangeset, Payload};
+use sync::{
+    self,
+    CollectionRequest,
+    IncomingChangeset,
+    OutgoingChangeset,
+    Payload,
+    ServerTimestamp,
+    Store,
+};
 use update_plan::UpdatePlan;
 use sql_support::{self, ConnExt};
 use util;
@@ -619,7 +627,7 @@ impl LoginDb {
         )?)
     }
 
-    pub fn set_last_sync(&self, last_sync: ServerTimestamp) -> Result<()> {
+    fn set_last_sync(&self, last_sync: ServerTimestamp) -> Result<()> {
         debug!("Updating last sync to {}", last_sync);
         let last_sync_millis = last_sync.as_millis() as i64;
         self.put_meta(schema::LAST_SYNC_META_KEY, &last_sync_millis)
@@ -627,11 +635,6 @@ impl LoginDb {
 
     pub fn set_global_state(&self, global_state: &str) -> Result<()> {
         self.put_meta(schema::GLOBAL_STATE_META_KEY, &global_state)
-    }
-
-    pub fn get_last_sync(&self) -> Result<Option<ServerTimestamp>> {
-        Ok(self.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?
-            .map(|millis| ServerTimestamp(millis as f64 / 1000.0)))
     }
 
     pub fn get_global_state(&self) -> Result<Option<String>> {
@@ -656,6 +659,13 @@ impl Store for LoginDb {
             &records_synced.iter().map(|r| r.as_str()).collect::<Vec<_>>(),
             new_timestamp
         )?)
+    }
+
+    fn get_collection_request(&self) -> result::Result<CollectionRequest, failure::Error> {
+        let since = self.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?
+                        .map(|millis| ServerTimestamp(millis as f64 / 1000.0))
+                        .unwrap_or_default();
+        Ok(CollectionRequest::new("passwords").full().newer_than(since))
     }
 }
 

--- a/logins-sql/src/db.rs
+++ b/logins-sql/src/db.rs
@@ -498,9 +498,8 @@ impl LoginDb {
     }
 
     pub fn wipe(&self) -> Result<()> {
-        info!("Executing reset on password store!");
+        info!("Executing wipe on password store!");
         let now_ms = util::system_time_ms_i64(SystemTime::now());
-
         self.execute(&format!("DELETE FROM loginsL WHERE sync_status = {new}", new = SyncStatus::New as u8), &[])?;
         self.execute_named(
             &format!("
@@ -525,7 +524,6 @@ impl LoginDb {
                 FROM loginsM",
                 changed = SyncStatus::Changed as u8),
             &[(":now_ms", &now_ms as &ToSql)])?;
-
         Ok(())
     }
 
@@ -643,6 +641,10 @@ impl LoginDb {
 }
 
 impl Store for LoginDb {
+    fn collection_name(&self) -> String {
+        "passwords".into()
+    }
+
     fn apply_incoming(
         &self,
         inbound: IncomingChangeset
@@ -666,6 +668,16 @@ impl Store for LoginDb {
                         .map(|millis| ServerTimestamp(millis as f64 / 1000.0))
                         .unwrap_or_default();
         Ok(CollectionRequest::new("passwords").full().newer_than(since))
+    }
+
+    fn reset(&self) -> result::Result<(), failure::Error> {
+        LoginDb::reset(self)?;
+        Ok(())
+    }
+
+    fn wipe(&self) -> result::Result<(), failure::Error> {
+        LoginDb::wipe(self)?;
+        Ok(())
     }
 }
 

--- a/logins-sql/src/engine.rs
+++ b/logins-sql/src/engine.rs
@@ -2,41 +2,65 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 use std::result;
-use login::Login;
-use error::*;
-use sync::{self, Sync15StorageClient, Sync15StorageClientInit, GlobalState, KeyBundle};
-use db::LoginDb;
 use std::path::Path;
 use std::cell::Cell;
+use login::Login;
+use error::*;
+use failure;
+use sync::{GlobalState, GlobalStateProvider, ClientInfo};
+use db::LoginDb;
 use serde_json;
 use rusqlite;
 
-#[derive(Debug)]
-pub(crate) struct SyncInfo {
-    pub state: GlobalState,
-    pub client: Sync15StorageClient,
-    // Used so that we know whether or not we need to re-initialize `client`
-    pub last_client_init: Sync15StorageClientInit,
+impl GlobalStateProvider for LoginDb {
+    fn load(&self) -> result::Result<Option<GlobalState>, failure::Error> {
+        Ok(match self.get_global_state()? {
+            Some(persisted_global_state) => {
+                match serde_json::from_str::<GlobalState>(&persisted_global_state) {
+                    Ok(state) => Some(state),
+                    _ => {
+                        // Don't log the error since it might contain sensitive
+                        // info like keys (the JSON does, after all).
+                        error!("Failed to parse GlobalState from JSON! Falling back to default");
+                        None
+                    }
+                }
+            }
+            None => None
+        })
+    }
+
+    fn save(&self, maybe_state: Option<&GlobalState>) -> result::Result<(), failure::Error> {
+        info!("Updating persisted global state");
+        let s: String = match maybe_state {
+            Some(state) => {
+                state.to_persistable_string()
+            },
+            None => "".to_string(),
+        };
+        self.set_global_state(&s)?;
+        Ok(())
+    }
 }
 
 // This isn't really an engine in the firefox sync15 desktop sense -- it's
 // really a bundle of state that contains the sync storage client, the sync
 // state, and the login DB.
 pub struct PasswordEngine {
-    sync: Cell<Option<SyncInfo>>,
-    db: LoginDb,
+    pub db: LoginDb,
+    pub client_info: Cell<Option<ClientInfo>>,
 }
 
 impl PasswordEngine {
 
     pub fn new(path: impl AsRef<Path>, encryption_key: Option<&str>) -> Result<Self> {
         let db = LoginDb::open(path, encryption_key)?;
-        Ok(Self { db, sync: Cell::new(None) })
+        Ok(Self { db, client_info: Cell::new(None) })
     }
 
     pub fn new_in_memory(encryption_key: Option<&str>) -> Result<Self> {
         let db = LoginDb::open_in_memory(encryption_key)?;
-        Ok(Self { db, sync: Cell::new(None) })
+        Ok(Self { db, client_info: Cell::new(None) })
     }
 
     pub fn list(&self) -> Result<Vec<Login>> {
@@ -56,11 +80,13 @@ impl PasswordEngine {
     }
 
     pub fn wipe(&self) -> Result<()> {
-        self.db.wipe()
+        self.db.wipe()?;
+        Ok(())
     }
 
     pub fn reset(&self) -> Result<()> {
-        self.db.reset()
+        self.db.reset()?;
+        Ok(())
     }
 
     pub fn update(&self, login: Login) -> Result<()> {
@@ -77,110 +103,8 @@ impl PasswordEngine {
     pub fn conn(&self) -> &rusqlite::Connection {
         &self.db.db
     }
-
-    pub fn sync(
-        &self,
-        storage_init: &Sync15StorageClientInit,
-        root_sync_key: &KeyBundle
-    ) -> result::Result<(), Error> {
-
-        // Note: If `to_ready` (or anything else with a ?) fails below, this
-        // `replace()` means we end up with `state.sync.is_none()`, which means the
-        // next sync will redownload meta/global, crypto/keys, etc. without
-        // needing to. Apparently this is both okay and by design.
-        let maybe_sync_info = self.sync.replace(None).map(Ok);
-
-        // `maybe_sync_info` is None if we haven't called `sync` since
-        // restarting the browser.
-        //
-        // If this is the case we may or may not have a persisted version of
-        // GlobalState stored in the DB (we will iff we've synced before, unless
-        // we've `reset()`, which clears it out).
-        let mut sync_info = maybe_sync_info.unwrap_or_else(|| -> Result<SyncInfo> {
-            info!("First time through since unlock. Trying to load persisted global state.");
-            let state = if let Some(persisted_global_state) = self.db.get_global_state()? {
-                serde_json::from_str::<GlobalState>(&persisted_global_state)
-                .unwrap_or_else(|_| {
-                    // Don't log the error since it might contain sensitive
-                    // info like keys (the JSON does, after all).
-                    error!("Failed to parse GlobalState from JSON! Falling back to default");
-                    // Unstick ourselves by using the default state.
-                    GlobalState::default()
-                })
-            } else {
-                info!("No previously persisted global state, using default");
-                GlobalState::default()
-            };
-            let client = Sync15StorageClient::new(storage_init.clone())?;
-            Ok(SyncInfo {
-                state,
-                client,
-                last_client_init: storage_init.clone(),
-            })
-        })?;
-
-        // If the options passed for initialization of the storage client aren't
-        // the same as the ones we used last time, reinitialize it. (Note that
-        // we could avoid the comparison in the case where we had `None` in
-        // `state.sync` before, but this probably doesn't matter).
-        //
-        // It's a little confusing that we do things this way (transparently
-        // re-initialize the client), but it reduces the size of the API surface
-        // exposed over the FFI, and simplifies the states that the client code
-        // has to consider (as far as it's concerned it just has to pass
-        // `current` values for these things, and not worry about having to
-        // re-initialize the sync state).
-        if storage_init != &sync_info.last_client_init {
-            info!("Detected change in storage client init, updating");
-            sync_info.client = Sync15StorageClient::new(storage_init.clone())?;
-            sync_info.last_client_init = storage_init.clone();
-        }
-
-        // Advance the state machine to the point where it can perform a full
-        // sync. This may involve uploading meta/global, crypto/keys etc.
-        {
-            // Scope borrow of `sync_info.client`
-            let mut state_machine =
-                sync::SetupStateMachine::for_full_sync(&sync_info.client, &root_sync_key);
-            info!("Advancing state machine to ready (full)");
-            let next_sync_state = state_machine.to_ready(sync_info.state)?;
-            sync_info.state = next_sync_state;
-        }
-
-        // Reset our local state if necessary.
-        if sync_info.state.engines_that_need_local_reset().contains("passwords") {
-            info!("Passwords sync ID changed; engine needs local reset");
-            self.db.reset()?;
-        }
-
-        // Persist the current sync state in the DB.
-        info!("Updating persisted global state");
-        let s = sync_info.state.to_persistable_string();
-        self.db.set_global_state(&s)?;
-
-        info!("Syncing passwords engine!");
-
-        // We don't use `?` here so that we can restore the value of of
-        // `self.sync` even if sync fails.
-        let result = sync::synchronize(
-            &sync_info.client,
-            &sync_info.state,
-            &self.db,
-            "passwords".into(),
-            true
-        );
-
-        match &result {
-            Ok(()) => info!("Sync was successful!"),
-            Err(e) => warn!("Sync failed! {:?}", e),
-        }
-
-        // Restore our value of `sync_info` even if the sync failed.
-        self.sync.replace(Some(sync_info));
-
-        Ok(result?)
-    }
 }
+
 
 #[cfg(test)]
 mod test {

--- a/logins-sql/src/engine.rs
+++ b/logins-sql/src/engine.rs
@@ -160,8 +160,6 @@ impl PasswordEngine {
 
         info!("Syncing passwords engine!");
 
-        let ts = self.db.get_last_sync()?.unwrap_or_default();
-
         // We don't use `?` here so that we can restore the value of of
         // `self.sync` even if sync fails.
         let result = sync::synchronize(
@@ -169,7 +167,6 @@ impl PasswordEngine {
             &sync_info.state,
             &self.db,
             "passwords".into(),
-            ts,
             true
         );
 

--- a/sync15-adapter/src/changeset.rs
+++ b/sync15-adapter/src/changeset.rs
@@ -6,7 +6,7 @@ use bso_record::{EncryptedBso, Payload};
 use client::Sync15StorageClient;
 use error::{self, ErrorKind, Result};
 use key_bundle::KeyBundle;
-use request::{NormalResponseHandler, UploadInfo};
+use request::{NormalResponseHandler, UploadInfo, CollectionRequest};
 use state::GlobalState;
 use util::ServerTimestamp;
 
@@ -66,9 +66,9 @@ impl IncomingChangeset {
         client: &Sync15StorageClient,
         state: &GlobalState,
         collection: String,
-        since: ServerTimestamp,
+        collection_request: &CollectionRequest,
     ) -> Result<IncomingChangeset> {
-        let records = client.get_encrypted_records(&collection, since)?;
+        let records = client.get_encrypted_records(collection_request)?;
         let timestamp = state.last_modified_or_zero(&collection);
         let mut result = IncomingChangeset::new(collection, timestamp);
         result.changes.reserve(records.len());

--- a/sync15-adapter/src/client.rs
+++ b/sync15-adapter/src/client.rs
@@ -120,12 +120,11 @@ impl Sync15StorageClient {
 
     pub fn get_encrypted_records(
         &self,
-        collection: &str,
-        since: ServerTimestamp,
+        collection_request: &CollectionRequest,
     ) -> error::Result<Vec<EncryptedBso>> {
         let mut resp = self.collection_request(
             Method::GET,
-            CollectionRequest::new(collection).full().newer_than(since),
+            collection_request,
         )?;
         Ok(resp.json()?)
     }
@@ -165,7 +164,9 @@ impl Sync15StorageClient {
     }
 
     fn exec_request(&self, req: Request, require_success: bool) -> error::Result<Response> {
+        trace!("request: {} {}", req.method(), req.url().path());
         let resp = self.http_client.execute(req)?;
+        trace!("response: {}", resp.status());
 
         self.update_timestamp(resp.headers());
 

--- a/sync15-adapter/src/lib.rs
+++ b/sync15-adapter/src/lib.rs
@@ -52,3 +52,4 @@ pub use util::{ServerTimestamp, SERVER_EPOCH};
 pub use key_bundle::KeyBundle;
 pub use client::{Sync15StorageClientInit, Sync15StorageClient};
 pub use state::{GlobalState, SetupStateMachine};
+pub use request::{CollectionRequest};

--- a/sync15-adapter/src/lib.rs
+++ b/sync15-adapter/src/lib.rs
@@ -40,6 +40,7 @@ pub mod util;
 pub mod request;
 pub mod changeset;
 pub mod sync;
+pub mod sync_stateful;
 pub mod client;
 pub mod state;
 
@@ -48,6 +49,7 @@ pub use bso_record::{BsoRecord, EncryptedBso, Payload, CleartextBso};
 pub use changeset::{RecordChangeset, IncomingChangeset, OutgoingChangeset};
 pub use error::{Result, Error, ErrorKind};
 pub use sync::{synchronize, Store};
+pub use sync_stateful::{GlobalStateProvider, ClientInfo, sync_stateful};
 pub use util::{ServerTimestamp, SERVER_EPOCH};
 pub use key_bundle::KeyBundle;
 pub use client::{Sync15StorageClientInit, Sync15StorageClient};

--- a/sync15-adapter/src/request.rs
+++ b/sync15-adapter/src/request.rs
@@ -64,49 +64,49 @@ impl CollectionRequest {
     }
 
     #[inline]
-    pub fn ids<V>(&mut self, v: V) -> &mut CollectionRequest where V: Into<Vec<String>> {
+    pub fn ids<V>(mut self, v: V) -> CollectionRequest where V: Into<Vec<String>> {
         self.ids = Some(v.into());
         self
     }
 
     #[inline]
-    pub fn full(&mut self) -> &mut CollectionRequest {
+    pub fn full(mut self) -> CollectionRequest {
         self.full = true;
         self
     }
 
     #[inline]
-    pub fn older_than(&mut self, ts: ServerTimestamp) -> &mut CollectionRequest {
+    pub fn older_than(mut self, ts: ServerTimestamp) -> CollectionRequest {
         self.older = Some(ts);
         self
     }
 
     #[inline]
-    pub fn newer_than(&mut self, ts: ServerTimestamp) -> &mut CollectionRequest {
+    pub fn newer_than(mut self, ts: ServerTimestamp) -> CollectionRequest {
         self.newer = Some(ts);
         self
     }
 
     #[inline]
-    pub fn sort_by(&mut self, order: RequestOrder) -> &mut CollectionRequest {
+    pub fn sort_by(mut self, order: RequestOrder) -> CollectionRequest {
         self.order = Some(order);
         self
     }
 
     #[inline]
-    pub fn limit(&mut self, num: usize) -> &mut CollectionRequest {
+    pub fn limit(mut self, num: usize) -> CollectionRequest {
         self.limit = num;
         self
     }
 
     #[inline]
-    pub fn batch(&mut self, batch: Option<String>) -> &mut CollectionRequest {
+    pub fn batch(mut self, batch: Option<String>) -> CollectionRequest {
         self.batch = batch;
         self
     }
 
     #[inline]
-    pub fn commit(&mut self, v: bool) -> &mut CollectionRequest {
+    pub fn commit(mut self, v: bool) -> CollectionRequest {
         self.commit = v;
         self
     }

--- a/sync15-adapter/src/sync.rs
+++ b/sync15-adapter/src/sync.rs
@@ -15,6 +15,8 @@ use util::ServerTimestamp;
 /// Different stores will produce errors of different types.  To accommodate this, we force them
 /// all to return failure::Error, which we expose as ErrorKind::StoreError.
 pub trait Store {
+    fn collection_name(&self) -> String;
+
     fn apply_incoming(
         &self,
         inbound: IncomingChangeset
@@ -32,15 +34,19 @@ pub trait Store {
     // engines might do something fancier. This could even later be extended
     // to handle "backfills" etc
     fn get_collection_request(&self) -> Result<CollectionRequest, failure::Error>;
+
+    fn reset(&self) -> Result<(), failure::Error>;
+
+    fn wipe(&self) -> Result<(), failure::Error>;
 }
 
 pub fn synchronize(client: &Sync15StorageClient,
                    state: &GlobalState,
                    store: &Store,
-                   collection: String,
                    fully_atomic: bool) -> Result<(), Error>
 {
 
+    let collection = store.collection_name();
     info!("Syncing collection {}", collection);
     let collection_request = store.get_collection_request()?;
     let incoming_changes = IncomingChangeset::fetch(client, state, collection.clone(), &collection_request)?;

--- a/sync15-adapter/src/sync_stateful.rs
+++ b/sync15-adapter/src/sync_stateful.rs
@@ -1,0 +1,126 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This helps you perform a "stateful" sync - ie, a sync which persists state
+// between syncs and uses this state to automatically do the right thing
+// with the stores etc.
+
+use std::result;
+use std::cell::Cell;
+use failure;
+use client::{Sync15StorageClient, Sync15StorageClientInit};
+use state::{GlobalState, SetupStateMachine};
+use sync::{self, Store};
+use key_bundle::KeyBundle;
+use error::Error;
+
+// Info stored in memory about the client to use. We reuse the client unless
+// we discover the client_init has changed, in which case we re-create one.
+pub struct ClientInfo {
+    // the client_init used to create the client.
+    client_init: Sync15StorageClientInit,
+    // the client we will reuse if possible.
+    client: Sync15StorageClient,
+}
+
+// This is used only to persist a GlobalState, which is serializable.
+
+// XXX - should we define this simply as a Cell<>, like last_client_info,
+// and leave the persisting to whoever provides the cell?
+
+// XXX - alternatively/additionally, instead of defining this in terms of
+// the GlobalState structure, we could consider defining it in terms of
+// Serializable/Deserializable?
+pub trait GlobalStateProvider {
+    fn load(&self) -> result::Result<Option<GlobalState>, failure::Error>;
+
+    fn save(&self, state: Option<&GlobalState>) -> result::Result<(), failure::Error>;
+}
+
+pub fn sync_stateful(
+    store: &Store,
+    gsp: &GlobalStateProvider,
+    last_client_info: &Cell<Option<ClientInfo>>,
+    storage_init: &Sync15StorageClientInit,
+    root_sync_key: &KeyBundle
+) -> result::Result<(), Error> {
+    let maybe_global = gsp.load()?;
+    // Note: We explicitly write a None back as the state, meaning if we
+    // unexpectedly fail below, the next sync will redownload meta/global,
+    // crypto/keys, etc. without needing to. Apparently this is both okay
+    // and by design.
+    gsp.save(None)?;
+    let mut global_state = match maybe_global {
+        Some(g) => g,
+        None => {
+            info!("First time through since unlock. Creating default global state.");
+            last_client_info.replace(None);
+            GlobalState::default()
+        }
+    };
+
+    // Ditto for the ClientInfo - if we fail below the GlobalStateProvider will
+    // not have the last client and client_init, so will be re-initialized on
+    // the next sync.
+    let client_info = match last_client_info.replace(None) {
+        Some(client_info) => {
+            if client_info.client_init != *storage_init {
+                ClientInfo {
+                    client_init: storage_init.clone(),
+                    client: Sync15StorageClient::new(storage_init.clone())?,
+                }
+            } else {
+                // we can reuse it.
+                client_info
+            }
+        },
+        None => {
+            ClientInfo {
+                client_init: storage_init.clone(),
+                client: Sync15StorageClient::new(storage_init.clone())?,
+            }
+        }
+    };
+
+    // Advance the state machine to the point where it can perform a full
+    // sync. This may involve uploading meta/global, crypto/keys etc.
+    {
+        // Scope borrow of `sync_info.client`
+        let mut state_machine =
+            SetupStateMachine::for_full_sync(&client_info.client, &root_sync_key);
+        info!("Advancing state machine to ready (full)");
+        global_state = state_machine.to_ready(global_state)?;
+    }
+
+    // Reset our local state if necessary.
+    if global_state.engines_that_need_local_reset().contains(&store.collection_name()) {
+        info!("{} sync ID changed; engine needs local reset", &store.collection_name());
+        store.reset()?;
+    }
+
+    // Persist the current sync state in the DB.
+    info!("Updating persisted global state");
+    gsp.save(Some(&global_state))?;
+
+    info!("Syncing {} engine!", store.collection_name());
+
+    // We don't use `?` here so that we can restore the value of of
+    // `self.sync` even if sync fails.
+    let result = sync::synchronize(
+        &client_info.client,
+        &global_state,
+        store,
+        true
+    );
+
+    match &result {
+        Ok(()) => info!("Sync was successful!"),
+        Err(e) => warn!("Sync failed! {:?}", e),
+    }
+
+    last_client_info.replace(Some(client_info));
+
+    Ok(result?)
+}
+


### PR DESCRIPTION
(hrm - github defeated my attempt at doing this PR cleanly - it depends on #355 so please look at just the "stateful" commit and not "files changed"

At a minimum, some XXX comments should be changed.

Note that I'm not particularly happy with the "stateful sync" name - I originally had it as a "driver" with the intention of taking a vector of stores, but I'm note sure we actually need that. So completely open to better names!

Also considering moving GlobalStateProvider to a Cell<Option<GlobalState>> which could remove the GlobalStateProvider entirely - I figured I'd get it up for discussion before I rearrange it yet again.

@thomcc, @linacambridge, WDYT?