### PR TITLE
Split FirefoxAccounts implementation in multiple files

### DIFF
--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -326,4 +326,5 @@ define_string_destructor!(fxa_str_free);
 define_handle_map_deleter!(ACCOUNTS, fxa_free);
 define_box_destructor!(AccessTokenInfoC, fxa_oauth_info_free);
 define_box_destructor!(ProfileC, fxa_profile_free);
+#[cfg(feature = "browserid")]
 define_box_destructor!(SyncKeysC, fxa_sync_keys_free);

--- a/components/fxa-client/src/browser_id.rs
+++ b/components/fxa-client/src/browser_id.rs
@@ -1,0 +1,125 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{
+    errors::*,
+    http_client::{browser_id::jwt_utils, Client},
+    login_sm::{LoginState, LoginStateMachine, MarriedState, ReadyForKeysState, SessionTokenState},
+    Config, FirefoxAccount, StateV2,
+};
+use serde_derive::*;
+use std::collections::HashMap;
+
+impl FirefoxAccount {
+    // Initialize state from Firefox Accounts credentials obtained using the
+    // web flow.
+    pub fn from_credentials(
+        content_url: &str,
+        client_id: &str,
+        redirect_uri: &str,
+        credentials: WebChannelResponse,
+    ) -> Result<Self> {
+        let config = Config::new(content_url, client_id, redirect_uri);
+        let session_token = hex::decode(credentials.session_token)?;
+        let key_fetch_token = hex::decode(credentials.key_fetch_token)?;
+        let unwrap_kb = hex::decode(credentials.unwrap_kb)?;
+        let login_state_data = ReadyForKeysState::new(
+            credentials.uid,
+            credentials.email,
+            session_token,
+            key_fetch_token,
+            unwrap_kb,
+        );
+        let login_state = if credentials.verified {
+            LoginState::EngagedAfterVerified(login_state_data)
+        } else {
+            LoginState::EngagedBeforeVerified(login_state_data)
+        };
+
+        Ok(Self::from_state(StateV2 {
+            config,
+            login_state,
+            refresh_token: None,
+            scoped_keys: HashMap::new(),
+        }))
+    }
+
+    fn to_married(&mut self) -> Option<&MarriedState> {
+        self.advance();
+        match self.state.login_state {
+            LoginState::Married(ref married) => Some(married),
+            _ => None,
+        }
+    }
+
+    pub fn advance(&mut self) {
+        let client = Client::new(&self.state.config);
+        let state_machine = LoginStateMachine::new(client);
+        let state = std::mem::replace(&mut self.state.login_state, LoginState::Unknown);
+        self.state.login_state = state_machine.advance(state);
+    }
+
+    pub(crate) fn session_token_from_state(state: &LoginState) -> Option<&[u8]> {
+        match state {
+            &LoginState::Separated(_) | LoginState::Unknown => None,
+            // Despite all these states implementing the same trait we can't treat
+            // them in a single arm, so this will do for now :/
+            &LoginState::EngagedBeforeVerified(ref state)
+            | &LoginState::EngagedAfterVerified(ref state) => Some(state.session_token()),
+            &LoginState::CohabitingBeforeKeyPair(ref state) => Some(state.session_token()),
+            &LoginState::CohabitingAfterKeyPair(ref state) => Some(state.session_token()),
+            &LoginState::Married(ref state) => Some(state.session_token()),
+        }
+    }
+
+    pub fn generate_assertion(&mut self, audience: &str) -> Result<String> {
+        let married = match self.to_married() {
+            Some(married) => married,
+            None => return Err(ErrorKind::NotMarried.into()),
+        };
+        let key_pair = married.key_pair();
+        let certificate = married.certificate();
+        Ok(jwt_utils::create_assertion(
+            key_pair,
+            &certificate,
+            audience,
+        )?)
+    }
+
+    pub fn get_sync_keys(&mut self) -> Result<SyncKeys> {
+        let married = match self.to_married() {
+            Some(married) => married,
+            None => return Err(ErrorKind::NotMarried.into()),
+        };
+        let sync_key = hex::encode(married.sync_key());
+        Ok(SyncKeys(sync_key, married.xcs().to_string()))
+    }
+
+    pub fn sign_out(mut self) {
+        let client = Client::new(&self.state.config);
+        client.sign_out();
+        self.state.login_state = self.state.login_state.to_separated();
+    }
+}
+
+#[derive(Deserialize)]
+pub struct WebChannelResponse {
+    uid: String,
+    email: String,
+    verified: bool,
+    #[serde(rename = "sessionToken")]
+    session_token: String,
+    #[serde(rename = "keyFetchToken")]
+    key_fetch_token: String,
+    #[serde(rename = "unwrapBKey")]
+    unwrap_kb: String,
+}
+
+impl WebChannelResponse {
+    pub fn from_json(json: &str) -> Result<WebChannelResponse> {
+        serde_json::from_str(json).map_err(|e| e.into())
+    }
+}
+
+pub struct SyncKeys(pub String, pub String);

--- a/components/fxa-client/src/ffi.rs
+++ b/components/fxa-client/src/ffi.rs
@@ -14,7 +14,9 @@
 
 #![cfg(feature = "ffi")]
 
-use crate::{AccessTokenInfo, Error, ErrorKind, Profile, SyncKeys};
+#[cfg(feature = "browserid")]
+use crate::SyncKeys;
+use crate::{AccessTokenInfo, Error, ErrorKind, Profile};
 use ffi_support::{
     destroy_c_string, opt_rust_string_to_c, rust_string_to_c, ErrorCode, ExternError, IntoFfi,
 };
