### PR TITLE
Rust 2018 simplifications

### DIFF
--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -12,7 +12,7 @@ sync15-adapter = { path = "../../sync15-adapter" }
 serde = "1.0.75"
 serde_derive = "1.0.75"
 serde_json = "1.0.26"
-log = "0.4.4"
+log = "0.4"
 lazy_static = "1.1.0"
 url = "1.7.1"
 failure = "0.1.3"

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
 serde_json = "1.0.28"
-log = "0.4.5"
+log = "0.4"
 url = "1.7.1"
 ffi-support = { path = "../../support/ffi" }
 

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -19,7 +19,7 @@ log_backtraces = ["backtrace"]
 [dependencies]
 serde_json = "1.0.32"
 serde = "1.0.79"
-log = "0.4.5"
+log = "0.4"
 
 [dependencies.backtrace]
 optional = true

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -8,7 +8,7 @@ default = ["sqlcipher"]
 sqlcipher = ["rusqlite/sqlcipher"]
 
 [dependencies]
-log = "0.4.5"
+log = "0.4"
 lazy_static = "1.1.0"
 
 [dependencies.rusqlite]

--- a/fxa-client/Cargo.toml
+++ b/fxa-client/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "fxa-client"
+edition = "2018"
 version = "0.1.0"
 authors = ["Edouard Oger <eoger@fastmail.com>"]
 
@@ -10,7 +11,7 @@ failure = "0.1.3"
 hawk = { version = "1.0.4", optional = true }
 hex = "0.3.2"
 lazy_static = "1.0.0"
-log = "0.4.5"
+log = "0.4"
 openssl = { version = "0.10.12", optional = true }
 regex = "1.0.0"
 reqwest = "0.9.1"

--- a/fxa-client/ffi/Cargo.toml
+++ b/fxa-client/ffi/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "fxaclient_ffi"
+edition = "2018"
 version = "0.1.0"
 authors = ["Edouard Oger <eoger@fastmail.com>"]
 

--- a/fxa-client/ffi/src/lib.rs
+++ b/fxa-client/ffi/src/lib.rs
@@ -4,16 +4,12 @@
 
 extern crate fxa_client;
 
-#[macro_use]
-extern crate ffi_support;
-
-use std::ffi::CString;
-use std::os::raw::c_char;
-
-use ffi_support::{call_with_output, call_with_result, rust_str_from_c, ExternError};
-
-use fxa_client::ffi::*;
-use fxa_client::{FirefoxAccount, PersistCallback};
+use ffi_support::{
+    call_with_output, call_with_result, define_box_destructor, define_string_destructor,
+    rust_str_from_c, ExternError,
+};
+use fxa_client::{ffi::*, FirefoxAccount, PersistCallback};
+use std::{ffi::CString, os::raw::c_char};
 
 /// Creates a [FirefoxAccount] from credentials obtained with the onepw FxA login flow.
 ///

--- a/fxa-client/src/config.rs
+++ b/fxa-client/src/config.rs
@@ -2,8 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::errors::*;
-use reqwest;
+use crate::errors::*;
+use serde_derive::*;
 use std::{cell::RefCell, sync::Arc};
 use url::Url;
 

--- a/fxa-client/src/errors.rs
+++ b/fxa-client/src/errors.rs
@@ -2,20 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::boxed::Box;
-use std::{fmt, result, string};
-
-use base64;
 #[cfg(feature = "browserid")]
 use failure::SyncFailure;
 use failure::{Backtrace, Context, Fail};
-#[cfg(feature = "browserid")]
-use hawk;
-use hex;
-#[cfg(feature = "browserid")]
-use openssl;
-use reqwest;
-use serde_json;
+use std::{boxed::Box, fmt, result, string};
 
 pub type Result<T> = result::Result<T, Error>;
 

--- a/fxa-client/src/ffi.rs
+++ b/fxa-client/src/ffi.rs
@@ -14,12 +14,13 @@
 
 #![cfg(feature = "ffi")]
 
+use crate::{AccessTokenInfo, Error, ErrorKind, FirefoxAccount, Profile, SyncKeys};
 use ffi_support::{
-    destroy_c_string, opt_rust_string_to_c, rust_string_to_c, ErrorCode, ExternError, IntoFfi,
+    destroy_c_string, implement_into_ffi_by_pointer, opt_rust_string_to_c, rust_string_to_c,
+    ErrorCode, ExternError, IntoFfi,
 };
-use serde_json;
+use log::*;
 use std::os::raw::c_char;
