### PR TITLE
Expose history sync over the ffi

### DIFF
--- a/components/places/android/library/src/main/java/org/mozilla/places/LibPlacesFFI.kt
+++ b/components/places/android/library/src/main/java/org/mozilla/places/LibPlacesFFI.kt
@@ -75,6 +75,15 @@ internal interface LibPlacesFFI : Library {
             out_err: RustError.ByReference
     ): Pointer?
 
+    fun sync15_history_sync(
+            conn: RawPlacesConnection,
+            key_id: String,
+            access_token: String,
+            sync_key: String,
+            tokenserver_url: String,
+            out_err: RustError.ByReference
+    )
+
     /** Destroy strings returned from libplaces_ffi calls. */
     fun places_destroy_string(s: Pointer)
 


### PR DESCRIPTION
This exposes sync over the ffi. It is based on the history-sync branch, so depends on #389 

It adds a new SyncAuthInfo, which is identical (except for the name) as SyncUnlockInfo - we'll need to integrate these if we ever want a multi-engine sync - a components/shared/sync crate might be helpful, but it's not clear it's worth doing now just for this.