### PR TITLE
Disable mlock and munlock in places if encryption wasn't requested

### DIFF
--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -329,7 +329,7 @@ impl FirefoxAccount {
                         return Err(ErrorKind::IllegalState(
                             "Got a JWE with have no JWK.".to_string(),
                         )
-                        .into())
+                        .into());
                     }
                 };
                 let decrypted_keys = scoped_keys_flow.decrypt_keys_jwe(jwe)?;


### PR DESCRIPTION
This is a >6x speedup for me in the autocomplete demo, and makes importing your history from places in it bearable.

I also fixed the fmt issue that the new `cargo fmt` (which our CI has already) insists on.