-use {AccessTokenInfo, Error, ErrorKind, FirefoxAccount, Profile, SyncKeys};
 
 pub mod error_codes {
     // Note: -1 and 0 (panic and success) codes are reserved by the ffi-support library

--- a/fxa-client/src/http_client/browser_id/jwt_utils.rs
+++ b/fxa-client/src/http_client/browser_id/jwt_utils.rs
@@ -2,13 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::{errors::*, http_client::browser_id::BrowserIDKeyPair};
+use serde_json::{self, json};
 use std::time::{SystemTime, UNIX_EPOCH};
-
-use base64;
-use errors::*;
-use serde_json;
-
-use http_client::browser_id::BrowserIDKeyPair;
 
 const DEFAULT_ASSERTION_ISSUER: &str = "127.0.0.1";
 const DEFAULT_ASSERTION_DURATION: u64 = 60 * 60 * 1000;
@@ -122,8 +118,8 @@ fn encode_and_sign(payload: &str, key_pair: &BrowserIDKeyPair) -> Result<String>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http_client::browser_id::rsa::RSABrowserIDKeyPair;
-    use http_client::browser_id::BrowserIDKeyPair;
+    use crate::http_client::browser_id::rsa::RSABrowserIDKeyPair;
+    use crate::http_client::browser_id::BrowserIDKeyPair;
 
     pub fn create_certificate(
         serialized_public_key: &serde_json::Value,
@@ -135,9 +131,9 @@ mod tests {
     ) -> Result<String> {
         let principal = json!({ "email": email });
         let payload = json!({
-        "principal": principal,
-        "public-key": serialized_public_key
-      });
+          "principal": principal,
+          "public-key": serialized_public_key
+        });
         Ok(
             SignedJWTBuilder::new(key_pair, issuer, issued_at, expires_at)
                 .payload(payload)

--- a/fxa-client/src/http_client/browser_id/mod.rs
+++ b/fxa-client/src/http_client/browser_id/mod.rs
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use serde_json;
-
-use errors::*;
-
+use crate::errors::*;
 pub mod jwt_utils;
 pub mod rsa;
 

--- a/fxa-client/src/http_client/browser_id/rsa.rs
+++ b/fxa-client/src/http_client/browser_id/rsa.rs
@@ -2,21 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std;
-use std::fmt;
-
-use openssl::bn::BigNum;
-use openssl::hash::MessageDigest;
-use openssl::pkey::{PKey, Private};
-use openssl::rsa::{Rsa, RsaPrivateKeyBuilder};
-use openssl::sign::{Signer, Verifier};
-use serde::de::{self, Deserialize, Deserializer, MapAccess, Visitor};
-use serde::ser;
-use serde::ser::{Serialize, SerializeStruct, Serializer};
-use serde_json;
-
 use super::BrowserIDKeyPair;
-use errors::*;
+use crate::errors::*;
+use openssl::{
+    bn::BigNum,
+    hash::MessageDigest,
+    pkey::{PKey, Private},
+    rsa::{Rsa, RsaPrivateKeyBuilder},
+    sign::{Signer, Verifier},
+};
+use serde::{
+    de::{self, Deserialize, Deserializer, MapAccess, Visitor},
+    ser::{self, Serialize, SerializeStruct, Serializer},
+};
+use serde_json::{self, json};
+use std::fmt;
 
 pub struct RSABrowserIDKeyPair {
     key: PKey<Private>,

--- a/fxa-client/src/http_client/hawk_request.rs
+++ b/fxa-client/src/http_client/hawk_request.rs
@@ -2,16 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::errors::*;
 use hawk::{Credentials, Key, PayloadHasher, RequestBuilder, SHA256};
-use hex;
 use reqwest::{
     header::{self, HeaderValue},
     Client, Method, Request,
 };
-use serde_json;
 use url::Url;
-
-use errors::*;
 
 const KEY_LENGTH: usize = 32;
 
@@ -39,37 +36,35 @@ impl<'a> HAWKRequestBuilder<'a> {
         self
     }
 
-    pub fn build(self) -> Result<Request> {
-        let hawk_header;
-        {
-            // Make sure we de-allocate the hash after hawk_request_builder.
-            let hash;
-            let method = format!("{}", self.method);
-            let mut hawk_request_builder = RequestBuilder::from_url(method.as_str(), &self.url)?;
-            if let Some(ref body) = self.body {
-                hash = PayloadHasher::hash("application/json", &SHA256, &body);
-                hawk_request_builder = hawk_request_builder.hash(&hash[..]);
-            }
-            let hawk_request = hawk_request_builder.request();
-            let token_id = hex::encode(&self.hkdf_sha256_key[0..KEY_LENGTH]);
-            let hmac_key = &self.hkdf_sha256_key[KEY_LENGTH..(2 * KEY_LENGTH)];
-            let hawk_credentials = Credentials {
-                id: token_id,
-                key: Key::new(hmac_key, &SHA256),
-            };
-            let header = hawk_request.make_header(&hawk_credentials)?;
-            hawk_header = format!("Hawk {}", header);
+    fn make_hawk_header(&self) -> Result<HeaderValue> {
+        // Make sure we de-allocate the hash after hawk_request_builder.
+        let hash;
+        let method = format!("{}", self.method);
+        let mut hawk_request_builder = RequestBuilder::from_url(method.as_str(), &self.url)?;
+        if let Some(ref body) = self.body {
+            hash = PayloadHasher::hash("application/json", &SHA256, &body);
+            hawk_request_builder = hawk_request_builder.hash(&hash[..]);
         }
+        let hawk_request = hawk_request_builder.request();
+        let token_id = hex::encode(&self.hkdf_sha256_key[0..KEY_LENGTH]);
+        let hmac_key = &self.hkdf_sha256_key[KEY_LENGTH..(2 * KEY_LENGTH)];
+        let hawk_credentials = Credentials {
+            id: token_id,
+            key: Key::new(hmac_key, &SHA256),
+        };
+        let header = hawk_request.make_header(&hawk_credentials)?;
+        Ok(HeaderValue::from_str(&format!("Hawk {}", header))?)
+    }
 
-        let mut request_builder = Client::new().request(self.method, self.url);
-        request_builder =
-            request_builder.header(header::AUTHORIZATION, HeaderValue::from_str(&hawk_header)?);
-
+    pub fn build(self) -> Result<Request> {
+        let hawk_header = self.make_hawk_header()?;
+        let mut request_builder = Client::new()
+            .request(self.method, self.url)
+            .header(header::AUTHORIZATION, hawk_header);
         if let Some(body) = self.body {
             request_builder = request_builder.header(header::CONTENT_TYPE, "application/json");
             request_builder = request_builder.body(body);
         }
-
-        request_builder.build().map_err(|e| e.into())
+        Ok(request_builder.build()?)
     }
 }

--- a/fxa-client/src/http_client/mod.rs
+++ b/fxa-client/src/http_client/mod.rs
@@ -2,25 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::{config::Config, errors::*};
+use reqwest::{self, header, Client as ReqwestClient, Method, Request, Response, StatusCode};
+use serde_derive::*;
+use serde_json::json;
 #[cfg(feature = "browserid")]
-use hex;
-use reqwest;
-use reqwest::{header, Client as ReqwestClient, Method, Request, Response, StatusCode};
-#[cfg(feature = "browserid")]
-use ring::{digest, hkdf, hmac};
-use serde_json;
-use std;
-#[cfg(feature = "browserid")]
-use util::Xorable;
-
-#[cfg(feature = "browserid")]
-use self::browser_id::rsa::RSABrowserIDKeyPair;
-#[cfg(feature = "browserid")]
-use self::browser_id::{jwt_utils, BrowserIDKeyPair};
-#[cfg(feature = "browserid")]
-use self::hawk_request::HAWKRequestBuilder;
-use config::Config;
-use errors::*;
+use {
+    self::{
+        browser_id::{jwt_utils, rsa::RSABrowserIDKeyPair, BrowserIDKeyPair},
+        hawk_request::HAWKRequestBuilder,
+    },
+    crate::util::Xorable,
+    ring::{digest, hkdf, hmac},
+};
 
 #[cfg(feature = "browserid")]
 pub mod browser_id;

--- a/fxa-client/src/scoped_keys.rs
+++ b/fxa-client/src/scoped_keys.rs
@@ -1,11 +1,11 @@
-use errors::*;
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use base64;
+use crate::errors::*;
 use byteorder::{BigEndian, ByteOrder};
-use ring::agreement::EphemeralPrivateKey;
-use ring::rand::SecureRandom;
-use ring::{aead, agreement, digest};
-use serde_json;
+use ring::{aead, agreement, agreement::EphemeralPrivateKey, digest, rand::SecureRandom};
+use serde_json::{self, json};
 use untrusted::Input;
 
 pub struct ScopedKeysFlow {
@@ -39,11 +39,11 @@ impl ScopedKeysFlow {
         let y = Vec::from(&pub_key[33..]);
         let y = base64::encode_config(&y, base64::URL_SAFE_NO_PAD);
         Ok(json!({
-        "crv": "P-256",
-        "kty": "EC",
-        "x": x,
-        "y": y,
-    })
+            "crv": "P-256",
+            "kty": "EC",
+            "x": x,
+            "y": y,
+        })
         .to_string())
     }
 

--- a/fxa-client/src/state_persistence.rs
+++ b/fxa-client/src/state_persistence.rs
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use config::Config;
-use errors::*;
-use serde_json;
-use std::collections::HashMap;
-use std::collections::HashSet;
-use std::iter::FromIterator;
-use {RefreshToken, ScopedKey, StateV2};
+use crate::{config::Config, errors::*, RefreshToken, ScopedKey, StateV2};
+use serde_derive::*;
+use std::{
+    collections::{HashMap, HashSet},
+    iter::FromIterator,
+};
 type State = StateV2;
 
 pub(crate) fn state_from_json(data: &str) -> Result<State> {
@@ -133,21 +132,40 @@ mod tests {
         let state = state_from_json(state_v1_json).unwrap();
         assert!(state.refresh_token.is_some());
         let refresh_token = state.refresh_token.unwrap();
-        assert_eq!(refresh_token.token, "bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188");
+        assert_eq!(
+            refresh_token.token,
+            "bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188"
+        );
         assert_eq!(refresh_token.scopes.len(), 3);
         assert!(refresh_token.scopes.contains("profile"));
-        assert!(refresh_token.scopes.contains("https://identity.mozilla.com/apps/oldsync"));
-        assert!(refresh_token.scopes.contains("https://identity.mozilla.com/apps/lockbox"));
+        assert!(refresh_token
+            .scopes
+            .contains("https://identity.mozilla.com/apps/oldsync"));
+        assert!(refresh_token
+            .scopes
+            .contains("https://identity.mozilla.com/apps/lockbox"));
         assert_eq!(state.scoped_keys.len(), 2);
-        let oldsync_key = state.scoped_keys.get("https://identity.mozilla.com/apps/oldsync").unwrap();
+        let oldsync_key = state
+            .scoped_keys
+            .get("https://identity.mozilla.com/apps/oldsync")
+            .unwrap();
         assert_eq!(oldsync_key.kid, "1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ");
         assert_eq!(oldsync_key.k, "kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg");
         assert_eq!(oldsync_key.kty, "oct");
-        assert_eq!(oldsync_key.scope, "https://identity.mozilla.com/apps/oldsync");
-        let lockbox_key = state.scoped_keys.get("https://identity.mozilla.com/apps/lockbox").unwrap();
+        assert_eq!(
+            oldsync_key.scope,
+            "https://identity.mozilla.com/apps/oldsync"
+        );
+        let lockbox_key = state
+            .scoped_keys
+            .get("https://identity.mozilla.com/apps/lockbox")
+            .unwrap();
         assert_eq!(lockbox_key.kid, "1231014287-KDVj0DFaO3wGpPJD8oPwVg");
         assert_eq!(lockbox_key.k, "Qk4K4xF2PgQ6XvBXW8X7B7AWwWgW2bHQov9NHNd4v-k");
         assert_eq!(lockbox_key.kty, "oct");
-        assert_eq!(lockbox_key.scope, "https://identity.mozilla.com/apps/lockbox");
+        assert_eq!(
+            lockbox_key.scope,
+            "https://identity.mozilla.com/apps/lockbox"
+        );
     }
 }

--- a/fxa-client/src/util.rs
+++ b/fxa-client/src/util.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use errors::*;
+use crate::errors::*;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // Gets the unix epoch in ms.

--- a/logins-sql/Cargo.toml
+++ b/logins-sql/Cargo.toml
@@ -12,7 +12,7 @@ sync15-adapter = { path = "../sync15-adapter" }
 serde = "1.0.79"
 serde_derive = "1.0.79"
 serde_json = "1.0.28"
-log = "0.4.5"
+log = "0.4"
 lazy_static = "1.1.0"
 url = "1.7.1"
 failure = "0.1.3"

--- a/logins-sql/ffi/Cargo.toml
+++ b/logins-sql/ffi/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
 serde_json = "1.0.28"
-log = "0.4.5"
+log = "0.4"
 url = "1.7.1"
 
 [dependencies.rusqlite]

--- a/sync15-adapter/Cargo.toml
+++ b/sync15-adapter/Cargo.toml
@@ -13,7 +13,7 @@ reqwest = "0.9.1"
 openssl = "0.10.12"
 hawk = { git = "https://github.com/eoger/rust-hawk", branch = "use-openssl" }
 hyper = "0.12.10"
-log = "0.4.5"
+log = "0.4"
 lazy_static = "1.0"
 base16 = "0.1.1"
 failure = "0.1.3"


### PR DESCRIPTION
Let's migrate at least fxa-client to get a taste of the new Rust 2018 world, then later the other sync crates.