### PR TITLE
Publish "-forUnitTests" Maven publication.

### DIFF
--- a/components/places/android/library/build.gradle
+++ b/components/places/android/library/build.gradle
@@ -119,4 +119,6 @@ apply from: '../../../../publish.gradle'
 ext.configurePublish(
         'org.mozilla.places',
         'places',
-        'Low level places storage implementation.')
+        'Low level places storage implementation.',
+        configurations.jnaForTest,
+)

--- a/logins-api/android/library/build.gradle
+++ b/logins-api/android/library/build.gradle
@@ -98,7 +98,6 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
-
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
     android.libraryVariants.all { variant ->
@@ -118,4 +117,6 @@ apply from: '../../../publish.gradle'
 ext.configurePublish(
         'org.mozilla.sync15',
         'logins',
-        'Sync 1.5 logins implementation.')
+        'Sync 1.5 logins implementation.',
+        configurations.jnaForTest,
+)

--- a/publish.gradle
+++ b/publish.gradle
@@ -2,7 +2,41 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
+ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg, jnaForTestConfiguration = null ->
+    // `jnaForTestConfiguration` is a hacky way to say yes, I'm using JNA and
+    // want to pack the JNA dispatch libraries and my Rust libraries into a
+    // single JAR for use in unit tests that run on a development host (and not
+    // an Android target device).  We extract the JNA libraries and our local
+    // Rust libraries and stick them into a JAR that consumers augment their
+    // test configuration with.
+    if (jnaForTestConfiguration != null) {
+        task extractJnaResources(type: Sync) {
+            dependsOn jnaForTestConfiguration
+
+            from zipTree(jnaForTestConfiguration.singleFile)
+
+            into "${buildDir}/jnaResources/"
+
+            eachFile { FileCopyDetails fcp ->
+                // The intention is to just keep the various `*jnidispatch.*` files.
+                if (fcp.relativePath.pathString.startsWith("META-INFO") || fcp.relativePath.pathString.endsWith(".class")) {
+                    fcp.exclude()
+                }
+            }
+
+            includeEmptyDirs false
+        }
+
+        def forUnitTestsJarTask = task forUnitTestsJar(type: Jar) {
+            from extractJnaResources
+            from "$buildDir/rustResources"
+        }
+
+        project.afterEvaluate {
+            forUnitTestsJarTask.dependsOn(tasks["cargoBuild"])
+        }
+    }
+
     task sourcesJar(type: Jar) {
         from android.sourceSets.main.java.srcDirs
         classifier = 'sources'
@@ -59,6 +93,43 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
                     }
                 }
             }
+
+            if (jnaForTestConfiguration != null) {
+                forUnitTestsJar(MavenPublication) {
+                    artifact tasks['forUnitTestsJar']
+
+                    pom {
+                        groupId = groupIdArg
+                        artifactId = "${artifactIdArg}-forUnitTests"
+                        description = descriptionArg
+                        version = rootProject.ext.library['version']
+
+                        licenses {
+                            license {
+                                name = properties.libLicense
+                                url = properties.libLicenseUrl
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                name = 'Mozilla Application Services'
+                                email = 'application-services@mozilla.com'
+                            }
+                        }
+
+                        scm {
+                            connection = properties.libVcsUrl
+                            developerConnection = properties.libVcsUrl
+                            url = properties.libUrl
+                        }
+                    }
+
+                    // This is never the publication we want to use when publishing a
+                    // parent project with us as a child `project()` dependency.
+                    alias = true
+                }
+            }
         }
     }
 
@@ -81,6 +152,12 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg ->
         key = localProperties != null ? localProperties.getProperty("bintray.apikey") : ""
 
         publications = ['aar']
