### PR TITLE
Refuse to insert overlong URLs, and truncate overlong titles

### DIFF
--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -112,4 +112,9 @@ pub enum InvalidPlaceInfo {
     InvalidGuid,
     #[fail(display = "Invalid parent: {}", _0)]
     InvalidParent(String),
+
+    // Only returned when attempting to insert a bookmark --
+    // for history we just ignore it.
+    #[fail(display = "URL too long")]
+    UrlTooLong,
 }


### PR DESCRIPTION
Fixes #636.

I don't think truncating the URL is right, since it will result in an insertion that never happened. Also, it's tricky to make sure that the URL that got truncated is still valid (must make sure that its not between %-encoded octets, might need to ensure its valid base64, etc. Places ignores these things, but a lot of our code will break if we insert invalid URLs), so this just ignores it. 

The downside of this is that we'll return an error if someone tries to insert a Bookmark with an overlong URL, but I'm not sure what else we can do.