### PR TITLE
Add SyncGuid::new() to create a new GUID.

### DIFF
--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -289,15 +289,14 @@ pub fn create(db: &PlacesDb) -> Result<()> {
 mod tests {
     use super::*;
     use crate::db::PlacesDb;
-    use crate::types::SyncStatus;
-    use sync15::util::random_guid;
+    use crate::types::{SyncGuid, SyncStatus};
     use url::Url;
 
-    fn has_tombstone(conn: &PlacesDb, guid: &str) -> bool {
+    fn has_tombstone(conn: &PlacesDb, guid: &SyncGuid) -> bool {
         let count: Result<Option<u32>> = conn.try_query_row(
             "SELECT COUNT(*) from moz_places_tombstones
                      WHERE guid = :guid",
-            &[(":guid", &guid)],
+            &[(":guid", guid)],
             |row| Ok(row.get_checked::<_, u32>(0)?),
             true,
         );
@@ -307,7 +306,7 @@ mod tests {
     #[test]
     fn test_places_no_tombstone() {
         let conn = PlacesDb::open_in_memory(None).expect("no memory db");
-        let guid = random_guid().expect("should get a guid");
+        let guid = SyncGuid::new();
 
         conn.execute_named_cached(
             "INSERT INTO moz_places (guid, url, url_hash) VALUES (:guid, :url, hash(:url))",
@@ -337,7 +336,7 @@ mod tests {
     #[test]
     fn test_places_tombstone_removal() {
         let conn = PlacesDb::open_in_memory(None).expect("no memory db");
-        let guid = random_guid().expect("should get a guid");
+        let guid = SyncGuid::new();
 
         conn.execute_named_cached(
             "INSERT INTO moz_places_tombstones VALUES (:guid)",

--- a/components/places/src/storage.rs
+++ b/components/places/src/storage.rs
@@ -248,9 +248,7 @@ pub fn update_frecency(db: &Connection, id: RowId, redirect_boost: Option<bool>)
 fn new_page_info(db: &impl ConnExt, url: &Url, new_guid: Option<SyncGuid>) -> Result<PageInfo> {
     let guid = match new_guid {
         Some(guid) => guid,
-        None => sync15::util::random_guid()
-            .expect("according to logins, this is fine :)")
-            .into(),
+        None => SyncGuid::new(),
     };
     let sql = "INSERT INTO moz_places (guid, url, url_hash)
                VALUES (:guid, :url, hash(:url))";

--- a/components/places/src/types.rs
+++ b/components/places/src/types.rs
@@ -12,6 +12,11 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct SyncGuid(pub String);
 
+impl SyncGuid {
+    pub fn new() -> Self {
+        SyncGuid(sync15::util::random_guid().unwrap())
+    }
+}
 impl AsRef<str> for SyncGuid {
     fn as_ref(&self) -> &str {
         self.0.as_ref()


### PR DESCRIPTION
We are ending up with `sync15::util::random_guid().expect("according to logins, this is fine :)");` being sprinkled everywhere we need a new GUID. This patch adds `SyncGuid::new()` to make this cleaner (and easier to move to alternative ways of creating GUIDs should they appear.