### PR TITLE
Expose SQLITE_BUSY errors to kotlin in places

### DIFF
--- a/components/places/android/library/src/main/java/org/mozilla/places/PlacesConnection.kt
+++ b/components/places/android/library/src/main/java/org/mozilla/places/PlacesConnection.kt
@@ -180,6 +180,7 @@ open class PlacesException(msg: String): Exception(msg)
 open class InternalPanic(msg: String): PlacesException(msg)
 open class UrlParseFailed(msg: String): PlacesException(msg)
 open class InvalidPlaceInfo(msg: String): PlacesException(msg)
+open class PlacesConnectionBusy(msg: String): PlacesException(msg)
 
 @SuppressWarnings("MagicNumber")
 enum class VisitType(val type: Int) {

--- a/components/places/android/library/src/main/java/org/mozilla/places/RustError.kt
+++ b/components/places/android/library/src/main/java/org/mozilla/places/RustError.kt
@@ -48,9 +48,12 @@ open class RustError : Structure() {
         }
         val message = this.consumeErrorMessage();
         when (code) {
-            1 -> return InvalidPlaceInfo(message)
-            2 -> return UrlParseFailed(message)
+            2 -> return InvalidPlaceInfo(message)
+            3 -> return UrlParseFailed(message)
+            4 -> return PlacesConnectionBusy(message)
             -1 -> return InternalPanic(message)
+            // Note: `1` is used as a generic catch all, but we
+            // might as well handle the others the same way.
             else -> return PlacesException(message)
         }
     }


### PR DESCRIPTION
Per request from a-c, to help with #394.

This also fixes a bug where some of the errors weren't properly translated to kotlin.