### PR TITLE
More complete origins support for places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@
 ### What's fixed
 
 - Locally deleted visits deleted using `deleteVisitsSince` should not be resurrected on future syncs. ([#621](https://github.com/mozilla/application-services/issues/621))
+- Places now properly updates frecency for origins, and generally supports
+  origins in a way more in line with how they're implemented on desktop. ([#429](https://github.com/mozilla/application-services/pull/429))
 
 # 0.16.1 (_2019-02-08_)
 

--- a/components/places/sql/create_temp_tables.sql
+++ b/components/places/sql/create_temp_tables.sql
@@ -1,0 +1,46 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+-- This table is used, along with moz_places_afterinsert_trigger, to update
+-- origins after places removals. During an INSERT into moz_places, origins are
+-- accumulated in this table, then a DELETE FROM moz_updateoriginsinsert_temp
+-- will take care of updating the moz_origins table for every new origin. See
+-- CREATE_PLACES_AFTERINSERT_TRIGGER_ORIGINS below for details.
+CREATE TEMP TABLE moz_updateoriginsinsert_temp (
+    place_id INTEGER PRIMARY KEY,
+    prefix TEXT NOT NULL,
+    host TEXT NOT NULL,
+    rev_host TEXT NOT NULL,
+    frecency INTEGER NOT NULL
+);
+
+
+
+-- This table is used (along with moz_updateoriginsupdate_temp) in a similar way
+-- to moz_updateoriginsinsert_temp, but for deletes, and triggered via
+-- moz_places_afterdelete_trigger.
+--
+-- When rows are added to this table, moz_places.origin_id may be null.  That's
+-- why this table uses prefix + host as its primary key, not origin_id.
+CREATE TEMP TABLE moz_updateoriginsdelete_temp (
+    prefix TEXT NOT NULL,
+    host TEXT NOT NULL,
+    frecency_delta INTEGER NOT NULL,
+    PRIMARY KEY (prefix, host)
+) WITHOUT ROWID;
+
+-- This table is used (along with moz_updateoriginsdelete_temp) in a similar way
+-- to moz_updateoriginsinsert_temp, but for updates to places' frecencies, and
+-- triggered via moz_places_afterupdate_frecency_trigger.
+--
+-- When rows are added to this table, moz_places.origin_id may be null.  That's
+-- why this table uses prefix + host as its primary key, not origin_id.
+CREATE TEMP TABLE moz_updateoriginsupdate_temp (
+    prefix TEXT NOT NULL,
+    host TEXT NOT NULL,
+    frecency_delta INTEGER NOT NULL,
+    PRIMARY KEY (prefix, host)
+) WITHOUT ROWID;
+

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -16,12 +16,51 @@ use sql_support::ConnExt;
 const VERSION: i64 = 5;
 
 const CREATE_SCHEMA_SQL: &str = include_str!("../../sql/create_schema.sql");
-const CREATE_TRIGGERS_SQL: &str = include_str!("../../sql/create_triggers.sql");
+const CREATE_TEMP_TABLES_SQL: &str = include_str!("../../sql/create_temp_tables.sql");
+
+lazy_static::lazy_static! {
+    static ref CREATE_TRIGGERS_SQL: String = {
+        format!(
+            include_str!("../../sql/create_triggers.sql"),
+            increase_frecency_stats = update_origin_frecency_stats("+"),
+            decrease_frecency_stats = update_origin_frecency_stats("-"),
+        )
+    };
+}
 
 // Keys in the moz_meta table.
-// pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_COUNT: &'static str = "origin_frecency_count";
-// pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM: &'static str = "origin_frecency_sum";
-// pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM_OF_SQUARES: &'static str = "origin_frecency_sum_of_squares";
+pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_COUNT: &'static str = "origin_frecency_count";
+pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM: &'static str = "origin_frecency_sum";
+pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM_OF_SQUARES: &'static str =
+    "origin_frecency_sum_of_squares";
+
+fn update_origin_frecency_stats(op: &str) -> String {
+    format!(
+        "
+        INSERT OR REPLACE INTO moz_meta(key, value)
+        SELECT
+            '{frecency_count}',
+            IFNULL((SELECT value FROM moz_meta WHERE key = '{frecency_count}'), 0)
+                {op} CAST (frecency > 0 AS INT)
+        FROM moz_origins WHERE prefix = OLD.prefix AND host = OLD.host
+        UNION
+        SELECT
+            '{frecency_sum}',
+            IFNULL((SELECT value FROM moz_meta WHERE key = '{frecency_sum}'), 0)
+                {op} MAX(frecency, 0)
+        FROM moz_origins WHERE prefix = OLD.prefix AND host = OLD.host
+        UNION
+        SELECT
+            '{frecency_sum_of_squares}',
+            IFNULL((SELECT value FROM moz_meta WHERE key = '{frecency_sum_of_squares}'), 0)
+                {op} (MAX(frecency, 0) * MAX(frecency, 0))
+        FROM moz_origins WHERE prefix = OLD.prefix AND host = OLD.host",
+        op = op,
+        frecency_count = MOZ_META_KEY_ORIGIN_FRECENCY_COUNT,
+        frecency_sum = MOZ_META_KEY_ORIGIN_FRECENCY_SUM,
+        frecency_sum_of_squares = MOZ_META_KEY_ORIGIN_FRECENCY_SUM_OF_SQUARES,
+    )
+}
 
 fn get_current_schema_version(db: &PlacesDb) -> Result<i64> {
     Ok(db.query_one::<i64>("PRAGMA user_version")?)
@@ -46,7 +85,8 @@ pub fn init(db: &PlacesDb) -> Result<()> {
     // Note that later we will not create these on the connection used for
     // sync, nor on read-only connections.
     log::debug!("Creating temp tables and triggers");
-    db.execute_batch(CREATE_TRIGGERS_SQL)?;
+    db.execute_batch(CREATE_TEMP_TABLES_SQL)?;
+    db.execute_batch(&CREATE_TRIGGERS_SQL)?;
     Ok(())
 }
 

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -8,7 +8,7 @@ use crate::api::history::can_add_url;
 use crate::error::*;
 use crate::storage::history::history_sync::{
     apply_synced_deletion, apply_synced_reconciliation, apply_synced_visits, fetch_outgoing,
-    fetch_visits, finish_outgoing, FetchedVisit, FetchedVisitPage, OutgoingInfo,
+    fetch_visits, finish_incoming, finish_outgoing, FetchedVisit, FetchedVisitPage, OutgoingInfo,
 };
 use crate::types::{SyncGuid, Timestamp, VisitTransition};
 use crate::valid_guid::is_valid_places_guid;
@@ -247,6 +247,7 @@ pub fn apply_plan(
             }
         };
     }
+    finish_incoming(&conn)?;
     tx.commit()?;
     // It might make sense for fetch_outgoing to manage its own
     // time_chunked_transaction - even though doesn't seem a large bottleneck

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -210,6 +210,7 @@ impl InsertableItem {
 pub fn insert_bookmark(db: &impl ConnExt, bm: &InsertableItem) -> Result<SyncGuid> {
     let tx = db.unchecked_transaction()?;
     let result = insert_bookmark_in_tx(db, bm);
+    super::delete_pending_temp_tables(db.conn())?;
     match result {
         Ok(_) => tx.commit()?,
         Err(_) => tx.rollback()?,
@@ -349,6 +350,7 @@ fn delete_bookmark_in_tx(db: &impl ConnExt, guid: &SyncGuid) -> Result<bool> {
         "DELETE from moz_bookmarks WHERE id = :id",
         &[(":id", &record.row_id)],
     )?;
+    super::delete_pending_temp_tables(db.conn())?;
     Ok(true)
 }
 
@@ -716,6 +718,7 @@ pub fn insert_tree(db: &impl ConnExt, tree: &FolderNode) -> Result<()> {
     for insertable in insert_infos {
         insert_bookmark_in_tx(db, &insertable)?;
     }
+    super::delete_pending_temp_tables(db.conn())?;
     tx.commit()?;
     Ok(())
 }

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -203,3 +203,13 @@ pub(crate) fn get_meta<T: FromSql>(db: &Connection, key: &str) -> Result<Option<
     )?;
     Ok(res)
 }
+
+/// Delete all items in the temp tables we use for staging changes.
+pub(crate) fn delete_pending_temp_tables(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "DELETE FROM moz_updateoriginsupdate_temp;
+         DELETE FROM moz_updateoriginsdelete_temp;
+         DELETE FROM moz_updateoriginsinsert_temp;",
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
This is still slightly WIP, but at this point the main missing things are tests and ensuring that the `feature` sets run as expected (If they're not, this will probably fail CI -- locally it passes so long as i turn off the sqlcipher feature). It's mostly done.

We can't really land until sqlcipher updates itself, unless we decide not to support encrypted places databases.

Connects to #318.