### PR TITLE
Document to need to install desktop dependencies manually.

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,6 +21,25 @@ To work on the code in this repo you will need to be familiar with
 the [Rust](https://www.rust-lang.org/) programming language.
 You can get a working rust compiler and toolchain via [rustup](https://rustup.rs/).
 
+Some components require `openssl` and `sqlcipher` in order to build correctly.
+You may be able to install these via your OS package manager, but for consistency
+we recommend using the versions included in this repo by doing the following from
+the root of your checkout:
+
+```
+source ./libs/bootstrap-desktop.sh
+```
+
+This will compile the dependencies if necessary and export environment variables
+to configure your rust build to use them.
+
+You can check that all dependencies are installed correctly by running the following from the
+root of your checkout:
+
+```
+cargo test --all
+```
+
 If you plan to work on the Android component bindings, you should also review
 the instructions for [setting up an Android build environment](https://github.com/mozilla/application-services/blob/master/docs/howtos/setup-android-build-environment.md)
 

--- a/libs/bootstrap-desktop.sh
+++ b/libs/bootstrap-desktop.sh
@@ -1,0 +1,21 @@
+# Set environment variables for using vendored dependencies in desktop builds.
+#
+# This file should be used via `source ./libs/bootstrap-desktop.sh` and will
+# not have the desired effect if you try to run it directly, because it
+# uses `export` to set environment variables.
+
+if [ ! -f "$(pwd)/libs/build-all.sh" ]; then
+  echo "ERROR: bootstrap-desktop.sh should be run from the root directory of the repo"
+else
+  if [ $(uname -s) == "Darwin" ]; then
+    APPSERVICES_PLATFORM_DIR="$(pwd)/libs/desktop/darwin"
+  else
+    APPSERVICES_PLATFORM_DIR="$(pwd)/libs/desktop/linux-x86-64"
+  fi
+  export SQLCIPHER_LIB_DIR="$APPSERVICES_PLATFORM_DIR/sqlcipher/lib"
+  export SQLCIPHER_INCLUDE_DIR="$APPSERVICES_PLATFORM_DIR/sqlcipher/include"
+  export OPENSSL_DIR="$APPSERVICES_PLATFORM_DIR/openssl"
+  if [ ! -d "$SQLCIPHER_LIB_DIR" -o ! -d "$OPENSSL_DIR" ]; then
+    pushd libs && ./build-all.sh desktop && popd
+  fi;
+fi


### PR DESCRIPTION
From slack conversation, it appears you need to install dependencies manually when you're just using `cargo` directly for local development, not via gradle etc.  This is my takeaway but please correct me if it's inaccurate or incomplete.