### PR TITLE
Fix bad changelog automerge from 36cff28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.15.0...master)
 
+## Places
+
+### What's New
+
+- New method on PlacesConnection (breaking change for classes implementing PlacesAPI): `fun interrupt()`. Cancels any calls to `queryAutocomplete` or `matchUrl` that are running on other threads. Those threads will throw an `OperationInterrupted` exception. ([#597](https://github.com/mozilla/application-services/pull/597))
+    - Using `interrupt()` during the execution of other methods may work, but will have mixed results (it will work if we're currently executing a SQL query, and not if we're running rust code). This limitation may be lifted in the future.
+
 # 0.15.0 (_2019-02-01_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.14.0...v0.15.0)
@@ -27,8 +34,6 @@
 ### What's New
 
 - New method on PlacesConnection (breaking change for classes implementing PlacesAPI): `fun matchUrl(query: String): String?`. This is similar to `queryAutocomplete`, but only searches for URL and Origin matches, and only returns (a portion of) the matching url (if found), or null (if not). ([#595](https://github.com/mozilla/application-services/pull/595))
-- New method on PlacesConnection (breaking change for classes implementing PlacesAPI): `fun interrupt()`. Cancels any calls to `queryAutocomplete` or `matchUrl` that are running on other threads. Those threads will throw an `OperationInterrupted` exception. ([#597](https://github.com/mozilla/application-services/pull/597))
-    - Using `interrupt()` during the execution of other methods may work, but will have mixed results (it will work if we're currently executing a SQL query, and not if we're running rust code). This limitation may be lifted in the future.
 
 ### What's Fixed
 


### PR DESCRIPTION
This put interrupt in the 0.15 changelog, but it's not released yet.