### PR TITLE
Fix case where we'd still try to run a unicode string through reverse_host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.17.0...master)
 
+## Places
+
+### What's Fixed
+
+- Autocomplete should no longer return an error when encountering certain emoji ([#691](https://github.com/mozilla/application-services/pull/691))
+
 # 0.17.0 (_2019-02-19_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.16.1...v0.17.0)


### PR DESCRIPTION
Fixes https://github.com/mozilla-mobile/reference-browser/issues/602