@@ -66,12 +68,14 @@ impl From<Error> for ExternError {
 // safety problems from safe rust code), but they're depended upon by the FFI, and cannot be
 // changed.
 
+#[cfg(feature = "browserid")]
 #[repr(C)]
 pub struct SyncKeysC {
     sync_key: *mut c_char,
     xcs: *mut c_char,
 }
 
+#[cfg(feature = "browserid")]
 impl Drop for SyncKeysC {
     fn drop(&mut self) {
         unsafe {
@@ -81,6 +85,7 @@ impl Drop for SyncKeysC {
     }
 }
 
+#[cfg(feature = "browserid")]
 impl From<SyncKeys> for SyncKeysC {
     fn from(sync_keys: SyncKeys) -> Self {
         SyncKeysC {
@@ -171,6 +176,7 @@ macro_rules! implement_into_ffi_converting {
     };
 }
 
+#[cfg(feature = "browserid")]
 implement_into_ffi_converting!(SyncKeys, SyncKeysC);
 implement_into_ffi_converting!(AccessTokenInfo, AccessTokenInfoC);
 implement_into_ffi_converting!(Profile, ProfileC);

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -461,26 +461,6 @@ impl FirefoxAccount {
         Ok(url)
     }
 
-    pub fn handle_push_message(&self) {
-        panic!("Not implemented yet!")
-    }
-
-    pub fn register_device(&self) {
-        panic!("Not implemented yet!")
-    }
-
-    pub fn get_devices_list(&self) {
-        panic!("Not implemented yet!")
-    }
-
-    pub fn send_message(&self) {
-        panic!("Not implemented yet!")
-    }
-
-    pub fn retrieve_messages(&self) {
-        panic!("Not implemented yet!")
-    }
-
     pub fn register_persist_callback(&mut self, persist_callback: PersistCallback) {
         self.persist_callback = Some(persist_callback);
     }

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -2,22 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub use crate::{config::Config, http_client::ProfileResponse as Profile};
+pub use crate::{config::Config, http_client::ProfileResponse as Profile, oauth::AccessTokenInfo};
 use crate::{
     errors::*,
     http_client::Client,
-    scoped_keys::ScopedKeysFlow,
-    util::{now, random_base64_url_string},
+    oauth::{OAuthFlow, RefreshToken, ScopedKey},
 };
 use lazy_static::lazy_static;
-use ring::{digest, rand::SystemRandom};
+use ring::rand::SystemRandom;
 use serde_derive::*;
-use std::{
-    collections::{HashMap, HashSet},
-    iter::FromIterator,
-    panic::RefUnwindSafe,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::{collections::HashMap, panic::RefUnwindSafe};
 use url::Url;
 #[cfg(feature = "browserid")]
 use {
@@ -35,14 +29,12 @@ pub mod ffi;
 mod http_client;
 #[cfg(feature = "browserid")]
 mod login_sm;
+mod oauth;
 mod scoped_keys;
 pub mod scopes;
 mod state_persistence;
 mod util;
 
-// If a cached token has less than `OAUTH_MIN_TIME_LEFT` seconds left to live,
-// it will be considered already expired.
-const OAUTH_MIN_TIME_LEFT: u64 = 60;
 // A cached profile response is considered fresh for `PROFILE_FRESHNESS_THRESHOLD` ms.
 const PROFILE_FRESHNESS_THRESHOLD: u64 = 120000; // 2 minutes
 
@@ -205,177 +197,6 @@ impl FirefoxAccount {
         self.state.login_state = state_machine.advance(state);
     }
 
-    pub fn get_access_token(&mut self, scope: &str) -> Result<AccessTokenInfo> {
-        if scope.contains(" ") {
-            return Err(ErrorKind::MultipleScopesRequested.into());
-        }
-        if let Some(oauth_info) = self.access_token_cache.get(scope) {
-            if oauth_info.expires_at > util::now_secs() + OAUTH_MIN_TIME_LEFT {
-                return Ok(oauth_info.clone());
-            }
-        }
-        let client = Client::new(&self.state.config);
-        let resp = match self.state.refresh_token {
-            Some(ref refresh_token) => match refresh_token.scopes.contains(scope) {
-                true => client.oauth_token_with_refresh_token(&refresh_token.token, &[scope])?,
-                false => return Err(ErrorKind::NoCachedToken(scope.to_string()).into()),
-            },
-            None => {
-                #[cfg(feature = "browserid")]
-                {
-                    match Self::session_token_from_state(&self.state.login_state) {
-                        Some(session_token) => {
-                            client.oauth_token_with_session_token(session_token, &[scope])?
-                        }
-                        None => return Err(ErrorKind::NoCachedToken(scope.to_string()).into()),
-                    }
-                }
-                #[cfg(not(feature = "browserid"))]
-                {
-                    return Err(ErrorKind::NoCachedToken(scope.to_string()).into());
-                }
-            }
-        };
-        let since_epoch = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_err(|_| ErrorKind::IllegalState("Current date before Unix Epoch.".to_string()))?;
-        let expires_at = since_epoch.as_secs() + resp.expires_in;
-        let token_info = AccessTokenInfo {
-            scope: resp.scope,
-            token: resp.access_token,
-            key: self.state.scoped_keys.get(scope).cloned(),
-            expires_at,
-        };
-        self.access_token_cache
-            .insert(scope.to_string(), token_info.clone());
-        Ok(token_info)
-    }
-
-    pub fn begin_pairing_flow(&mut self, pairing_url: &str, scopes: &[&str]) -> Result<String> {
-        let mut url = self.state.config.content_url_path("/pair/supp")?;
-        let pairing_url = Url::parse(pairing_url)?;
-        if url.host_str() != pairing_url.host_str() {
-            return Err(ErrorKind::OriginMismatch.into());
-        }
-        url.set_fragment(pairing_url.fragment());
-        self.oauth_flow(url, scopes, true)
-    }
-
-    pub fn begin_oauth_flow(&mut self, scopes: &[&str], wants_keys: bool) -> Result<String> {
-        let mut url = self.state.config.authorization_endpoint()?;
-        url.query_pairs_mut()
-            .append_pair("action", "email")
-            .append_pair("response_type", "code");
-        let scopes: Vec<String> = match self.state.refresh_token {
-            Some(ref refresh_token) => {
-                // Union of the already held scopes and the one requested.
-                let mut all_scopes: Vec<String> = vec![];
-                all_scopes.extend(scopes.iter().map(|s| s.to_string()));
-                let existing_scopes = refresh_token.scopes.clone();
-                all_scopes.extend(existing_scopes);
-                HashSet::<String>::from_iter(all_scopes)
-                    .into_iter()
-                    .collect()
-            }
-            None => scopes.iter().map(|s| s.to_string()).collect(),
-        };
-        let scopes: Vec<&str> = scopes.iter().map(<_>::as_ref).collect();
-        self.oauth_flow(url, &scopes, wants_keys)
-    }
-
-    fn oauth_flow(&mut self, mut url: Url, scopes: &[&str], wants_keys: bool) -> Result<String> {
-        let state = random_base64_url_string(&*RNG, 16)?;
-        let code_verifier = random_base64_url_string(&*RNG, 43)?;
-        let code_challenge = digest::digest(&digest::SHA256, &code_verifier.as_bytes());
-        let code_challenge = base64::encode_config(&code_challenge, base64::URL_SAFE_NO_PAD);
-        url.query_pairs_mut()
-            .append_pair("client_id", &self.state.config.client_id)
-            .append_pair("redirect_uri", &self.state.config.redirect_uri)
-            .append_pair("scope", &scopes.join(" "))
-            .append_pair("state", &state)
-            .append_pair("code_challenge_method", "S256")
-            .append_pair("code_challenge", &code_challenge)
-            .append_pair("access_type", "offline");
-        let scoped_keys_flow = match wants_keys {
-            true => {
-                let flow = ScopedKeysFlow::with_random_key(&*RNG)?;
-                let jwk_json = flow.generate_keys_jwk()?;
-                let keys_jwk = base64::encode_config(&jwk_json, base64::URL_SAFE_NO_PAD);
-                url.query_pairs_mut().append_pair("keys_jwk", &keys_jwk);
-                Some(flow)
-            }
-            false => None,
-        };
-        self.flow_store.insert(
-            state.clone(), // Since state is supposed to be unique, we use it to key our flows.
-            OAuthFlow {
-                scoped_keys_flow,
-                code_verifier,
-            },
-        );
-        Ok(url.to_string())
-    }
-
-    pub fn complete_oauth_flow(&mut self, code: &str, state: &str) -> Result<()> {
-        let oauth_flow = match self.flow_store.remove(state) {
-            Some(oauth_flow) => oauth_flow,
-            None => return Err(ErrorKind::UnknownOAuthState.into()),
-        };
-        let client = Client::new(&self.state.config);
-        let resp = client.oauth_token_with_code(&code, &oauth_flow.code_verifier)?;
-        // This assumes that if the server returns keys_jwe, the jwk argument is Some.
-        match resp.keys_jwe {
-            Some(ref jwe) => {
-                let scoped_keys_flow = match oauth_flow.scoped_keys_flow {
-                    Some(flow) => flow,
-                    None => {
-                        return Err(ErrorKind::UnrecoverableServerError(
-                            "Got a JWE without sending a JWK.",
-                        )
-                        .into());
-                    }
-                };
-                let decrypted_keys = scoped_keys_flow.decrypt_keys_jwe(jwe)?;
-                let scoped_keys: serde_json::Map<String, serde_json::Value> =
-                    serde_json::from_str(&decrypted_keys)?;
-                for (scope, key) in scoped_keys {
-                    let scoped_key: ScopedKey = serde_json::from_value(key)?;
-                    self.state.scoped_keys.insert(scope, scoped_key);
-                }
-            }
-            None => {
-                if oauth_flow.scoped_keys_flow.is_some() {
-                    log::error!("Expected to get keys back alongside the token but the server didn't send them.");
-                    return Err(ErrorKind::TokenWithoutKeys.into());
-                }
-            }
-        };
-        let client = Client::new(&self.state.config);
-        // We are only interested in the refresh token at this time because we
-        // don't want to return an over-scoped access token.
-        // Let's be good citizens and destroy this access token.
-        if let Err(err) = client.destroy_oauth_token(&resp.access_token) {
-            log::warn!("Access token destruction failure: {:?}", err);
-        }
-        let refresh_token = match resp.refresh_token {
-            Some(ref refresh_token) => refresh_token.clone(),
-            None => return Err(ErrorKind::RefreshTokenNotPresent.into()),
-        };
-        // In order to keep 1 and only 1 refresh token alive per client instance,
-        // we also destroy the existing refresh token.
-        if let Some(ref old_refresh_token) = self.state.refresh_token {
-            if let Err(err) = client.destroy_oauth_token(&old_refresh_token.token) {
-                log::warn!("Refresh token destruction failure: {:?}", err);
-            }
-        }
-        self.state.refresh_token = Some(RefreshToken {
-            token: refresh_token,
-            scopes: HashSet::from_iter(resp.scope.split(' ').map(|s| s.to_string())),
-        });
-        self.maybe_call_persist_callback();
-        Ok(())
-    }
-
     #[cfg(feature = "browserid")]
     fn session_token_from_state(state: &LoginState) -> Option<&[u8]> {
         match state {
@@ -410,7 +231,8 @@ impl FirefoxAccount {
         let profile_access_token = self.get_access_token(scopes::PROFILE)?.token;
         let mut etag = None;
         if let Some(ref cached_profile) = self.profile_cache {
-            if !ignore_cache && now() < cached_profile.cached_at + PROFILE_FRESHNESS_THRESHOLD {
+            if !ignore_cache && util::now() < cached_profile.cached_at + PROFILE_FRESHNESS_THRESHOLD
+            {
                 return Ok(cached_profile.response.clone());
             }
             etag = Some(cached_profile.etag.clone());
@@ -421,7 +243,7 @@ impl FirefoxAccount {
                 if let Some(etag) = response_and_etag.etag {
                     self.profile_cache = Some(CachedResponse {
                         response: response_and_etag.response.clone(),
-                        cached_at: now(),
+                        cached_at: util::now(),
                         etag,
                     });
                 }
@@ -490,44 +312,9 @@ impl FirefoxAccount {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct ScopedKey {
-    pub kty: String,
-    pub scope: String,
-    /// URL Safe Base 64 encoded key.
-    pub k: String,
-    pub kid: String,
-}
-
-impl ScopedKey {
-    pub fn key_bytes(&self) -> Result<Vec<u8>> {
-        Ok(base64::decode_config(&self.k, base64::URL_SAFE_NO_PAD)?)
-    }
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RefreshToken {
-    pub token: String,
-    pub scopes: HashSet<String>,
-}
-
-pub struct OAuthFlow {
-    pub scoped_keys_flow: Option<ScopedKeysFlow>,
-    pub code_verifier: String,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct AccessTokenInfo {
-    pub scope: String,
-    pub token: String,
-    pub key: Option<ScopedKey>,
-    pub expires_at: u64, // seconds since epoch
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::borrow::Cow;
 
     #[test]
     fn test_fxa_is_send() {
@@ -544,209 +331,6 @@ mod tests {
         let fxa2 = FirefoxAccount::from_json(&fxa1_json).unwrap();
         let fxa2_json = fxa2.to_json().unwrap();
         assert_eq!(fxa1_json, fxa2_json);
-    }
-
-    #[test]
-    fn test_oauth_flow_url() {
-        let mut fxa = FirefoxAccount::new(
-            "https://accounts.firefox.com",
-            "12345678",
-            "https://foo.bar",
-        );
-        let url = fxa.begin_oauth_flow(&["profile"], false).unwrap();
-        let flow_url = Url::parse(&url).unwrap();
-
-        assert_eq!(flow_url.host_str(), Some("accounts.firefox.com"));
-        assert_eq!(flow_url.path(), "/authorization");
-
-        let mut pairs = flow_url.query_pairs();
-        assert_eq!(pairs.count(), 9);
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("action"), Cow::Borrowed("email")))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("response_type"), Cow::Borrowed("code")))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("client_id"), Cow::Borrowed("12345678")))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((
-                Cow::Borrowed("redirect_uri"),
-                Cow::Borrowed("https://foo.bar")
-            ))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("scope"), Cow::Borrowed("profile")))
-        );
-        let state_param = pairs.next().unwrap();
-        assert_eq!(state_param.0, Cow::Borrowed("state"));
-        assert_eq!(state_param.1.len(), 22);
-        assert_eq!(
-            pairs.next(),
-            Some((
-                Cow::Borrowed("code_challenge_method"),
-                Cow::Borrowed("S256")
-            ))
-        );
-        let code_challenge_param = pairs.next().unwrap();
-        assert_eq!(code_challenge_param.0, Cow::Borrowed("code_challenge"));
-        assert_eq!(code_challenge_param.1.len(), 43);
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("access_type"), Cow::Borrowed("offline")))
-        );
-    }
-
-    #[test]
-    fn test_oauth_flow_url_with_keys() {
-        let mut fxa = FirefoxAccount::new(
-            "https://accounts.firefox.com",
-            "12345678",
-            "https://foo.bar",
-        );
-        let url = fxa.begin_oauth_flow(&["profile"], true).unwrap();
-        let flow_url = Url::parse(&url).unwrap();
-
-        assert_eq!(flow_url.host_str(), Some("accounts.firefox.com"));
-        assert_eq!(flow_url.path(), "/authorization");
-
-        let mut pairs = flow_url.query_pairs();
-        assert_eq!(pairs.count(), 10);
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("action"), Cow::Borrowed("email")))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("response_type"), Cow::Borrowed("code")))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("client_id"), Cow::Borrowed("12345678")))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((
-                Cow::Borrowed("redirect_uri"),
-                Cow::Borrowed("https://foo.bar")
-            ))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("scope"), Cow::Borrowed("profile")))
-        );
-        let state_param = pairs.next().unwrap();
-        assert_eq!(state_param.0, Cow::Borrowed("state"));
-        assert_eq!(state_param.1.len(), 22);
-        assert_eq!(
-            pairs.next(),
-            Some((
-                Cow::Borrowed("code_challenge_method"),
-                Cow::Borrowed("S256")
-            ))
-        );
-        let code_challenge_param = pairs.next().unwrap();
-        assert_eq!(code_challenge_param.0, Cow::Borrowed("code_challenge"));
-        assert_eq!(code_challenge_param.1.len(), 43);
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("access_type"), Cow::Borrowed("offline")))
-        );
-        let keys_jwk = pairs.next().unwrap();
-        assert_eq!(keys_jwk.0, Cow::Borrowed("keys_jwk"));
-        assert_eq!(keys_jwk.1.len(), 168);
-    }
-
-    #[test]
-    fn test_pairing_flow_url() {
-        static SCOPES: &'static [&'static str] = &["https://identity.mozilla.com/apps/oldsync"];
-        static PAIRING_URL: &'static str = "https://accounts.firefox.com/pair#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
-        static EXPECTED_URL: &'static str = "https://accounts.firefox.com/pair/supp?client_id=12345678&redirect_uri=https%3A%2F%2Ffoo.bar&scope=https%3A%2F%2Fidentity.mozilla.com%2Fapps%2Foldsync&state=SmbAA_9EA5v1R2bgIPeWWw&code_challenge_method=S256&code_challenge=ZgHLPPJ8XYbXpo7VIb7wFw0yXlTa6MUOVfGiADt0JSM&access_type=offline&keys_jwk=eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6Ing5LUltQjJveDM0LTV6c1VmbW5sNEp0Ti14elV2eFZlZXJHTFRXRV9BT0kiLCJ5IjoiNXBKbTB3WGQ4YXdHcm0zREl4T1pWMl9qdl9tZEx1TWlMb1RkZ1RucWJDZyJ9#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
-
-        let mut fxa = FirefoxAccount::new(
-            "https://accounts.firefox.com",
-            "12345678",
-            "https://foo.bar",
-        );
-        let url = fxa.begin_pairing_flow(&PAIRING_URL, &SCOPES).unwrap();
-        let flow_url = Url::parse(&url).unwrap();
-        let expected_parsed_url = Url::parse(EXPECTED_URL).unwrap();
-
-        assert_eq!(flow_url.host_str(), Some("accounts.firefox.com"));
-        assert_eq!(flow_url.path(), "/pair/supp");
-        assert_eq!(flow_url.fragment(), expected_parsed_url.fragment());
-
-        let mut pairs = flow_url.query_pairs();
-        assert_eq!(pairs.count(), 8);
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("client_id"), Cow::Borrowed("12345678")))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((
-                Cow::Borrowed("redirect_uri"),
-                Cow::Borrowed("https://foo.bar")
-            ))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((
-                Cow::Borrowed("scope"),
-                Cow::Borrowed("https://identity.mozilla.com/apps/oldsync")
-            ))
-        );
-        let state_param = pairs.next().unwrap();
-        assert_eq!(state_param.0, Cow::Borrowed("state"));
-        assert_eq!(state_param.1.len(), 22);
-        assert_eq!(
-            pairs.next(),
-            Some((
-                Cow::Borrowed("code_challenge_method"),
-                Cow::Borrowed("S256")
-            ))
-        );
-        let code_challenge_param = pairs.next().unwrap();
-        assert_eq!(code_challenge_param.0, Cow::Borrowed("code_challenge"));
-        assert_eq!(code_challenge_param.1.len(), 43);
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("access_type"), Cow::Borrowed("offline")))
-        );
-        let keys_jwk = pairs.next().unwrap();
-        assert_eq!(keys_jwk.0, Cow::Borrowed("keys_jwk"));
-        assert_eq!(keys_jwk.1.len(), 168);
-    }
-
-    #[test]
-    fn test_pairing_flow_origin_mismatch() {
-        static PAIRING_URL: &'static str =
-            "https://bad.origin.com/pair#channel_id=foo&channel_key=bar";
-        let mut fxa = FirefoxAccount::new(
-            "https://accounts.firefox.com",
-            "12345678",
-            "https://foo.bar",
-        );
-        let url =
-            fxa.begin_pairing_flow(&PAIRING_URL, &["https://identity.mozilla.com/apps/oldsync"]);
-
-        assert!(url.is_err());
-
-        match url {
-            Ok(_) => {
-                panic!("should have error");
-            }
-            Err(err) => match err.kind() {
-                ErrorKind::OriginMismatch { .. } => {}
-                _ => panic!("error not OriginMismatch"),
-            },
-        }
     }
 
     #[test]

