### PR TITLE
Prefer rusqlite::Row::get_checked() over rusqlite::Row::get(), fixes #462

### DIFF
--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -215,12 +215,12 @@ impl LoginDb {
                 let mut stmt = self.db.prepare(&query)?;
 
                 let rows = stmt.query_and_then(chunk, |row| {
-                    let guid_idx_i = row.get::<_, i64>("guid_idx");
+                    let guid_idx_i = row.get_checked::<_, i64>("guid_idx")?;
                     // Hitting this means our math is wrong...
                     assert!(guid_idx_i >= 0);
 
                     let guid_idx = guid_idx_i as usize;
-                    let is_mirror: bool = row.get("is_mirror");
+                    let is_mirror: bool = row.get_checked("is_mirror")?;
                     if is_mirror {
                         sync_data[guid_idx].set_mirror(MirrorLogin::from_row(row)?)?;
                     } else {
@@ -671,7 +671,7 @@ impl LoginDb {
             synced = SyncStatus::Synced as u8
         ))?;
         let rows = stmt.query_and_then(&[], |row| {
-            Ok(if row.get::<_, bool>("is_deleted") {
+            Ok(if row.get_checked::<_, bool>("is_deleted")? {
                 Payload::new_tombstone(row.get_checked::<_, String>("guid")?)
             } else {
                 let login = Login::from_row(row)?;

--- a/components/places/src/api/history.rs
+++ b/components/places/src/api/history.rs
@@ -60,9 +60,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_insert() -> Result<()> {
-        let mut c = PlacesDb::open_in_memory(None)?;
-        let url = Url::parse("http://example.com")?;
+    fn test_insert() {
+        let mut c = PlacesDb::open_in_memory(None).expect("should get a connection");
+        let url = Url::parse("http://example.com").expect("it's a valid url");
         let date = Timestamp::now();
         let visits = vec![AddableVisit {
             date,
@@ -76,7 +76,7 @@ mod tests {
             visits,
         };
 
-        insert(&mut c, a)?;
+        insert(&mut c, a).expect("should insert");
 
         // For now, a raw read of the DB.
         let sql = "SELECT p.id, p.url, p.title,
@@ -90,16 +90,25 @@ mod tests {
                     FROM moz_places p, moz_historyvisits v
                     WHERE v.place_id = p.id";
 
-        let mut stmt = c.db.prepare(sql)?;
-        let mut rows = stmt.query(&[])?;
+        let mut stmt = c.db.prepare(sql).expect("valid sql");
+        let mut rows = stmt.query(&[]).expect("should execute");
         let result = rows.next().expect("should get a row");
         let row = result.expect("expect anything");
 
-        assert_eq!(row.get_checked::<_, String>("url")?, "http://example.com/"); // hrmph - note trailing slash
-        assert_eq!(row.get_checked::<_, Timestamp>("visit_date")?, date);
-        assert_ne!(row.get_checked::<_, i32>("frecency")?, 0);
+        assert_eq!(
+            row.get_checked::<_, String>("url").expect("should work"),
+            "http://example.com/"
+        ); // hrmph - note trailing slash
+        assert_eq!(
+            row.get_checked::<_, Timestamp>("visit_date")
+                .expect("should work"),
+            date
+        );
+        assert_ne!(
+            row.get_checked::<_, i32>("frecency").expect("should work"),
+            0
+        );
         // XXX - check more.
-        Ok(())
     }
 }
 

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -298,7 +298,7 @@ mod tests {
             "SELECT COUNT(*) from moz_places_tombstones
                      WHERE guid = :guid",
             &[(":guid", &guid)],
-            |row| Ok(row.get::<_, u32>(0)),
+            |row| Ok(row.get_checked::<_, u32>(0)?),
             true,
         );
         count.unwrap().unwrap() == 1

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -313,7 +313,7 @@ mod tests {
         let result: Result<Option<u32>> = conn.try_query_row(
             "SELECT COUNT(*) from moz_places_tombstones;",
             &[],
-            |row| Ok(row.get::<_, u32>(0).clone()),
+            |row| Ok(row.get_checked::<_, u32>(0)?.clone()),
             true,
         );
         result
@@ -330,8 +330,8 @@ mod tests {
             &[(":url", &url.clone().into_string())],
             |row| {
                 Ok((
-                    SyncStatus::from_u8(row.get::<_, u8>(0)),
-                    row.get::<_, u32>(1),
+                    SyncStatus::from_u8(row.get_checked::<_, u8>(0)?),
+                    row.get_checked::<_, u32>(1)?,
                 ))
             },
             true,


### PR DESCRIPTION
I hope I got this right. There's only 1 left in components/logins/examples/sync_pass_sql.rs, which I didn't bother fixing.