### PR TITLE
Combine FxA remote and local configurations

### DIFF
--- a/components/places/examples/sync_history.rs
+++ b/components/places/examples/sync_history.rs
@@ -32,6 +32,8 @@ use places::{PlacesDb};
 use places::history_sync::store::{HistoryStore};
 
 const CONTENT_BASE: &str = "https://accounts.firefox.com";
+const CLIENT_ID: &str = "";
+const REDIRECT_URI: &str = "";
 const SYNC_SCOPE: &str = "https://identity.mozilla.com/apps/oldsync";
 
 // I'm completely punting on good error handling here.
@@ -110,7 +112,7 @@ fn main() -> Result<()> {
     debug!("Using credential file = {:?}, db = {:?}", cred_file, db_path);
 
     // TODO: allow users to use stage/etc.
-    let cfg = Config::import_from(CONTENT_BASE)?;
+    let cfg = Config::import_from(CONTENT_BASE, CLIENT_ID, REDIRECT_URI)?;
     let tokenserver_url = cfg.token_server_endpoint_url()?;
 
     // TODO: we should probably set a persist callback on acct?

--- a/fxa-client/sdks/android/library/src/main/java/org/mozilla/fxaclient/internal/Config.kt
+++ b/fxa-client/sdks/android/library/src/main/java/org/mozilla/fxaclient/internal/Config.kt
@@ -20,10 +20,13 @@ class Config internal constructor(rawPointer: RawConfig) : RustObject<RawConfig>
          * Set up endpoints used in the production Firefox Accounts instance.
          *
          * This performs network requests, and should not be used on the main thread.
+         *
+         * @param clientId Client Id of the FxA relier
+         * @param redirectUri Redirect Uri of the FxA relier
          */
-        fun release(): Config {
+        fun release(clientId: String, redirectUri: String): Config {
             return Config(unlockedRustCall { e ->
-                FxaClient.INSTANCE.fxa_get_release_config(e)
+                FxaClient.INSTANCE.fxa_get_release_config(clientId, redirectUri, e)
             })
         }
 
@@ -32,11 +35,13 @@ class Config internal constructor(rawPointer: RawConfig) : RustObject<RawConfig>
          *
          * This performs network requests, and should not be used on the main thread.
          *
-         * @param content_base Hostname of the FxA auth service provider
+         * @param contentBase Hostname of the FxA auth service provider
+         * @param clientId Client Id of the FxA relier
+         * @param redirectUri Redirect Uri of the FxA relier
          */
-        fun custom(content_base: String): Config {
+        fun custom(contentBase: String, clientId: String, redirectUri: String): Config {
             return Config(unlockedRustCall { e ->
-                FxaClient.INSTANCE.fxa_get_custom_config(content_base, e)
+                FxaClient.INSTANCE.fxa_get_custom_config(contentBase, clientId, redirectUri, e)
             })
         }
     }

--- a/fxa-client/sdks/android/library/src/main/java/org/mozilla/fxaclient/internal/FirefoxAccount.kt
+++ b/fxa-client/sdks/android/library/src/main/java/org/mozilla/fxaclient/internal/FirefoxAccount.kt
@@ -12,16 +12,16 @@ class FirefoxAccount : RustObject<RawFxAccount> {
     internal constructor(rawPointer: RawFxAccount): super(rawPointer)
 
     /**
-     * Create a FirefoxAccount using the given config, client id, and redirect uri.
+     * Create a FirefoxAccount using the given config.
      *
      * If the config is passed into this method, calling `close` on it is no longer required
      * (but may be done if desired).
      *
      * This does not make network requests, and can be used on the main thread.
      */
-    constructor(config: Config, clientId: String, redirectUri: String)
+    constructor(config: Config)
     : this(config.rustCall { e ->
-        FxaClient.INSTANCE.fxa_new(config.consumePointer(), clientId, redirectUri, e)
+        FxaClient.INSTANCE.fxa_new(config.consumePointer(), e)
     })
 
     override fun destroy(p: RawFxAccount) {
@@ -96,6 +96,17 @@ class FirefoxAccount : RustObject<RawFxAccount> {
     fun getTokenServerEndpointURL(): String {
         return rustCall { e ->
             FxaClient.INSTANCE.fxa_get_token_server_endpoint_url(validPointer(), e)
+        }.getAndConsumeString()
+    }
+
+    /**
+     * Fetches the connection success url.
+     *
+     * This does not make network requests, and can be used on the main thread.
+     */
+    fun getConnectionSuccessURL(): String {
+        return rustCall { e ->
+            FxaClient.INSTANCE.fxa_get_connection_success_url(validPointer(), e)
         }.getAndConsumeString()
     }
 

--- a/fxa-client/sdks/android/library/src/main/java/org/mozilla/fxaclient/internal/FxaClient.kt
+++ b/fxa-client/sdks/android/library/src/main/java/org/mozilla/fxaclient/internal/FxaClient.kt
@@ -42,14 +42,12 @@ internal interface FxaClient : Library {
         }
     }
 
-    fun fxa_get_release_config(e: Error.ByReference): RawConfig?
-    fun fxa_get_custom_config(content_base: String, e: Error.ByReference): RawConfig?
+    fun fxa_get_release_config(clientId: String, redirectUri: String, e: Error.ByReference): RawConfig?
+    fun fxa_get_custom_config(contentBase: String, clientId: String, redirectUri: String, e: Error.ByReference): RawConfig?
 
-    fun fxa_new(config: RawConfig, clientId: String, redirectUri: String, e: Error.ByReference): RawFxAccount?
+    fun fxa_new(config: RawConfig, e: Error.ByReference): RawFxAccount?
     fun fxa_from_credentials(
         config: RawConfig,
-        clientId: String,
-        redirectUri: String,
         webChannelResponse: String,
         e: Error.ByReference
     ): RawFxAccount?
@@ -74,6 +72,7 @@ internal interface FxaClient : Library {
     fun fxa_profile(fxa: RawFxAccount, ignoreCache: Boolean, e: Error.ByReference): Profile.Raw?
 
     fun fxa_get_token_server_endpoint_url(fxa: RawFxAccount, e: Error.ByReference): Pointer?
+    fun fxa_get_connection_success_url(fxa: RawFxAccount, e: Error.ByReference): Pointer?
 
     fun fxa_complete_oauth_flow(fxa: RawFxAccount, code: String, state: String, e: Error.ByReference)
     fun fxa_get_access_token(fxa: RawFxAccount, scope: String, e: Error.ByReference): AccessTokenInfo.Raw?

--- a/fxa-client/sdks/swift/FxAClient/FxAClient/fxa.h
+++ b/fxa-client/sdks/swift/FxAClient/FxAClient/fxa.h
@@ -56,9 +56,11 @@ typedef struct ProfileC {
 typedef struct FirefoxAccount FirefoxAccount;
 typedef struct Config Config;
 
-Config *_Nullable fxa_get_release_config(FxAErrorC *_Nonnull out);
+Config *_Nullable fxa_get_release_config(const char *_Nonnull client_id, const char *_Nonnull redirect_uri, FxAErrorC *_Nonnull out);
 
 Config *_Nullable fxa_get_custom_config(const char *_Nonnull content_base,
+                                        const char *_Nonnull client_id,
+                                        const char *_Nonnull redirect_uri,
                                         FxAErrorC *_Nonnull out);
 
 char *_Nonnull fxa_begin_oauth_flow(FirefoxAccount *_Nonnull fxa,
@@ -89,8 +91,6 @@ void fxa_unregister_persist_callback(FirefoxAccount *_Nonnull fxa,
                                      FxAErrorC *_Nonnull out);
 
 FirefoxAccount *_Nullable fxa_new(Config *_Nonnull config,
-                                  const char *_Nonnull client_id,
-                                  const char *_Nonnull redirect_uri,
                                   FxAErrorC *_Nonnull out);
 
 ProfileC *_Nullable fxa_profile(FirefoxAccount *_Nonnull fxa,
@@ -98,8 +98,6 @@ ProfileC *_Nullable fxa_profile(FirefoxAccount *_Nonnull fxa,
                                 FxAErrorC *_Nonnull out);
 
 FirefoxAccount *_Nullable fxa_from_credentials(Config *_Nonnull config,
-                                               const char *_Nonnull client_id,
-                                               const char *_Nonnull redirect_uri,
                                                const char *_Nonnull json,
                                                FxAErrorC *_Nonnull out);
 
@@ -109,6 +107,9 @@ char *_Nullable fxa_assertion_new(FirefoxAccount *_Nonnull fxa,
 
 char *_Nullable fxa_get_token_server_endpoint_url(FirefoxAccount *_Nonnull fxa,
                                                   FxAErrorC *_Nonnull out);
+
+char *_Nullable fxa_get_connection_success_url(FirefoxAccount *_Nonnull fxa,
+                                               FxAErrorC *_Nonnull out);
 
 SyncKeysC *_Nullable fxa_get_sync_keys(FirefoxAccount *_Nonnull fxa,
                                        FxAErrorC *_Nonnull out);

--- a/fxa-client/src/http_client/mod.rs
+++ b/fxa-client/src/http_client/mod.rs
@@ -182,7 +182,6 @@ impl<'a> Client<'a> {
     #[cfg(feature = "browserid")]
     pub fn oauth_token_with_session_token(
         &self,
-        client_id: &str,
         session_token: &[u8],
         scopes: &[&str],
     ) -> Result<OAuthTokenResponse> {
@@ -192,7 +191,7 @@ impl<'a> Client<'a> {
         let assertion = jwt_utils::create_assertion(&key_pair, &certificate, &audience)?;
         let parameters = json!({
           "assertion": assertion,
-          "client_id": client_id,
+          "client_id": self.config.client_id,
           "response_type": "token",
           "scope": scopes.join(" ")
         });
@@ -208,11 +207,10 @@ impl<'a> Client<'a> {
         &self,
         code: &str,
         code_verifier: &str,
-        client_id: &str,
     ) -> Result<OAuthTokenResponse> {
         let body = json!({
             "code": code,
-            "client_id": client_id,
+            "client_id": self.config.client_id,
             "code_verifier": code_verifier
         });
         self.make_oauth_token_request(body)
@@ -220,13 +218,12 @@ impl<'a> Client<'a> {
 
     pub fn oauth_token_with_refresh_token(
         &self,
-        client_id: &str,
         refresh_token: &str,
         scopes: &[&str],
     ) -> Result<OAuthTokenResponse> {
         let body = json!({
             "grant_type": "refresh_token",
-            "client_id": client_id,
+            "client_id": self.config.client_id,
             "refresh_token": refresh_token,
             "scope": scopes.join(" ")
         });

--- a/fxa-client/src/state_persistence.rs
+++ b/fxa-client/src/state_persistence.rs
@@ -63,8 +63,6 @@ impl From<StateV1> for Result<StateV2> {
                 scopes: HashSet::from_iter(token.scopes.iter().map(|s| s.to_string())),
             });
         Ok(StateV2 {
-            client_id: state.client_id,
-            redirect_uri: state.redirect_uri,
             config: Config::new(
                 state.config.content_url,
                 state.config.auth_url,
@@ -76,6 +74,8 @@ impl From<StateV1> for Result<StateV2> {
                 state.config.jwks_uri,
                 state.config.token_endpoint,
                 state.config.userinfo_endpoint,
+                state.client_id,
+                state.redirect_uri,
             ),
             #[cfg(feature = "browserid")]
             login_state: super::login_sm::LoginState::Unknown,

--- a/logins-sql/examples/sync_pass_sql.rs
+++ b/logins-sql/examples/sync_pass_sql.rs
@@ -68,7 +68,7 @@ fn load_or_create_fxa_creds(path: &str, cfg: Config) -> Result<FirefoxAccount> {
 }
 
 fn create_fxa_creds(path: &str, cfg: Config) -> Result<FirefoxAccount> {
-    let mut acct = FirefoxAccount::new(cfg, CLIENT_ID, REDIRECT_URI);
+    let mut acct = FirefoxAccount::new(cfg);
     let oauth_uri = acct.begin_oauth_flow(&[SYNC_SCOPE], true)?;
 
     if let Err(_) = webbrowser::open(&oauth_uri.as_ref()) {
@@ -352,7 +352,7 @@ fn main() -> Result<()> {
     debug!("Using credential file = {:?}, db = {:?}", cred_file, db_path);
 
     // TODO: allow users to use stage/etc.
-    let cfg = Config::import_from(CONTENT_BASE)?;
+    let cfg = Config::import_from(CONTENT_BASE, CLIENT_ID, REDIRECT_URI)?;
     let tokenserver_url = cfg.token_server_endpoint_url()?;
 
     // TODO: we should probably set a persist callback on acct?

--- a/sandvich/desktop/src/main.rs
+++ b/sandvich/desktop/src/main.rs
@@ -12,8 +12,8 @@ static REDIRECT_URI: &'static str = "https://mozilla.github.io/notes/fxa/android
 static SCOPES: &'static [&'static str] = &["https://identity.mozilla.com/apps/oldsync"];
 
 fn main() {
-    let config = Config::import_from(CONTENT_SERVER).unwrap();
-    let mut fxa = FirefoxAccount::new(config, CLIENT_ID, REDIRECT_URI);
+    let config = Config::import_from(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI).unwrap();
+    let mut fxa = FirefoxAccount::new(config);
     let url = fxa.begin_oauth_flow(&SCOPES, false).unwrap();
     println!("Open the following URL:");
     println!("{}", url);


### PR DESCRIPTION
Connects to https://github.com/mozilla-mobile/android-components/issues/1085
Fixes https://github.com/mozilla/application-services/issues/303

This PR does the following

* Combines remote and local FxA configurations. Adds `client_id` and `redirect_uri` to `Config` struct.
* Updates `FirefoxAccount` to only take a `Config` which can be used to get client_id and redirect_uri
* Updates Kotlin and Swift to use new methods
* Updates migration `StateV2` to use new Config
* Adds helper function `fxa_get_connection_success_url`
* Adds `RemoteConfig` struct that only contains config values from OpenID configuration and well-known configuration