### PR TITLE
Clients instances API

### DIFF
--- a/fxa-client/src/errors.rs
+++ b/fxa-client/src/errors.rs
@@ -79,11 +79,14 @@ pub enum ErrorKind {
     #[fail(display = "No cached token for scope {}", _0)]
     NoCachedToken(String),
 
+    #[fail(display = "No stored refresh token")]
+    NoRefreshToken,
+
     #[fail(display = "Could not find a refresh token in the server response")]
     RefreshTokenNotPresent,
 
-    #[fail(display = "Unrecoverable server error")]
-    UnrecoverableServerError,
+    #[fail(display = "Unrecoverable server error {}", _0)]
+    UnrecoverableServerError(&'static str),
 
     #[fail(display = "Invalid OAuth scope value {}", _0)]
     InvalidOAuthScopeValue(String),

--- a/fxa-client/src/ffi.rs
+++ b/fxa-client/src/ffi.rs
@@ -35,6 +35,7 @@ fn get_code(err: &Error) -> ErrorCode {
     match err.kind() {
         ErrorKind::RemoteError { code: 401, .. }
         | ErrorKind::NotMarried
+        | ErrorKind::NoRefreshToken
         | ErrorKind::NoCachedToken(_) => {
             warn!("Authentication error: {:?}", err);
             ErrorCode::new(error_codes::AUTHENTICATION)

--- a/fxa-client/src/http_client/browser_id/jwt_utils.rs
+++ b/fxa-client/src/http_client/browser_id/jwt_utils.rs
@@ -135,9 +135,9 @@ mod tests {
     ) -> Result<String> {
         let principal = json!({ "email": email });
         let payload = json!({
-        "principal": principal,
-        "public-key": serialized_public_key
-      });
+            "principal": principal,
+            "public-key": serialized_public_key
+        });
         Ok(
             SignedJWTBuilder::new(key_pair, issuer, issued_at, expires_at)
                 .payload(payload)

--- a/fxa-client/src/http_client/browser_id/rsa.rs
+++ b/fxa-client/src/http_client/browser_id/rsa.rs
@@ -67,9 +67,9 @@ impl BrowserIDKeyPair for RSABrowserIDKeyPair {
         let n = format!("{}", rsa.n().to_dec_str()?);
         let e = format!("{}", rsa.e().to_dec_str()?);
         Ok(json!({
-          "algorithm": "RS",
-          "n": n,
-          "e": e
+            "algorithm": "RS",
+            "n": n,
+            "e": e
         }))
     }
 }

--- a/fxa-client/src/scoped_keys.rs
+++ b/fxa-client/src/scoped_keys.rs
@@ -39,11 +39,11 @@ impl ScopedKeysFlow {
         let y = Vec::from(&pub_key[33..]);
         let y = base64::encode_config(&y, base64::URL_SAFE_NO_PAD);
         Ok(json!({
-        "crv": "P-256",
-        "kty": "EC",
-        "x": x,
-        "y": y,
-    })
+            "crv": "P-256",
+            "kty": "EC",
+            "x": x,
+            "y": y,
+        })
         .to_string())
     }
 

--- a/fxa-client/src/scopes.rs
+++ b/fxa-client/src/scopes.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub const PROFILE: &'static str = "profile";
+pub const INSTANCES_READ: &'static str = "clients:read";
+pub const COMMANDS_WRITE: &'static str = "commands:write";

--- a/fxa-client/src/state_persistence.rs
+++ b/fxa-client/src/state_persistence.rs
@@ -133,11 +133,18 @@ mod tests {
         let state = state_from_json(state_v1_json).unwrap();
         assert!(state.refresh_token.is_some());
         let refresh_token = state.refresh_token.unwrap();
-        assert_eq!(refresh_token.token, "bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188");
+        assert_eq!(
+            refresh_token.token,
+            "bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188"
+        );
         assert_eq!(refresh_token.scopes.len(), 3);
         assert!(refresh_token.scopes.contains("profile"));
-        assert!(refresh_token.scopes.contains("https://identity.mozilla.com/apps/oldsync"));
-        assert!(refresh_token.scopes.contains("https://identity.mozilla.com/apps/lockbox"));
+        assert!(refresh_token
+            .scopes
+            .contains("https://identity.mozilla.com/apps/oldsync"));
+        assert!(refresh_token
+            .scopes
+            .contains("https://identity.mozilla.com/apps/lockbox"));
         assert_eq!(state.scoped_keys.len(), 2);
         assert_eq!(state.scoped_keys.get("https://identity.mozilla.com/apps/oldsync").unwrap().to_string(), "{\"k\":\"kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg\",\"kid\":\"1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ\",\"kty\":\"oct\",\"scope\":\"https://identity.mozilla.com/apps/oldsync\"}");
         assert_eq!(state.scoped_keys.get("https://identity.mozilla.com/apps/lockbox").unwrap().to_string(), "{\"k\":\"Qk4K4xF2PgQ6XvBXW8X7B7AWwWgW2bHQov9NHNd4v-k\",\"kid\":\"1231014287-KDVj0DFaO3wGpPJD8oPwVg\",\"kty\":\"oct\",\"scope\":\"https://identity.mozilla.com/apps/lockbox\"}");

--- a/fxa-client/src/util.rs
+++ b/fxa-client/src/util.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use errors::*;
+use ring::rand::SecureRandom;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // Gets the unix epoch in ms.
@@ -18,6 +19,12 @@ pub fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .expect("Something is very wrong.");
     since_epoch.as_secs()
+}
+
+pub fn random_base64_url_string(rng: &SecureRandom, len: usize) -> Result<String> {
+    let mut out = vec![0u8; len];
+    rng.fill(&mut out).map_err(|_| ErrorKind::RngFailure)?;
+    Ok(base64::encode_config(&out, base64::URL_SAFE_NO_PAD))
 }
 
 pub trait Xorable {


### PR DESCRIPTION
This basically extracts the low level clients instances API changes from https://github.com/mozilla/application-services/pull/391 and make them pretty and ready for prime time so we can build a proper send tab module on top of of it.

Fixes https://github.com/mozilla/application-services/issues/125