### PR TITLE
Add incoming history syncing.

### DIFF
--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -37,6 +37,8 @@ find-places-db = "0.1.0"
 clap = "2.32.0"
 tempfile = "3.0.4"
 rand = "0.5.5"
+fxa-client = { path = "../../fxa-client" }
+
 
 # While we don't have a replacement for termion on Windows yet (and thus
 # our example doesn't work on Windows), it does get further in the compilation

--- a/components/places/examples/sync_history.rs
+++ b/components/places/examples/sync_history.rs
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+extern crate sync15_adapter;
+extern crate fxa_client;
+extern crate url;
+
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+
+extern crate rusqlite;
+
+extern crate clap;
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+extern crate chrono;
+extern crate failure;
+
+extern crate places;
+
+use failure::Fail;
+
+use std::{fs, io::{Read}};
+use std::collections::HashMap;
+use fxa_client::{FirefoxAccount, Config, OAuthInfo};
+use sync15_adapter::{Sync15StorageClientInit, KeyBundle};
+use places::{PlacesDb};
+use places::history_sync::store::{HistoryStore};
+
+const CONTENT_BASE: &str = "https://accounts.firefox.com";
+const SYNC_SCOPE: &str = "https://identity.mozilla.com/apps/oldsync";
+
+const SCOPES: &[&str] = &[
+    SYNC_SCOPE,
+    "https://identity.mozilla.com/apps/lockbox",
+];
+
+// I'm completely punting on good error handling here.
+type Result<T> = std::result::Result<T, failure::Error>;
+
+#[derive(Debug, Deserialize)]
+struct ScopedKeyData {
+    k: String,
+    kty: String,
+    kid: String,
+    scope: String,
+}
+
+fn load_fxa_creds(path: &str) -> Result<FirefoxAccount> {
+    let mut file = fs::File::open(path)?;
+    let mut s = String::new();
+    file.read_to_string(&mut s)?;
+    Ok(FirefoxAccount::from_json(&s)?)
+}
+
+
+fn init_logging() {
+    // Explicitly ignore some rather noisy crates. Turn on trace for everyone else.
+    let spec = "trace,tokio_threadpool=warn,tokio_reactor=warn,tokio_core=warn,tokio=warn,hyper=warn,want=warn,mio=warn,reqwest=warn";
+    env_logger::init_from_env(
+        env_logger::Env::default().filter_or("RUST_LOG", spec)
+    );
+}
+
+fn main() -> Result<()> {
+    init_logging();
+
+    let matches = clap::App::new("sync_history")
+        .about("History syncing tool")
+
+        .arg(clap::Arg::with_name("database_path")
+            .short("d")
+            .long("database")
+            .value_name("LOGINS_DATABASE")
+            .takes_value(true)
+            .help("Path to the logins database (default: \"./logins.db\")"))
+
+        .arg(clap::Arg::with_name("encryption_key")
+            .short("k")
+            .long("key")
+            .value_name("ENCRYPTION_KEY")
+            .takes_value(true)
+            .help("Database encryption key.")
+            .required(true))
+
+        .arg(clap::Arg::with_name("credential_file")
+            .short("c")
+            .long("credentials")
+            .value_name("CREDENTIAL_JSON")
+            .takes_value(true)
+            .help("Path to store our cached fxa credentials (defaults to \"./credentials.json\""))
+
+        .get_matches();
+
+    let cred_file = matches.value_of("credential_file").unwrap_or("./credentials.json");
+    let db_path = matches.value_of("database_path").unwrap_or("./logins.db");
+    // This should already be checked by `clap`, IIUC
+    let encryption_key = matches.value_of("encryption_key").expect("Encryption key is not optional");
+
+    // Lets not log the encryption key, it's just not a good habit to be in.
+    debug!("Using credential file = {:?}, db = {:?}", cred_file, db_path);
+
+    // TODO: allow users to use stage/etc.
+    let cfg = Config::import_from(CONTENT_BASE)?;
+    let tokenserver_url = cfg.token_server_endpoint_url()?;
+
+    // TODO: we should probably set a persist callback on acct?
+    let mut acct = load_fxa_creds(cred_file)?;
+    let token: OAuthInfo = match acct.get_oauth_token(SCOPES)? {
+        Some(t) => t,
+        None => {
+            // The cached credentials did not have appropriate scope, sign in again.
+            panic!("No creds - run some other tool to set them up.");
+        }
+    };
+
+    let keys: HashMap<String, ScopedKeyData> = serde_json::from_str(&token.keys.unwrap())?;
+
+    let key = keys.get(SYNC_SCOPE).unwrap();
+
+    let client_init = Sync15StorageClientInit {
+        key_id: key.kid.clone(),
+        access_token: token.access_token.clone(),
+        tokenserver_url,
+    };
+    let root_sync_key = KeyBundle::from_ksync_base64(&key.k)?;
+
+    let db = PlacesDb::open(db_path, Some(encryption_key))?;
+    let store = HistoryStore::new(&db);
+
+    info!("Syncing!");
+    if let Err(e) = store.sync(&client_init, &root_sync_key) {
+        warn!("Sync failed! {}", e);
+        warn!("BT: {:?}", e.backtrace());
+    } else {
+        info!("Sync was successful!");
+    }
+    println!("Exiting (bye!)");
+    Ok(())
+}

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -17,6 +17,9 @@ ffi-support = { path = "../../support/ffi" }
 version = "0.14.0"
 features = ["sqlcipher", "limits", "functions"]
 
