### PR TITLE
Pin reqwest to 0.9.5 in fxa-client and sync15 and cut another release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 **TODO: remove before tagging/publishing a release**
 
+# 0.13.1 (_2019-01-10_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.0...v0.13.1)
+
+Note: This is a patch release that works around a bug introduced by a dependency. No functionality has been changed.
+
+## General
+
+### What's New
+
+N/A
+
+### What's Fixed
+
+- Network requests on Android. Due to a [bug in `reqwest`](https://github.com/seanmonstar/reqwest/issues/427), it's version has been pinned until we can resolve this issue. ([#530](https://github.com/mozilla/application-services/pull/530))
+
 # 0.13.0 (_2019-01-09_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.12.1...v0.13.0)

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.10'
 
     ext.library = [
-        version: '0.13.0'
+        version: '0.13.1'
     ]
 
     ext.build = [

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -14,7 +14,7 @@ lazy_static = "1.0.0"
 log = "0.4"
 openssl = { version = "0.10.12", optional = true }
 regex = "1.0.0"
-reqwest = "0.9.1"
+reqwest = "=0.9.5"
 ring = "0.13.5"
 serde = { version = "1.0.79", features = ["rc"] }
 serde_derive = "1.0.79"

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -10,7 +10,7 @@ serde = "1.0.79"
 serde_derive = "1.0.79"
 serde_json = "1.0.28"
 url = "1.7.1"
-reqwest = "0.9.1"
+reqwest = "=0.9.5"
 openssl = "0.10.12"
 hawk = { git = "https://github.com/eoger/rust-hawk", branch = "use-openssl" }
 hyper = "0.12.10"


### PR DESCRIPTION
This works around https://github.com/seanmonstar/reqwest/issues/427, which was the cause of the issues we saw in https://github.com/mozilla-mobile/android-components/pull/1692#issuecomment-452928606 and other places.

I also will cut a release when it lands, so this PR includes a changelog (the changelog assumes the release will happen tomorrow).