### PR TITLE
Use opt-level s instead of z

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ members = [
 ]
 
 [profile.release]
-opt-level = "z"
+opt-level = "s"
 debug = true
 lto = true


### PR DESCRIPTION
I ran a test last night that found this was smaller by 100k-200k in all cases for our code than using opt-level "z":

<img width="563" alt="screen shot 2019-01-17 at 11 22 52 am" src="https://user-images.githubusercontent.com/860665/51344141-d121ca00-1a4c-11e9-8491-e3557b6e0cd9.png">

(ignore the third directory, that was just a sanity check, but isn't really relevant here)