### PR TITLE
Ensure deleting the last visit for a place works.

### DIFF
--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -139,12 +139,12 @@ lazy_static! {
             UPDATE moz_places SET
                 visit_count_local = visit_count_local - (OLD.visit_type NOT IN ({excluded}) AND OLD.is_local),
                 visit_count_remote = visit_count_remote - (OLD.visit_type NOT IN ({excluded}) AND NOT(OLD.is_local)),
-                last_visit_date_local = (SELECT visit_date FROM moz_historyvisits
-                                         WHERE place_id = OLD.place_id AND is_local
-                                         ORDER BY visit_date DESC LIMIT 1),
-                last_visit_date_remote = (SELECT visit_date FROM moz_historyvisits
-                                          WHERE place_id = OLD.place_id AND NOT(is_local)
-                                          ORDER BY visit_date DESC LIMIT 1)
+                last_visit_date_local = IFNULL((SELECT visit_date FROM moz_historyvisits
+                                                WHERE place_id = OLD.place_id AND is_local
+                                                ORDER BY visit_date DESC LIMIT 1), 0),
+                last_visit_date_remote = IFNULL((SELECT visit_date FROM moz_historyvisits
+                                                 WHERE place_id = OLD.place_id AND NOT(is_local)
+                                                 ORDER BY visit_date DESC LIMIT 1), 0)
             WHERE id = OLD.place_id;
         END", excluded = EXCLUDED_VISIT_TYPES);
 }


### PR DESCRIPTION
Currently you can't do that due to #351 - it tries to leave null values
behind, but the new "NOT NULL" constraints fail. It's possible that in the
future we will kill the place in that case, but for now we should allow
their deletion.