### PR TITLE
Add a feature (default on) to ffi-support for logging backtraces in panics and errors

### DIFF
--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -3,7 +3,16 @@ name = "ffi-support"
 version = "0.1.0"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 
+[features]
+default = ["log_backtraces"]
+log_backtraces = ["backtrace"]
+
 [dependencies]
 serde_json = "1.0.32"
 serde = "1.0.79"
 log = "0.4.5"
+
+[dependencies.backtrace]
+optional = true
+version = "0.3.9"
+


### PR DESCRIPTION
This logs the backtrace, as well as file/line info (in case the lib was stripped, which they always seem to be on device...).