### PR TITLE
Use `maven-publish` to produce Maven publications.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Publish.
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'digital.wup:android-maven-publish:3.6.2'
 
         classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.6.0'
 
@@ -48,6 +48,25 @@ allprojects {
     repositories {
         google()
         jcenter()
+    }
+}
+
+subprojects {
+    apply plugin: 'digital.wup.android-maven-publish'
+
+    // This allows to invoke Gradle like `./gradlew publishToRootProjectBuildDir` (equivalent to
+    // `./gradlew publish`) and also `./gradlew publishToProjectBuildDir`.
+    publishing {
+        repositories {
+            maven {
+                name = "rootProjectBuildDir"
+                url "file://${project.rootProject.buildDir}/maven"
+            }
+            maven {
+                name = "projectBuildDir"
+                url "file://${project.buildDir}/maven"
+            }
+        }
     }
 }
 

--- a/components/places/android/library/build.gradle
+++ b/components/places/android/library/build.gradle
@@ -3,8 +3,6 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
-apply plugin: 'com.github.dcendents.android-maven'
-
 android {
     compileSdkVersion 27
 
@@ -116,8 +114,6 @@ afterEvaluate {
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
     }
 }
-
-archivesBaseName = 'places'
 
 apply from: '../../../../publish.gradle'
 ext.configurePublish(

--- a/fxa-client/sdks/android/library/build.gradle
+++ b/fxa-client/sdks/android/library/build.gradle
@@ -81,8 +81,6 @@ afterEvaluate {
     }
 }
 
-archivesBaseName = 'fxaclient'
-
 apply from: '../../../../publish.gradle'
 ext.configurePublish(
         'org.mozilla.fxaclient',

--- a/logins-api/android/library/build.gradle
+++ b/logins-api/android/library/build.gradle
@@ -3,8 +3,6 @@ apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
-apply plugin: 'com.github.dcendents.android-maven'
-
 android {
     compileSdkVersion 27
 
@@ -115,8 +113,6 @@ afterEvaluate {
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
     }
 }
-
-archivesBaseName = 'logins'
 
 apply from: '../../../publish.gradle'
 ext.configurePublish(

--- a/publish.gradle
+++ b/publish.gradle
@@ -2,58 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-def libRepoName = properties.libRepositoryName
-def libUrl = properties.libUrl
-def libVcsUrl = properties.libVcsUrl
-def libLicense = properties.libLicense
-def libLicenseUrl = properties.libLicenseUrl
-
 ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
-    apply plugin: 'com.github.dcendents.android-maven'
-
-    group = groupIdArg
-
-    install {
-        repositories.mavenInstaller {
-            pom {
-                project {
-                    packaging 'aar'
-                    groupId groupIdArg
-                    artifactId artifactIdArg
-
-                    name libRepoName
-                    description descriptionArg
-                    url libUrl
-
-                    licenses {
-                        license {
-                            name libLicense
-                            url libLicenseUrl
-                        }
-                    }
-
-                    developers {
-                        developer {
-                            id 'nalexander'
-                            name 'Nick Alexander'
-                            email 'nalexander@mozilla.com'
-                        }
-                    }
-
-                    scm {
-                        connection libVcsUrl
-                        developerConnection libVcsUrl
-                        url libUrl
-                    }
-                }
-            }
-        }
-    }
-
-    apply plugin: 'com.jfrog.bintray'
-
-    version = rootProject.ext.library['version']
-
     task sourcesJar(type: Jar) {
         from android.sourceSets.main.java.srcDirs
         classifier = 'sources'
@@ -69,10 +18,57 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
         from javadoc.destinationDir
     }
 
-    artifacts {
-        //archives javadocJar
-        archives sourcesJar
+    publishing {
+        publications {
+            aar(MavenPublication) {
+                project.afterEvaluate {
+                    from components.findByName("androidRelease")
+                }
+                artifact sourcesJar
+                // Can't publish Javadoc yet: fxaclient isn't well behaved.
+                // artifact javadocJar
+
+                // If this goes haywire with
+                // 'Cannot configure the 'publishing' extension after it has been accessed.',
+                // see https://github.com/researchgate/gradle-release/issues/125 and
+                // https://stackoverflow.com/q/28020520.
+                pom {
+                    groupId = groupIdArg
+                    artifactId = artifactIdArg
+                    description = descriptionArg
+                    version = rootProject.ext.library['version']
+
+                    licenses {
+                        license {
+                            name = properties.libLicense
+                            url = properties.libLicenseUrl
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            name = 'Mozilla Application Services'
+                            email = 'application-services@mozilla.com'
+                        }
+                    }
+
+                    scm {
+                        connection = properties.libVcsUrl
+                        developerConnection = properties.libVcsUrl
+                        url = properties.libUrl
+                    }
+                }
+            }
+        }
     }
+
+    apply plugin: 'com.jfrog.bintray'
+
+    // It feels like this shouldn't be necessary, but without it an
+    // "unspecified" creeps into bintray URLs -- just like
+    // https://github.com/bintray/gradle-bintray-plugin/issues/244, but not
+    // fixed by gradle-bintray-plugin:1.8.4.
+    version = rootProject.ext.library['version']
 
     Properties localProperties = null;
     if (project.rootProject.file('local.properties').canRead()) {
@@ -84,17 +80,17 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
         user = localProperties != null ? localProperties.getProperty("bintray.user") : ""
         key = localProperties != null ? localProperties.getProperty("bintray.apikey") : ""
 
-        configurations = ['archives']
+        publications = ['aar']
         pkg {
-            repo = libRepoName
+            repo = properties.libRepositoryName
             name = artifactIdArg
             desc = descriptionArg
-            websiteUrl = libUrl
-            vcsUrl = libVcsUrl
+            websiteUrl = properties.libUrl
+            vcsUrl = properties.libVcsUrl
             if (project.ext.has('vcsTag')) {
                 vcsTag = project.ext.vcsTag
             }
-            licenses = [libLicense]
+            licenses = [properties.libLicense]
             publish = true
             publicDownloadNumbers = true
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,6 @@
+// See https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:deferred_configuration.
+enableFeaturePreview('STABLE_PUBLISHING')
+
 include ':fxa-client-library'
 include ':logins-library'
 include ':places-library'


### PR DESCRIPTION
This builds on top of #398 (for convenience).  It's laying the ground-work for #262 and for #263, which both want to publish multiple Maven artifacts.

It's a no-op until we push a release, which I've done locally (with dry run) but haven't done from TC yet.