+        if (jnaForTestConfiguration != null) {
+            // Scoping in extensions can be strange: appending to the list isn't
+            // doing what I expect, so I'll just set it twice.
+            publications = ['aar', 'forUnitTestsJar']
+        }
+
         pkg {
             repo = properties.libRepositoryName
             name = artifactIdArg


### PR DESCRIPTION
This builds on #400 to start producing an additional JAR for upstream unit testers, namely Lockbox for Android.  The Maven repo looks like:
```
  /Users/nalexander/Mozilla/application-services/build/maven:
  total used in directory 0 available 9223372036852075427
  drwxr-xr-x   3 nalexander  staff   96  9 Nov 15:32 .
  drwxr-xr-x  10 nalexander  staff  320 14 Nov 14:14 ..
  drwxr-xr-x   3 nalexander  staff   96  9 Nov 15:32 org
  drwxr-xr-x  5 nalexander  staff  160 14 Nov 20:22 mozilla
  drwxr-xr-x  3 nalexander  staff   96 14 Nov 20:16 fxaclient
  drwxr-xr-x  6 nalexander  staff  192 14 Nov 20:16 fxaclient
  drwxr-xr-x  11 nalexander  staff  352 14 Nov 20:16 0.10.0
  -rw-r--r--   1 nalexander  staff  312 15 Nov 11:01 maven-metadata.xml
  -rw-r--r--   1 nalexander  staff   32 15 Nov 11:01 maven-metadata.xml.md5
  -rw-r--r--   1 nalexander  staff   40 15 Nov 11:01 maven-metadata.xml.sha1
  drwxr-xr-x  4 nalexander  staff  128 15 Nov 10:52 places
  drwxr-xr-x  6 nalexander  staff  192 14 Nov 20:17 places
  drwxr-xr-x  11 nalexander  staff  352 14 Nov 20:17 0.10.0
  -rw-r--r--   1 nalexander  staff  306 15 Nov 11:01 maven-metadata.xml
  -rw-r--r--   1 nalexander  staff   32 15 Nov 11:01 maven-metadata.xml.md5
  -rw-r--r--   1 nalexander  staff   40 15 Nov 11:01 maven-metadata.xml.sha1
  drwxr-xr-x  6 nalexander  staff  192 15 Nov 10:52 places-forUnitTests
  drwxr-xr-x  8 nalexander  staff  256 15 Nov 10:52 0.10.0
  -rw-r--r--  1 nalexander  staff  2774333 15 Nov 11:01 places-forUnitTests-0.10.0.jar
  -rw-r--r--  1 nalexander  staff       32 15 Nov 11:01 places-forUnitTests-0.10.0.jar.md5
  -rw-r--r--  1 nalexander  staff       40 15 Nov 11:01 places-forUnitTests-0.10.0.jar.sha1
  -rw-r--r--  1 nalexander  staff      700 15 Nov 11:01 places-forUnitTests-0.10.0.pom
  -rw-r--r--  1 nalexander  staff       32 15 Nov 11:01 places-forUnitTests-0.10.0.pom.md5
  -rw-r--r--  1 nalexander  staff       40 15 Nov 11:01 places-forUnitTests-0.10.0.pom.sha1
  -rw-r--r--  1 nalexander  staff  319 15 Nov 11:01 maven-metadata.xml
  -rw-r--r--  1 nalexander  staff   32 15 Nov 11:01 maven-metadata.xml.md5
  -rw-r--r--  1 nalexander  staff   40 15 Nov 11:01 maven-metadata.xml.sha1
  drwxr-xr-x  4 nalexander  staff  128 15 Nov 10:34 sync15
  drwxr-xr-x  6 nalexander  staff  192 14 Nov 20:16 logins
  drwxr-xr-x  11 nalexander  staff  352 14 Nov 20:16 0.10.0
  -rw-r--r--   1 nalexander  staff     10341 15 Nov 11:01 logins-0.10.0-sources.jar
  -rw-r--r--   1 nalexander  staff        32 15 Nov 11:01 logins-0.10.0-sources.jar.md5
  -rw-r--r--   1 nalexander  staff        40 15 Nov 11:01 logins-0.10.0-sources.jar.sha1
  -rw-r--r--   1 nalexander  staff  14026615 15 Nov 11:01 logins-0.10.0.aar
  -rw-r--r--   1 nalexander  staff        32 15 Nov 11:01 logins-0.10.0.aar.md5
  -rw-r--r--   1 nalexander  staff        40 15 Nov 11:01 logins-0.10.0.aar.sha1
  -rw-r--r--   1 nalexander  staff      1462 15 Nov 11:01 logins-0.10.0.pom
  -rw-r--r--   1 nalexander  staff        32 15 Nov 11:01 logins-0.10.0.pom.md5
  -rw-r--r--   1 nalexander  staff        40 15 Nov 11:01 logins-0.10.0.pom.sha1
  -rw-r--r--   1 nalexander  staff  306 15 Nov 11:01 maven-metadata.xml
  -rw-r--r--   1 nalexander  staff   32 15 Nov 11:01 maven-metadata.xml.md5
  -rw-r--r--   1 nalexander  staff   40 15 Nov 11:01 maven-metadata.xml.sha1
  drwxr-xr-x  6 nalexander  staff  192 15 Nov 10:34 logins-forUnitTests
  drwxr-xr-x  8 nalexander  staff  256 15 Nov 10:34 0.10.0
  -rw-r--r--  1 nalexander  staff  4477417 15 Nov 11:01 logins-forUnitTests-0.10.0.jar
  -rw-r--r--  1 nalexander  staff       32 15 Nov 11:01 logins-forUnitTests-0.10.0.jar.md5
  -rw-r--r--  1 nalexander  staff       40 15 Nov 11:01 logins-forUnitTests-0.10.0.jar.sha1
  -rw-r--r--  1 nalexander  staff      691 15 Nov 11:01 logins-forUnitTests-0.10.0.pom
  -rw-r--r--  1 nalexander  staff       32 15 Nov 11:01 logins-forUnitTests-0.10.0.pom.md5
  -rw-r--r--  1 nalexander  staff       40 15 Nov 11:01 logins-forUnitTests-0.10.0.pom.sha1
  -rw-r--r--  1 nalexander  staff  319 15 Nov 11:01 maven-metadata.xml
  -rw-r--r--  1 nalexander  staff   32 15 Nov 11:01 maven-metadata.xml.md5
  -rw-r--r--  1 nalexander  staff   40 15 Nov 11:01 maven-metadata.xml.sha1
```
and one of the `-forUnitTests` JARs looks like:
```
M Filemode      Length  Date         Time      File
- ----------  --------  -----------  --------  --------------------------------------------
  drwxr-xr-x         0  15-Nov-2018  10:34:46  META-INF/
  -rw-r--r--        25  15-Nov-2018  10:34:46  META-INF/MANIFEST.MF
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/linux-mips64el/
  -rw-r--r--    132984  15-Nov-2018  10:34:46  com/sun/jna/linux-mips64el/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/linux-arm/
  -rw-r--r--    107380  15-Nov-2018  10:34:46  com/sun/jna/linux-arm/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/sunos-sparcv9/
  -rw-r--r--    138936  15-Nov-2018  10:34:46  com/sun/jna/sunos-sparcv9/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/freebsd-x86-64/
  -rw-r--r--    112802  15-Nov-2018  10:34:46  com/sun/jna/freebsd-x86-64/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/aix-ppc/
  -rw-r--r--    487236  15-Nov-2018  10:34:46  com/sun/jna/aix-ppc/libjnidispatch.a
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/linux-aarch64/
  -rw-r--r--    104800  15-Nov-2018  10:34:46  com/sun/jna/linux-aarch64/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/sunos-x86/
  -rw-r--r--    120756  15-Nov-2018  10:34:46  com/sun/jna/sunos-x86/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/linux-x86/
  -rw-r--r--    102464  15-Nov-2018  10:34:46  com/sun/jna/linux-x86/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/freebsd-x86/
  -rw-r--r--    105466  15-Nov-2018  10:34:46  com/sun/jna/freebsd-x86/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/sunos-sparc/
  -rw-r--r--    127196  15-Nov-2018  10:34:46  com/sun/jna/sunos-sparc/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/openbsd-x86-64/
  -rw-r--r--    114333  15-Nov-2018  10:34:46  com/sun/jna/openbsd-x86-64/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/win32-x86/
  -rw-r--r--    207872  15-Nov-2018  10:34:46  com/sun/jna/win32-x86/jnidispatch.dll
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/sunos-x86-64/
  -rw-r--r--    131832  15-Nov-2018  10:34:46  com/sun/jna/sunos-x86-64/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/openbsd-x86/
  -rw-r--r--    107886  15-Nov-2018  10:34:46  com/sun/jna/openbsd-x86/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/linux-ppc/
  -rw-r--r--    123264  15-Nov-2018  10:34:46  com/sun/jna/linux-ppc/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/win32-x86-64/
  -rw-r--r--    246272  15-Nov-2018  10:34:46  com/sun/jna/win32-x86-64/jnidispatch.dll
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/darwin/
  -rw-r--r--    181004  15-Nov-2018  10:34:46  com/sun/jna/darwin/libjnidispatch.jnilib
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/linux-x86-64/
  -rw-r--r--    112921  15-Nov-2018  10:34:46  com/sun/jna/linux-x86-64/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/aix-ppc64/
  -rw-r--r--    526284  15-Nov-2018  10:34:46  com/sun/jna/aix-ppc64/libjnidispatch.a
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/linux-ppc64le/
  -rw-r--r--    133280  15-Nov-2018  10:34:46  com/sun/jna/linux-ppc64le/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/linux-armel/
  -rw-r--r--    111524  15-Nov-2018  10:34:46  com/sun/jna/linux-armel/libjnidispatch.so
  drwxr-xr-x         0  15-Nov-2018  10:34:46  com/sun/jna/linux-s390x/
  -rw-r--r--    132640  15-Nov-2018  10:34:46  com/sun/jna/linux-s390x/libjnidispatch.so
  drwxr-xr-x         0   9-Nov-2018  15:32:38  darwin/
  -rwxr-xr-x   9945544  15-Nov-2018  10:34:44  darwin/liblogins_ffi.dylib
- ----------  --------  -----------  --------  --------------------------------------------
              13614701                         51 files
```
