### PR TITLE
Disable tests against nightly in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,12 +85,6 @@ jobs:
     steps:
       - rust-tests:
           rust-version: "beta"
-  Rust tests - nightly:
-    docker:
-      - image: circleci/rust:latest
-    steps:
-      - rust-tests:
-          rust-version: "nightly"
   Sync integration tests:
     docker:
       - image: circleci/rust:latest-browsers
@@ -106,5 +100,4 @@ workflows:
     jobs:
       - Rust tests - stable
       - Rust tests - beta
-      - Rust tests - nightly
       - Sync integration tests


### PR DESCRIPTION
Nightly has been busted for about 2 days, causing us to fail in CI. We don't need to test against nightly, we don't use it, and we get enough warning from beta about incoming bustage.