--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -1,0 +1,435 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{
+    errors::*, http_client::Client, scoped_keys::ScopedKeysFlow, util, FirefoxAccount, RNG,
+};
+use ring::digest;
+use serde_derive::*;
+use std::{
+    collections::HashSet,
+    iter::FromIterator,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use url::Url;
+
+// If a cached token has less than `OAUTH_MIN_TIME_LEFT` seconds left to live,
+// it will be considered already expired.
+const OAUTH_MIN_TIME_LEFT: u64 = 60;
+
+impl FirefoxAccount {
+    pub fn get_access_token(&mut self, scope: &str) -> Result<AccessTokenInfo> {
+        if scope.contains(" ") {
+            return Err(ErrorKind::MultipleScopesRequested.into());
+        }
+        if let Some(oauth_info) = self.access_token_cache.get(scope) {
+            if oauth_info.expires_at > util::now_secs() + OAUTH_MIN_TIME_LEFT {
+                return Ok(oauth_info.clone());
+            }
+        }
+        let client = Client::new(&self.state.config);
+        let resp = match self.state.refresh_token {
+            Some(ref refresh_token) => match refresh_token.scopes.contains(scope) {
+                true => client.oauth_token_with_refresh_token(&refresh_token.token, &[scope])?,
+                false => return Err(ErrorKind::NoCachedToken(scope.to_string()).into()),
+            },
+            None => {
+                #[cfg(feature = "browserid")]
+                {
+                    match Self::session_token_from_state(&self.state.login_state) {
+                        Some(session_token) => {
+                            client.oauth_token_with_session_token(session_token, &[scope])?
+                        }
+                        None => return Err(ErrorKind::NoCachedToken(scope.to_string()).into()),
+                    }
+                }
+                #[cfg(not(feature = "browserid"))]
+                {
+                    return Err(ErrorKind::NoCachedToken(scope.to_string()).into());
+                }
+            }
+        };
+        let since_epoch = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| ErrorKind::IllegalState("Current date before Unix Epoch.".to_string()))?;
+        let expires_at = since_epoch.as_secs() + resp.expires_in;
+        let token_info = AccessTokenInfo {
+            scope: resp.scope,
+            token: resp.access_token,
+            key: self.state.scoped_keys.get(scope).cloned(),
+            expires_at,
+        };
+        self.access_token_cache
+            .insert(scope.to_string(), token_info.clone());
+        Ok(token_info)
+    }
+
+    pub fn begin_pairing_flow(&mut self, pairing_url: &str, scopes: &[&str]) -> Result<String> {
+        let mut url = self.state.config.content_url_path("/pair/supp")?;
+        let pairing_url = Url::parse(pairing_url)?;
+        if url.host_str() != pairing_url.host_str() {
+            return Err(ErrorKind::OriginMismatch.into());
+        }
+        url.set_fragment(pairing_url.fragment());
+        self.oauth_flow(url, scopes, true)
+    }
+
+    pub fn begin_oauth_flow(&mut self, scopes: &[&str], wants_keys: bool) -> Result<String> {
+        let mut url = self.state.config.authorization_endpoint()?;
+        url.query_pairs_mut()
+            .append_pair("action", "email")
+            .append_pair("response_type", "code");
+        let scopes: Vec<String> = match self.state.refresh_token {
+            Some(ref refresh_token) => {
+                // Union of the already held scopes and the one requested.
+                let mut all_scopes: Vec<String> = vec![];
+                all_scopes.extend(scopes.iter().map(|s| s.to_string()));
+                let existing_scopes = refresh_token.scopes.clone();
+                all_scopes.extend(existing_scopes);
+                HashSet::<String>::from_iter(all_scopes)
+                    .into_iter()
+                    .collect()
+            }
+            None => scopes.iter().map(|s| s.to_string()).collect(),
+        };
+        let scopes: Vec<&str> = scopes.iter().map(<_>::as_ref).collect();
+        self.oauth_flow(url, &scopes, wants_keys)
+    }
+
+    fn oauth_flow(&mut self, mut url: Url, scopes: &[&str], wants_keys: bool) -> Result<String> {
+        let state = util::random_base64_url_string(&*RNG, 16)?;
+        let code_verifier = util::random_base64_url_string(&*RNG, 43)?;
+        let code_challenge = digest::digest(&digest::SHA256, &code_verifier.as_bytes());
+        let code_challenge = base64::encode_config(&code_challenge, base64::URL_SAFE_NO_PAD);
+        url.query_pairs_mut()
+            .append_pair("client_id", &self.state.config.client_id)
+            .append_pair("redirect_uri", &self.state.config.redirect_uri)
+            .append_pair("scope", &scopes.join(" "))
+            .append_pair("state", &state)
+            .append_pair("code_challenge_method", "S256")
+            .append_pair("code_challenge", &code_challenge)
+            .append_pair("access_type", "offline");
+        let scoped_keys_flow = match wants_keys {
+            true => {
+                let flow = ScopedKeysFlow::with_random_key(&*RNG)?;
+                let jwk_json = flow.generate_keys_jwk()?;
+                let keys_jwk = base64::encode_config(&jwk_json, base64::URL_SAFE_NO_PAD);
+                url.query_pairs_mut().append_pair("keys_jwk", &keys_jwk);
+                Some(flow)
+            }
+            false => None,
+        };
+        self.flow_store.insert(
+            state.clone(), // Since state is supposed to be unique, we use it to key our flows.
+            OAuthFlow {
+                scoped_keys_flow,
+                code_verifier,
+            },
+        );
+        Ok(url.to_string())
+    }
+
+    pub fn complete_oauth_flow(&mut self, code: &str, state: &str) -> Result<()> {
+        let oauth_flow = match self.flow_store.remove(state) {
+            Some(oauth_flow) => oauth_flow,
+            None => return Err(ErrorKind::UnknownOAuthState.into()),
+        };
+        let client = Client::new(&self.state.config);
+        let resp = client.oauth_token_with_code(&code, &oauth_flow.code_verifier)?;
+        // This assumes that if the server returns keys_jwe, the jwk argument is Some.
+        match resp.keys_jwe {
+            Some(ref jwe) => {
+                let scoped_keys_flow = match oauth_flow.scoped_keys_flow {
+                    Some(flow) => flow,
+                    None => {
+                        return Err(ErrorKind::UnrecoverableServerError(
+                            "Got a JWE without sending a JWK.",
+                        )
+                        .into());
+                    }
+                };
+                let decrypted_keys = scoped_keys_flow.decrypt_keys_jwe(jwe)?;
+                let scoped_keys: serde_json::Map<String, serde_json::Value> =
+                    serde_json::from_str(&decrypted_keys)?;
+                for (scope, key) in scoped_keys {
+                    let scoped_key: ScopedKey = serde_json::from_value(key)?;
+                    self.state.scoped_keys.insert(scope, scoped_key);
+                }
+            }
+            None => {
+                if oauth_flow.scoped_keys_flow.is_some() {
+                    log::error!("Expected to get keys back alongside the token but the server didn't send them.");
+                    return Err(ErrorKind::TokenWithoutKeys.into());
+                }
+            }
+        };
+        let client = Client::new(&self.state.config);
+        // We are only interested in the refresh token at this time because we
+        // don't want to return an over-scoped access token.
+        // Let's be good citizens and destroy this access token.
+        if let Err(err) = client.destroy_oauth_token(&resp.access_token) {
+            log::warn!("Access token destruction failure: {:?}", err);
+        }
+        let refresh_token = match resp.refresh_token {
+            Some(ref refresh_token) => refresh_token.clone(),
+            None => return Err(ErrorKind::RefreshTokenNotPresent.into()),
+        };
+        // In order to keep 1 and only 1 refresh token alive per client instance,
+        // we also destroy the existing refresh token.
+        if let Some(ref old_refresh_token) = self.state.refresh_token {
+            if let Err(err) = client.destroy_oauth_token(&old_refresh_token.token) {
+                log::warn!("Refresh token destruction failure: {:?}", err);
+            }
+        }
+        self.state.refresh_token = Some(RefreshToken {
+            token: refresh_token,
+            scopes: HashSet::from_iter(resp.scope.split(' ').map(|s| s.to_string())),
+        });
+        self.maybe_call_persist_callback();
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ScopedKey {
+    pub kty: String,
+    pub scope: String,
+    /// URL Safe Base 64 encoded key.
+    pub k: String,
+    pub kid: String,
+}
+
+impl ScopedKey {
+    pub fn key_bytes(&self) -> Result<Vec<u8>> {
+        Ok(base64::decode_config(&self.k, base64::URL_SAFE_NO_PAD)?)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RefreshToken {
+    pub token: String,
+    pub scopes: HashSet<String>,
+}
+
+pub struct OAuthFlow {
+    pub scoped_keys_flow: Option<ScopedKeysFlow>,
+    pub code_verifier: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AccessTokenInfo {
+    pub scope: String,
+    pub token: String,
+    pub key: Option<ScopedKey>,
+    pub expires_at: u64, // seconds since epoch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[test]
+    fn test_oauth_flow_url() {
+        let mut fxa = FirefoxAccount::new(
+            "https://accounts.firefox.com",
+            "12345678",
+            "https://foo.bar",
+        );
+        let url = fxa.begin_oauth_flow(&["profile"], false).unwrap();
+        let flow_url = Url::parse(&url).unwrap();
+
+        assert_eq!(flow_url.host_str(), Some("accounts.firefox.com"));
+        assert_eq!(flow_url.path(), "/authorization");
+
+        let mut pairs = flow_url.query_pairs();
+        assert_eq!(pairs.count(), 9);
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("action"), Cow::Borrowed("email")))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("response_type"), Cow::Borrowed("code")))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("client_id"), Cow::Borrowed("12345678")))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((
+                Cow::Borrowed("redirect_uri"),
+                Cow::Borrowed("https://foo.bar")
+            ))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("scope"), Cow::Borrowed("profile")))
+        );
+        let state_param = pairs.next().unwrap();
+        assert_eq!(state_param.0, Cow::Borrowed("state"));
+        assert_eq!(state_param.1.len(), 22);
+        assert_eq!(
+            pairs.next(),
+            Some((
+                Cow::Borrowed("code_challenge_method"),
+                Cow::Borrowed("S256")
+            ))
+        );
+        let code_challenge_param = pairs.next().unwrap();
+        assert_eq!(code_challenge_param.0, Cow::Borrowed("code_challenge"));
+        assert_eq!(code_challenge_param.1.len(), 43);
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("access_type"), Cow::Borrowed("offline")))
+        );
+    }
+
+    #[test]
+    fn test_oauth_flow_url_with_keys() {
+        let mut fxa = FirefoxAccount::new(
+            "https://accounts.firefox.com",
+            "12345678",
+            "https://foo.bar",
+        );
+        let url = fxa.begin_oauth_flow(&["profile"], true).unwrap();
+        let flow_url = Url::parse(&url).unwrap();
+
+        assert_eq!(flow_url.host_str(), Some("accounts.firefox.com"));
+        assert_eq!(flow_url.path(), "/authorization");
+
+        let mut pairs = flow_url.query_pairs();
+        assert_eq!(pairs.count(), 10);
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("action"), Cow::Borrowed("email")))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("response_type"), Cow::Borrowed("code")))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("client_id"), Cow::Borrowed("12345678")))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((
+                Cow::Borrowed("redirect_uri"),
+                Cow::Borrowed("https://foo.bar")
+            ))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("scope"), Cow::Borrowed("profile")))
+        );
+        let state_param = pairs.next().unwrap();
+        assert_eq!(state_param.0, Cow::Borrowed("state"));
+        assert_eq!(state_param.1.len(), 22);
+        assert_eq!(
+            pairs.next(),
+            Some((
+                Cow::Borrowed("code_challenge_method"),
+                Cow::Borrowed("S256")
+            ))
+        );
+        let code_challenge_param = pairs.next().unwrap();
+        assert_eq!(code_challenge_param.0, Cow::Borrowed("code_challenge"));
+        assert_eq!(code_challenge_param.1.len(), 43);
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("access_type"), Cow::Borrowed("offline")))
+        );
+        let keys_jwk = pairs.next().unwrap();
+        assert_eq!(keys_jwk.0, Cow::Borrowed("keys_jwk"));
+        assert_eq!(keys_jwk.1.len(), 168);
+    }
+
+    #[test]
+    fn test_pairing_flow_url() {
+        static SCOPES: &'static [&'static str] = &["https://identity.mozilla.com/apps/oldsync"];
+        static PAIRING_URL: &'static str = "https://accounts.firefox.com/pair#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
+        static EXPECTED_URL: &'static str = "https://accounts.firefox.com/pair/supp?client_id=12345678&redirect_uri=https%3A%2F%2Ffoo.bar&scope=https%3A%2F%2Fidentity.mozilla.com%2Fapps%2Foldsync&state=SmbAA_9EA5v1R2bgIPeWWw&code_challenge_method=S256&code_challenge=ZgHLPPJ8XYbXpo7VIb7wFw0yXlTa6MUOVfGiADt0JSM&access_type=offline&keys_jwk=eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6Ing5LUltQjJveDM0LTV6c1VmbW5sNEp0Ti14elV2eFZlZXJHTFRXRV9BT0kiLCJ5IjoiNXBKbTB3WGQ4YXdHcm0zREl4T1pWMl9qdl9tZEx1TWlMb1RkZ1RucWJDZyJ9#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
+
+        let mut fxa = FirefoxAccount::new(
+            "https://accounts.firefox.com",
+            "12345678",
+            "https://foo.bar",
+        );
+        let url = fxa.begin_pairing_flow(&PAIRING_URL, &SCOPES).unwrap();
+        let flow_url = Url::parse(&url).unwrap();
+        let expected_parsed_url = Url::parse(EXPECTED_URL).unwrap();
+
+        assert_eq!(flow_url.host_str(), Some("accounts.firefox.com"));
+        assert_eq!(flow_url.path(), "/pair/supp");
+        assert_eq!(flow_url.fragment(), expected_parsed_url.fragment());
+
+        let mut pairs = flow_url.query_pairs();
+        assert_eq!(pairs.count(), 8);
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("client_id"), Cow::Borrowed("12345678")))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((
+                Cow::Borrowed("redirect_uri"),
+                Cow::Borrowed("https://foo.bar")
+            ))
+        );
+        assert_eq!(
+            pairs.next(),
+            Some((
+                Cow::Borrowed("scope"),
+                Cow::Borrowed("https://identity.mozilla.com/apps/oldsync")
+            ))
+        );
+        let state_param = pairs.next().unwrap();
+        assert_eq!(state_param.0, Cow::Borrowed("state"));
+        assert_eq!(state_param.1.len(), 22);
+        assert_eq!(
+            pairs.next(),
+            Some((
+                Cow::Borrowed("code_challenge_method"),
+                Cow::Borrowed("S256")
+            ))
+        );
+        let code_challenge_param = pairs.next().unwrap();
+        assert_eq!(code_challenge_param.0, Cow::Borrowed("code_challenge"));
+        assert_eq!(code_challenge_param.1.len(), 43);
+        assert_eq!(
+            pairs.next(),
+            Some((Cow::Borrowed("access_type"), Cow::Borrowed("offline")))
+        );
+        let keys_jwk = pairs.next().unwrap();
+        assert_eq!(keys_jwk.0, Cow::Borrowed("keys_jwk"));
+        assert_eq!(keys_jwk.1.len(), 168);
+    }
+
+    #[test]
+    fn test_pairing_flow_origin_mismatch() {
+        static PAIRING_URL: &'static str =
+            "https://bad.origin.com/pair#channel_id=foo&channel_key=bar";
+        let mut fxa = FirefoxAccount::new(
+            "https://accounts.firefox.com",
+            "12345678",
+            "https://foo.bar",
+        );
+        let url =
+            fxa.begin_pairing_flow(&PAIRING_URL, &["https://identity.mozilla.com/apps/oldsync"]);
+
+        assert!(url.is_err());
+
+        match url {
+            Ok(_) => {
+                panic!("should have error");
+            }
+            Err(err) => match err.kind() {
+                ErrorKind::OriginMismatch { .. } => {}
+                _ => panic!("error not OriginMismatch"),
+            },
+        }
+    }
+}

