### PR TITLE
Add sync_status/sync_change_counter fields, and a moz_places_tombstones table.

### DIFF
--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -12,7 +12,7 @@ use sql_support::ConnExt;
 
 use error::*;
 
-const VERSION: i64 = 1;
+const VERSION: i64 = 2;
 
 const CREATE_TABLE_PLACES_SQL: &str =
     "CREATE TABLE IF NOT EXISTS moz_places (
@@ -36,8 +36,17 @@ const CREATE_TABLE_PLACES_SQL: &str =
         -- origin_id would ideally be NOT NULL, but we use a trigger to keep
         -- it up to date, so do perform the initial insert with a null.
         origin_id INTEGER,
+        -- a couple of sync-related fields.
+        sync_status TINYINT NOT NULL DEFAULT 1, -- 1 is SyncStatus::New
+        sync_change_counter INTEGER NOT NULL DEFAULT 0, -- adding visits will increment this
 
         FOREIGN KEY(origin_id) REFERENCES moz_origins(id) ON DELETE CASCADE
+    )";
+
+const CREATE_TABLE_PLACES_TOMBSTONES_SQL: &str =
+    "CREATE TABLE IF NOT EXISTS moz_places_tombstones (
+        id INTEGER PRIMARY KEY,
+        guid TEXT NOT NULL UNIQUE
     )";
 
 
@@ -110,6 +119,15 @@ const CREATE_TRIGGER_AFTER_INSERT_ON_PLACES: &str = "
                              host = get_host_and_port(NEW.url) AND
                              rev_host = reverse_host(get_host_and_port(NEW.url)))
         WHERE id = NEW.id;
+    END
+";
+
+const CREATE_TRIGGER_MOZPLACES_AFTERDELETE: &str = "
+    CREATE TEMP TRIGGER moz_places_afterdelete_trigger
+    AFTER DELETE ON moz_places
+    FOR EACH ROW WHEN OLD.sync_status == 2 -- 2 == SyncStatus::Normal
+    BEGIN
+        INSERT OR IGNORE INTO moz_places_tombstones (guid) VALUES (OLD.guid);
     END
 ";
 
@@ -230,6 +248,7 @@ pub fn create(db: &PlacesDb) -> Result<()> {
     debug!("Creating schema");
     db.execute_all(&[
         CREATE_TABLE_PLACES_SQL,
+        CREATE_TABLE_PLACES_TOMBSTONES_SQL,
         CREATE_TABLE_HISTORYVISITS_SQL,
         CREATE_TABLE_INPUTHISTORY_SQL,
         CREATE_TABLE_BOOKMARKS_SQL,
@@ -257,7 +276,72 @@ pub fn create(db: &PlacesDb) -> Result<()> {
         CREATE_TRIGGER_AFTER_INSERT_ON_PLACES,
         &CREATE_TRIGGER_HISTORYVISITS_AFTERINSERT,
         &CREATE_TRIGGER_HISTORYVISITS_AFTERDELETE,
+        &CREATE_TRIGGER_MOZPLACES_AFTERDELETE
     ])?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::{Url};
+    use db::{PlacesDb};
+    use types::{SyncStatus};
+    use sync::util::{random_guid};
+
+    fn has_tombstone(conn: &PlacesDb, guid: &str) -> bool {
+        let count: Result<Option<u32>> = conn.try_query_row(
+                    "SELECT COUNT(*) from moz_places_tombstones
+                     WHERE guid = :guid",
+                    &[(":guid", &guid)],
+                    |row| Ok(row.get::<_, u32>(0)), true);
+        count.unwrap().unwrap() == 1
+    }
+
+    #[test]
+    fn test_places_no_tombstone() {
+        let conn = PlacesDb::open_in_memory(None).expect("no memory db");
+        let guid = random_guid().expect("should get a guid");
+
+        conn.execute_named_cached(
+            "INSERT INTO moz_places (guid, url, url_hash) VALUES (:guid, :url, hash(:url))",
+            &[(":guid", &guid),
+              (":url", &Url::parse("http://example.com").expect("valid url").into_string())
+             ]
+        ).expect("should work");
+
+        let place_id = conn.last_insert_rowid();
+        conn.execute_named_cached(
+            "DELETE FROM moz_places WHERE id = :id",
+            &[(":id", &place_id)]
+        ).expect("should work");
+
+        // should not have a tombstone.
+        assert!(!has_tombstone(&conn, &guid));
+    }
+
+    #[test]
+    fn test_places_tombstone() {
+        let conn = PlacesDb::open_in_memory(None).expect("no memory db");
+        let guid = random_guid().expect("should get a guid");
+
+        conn.execute_named_cached(
+            "INSERT INTO moz_places (guid, url, url_hash, sync_status)
+             VALUES (:guid, :url, hash(:url), :sync_status)",
+            &[(":guid", &guid),
+              (":url", &Url::parse("http://example.com").expect("valid url").into_string()),
+              (":sync_status", &SyncStatus::Normal),
+             ]
+        ).expect("should work");
+
+        let place_id = conn.last_insert_rowid();
+        conn.execute_named_cached(
+            "DELETE FROM moz_places WHERE id = :id",
+            &[(":id", &place_id)]
+        ).expect("should work");
+
+        // should have a tombstone.
+        assert!(has_tombstone(&conn, &guid));
+    }
 }

--- a/components/places/src/types.rs
+++ b/components/places/src/types.rs
@@ -169,6 +169,43 @@ impl<'de> serde::Deserialize<'de> for VisitTransition {
     }
 }
 
+// Re SyncStatus - note that:
+// * logins_sql has synced=0, changed=1, new=2
+// * desktop bookmarks has unknown=0, new=1, normal=2
+// This is "places", so eventually bookmarks will have a status - should history and bookmarks share it?
+// Note that history specifically needs neither (a) login's "changed" (the changeCounter works there),
+// nor (b) bookmark's "unknown" (as that's only used after a restore)
+// History only needs a distinction between "synced" and "new" so it doesn't
+// accumulate never-to-be-synced tombstones - so we basically copy bookmarks
+// and treat unknown as new.
+// Which means we get the "bonus side-effect" ;) of ::Unknown replacing Option<>!
+//
+// Note that some of these values are in schema.rs
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(u8)]
+pub enum SyncStatus {
+    Unknown = 0,
+    New = 1,
+    Normal = 2,
+}
+
+impl SyncStatus {
+    #[inline]
+    pub fn from_u8(v: u8) -> Self {
+        match v {
+            1 => SyncStatus::New,
+            2 => SyncStatus::Normal,
+            _ => SyncStatus::Unknown,
+        }
+    }
+}
+
+impl ToSql for SyncStatus {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput> {
+        Ok(ToSqlOutput::from(*self as u8))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This adds the fields we've been discussing. I've split it from the "sync" commits for ease of reviewing.

Note that I bumped the schema version but made no attempt to implement a schema migration - that means old DBs will panic, but I think that's fine currently - anyone using this against the reference browser need only uninstall and reinstall the app.