+[dependencies.sync15-adapter]
+path = "../../../sync15-adapter"
+
 [dependencies.places]
 path = ".."
 features = ["ffi"]

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -5,6 +5,7 @@
 extern crate serde_json;
 extern crate rusqlite;
 extern crate places;
+extern crate sync15_adapter;
 extern crate url;
 
 #[macro_use]
@@ -18,12 +19,18 @@ extern crate ffi_support;
 
 use std::os::raw::c_char;
 use places::{storage, PlacesDb};
-use ffi_support::{call_with_result, ExternError};
+use places::history_sync::store::{HistoryStore};
+use ffi_support::{call_with_result, rust_string_from_c, rust_str_from_c, ExternError};
 
 use places::api::matcher::{
     search_frecent,
     SearchParams,
 };
+
+// indirection to help `?` figure out the target error type
+fn parse_url(url: &str) -> sync15_adapter::Result<url::Url> {
+    Ok(url::Url::parse(url)?)
+}
 
 fn logging_init() {
     #[cfg(target_os = "android")]
@@ -130,6 +137,34 @@ pub extern "C" fn places_get_visited_urls_in_range(
             include_remote != 0
         )?;
         Ok(serde_json::to_string(&visited)?)
+    })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sync15_history_sync(
+    conn: &PlacesDb,
+    key_id: *const c_char,
+    access_token: *const c_char,
+    sync_key: *const c_char,
+    tokenserver_url: *const c_char,
+    error: &mut ExternError
+) {
+    trace!("sync15_history_sync");
+    // TODO: Is there any way to convince rust that some `&mut T` is unwind safe?
+    call_with_result(error, || -> places::Result<()> {
+        // XXX - this is wrong - we kinda want this to be long-lived - the "Db"
+        // should own the store, but it's not part of the db.
+        let store = HistoryStore::new(conn);
+        store.sync(
+            &sync15_adapter::Sync15StorageClientInit {
+                key_id: rust_string_from_c(key_id),
+                access_token: rust_string_from_c(access_token),
+                tokenserver_url: parse_url(rust_str_from_c(tokenserver_url))?,
+            },
+            &sync15_adapter::KeyBundle::from_ksync_base64(
+                rust_str_from_c(sync_key)
+            )?
+        )
     })
 }
 

--- a/components/places/src/api/history.rs
+++ b/components/places/src/api/history.rs
@@ -12,8 +12,7 @@ use observation::{VisitObservation};
 
 // This module can become, roughly: PlacesUtils.history()
 
