### PR TITLE
Consume pre-built OpenSSL and SQLcipher libs locally.

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -42,6 +42,7 @@ build_env = {
     "RUST_BACKTRACE": "1",
     "RUSTFLAGS": "-Dwarnings",
     "CARGO_INCREMENTAL": "0",
+    "CI": "1",
 }
 linux_build_env = {
     "TERM": "dumb",  # Keep Gradle output sensible.

--- a/build.gradle
+++ b/build.gradle
@@ -34,10 +34,15 @@ buildscript {
         // computation at build time.
         classpath 'net.java.dev.jna:jna:4.5.2'
 
+        // Downloading libs/ archives from Taskcluster.
+        classpath 'de.undercouch:gradle-download-task:3.4.3'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
+
+apply plugin: 'de.undercouch.download'
 
 allprojects {
     repositories {
@@ -54,27 +59,108 @@ task clean(type: Delete) {
 // { ... }`, to avoid issues with importing.
 import com.sun.jna.Platform as DefaultPlatform
 
+// This is the output `git rev-parse HEAD:libs`.  We could discover this automatically, but
+// let's keep things simple and bump this manually for a while.  If and when we grow SNAPSHOT
+// support on maven.mozilla.org, we can invest in a better approach for versioning these
+// prerequisite libraries.
+//
+// Set this to `= null` in order to use libs from the source directory.
+ext.libsGitSha = '403ce07fceaa7550aa419f19cd8acd98c7fdcf2a'
+
+if (rootProject.ext.libsGitSha != null) {
+    task downloadAndroidLibs(type: Download) {
+        src "https://index.taskcluster.net/v1/task/project.application-services.application-services.build.libs.android.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
+        dest new File(buildDir, "libs.android.${rootProject.ext.libsGitSha}.tar.gz")
+
+        doFirst {
+            if (it.dest.exists()) {
+                throw new StopExecutionException("File to download already exists: ${it.dest.path}")
+            }
+        }
+        overwrite true
+    }
+
+    task untarAndroidLibs(dependsOn: downloadAndroidLibs, type: Copy) {
+        from tarTree(downloadAndroidLibs.dest)
+        into rootProject.buildDir
+    }
+
+    task downloadDesktopLibs(type: Download) {
+        src {
+            switch (DefaultPlatform.RESOURCE_PREFIX) {
+                case 'darwin':
+                    return "https://index.taskcluster.net/v1/task/project.application-services.application-services.build.libs.desktop.macos.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
+                case 'linux-x86-64':
+                    return "https://index.taskcluster.net/v1/task/project.application-services.application-services.build.libs.desktop.linux.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
+                default:
+                    throw new GradleException("Unknown host platform '${DefaultPlatform.RESOURCE_PREFIX}'.  " +
+                                              "Set `ext.libsGitSha = null` in ${rootProject.rootDir}/build.gradle and build your own libs.  " +
+                                              "If you don't want to build your own libs for Android, you can untar\n\n${downloadAndroidLibs.src}\n\nat top-level to populate `libs/android/`.  " +
+                                              "You'll need build your own libs for your host platform in order to be able to build and run unit tests.")
+            }
+        }
+
+        dest {
+            switch (DefaultPlatform.RESOURCE_PREFIX) {
+                case 'darwin':
+                    return new File(buildDir, "libs.desktop.macos.${rootProject.ext.libsGitSha}.tar.gz")
+                case 'linux-x86-64':
+                    return new File(buildDir, "libs.desktop.linux.${rootProject.ext.libsGitSha}.tar.gz")
+                default:
+                    throw new GradleException("Unknown host platform '${DefaultPlatform.RESOURCE_PREFIX}'.  " +
+                                              "Set `ext.libsGitSha = null` in ${rootProject.rootDir}/build.gradle and build your own libs.")
+            }
+        }
+
+        doFirst {
+            if (it.dest.exists()) {
+                throw new StopExecutionException("File to download already exists: ${it.dest.path}")
+            }
+        }
+        overwrite true
+    }
+
+    task untarDesktopLibs(dependsOn: downloadDesktopLibs, type: Copy) {
+        from tarTree(downloadDesktopLibs.dest)
+        into rootProject.buildDir
+    }
+
+    subprojects { project ->
+        afterEvaluate {
+            android.libraryVariants.all { v ->
+                def task = v.preBuild
+                task.dependsOn(rootProject.untarAndroidLibs)
+                task.dependsOn(rootProject.untarDesktopLibs)
+            }
+        }
+    }
+}
+
 // Configure some environment variables, per toolchain, that will apply during
 // the Cargo build.  We assume that the `libs/` directory has been populated
 // before invoking Gradle (or Cargo).
 ext.cargoExec = { spec, toolchain ->
     spec.environment("OPENSSL_STATIC", "1")
 
+    // Use in-tree libs from the source directory in CI or if the git SHA is unset; otherwise use
+    // downloaded libs.
+    def libsRootDir = (System.getenv('CI') || ext.libsGitSha == null) ? rootProject.rootDir : rootProject.buildDir
+
     switch (toolchain.platform) {
         case 'default':
-            spec.environment("OPENSSL_DIR",           rootProject.file("libs/desktop/${DefaultPlatform.RESOURCE_PREFIX}/openssl").absolutePath)
-            spec.environment("SQLCIPHER_LIB_DIR",     rootProject.file("libs/desktop/${DefaultPlatform.RESOURCE_PREFIX}/sqlcipher/lib").absolutePath)
-            spec.environment("SQLCIPHER_INCLUDE_DIR", rootProject.file("libs/desktop/${DefaultPlatform.RESOURCE_PREFIX}/sqlcipher/include").absolutePath)
+            spec.environment("OPENSSL_DIR",           new File(libsRootDir, "libs/desktop/${DefaultPlatform.RESOURCE_PREFIX}/openssl").absolutePath)
+            spec.environment("SQLCIPHER_LIB_DIR",     new File(libsRootDir, "libs/desktop/${DefaultPlatform.RESOURCE_PREFIX}/sqlcipher/lib").absolutePath)
+            spec.environment("SQLCIPHER_INCLUDE_DIR", new File(libsRootDir, "libs/desktop/${DefaultPlatform.RESOURCE_PREFIX}/sqlcipher/include").absolutePath)
             break;
         case 'arm':
         case 'arm64':
         case 'x86':
         case 'x86_64':
-            spec.environment("OPENSSL_DIR",           rootProject.file("libs/android/${toolchain.platform}/openssl").absolutePath)
-            spec.environment("SQLCIPHER_LIB_DIR",     rootProject.file("libs/android/${toolchain.platform}/sqlcipher/lib").absolutePath)
-            spec.environment("SQLCIPHER_INCLUDE_DIR", rootProject.file("libs/android/${toolchain.platform}/sqlcipher/include").absolutePath)
+            spec.environment("OPENSSL_DIR",           new File(libsRootDir, "libs/android/${toolchain.platform}/openssl").absolutePath)
+            spec.environment("SQLCIPHER_LIB_DIR",     new File(libsRootDir, "libs/android/${toolchain.platform}/sqlcipher/lib").absolutePath)
+            spec.environment("SQLCIPHER_INCLUDE_DIR", new File(libsRootDir, "libs/android/${toolchain.platform}/sqlcipher/include").absolutePath)
             break;
         default:
-            throw GradleException("Unknown toolchain platform ${toolchain.platform}")
+            throw new GradleException("Unknown toolchain platform ${toolchain.platform}")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,3 +49,32 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+// Avoid Gradle namespace collision.  This is here, rather than in `buildscript
+// { ... }`, to avoid issues with importing.
+import com.sun.jna.Platform as DefaultPlatform
+
+// Configure some environment variables, per toolchain, that will apply during
+// the Cargo build.  We assume that the `libs/` directory has been populated
+// before invoking Gradle (or Cargo).
+ext.cargoExec = { spec, toolchain ->
+    spec.environment("OPENSSL_STATIC", "1")
+
+    switch (toolchain.platform) {
+        case 'default':
+            spec.environment("OPENSSL_DIR",           rootProject.file("libs/desktop/${DefaultPlatform.RESOURCE_PREFIX}/openssl").absolutePath)
+            spec.environment("SQLCIPHER_LIB_DIR",     rootProject.file("libs/desktop/${DefaultPlatform.RESOURCE_PREFIX}/sqlcipher/lib").absolutePath)
+            spec.environment("SQLCIPHER_INCLUDE_DIR", rootProject.file("libs/desktop/${DefaultPlatform.RESOURCE_PREFIX}/sqlcipher/include").absolutePath)
+            break;
+        case 'arm':
+        case 'arm64':
+        case 'x86':
+        case 'x86_64':
+            spec.environment("OPENSSL_DIR",           rootProject.file("libs/android/${toolchain.platform}/openssl").absolutePath)
+            spec.environment("SQLCIPHER_LIB_DIR",     rootProject.file("libs/android/${toolchain.platform}/sqlcipher/lib").absolutePath)
+            spec.environment("SQLCIPHER_INCLUDE_DIR", rootProject.file("libs/android/${toolchain.platform}/sqlcipher/include").absolutePath)
+            break;
+        default:
+            throw GradleException("Unknown toolchain platform ${toolchain.platform}")
+    }
+}

--- a/components/places/android/library/build.gradle
+++ b/components/places/android/library/build.gradle
@@ -5,8 +5,6 @@ apply plugin: 'kotlin-android-extensions'
 
 apply plugin: 'com.github.dcendents.android-maven'
 
-import com.sun.jna.Platform
-
 android {
     compileSdkVersion 27
 
@@ -61,34 +59,12 @@ cargo {
     // `debug = true` in Cargo.toml).
     profile = "release"
 
-    // Configure some environment variables, per toolchain, that will apply
-    // during the Cargo build.  Paths are relative to this file.  We assume that
-    // the `libs/` directory has been populated before invoking Gradle (or Cargo).
-    exec = { spec, toolchain ->
-        switch (toolchain.platform) {
-            case 'default':
-                 spec.environment("OPENSSL_STATIC", "1")
-                 spec.environment("OPENSSL_DIR",           file("../../../../libs/desktop/openssl").absolutePath)
-                 spec.environment("SQLCIPHER_LIB_DIR",     file("../../../../libs/desktop/sqlcipher/lib").absolutePath)
-                 spec.environment("SQLCIPHER_INCLUDE_DIR", file("../../../../libs/desktop/sqlcipher/include").absolutePath)
-                 break;
-            case 'arm':
-            case 'arm64':
-            case 'x86':
-                spec.environment("OPENSSL_STATIC",        "1")
-                spec.environment("OPENSSL_DIR",           file("../../../../libs/android/${toolchain.platform}/openssl").absolutePath)
-                spec.environment("SQLCIPHER_LIB_DIR",     file("../../../../libs/android/${toolchain.platform}/sqlcipher/lib").absolutePath)
-                spec.environment("SQLCIPHER_INCLUDE_DIR", file("../../../../libs/android/${toolchain.platform}/sqlcipher/include").absolutePath)
-                break;
-            default:
-                throw GradleException("Unknown toolchain platform ${toolchain.platform}")
-        }
-    }
+    exec = rootProject.ext.cargoExec
 
     // For unit tests.
     // This puts the output of `cargo build` (the "default" toolchain) into the correct directory
     // for JNA to find it.
-    defaultToolchainBuildPrefixDir = Platform.RESOURCE_PREFIX
+    defaultToolchainBuildPrefixDir = com.sun.jna.Platform.RESOURCE_PREFIX
 }
 
 configurations {

--- a/fxa-client/sdks/android/library/build.gradle
+++ b/fxa-client/sdks/android/library/build.gradle
@@ -53,30 +53,12 @@ cargo {
     // `debug = true` in Cargo.toml).
     profile = "release"
 
-    // Configure some environment variables, per toolchain, that will apply
-    // during the Cargo build.  Paths are relative to this file.  We assume that
-    // the `libs/` directory has been populated before invoking Gradle (or Cargo).
-    exec = { spec, toolchain ->
-        switch (toolchain.platform) {
-            // TODO: For unit tests.
-            // case 'default':
-            //     spec.environment("OPENSSL_DIR", file('../../../../libs/desktop/openssl').absolutePath)
-            //     break;
-            case 'arm':
-            case 'arm64':
-            case 'x86':
-                spec.environment("OPENSSL_STATIC",        "1")
-                spec.environment("OPENSSL_DIR",           file("../../../../libs/android/${toolchain.platform}/openssl").absolutePath)
-                break;
-            default:
-                throw GradleException("Unknown toolchain platform ${toolchain.platform}")
-        }
-    }
+    exec = rootProject.ext.cargoExec
 
     // TODO: For unit tests.
     // This puts the output of `cargo build` (the "default" toolchain) into the correct directory
     // for JNA to find it.
-    // defaultToolchainBuildPrefixDir = Platform.RESOURCE_PREFIX
+    // defaultToolchainBuildPrefixDir = com.sun.jna.Platform.RESOURCE_PREFIX
 }
 
 dependencies {

--- a/logins-api/android/library/build.gradle
+++ b/logins-api/android/library/build.gradle
@@ -5,8 +5,6 @@ apply plugin: 'kotlin-android-extensions'
 
 apply plugin: 'com.github.dcendents.android-maven'
 
-import com.sun.jna.Platform
-
 android {
     compileSdkVersion 27
 
@@ -61,34 +59,12 @@ cargo {
     // `debug = true` in Cargo.toml).
     profile = "release"
 
-    // Configure some environment variables, per toolchain, that will apply
-    // during the Cargo build.  Paths are relative to this file.  We assume that
-    // the `libs/` directory has been populated before invoking Gradle (or Cargo).
-    exec = { spec, toolchain ->
-        switch (toolchain.platform) {
-            case 'default':
-                 spec.environment("OPENSSL_STATIC", "1")
-                 spec.environment("OPENSSL_DIR",           file("../../../libs/desktop/${Platform.RESOURCE_PREFIX}/openssl").absolutePath)
-                 spec.environment("SQLCIPHER_LIB_DIR",     file("../../../libs/desktop/${Platform.RESOURCE_PREFIX}/sqlcipher/lib").absolutePath)
-                 spec.environment("SQLCIPHER_INCLUDE_DIR", file("../../../libs/desktop/${Platform.RESOURCE_PREFIX}/sqlcipher/include").absolutePath)
-                 break;
-            case 'arm':
-            case 'arm64':
-            case 'x86':
-                spec.environment("OPENSSL_STATIC",        "1")
-                spec.environment("OPENSSL_DIR",           file("../../../libs/android/${toolchain.platform}/openssl").absolutePath)
-                spec.environment("SQLCIPHER_LIB_DIR",     file("../../../libs/android/${toolchain.platform}/sqlcipher/lib").absolutePath)
-                spec.environment("SQLCIPHER_INCLUDE_DIR", file("../../../libs/android/${toolchain.platform}/sqlcipher/include").absolutePath)
-                break;
-            default:
-                throw GradleException("Unknown toolchain platform ${toolchain.platform}")
-        }
-    }
+    exec = rootProject.ext.cargoExec
 
     // For unit tests.
     // This puts the output of `cargo build` (the "default" toolchain) into the correct directory
     // for JNA to find it.
-    defaultToolchainBuildPrefixDir = Platform.RESOURCE_PREFIX
+    defaultToolchainBuildPrefixDir = com.sun.jna.Platform.RESOURCE_PREFIX
 }
 
 configurations {


### PR DESCRIPTION
This is one simple way to get macOS and Linux developers using pre-built libraries.  I've tried to let Windows developers accommodate themselves until we can do better cross-compiling for them.