### PR TITLE
places: Handle unicode origin searches in origins. Fixes #298

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.14.0...master)
 
+## Places
+
+### What's Fixed
+
+- Autocomplete will no longer return an error when asked to match a unicode string. ([#298](https://github.com/mozilla/application-services/issues/298))
+
 # 0.14.0 (_2019-01-23_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.3...v0.14.0)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "ffi-support 0.1.4",
  "find-places-db 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxa-client 0.1.0",
+ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -24,6 +24,7 @@ sql-support = { path = "../support/sql" }
 url_serde = "0.2.0"
 ffi-support = { path = "../support/ffi", optional = true }
 bitflags = "1.0.4"
+idna = "0.1.5"
 
 [dependencies.rusqlite]
 version = "0.16.0"


### PR DESCRIPTION
Previously we'd complain in reverse_host.

This doesn't handle them in AUTOCOMPLETE_MATCH, but hey, neither does firefox desktop. (Actually, desktop doesn't even handle them in origins either, so after this, we'll have one up there).