### PR TITLE
Improve logging in fxa-client, and bump android_logger version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 **TODO: remove before tagging/publishing a release**
 
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.1...master)
+
+## Firefox Accounts
+
+### What's New
+
+- The fxa-client android library will now write logs to logcat. ([#533](https://github.com/mozilla/application-services/pull/533))
+
 # 0.13.1 (_2019-01-10_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.0...v0.13.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "android_logger"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_log-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -453,8 +453,10 @@ dependencies = [
 name = "fxaclient_ffi"
 version = "0.1.0"
 dependencies = [
+ "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.1.3",
  "fxa-client 0.1.0",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -701,7 +703,7 @@ dependencies = [
 name = "logins_ffi"
 version = "0.1.0"
 dependencies = [
- "android_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base16 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.1.3",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1001,7 +1003,7 @@ dependencies = [
 name = "places-ffi"
 version = "0.1.0"
 dependencies = [
- "android_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.1.3",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "places 0.1.0",
@@ -1947,7 +1949,7 @@ dependencies = [
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum android_log-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8052e2d8aabbb8d556d6abbcce2a22b9590996c5f849b9c7ce4544a2e3b984e"
-"checksum android_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bad99185bc195e796e1591740c26716667b58ac9210a48731f71f803fc6ca43a"
+"checksum android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf44378e81264148f08e58336674542f82d0021f685d0be0320c82e1653dbe0b"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"

--- a/components/fxa-client/ffi/Cargo.toml
+++ b/components/fxa-client/ffi/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
 ffi-support = { path = "../../support/ffi" }
+log = "0.4.6"
 
 [dependencies.fxa-client]
 path = "../"
@@ -17,3 +18,6 @@ features = ["ffi"]
 
 [features]
 browserid = ["fxa-client/browserid"]
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_logger = "0.7.0"

--- a/components/fxa-client/src/errors.rs
+++ b/components/fxa-client/src/errors.rs
@@ -174,6 +174,9 @@ macro_rules! impl_from_error {
         impl From<$type> for ErrorKind {
             #[inline]
             fn from(e: $type) -> ErrorKind {
+                // We lose some information when boxing the wrapped errors, so
+                // log them here before that happens.
+                log::error!("FxA error `{}`: {:?}", stringify!($type), e);
                 ErrorKind::$variant(e)
             }
         }

--- a/components/logins/ffi/Cargo.toml
+++ b/components/logins/ffi/Cargo.toml
@@ -29,4 +29,4 @@ path = "../../sync15"
 path = "../../support/ffi"
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.6.0"
+android_logger = "0.7.0"

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -26,4 +26,4 @@ path = ".."
 features = ["ffi"]
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.6.0"
+android_logger = "0.7.0"


### PR DESCRIPTION
It looks like #472 has a decent amount of additional work needed, and this would have made debugging #530 much easier (and brings it in line with what the other crates do), so it doesn't seem like something I should just let live in my `git stash` stack forever.