### PR TITLE
Don't implement Drop for ByteBuffer.

### DIFF
--- a/components/support/android/src/main/java/mozilla/appservices/support/RustBuffer.kt
+++ b/components/support/android/src/main/java/mozilla/appservices/support/RustBuffer.kt
@@ -23,9 +23,9 @@ import java.util.Arrays
  * # Caveats:
  *
  * 1. It is for receiving data *FROM* Rust, and not the other direction.
- *    Rust code assumes that it owns `RustBuffer`s, and will release
- *    their memory when it `Drop`s them. (RustBuffer doesn't expose
- *    a way to inspect its contents from Rust anyway).
+ *    RustBuffer doesn't expose a way to inspect its contents from Rust.
+ *    See `docs/howtos/passing-protobuf-data-over-ffi.md` for how to do
+ *    this instead.
  *
  * 2. A `RustBuffer` passed into kotlin code must be freed by kotlin
  *    code *after* the protobuf message is completely deserialized.

--- a/components/support/ffi/src/handle_map.rs
+++ b/components/support/ffi/src/handle_map.rs
@@ -686,6 +686,8 @@ unsafe impl IntoFfi for Handle {
 /// define_handle_map_deleter!(ITEMS, mylib_destroy_thing);
 /// ```
 pub struct ConcurrentHandleMap<T> {
+    /// The underlying map. Public so that more advanced use-cases
+    /// may use it as they please.
     pub map: RwLock<HandleMap<Mutex<T>>>,
 }
 

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![deny(missing_docs)]
+
 //! # FFI Support
 //!
 //! This crate implements a support library to simplify implementing the patterns that the

--- a/components/support/ffi/src/macros.rs
+++ b/components/support/ffi/src/macros.rs
@@ -229,13 +229,12 @@ macro_rules! define_box_destructor {
 /// # use ffi_support::define_bytebuffer_destructor;
 /// define_bytebuffer_destructor!(mylib_destroy_bytebuffer);
 /// ```
-
 #[macro_export]
 macro_rules! define_bytebuffer_destructor {
     ($destructor_name:ident) => {
         #[no_mangle]
         pub extern "C" fn $destructor_name(v: $crate::ByteBuffer) {
-            drop(v);
+            v.destroy()
         }
     };
 }

--- a/docs/howtos/passing-protobuf-data-over-ffi.md
+++ b/docs/howtos/passing-protobuf-data-over-ffi.md
@@ -166,13 +166,7 @@ follow the examples of the other steps it takes.
         implementation 'com.google.protobuf:protobuf-lite:3.0.0'
         implementation project(':as-support-library')
         ```
-
-2. Add a new file, ByteBuffer.kt:
-
-    In the future we will share this class (for once we actually could!) however,
-    at the moment we cannot, and so you must copy/paste it.
-
-3. In the file where the foreign functions are defined, make sure that the
+2. In the file where the foreign functions are defined, make sure that the
    function returning this type returns a `RustBuffer.ByValue` (`RustBuffer` is
    in `mozilla.appservices.support`).
 
@@ -182,7 +176,7 @@ follow the examples of the other steps it takes.
    fun mylib_destroy_bytebuffer(v: RustBuffer.ByValue)
    ```
 
-4. Usage code then looks as follows:
+3. Usage code then looks as follows:
     ```kotlin
         val rustBuffer = rustCall { error ->
             MyLibFFI.INSTANCE.call_thing_returning_rustbuffer(...)


### PR DESCRIPTION
Also fixes up some doc issues.

Doesn't need an ffi_support version bump since I haven't pushed out the one from last night yet.