### PR TITLE
Handle invalid urls in places_get_visited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.3...master)
 
+## Places
+
+### What's Fixed
+
+- PlacesConnection.getVisited will now return that invalid URLs have not been visited, instead of throwing. ([#552](https://github.com/mozilla/application-services/issues/552))
+
 # 0.13.3 (_2019-01-11_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.2...v0.13.3)

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -63,6 +63,9 @@ cargo {
     // The Cargo targets to invoke.  The mapping from short name to target
     // triple is defined by the `rust-android-gradle` plugin.
     targets = [
+        'linux-x86-64',
+        'darwin',
+        'win32-x86-64-gnu',
         'arm',
         'arm64',
         'x86',

--- a/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
@@ -9,6 +9,7 @@ import com.sun.jna.Library
 import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.PointerType
+import com.sun.jna.StringArray
 import java.lang.reflect.Proxy
 
 internal interface LibPlacesFFI : Library {
@@ -46,7 +47,6 @@ internal interface LibPlacesFFI : Library {
             out_err: RustError.ByReference
     ): RawPlacesConnection?
 
-    /** Returns JSON string, which you need to free with places_destroy_string */
     fun places_note_observation(
             conn: RawPlacesConnection,
             json_observation_data: String,
@@ -61,11 +61,17 @@ internal interface LibPlacesFFI : Library {
             out_err: RustError.ByReference
     ): Pointer?
 
+    /** Note: urls_len and buffer_len must be the same length. The argument is somewhat redundant, but
+     * is provided for a slight additional amount of sanity checking. These lengths are the number
+     * of elements present (and not e.g. the number of bytes allocated). */
     fun places_get_visited(
             conn: RawPlacesConnection,
-            urls_json: String,
+            urls: StringArray,
+            urls_len: Int,
+            buffer: Pointer,
+            buf_len: Int,
             out_err: RustError.ByReference
-    ): Pointer?
+    )
 
     fun places_get_visited_urls_in_range(
             conn: RawPlacesConnection,

--- a/components/places/android/src/test/java/org/mozilla/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/org/mozilla/places/PlacesConnectionTest.kt
@@ -1,0 +1,111 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package org.mozilla.places
+
+
+import org.junit.After
+import org.junit.rules.TemporaryFolder
+import org.junit.Rule
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.Before
+
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class PlacesConnectionTest {
+    @Rule
+    @JvmField
+    val dbFolder = TemporaryFolder()
+
+    lateinit var db: PlacesConnection
+
+    @Before
+    fun initDB() {
+        db = PlacesConnection(path = dbFolder.newFile().absolutePath)
+    }
+
+    @After
+    fun closeDB() {
+        db.close()
+    }
+
+    // Basically equivalent to test_get_visited in rust, but exercises the FFI,
+    // as well as the handling of invalid urls.
+    @Test
+    fun testGetVisited() {
+
+        val unicodeInPath = "http://www.example.com/tëst😀abc"
+        val escapedUnicodeInPath = "http://www.example.com/t%C3%ABst%F0%9F%98%80abc";
+
+        val unicodeInDomain = "http://www.exämple😀123.com"
+        val escapedUnicodeInDomain = "http://www.xn--exmple123-w2a24222l.com"
+
+        val toAdd = listOf(
+                "https://www.example.com/1",
+                "https://www.example.com/12",
+                "https://www.example.com/123",
+                "https://www.example.com/1234",
+                "https://www.mozilla.com",
+                "https://www.firefox.com",
+                "$unicodeInPath/1",
+                "$escapedUnicodeInPath/2",
+                "$unicodeInDomain/1",
+                "$escapedUnicodeInDomain/2"
+        )
+
+        for (url in toAdd) {
+            db.noteObservation(VisitObservation(url = url, visitType = VisitType.LINK))
+        }
+
+        val toSearch = listOf(
+                Pair("https://www.example.com", false),
+                Pair("https://www.example.com/1", true),
+                Pair("https://www.example.com/12", true),
+                Pair("https://www.example.com/123", true),
+                Pair("https://www.example.com/1234", true),
+                Pair("https://www.example.com/12345", false),
+                // Bad URLs should still work without.
+                Pair("https://www.example.com:badurl", false),
+
+                Pair("https://www.mozilla.com", true),
+                Pair("https://www.firefox.com", true),
+                Pair("https://www.mozilla.org", false),
+
+                // Dupes should still work
+                Pair("https://www.example.com/1234", true),
+                Pair("https://www.example.com/12345", false),
+
+                // The unicode URLs should work when escaped the way we
+                // encountered them
+                Pair("$unicodeInPath/1", true),
+                Pair("$escapedUnicodeInPath/2", true),
+                Pair("$unicodeInDomain/1", true),
+                Pair("$escapedUnicodeInDomain/2", true),
+
+                // But also the other way.
+                Pair("$unicodeInPath/2", true),
+                Pair("$escapedUnicodeInPath/1", true),
+                Pair("$unicodeInDomain/2", true),
+                Pair("$escapedUnicodeInDomain/1", true)
+        )
+
+        val visited = db.getVisited(toSearch.map { it.first }.toList())
+
+        assertEquals(visited.size, toSearch.size)
+
+        for (i in 0 until visited.size) {
+            assert(visited[i] == toSearch[i].second) {
+                "Test $i failed for url ${toSearch[i].first} (got ${visited[i]}, want ${toSearch[i].second})"
+            }
+        }
+    }
+
+
+
+}
+


### PR DESCRIPTION
(I had a patch already that did this optimization and added the tests, so adding the handling for bad urls wasn't so bad).

The optimization is mainly avoiding going through JSON both ways, which cuts down on many of our unnecessary conversions. I don't think it really makes the code much more complex either.

This also improves our rust tests of the feature, as well as adding places android tests (just of get_visited at the moment, but it's easier to add more now that the start of it is in place).

Fixes #552 