-// functions used internally.
-fn can_add_url(_url: &Url) -> Result<bool> {
+pub fn can_add_url(_url: &Url) -> Result<bool> {
     Ok(true)
 }
 

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -10,6 +10,7 @@ use std::boxed::Box;
 use rusqlite;
 use serde_json;
 use url;
+use sync15_adapter;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -63,8 +64,8 @@ pub enum ErrorKind {
     #[fail(display = "Invalid place info: {}", _0)]
     InvalidPlaceInfo(InvalidPlaceInfo),
 
-//    #[fail(display = "Error synchronizing: {}", _0)]
-//    SyncAdapterError(#[fail(cause)] sync::Error),
+    #[fail(display = "Error synchronizing: {}", _0)]
+    SyncAdapterError(#[fail(cause)] sync15_adapter::Error),
 
     #[fail(display = "Error parsing JSON data: {}", _0)]
     JsonError(#[fail(cause)] serde_json::Error),
@@ -95,7 +96,7 @@ macro_rules! impl_from_error {
 }
 
 impl_from_error! {
-//    (SyncAdapterError, sync::Error),
+    (SyncAdapterError, sync15_adapter::Error),
     (JsonError, serde_json::Error),
     (UrlParseError, url::ParseError),
     (SqlError, rusqlite::Error),

--- a/components/places/src/history_sync/mod.rs
+++ b/components/places/src/history_sync/mod.rs
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub mod store;
+pub mod record;
+mod plan;
+
+static MAX_INCOMING_PLACES: usize = 5000;
+static MAX_VISITS: usize = 20;

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -1,0 +1,331 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashSet;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{Connection};
+use url::{Url};
+
+use super::{MAX_VISITS};
+use super::record::{HistoryRecord, HistoryRecordVisit, HistorySyncRecord};
+use types::{SyncGuid, Timestamp, VisitTransition};
+use storage::history_sync::{
+    apply_synced_deletion,
+    apply_synced_visits,
+    fetch_visits,
+    FetchedVisit,
+    FetchedVisitPage
+};
+use api::history::{can_add_url};
+use error::*;
+
+use sync15_adapter::{
+    IncomingChangeset,
+    OutgoingChangeset,
+    Payload,
+};
+
+// In desktop sync, bookmarks are clamped to Jan 23, 1993 (which is 727747200000)
+// There's no good reason history records could be older than that, so we do
+// the same here (even though desktop's history currently doesn't)
+const EARLIEST_TIMESTAMP: Timestamp = Timestamp(727747200000);
+
+/// Clamps a history visit date between the current date and the earliest
+/// sensible date.
+fn clamp_visit_date(visit_date: Timestamp) -> Timestamp {
+    let now = Timestamp::now();
+    if visit_date > now {
+        return visit_date;
+    }
+    if visit_date < EARLIEST_TIMESTAMP {
+        return EARLIEST_TIMESTAMP;
+    }
+    return visit_date;
+}
+
+#[derive(Debug)]
+pub enum IncomingPlan {
+    Skip, // An entry we just want to ignore - either due to the URL etc, or because no changes.
+    Invalid(Error), // Something's wrong with this entry.
+    Failed(Error), // The entry appears sane, but there was some error.
+    Delete(), // We should delete this.
+    // We should apply this. If SyncGuid is Some, then it is the existing guid
+    // for the same URL, and if that doesn't match the incoming record, we
+    // should change the existing item to the incoming one and upload a tombstone.
+    Apply(Option<SyncGuid>, Url, Option<String>, Vec<HistoryRecordVisit>),
+}
+
+
+fn plan_incoming_record(conn: &Connection, record: HistoryRecord, max_visits: usize) -> IncomingPlan {
+    let url = match Url::parse(&record.hist_uri) {
+        Ok(u) => u,
+        Err(e) => return IncomingPlan::Invalid(e.into()),
+    };
+    match can_add_url(&url) {
+        Ok(can) => if !can { return IncomingPlan::Skip },
+        Err(e) => return IncomingPlan::Failed(e.into()),
+    }
+    // Let's get what we know about it, if anything - last 20, like desktop?
+    let visit_tuple = match fetch_visits(conn, &url, max_visits) {
+        Ok(v) => v,
+        Err(e) => return IncomingPlan::Failed(e.into()),
+    };
+
+    // This all seems more messy than it should be - struggling to find the
+    // correct signature for fetch_visits
+    let (existing_page, existing_visits): (Option<FetchedVisitPage>, Vec<FetchedVisit>) = match visit_tuple {
+        None => (None, Vec::new()),
+        Some((p, v)) => (Some(p), v),
+    };
+
+    let mut old_guid: Option<SyncGuid> = None;
+    let mut cur_visit_map: HashSet<(VisitTransition, Timestamp)> = HashSet::new();
+    if let Some(p) = &existing_page {
+        if p.guid != record.id {
+            old_guid = Some(p.guid.clone());
+        }
+        for visit in &existing_visits {
+            // it should be impossible for us to have invalid visits locally, but...
+            let transition = match visit.visit_type {
+                Some(t) => t,
+                None => continue,
+            };
+            let date_use = clamp_visit_date(visit.visit_date);
+            cur_visit_map.insert((transition, date_use));
+        }
+    }
+    // If we already have MAX_RECORDS visits, then we will ignore incoming
+    // visits older than that. (Not really clear why we do this and why 20 is
+    // magic, but what's good enough for desktop is good enough for us at this
+    // stage.)
+    let earliest_allowed: SystemTime = if existing_visits.len() == max_visits as usize {
+        existing_visits[existing_visits.len() - 1].visit_date.into()
+    } else {
+        UNIX_EPOCH
+    };
+
+    // work out which of the incoming records we should apply.
+    let mut to_apply = Vec::with_capacity(record.visits.len());
+    for incoming_visit in record.visits {
+        let transition = match VisitTransition::from_primitive(incoming_visit.transition) {
+            Some(v) => v,
+            None => continue,
+        };
+        let timestamp = clamp_visit_date(incoming_visit.date);
+        if earliest_allowed > timestamp.into() {
+            continue;
+        }
+        // If the entry isn't in our map we should add it.
+        let key = (transition, timestamp);
+        if !cur_visit_map.contains(&key) {
+            to_apply.push(HistoryRecordVisit { date: timestamp, transition: transition as u8 });
+            cur_visit_map.insert(key);
+        }
+    }
+    if to_apply.len() != 0 || old_guid.is_some() {
+        // Now we need to check the other attributes.
+        // XXX - check if we should update title? For now, assume yes.
+        let new_title = Some(record.title);
+        IncomingPlan::Apply(old_guid, url.clone(), new_title, to_apply)
+    } else {
+        IncomingPlan::Skip
+    }
+}
+
+pub fn apply_plan(conn: &Connection, inbound: IncomingChangeset) -> Result<OutgoingChangeset> {
+    // for a first-cut, let's do this in the most naive way possible...
+    let mut plans: Vec<(SyncGuid, IncomingPlan)> = Vec::with_capacity(inbound.changes.len());
+    for incoming in inbound.changes.iter() {
+        let item = HistorySyncRecord::from_payload(incoming.0.clone())?;
+        let plan = match item.record {
+            Some(record) => plan_incoming_record(conn, record, MAX_VISITS),
+            None => IncomingPlan::Delete(),
+        };
+        let guid = item.guid.clone();
+        plans.push((guid, plan));
+    }
+
+    let mut outgoing = OutgoingChangeset::new("history".into(), inbound.timestamp);
+    for (guid, plan) in plans {
+        match &plan {
+            IncomingPlan::Skip => {
+                trace!("skipping the item");
+            },
+            IncomingPlan::Invalid(err) => {
+                warn!("record {:?} skipped because it is invalid: {}", guid, err);
+            },
+            IncomingPlan::Failed(err) => {
+                error!("record {:?} failed to apply: {}", guid, err);
+            },
+            IncomingPlan::Delete() => {
+                trace!("deleting {:?}", guid);
+                apply_synced_deletion(&conn, &guid)?;
+            },
+            IncomingPlan::Apply(old_guid, url, title, visits_to_add) => {
+                trace!("will apply {:?}: url={:?}, title={:?}, to_add={}",
+                      guid, url, title, visits_to_add.len());
+                apply_synced_visits(&conn, &guid, &old_guid, &url, title, visits_to_add)?;
+                if let Some(ref old_guid) = old_guid {
+                    outgoing.changes.push(Payload::new_tombstone(old_guid.0.clone()));
+                }
+            },
+        };
+    }
+    Ok(outgoing)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use storage::{apply_observation};
+    use storage::history_sync::{fetch_visits};
+    use observation::{VisitObservation};
+    use api::matcher::{SearchParams, search_frecent};
+    use types::{Timestamp};
+    use db::PlacesDb;
+
+    use sql_support::ConnExt;
+    use sync15_adapter::util::{random_guid};
+
+    use sync15_adapter::{IncomingChangeset, ServerTimestamp};
+    use url::{Url};
+
+    fn get_existing_guid(conn: &PlacesDb, url: &Url) -> SyncGuid {
+        let guid_result: Result<Option<String>> = conn.try_query_row(
+                    "SELECT guid from moz_places WHERE url = :url;",
+                    &[(":url", &url.clone().into_string())],
+                    |row| Ok(row.get::<_, String>(0).clone()), true);
+        guid_result.expect("should have worked").expect("should have got a value").into()
+    }
+
+    #[test]
+    fn test_invalid() {
+        let conn = PlacesDb::open_in_memory(None).expect("no memory db");
+        let record = HistoryRecord { id: SyncGuid("foo".to_string()),
+                                     title: "title".into(),
+                                     hist_uri: "invalid".into(),
+                                     sortindex: 0,
+                                     visits: vec![]};
+
+        assert!(match plan_incoming_record(&conn, record, 10) {
+            IncomingPlan::Invalid(_) => true,
+            _ => false
+        });
+    }
+
+    #[test]
+    fn test_new() {
+        let conn = PlacesDb::open_in_memory(None).expect("no memory db");
+        let visits = vec![HistoryRecordVisit {date: SystemTime::now().into(),
+                                              transition: 1}];
+        let record = HistoryRecord { id: SyncGuid("foo".to_string()),
+                                     title: "title".into(),
+                                     hist_uri: "https://example.com".into(),
+                                     sortindex: 0,
+                                     visits};
+
+        assert!(match plan_incoming_record(&conn, record, 10) {
+            IncomingPlan::Apply(None, _, _, _) => true,
+            _ => false,
+        });
+    }
+
+    #[test]
+    fn test_dupe_visit_same_guid() {
+        let mut conn = PlacesDb::open_in_memory(None).expect("no memory db");
+        let now = SystemTime::now();
+        let url = Url::parse("https://example.com").expect("is valid");
+        // add it locally
+        let obs = VisitObservation::new(url.clone())
+                      .with_visit_type(VisitTransition::Link)
+                      .with_at(Some(now.into()));
+        apply_observation(&mut conn, obs).expect("should apply");
+
+        let guid = get_existing_guid(&conn, &url);
+
+        // try and add it remotely.
+        let visits = vec![HistoryRecordVisit {date: now.into(), transition: 1}];
+        let record = HistoryRecord { id: guid,
+                                     title: "title".into(),
+                                     hist_uri: "https://example.com".into(),
+                                     sortindex: 0,
+                                     visits };
+        // We should skip it.
+        assert!(match plan_incoming_record(&conn, record, 10) {
+            IncomingPlan::Skip => true,
+            _ => false,
+        });
+    }
+
+    #[test]
+    fn test_dupe_visit_different_guid() {
+        let mut conn = PlacesDb::open_in_memory(None).expect("no memory db");
+        let now = SystemTime::now();
+        let url = Url::parse("https://example.com").expect("is valid");
+        // add it locally
+        let obs = VisitObservation::new(url.clone())
+                      .with_visit_type(VisitTransition::Link)
+                      .with_at(Some(now.into()));
+        apply_observation(&mut conn, obs).expect("should apply");
+
+        let old_guid = get_existing_guid(&conn, &url);
+
+        // try and add an incoming record with the same URL but different guid.
+        let new_guid = random_guid().expect("according to logins-sql, this is fine :)");
+        let visits = vec![HistoryRecordVisit {date: now.into(), transition: 1}];
+        let record = HistoryRecord { id: new_guid.into(),
+                                     title: "title".into(),
+                                     hist_uri: "https://example.com".into(),
+                                     sortindex: 0,
+                                     visits };
+        // Even though there are no visits we should record that it will be
+        // applied with the guid change.
+        assert!(match plan_incoming_record(&conn, record, 10) {
+            IncomingPlan::Apply(Some(got_old_guid), _, _, _) => {
+                assert_eq!(got_old_guid, old_guid);
+                true
+            },
+            _ => false,
+        });
+    }
+
+    #[test]
+    fn test_apply_plan_incoming_new() {
+        let now: Timestamp = SystemTime::now().into();
+        let json = json!({
+            "id": "foo",
+            "title": "title",
+            "histUri": "http://example.com",
+            "sortindex": 0,
+            "visits": [ {"date": now, "type": 1}]
+        });
+        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let payload = Payload::from_json(json).unwrap();
+        result.changes.push((payload, ServerTimestamp(0f64)));
+
+        let db = PlacesDb::open_in_memory(None).expect("no memory db");
+        let outgoing = apply_plan(&db, result).expect("should work");
+
+        // should have applied it locally.
+        let (page, visits) = fetch_visits(&db, &Url::parse("http://example.com").unwrap(), 2)
+                             .expect("should work").expect("page exists");
+        assert_eq!(page.title, "title");
+        assert_eq!(visits.len(), 1);
+        let visit = visits.into_iter().next().unwrap();
+        assert_eq!(visit.visit_date, now);
+
+        // page should have frecency (going through a public api to get this is a pain)
+        // XXX - FIXME - searching for "title" here fails to find a result?
+        // But above, we've checked title is in the record.
+        let found = search_frecent(&db, SearchParams{ search_string: "http://example.com".into(), limit: 2 }
+                                   ).expect("should have worked");
+        assert_eq!(found.len(), 1);
+        let result = found.into_iter().next().unwrap();
+        assert!(result.frecency > 0, "should have frecency");
+
+        // and nothing outgoing.
+        assert_eq!(outgoing.changes.len(), 0);
+    }
+}

--- a/components/places/src/history_sync/record.rs
+++ b/components/places/src/history_sync/record.rs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use types::{SyncGuid, Timestamp};
+use error::*;
+use sync15_adapter;
+
+#[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryRecordVisit {
+    pub date: Timestamp,
+    #[serde(rename = "type")]
+    pub transition: u8,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryRecord {
+    // TODO: consider `#[serde(rename = "id")] pub guid: String` to avoid confusion
+    pub id: SyncGuid,
+
+    #[serde(default)]
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub title: String,
+
+    pub hist_uri: String,
+    pub sortindex: i32,
+    pub visits: Vec<HistoryRecordVisit>,
+}
+
+#[derive(Debug)]
+pub struct HistorySyncRecord {
+    pub guid: SyncGuid,
+    pub record: Option<HistoryRecord>,
+}
+
+impl HistorySyncRecord {
+    pub fn from_payload(payload: sync15_adapter::Payload) -> Result<Self> {
+        let guid = payload.id.clone();
+        let record: Option<HistoryRecord> =
+            if payload.is_tombstone() {
+                None
+            } else {
+                let record: HistoryRecord = payload.into_record()?;
+                Some(record)
+            };
+        Ok(Self { guid: guid.into(), record })
+    }
+}

--- a/components/places/src/history_sync/store.rs
+++ b/components/places/src/history_sync/store.rs
@@ -1,0 +1,155 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::result;
+use std::cell::Cell;
+use std::ops::Deref;
+use error::*;
+use failure;
+use rusqlite::{Connection};
+use rusqlite::{types::{ToSql, FromSql}};
+use sql_support::{ConnExt};
+use sync15_adapter::{
+    ClientInfo,
+    IncomingChangeset,
+    KeyBundle,
+    OutgoingChangeset,
+    Store,
+    ServerTimestamp,
+    Sync15StorageClientInit,
+    sync_multiple,
+};
+use sync15_adapter::request::{CollectionRequest};
+
+use super::plan::{apply_plan};
+use super::{MAX_INCOMING_PLACES};
+
+static LAST_SYNC_META_KEY:    &'static str = "history_last_sync_time";
+static GLOBAL_STATE_META_KEY: &'static str = "history_global_state";
+
+// Lifetime here seems wrong
+pub struct HistoryStore<'a> {
+    pub db: &'a Connection,
+    pub client_info: Cell<Option<ClientInfo>>,
+}
+
+impl<'a> HistoryStore<'a> {
+    pub fn new(db: &'a Connection) -> Self {
+        Self { db, client_info: Cell::new(None) }
+    }
+
+    fn put_meta(&self, key: &str, value: &ToSql) -> Result<()> {
+        self.execute_named_cached(
+            "REPLACE INTO moz_meta (key, value) VALUES (:key, :value)",
+            &[(":key", &key as &ToSql), (":value", value)]
+        )?;
+        Ok(())
+    }
+
+    fn get_meta<T: FromSql>(&self, key: &str) -> Result<Option<T>> {
+        Ok(self.try_query_row(
+            "SELECT value FROM moz_meta WHERE key = :key",
+            &[(":key", &key as &ToSql)],
+            |row| Ok::<_, Error>(row.get_checked(0)?),
+            true
+        )?)
+    }
+
+    fn do_apply_incoming(
+        &self,
+        inbound: IncomingChangeset
+    ) -> Result<OutgoingChangeset> {
+        apply_plan(&self, inbound)
+    }
+
+    fn set_global_state(&self, global_state: Option<String>) -> Result<()> {
+        let to_write = match global_state {
+            Some(ref s) => s,
+            None => "",
+        };
+        self.put_meta(GLOBAL_STATE_META_KEY, &to_write)
+    }
+
+    fn get_global_state(&self) -> Result<Option<String>> {
+        self.get_meta::<String>(GLOBAL_STATE_META_KEY)
+    }
+
+    /// A convenience wrapper around sync_multiple.
+    pub fn sync(&self,
+                storage_init: &Sync15StorageClientInit,
+                root_sync_key: &KeyBundle) -> Result<()> {
+        let global_state: Cell<Option<String>> = Cell::new(self.get_global_state()?);
+        let result = sync_multiple(&[self],
+                                   &global_state,
+                                   &self.client_info,
+                                   storage_init,
+                                   root_sync_key);
+        self.set_global_state(global_state.replace(None))?;
+        let failures = result?;
+        if failures.len() == 0 {
+            Ok(())
+        } else {
+            assert_eq!(failures.len(), 1);
+            let (name, err) = failures.into_iter().next().unwrap();
+            assert_eq!(name, "history");
+            Err(err.into())
+        }
+    }
+}
+
+
+impl<'a> ConnExt for HistoryStore<'a> {
+    #[inline]
+    fn conn(&self) -> &Connection {
+        &self.db
+    }
+}
+
+impl<'a> Deref for HistoryStore<'a> {
+    type Target = Connection;
+    #[inline]
+    fn deref(&self) -> &Connection {
+        &self.db
+    }
+}
+
+impl<'a> Store for HistoryStore<'a> {
+    fn collection_name(&self) -> &'static str {
+        "history"
+    }
+
+    fn apply_incoming(
+        &self,
+        inbound: IncomingChangeset
+    ) -> result::Result<OutgoingChangeset, failure::Error> {
+        Ok(self.do_apply_incoming(inbound)?)
+    }
+
+    fn sync_finished(
+        &self,
+        new_timestamp: ServerTimestamp,
+        records_synced: &[String],
+    ) -> result::Result<(), failure::Error> {
+        println!("sync completed {} records, should advance timestamp to {}",
+                 records_synced.len(), new_timestamp);
+        Ok(())
+    }
+
+    fn get_collection_request(&self) -> result::Result<CollectionRequest, failure::Error> {
+        let since = self.get_meta::<i64>(LAST_SYNC_META_KEY)?
+                        .map(|millis| ServerTimestamp(millis as f64 / 1000.0))
+                        .unwrap_or_default();
+        Ok(CollectionRequest::new("history").full().newer_than(since).limit(MAX_INCOMING_PLACES))
+    }
+
+    fn reset(&self) -> result::Result<(), failure::Error> {
+        warn!("reset not implemented");
+        Ok(())
+    }
+
+    fn wipe(&self) -> result::Result<(), failure::Error> {
+        warn!("not implemented");
+        Ok(())
+    }
+}

--- a/components/places/src/lib.rs
+++ b/components/places/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-extern crate sync15_adapter as sync;
+extern crate sync15_adapter;
 
 #[macro_use]
 extern crate log;
@@ -22,6 +22,7 @@ extern crate url;
 extern crate rusqlite;
 
 extern crate serde;
+#[cfg_attr(test, macro_use)]
 extern crate serde_json;
 
 #[macro_use]
@@ -50,6 +51,7 @@ pub mod storage;
 pub mod hash;
 pub mod frecency;
 pub mod observation;
+pub mod history_sync;
 mod util;
 #[cfg(feature = "ffi")]
 pub mod ffi;


### PR DESCRIPTION
This doesn't attempt to handle outgoing at all (although I do have work that moves towards that). It also doesn't update the timestamp, so every sync will re-fetch every record - but it reconciles them so future syncs are a no-op in terms of writing.

I've applied most of Thom's review comments in my previous version of this.

I don't think it's necessary to wait for outgoing before landing this, although I'm open to different opinions there :)