### PR TITLE
Bump to version 0.12.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.2.50'
 
     ext.library = [
-        version: '0.11.5'
+        version: '0.12.0'
     ]
 
     ext.build = [


### PR DESCRIPTION
After publishing the plugin and modifying some Maven publication names, it's time for a new version.