### PR TITLE
Run Rust tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,84 @@
-version: 2
+version: 2.1
+
+commands:
+  build-libs:
+    steps:
+      - restore_cache:
+          name: Restore libs cache
+          keys:
+            - libs-cache-v2-{{ arch }}-{{ checksum "libs/build-all.sh" }}-{{ checksum "libs/build-openssl-desktop.sh" }}-{{ checksum "libs/build-sqlcipher-desktop.sh" }}
+      - run:
+          name: Build libs
+          command: |
+            sudo apt-get install tcl
+            pushd libs && ./build-all.sh desktop && popd
+            echo 'export OPENSSL_DIR=$(pwd)/libs/desktop/linux-x86-64/openssl' >> $BASH_ENV
+            echo 'export SQLCIPHER_LIB_DIR=$(pwd)/libs/desktop/linux-x86-64/sqlcipher/lib' >> $BASH_ENV
+            echo 'export SQLCIPHER_INCLUDE_DIR=$(pwd)/libs/desktop/linux-x86-64/sqlcipher/include' >> $BASH_ENV
+      - save_cache:
+          name: Save libs cache
+          key: libs-cache-v2-{{ arch }}-{{ checksum "libs/build-all.sh" }}-{{ checksum "libs/build-openssl-desktop.sh" }}-{{ checksum "libs/build-sqlcipher-desktop.sh" }}
+          paths:
+            - libs/desktop
+  rust-tests:
+    parameters:
+      rust-version:
+        type: string
+        default: "stable"
+    steps:
+      - checkout
+      - build-libs
+      - run:
+          name: Rust setup
+          command: |
+            rustup install <<parameters.rust-version>>
+            rustup default <<parameters.rust-version>>
+            rustc --version
+      # Test with 1. only default features on, 2. all features on, 3. no features on.
+      # This is not perfect (really we want the cartesian product), but is good enough in practice.
+      - run:
+          name: Test
+          command: cargo test --all --verbose
+      - run:
+          name: Test (all features)
+          command: cargo test --all --all-features --verbose
+      - run:
+          name: Test (no default features)
+          command: cargo test --all --no-default-features --verbose
+
 jobs:
-  rustfmt:
+  Check Rust formatting:
     docker:
       - image: circleci/rust:latest
     steps:
       - checkout
       - run: rustup component add rustfmt
       - run: cargo fmt -- --check
+  Rust tests - stable:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - rust-tests
+  Rust tests - beta:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - rust-tests:
+          rust-version: "beta"
+  Rust tests - nightly:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - rust-tests:
+          rust-version: "nightly"
+
 workflows:
   version: 2
-  check_formating:
+  check-formating:
     jobs:
-      - rustfmt
+      - Check Rust formatting
+  run-tests:
+    jobs:
+      - Rust tests - stable
+      - Rust tests - beta
+      - Rust tests - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,3 @@
-language: rust
-# We use OSX so that we can get a reasonably up to date version of SQLCipher.
-# (The version in Travis's default Ubuntu Trusty is much too old).
-os: osx
-osx_image:
-  - xcode10.1
-rust:
-  - stable
-  - beta
-  - nightly
-cache: cargo
-matrix:
-  allow_failures:
-    - rust: nightly
-  fast_finish: true
 env:
   global:
     - FRAMEWORK_NAME=ApplicationServices.framework.zip
@@ -25,19 +10,18 @@ before_deploy:
   - carthage build --no-skip-current --verbose
   - carthage archive --output $FRAMEWORK_NAME
   - rm -rf Carthage
-script:
-  # Test with 1. only default features on, 2. all features on, 3. no features on.
-  # This is not perfect (really we want the cartesian product), but is good enough in practice.
-  - cargo test --all --verbose
-  - cargo test --all --all-features --verbose
-  - cargo test --all --no-default-features --verbose
 
 jobs:
   include:
     - stage: Carthage framework GitHub Release
       if: tag IS present
+      language: rust
       rust: stable
+      # We use OSX so that we can get a reasonably up to date version of SQLCipher.
+      # (The version in Travis's default Ubuntu Trusty is much too old).
+      os: osx
       osx_image: xcode10.1
+      if: tag IS present
       script: skip # Do not re-run tests
       deploy:
         provider: releases

--- a/libs/build-openssl-desktop.sh
+++ b/libs/build-openssl-desktop.sh
@@ -9,9 +9,9 @@ export -f abspath
 
 if [ "$#" -lt 1 -o "$#" -gt 2 ]
 then
-    echo "Usage:"
-    echo "./build-openssl-desktop.sh <OPENSSL_SRC_PATH> [CROSS_COMPILE_TARGET]"
-    exit 1
+  echo "Usage:"
+  echo "./build-openssl-desktop.sh <OPENSSL_SRC_PATH> [CROSS_COMPILE_TARGET]"
+  exit 1
 fi
 
 OPENSSL_SRC_PATH=$1

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -5,7 +5,7 @@ set -euvx
 abspath () { case "$1" in /*)printf "%s\\n" "$1";; *)printf "%s\\n" "$PWD/$1";; esac; }
 export -f abspath
 
-if [ "$#" -lt 1 -o "$#" -gt 2 -o ]
+if [ "$#" -lt 1 -o "$#" -gt 2 ]
 then
   echo "Usage:"
   echo "./build-sqlcipher-desktop.sh <SQLCIPHER_SRC_PATH> [CROSS_COMPILE_TARGET]"


### PR DESCRIPTION
We get:
  - Faster test runs (2 minutes versus 10-15 minutes). This can be explained by CircleCI spinning up instances *very* fast, using Linux instead of macos and probably because CircleCI has beefier machines in general.
 - Test runs closer to "real production builds": we do not rely on brew's sqlcipher/macos openssl anymore, we use our `libs/` carefully-crafted gmo-free libraries instead. `libs/desktop` is cached so we don't re-build openssl/sqlcipher every time.
- Easier to maintain CI config file: as the main maintainer of this file, I find circleci config files to be more verbose but with less magic and limitations.

Note that releases are still done using Travis CI because it's a bit more work. We can address this in a future PR.