### PR TITLE
Bump to Android-Gradle plugin 3.2.1. Fixes #484.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.50'
+    ext.kotlin_version = '1.3.10'
 
     ext.library = [
         version: '0.12.1'
@@ -21,7 +21,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Publish.

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -101,7 +101,14 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'net.java.dev.jna:jna:4.5.2@aar'
 
-    testImplementation files(configurations.jnaForTest.files)
+    // For reasons unknown, resolving the jnaForTest configuration directly
+    // trips a nasty issue with the Android-Gradle plugin 3.2.1, like `Cannot
+    // change attributes of configuration ':PROJECT:kapt' after it has been
+    // resolved`.  I think that the configuration is being made a
+    // super-configuration of the testImplementation and then the `.files` is
+    // causing it to be resolved.  Cloning first dissociates the configuration,
+    // avoiding other configurations from being resolved.  Tricky!
+    testImplementation files(configurations.jnaForTest.copyRecursive().files)
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.8'
     testImplementation 'org.mockito:mockito-core:2.21.0'

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -98,7 +98,14 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'net.java.dev.jna:jna:4.5.2@aar'
 
-    testImplementation files(configurations.jnaForTest.files)
+    // For reasons unknown, resolving the jnaForTest configuration directly
+    // trips a nasty issue with the Android-Gradle plugin 3.2.1, like `Cannot
+    // change attributes of configuration ':PROJECT:kapt' after it has been
+    // resolved`.  I think that the configuration is being made a
+    // super-configuration of the testImplementation and then the `.files` is
+    // causing it to be resolved.  Cloning first dissociates the configuration,
+    // avoiding other configurations from being resolved.  Tricky!
+    testImplementation files(configurations.jnaForTest.copyRecursive().files)
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.robolectric:robolectric:3.8'
     testImplementation 'org.mockito:mockito-core:2.21.0'

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     // It will be more robust if it's compileOnly, 'cuz then we should use the version from the
     // consuming project's Android plugin.
     implementation 'com.android.tools.build:gradle:3.1.4'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
         exclude module: 'groovy-all'

--- a/publish.gradle
+++ b/publish.gradle
@@ -26,7 +26,13 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg,
         task extractJnaResources(type: Sync) {
             dependsOn jnaForTestConfiguration
 
-            from zipTree(jnaForTestConfiguration.singleFile)
+            from {
+                // Defer the resolution of the configuration.  This helps to
+                // avoid a nasty issue with the Android-Gradle plugin 3.2.1,
+                // like `Cannot change attributes of configuration
+                // ':PROJECT:kapt' after it has been resolved`.
+                zipTree(jnaForTestConfiguration.singleFile)
+            }
 
             into "${buildDir}/jnaResources/"
 


### PR DESCRIPTION
This is necessary to make Development with the Reference
Browser (https://mozilla.github.io/application-services/docs/applications/working-with-reference-browser.html)
smooth.

This was hard because the new kapt feature in 3.2.0+ interacts badly
with configuration resolution, and we were triggering resolution
earlier than the plugin could accommodate.  This is a generally
challenging thing to manage in Gradle, with confusing side effects;
this is one such confusing side effect!  See the in-code comments for
the details, which can't be left to a commit message.