### PR TITLE
Closes #437: Temporarily patch around migration panics

### DIFF
--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -249,7 +249,8 @@ fn upgrade(_db: &PlacesDb, from: i64) -> Result<()> {
     if from == VERSION {
         return Ok(());
     }
-    // hrmph - do something here?
+    // FIXME https://github.com/mozilla/application-services/issues/438
+    // NB: PlacesConnection.kt checks for this error message verbatim as a workaround.
     panic!("sorry, no upgrades yet - delete your db!");
 }
 


### PR DESCRIPTION
This is a temporary fix, please remove as soon as feasible via https://github.com/mozilla/application-services/issues/438.