### PR TITLE
Fix logins strings issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.16.0...master)
 
+## Logins
+
+### What's Fixed
+
+- iOS `LoginRecord`s will no longer use empty strings for `httpRealm` and `formSubmitUrl` in cases where they claim to use nil. ([#623](https://github.com/mozilla/application-services/issues/623))
+    - More broadly, all optional strings in LoginRecords were were being represented as empty strings (instead of nil) unintentionally. This is fixed.
+- iOS: Errors that were being accidentally swallowed should now be properly reported. ([#640](https://github.com/mozilla/application-services/issues/640))
+
+### Breaking changes
+
+- iOS: Code that expects empty strings (and not nil) for optional strings should be updated to check for nil instead. ([#623](https://github.com/mozilla/application-services/issues/623))
 
 # 0.16.0 (_2019-02-06_)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 - iOS: Code that expects empty strings (and not nil) for optional strings should be updated to check for nil instead. ([#623](https://github.com/mozilla/application-services/issues/623))
 
+## FxA
+
+### What's Fixed
+
+- iOS: Some errors that were being accidentally swallowed should now be properly reported. ([#640](https://github.com/mozilla/application-services/issues/640))
+
 # 0.16.0 (_2019-02-06_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.15.0...v0.16.0)

--- a/components/fxa-client/ios/FxAClient/Errors/FxAError.swift
+++ b/components/fxa-client/ios/FxAClient/Errors/FxAError.swift
@@ -40,6 +40,11 @@ public enum FxAError: Error {
             }
             throw ResultError.empty
         }
+        // result might not be nil (e.g. it could be 0), while still indicating failure. Ultimately,
+        // `err` is the source of truth here.
+        if let fxaErr = FxAError.fromConsuming(err) {
+            throw fxaErr
+        }
         return result
     }
 
@@ -51,6 +56,11 @@ public enum FxAError: Error {
                 throw fxaErr
             }
             return nil
+        }
+        // result might not be nil (e.g. it could be 0), while still indicating failure. Ultimately,
+        // `err` is the source of truth here.
+        if let fxaErr = FxAError.fromConsuming(err) {
+            throw fxaErr
         }
         return result
     }

--- a/components/logins/ios/Logins/Errors/LoginStoreError.swift
+++ b/components/logins/ios/Logins/Errors/LoginStoreError.swift
@@ -47,7 +47,7 @@ public enum LoginsStoreError: Error {
     // function
     static func fromConsuming(_ rustError: Sync15PasswordsError) -> LoginsStoreError? {
         let message = rustError.message
-        
+
         switch rustError.code {
         case Sync15Passwords_NoError:
             return nil
@@ -75,7 +75,7 @@ public enum LoginsStoreError: Error {
 
         case Sync15Passwords_NetworkError:
             return .Network(message: String(freeingRustString: message!))
-                
+
         default:
             return .Unspecified(message: String(freeingRustString: message!))
         }

--- a/components/logins/ios/Logins/Errors/LoginStoreError.swift
+++ b/components/logins/ios/Logins/Errors/LoginStoreError.swift
@@ -90,6 +90,11 @@ public enum LoginsStoreError: Error {
             }
             throw ResultError.empty
         }
+        // result might not be nil (e.g. it could be 0), while still indicating failure. Ultimately,
+        // `err` is the source of truth here.
+        if let loginErr = LoginsStoreError.fromConsuming(err) {
+            throw loginErr
+        }
         return result
     }
 
@@ -101,6 +106,11 @@ public enum LoginsStoreError: Error {
                 throw loginErr
             }
             return nil
+        }
+        // result might not be nil (e.g. it could be 0), while still indicating failure. Ultimately,
+        // `err` is the source of truth here.
+        if let loginErr = LoginsStoreError.fromConsuming(err) {
+            throw loginErr
         }
         return result
     }

--- a/components/logins/ios/Logins/LoginRecord.swift
+++ b/components/logins/ios/Logins/LoginRecord.swift
@@ -10,34 +10,34 @@ open class LoginRecord {
     /// collides with an existing record, a `LoginsStoreError.DuplicateGuid`
     /// will be emitted.
     public var id: String
-    
+
     /// This record's hostname. Required. Attempting to insert
     /// or update a record to have a blank hostname, will result in a
     /// `LoginsStoreError.InvalidLogin`.
     public var hostname: String
-    
+
     /// This record's password. Required. Attempting to insert
     /// or update a record to have a blank password, will result in a
     /// `LoginsStoreError.InvalidLogin`.
     public var password: String
-    
+
     /// This record's username, if any.
     public var username: String? = nil
-    
+
     /// The challenge string for HTTP Basic authentication.
     ///
     /// Exactly one of `httpRealm` or `formSubmitURL` is allowed to be present,
     /// and attempting to insert or update a record to have both or neither will
     /// result in an `LoginsStoreError.InvalidLogin`.
     public var httpRealm: String? = nil
-    
+
     /// The submission URL for the form where this login may be entered.
     ///
     /// As mentioned above, exactly one of `httpRealm` or `formSubmitURL` is allowed
     /// to be present, and attempting to insert or update a record to have
     /// both or neither will result in an `LoginsStoreError.InvalidLogin`.
     public var formSubmitURL: String? = nil
-    
+
     /// A lower bound on the number of times this record has been "used".
     ///
     /// A use is recorded (and `timeLastUsed` is updated accordingly) in
@@ -50,17 +50,17 @@ open class LoginRecord {
     ///
     /// This is ignored by `add` and `update`.
     public var timesUsed: Int = 0
-    
+
     /// An upper bound on the time of creation in milliseconds from the unix epoch.
     ///
     /// This is ignored by `add` and `update`.
     public var timeCreated: Int64 = 0
-    
+
     /// A lower bound on the time of last use in milliseconds from the unix epoch.
     ///
     /// This is ignored by `add` and `update`.
     public var timeLastUsed: Int64 = 0
-    
+
     /// A lower bound on the time of last use in milliseconds from the unix epoch.
     ///
     /// This is ignored by `add` and `update`.
@@ -71,8 +71,7 @@ open class LoginRecord {
 
     /// HTML field name of the password, if known.
     public var passwordField: String? = nil
-    
-    
+
     open func toJSONDict() -> [String: Any] {
         var dict: [String: Any] = [
             "id": self.id,
@@ -84,7 +83,7 @@ open class LoginRecord {
             "timeLastUsed": self.timeLastUsed,
             "timePasswordChanged": self.timePasswordChanged,
         ]
-        
+
         if let username = self.username {
             dict["username"] = username
         }
@@ -96,7 +95,7 @@ open class LoginRecord {
         if let formSubmitURL = self.formSubmitURL {
             dict["formSubmitURL"] = formSubmitURL
         }
-        
+
         if let passwordField = self.passwordField {
             dict["passwordField"] = passwordField
         }
@@ -106,13 +105,13 @@ open class LoginRecord {
         }
         return dict
     }
-    
+
     open func toJSON() throws -> String {
         // We need a String to pass back to rust.
         let data: Data = try JSONSerialization.data(withJSONObject: self.toJSONDict())
         return String(data: data, encoding: String.Encoding.utf8)!
     }
-    
+
     // TODO: handle errors in these... (they shouldn't ever happen
     // outside of bugs since we write the json in rust, but still)
 

--- a/components/logins/ios/Logins/LoginRecord.swift
+++ b/components/logins/ios/Logins/LoginRecord.swift
@@ -121,18 +121,18 @@ open class LoginRecord {
             password: dict["password"] as? String ?? "",
             hostname: dict["hostname"] as? String ?? "",
 
-            username: dict["username"] as? String ?? "",
+            username: dict["username"] as? String,
 
-            formSubmitURL: dict["formSubmitURL"] as? String ?? "",
-            httpRealm: dict["httpRealm"] as? String ?? "",
+            formSubmitURL: dict["formSubmitURL"] as? String,
+            httpRealm: dict["httpRealm"] as? String,
 
             timesUsed: (dict["timesUsed"] as? Int) ?? 0,
             timeLastUsed: (dict["timeLastUsed"] as? Int64) ?? 0,
             timeCreated: (dict["timeCreated"] as? Int64) ?? 0,
             timePasswordChanged: (dict["timePasswordChanged"] as? Int64) ?? 0,
 
-            usernameField: dict["usernameField"] as? String ?? "",
-            passwordField: dict["passwordField"] as? String ?? ""
+            usernameField: dict["usernameField"] as? String,
+            passwordField: dict["passwordField"] as? String
         )
     }
 

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -23,15 +23,15 @@ open class SyncUnlockInfo {
 open class LoginsStorage {
     private var raw: UInt64 = 0
     let dbPath: String
-    
+
     public init(databasePath: String) {
         self.dbPath = databasePath
     }
-    
+
     deinit {
         self.close()
     }
-    
+
     private func doDestroy() {
         let raw = self.raw
         self.raw = 0
@@ -59,7 +59,7 @@ open class LoginsStorage {
             return self.raw == 0
         })
     }
-    
+
     // helper to reduce boilerplate, we don't use queue.sync
     // since we expect the caller to do so.
     private func getUnlocked() throws -> UInt64 {
@@ -97,7 +97,7 @@ open class LoginsStorage {
             self.doDestroy()
         })
     }
-    
+
     /// Synchronize with the server.
     open func sync(unlockInfo: SyncUnlockInfo) throws {
         try queue.sync(execute: {
@@ -128,7 +128,7 @@ open class LoginsStorage {
             })
         })
     }
-    
+
     /// Delete the record with the given ID. Returns false if no such record existed.
     open func delete(id: String) throws -> Bool {
         return try queue.sync(execute: {
@@ -139,7 +139,7 @@ open class LoginsStorage {
             return boolAsU8 != 0
         })
     }
-    
+
     /// Bump the usage count for the record with the given id.
     ///
     /// Throws `LoginStoreError.NoSuchRecord` if there was no such record.
@@ -166,7 +166,7 @@ open class LoginsStorage {
             return String(freeingRustString: ptr)
         })
     }
-    
+
     /// Update `login` in the database. If `login.id` does not refer to a known
     /// login, then this throws `LoginStoreError.NoSuchRecord`.
     open func update(login: LoginRecord) throws {
@@ -193,8 +193,7 @@ open class LoginsStorage {
             return try LoginRecord(fromJSONString: jsonStr)
         })
     }
-    
-    
+
     /// Get the entire list of records.
     open func list() throws -> [LoginRecord] {
         return try queue.sync(execute: {

--- a/components/logins/ios/LoginsTests/LoginsTests.swift
+++ b/components/logins/ios/LoginsTests/LoginsTests.swift
@@ -6,6 +6,15 @@ import XCTest
 
 class LoginsTests: XCTestCase {
 
+    func getTestStorage() -> LoginsStorage {
+        let directory = NSTemporaryDirectory()
+        let filename = "testdb-\(UUID().uuidString).db"
+        let fileURL = URL(fileURLWithPath: directory).appendingPathComponent(filename)
+        // Note: SQLite supports using file: urls, so this works. (Maybe we should allow
+        // passing in a URL argument too?)
+        return LoginsStorage(databasePath: fileURL.absoluteString)
+    }
+
     override func setUp() {
         // This method is called before the invocation of each test method in the class.
     }
@@ -15,7 +24,7 @@ class LoginsTests: XCTestCase {
     }
 
     func testBadEncryptionKey() {
-        let storage = LoginsStorage(databasePath: "test-rust-logins.db")
+        let storage = getTestStorage()
         var dbOpened = true
         do {
               try storage.unlock(withEncryptionKey: "foofoofoo")
@@ -24,7 +33,7 @@ class LoginsTests: XCTestCase {
         }
 
         try! storage.lock()
-
+        
         do {
             try storage.unlock(withEncryptionKey: "zebra")
         } catch {
@@ -32,5 +41,48 @@ class LoginsTests: XCTestCase {
         }
 
         XCTAssertFalse(dbOpened, "Bad key unlocked the db!")
+    }
+
+    func testLoginRecordNil() {
+        let storage = getTestStorage()
+        try! storage.unlock(withEncryptionKey: "test123")
+        let id0 = try! storage.add(login: LoginRecord(
+            id: "",
+            password: "hunter2",
+            hostname: "https://www.example.com",
+            username: "cooluser33",
+            formSubmitURL: "https://www.example.com/login",
+            httpRealm: nil,
+            timesUsed: nil,
+            timeLastUsed: nil,
+            timeCreated: nil,
+            timePasswordChanged: nil,
+            usernameField: nil,
+            passwordField: nil
+        ))
+
+        let record0 = try! storage.get(id: id0)!
+        XCTAssertNil(record0.httpRealm)
+        XCTAssertEqual(record0.formSubmitURL, "https://www.example.com/login")
+
+        let id1 = try! storage.add(login: LoginRecord(
+            id: "",
+            password: "hunter3",
+            hostname: "https://www.example2.com",
+            username: "cooluser44",
+            formSubmitURL: nil,
+            httpRealm: "Something Something",
+            timesUsed: nil,
+            timeLastUsed: nil,
+            timeCreated: nil,
+            timePasswordChanged: nil,
+            usernameField: nil,
+            passwordField: nil
+        ))
+
+        let record1 = try! storage.get(id: id1)!
+
+        XCTAssertNil(record1.formSubmitURL)
+        XCTAssertEqual(record1.httpRealm, "Something Something")
     }
 }


### PR DESCRIPTION
I also hit #640, which had been mentioned but I hadn't realized was definitely still a thing. So I fixed it too.

Also the first commit cleans up a bunch of trailing whitespace because I hadn't realized it was there. Not sure how to make xcode not do that, but, well, eventually I'll look into it.

Fixes #623 
Fixes #640