### PR TITLE
Add ability to automatically log query plans.

### DIFF
--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 
 [features]
 ffi = ["ffi-support"]
+log_query_plans = ["sql-support/log_query_plans"]
 default = []
 
 [dependencies]

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -6,6 +6,7 @@ authors = []
 
 [features]
 ffi = ["ffi-support"]
+log_query_plans = ["sql-support/log_query_plans"]
 default = []
 
 [dependencies]

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -372,7 +372,7 @@ const ORIGIN_SQL: &'static str = "
 impl<'query, 'conn> Matcher for OriginOrUrl<'query, 'conn> {
     fn search(&self, _: u32) -> Result<Vec<SearchResult>> {
         Ok(if looks_like_origin(self.query) {
-            self.conn.query_rows_and_then_named(
+            self.conn.query_rows_and_then_named_cached(
                 ORIGIN_SQL,
                 &[
                     (":prefix", &rusqlite::types::Null),
@@ -385,7 +385,7 @@ impl<'query, 'conn> Matcher for OriginOrUrl<'query, 'conn> {
             let (host, remainder) = split_after_host_and_port(self.query);
             let punycode_host = idna::domain_to_ascii(host).ok();
             let host_str = punycode_host.as_ref().map(|s| s.as_str()).unwrap_or(host);
-            self.conn.query_rows_and_then_named(
+            self.conn.query_rows_and_then_named_cached(
                 URL_SQL,
                 &[
                     (":searchString", &self.query),
@@ -435,7 +435,7 @@ impl<'query, 'conn> Adaptive<'query, 'conn> {
 
 impl<'query, 'conn> Matcher for Adaptive<'query, 'conn> {
     fn search(&self, max_results: u32) -> Result<Vec<SearchResult>> {
-        Ok(self.conn.query_rows_and_then_named(
+        Ok(self.conn.query_rows_and_then_named_cached(
             "
             SELECT h.url as url,
                    h.title as title,
@@ -512,7 +512,7 @@ impl<'query, 'conn> Suggestions<'query, 'conn> {
 
 impl<'query, 'conn> Matcher for Suggestions<'query, 'conn> {
     fn search(&self, max_results: u32) -> Result<Vec<SearchResult>> {
-        Ok(self.conn.query_rows_and_then_named(
+        Ok(self.conn.query_rows_and_then_named_cached(
             "
             SELECT h.url, h.title,
                    EXISTS(SELECT 1 FROM moz_bookmarks

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 [features]
 default = ["sqlcipher"]
 sqlcipher = ["rusqlite/sqlcipher"]
+log_query_plans = []
 
 [dependencies]
 log = "0.4"

--- a/components/support/sql/doc/query-plan.md
+++ b/components/support/sql/doc/query-plan.md
@@ -1,0 +1,79 @@
+# Getting query plans out of places/logins/other consumers.
+
+If these crates are built with the `log_query_plans` feature enabled (or cargo decides to use a version of `sql-support` that has beeen built with that feature), then queries that go through sql-support will have their [query plans](https://www.sqlite.org/eqp.html) logged. The default place they get logged is stdout, however you can also specify a file by setting the `QUERY_PLAN_LOG` variable in the environment to a file where the plans will be appended.
+
+Worth noting that new logs will be appended to `QUERY_PLAN_LOG`, we don't clear the file. This is so that you can more easily see how the query plan changed during testing.
+
+The queries that go through this are any that are
+
+1. Executed entirely within sql-support (we need both the query and it's parameters)
+2. Take named (and not positional) parameters.
+
+At the time of writing this, that includes:
+
+- `try_query_row`
+- `query_rows_and_then_named_cached`
+- `query_rows_and_then_named`
+- `query_row_and_then_named`
+- `query_one`
+- `execute_named_cached`
+- Possibly more, check [ConnExt](https://github.com/mozilla/application-services/blob/master/components/support/sql/src/conn_ext.rs).
+
+In particular, this excludes queries where the statement is prepared separately from execution.
+
+## Usage
+
+As mentioned, this is turned on with the log_query_plans feature. I don't know why, but I've had mediocre luck enabling it explicitly, but 100% success enabling it via `--all-features`. So that's what I recommend.
+
+Note that for tests, if you're logging to stdout, you'll need to end the test command with `-- --no-capture`, or else it will hide stdout output from you. You also may want to pass `--test-threads 1` (also after the `--`) so that the plans are logged near the tests that are executing, but it doesn't matter that much, since we log the SQL before the plan.
+
+
+Executing tests, having the output logged to stdout:
+
+```
+$ cargo test -p logins --all-features -- --no-capture
+... <snip>
+test engine::test::test_general ...
+### QUERY PLAN
+#### SQL:
+      SELECT <bunch of fields here>
+      FROM loginsL
+      WHERE is_deleted = 0
+        AND guid = :guid
+      UNION ALL
+      SELECT <same bunch of fields here>
+      FROM loginsM
+      WHERE is_overridden IS NOT 1
+        AND guid = :guid
+      ORDER BY hostname ASC
+      LIMIT 1
+
+#### PLAN:
+QUERY PLAN
+`--MERGE (UNION ALL)
+   |--LEFT
+   |  `--SEARCH TABLE loginsL USING INDEX sqlite_autoindex_loginsL_1 (guid=?)
+   `--RIGHT
+      `--SEARCH TABLE loginsM USING INDEX sqlite_autoindex_loginsM_1 (guid=?)
+### END QUERY PLAN
+... <snip>
+```
+
+Executing an example, with the output logged to a file.
+
+```
+$ env QUERY_PLAN_LOG=/path/to/my/logfile.txt cargo run -p places --all-features --example autocomplete -- <args for example go here>
+# (many shells can also do this as follows)
+$ QUERY_PLAN_LOG=/path/to/my/logfile.txt cargo run -p places --all-features --example autocomplete -- <args for example go here>
+```
+
+## Using from code
+
+This is also available as types on `sql_support`.
+
+```rust
+println!("This prints the same output as is normally logged, and works \
+          even when the logging feature is off: {}",
+         sql_support:QueryPlan::new(conn, sql, params));
+```
+

--- a/components/support/sql/src/conn_ext.rs
+++ b/components/support/sql/src/conn_ext.rs
@@ -12,6 +12,8 @@ use std::time::Instant;
 
 use crate::maybe_cached::MaybeCached;
 
+pub struct Conn(rusqlite::Connection);
+
 /// This trait exists so that we can use these helpers on `rusqlite::{Transaction, Connection}`.
 /// Note that you must import ConnExt in order to call these methods on anything.
 pub trait ConnExt {
@@ -50,12 +52,14 @@ pub trait ConnExt {
     /// Equivalent to `Connection::execute_named` but caches the statement so that subsequent
     /// calls to `execute_named_cached` will have imprroved performance.
     fn execute_named_cached(&self, sql: &str, params: &[(&str, &dyn ToSql)]) -> SqlResult<usize> {
+        crate::maybe_log_plan(self.conn(), sql, params);
         let mut stmt = self.conn().prepare_cached(sql)?;
         stmt.execute_named(params)
     }
 
     /// Execute a query that returns a single result column, and return that result.
     fn query_one<T: FromSql>(&self, sql: &str) -> SqlResult<T> {
+        crate::maybe_log_plan(self.conn(), sql, &[]);
         let res: T = self
             .conn()
             .query_row_and_then(sql, NO_PARAMS, |row| row.get_checked(0))?;
@@ -76,9 +80,45 @@ pub trait ConnExt {
         E: From<rusqlite::Error>,
         F: FnOnce(&Row) -> Result<T, E>,
     {
+        crate::maybe_log_plan(self.conn(), sql, params);
         Ok(self
             .try_query_row(sql, params, mapper, cache)?
             .ok_or(rusqlite::Error::QueryReturnedNoRows)?)
+    }
+
+    /// Helper for when you'd like to get a Vec<T> of all the rows returned by a
+    /// query that takes named arguments. See also
+    /// `query_rows_and_then_named_cached`.
+    fn query_rows_and_then_named<T, E, F>(
+        &self,
+        sql: &str,
+        params: &[(&str, &dyn ToSql)],
+        mapper: F,
+    ) -> Result<Vec<T>, E>
+    where
+        Self: Sized,
+        E: From<rusqlite::Error>,
+        F: FnMut(&Row) -> Result<T, E>,
+    {
+        crate::maybe_log_plan(self.conn(), sql, params);
+        query_rows_and_then_named(self.conn(), sql, params, mapper, false)
+    }
+
+    /// Helper for when you'd like to get a Vec<T> of all the rows returned by a
+    /// query that takes named arguments.
+    fn query_rows_and_then_named_cached<T, E, F>(
+        &self,
+        sql: &str,
+        params: &[(&str, &dyn ToSql)],
+        mapper: F,
+    ) -> Result<Vec<T>, E>
+    where
+        Self: Sized,
+        E: From<rusqlite::Error>,
+        F: FnMut(&Row) -> Result<T, E>,
+    {
+        crate::maybe_log_plan(self.conn(), sql, params);
+        query_rows_and_then_named(self.conn(), sql, params, mapper, true)
     }
 
     // This should probably have a longer name...
@@ -95,6 +135,7 @@ pub trait ConnExt {
         E: From<rusqlite::Error>,
         F: FnOnce(&Row) -> Result<T, E>,
     {
+        crate::maybe_log_plan(self.conn(), sql, params);
         let conn = self.conn();
         let mut stmt = MaybeCached::prepare(conn, sql, cache)?;
         let mut rows = stmt.query_named(params)?;
@@ -212,4 +253,23 @@ impl<'conn> ConnExt for UncheckedTransaction<'conn> {
     fn conn(&self) -> &Connection {
         &*self
     }
+}
+
+fn query_rows_and_then_named<T, E, F>(
+    conn: &Connection,
+    sql: &str,
+    params: &[(&str, &dyn ToSql)],
+    mapper: F,
+    cache: bool,
+) -> Result<Vec<T>, E>
+where
+    E: From<rusqlite::Error>,
+    F: FnMut(&Row) -> Result<T, E>,
+{
+    let mut stmt = conn.prepare_maybe_cached(sql, cache)?;
+    let mut res = vec![];
+    for item in stmt.query_and_then_named(params, mapper)? {
+        res.push(item?);
+    }
+    Ok(res)
 }

--- a/components/support/sql/src/lib.rs
+++ b/components/support/sql/src/lib.rs
@@ -5,11 +5,13 @@
 mod conn_ext;
 mod each_chunk;
 mod maybe_cached;
+mod query_plan;
 mod repeat;
 
 pub use crate::conn_ext::*;
 pub use crate::each_chunk::*;
 pub use crate::maybe_cached::*;
+pub use crate::query_plan::*;
 pub use crate::repeat::*;
 
 /// In PRAGMA foo='bar', `'bar'` must be a constant string (it cannot be a

--- a/components/support/sql/src/query_plan.rs
+++ b/components/support/sql/src/query_plan.rs
@@ -1,0 +1,145 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use rusqlite::{types::ToSql, Connection, Result as SqlResult};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueryPlanStep {
+    pub select_id: i32,
+    pub order: i32,
+    pub from: i32,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct QueryPlan {
+    pub query: String,
+    pub plan: Vec<QueryPlanStep>,
+}
+
+impl QueryPlan {
+    // TODO: support positional params (it's a pain...)
+    pub fn new(conn: &Connection, sql: &str, params: &[(&str, &dyn ToSql)]) -> SqlResult<Self> {
+        let plan_sql = format!("EXPLAIN QUERY PLAN {}", sql);
+        let mut stmt = conn.prepare(&plan_sql)?;
+        let plan = stmt
+            .query_and_then_named(params, |row| -> SqlResult<_> {
+                Ok(QueryPlanStep {
+                    select_id: row.get_checked(0)?,
+                    order: row.get_checked(1)?,
+                    from: row.get_checked(2)?,
+                    detail: row.get_checked(3)?,
+                })
+            })?
+            .collect::<Result<Vec<QueryPlanStep>, _>>()?;
+        Ok(QueryPlan {
+            query: sql.into(),
+            plan,
+        })
+    }
+}
+
+impl std::fmt::Display for QueryPlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        writeln!(f, "### QUERY PLAN")?;
+        writeln!(f, "#### SQL:\n{}\n#### PLAN:", self.query)?;
+        for step in self.plan.iter() {
+            writeln!(
+                f,
+                "|{}|{}|{}|{}|",
+                step.select_id, step.order, step.from, step.detail
+            )?;
+        }
+        writeln!(f, "### END QUERY PLAN")
+    }
+}
+
+/// Log a query plan if the `log_query_plans` feature is enabled and it hasn't been logged yet.
+#[inline]
+pub fn maybe_log_plan(_conn: &Connection, _sql: &str, _params: &[(&str, &dyn ToSql)]) {
+    // Note: underscores ar needed becasue those go unused if the feature is not turned on.
+    #[cfg(feature = "log_query_plans")]
+    {
+        plan_log::log_plan(_conn, _sql, _params)
+    }
+}
+
+#[cfg(feature = "log_query_plans")]
+mod plan_log {
+    use super::*;
+    use std::collections::HashMap;
+    use std::io::Write;
+    use std::sync::Mutex;
+
+    struct PlanLogger {
+        seen: HashMap<String, QueryPlan>,
+        out: Box<dyn Write + Send>,
+    }
+
+    impl PlanLogger {
+        fn new() -> Self {
+            let out_file = std::env::var("QUERY_PLAN_LOG").unwrap_or_default();
+            let output: Box<dyn Write + Send> = if out_file != "" {
+                let mut file = std::fs::OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(out_file)
+                    .expect("QUERY_PLAN_LOG file does not exist!");
+                writeln!(
+                    file,
+                    "\n\n# Query Plan Log starting at time: {:?}\n",
+                    std::time::SystemTime::now()
+                )
+                .expect("Failed to write to plan log file");
+                Box::new(file)
+            } else {
+                println!("QUERY_PLAN_LOG was not set, logging to stdout");
+                Box::new(std::io::stdout())
+            };
+            Self {
+                seen: Default::default(),
+                out: output,
+            }
+        }
+
+        fn maybe_log(&mut self, plan: QueryPlan) {
+            use std::collections::hash_map::Entry;
+            match self.seen.entry(plan.query.clone()) {
+                Entry::Occupied(mut o) => {
+                    if o.get() == &plan {
+                        return;
+                    }
+                    // Ignore IO failures.
+                    let _ = writeln!(self.out, "### QUERY PLAN CHANGED!\n{}", plan);
+                    o.insert(plan);
+                }
+                Entry::Vacant(v) => {
+                    let _ = writeln!(self.out, "{}", plan);
+                    v.insert(plan);
+                }
+            }
+            let _ = self.out.flush();
+        }
+    }
+
+    lazy_static::lazy_static! {
+        static ref PLAN_LOGGER: Mutex<PlanLogger> = Mutex::new(PlanLogger::new());
+    }
+
+    pub fn log_plan(conn: &Connection, sql: &str, params: &[(&str, &dyn ToSql)]) {
+        if sql.starts_with("EXPLAIN") {
+            return;
+        }
+        let plan = match QueryPlan::new(conn, sql, params) {
+            Ok(plan) => plan,
+            Err(e) => {
+                // We're usually doing this during tests where logs often arent available
+                eprintln!("Failed to get query plan for {}: {}", sql, e);
+                return;
+            }
+        };
+        let mut logger = PLAN_LOGGER.lock().unwrap();
+        logger.maybe_log(plan);
+    }
+}


### PR DESCRIPTION
If you enable the `log_query_plans`, query plans will bee logged to stdout. Alternatively, you can log them to a file with the `QUERY_PLAN_LOG` environment var. This only works for queries that are executed on ConnExt, which means things using `prepare()` directly can't use it.

This also adds some new helpers to avoid needing prepare in the case you just want a Vec of all rows, and changes places to use this when it can.

If you're in a case where you really just want the plan, you can use QueryPlan::new directly. The format it writes to stdout / the log file is the same as it's `Display` implemention.