### PR TITLE
Refactor logins syncing back into the sync crate allowing for reuse b…

### DIFF
--- a/logins-sql/examples/sync_pass_sql.rs
+++ b/logins-sql/examples/sync_pass_sql.rs
@@ -362,16 +362,15 @@ fn main() -> Result<()> {
 
     // TODO: we should probably set a persist callback on acct?
     let mut acct = load_or_create_fxa_creds(cred_file, cfg.clone())?;
-    let token: OAuthInfo;
-    match acct.get_oauth_token(SCOPES)? {
-        Some(t) => token = t,
+    let token: OAuthInfo = match acct.get_oauth_token(SCOPES)? {
+        Some(t) => t,
         None => {
             // The cached credentials did not have appropriate scope, sign in again.
             warn!("Credentials do not have appropriate scope, launching OAuth flow.");
             acct = create_fxa_creds(cred_file, cfg.clone())?;
-            token = acct.get_oauth_token(SCOPES)?.unwrap();
+            acct.get_oauth_token(SCOPES)?.unwrap()
         }
-    }
+    };
 
     let keys: HashMap<String, ScopedKeyData> = serde_json::from_str(&token.keys.unwrap())?;
 
@@ -443,13 +442,13 @@ fn main() -> Result<()> {
             }
             'R' | 'r' => {
                 info!("Resetting client.");
-                if let Err(e) = engine.reset() {
+                if let Err(e) = engine.db.reset() {
                     warn!("Failed to reset! {}", e);
                 }
             }
             'W' | 'w' => {
                 info!("Wiping all data from client!");
-                if let Err(e) = engine.wipe() {
+                if let Err(e) = engine.db.wipe() {
                     warn!("Failed to wipe! {}", e);
                 }
             }

--- a/logins-sql/ffi/src/lib.rs
+++ b/logins-sql/ffi/src/lib.rs
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn sync15_passwords_sync(
 ) {
     trace!("sync15_passwords_sync");
     // TODO: Is there any way to convince rust that some `&mut T` is unwind safe?
-    call_with_result(error, || {
+    call_with_result(error, || -> Result<()> {
         state.sync(
             &sync15_adapter::Sync15StorageClientInit {
                 key_id: rust_string_from_c(key_id),

--- a/logins-sql/src/engine.rs
+++ b/logins-sql/src/engine.rs
@@ -1,42 +1,37 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use std::result;
-use login::Login;
-use error::*;
-use sync::{self, Sync15StorageClient, Sync15StorageClientInit, GlobalState, KeyBundle};
-use db::LoginDb;
 use std::path::Path;
 use std::cell::Cell;
-use serde_json;
+use login::Login;
+use error::*;
+use sync::{
+    ClientInfo,
+    KeyBundle,
+    Sync15StorageClientInit,
+    sync_multiple
+};
+use db::LoginDb;
 use rusqlite;
-
-#[derive(Debug)]
-pub(crate) struct SyncInfo {
-    pub state: GlobalState,
-    pub client: Sync15StorageClient,
-    // Used so that we know whether or not we need to re-initialize `client`
-    pub last_client_init: Sync15StorageClientInit,
-}
 
 // This isn't really an engine in the firefox sync15 desktop sense -- it's
 // really a bundle of state that contains the sync storage client, the sync
 // state, and the login DB.
 pub struct PasswordEngine {
-    sync: Cell<Option<SyncInfo>>,
-    db: LoginDb,
+    pub db: LoginDb,
+    pub client_info: Cell<Option<ClientInfo>>,
 }
 
 impl PasswordEngine {
 
     pub fn new(path: impl AsRef<Path>, encryption_key: Option<&str>) -> Result<Self> {
         let db = LoginDb::open(path, encryption_key)?;
-        Ok(Self { db, sync: Cell::new(None) })
+        Ok(Self { db, client_info: Cell::new(None) })
     }
 
     pub fn new_in_memory(encryption_key: Option<&str>) -> Result<Self> {
         let db = LoginDb::open_in_memory(encryption_key)?;
-        Ok(Self { db, sync: Cell::new(None) })
+        Ok(Self { db, client_info: Cell::new(None) })
     }
 
     pub fn list(&self) -> Result<Vec<Login>> {
@@ -56,11 +51,13 @@ impl PasswordEngine {
     }
 
     pub fn wipe(&self) -> Result<()> {
-        self.db.wipe()
+        self.db.wipe()?;
+        Ok(())
     }
 
     pub fn reset(&self) -> Result<()> {
-        self.db.reset()
+        self.db.reset()?;
+        Ok(())
     }
 
     pub fn update(&self, login: Login) -> Result<()> {
@@ -72,113 +69,32 @@ impl PasswordEngine {
         self.db.add(login).map(|record| record.id)
     }
 
-    // This is basiclaly exposed just for sync_pass_sql, but it doesn't seem
+    // This is basically exposed just for sync_pass_sql, but it doesn't seem
     // unreasonable.
     pub fn conn(&self) -> &rusqlite::Connection {
         &self.db.db
     }
 
-    pub fn sync(
-        &self,
-        storage_init: &Sync15StorageClientInit,
-        root_sync_key: &KeyBundle
-    ) -> result::Result<(), Error> {
-
-        // Note: If `to_ready` (or anything else with a ?) fails below, this
-        // `replace()` means we end up with `state.sync.is_none()`, which means the
-        // next sync will redownload meta/global, crypto/keys, etc. without
-        // needing to. Apparently this is both okay and by design.
-        let maybe_sync_info = self.sync.replace(None).map(Ok);
-
-        // `maybe_sync_info` is None if we haven't called `sync` since
-        // restarting the browser.
-        //
-        // If this is the case we may or may not have a persisted version of
-        // GlobalState stored in the DB (we will iff we've synced before, unless
-        // we've `reset()`, which clears it out).
-        let mut sync_info = maybe_sync_info.unwrap_or_else(|| -> Result<SyncInfo> {
-            info!("First time through since unlock. Trying to load persisted global state.");
-            let state = if let Some(persisted_global_state) = self.db.get_global_state()? {
-                serde_json::from_str::<GlobalState>(&persisted_global_state)
-                .unwrap_or_else(|_| {
-                    // Don't log the error since it might contain sensitive
-                    // info like keys (the JSON does, after all).
-                    error!("Failed to parse GlobalState from JSON! Falling back to default");
-                    // Unstick ourselves by using the default state.
-                    GlobalState::default()
-                })
-            } else {
-                info!("No previously persisted global state, using default");
-                GlobalState::default()
-            };
-            let client = Sync15StorageClient::new(storage_init.clone())?;
-            Ok(SyncInfo {
-                state,
-                client,
-                last_client_init: storage_init.clone(),
-            })
-        })?;
-
-        // If the options passed for initialization of the storage client aren't
-        // the same as the ones we used last time, reinitialize it. (Note that
-        // we could avoid the comparison in the case where we had `None` in
-        // `state.sync` before, but this probably doesn't matter).
-        //
-        // It's a little confusing that we do things this way (transparently
-        // re-initialize the client), but it reduces the size of the API surface
-        // exposed over the FFI, and simplifies the states that the client code
-        // has to consider (as far as it's concerned it just has to pass
-        // `current` values for these things, and not worry about having to
-        // re-initialize the sync state).
-        if storage_init != &sync_info.last_client_init {
-            info!("Detected change in storage client init, updating");
-            sync_info.client = Sync15StorageClient::new(storage_init.clone())?;
-            sync_info.last_client_init = storage_init.clone();
+    /// A convenience wrapper around sync_multiple.
+    pub fn sync(&self,
+                storage_init: &Sync15StorageClientInit,
+                root_sync_key: &KeyBundle) -> Result<()> {
+        let global_state: Cell<Option<String>> = Cell::new(self.db.get_global_state()?);
+        let result = sync_multiple(&[&self.db],
+                                   &global_state,
+                                   &self.client_info,
+                                   storage_init,
+                                   root_sync_key);
+        self.db.set_global_state(global_state.replace(None))?;
+        let failures = result?;
+        if failures.len() == 0 {
+            Ok(())
+        } else {
+            assert_eq!(failures.len(), 1);
+            let (name, err) = failures.into_iter().next().unwrap();
+            assert_eq!(name, "passwords");
+            Err(err.into())
         }
-
-        // Advance the state machine to the point where it can perform a full
-        // sync. This may involve uploading meta/global, crypto/keys etc.
-        {
-            // Scope borrow of `sync_info.client`
-            let mut state_machine =
-                sync::SetupStateMachine::for_full_sync(&sync_info.client, &root_sync_key);
-            info!("Advancing state machine to ready (full)");
-            let next_sync_state = state_machine.to_ready(sync_info.state)?;
-            sync_info.state = next_sync_state;
-        }
-
-        // Reset our local state if necessary.
-        if sync_info.state.engines_that_need_local_reset().contains("passwords") {
-            info!("Passwords sync ID changed; engine needs local reset");
-            self.db.reset()?;
-        }
-
-        // Persist the current sync state in the DB.
-        info!("Updating persisted global state");
-        let s = sync_info.state.to_persistable_string();
-        self.db.set_global_state(&s)?;
-
-        info!("Syncing passwords engine!");
-
-        // We don't use `?` here so that we can restore the value of of
-        // `self.sync` even if sync fails.
-        let result = sync::synchronize(
-            &sync_info.client,
-            &sync_info.state,
-            &self.db,
-            "passwords".into(),
-            true
-        );
-
-        match &result {
-            Ok(()) => info!("Sync was successful!"),
-            Err(e) => warn!("Sync failed! {:?}", e),
-        }
-
-        // Restore our value of `sync_info` even if the sync failed.
-        self.sync.replace(Some(sync_info));
-
-        Ok(result?)
     }
 }
 

--- a/sync15-adapter/src/lib.rs
+++ b/sync15-adapter/src/lib.rs
@@ -40,6 +40,7 @@ pub mod util;
 pub mod request;
 pub mod changeset;
 pub mod sync;
+pub mod sync_multiple;
 pub mod client;
 pub mod state;
 
@@ -48,6 +49,7 @@ pub use bso_record::{BsoRecord, EncryptedBso, Payload, CleartextBso};
 pub use changeset::{RecordChangeset, IncomingChangeset, OutgoingChangeset};
 pub use error::{Result, Error, ErrorKind};
 pub use sync::{synchronize, Store};
+pub use sync_multiple::{ClientInfo, sync_multiple};
 pub use util::{ServerTimestamp, SERVER_EPOCH};
 pub use key_bundle::KeyBundle;
 pub use client::{Sync15StorageClientInit, Sync15StorageClient};


### PR DESCRIPTION
…y history

This also allows for multiple stores to be synced at the same time and a
generic way of storing the state needed for these syncs.

Note that this replace #357, primarily because the branch the PR is based on is now in this repo. I've addressed all of Thom's comments.