### PR TITLE
Allow places operations to be interrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### What's New
 
 - New method on PlacesConnection (breaking change for classes implementing PlacesAPI): `fun matchUrl(query: String): String?`. This is similar to `queryAutocomplete`, but only searches for URL and Origin matches, and only returns (a portion of) the matching url (if found), or null (if not). ([#595](https://github.com/mozilla/application-services/pull/595))
+- New method on PlacesConnection (breaking change for classes implementing PlacesAPI): `fun interrupt()`. Cancels any calls to `queryAutocomplete` or `matchUrl` that are running on other threads. Those threads will throw an `OperationInterrupted` exception. ([#597](https://github.com/mozilla/application-services/pull/597))
+    - Using `interrupt()` during the execution of other methods may work, but will have mixed results (it will work if we're currently executing a SQL query, and not if we're running rust code). This limitation may be lifted in the future.
 
 ### What's Fixed
 

--- a/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
@@ -95,6 +95,16 @@ internal interface LibPlacesFFI : Library {
             out_err: RustError.ByReference
     ): Pointer?
 
+    fun places_new_interrupt_handle(
+            conn: PlacesConnectionHandle,
+            out_err: RustError.ByReference
+    ): RawPlacesInterruptHandle?
+
+    fun places_interrupt(
+            conn: RawPlacesInterruptHandle,
+            out_err: RustError.ByReference
+    )
+
     fun sync15_history_sync(
             handle: PlacesConnectionHandle,
             key_id: String,
@@ -108,7 +118,15 @@ internal interface LibPlacesFFI : Library {
     fun places_destroy_string(s: Pointer)
 
     /** Destroy connection created using `places_connection_new` */
+
     fun places_connection_destroy(handle: PlacesConnectionHandle, out_err: RustError.ByReference)
+    /** Destroy handle created using `places_new_interrupt_handle` */
+    fun places_interrupt_handle_destroy(obj: RawPlacesInterruptHandle)
 }
 
 internal typealias PlacesConnectionHandle = Long;
+
+// This doesn't use a handle to avoid unnecessary locking and
+// because the type is panic safe, sync, and send.
+class RawPlacesInterruptHandle : PointerType()
+

--- a/components/places/android/src/main/java/org/mozilla/places/RustError.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/RustError.kt
@@ -51,6 +51,7 @@ open class RustError : Structure() {
             2 -> return InvalidPlaceInfo(message)
             3 -> return UrlParseFailed(message)
             4 -> return PlacesConnectionBusy(message)
+            5 -> return OperationInterrupted(message)
             -1 -> return InternalPanic(message)
             // Note: `1` is used as a generic catch all, but we
             // might as well handle the others the same way.

--- a/components/places/src/db/interrupt.rs
+++ b/components/places/src/db/interrupt.rs
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::error::*;
+use rusqlite::InterruptHandle;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+
+// SeqCst is overkill for much of this, but whatever.
+
+/// A Sync+Send type which can be used allow someone to interrupt an
+/// operation, even if it happens while rust code (and not SQL) is
+/// executing.
+pub struct PlacesInterruptHandle {
+    pub(crate) db_handle: InterruptHandle,
+    pub(crate) interrupt_counter: Arc<AtomicUsize>,
+}
+
+impl PlacesInterruptHandle {
+    pub fn interrupt(&self) {
+        self.interrupt_counter.fetch_add(1, Ordering::SeqCst);
+        self.db_handle.interrupt();
+    }
+}
+
+/// A helper that can be used to determine if an interrupt request has come in while
+/// the object lives. This is used to avoid a case where we aren't running any
+/// queries when the request to stop comes in, but we're still not done (for example,
+/// maybe we've run some of the autocomplete matchers, and are about to start
+/// running the others. If we rely solely on sqlite3_interrupt(), we'd miss
+/// the message that we should stop).
+pub(crate) struct InterruptScope {
+    // The value of the interrupt counter when the scope began
+    start_value: usize,
+    // This could be &'conn AtomicUsize, but it would prevent the connection
+    // from being mutably borrowed for no real reason...
+    ptr: Arc<AtomicUsize>,
+}
+
+impl InterruptScope {
+    #[inline]
+    pub(crate) fn new(ptr: Arc<AtomicUsize>) -> Self {
+        let start_value = ptr.load(Ordering::SeqCst);
+        Self { start_value, ptr }
+    }
+
+    #[inline]
+    pub(crate) fn was_interrupted(&self) -> bool {
+        self.ptr.load(Ordering::SeqCst) != self.start_value
+    }
+
+    #[inline]
+    pub(crate) fn err_if_interrupted(&self) -> Result<()> {
+        if self.was_interrupted() {
+            Err(ErrorKind::InterruptedError.into())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_sync_send() {
+        fn is_sync<T: Sync>() {}
+        fn is_send<T: Send>() {}
+        // Make sure this compiles
+        is_sync::<PlacesInterruptHandle>();
+        is_send::<PlacesInterruptHandle>();
+    }
+}

--- a/components/places/src/db/mod.rs
+++ b/components/places/src/db/mod.rs
@@ -4,6 +4,7 @@
 
 // We don't want 'db.rs' as a sub-module. We could move the contents here? Or something else?
 pub mod db;
-pub use crate::db::db::PlacesDb;
-
+mod interrupt;
 mod schema;
+pub use self::interrupt::PlacesInterruptHandle;
+pub use crate::db::db::PlacesDb;

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -71,6 +71,11 @@ pub enum ErrorKind {
 
     #[fail(display = "Error parsing URL: {}", _0)]
     UrlParseError(#[fail(cause)] url::ParseError),
+
+    // Maybe we should try to fabricate a rusqlite::Error that looks like the
+    // interrupted error?
+    #[fail(display = "Operation interrupted")]
+    InterruptedError,
 }
 
 macro_rules! impl_from_error {

--- a/components/places/src/lib.rs
+++ b/components/places/src/lib.rs
@@ -19,7 +19,7 @@ mod util;
 mod valid_guid;
 
 pub use crate::api::apply_observation;
-pub use crate::db::PlacesDb;
+pub use crate::db::{PlacesDb, PlacesInterruptHandle};
 pub use crate::error::*;
 pub use crate::observation::VisitObservation;
 pub use crate::storage::PageInfo;


### PR DESCRIPTION
The Rust API is different than the Kotlin API, since `PlacesDb` isn't `Sync`. (`InterruptHandle` is a `Sync+Send` object. It does have a Kotlin wrapper, but it's not public, and exists make object management clear).

CC @grigoryk 