### PR TITLE
Implement pruning APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,33 @@
     - `fun deleteVisitsBetween(start: Long, end: Long)`: Similar to `deleteVisitsSince(start)`, but takes an end date. ([#621](https://github.com/mozilla/application-services/issues/621))
     - `fun getVisitInfos(start: Long, end: Long = Long.MAX_VALUE): List<VisitInfo>`: Returns a more detailed set of information about the visits that occured. ([#619](https://github.com/mozilla/application-services/issues/619))
         - `VisitInfo` is a new data class that contains a visit's url, title, timestamp, and type.
+    - `fun wipeLocal()`: Deletes all history entries without recording any sync information. ([#611](https://github.com/mozilla/application-services/issues/611))
+
+    - `fun runMaintenance()`: Perform automatic maintenance. ([#611](https://github.com/mozilla/application-services/issues/611))
+
+        This should be called at least once per day, however that is a
+        recommendation and not a requirement, and nothing dire happens if it is
+        not called.
+
+        The maintenance it may perform potentially includes, but is not limited to:
+
+        - Running `VACUUM`.
+        - Requesting that SQLite optimize our indices.
+        - Expiring old visits.
+        - Deleting or fixing corrupt or invalid rows.
+        - Etc.
+
+        However not all of these are currently implemented.
+
+    - `fun pruneDestructively()`: Aggressively prune history visits. ([#611](https://github.com/mozilla/application-services/issues/611))
+
+        These deletions are not intended to be synced, however due to the way
+        history sync works, this can still cause data loss.
+
+        As a result, this should only be called if a low disk space notification
+        is received from the OS, and things like the network cache have already
+        been cleared.
+
 
 ### Breaking Changes
 

--- a/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
@@ -126,6 +126,11 @@ internal interface LibPlacesFFI : Library {
             out_err: RustError.ByReference
     )
 
+    fun places_wipe_local(
+            handle: PlacesConnectionHandle,
+            out_err: RustError.ByReference
+    )
+
     fun places_get_visit_infos(
             handle: PlacesConnectionHandle,
             startDate: Long,

--- a/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
@@ -131,6 +131,11 @@ internal interface LibPlacesFFI : Library {
             out_err: RustError.ByReference
     )
 
+    fun places_run_maintenance(
+            handle: PlacesConnectionHandle,
+            out_err: RustError.ByReference
+    )
+
     fun places_get_visit_infos(
             handle: PlacesConnectionHandle,
             startDate: Long,

--- a/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
@@ -136,6 +136,11 @@ internal interface LibPlacesFFI : Library {
             out_err: RustError.ByReference
     )
 
+    fun places_prune_destructively(
+            handle: PlacesConnectionHandle,
+            out_err: RustError.ByReference
+    )
+
     fun places_get_visit_infos(
             handle: PlacesConnectionHandle,
             startDate: Long,

--- a/components/places/android/src/main/java/org/mozilla/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/PlacesConnection.kt
@@ -172,6 +172,11 @@ class PlacesConnection(path: String, encryption_key: String? = null) : PlacesAPI
                     this.handle.get(), startTime, endTime, error)
         }
     }
+    override fun wipeLocal() {
+        rustCall { error ->
+            LibPlacesFFI.INSTANCE.places_wipe_local(this.handle.get(), error)
+        }
+    }
 
     override fun sync(syncInfo: SyncAuthInfo) {
         rustCall { error ->
@@ -262,6 +267,14 @@ interface PlacesAPI {
      * corresponding page URI from [urls].
      */
     fun getVisited(urls: List<String>): List<Boolean>
+
+    /**
+     * Deletes all history visits, without recording tombstones.
+     *
+     * That is, these deletions will not be synced. Any changes which were
+     * pending upload on the next sync are discarded and will be lost.
+     */
+    fun wipeLocal()
 
     /**
      * Returns a list of visited URLs for a given time range.

--- a/components/places/android/src/main/java/org/mozilla/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/PlacesConnection.kt
@@ -172,9 +172,16 @@ class PlacesConnection(path: String, encryption_key: String? = null) : PlacesAPI
                     this.handle.get(), startTime, endTime, error)
         }
     }
+
     override fun wipeLocal() {
         rustCall { error ->
             LibPlacesFFI.INSTANCE.places_wipe_local(this.handle.get(), error)
+        }
+    }
+
+    override fun runMaintenance() {
+        rustCall { error ->
+            LibPlacesFFI.INSTANCE.places_run_maintenance(this.handle.get(), error)
         }
     }
 
@@ -275,6 +282,22 @@ interface PlacesAPI {
      * pending upload on the next sync are discarded and will be lost.
      */
     fun wipeLocal()
+
+    /**
+     * Run periodic database maintenance. This might include, but is not limited
+     * to:
+     *
+     * - `VACUUM`ing.
+     * - Requesting that the indices in our tables be optimized.
+     * - Expiring irrelevant history visits.
+     * - Periodic repair or deletion of corrupted records.
+     * - etc.
+     *
+     * It should be called at least once a day, but this is merely a
+     * recommendation and nothing too dire should happen if it is not
+     * called.
+     */
+    fun runMaintenance()
 
     /**
      * Returns a list of visited URLs for a given time range.

--- a/components/places/android/src/main/java/org/mozilla/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/PlacesConnection.kt
@@ -185,6 +185,12 @@ class PlacesConnection(path: String, encryption_key: String? = null) : PlacesAPI
         }
     }
 
+    override fun pruneDestructively() {
+        rustCall { error ->
+            LibPlacesFFI.INSTANCE.places_prune_destructively(this.handle.get(), error)
+        }
+    }
+
     override fun sync(syncInfo: SyncAuthInfo) {
         rustCall { error ->
             LibPlacesFFI.INSTANCE.sync15_history_sync(
@@ -298,6 +304,17 @@ interface PlacesAPI {
      * called.
      */
     fun runMaintenance()
+
+    /**
+     * Aggressively prune history visits. These deletions are not intended
+     * to be synced, however due to the way history sync works, this can
+     * still cause data loss.
+     *
+     * As a result, this should only be called if a low disk space
+     * notification is received from the OS, and things like the network
+     * cache have already been cleared.
+     */
+    fun pruneDestructively()
 
     /**
      * Returns a list of visited URLs for a given time range.

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -226,6 +226,12 @@ pub unsafe extern "C" fn places_delete_visit(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn places_wipe_local(handle: u64, error: &mut ExternError) {
+    log::debug!("places_wipe_local");
+    CONNECTIONS.call_with_result(error, handle, |conn| storage::history::wipe_local(conn))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn places_get_visit_infos(
     handle: u64,
     start_date: i64,

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -238,6 +238,14 @@ pub unsafe extern "C" fn places_run_maintenance(handle: u64, error: &mut ExternE
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn places_prune_destructively(handle: u64, error: &mut ExternError) {
+    log::debug!("places_prune_destructively");
+    CONNECTIONS.call_with_result(error, handle, |conn| {
+        storage::history::prune_destructively(conn)
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn places_get_visit_infos(
     handle: u64,
     start_date: i64,

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -232,6 +232,12 @@ pub unsafe extern "C" fn places_wipe_local(handle: u64, error: &mut ExternError)
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn places_run_maintenance(handle: u64, error: &mut ExternError) {
+    log::debug!("places_run_maintenance");
+    CONNECTIONS.call_with_result(error, handle, |conn| storage::run_maintenance(conn))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn places_get_visit_infos(
     handle: u64,
     start_date: i64,

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -210,6 +210,11 @@ pub fn delete_place_visit_at_time(db: &impl ConnExt, place: &Url, visit: Timesta
     Ok(())
 }
 
+pub fn prune_destructively(db: &impl ConnExt) -> Result<()> {
+    // For now, just fall back to wipe_local until we decide how this should work.
+    wipe_local(db)
+}
+
 pub fn wipe_local(db: &impl ConnExt) -> Result<()> {
     let tx = db.unchecked_transaction()?;
     wipe_local_in_tx(db)?;

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -219,6 +219,8 @@ pub fn wipe_local(db: &impl ConnExt) -> Result<()> {
     let tx = db.unchecked_transaction()?;
     wipe_local_in_tx(db)?;
     tx.commit()?;
+    // Note: SQLite cannot VACUUM within a transaction.
+    db.conn().execute("VACUUM", NO_PARAMS)?;
     Ok(())
 }
 

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -186,3 +186,8 @@ impl HistoryVisitInfo {
         })
     }
 }
+
+pub fn run_maintenance(conn: &impl ConnExt) -> Result<()> {
+    conn.execute_all(&["VACUUM", "PRAGMA optimize"])?;
+    Ok(())
+}


### PR DESCRIPTION
This implements the three pruning APIs described in #611, although it punts on them a bit.

- `wipeLocal` is fully implemented.
- `runMaintenance` currently just implemented as VACUUM and PRAGMA optimize.
- `pruneDestructively` just calls `wipeLocal`.