### PR TITLE
make avatar members public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
     - `fun deleteVisitsSince(since: Long)`: Deletes all visits between the given unix timestamp (in milliseconds) and the present ([#591](https://github.com/mozilla/application-services/pull/591)).
         - Note that these deletions are synced!
 
+## FxA
+
+### What's Fixed
+
+- iOS Framework: Members of Avatar struct are now public. ([#615](https://github.com/mozilla/application-services/pull/615))
+
+
 # 0.15.0 (_2019-02-01_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.14.0...v0.15.0)

--- a/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
@@ -288,8 +288,8 @@ open class AccessTokenInfo: RustStructPointer<AccessTokenInfoC> {
 }
 
 public struct Avatar {
-    let url: String
-    let isDefault: Bool
+    public let url: String
+    public let isDefault: Bool
 }
 
 open class Profile: RustStructPointer<ProfileC> {


### PR DESCRIPTION
Change Avatar member's to be public accessible so apps that import the library can access them.