### PR TITLE
Set consumer Proguard rules.

### DIFF
--- a/components/places/android/library/build.gradle
+++ b/components/places/android/library/build.gradle
@@ -17,6 +17,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
         }
 
         withoutLib {

--- a/composites/lockbox/android/library/build.gradle
+++ b/composites/lockbox/android/library/build.gradle
@@ -17,6 +17,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
         }
     }
 

--- a/composites/reference-browser/android/library/build.gradle
+++ b/composites/reference-browser/android/library/build.gradle
@@ -17,6 +17,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
         }
     }
 

--- a/fxa-client/sdks/android/library/build.gradle
+++ b/fxa-client/sdks/android/library/build.gradle
@@ -17,6 +17,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
         }
 
         withoutLib {

--- a/logins-api/android/library/build.gradle
+++ b/logins-api/android/library/build.gradle
@@ -17,6 +17,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
         }
 
         withoutLib {

--- a/proguard-rules-consumer-jna.pro
+++ b/proguard-rules-consumer-jna.pro
@@ -1,0 +1,7 @@
+# ProGuard rules for consumers of this library.
+
+# JNA specific rules
+# See https://github.com/java-native-access/jna/blob/master/www/FrequentlyAskedQuestions.md#jna-on-android
+-dontwarn java.awt.*
+-keep class com.sun.jna.* { *; }
+-keepclassmembers class * extends com.sun.jna.* { public *; }


### PR DESCRIPTION
This is a counterpart to https://github.com/mozilla-mobile/android-components/pull/1496, and will need to land before that PR does.