--- a/components/fxa-client/src/profile.rs
+++ b/components/fxa-client/src/profile.rs
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub use crate::http_client::ProfileResponse as Profile;
+use crate::{errors::*, http_client::Client, scopes, util, CachedResponse, FirefoxAccount};
+
+// A cached profile response is considered fresh for `PROFILE_FRESHNESS_THRESHOLD` ms.
+const PROFILE_FRESHNESS_THRESHOLD: u64 = 120000; // 2 minutes
+
+impl FirefoxAccount {
+    pub fn get_profile(&mut self, ignore_cache: bool) -> Result<Profile> {
+        let profile_access_token = self.get_access_token(scopes::PROFILE)?.token;
+        let mut etag = None;
+        if let Some(ref cached_profile) = self.profile_cache {
+            if !ignore_cache && util::now() < cached_profile.cached_at + PROFILE_FRESHNESS_THRESHOLD
+            {
+                return Ok(cached_profile.response.clone());
+            }
+            etag = Some(cached_profile.etag.clone());
+        }
+        let client = Client::new(&self.state.config);
+        match client.profile(&profile_access_token, etag)? {
+            Some(response_and_etag) => {
+                if let Some(etag) = response_and_etag.etag {
+                    self.profile_cache = Some(CachedResponse {
+                        response: response_and_etag.response.clone(),
+                        cached_at: util::now(),
+                        etag,
+                    });
+                }
+                Ok(response_and_etag.response)
+            }
+            None => match self.profile_cache {
+                Some(ref cached_profile) => Ok(cached_profile.response.clone()),
+                None => Err(ErrorKind::UnrecoverableServerError(
+                    "Got a 304 without having sent an eTag.",
+                )
+                .into()),
+            },
+        }
+    }
+}


### PR DESCRIPTION
The split is done by functionality, and makes our `lib.rs` file somewhat readable again.