### PR TITLE
Optimize autocomplete. Fixes #589

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - Autocomplete will no longer return an error when asked to match a unicode string. ([#298](https://github.com/mozilla/application-services/issues/298))
 
+- Autocomplete is now much faster for non-matching queries and queries that look like URLs. ([#589](https://github.com/mozilla/application-services/issues/589))
+
 ## FxA
 
 ### What's New

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ name = "aho-corasick"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -759,12 +759,11 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -996,6 +995,7 @@ dependencies = [
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1250,7 +1250,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2016,7 +2016,7 @@ dependencies = [
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
-"checksum memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "db4c41318937f6e76648f42826b1d9ade5c09cafb5aef7e351240a70f39206e9"
+"checksum memchr 2.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1dd4eaac298c32ce07eb6ed9242eda7d82955b9170b7d6db59b2e02cc63fcb8"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -26,6 +26,7 @@ url_serde = "0.2.0"
 ffi-support = { path = "../support/ffi", optional = true }
 bitflags = "1.0.4"
 idna = "0.1.5"
+memchr = "2.1.3"
 
 [dependencies.rusqlite]
 version = "0.16.0"

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -35,12 +35,7 @@ pub fn search_frecent(conn: &PlacesDb, params: SearchParams) -> Result<Vec<Searc
         &[
             // Try to match on the origin, or the full URL.
             &OriginOrUrl::new(&params.search_string, conn),
-            // After the first result, try the queries for adaptive matches and
-            // suggestions for bookmarked URLs.
-            &Adaptive::new(&params.search_string, conn),
-            &Suggestions::new(&params.search_string, conn),
-            // If we don't have enough results, query adaptive matches and
-            // suggestions again, matching anywhere instead of on boundaries.
+            // query adaptive matches and suggestions, matching Anywhere.
             &Adaptive::with_behavior(
                 &params.search_string,
                 conn,
@@ -404,15 +399,6 @@ struct Adaptive<'query, 'conn> {
 }
 
 impl<'query, 'conn> Adaptive<'query, 'conn> {
-    pub fn new(query: &'query str, conn: &'conn PlacesDb) -> Adaptive<'query, 'conn> {
-        Adaptive::with_behavior(
-            query,
-            conn,
-            MatchBehavior::BoundaryAnywhere,
-            SearchBehavior::default(),
-        )
-    }
-
     pub fn with_behavior(
         query: &'query str,
         conn: &'conn PlacesDb,
@@ -481,15 +467,6 @@ struct Suggestions<'query, 'conn> {
 }
 
 impl<'query, 'conn> Suggestions<'query, 'conn> {
-    pub fn new(query: &'query str, conn: &'conn PlacesDb) -> Suggestions<'query, 'conn> {
-        Suggestions::with_behavior(
-            query,
-            conn,
-            MatchBehavior::BoundaryAnywhere,
-            SearchBehavior::default(),
-        )
-    }
-
     pub fn with_behavior(
         query: &'query str,
         conn: &'conn PlacesDb,

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -80,8 +80,12 @@ impl PlacesDb {
 
         db.execute_batch(&initial_pragmas)?;
         define_functions(&db)?;
-        let mut res = Self { db };
-        schema::init(&mut res)?;
+        let res = Self { db };
+        // Even though we're the owner of the db, we need it to be an unchecked tx
+        // since we want to pass &PlacesDb and not &Connection to schema::init.
+        let tx = res.unchecked_transaction()?;
+        schema::init(&res)?;
+        tx.commit()?;
 
         Ok(res)
     }

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -12,7 +12,7 @@ use crate::error::*;
 use lazy_static::lazy_static;
 use sql_support::ConnExt;
 
-const VERSION: i64 = 2;
+const VERSION: i64 = 3;
 
 const CREATE_TABLE_PLACES_SQL: &str =
     "CREATE TABLE IF NOT EXISTS moz_places (
@@ -178,7 +178,7 @@ const CREATE_TABLE_META_SQL: &str = "CREATE TABLE moz_meta (
 // See https://searchfox.org/mozilla-central/source/toolkit/components/places/nsPlacesIndexes.h
 const CREATE_IDX_MOZ_PLACES_URL_HASH: &str = "CREATE INDEX url_hashindex ON moz_places(url_hash)";
 
-// const CREATE_IDX_MOZ_PLACES_REVHOST: &str = "CREATE INDEX hostindex ON moz_places(rev_host)";
+const CREATE_IDX_MOZ_ORIGINS_REVHOST: &str = "CREATE INDEX hostindex ON moz_origins(rev_host)";
 
 const CREATE_IDX_MOZ_PLACES_VISITCOUNT_LOCAL: &str =
     "CREATE INDEX visitcountlocal ON moz_places(visit_count_local)";
@@ -278,6 +278,7 @@ pub fn create(db: &PlacesDb) -> Result<()> {
         CREATE_IDX_MOZ_HISTORYVISITS_FROMVISIT,
         CREATE_IDX_MOZ_HISTORYVISITS_VISITDATE,
         CREATE_IDX_MOZ_HISTORYVISITS_ISLOCAL,
+        CREATE_IDX_MOZ_ORIGINS_REVHOST,
         CREATE_IDX_MOZ_BOOKMARKS_PLACELASTMODIFIED,
         &format!("PRAGMA user_version = {version}", version = VERSION),
     ])?;

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -219,8 +219,12 @@ const CREATE_IDX_MOZ_BOOKMARKS_PLACELASTMODIFIED: &str =
 // pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM: &'static str = "origin_frecency_sum";
 // pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM_OF_SQUARES: &'static str = "origin_frecency_sum_of_squares";
 
+fn get_current_schema_version(db: &PlacesDb) -> Result<i64> {
+    Ok(db.query_one::<i64>("PRAGMA user_version")?)
+}
+
 pub fn init(db: &PlacesDb) -> Result<()> {
-    let user_version = db.query_one::<i64>("PRAGMA user_version")?;
+    let user_version = get_current_schema_version(db)?;
     if user_version == 0 {
         create(db)?;
     } else if user_version != VERSION {
@@ -245,10 +249,44 @@ pub fn init(db: &PlacesDb) -> Result<()> {
     Ok(())
 }
 
-// https://github.com/mozilla-mobile/firefox-ios/blob/master/Storage/SQL/LoginsSchema.swift#L100
-fn upgrade(_db: &PlacesDb, from: i64) -> Result<()> {
+/// Helper for upgrade. Intended use:
+///
+/// ```rust,ignore
+/// migration(db, 2, 3, &[stuff, to, migrate, version2, to, version3])?;
+/// migration(db, 3, 4, &[stuff, to, migrate, version3, to, version4])?;
+/// migration(db, 4, 5, &[stuff, to, migrate, version4, to, version5])?;
+/// assert_eq!(get_current_schema_version(), 5);
+/// ```
+
+fn migration(db: &PlacesDb, from: i64, to: i64, stmts: &[&str]) -> Result<()> {
+    use sql_support::ConnExt;
+    // In the future maybe we want to avoid calling this
+    let cur_version = get_current_schema_version(db)?;
+    if cur_version == from {
+        log::debug!("Upgrading schema from {} to {}", cur_version, to);
+        db.execute_all(stmts)?;
+        db.execute_batch(&format!("PRAGMA user_version = {};", to))?;
+    } else {
+        log::debug!(
+            "Not executing places migration of v{} -> v{} on v{}",
+            from,
+            to,
+            cur_version
+        );
+    }
+    Ok(())
+}
+
+fn upgrade(db: &PlacesDb, from: i64) -> Result<()> {
     log::debug!("Upgrading schema from {} to {}", from, VERSION);
     if from == VERSION {
+        return Ok(());
+    }
+
+    migration(db, 2, 3, &[CREATE_IDX_MOZ_ORIGINS_REVHOST])?;
+    // Add more migrations here...
+
+    if get_current_schema_version(db)? == VERSION {
         return Ok(());
     }
     // FIXME https://github.com/mozilla/application-services/issues/438

--- a/components/places/src/match_impl.rs
+++ b/components/places/src/match_impl.rs
@@ -372,6 +372,12 @@ impl<'search, 'url, 'title, 'tags> AutocompleteMatch<'search, 'url, 'title, 'tag
                 s = &s[6..];
             }
         }
+        // Bail out early if we don't need to percent decode. It's a
+        // little weird that it's measurably faster to check this
+        // separately, but whatever.
+        if memchr::memchr(b'%', s.as_bytes()).is_none() {
+            return Cow::Borrowed(s);
+        }
         // TODO: would be nice to decode punycode here too, but for now
         // this is probably fine.
         match percent_encoding::percent_decode(s.as_bytes()).decode_utf8() {


### PR DESCRIPTION
This makes it ~4x faster on my machine. About half of it comes from only running autocomplete queries a single time, and the other half from the missing index. The rest of the things do speed things up by about 100ms though (on my 160k row test case).

This manages to avoid [optimizing the hell out of AUTOCOMPLETE_MATCH](https://github.com/thomcc/application-services/commit/f36aeeab46d69f2ead48c75e1e6b56ce9bf93d89), since while that code does speed things up a bit, it's also a lot harder to maintain.

Important: it's still too slow to block the UI thread. @grigoryk / @csadilek really, you need to run this in the background asynchronously without blocking the user's typing on the response. (Even our autocomplete demo code manages to do this!)

That said, it is a lot better and closes the gap with desktop.