### PR TITLE
Implement deleteEverything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,17 @@
     - `fun deleteVisitsBetween(start: Long, end: Long)`: Similar to `deleteVisitsSince(start)`, but takes an end date. ([#621](https://github.com/mozilla/application-services/issues/621))
     - `fun getVisitInfos(start: Long, end: Long = Long.MAX_VALUE): List<VisitInfo>`: Returns a more detailed set of information about the visits that occured. ([#619](https://github.com/mozilla/application-services/issues/619))
         - `VisitInfo` is a new data class that contains a visit's url, title, timestamp, and type.
-    - `fun wipeLocal()`: Deletes all history entries without recording any sync information. ([#611](https://github.com/mozilla/application-services/issues/611))
+    - `fun wipeLocal()`: Deletes all history entries without recording any sync information. ([#611](https://github.com/mozilla/application-services/issues/611)).
+
+        This means that these visits are likely to start slowly trickling back
+        in over time, and many of them will come back entirely if a full sync
+        is performed (which may not happen for some time, admittedly). The
+        intention here is that this is a method that's used if data should be
+        discarded when disconnecting sync, assuming that it would be desirable
+        for the data to show up again if sync is reconnected.
+
+        For more permanent local deletions, see `deleteEverything`, also added
+        in this version.
 
     - `fun runMaintenance()`: Perform automatic maintenance. ([#611](https://github.com/mozilla/application-services/issues/611))
 
@@ -52,6 +62,16 @@
         As a result, this should only be called if a low disk space notification
         is received from the OS, and things like the network cache have already
         been cleared.
+
+    - `fun deleteEverything()`: Delete all history visits. ([#647](https://github.com/mozilla/application-services/issues/647))
+
+        For sync users, this will not cause the visits to disappear from the
+        users remote devices, however it will prevent them from ever showing
+        up again, even across full syncs, or sync sign-in and sign-out.
+
+        See also `wipeLocal`, also added in this version, which is less
+        permanent with respect to sync data (a full sync is likely to bring
+        most of it back).
 
 
 ### Breaking Changes

--- a/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/LibPlacesFFI.kt
@@ -141,6 +141,11 @@ internal interface LibPlacesFFI : Library {
             out_err: RustError.ByReference
     )
 
+    fun places_delete_everything(
+            handle: PlacesConnectionHandle,
+            out_err: RustError.ByReference
+    )
+
     fun places_get_visit_infos(
             handle: PlacesConnectionHandle,
             startDate: Long,

--- a/components/places/android/src/main/java/org/mozilla/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/org/mozilla/places/PlacesConnection.kt
@@ -191,6 +191,12 @@ class PlacesConnection(path: String, encryption_key: String? = null) : PlacesAPI
         }
     }
 
+    override fun deleteEverything() {
+        rustCall { error ->
+            LibPlacesFFI.INSTANCE.places_delete_everything(this.handle.get(), error)
+        }
+    }
+
     override fun sync(syncInfo: SyncAuthInfo) {
         rustCall { error ->
             LibPlacesFFI.INSTANCE.sync15_history_sync(
@@ -315,6 +321,21 @@ interface PlacesAPI {
      * cache have already been cleared.
      */
     fun pruneDestructively()
+
+    /**
+     * Delete everything locally.
+     *
+     * This will not delete visits from remote devices, however it will
+     * prevent them from trickling in over time when future syncs occur.
+     *
+     * The difference between this and wipeLocal is that wipeLocal does
+     * not prevent the deleted visits from returning. For wipeLocal,
+     * the visits will return on the next full sync (which may be
+     * arbitrarially far in the future), wheras items which were
+     * deleted by deleteEverything (or potentially could have been)
+     * should not return.
+     */
+    fun deleteEverything()
 
     /**
      * Returns a list of visited URLs for a given time range.

--- a/components/places/examples/places-utils.rs
+++ b/components/places/examples/places-utils.rs
@@ -11,14 +11,14 @@ use places::storage::bookmarks::{
 use places::types::{BookmarkType, SyncGuid, Timestamp};
 use places::PlacesDb;
 
+use failure::Fail;
 use serde_derive::*;
 use sql_support::ConnExt;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use structopt::StructOpt;
-use url::Url;
 use sync15::{telemetry, Store};
-use failure::Fail;
+use url::Url;
 
 type Result<T> = std::result::Result<T, failure::Error>;
 
@@ -157,7 +157,13 @@ fn run_native_export(db: &PlacesDb, filename: String) -> Result<()> {
     Ok(())
 }
 
-fn sync(db: &PlacesDb, engine_names: Vec<String>, cred_file: String, wipe: bool, reset: bool) -> Result<()> {
+fn sync(
+    db: &PlacesDb,
+    engine_names: Vec<String>,
+    cred_file: String,
+    wipe: bool,
+    reset: bool,
+) -> Result<()> {
     let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file)?;
 
     // We will want this as a Vec<sync15::Store> eventually...
@@ -177,7 +183,11 @@ fn sync(db: &PlacesDb, engine_names: Vec<String>, cred_file: String, wipe: bool,
         }
 
         log::info!("Syncing {}", store.collection_name());
-        if let Err(e) = store.sync(&cli_fxa.client_init.clone(), &cli_fxa.root_sync_key, &mut sync_ping) {
+        if let Err(e) = store.sync(
+            &cli_fxa.client_init.clone(),
+            &cli_fxa.root_sync_key,
+            &mut sync_ping,
+        ) {
             log::warn!("Sync failed! {}", e);
             log::warn!("BT: {:?}", e.backtrace());
         } else {
@@ -263,7 +273,6 @@ enum Command {
         /// Imports bookmarks from a desktop export
         input_file: String,
     },
-
 }
 
 fn main() -> Result<()> {
@@ -277,7 +286,12 @@ fn main() -> Result<()> {
     let db = PlacesDb::open(db_path, encryption_key)?;
 
     match opts.cmd {
-        Command::Sync{ engines, credential_file, wipe, reset } => sync(&db, engines, credential_file, wipe, reset),
+        Command::Sync {
+            engines,
+            credential_file,
+            wipe,
+            reset,
+        } => sync(&db, engines, credential_file, wipe, reset),
         Command::ExportBookmarks { output_file } => run_native_export(&db, output_file),
         Command::ImportBookmarks { input_file } => run_native_import(&db, input_file),
         Command::ImportDesktopBookmarks { input_file } => run_desktop_import(&db, input_file),

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -246,6 +246,14 @@ pub unsafe extern "C" fn places_prune_destructively(handle: u64, error: &mut Ext
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn places_delete_everything(handle: u64, error: &mut ExternError) {
+    log::debug!("places_delete_everything");
+    CONNECTIONS.call_with_result(error, handle, |conn| {
+        storage::history::delete_everything(conn)
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn places_get_visit_infos(
     handle: u64,
     start_date: i64,

--- a/components/places/src/history_sync/store.rs
+++ b/components/places/src/history_sync/store.rs
@@ -38,20 +38,11 @@ impl<'a> HistoryStore<'a> {
     }
 
     fn put_meta(&self, key: &str, value: &ToSql) -> Result<()> {
-        self.execute_named_cached(
-            "REPLACE INTO moz_meta (key, value) VALUES (:key, :value)",
-            &[(":key", &key as &ToSql), (":value", value)],
-        )?;
-        Ok(())
+        crate::storage::put_meta(self.db, key, value)
     }
 
     fn get_meta<T: FromSql>(&self, key: &str) -> Result<Option<T>> {
-        Ok(self.try_query_row(
-            "SELECT value FROM moz_meta WHERE key = :key",
-            &[(":key", &key as &ToSql)],
-            |row| Ok::<_, Error>(row.get_checked(0)?),
-            true,
-        )?)
+        crate::storage::get_meta(self.db, key)
     }
 
     fn do_apply_incoming(

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -8,12 +8,21 @@ use crate::error::Result;
 use crate::frecency;
 use crate::hash;
 use crate::observation::VisitObservation;
+use crate::storage::{get_meta, put_meta};
 use crate::types::{SyncGuid, SyncStatus, Timestamp, VisitTransition};
 use rusqlite::types::ToSql;
 use rusqlite::Result as RusqliteResult;
 use rusqlite::{Connection, Row, NO_PARAMS};
 use sql_support::{self, ConnExt};
 use url::Url;
+
+/// When `delete_everything` is called (to perform a permanent local deletion), in
+/// addition to performing the deletion as requested, we make a note of the time
+/// when it occurred, and refuse to sync incoming visits from before this time.
+///
+/// This allows us to avoid these visits trickling back in as other devices
+/// add visits to them remotely.
+static DELETION_HIGH_WATER_MARK_META_KEY: &'static str = "history_deleted_hwm";
 
 /// Returns the RowId of a new visit in moz_historyvisits, or None if no new visit was added.
 pub fn apply_observation(db: &mut PlacesDb, visit_ob: VisitObservation) -> Result<Option<RowId>> {
@@ -217,14 +226,11 @@ pub fn prune_destructively(db: &impl ConnExt) -> Result<()> {
 
 pub fn wipe_local(db: &impl ConnExt) -> Result<()> {
     let tx = db.unchecked_transaction()?;
-    wipe_local_in_tx(db)?;
-    tx.commit()?;
-    // Note: SQLite cannot VACUUM within a transaction.
-    db.conn().execute("VACUUM", NO_PARAMS)?;
+    wipe_local_in_tx(db, tx)?;
     Ok(())
 }
 
-fn wipe_local_in_tx(db: &impl ConnExt) -> Result<()> {
+fn wipe_local_in_tx(db: &impl ConnExt, tx: sql_support::UncheckedTransaction) -> Result<()> {
     use crate::frecency::DEFAULT_FRECENCY_SETTINGS;
     db.execute_all(&[
         "DELETE FROM moz_places
@@ -252,6 +258,31 @@ fn wipe_local_in_tx(db: &impl ConnExt) -> Result<()> {
     for row_id in need_frecency_update {
         update_frecency(db.conn(), row_id, None)?;
     }
+    tx.commit()?;
+    // Note: SQLite cannot VACUUM within a transaction.
+    db.conn().execute("VACUUM", NO_PARAMS)?;
+    Ok(())
+}
+
+pub fn delete_everything(db: &PlacesDb) -> Result<()> {
+    let tx = db.unchecked_transaction()?;
+
+    // Remote visits could have a higher date than `now` if our clock is weird.
+    let most_recent_known_visit_time = db
+        .try_query_one::<Timestamp>("SELECT MAX(visit_date) FROM moz_historyvisits", &[], false)?
+        .unwrap_or_default();
+
+    // Check the old value (if any) for the same reason
+    let previous_mark =
+        get_meta::<Timestamp>(db, DELETION_HIGH_WATER_MARK_META_KEY)?.unwrap_or_default();
+
+    let new_mark = Timestamp::now()
+        .max(previous_mark)
+        .max(most_recent_known_visit_time);
+
+    put_meta(db, DELETION_HIGH_WATER_MARK_META_KEY, &new_mark)?;
+
+    wipe_local_in_tx(db, tx)?;
     Ok(())
 }
 
@@ -561,6 +592,18 @@ pub mod history_sync {
         title: &Option<String>,
         visits: &[HistoryRecordVisit],
     ) -> Result<()> {
+        // At some point we may have done a local wipe of all visits. We skip applying
+        // incoming visits that could have been part of that deletion, to avoid them
+        // trickling back in.
+        let visit_ignored_mark =
+            get_meta::<Timestamp>(db, DELETION_HIGH_WATER_MARK_META_KEY)?.unwrap_or_default();
+
+        let visits = visits
+            .iter()
+            .cloned()
+            .filter(|v| Timestamp::from(v.date) > visit_ignored_mark)
+            .collect::<Vec<_>>();
+
         let mut counter_incr = 0;
         let page_info = match fetch_page_info(db, &url)? {
             Some(mut info) => {
@@ -583,7 +626,14 @@ pub mod history_sync {
                 }
                 info.page
             }
-            None => new_page_info(db, &url, Some(incoming_guid.clone()))?,
+            None => {
+                // Before we insert a new page_info, make sure we actually will
+                // have any visits to add.
+                if visits.len() == 0 {
+                    return Ok(());
+                }
+                new_page_info(db, &url, Some(incoming_guid.clone()))?
+            }
         };
 
         if visits.len() > 0 {
@@ -1903,4 +1953,101 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn test_delete_everything() {
+        use url::Url;
+        let _ = env_logger::try_init();
+        let mut conn = PlacesDb::open_in_memory(None).unwrap();
+        let start = Timestamp::now();
+
+        let urls = &[
+            Url::parse("http://example.com/1").unwrap(),
+            Url::parse("http://example.com/2").unwrap(),
+        ];
+
+        let dates = &[
+            Timestamp(start.0 - 10000),
+            Timestamp(start.0 - 5000),
+            Timestamp(start.0),
+        ];
+
+        for url in urls {
+            for &date in dates {
+                get_custom_observed_page(&mut conn, url.as_str(), |o| o.with_at(date)).unwrap();
+            }
+        }
+
+        delete_everything(&conn).unwrap();
+
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        assert_eq!(
+            0,
+            conn.query_one::<i64>("SELECT COUNT(*) FROM moz_places")
+                .unwrap(),
+        );
+
+        assert_eq!(
+            0,
+            conn.query_one::<i64>("SELECT COUNT(*) FROM moz_historyvisits")
+                .unwrap(),
+        );
+
+        apply_synced_visits(
+            &conn,
+            &SyncGuid::new(),
+            &url::Url::parse("http://www.example.com/123").unwrap(),
+            &None,
+            &[
+                HistoryRecordVisit {
+                    // This should make it in
+                    date: Timestamp::now().into(),
+                    transition: VisitTransition::Link as u8,
+                },
+                HistoryRecordVisit {
+                    // This should not.
+                    date: start.into(),
+                    transition: VisitTransition::Link as u8,
+                },
+            ],
+        )
+        .unwrap();
+        assert_eq!(
+            1,
+            conn.query_one::<i64>("SELECT COUNT(*) FROM moz_places")
+                .unwrap(),
+        );
+        // Only one visit should be applied.
+        assert_eq!(
+            1,
+            conn.query_one::<i64>("SELECT COUNT(*) FROM moz_historyvisits")
+                .unwrap(),
+        );
+
+        // Check that we don't insert a place if all visits are too old.
+        apply_synced_visits(
+            &conn,
+            &SyncGuid::new(),
+            &url::Url::parse("http://www.example.com/1234").unwrap(),
+            &None,
+            &[HistoryRecordVisit {
+                date: start.into(),
+                transition: VisitTransition::Link as u8,
+            }],
+        )
+        .unwrap();
+        // unchanged.
+        assert_eq!(
+            1,
+            conn.query_one::<i64>("SELECT COUNT(*) FROM moz_places")
+                .unwrap(),
+        );
+        assert_eq!(
+            1,
+            conn.query_one::<i64>("SELECT COUNT(*) FROM moz_historyvisits")
+                .unwrap(),
+        );
+    }
+
 }

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -12,7 +12,7 @@ use crate::error::Result;
 use crate::types::{SyncGuid, SyncStatus, Timestamp, VisitTransition};
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::Result as RusqliteResult;
-use rusqlite::Row;
+use rusqlite::{Connection, Row};
 use serde_derive::*;
 use sql_support::{self, ConnExt};
 use std::fmt;
@@ -190,4 +190,21 @@ impl HistoryVisitInfo {
 pub fn run_maintenance(conn: &impl ConnExt) -> Result<()> {
     conn.execute_all(&["VACUUM", "PRAGMA optimize"])?;
     Ok(())
+}
+
+pub(crate) fn put_meta(db: &Connection, key: &str, value: &ToSql) -> Result<()> {
+    db.execute_named_cached(
+        "REPLACE INTO moz_meta (key, value) VALUES (:key, :value)",
+        &[(":key", &key), (":value", value)],
+    )?;
+    Ok(())
+}
+
+pub(crate) fn get_meta<T: FromSql>(db: &Connection, key: &str) -> Result<Option<T>> {
+    let res = db.try_query_one(
+        "SELECT value FROM moz_meta WHERE key = :key",
+        &[(":key", &key)],
+        true,
+    )?;
+    Ok(res)
 }


### PR DESCRIPTION
Follows the plan set out in the meeting today. Only difference is that we don't delete it on sync disconnect, since we don't have a way we get told about this. I also think that it makes sense that if you delete things, the deletion persists across reconnecting to sync.

Also clarifies the documentation about wipeLocal vs deleteEverything.

Fixes #647 
Fixes #633 (by making it invalid).
