### PR TITLE
Dont enable trace logs in the FFI so that we avoid logging PII.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 **TODO: remove before tagging/publishing a release**
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.2...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.3...master)
+
+# 0.13.3 (_2019-01-11_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.2...v0.13.3)
+
+## Places
+
+### What's Fixed
+
+- Places will no longer log PII. ([#540](https://github.com/mozilla/application-services/pull/540))
 
 # 0.13.2 (_2019-01-11_)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.10'
 
     ext.library = [
-        version: '0.13.2'
+        version: '0.13.3'
     ]
 
     ext.build = [

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -13,7 +13,7 @@ fn logging_init() {
     #[cfg(target_os = "android")]
     {
         android_logger::init_once(
-            android_logger::Filter::default().with_min_level(log::Level::Trace),
+            android_logger::Filter::default().with_min_level(log::Level::Debug),
             Some("libfxaclient_ffi"),
         );
         log::debug!("Android logging should be hooked up!")
@@ -40,7 +40,7 @@ pub unsafe extern "C" fn fxa_from_credentials(
 ) -> *mut FirefoxAccount {
     use fxa_client::WebChannelResponse;
     logging_init();
-    log::trace!("fxa_from_credentials");
+    log::debug!("fxa_from_credentials");
     call_with_result(err, || {
         let content_url = rust_str_from_c(content_url);
         let client_id = rust_str_from_c(client_id);
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn fxa_new(
     err: &mut ExternError,
 ) -> *mut FirefoxAccount {
     logging_init();
-    log::trace!("fxa_new");
+    log::debug!("fxa_new");
     call_with_output(err, || {
         let content_url = rust_str_from_c(content_url);
         let client_id = rust_str_from_c(client_id);
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn fxa_from_json(
     err: &mut ExternError,
 ) -> *mut FirefoxAccount {
     logging_init();
-    log::trace!("fxa_from_json");
+    log::debug!("fxa_from_json");
     call_with_result(err, || FirefoxAccount::from_json(rust_str_from_c(json)))
 }
 
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn fxa_from_json(
 /// pointer type.
 #[no_mangle]
 pub extern "C" fn fxa_to_json(fxa: &mut FirefoxAccount, error: &mut ExternError) -> *mut c_char {
-    log::trace!("fxa_to_json");
+    log::debug!("fxa_to_json");
     call_with_result(error, || fxa.to_json())
 }
 
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn fxa_register_persist_callback(
     callback: extern "C" fn(json: *const c_char),
     error: &mut ExternError,
 ) {
-    log::trace!("fxa_register_persist_callback");
+    log::debug!("fxa_register_persist_callback");
     call_with_output(error, || {
         fxa.register_persist_callback(PersistCallback::new(move |json| {
             // It's impossible for JSON to have embedded null bytes.
@@ -129,7 +129,7 @@ pub extern "C" fn fxa_unregister_persist_callback(
     fxa: &mut FirefoxAccount,
     error: &mut ExternError,
 ) {
-    log::trace!("fxa_unregister_persist_callback");
+    log::debug!("fxa_unregister_persist_callback");
     call_with_output(error, || {
         fxa.unregister_persist_callback();
     });
@@ -150,7 +150,7 @@ pub extern "C" fn fxa_profile(
     ignore_cache: bool,
     error: &mut ExternError,
 ) -> *mut ProfileC {
-    log::trace!("fxa_profile");
+    log::debug!("fxa_profile");
     call_with_result(error, || fxa.get_profile(ignore_cache))
 }
 
@@ -165,7 +165,7 @@ pub extern "C" fn fxa_get_token_server_endpoint_url(
     fxa: &FirefoxAccount,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("fxa_get_token_server_endpoint_url");
+    log::debug!("fxa_get_token_server_endpoint_url");
     call_with_result(error, || {
         fxa.get_token_server_endpoint_url().map(|u| u.to_string())
     })
@@ -182,7 +182,7 @@ pub extern "C" fn fxa_get_connection_success_url(
     fxa: &FirefoxAccount,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("fxa_get_connection_success_url");
+    log::debug!("fxa_get_connection_success_url");
     call_with_result(error, || {
         fxa.get_connection_success_url().map(|u| u.to_string())
     })
@@ -202,7 +202,7 @@ pub unsafe extern "C" fn fxa_assertion_new(
     audience: *const c_char,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("fxa_assertion_new");
+    log::debug!("fxa_assertion_new");
     call_with_result(error, || {
         let audience = rust_str_from_c(audience);
         fxa.generate_assertion(audience)
@@ -222,7 +222,7 @@ pub extern "C" fn fxa_get_sync_keys(
     fxa: &mut FirefoxAccount,
     error: &mut ExternError,
 ) -> *mut SyncKeysC {
-    log::trace!("fxa_get_sync_keys");
+    log::debug!("fxa_get_sync_keys");
     call_with_result(error, || fxa.get_sync_keys())
 }
 
@@ -243,7 +243,7 @@ pub unsafe extern "C" fn fxa_begin_pairing_flow(
     scope: *const c_char,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("fxa_begin_pairing_flow");
+    log::debug!("fxa_begin_pairing_flow");
     call_with_result(error, || {
         let pairing_url = rust_str_from_c(pairing_url);
         let scope = rust_str_from_c(scope);
@@ -273,7 +273,7 @@ pub unsafe extern "C" fn fxa_begin_oauth_flow(
     wants_keys: bool,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("fxa_begin_oauth_flow");
+    log::debug!("fxa_begin_oauth_flow");
     call_with_result(error, || {
         let scope = rust_str_from_c(scope);
         let scopes: Vec<&str> = scope.split(" ").collect();
@@ -294,7 +294,7 @@ pub unsafe extern "C" fn fxa_complete_oauth_flow(
     state: *const c_char,
     error: &mut ExternError,
 ) {
-    log::trace!("fxa_complete_oauth_flow");
+    log::debug!("fxa_complete_oauth_flow");
     call_with_result(error, || {
         let code = rust_str_from_c(code);
         let state = rust_str_from_c(state);
@@ -319,7 +319,7 @@ pub unsafe extern "C" fn fxa_get_access_token(
     scope: *const c_char,
     error: &mut ExternError,
 ) -> *mut AccessTokenInfoC {
-    log::trace!("fxa_get_access_token");
+    log::debug!("fxa_get_access_token");
     call_with_result(error, || {
         let scope = rust_str_from_c(scope);
         fxa.get_access_token(&scope)

--- a/components/logins/ffi/src/lib.rs
+++ b/components/logins/ffi/src/lib.rs
@@ -14,7 +14,7 @@ fn logging_init() {
     #[cfg(target_os = "android")]
     {
         android_logger::init_once(
-            android_logger::Filter::default().with_min_level(log::Level::Trace),
+            android_logger::Filter::default().with_min_level(log::Level::Debug),
             Some("liblogins_ffi"),
         );
         log::debug!("Android logging should be hooked up!")
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn sync15_passwords_state_new(
     error: &mut ExternError,
 ) -> *mut PasswordEngine {
     logging_init();
-    log::trace!("sync15_passwords_state_new");
+    log::debug!("sync15_passwords_state_new");
     call_with_result(error, || {
         let path = rust_str_from_c(db_path);
         let key = rust_str_from_c(encryption_key);
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn sync15_passwords_state_new_with_hex_key(
     error: &mut ExternError,
 ) -> *mut PasswordEngine {
     logging_init();
-    log::trace!("sync15_passwords_state_new_with_hex_key");
+    log::debug!("sync15_passwords_state_new_with_hex_key");
     call_with_result(error, || {
         let path = rust_str_from_c(db_path);
         let key = bytes_to_key_string(encryption_key, encryption_key_len as usize);
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn sync15_passwords_sync(
     tokenserver_url: *const c_char,
     error: &mut ExternError,
 ) {
-    log::trace!("sync15_passwords_sync");
+    log::debug!("sync15_passwords_sync");
     call_with_result(error, || -> Result<()> {
         let mut sync_ping = telemetry::SyncTelemetryPing::new();
         let result = state.sync(
@@ -109,7 +109,7 @@ pub unsafe extern "C" fn sync15_passwords_touch(
     id: *const c_char,
     error: &mut ExternError,
 ) {
-    log::trace!("sync15_passwords_touch");
+    log::debug!("sync15_passwords_touch");
     call_with_result(error, || state.touch(rust_str_from_c(id)))
 }
 
@@ -119,13 +119,13 @@ pub unsafe extern "C" fn sync15_passwords_delete(
     id: *const c_char,
     error: &mut ExternError,
 ) -> u8 {
-    log::trace!("sync15_passwords_delete");
+    log::debug!("sync15_passwords_delete");
     call_with_result(error, || state.delete(rust_str_from_c(id)))
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn sync15_passwords_wipe(state: &PasswordEngine, error: &mut ExternError) {
-    log::trace!("sync15_passwords_wipe");
+    log::debug!("sync15_passwords_wipe");
     call_with_result(error, || state.wipe())
 }
 
@@ -134,13 +134,13 @@ pub unsafe extern "C" fn sync15_passwords_wipe_local(
     state: &PasswordEngine,
     error: &mut ExternError,
 ) {
-    log::trace!("sync15_passwords_wipe_local");
+    log::debug!("sync15_passwords_wipe_local");
     call_with_result(error, || state.wipe_local())
 }
 
 #[no_mangle]
 pub extern "C" fn sync15_passwords_reset(state: &PasswordEngine, error: &mut ExternError) {
-    log::trace!("sync15_passwords_reset");
+    log::debug!("sync15_passwords_reset");
     call_with_result(error, || state.reset())
 }
 
@@ -149,7 +149,7 @@ pub extern "C" fn sync15_passwords_get_all(
     state: &PasswordEngine,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("sync15_passwords_get_all");
+    log::debug!("sync15_passwords_get_all");
     call_with_result(error, || -> Result<String> {
         let all_passwords = state.list()?;
         let result = serde_json::to_string(&all_passwords)?;
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn sync15_passwords_get_by_id(
     id: *const c_char,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("sync15_passwords_get_by_id");
+    log::debug!("sync15_passwords_get_by_id");
     call_with_result(error, || state.get(rust_str_from_c(id)))
 }
 
@@ -173,7 +173,7 @@ pub unsafe extern "C" fn sync15_passwords_add(
     record_json: *const c_char,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("sync15_passwords_add");
+    log::debug!("sync15_passwords_add");
     call_with_result(error, || {
         let mut parsed: serde_json::Value = serde_json::from_str(rust_str_from_c(record_json))?;
         if parsed.get("id").is_none() {
@@ -191,7 +191,7 @@ pub unsafe extern "C" fn sync15_passwords_update(
     record_json: *const c_char,
     error: &mut ExternError,
 ) {
-    log::trace!("sync15_passwords_update");
+    log::debug!("sync15_passwords_update");
     call_with_result(error, || {
         let parsed: Login = serde_json::from_str(rust_str_from_c(record_json))?;
         state.update(parsed)

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -23,7 +23,7 @@ fn logging_init() {
     #[cfg(target_os = "android")]
     {
         android_logger::init_once(
-            android_logger::Filter::default().with_min_level(log::Level::Trace),
+            android_logger::Filter::default().with_min_level(log::Level::Debug),
             Some("libplaces_ffi"),
         );
         log::debug!("Android logging should be hooked up!")
@@ -41,7 +41,7 @@ pub unsafe extern "C" fn places_connection_new(
     encryption_key: *const c_char,
     error: &mut ExternError,
 ) -> *mut PlacesDb {
-    log::trace!("places_connection_new");
+    log::debug!("places_connection_new");
     logging_init();
     call_with_result(error, || {
         let path = ffi_support::rust_string_from_c(db_path);
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn places_note_observation(
     json_observation: *const c_char,
     error: &mut ExternError,
 ) {
-    log::trace!("places_note_observation");
+    log::debug!("places_note_observation");
     call_with_result(error, || {
         let json = ffi_support::rust_str_from_c(json_observation);
         let visit: places::VisitObservation = serde_json::from_str(&json)?;
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn places_query_autocomplete(
     limit: u32,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("places_query_autocomplete");
+    log::debug!("places_query_autocomplete");
     call_with_result(error, || {
         search_frecent(
             conn,
@@ -93,7 +93,7 @@ pub unsafe extern "C" fn places_get_visited(
     urls_json: *const c_char,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("places_get_visited");
+    log::debug!("places_get_visited");
     // This function has a dumb amount of overhead and copying...
     call_with_result(error, || -> places::Result<String> {
         let json = ffi_support::rust_str_from_c(urls_json);
@@ -117,7 +117,7 @@ pub extern "C" fn places_get_visited_urls_in_range(
     include_remote: u8, // JNA has issues with bools...
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::trace!("places_get_visited_in_range");
+    log::debug!("places_get_visited_in_range");
     call_with_result(error, || -> places::Result<String> {
         let visited = storage::history::get_visited_urls(
             conn,
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn sync15_history_sync(
     tokenserver_url: *const c_char,
     error: &mut ExternError,
 ) {
-    log::trace!("sync15_history_sync");
+    log::debug!("sync15_history_sync");
     call_with_result(error, || -> places::Result<()> {
         // XXX - this is wrong - we kinda want this to be long-lived - the "Db"
         // should own the store, but it's not part of the db.

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -529,7 +529,7 @@ pub mod history_sync {
         // we can't do chunking and building a literal string with the ids seems
         // wrong and likely to hit max sql length limits.
         // So we use a temp table.
-        log::trace!("Updating all synced rows");
+        log::debug!("Updating all synced rows");
         // XXX - is there a better way to express this SQL? Multi-selects
         // doesn't seem ideal...
         db.conn().execute_cached(
@@ -542,7 +542,7 @@ pub mod history_sync {
             NO_PARAMS,
         )?;
 
-        log::trace!("Updating all non-synced rows");
+        log::debug!("Updating all non-synced rows");
         db.execute_all(&[
             &format!(
                 "UPDATE moz_places
@@ -553,7 +553,7 @@ pub mod history_sync {
             "DELETE FROM temp_sync_updated_meta",
         ])?;
 
-        log::trace!("Removing local tombstones");
+        log::debug!("Removing local tombstones");
         db.conn()
             .execute_cached("DELETE from moz_places_tombstones", NO_PARAMS)?;
 

--- a/components/support/sql/src/conn_ext.rs
+++ b/components/support/sql/src/conn_ext.rs
@@ -168,7 +168,7 @@ impl<'conn> UncheckedTransaction<'conn> {
     /// Consumes and commits an unchecked transaction.
     pub fn commit(self) -> SqlResult<()> {
         self.conn.execute_batch("COMMIT")?;
-        log::trace!("Transaction commited after {:?}", self.started_at.elapsed());
+        log::debug!("Transaction commited after {:?}", self.started_at.elapsed());
         Ok(())
     }
 

--- a/components/sync15/src/token.rs
+++ b/components/sync15/src/token.rs
@@ -82,7 +82,7 @@ impl TokenFetcher for TokenServerFetcher {
         if !resp.status().is_success() {
             log::warn!("Non-success status when fetching token: {}", resp.status());
             // TODO: the body should be JSON and contain a status parameter we might need?
-            log::debug!(
+            log::trace!(
                 "  Response body {}",
                 resp.text().unwrap_or_else(|_| "???".into())
             );


### PR DESCRIPTION
I also made some trace logs that don't include PII and are helpful for debugging into debug logs. I also audited our logging and adjusted the levels in a couple other places to ensure no PII was logged at the debug level.

Includes a bump to 0.13.3 as per request in slack.

CC @grigoryk 