### PR TITLE
Implement swift bindings for rc_log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 - Autocomplete should no longer return an error when encountering certain emoji ([#691](https://github.com/mozilla/application-services/pull/691))
 
+## Logging
+
+### What's New
+
+- The `rc_log` component now has support for iOS. It is only available as part of the
+  MozillaAppServices megazord. ([#618](https://github.com/mozilla/application-services/issues/618))
+
 # 0.17.0 (_2019-02-19_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.16.1...v0.17.0)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -76,7 +76,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -270,8 +270,8 @@ dependencies = [
  "rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinytemplate 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -308,7 +308,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -389,7 +389,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "csv-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -462,7 +462,7 @@ name = "error-chain"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -470,7 +470,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -498,13 +498,13 @@ dependencies = [
 name = "ffi-support"
 version = "0.2.0"
 dependencies = [
- "backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -592,10 +592,10 @@ dependencies = [
  "prost-build 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "text_io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -622,7 +622,7 @@ dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,7 +671,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "http"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -701,7 +701,7 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -806,7 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libflate"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -870,8 +870,8 @@ dependencies = [
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "sync15 0.1.0",
@@ -914,6 +914,7 @@ dependencies = [
  "fxaclient_ffi 0.1.0",
  "logins_ffi 0.1.0",
  "places-ffi 0.1.0",
+ "rc_log_ffi 0.1.0",
 ]
 
 [[package]]
@@ -1009,7 +1010,7 @@ dependencies = [
  "schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1102,7 +1103,7 @@ dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1184,14 +1185,14 @@ dependencies = [
  "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "structopt 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "sync15 0.1.0",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1473,6 +1474,7 @@ dependencies = [
 name = "rc_log_ffi"
 version = "0.1.0"
 dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.2.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1525,7 +1527,7 @@ name = "regex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1550,22 +1552,22 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libflate 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libflate 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1697,12 +1699,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1717,7 +1719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1727,7 +1729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1743,11 +1745,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "spin"
@@ -1849,9 +1848,9 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1878,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1961,7 +1960,7 @@ name = "tinytemplate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2107,7 +2106,7 @@ name = "unicode-normalization"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2124,14 +2123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "untrusted"
@@ -2153,7 +2144,7 @@ name = "url_serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2183,11 +2174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "version_check"
 version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "void"
-version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2282,7 +2268,7 @@ dependencies = [
 [metadata]
 "checksum MacTypes-sys 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eaf9f0d0b1cc33a4d2aee14fb4b2eac03462ef4db29c8ac4057327d8a71ad86f"
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
-"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
+"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
 "checksum android_log-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8052e2d8aabbb8d556d6abbcce2a22b9590996c5f849b9c7ce4544a2e3b984e"
 "checksum android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cf44378e81264148f08e58336674542f82d0021f685d0be0320c82e1653dbe0b"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
@@ -2290,7 +2276,7 @@ dependencies = [
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
-"checksum backtrace 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b5b493b66e03090ebc4343eb02f94ff944e0cbc9ac6571491d170ba026741eb5"
+"checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base16 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fd4a4949666bf485542a06de6795ccba71eeabc1f5e9db7a2d82edc3573f6a"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
@@ -2349,7 +2335,7 @@ dependencies = [
 "checksum hawk 2.0.0 (git+https://github.com/eoger/rust-hawk?branch=use-openssl)" = "<none>"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-"checksum http 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1a10e5b573b9a0146545010f50772b9e8b1dd0a256564cc4307694c68832a2f5"
+"checksum http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)" = "fdfa9b401ef6c4229745bb6e9b2529192d07b920eed624cdee2a82348cd550af"
@@ -2365,7 +2351,7 @@ dependencies = [
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
-"checksum libflate 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "bff3ac7d6f23730d3b533c35ed75eef638167634476a499feef16c428d74b57b"
+"checksum libflate 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "54d1ddf9c52870243c5689d7638d888331c1116aa5b398f3ba1acfa7d8758ca1"
 "checksum libsqlite3-sys 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3567bc1a0c84e2c0d71eeb4a1f08451babf7843babd733158777d9c686dad9f3"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
@@ -2432,7 +2418,7 @@ dependencies = [
 "checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum reqwest 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)" = "09d6e187a58d923ee132fcda141c94e716bcfe301c2ea2bef5c81536e0085376"
+"checksum reqwest 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)" = "f205a95638627fc0d21c53901671b06f439dc2830311ff11ecdff34ae2d839a8"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6381ddfe91dbb659b4b132168da15985bc84162378cf4fcdc4eb99c857d063e2"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
@@ -2449,13 +2435,13 @@ dependencies = [
 "checksum security-framework-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3d6696852716b589dff9e886ff83778bb635150168e83afa8ac6b8a78cb82abc"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "2e20fde37801e83c891a2dc4ebd3b81f0da4d1fb67a9e0a2a3b921e2536a58ee"
-"checksum serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)" = "633e97856567e518b59ffb2ad7c7a4fd4c5d91d9c7f32dd38a27b2bf7e8114ea"
+"checksum serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)" = "9f301d728f2b94c9a7691c90f07b0b4e8a4517181d9461be94c04bddeb4bd850"
+"checksum serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)" = "beed18e6f5175aef3ba670e57c60ef3b1b74d250d962a26604bff4c80e970dd4"
 "checksum serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "27dce848e7467aa0e2fcaf0a413641499c0b745452aaca1194d24dedde9e13c9"
 "checksum serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d48f9f99cd749a2de71d29da5f948de7f2764cc5a9d7f3c97e3514d4ee6eabf2"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-"checksum smallvec 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "88aea073965ab29f6edb5493faf96ad662fb18aa9eeb186a3b7057951605ed15"
+"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
@@ -2466,7 +2452,7 @@ dependencies = [
 "checksum syn 0.15.26 (registry+https://github.com/rust-lang/crates.io-index)" = "f92e629aa1d9c827b2bb8297046c1ccffc57c99b947a680d3ccff1f136a3bee9"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-"checksum tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "37daa55a7240c4931c84559f03b3cad7d19535840d1c4a0cc4e9b2fb0dcf70ff"
+"checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
@@ -2493,7 +2479,6 @@ dependencies = [
 "checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
@@ -2502,7 +2487,6 @@ dependencies = [
 "checksum vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "def296d3eb3b12371b2c7d0e83bfe1403e4db2d7a0bba324a12b21c4ee13143d"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum webbrowser 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21c311234fd1392a0071c1476cb7a4338dd2479e03e80e2328fbbf2db117b028"

--- a/components/rc_log/Cargo.toml
+++ b/components/rc_log/Cargo.toml
@@ -8,7 +8,13 @@ authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 name = "rc_log_ffi"
 crate-type = ["lib", "staticlib", "cdylib"]
 
+[features]
+default = []
+# Required for gradle in robolectric
+force_android = []
+
 [dependencies]
 log = { version = "0.4.6", features = ["std"] }
 ffi-support = { path = "../support/ffi" }
 lazy_static = "1.2.0"
+cfg-if = "0.1.6"

--- a/components/rc_log/android/build.gradle
+++ b/components/rc_log/android/build.gradle
@@ -76,6 +76,10 @@ cargo {
     profile = "release"
 
     exec = rootProject.ext.cargoExec
+
+    features {
+        defaultAnd("force_android")
+    }
 }
 
 configurations {

--- a/components/rc_log/android/src/main/java/mozilla/appservices/rustlog/LibRustLogAdapter.java
+++ b/components/rc_log/android/src/main/java/mozilla/appservices/rustlog/LibRustLogAdapter.java
@@ -28,26 +28,25 @@ class LibRustLogAdapter {
         }
     }
 
-    static native RawLogAdapter ac_log_adapter_create(
+    static native RawLogAdapter rc_log_adapter_create(
             RawLogCallback callback,
             RustError.ByReference out_err
     );
 
-    static native RawLogAdapter ac_log_adapter_set_max_level(
-            RawLogAdapter adapter,
+    static native void rc_log_adapter_set_max_level(
             int level,
             RustError.ByReference out_err
     );
 
-    static native RawLogAdapter ac_log_adapter_destroy(
+    static native void rc_log_adapter_destroy(
             RawLogAdapter adapter
     );
 
-    static native RawLogAdapter ac_log_adapter_destroy_string(
+    static native void rc_log_adapter_destroy_string(
             Pointer stringPtr
     );
 
-    static native RawLogAdapter ac_log_adapter_test__log_msg(
+    static native void rc_log_adapter_test__log_msg(
             String string
     );
 

--- a/components/rc_log/android/src/main/java/mozilla/appservices/rustlog/RustLogAdapter.kt
+++ b/components/rc_log/android/src/main/java/mozilla/appservices/rustlog/RustLogAdapter.kt
@@ -66,7 +66,7 @@ class RustLogAdapter private constructor(
             // make callbackImpl isn't GCed here, or very bad things will happen. (Should the logger
             // init code abort on panic?)
             val adapter = rustCall { err ->
-                LibRustLogAdapter.ac_log_adapter_create(callbackImpl, err)
+                LibRustLogAdapter.rc_log_adapter_create(callbackImpl, err)
             }
             // For example, it would be *extremely bad* if somehow adapter were actually null here.
             instance = RustLogAdapter(callbackImpl, adapter!!)
@@ -91,7 +91,7 @@ class RustLogAdapter private constructor(
         @Synchronized
         fun disable() {
             val state = instance ?: return
-            LibRustLogAdapter.ac_log_adapter_destroy(state.adapter)
+            LibRustLogAdapter.rc_log_adapter_destroy(state.adapter)
             // XXX Letting that callback get GCed still makes me extremely uneasy...
             // Maybe we should just null out the callback provided by the user so that
             // it can be GCed (while letting the RawLogCallbackImpl which actually is
@@ -104,8 +104,7 @@ class RustLogAdapter private constructor(
         fun setMaxLevel(level: LogLevelFilter) {
             if (isEnabled) {
                 rustCall { e ->
-                    LibRustLogAdapter.ac_log_adapter_set_max_level(
-                            instance!!.adapter,
+                    LibRustLogAdapter.rc_log_adapter_set_max_level(
                             level.value,
                             e
                     )
@@ -187,6 +186,6 @@ internal fun Pointer.getAndConsumeRustString(): String {
     try {
         return this.getString(0, "utf8")
     } finally {
-        LibRustLogAdapter.ac_log_adapter_destroy_string(this)
+        LibRustLogAdapter.rc_log_adapter_destroy_string(this)
     }
 }

--- a/components/rc_log/android/src/test/java/mozilla/appservices/rustlog/LogTest.kt
+++ b/components/rc_log/android/src/test/java/mozilla/appservices/rustlog/LogTest.kt
@@ -18,7 +18,7 @@ import java.util.*
 class LogTest {
 
     fun writeTestLog(m: String) {
-        LibRustLogAdapter.ac_log_adapter_test__log_msg(m)
+        LibRustLogAdapter.rc_log_adapter_test__log_msg(m)
         Thread.sleep(100) // Wait for it to arrive...
     }
 

--- a/components/rc_log/src/android.rs
+++ b/components/rc_log/src/android.rs
@@ -1,0 +1,210 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This is the android backend for rc_log. It has a decent amount of
+//! complexity, as Rust logs can be emitted by any thread, regardless of whether
+//! or not they have an associated JVM thread. JNA's Callback class helps us
+//! here, by providing a way for mapping native threads to JVM threads.
+//! Unfortunately, naive usage of this class in a multithreaded context will be
+//! very suboptimal in terms of memory and thread usage.
+//!
+//! To avoid this, we only call into the JVM from a single thread, which we
+//! launch when initializing the logger. This thread just polls a channel
+//! listening for log messages, where a log message is an enum (`LogMessage`)
+//! that either tells it to log an item, or to stop logging all together.
+//!
+//! 1. We cannot guarantee that the callback from android lives past when the
+//!    android code tells us to stop logging, so in order to be memory safe, we
+//!    need to stop logging immediately when this happens. We do this using an
+//!    `Arc<AtomicBool>`, used to indicate that we should stop logging.
+//!
+//! 2. There's no safe way to terminate a thread in Rust (for good reason), so
+//!    the background thread must close willingly. To make sure this happens
+//!    promptly (e.g. to avoid a case where we're blocked until some thread
+//!    somewhere else happens to log something), we need to add something onto
+//!    the log channel, hence the existence of `LogMessage::Stop`.
+//!
+//!    It's important to note that because of point 1, the polling thread may
+//!    have to stop prior to getting `LogMessage::Stop`. We do not want to wait
+//!    for it to process whatever log messages were sent prior to being told to
+//!    stop.
+
+use std::{
+    ffi::CString,
+    os::raw::c_char,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{sync_channel, SyncSender},
+        Arc, Mutex,
+    },
+    thread,
+};
+
+use crate::LogLevel;
+
+/// Type of the log callback provided to us by java/swift. Takes the following
+/// arguments:
+///
+/// - Log level (an i32).
+///
+/// - Tag: a (nullable) nul terminated c string. The callback must not free this
+///   string, which is only valid until the the callback returns. If you need
+///   it past that, you must copy it into an internal buffer!
+///
+/// - Message: a (non-nullable) nul terminated c string. The callback must not free this
+///   string, which is only valid until the the callback returns. If you need
+///   it past that, you must copy it into an internal buffer!
+///
+/// and returns 0 if we should close the thread, and 1 otherwise. This is done
+/// because attempting to call `disable` from within the log callback will
+/// deadlock.
+pub type LogCallback = unsafe extern "C" fn(i32, *const c_char, *const c_char) -> u8;
+
+// TODO: use serde to send this to the other thread as bincode or something,
+// rather than allocating all these strings for every message.
+struct LogRecord {
+    level: LogLevel,
+    tag: Option<CString>,
+    message: CString,
+}
+
+impl<'a, 'b> From<&'b log::Record<'a>> for LogRecord {
+    // XXX important! Don't log in this function!
+    fn from(r: &'b log::Record<'a>) -> Self {
+        let message = format!("{}", r.args());
+        Self {
+            level: r.level().into(),
+            tag: r
+                .module_path()
+                .and_then(|mp| CString::new(mp.to_owned()).ok()),
+            message: crate::string_to_cstring_lossy(message),
+        }
+    }
+}
+
+enum LogMessage {
+    Stop,
+    Record(LogRecord),
+}
+
+pub struct LogAdapterState {
+    // Thread handle for the BG thread.
+    handle: Option<std::thread::JoinHandle<()>>,
+    stopped: Arc<Mutex<bool>>,
+    sender: SyncSender<LogMessage>,
+}
+
+pub struct LogSink {
+    sender: SyncSender<LogMessage>,
+    // Used locally for preventing unnecessary work after the `sender`
+    // is closed. Not shared. Not required for correctness.
+    disabled: AtomicBool,
+}
+
+impl log::Log for LogSink {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        // Really this could just be Acquire but whatever
+        !self.disabled.load(Ordering::SeqCst)
+    }
+
+    fn flush(&self) {}
+    fn log(&self, record: &log::Record) {
+        // Important: we check stopped before writing, which means
+        // it must be set before
+        if self.disabled.load(Ordering::SeqCst) {
+            // Note: `enabled` is not automatically called.
+            return;
+        }
+        // Either the queue is full, or the receiver is closed.
+        // In either case, we want to stop all logging immediately.
+        if self
+            .sender
+            .try_send(LogMessage::Record(record.into()))
+            .is_err()
+        {
+            self.disabled.store(true, Ordering::SeqCst);
+        }
+    }
+}
+
+impl LogAdapterState {
+    pub fn init(callback: LogCallback) -> Self {
+        // This uses a mutex (instead of an atomic bool) to avoid a race condition
+        // where `stopped` gets set by another thread between when we read it and
+        // when we call the callback. This way, they'll block.
+        let stopped = Arc::new(Mutex::new(false));
+        let (message_sender, message_recv) = sync_channel(4096);
+        let handle = {
+            let stopped = stopped.clone();
+            thread::spawn(move || {
+                // We stop if we see `Err` (which means the channel got closed,
+                // which probably can't happen since the sender owned by the
+                // logger will never get dropped), or if we get `LogMessage::Stop`,
+                // which means we should stop processing.
+                while let Ok(LogMessage::Record(record)) = message_recv.recv() {
+                    let LogRecord {
+                        tag,
+                        level,
+                        message,
+                    } = record;
+                    let tag_ptr = tag
+                        .as_ref()
+                        .map(|s| s.as_ptr())
+                        .unwrap_or_else(std::ptr::null);
+                    let msg_ptr = message.as_ptr();
+
+                    let mut stop_guard = stopped.lock().unwrap();
+                    if *stop_guard {
+                        return;
+                    }
+                    let keep_going = unsafe { callback(level as i32, tag_ptr, msg_ptr) };
+                    if keep_going == 0 {
+                        *stop_guard = true;
+                        return;
+                    }
+                }
+            })
+        };
+
+        let sink = LogSink {
+            sender: message_sender.clone(),
+            disabled: AtomicBool::new(false),
+        };
+
+        crate::settable_log::set_logger(Box::new(sink));
+        log::set_max_level(log::LevelFilter::Debug);
+        log::info!("rc_log adapter initialized!");
+        Self {
+            handle: Some(handle),
+            stopped,
+            sender: message_sender,
+        }
+    }
+}
+
+impl Drop for LogAdapterState {
+    fn drop(&mut self) {
+        {
+            // It would be nice to write a log that says something like
+            // "if we deadlock here it's because you tried to close the
+            // log adapter from within the log callback", but, well, we
+            // can't exactly log anything from here (and even if we could,
+            // they'd never see it if they hit that situation)
+            let mut stop_guard = self.stopped.lock().unwrap();
+            *stop_guard = true;
+            // We can ignore a failure here because it means either
+            // - The recv is dropped, in which case we don't need to send anything
+            // - The recv is completely full, in which case it will see the flag we
+            //   wrote into `stop_guard` soon enough anyway.
+            let _ = self.sender.try_send(LogMessage::Stop);
+        }
+        // Wait for the calling thread to stop. This should be relatively
+        // quickly unless something terrible has happened.
+        if let Some(h) = self.handle.take() {
+            h.join().unwrap();
+        }
+    }
+}
+
+ffi_support::implement_into_ffi_by_pointer!(LogAdapterState);

--- a/components/rc_log/src/ios.rs
+++ b/components/rc_log/src/ios.rs
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::LogLevel;
+use std::ffi::CString;
+use std::os::raw::c_char;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+/// Type of the log callback provided to us by swift. Takes the following
+/// arguments:
+///
+/// - Log level (an i32).
+///
+/// - Tag: a (nullable) nul terminated c string. The callback must not free this
+///   string, which is only valid until the the callback returns. If you need
+///   it past that, you must copy it into an internal buffer!
+///
+/// - Message: a (non-nullable) nul terminated c string. The callback must not free this
+///   string, which is only valid until the the callback returns. If you need
+///   it past that, you must copy it into an internal buffer!
+///
+/// This is equivalent to the callback java uses **except** it cannot return 1/0
+/// for disabling. Instead, the swift bindings allow calling disable from the
+/// callback (which is more difficult for the java bindings).
+pub type LogCallback = unsafe extern "C" fn(i32, *const c_char, *const c_char);
+
+pub struct LogAdapterState {
+    stop: Arc<AtomicBool>,
+}
+
+struct Logger {
+    callback: LogCallback,
+    stop: Arc<AtomicBool>,
+}
+
+impl log::Log for Logger {
+    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+        !self.stop.load(Ordering::SeqCst)
+    }
+
+    fn flush(&self) {}
+    fn log(&self, record: &log::Record) {
+        if self.stop.load(Ordering::SeqCst) {
+            // Note: `enabled` is not automatically called.
+            return;
+        }
+        let tag = record
+            .module_path()
+            .and_then(|mp| CString::new(mp.as_bytes()).ok());
+
+        // TODO: use SmallVec<[u8; 4096]> or something?
+        let msg_str = crate::string_to_cstring_lossy(format!("{}", record.args()));
+
+        let tag_ptr = tag
+            .as_ref()
+            .map(|s| s.as_ptr())
+            .unwrap_or_else(std::ptr::null);
+        let msg_ptr = msg_str.as_ptr() as *const c_char;
+
+        let level: LogLevel = record.level().into();
+
+        unsafe { (self.callback)(level as i32, tag_ptr, msg_ptr) };
+    }
+}
+
+impl LogAdapterState {
+    pub fn init(callback: LogCallback) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let log = Logger {
+            callback,
+            stop: stop.clone(),
+        };
+        crate::settable_log::set_logger(Box::new(log));
+        log::set_max_level(log::LevelFilter::Debug);
+        log::info!("rc_log adapter initialized!");
+        Self { stop }
+    }
+}
+
+impl Drop for LogAdapterState {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+    }
+}
+
+ffi_support::implement_into_ffi_by_pointer!(LogAdapterState);

--- a/components/rc_log/src/lib.rs
+++ b/components/rc_log/src/lib.rs
@@ -4,53 +4,52 @@
 
 //! This crate allows users from the other side of the FFI to hook into Rust's
 //! `log` crate, which is used by us and several of our dependencies. The
-//! primary use case is providing logs to Android in a way that is more flexible
-//! than writing to liblog (which goes to logcat, which cannot be accessed by
-//! programs on the device, short of rooting it).
+//! primary use case is providing logs to Android and iOS in a way that is more
+//! flexible than writing to liblog (which goes to logcat, which cannot be
+//! accessed by programs on the device, short of rooting it), or stdout/stderr.
 //!
-//! Even worse, Rust logs can be emitted by any thread, regardless of whether or
-//! not they have an associated JVM thread. JNA's Callback class helps us here,
-//! by providing a way for mapping native threads to JVM threads. Unfortunately,
-//! naive usage of this class in a multithreaded context will be very suboptimal
-//! in terms of memory and thread usage.
+//! See the header comment in android.rs and fallback.rs for details.
 //!
-//! To avoid this, we only call into the JVM from a single thread, which we
-//! launch when initializing the logger. This thread just polls a channel
-//! listening for log messages, where a log message is an enum (`LogMessage`)
-//! that either tells it to log an item, or to stop logging all together.
-//!
-//! 1. We cannot guarantee the the callback from android lives past when the
-//!    android code tells us to stop logging, so in order to be memory safe, we
-//!    need to stop logging immediately when this happens. We do this using an
-//!    `Arc<AtomicBool>`, used to indicate that we should stop logging.
-//!
-//! 2. There's no safe way to terminate a thread in Rust (for good reason), so
-//!    the background thread must close willingly. To make sure this happens
-//!    promptly (e.g. to avoid a case where we're blocked until some thread
-//!    somewhere else happens to log something), we need to add something onto
-//!    the log channel, hence the existence of `LogMessage::Stop`.
-//!
-//!    It's important to note that because of point 1, the polling thread may
-//!    have to stop prior to getting `LogMessage::Stop`. We do not want to wait
-//!    for it to process whatever log messages were sent prior to being told
-//!    to stop.
-//!
-//! Finally, it's worth noting that the log crate is rather inflexable, in that
+//! It's worth noting that the log crate is rather inflexable, in that
 //! it does not allow users to change loggers after the first initialization. We
 //! work around this using our `settable_log` module.
 
-use std::{
-    ffi::CString,
-    os::raw::c_char,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        mpsc::{sync_channel, SyncSender},
-        Arc, Mutex,
-    },
-    thread,
-};
+// We always include both modules when doing test builds, so for test builds,
+// allow dead code.
+#![cfg_attr(test, allow(dead_code))]
+
+use std::ffi::CString;
+use std::os::raw::c_char;
+
+// Import this in tests (even on non-android builds / cases where the
+// force_android feature is not enabled) so we can check that it compiles
+// easily.
+#[cfg(any(test, os = "android", feature = "force_android"))]
+pub mod android;
+// Import this in tests (even if we're building for android or force_android is
+// turned on) so we can check that it compiles easily
+#[cfg(any(test, not(any(os = "android", feature = "force_android"))))]
+pub mod ios;
 
 mod settable_log;
+
+cfg_if::cfg_if! {
+    if #[cfg(any(os = "android", feature = "force_android"))] {
+        use crate::android as imp;
+    } else {
+        use crate::ios as imp;
+    }
+}
+
+pub(crate) fn string_to_cstring_lossy(s: String) -> CString {
+    let mut bytes = s.into_bytes();
+    for byte in bytes.iter_mut() {
+        if *byte == 0 {
+            *byte = b'?';
+        }
+    }
+    CString::new(bytes).expect("Bug in string_to_cstring_lossy!")
+}
 
 #[derive(Clone, Copy)]
 #[repr(i32)]
@@ -75,185 +74,12 @@ impl From<log::Level> for LogLevel {
     }
 }
 
-// TODO: use serde to send this to the other thread as bincode or something,
-// rather than allocating all these strings for every message.
-struct LogRecord {
-    level: LogLevel,
-    tag: Option<CString>,
-    message: CString,
-}
-
-fn string_to_cstring_lossy(s: String) -> CString {
-    let mut bytes = s.into_bytes();
-    for byte in bytes.iter_mut() {
-        if *byte == 0 {
-            *byte = b'?';
-        }
-    }
-    CString::new(bytes).expect("Bug in string_to_cstring_lossy!")
-}
-
-impl<'a, 'b> From<&'b log::Record<'a>> for LogRecord {
-    // XXX important! Don't log in this function!
-    fn from(r: &'b log::Record<'a>) -> Self {
-        let message = format!("{}", r.args());
-        Self {
-            level: r.level().into(),
-            tag: r
-                .module_path()
-                .and_then(|mp| CString::new(mp.to_owned()).ok()),
-            message: string_to_cstring_lossy(message),
-        }
-    }
-}
-
-/// Type of the log callback provided to us by java.
-/// Takes the following arguments:
-///
-/// - Log level (an i32).
-/// - Tag: a (nullable) nul terminated c string. Caller must not free this string!
-/// - Message: a (non-nullable) nul terminated c string. Caller must not free this string!
-///
-/// and returns 0 if we should close the thread, and 1 otherwise. This is done because
-/// attempting to call `close` from within the log callback will deadlock.
-pub type LogCallback = extern "C" fn(LogLevel, *const c_char, *const c_char) -> u8;
-
-enum LogMessage {
-    Stop,
-    Record(LogRecord),
-}
-
-pub struct LogAdapterState {
-    // Thread handle for the BG thread. We can't drop this without problems so weu32
-    // prefix with _ to shut rust up about it being unused.
-    handle: Option<std::thread::JoinHandle<()>>,
-    stopped: Arc<Mutex<bool>>,
-    sender: SyncSender<LogMessage>,
-}
-
-pub struct LogSink {
-    sender: SyncSender<LogMessage>,
-    // Used locally for preventing unnecessary work after the `sender`
-    // is closed. Not shared. Not required for correctness.
-    disabled: AtomicBool,
-}
-
-impl log::Log for LogSink {
-    fn enabled(&self, _metadata: &log::Metadata) -> bool {
-        // Really this could just be Acquire but whatever
-        !self.disabled.load(Ordering::SeqCst)
-    }
-
-    fn flush(&self) {}
-    fn log(&self, record: &log::Record) {
-        // Important: we check stopped before writing, which means
-        // it must be set before
-        if self.disabled.load(Ordering::SeqCst) {
-            // Note: `enabled` is not automatically called.
-            return;
-        }
-        // Either the queue is full, or the receiver is closed.
-        // In either case, we want to stop all logging immediately.
-        if self
-            .sender
-            .try_send(LogMessage::Record(record.into()))
-            .is_err()
-        {
-            self.disabled.store(true, Ordering::SeqCst);
-        }
-    }
-}
-
-impl LogAdapterState {
-    pub fn init(callback: LogCallback) -> Self {
-        // This uses a mutex (instead of an atomic bool) to avoid a race condition
-        // where `stopped` gets set by another thread between when we read it and
-        // when we call the callback. This way, they'll block.
-        let stopped = Arc::new(Mutex::new(false));
-        let (message_sender, message_recv) = sync_channel(4096);
-        let handle = {
-            let stopped = stopped.clone();
-            thread::spawn(move || {
-                // We stop if we see `Err` (which means the channel got closed,
-                // which probably can't happen since the sender owned by the
-                // logger will never get dropped), or if we get `LogMessage::Stop`,
-                // which means we should stop processing.
-                while let Ok(LogMessage::Record(record)) = message_recv.recv() {
-                    let LogRecord {
-                        tag,
-                        level,
-                        message,
-                    } = record;
-                    let tag_ptr = tag
-                        .as_ref()
-                        .map(|s| s.as_ptr())
-                        .unwrap_or_else(std::ptr::null);
-                    let msg_ptr = message.as_ptr();
-
-                    let mut stop_guard = stopped.lock().unwrap();
-                    if *stop_guard {
-                        return;
-                    }
-                    let keep_going = callback(level, tag_ptr, msg_ptr);
-                    if keep_going == 0 {
-                        *stop_guard = true;
-                        return;
-                    }
-                }
-            })
-        };
-
-        let sink = LogSink {
-            sender: message_sender.clone(),
-            disabled: AtomicBool::new(false),
-        };
-
-        settable_log::set_logger(Box::new(sink));
-        log::set_max_level(log::LevelFilter::Debug);
-        log::info!("ac_log adapter initialized!");
-        Self {
-            handle: Some(handle),
-            stopped,
-            sender: message_sender,
-        }
-    }
-}
-
-impl Drop for LogAdapterState {
-    fn drop(&mut self) {
-        {
-            // It would be nice to write a log that says something like
-            // "if we deadlock here it's because you tried to close the
-            // log adapter from within the log callback", but, well, we
-            // can't exactly log anything from here (and even if we could,
-            // they'd never see it if they hit that situation)
-            let mut stop_guard = self.stopped.lock().unwrap();
-            *stop_guard = true;
-            // We can ignore a failure here because it means either
-            // - The recv is dropped, in which case we don't need to send anything
-            // - The recv is completely full, in which case it will see the flag we
-            //   wrote into `stop_guard` soon enough anyway.
-            let _ = self.sender.try_send(LogMessage::Stop);
-        }
-        // Wait for the calling thread to stop. This should be relatively
-        // quickly unless something terrible has happened.
-        // TODO: can we safely return from this (I suspect the answer is no, and
-        // we have to panic and abort higher up...)
-        if let Some(h) = self.handle.take() {
-            h.join().unwrap();
-        }
-    }
-}
-
-ffi_support::implement_into_ffi_by_pointer!(LogAdapterState);
-ffi_support::define_string_destructor!(ac_log_adapter_destroy_string);
-
 #[no_mangle]
-pub extern "C" fn ac_log_adapter_create(
-    callback: LogCallback,
+pub extern "C" fn rc_log_adapter_create(
+    callback: imp::LogCallback,
     out_err: &mut ffi_support::ExternError,
-) -> *mut LogAdapterState {
-    ffi_support::call_with_output(out_err, || LogAdapterState::init(callback))
+) -> *mut imp::LogAdapterState {
+    ffi_support::call_with_output(out_err, || imp::LogAdapterState::init(callback))
 }
 
 // Note: keep in sync with LogLevelFilter in kotlin.
@@ -271,11 +97,7 @@ fn level_filter_from_i32(level_arg: i32) -> log::LevelFilter {
 }
 
 #[no_mangle]
-pub extern "C" fn ac_log_adapter_set_max_level(
-    _state: &mut LogAdapterState,
-    level: i32,
-    out_err: &mut ffi_support::ExternError,
-) {
+pub extern "C" fn rc_log_adapter_set_max_level(level: i32, out_err: &mut ffi_support::ExternError) {
     ffi_support::call_with_output(out_err, || log::set_max_level(level_filter_from_i32(level)))
 }
 
@@ -283,7 +105,7 @@ pub extern "C" fn ac_log_adapter_set_max_level(
 // keep this around globally (as lazy_static or something) and basically just
 // turn it on/off in create/destroy... Might be more reliable?
 #[no_mangle]
-pub unsafe extern "C" fn ac_log_adapter_destroy(to_destroy: *mut LogAdapterState) {
+pub unsafe extern "C" fn rc_log_adapter_destroy(to_destroy: *mut imp::LogAdapterState) {
     ffi_support::abort_on_panic::call_with_output(|| {
         log::set_max_level(log::LevelFilter::Off);
         drop(Box::from_raw(to_destroy));
@@ -293,8 +115,10 @@ pub unsafe extern "C" fn ac_log_adapter_destroy(to_destroy: *mut LogAdapterState
 
 // Used just to allow tests to produce logs.
 #[no_mangle]
-pub unsafe extern "C" fn ac_log_adapter_test__log_msg(msg: *const c_char) {
+pub unsafe extern "C" fn rc_log_adapter_test__log_msg(msg: *const c_char) {
     ffi_support::abort_on_panic::call_with_output(|| {
         log::info!("testing: {}", ffi_support::rust_str_from_c(msg));
     });
 }
+
+ffi_support::define_string_destructor!(rc_log_adapter_destroy_string);

--- a/megazords/ios/MozillaAppServices.h
+++ b/megazords/ios/MozillaAppServices.h
@@ -9,4 +9,4 @@ FOUNDATION_EXPORT const unsigned char MegazordClientVersionString[];
 
 #import <fxa.h>
 #import <RustPasswordAPI.h>
-
+#import <RustLogFFI.h>

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		C852EEE8220A2A2B00A6E79A /* String+Free_FxAClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C852EEDF220A2A2B00A6E79A /* String+Free_FxAClient.swift */; };
 		C852EEEB220A2A2B00A6E79A /* FxAError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C852EEE3220A2A2B00A6E79A /* FxAError.swift */; };
 		C852EEEF220A2E9400A6E79A /* libmegazord_ios.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C852EEEE220A2E9400A6E79A /* libmegazord_ios.a */; };
+		CD4CFDD3221DFA5100EB3B33 /* LogTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4CFDD2221DFA5100EB3B33 /* LogTest.swift */; };
+		CDC21B14221DCE3700AA71E5 /* RustLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC21B12221DCE3700AA71E5 /* RustLog.swift */; };
+		CDC21B15221DCE3700AA71E5 /* RustLogFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = CDC21B13221DCE3700AA71E5 /* RustLogFFI.h */; };
 		EB7DE84D2214D30B00E7CF17 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB7DE84C2214D30B00E7CF17 /* SwiftProtobuf.framework */; };
 		EB7DE84F2214D39600E7CF17 /* RustProtobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB7DE84E2214D39600E7CF17 /* RustProtobuf.swift */; };
 		EB879D64221231F400753DC9 /* CommonErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB879D4D221231F400753DC9 /* CommonErrors.swift */; };
@@ -66,6 +69,9 @@
 		C852EEE3220A2A2B00A6E79A /* FxAError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAError.swift; sourceTree = "<group>"; };
 		C852EEEE220A2E9400A6E79A /* libmegazord_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmegazord_ios.a; path = ../../target/universal/release/libmegazord_ios.a; sourceTree = "<group>"; };
 		C852EEF2220A3C6800A6E79A /* MozillaAppServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MozillaAppServices.h; sourceTree = "<group>"; };
+		CD4CFDD2221DFA5100EB3B33 /* LogTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogTest.swift; sourceTree = "<group>"; };
+		CDC21B12221DCE3700AA71E5 /* RustLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustLog.swift; sourceTree = "<group>"; };
+		CDC21B13221DCE3700AA71E5 /* RustLogFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RustLogFFI.h; sourceTree = "<group>"; };
 		CE9D202020914D0D00F1C8FA /* MozillaAppServices.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MozillaAppServices.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB7DE84C2214D30B00E7CF17 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftProtobuf.framework; path = ../../Carthage/Build/iOS/SwiftProtobuf.framework; sourceTree = "<group>"; };
 		EB7DE84E2214D39600E7CF17 /* RustProtobuf.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustProtobuf.swift; sourceTree = "<group>"; };
@@ -181,9 +187,19 @@
 			path = Errors;
 			sourceTree = "<group>";
 		};
+		CDC21B11221DCE3700AA71E5 /* RustLog */ = {
+			isa = PBXGroup;
+			children = (
+				CDC21B12221DCE3700AA71E5 /* RustLog.swift */,
+				CDC21B13221DCE3700AA71E5 /* RustLogFFI.h */,
+			);
+			path = RustLog;
+			sourceTree = "<group>";
+		};
 		CE9D201620914D0D00F1C8FA = {
 			isa = PBXGroup;
 			children = (
+				CDC21B11221DCE3700AA71E5 /* RustLog */,
 				C852EEF2220A3C6800A6E79A /* MozillaAppServices.h */,
 				C852EEB2220A285B00A6E79A /* config */,
 				EB879D4B221231F400753DC9 /* support */,
@@ -236,6 +252,7 @@
 			children = (
 				EB879D7E221234EB00753DC9 /* Info.plist */,
 				EB879D8A22123FD900753DC9 /* MozillaAppServicesTest.swift */,
+				CD4CFDD2221DFA5100EB3B33 /* LogTest.swift */,
 			);
 			path = MozillaAppServicesTests;
 			sourceTree = "<group>";
@@ -247,6 +264,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDC21B15221DCE3700AA71E5 /* RustLogFFI.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -376,6 +394,7 @@
 				C852EED8220A29FE00A6E79A /* LockError.swift in Sources */,
 				C852EED5220A29FE00A6E79A /* LoginRecord.swift in Sources */,
 				C852EEE7220A2A2B00A6E79A /* FirefoxAccount.swift in Sources */,
+				CDC21B14221DCE3700AA71E5 /* RustLog.swift in Sources */,
 				C852EED6220A29FE00A6E79A /* LoginsStorage.swift in Sources */,
 				C852EED3220A29FE00A6E79A /* String+Free_Logins.swift in Sources */,
 			);
@@ -385,6 +404,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD4CFDD3221DFA5100EB3B33 /* LogTest.swift in Sources */,
 				EB879D8B22123FD900753DC9 /* MozillaAppServicesTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/megazords/ios/MozillaAppServicesTests/LogTest.swift
+++ b/megazords/ios/MozillaAppServicesTests/LogTest.swift
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import XCTest
+import Foundation
+
+@testable import MozillaAppServices
+
+class LogTests: XCTestCase {
+
+    func writeTestLog(_ message: String) {
+        RustLog.shared.logTestMessage(message: message)
+        // Wait for the log to come in. Cludgey but good enough.
+        Thread.sleep(forTimeInterval: 0.1)
+        // Force us to synchronize on the queue.
+        let _ = RustLog.shared.isEnabled
+    }
+
+    func testLogging() {
+        var logs: [(LogLevel, String?, String)] = [];
+
+        assert(!RustLog.shared.isEnabled)
+
+        try! RustLog.shared.enable { level, tag, msg in
+            let info = "Rust | Level: \(level) | tag: \(String(describing: tag)) | message: \(msg)"
+            print(info)
+            logs.append((level, tag, msg))
+            return true
+        }
+
+        // We log an informational message after initializing (but it's processed asynchronously).
+        Thread.sleep(forTimeInterval: 0.1)
+        XCTAssert(RustLog.shared.isEnabled)
+        XCTAssertEqual(logs.count, 1)
+        writeTestLog("Test1")
+        XCTAssertEqual(logs.count, 2)
+        do {
+            try RustLog.shared.enable { _, _, _ in return true }
+            XCTFail("Enable should fail")
+        } catch let error as RustLogError {
+            switch error {
+            case .alreadyEnabled:
+                print("enable failed as it should")
+            default:
+                XCTFail("Wrong RustLogError: \(error)")
+            }
+        } catch let error {
+            XCTFail("Wrong error: \(error)")
+        }
+        // tryEnable should return false
+        XCTAssert(!RustLog.shared.tryEnable { _, _, _ in return true });
+
+        // Adjust the max level so that the test log (which is logged at info level)
+        // will not be present.
+        try! RustLog.shared.setLevelFilter(filter: .warn)
+        writeTestLog("Test2")
+        // Should not increase
+        XCTAssertEqual(logs.count, 2)
+        try! RustLog.shared.setLevelFilter(filter: .info)
+        writeTestLog("Test3")
+        XCTAssertEqual(logs.count, 3)
+
+        RustLog.shared.disable()
+        XCTAssert(!RustLog.shared.isEnabled)
+
+        // Shouldn't do anything, we disabled the log.
+        writeTestLog("Test4")
+
+        XCTAssertEqual(logs.count, 3)
+        var counter = 0;
+        let didEnable = RustLog.shared.tryEnable { level, tag, msg in
+            let info = "Rust | Level: \(level) | tag: \(String(describing: tag)) | message: \(msg)"
+            print(info)
+            logs.append((level, tag, msg))
+            counter += 1
+            if counter == 3 {
+                // Test disabling from inside log callback
+                print("Disabling log from inside callback")
+                return false
+            } else {
+                return true
+            }
+        }
+        XCTAssert(didEnable)
+        // Wait for the 'we enabled logging' log to come in asynchronously
+        Thread.sleep(forTimeInterval: 0.1)
+        XCTAssert(RustLog.shared.isEnabled)
+        XCTAssertEqual(logs.count, 4)
+
+        writeTestLog("Test5")
+        XCTAssertEqual(logs.count, 5)
+
+        writeTestLog("Test6")
+        XCTAssertEqual(logs.count, 6)
+        // Should be disabled now,
+        XCTAssert(!RustLog.shared.isEnabled)
+
+    }
+}

--- a/megazords/ios/RustLog/RustLog.swift
+++ b/megazords/ios/RustLog/RustLog.swift
@@ -1,0 +1,247 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/// The level of a log message
+public enum LogLevel: Int32 {
+    /// The log message in question is verbose information which
+    /// may contain user PII.
+    case trace = 2
+    /// The log message in question is verbose information,
+    /// but should contain no PII.
+    case debug
+    /// The log message is informational
+    case info
+    /// The log message is a warning
+    case warn
+    /// The log message indicates an error.
+    case error
+
+    init(safeRawValue value: Int32) {
+        if let result = LogLevel(rawValue: value) {
+            self = result
+            return
+        }
+
+        if value < LogLevel.trace.rawValue {
+            self = .trace
+        } else {
+            self = .error
+        }
+    }
+}
+
+/// An enum representing a maximum log level. It is used with
+/// `RustLog.shared.setLevelFilter`.
+///
+/// This is roughly equivalent to LogLevel, however contains
+/// `Off`, for filtering all logging.
+public enum LogLevelFilter: Int32 {
+    /// Disable all logging
+    case off
+    /// Only allow `error` logs.
+    case error
+    /// Allow `warn` and `error` logs.
+    case warn
+    /// Allow `warn`, `error`, and `info` logs.
+    case info
+    /// Allow `warn`, `error`, `info`, and `debug` logs. The default.
+    case debug
+    /// Allow all logs, including those that may contain PII.
+    case trace
+}
+
+/// The type of the log callback. You can provide a value of this type to
+/// `RustLog.shared.enable` or `RustLog.shared.tryEnable`, and it will be called for
+/// all log messages emitted by Rust code.
+///
+/// The first argument is the level of the log. The maximum value of this can
+/// be provided using the `RustLog.shared.setLevelFilter` method.
+///
+/// The second argument is the tag, which is typically a rust module path
+/// string. It might be nil in some cases that aren't documented by the
+/// underlying rust log crate.
+///
+/// The last argument is the log message. It will not be nil.
+///
+/// This callback should return `true` to indicate everything is fine, and
+/// false if we should disable the logger. You cannot call `disable()`
+/// from inside the callback (it's protected by a dispatch queue you're
+/// already running on).
+public typealias LogCallback = (_ level: LogLevel, _ tag: String?, _ message: String) -> Bool;
+
+/// The public interface to Rust's logger.
+///
+/// This is a singleton, and should be used via the
+/// `shared` static member.
+public class RustLog {
+    fileprivate let state = RustLogState()
+    fileprivate let queue = DispatchQueue(label: "com.mozilla.appservices.rust-log")
+    /// The singleton instance of RustLog
+    public static let shared = RustLog()
+
+    private init() {}
+
+    /// True if the logger currently has a bound callback.
+    public var isEnabled: Bool {
+        return queue.sync { state.isEnabled }
+    }
+
+    /// Set the current log callback.
+    ///
+    /// Note that by default, after enabling the level filter
+    /// will be at the `debug` level. If you want to increase or decrease it,
+    /// you may use `setLevelFilter`
+    ///
+    ///
+    /// See alse `tryEnable`.
+    ///
+    /// Throws:
+    ///
+    /// - `RustLogError.alreadyEnabled`: If we're already enabled. Explicitly disable first.
+    ///
+    /// - `RustLogError.unexpectedError`: If the rust code panics. This shouldn't happen,
+    ///   but if it does, we would appreciate reports from telemetry or similar
+    public func enable(_ callback: @escaping LogCallback) throws {
+        try queue.sync {
+            try state.enable(callback)
+        }
+    }
+
+    /// Set the level filter (the maximum log level) of the logger.
+    ///
+    /// Throws:
+    /// - `RustLogError.unexpectedError`: If the rust code panics. This shouldn't happen,
+    ///   but if it does, we would appreciate reports from telemetry or similar
+    public func setLevelFilter(filter: LogLevelFilter) throws {
+        // Note: Doesn't need to synchronize.
+        try rustCall { error in
+            rc_log_adapter_set_max_level(filter.rawValue, error)
+        }
+    }
+
+    /// Disable the previously set logger. This also sets the level filter to `.off`.
+    ///
+    /// Does nothing if the logger is disabled
+    public func disable() {
+        queue.sync {
+            state.disable()
+        }
+    }
+
+    /// Enable the logger if possible.
+    ///
+    /// Returns false in the cases where `enable` would throw, true otherwise.
+    ///
+    /// If it would throw due to a panic, it also writes some information about
+    /// the panic to the provided callback
+    public func tryEnable(_ callback: @escaping LogCallback) -> Bool {
+        return queue.sync {
+            state.tryEnable(callback)
+        }
+    }
+
+    /// Log a test message at `.info` severity.
+    public func logTestMessage(message: String) {
+        rc_log_adapter_test__log_msg(message)
+    }
+}
+
+/// The type of errors reported by RustLog. These either indicate bugs
+/// in our logging code (as in `UnexpectedError`), or usage errors
+/// (as in `AlreadyEnabled`)
+public enum RustLogError: Error {
+    /// This generally means a panic occurred, or something went very wrong.
+    /// We would appreciate bug reports about when these appear in the wild, if they do.
+    case unexpectedError(message: String)
+
+    /// Error indicating that the log adapter cannot be enabled
+    /// because it is already enabled.
+    ///
+    /// This is a usage error, either `disable` it first, or
+    /// use `RustLog.shared.tryEnable`
+    case alreadyEnabled
+}
+
+@discardableResult
+fileprivate func rustCall<T>(_ callback: (UnsafeMutablePointer<RcLogError>) throws -> T) throws -> T {
+    var err = RcLogError(code: 0, message: nil)
+    let result = try callback(&err)
+    if err.code != 0 {
+        let message: String
+        if let messageP = err.message {
+            defer { rc_log_adapter_destroy_string(messageP) }
+            message = String(cString: messageP)
+        } else {
+            message = "Bug: No message provided with code \(err.code)!"
+        }
+        throw RustLogError.unexpectedError(message: message)
+    }
+    return result
+}
+
+// This is the function actually passed to Rust.
+fileprivate func logCallbackFunc(level: Int32, optTagP: UnsafePointer<CChar>?, msgP: UnsafePointer<CChar>) {
+    guard let callback = RustLog.shared.state.callback else {
+        return
+    }
+    let msg = String(cString: msgP)
+    // Probably a better way to do this...
+    let tag: String?
+    if let optTagP = optTagP {
+        tag = String(cString: optTagP)
+    } else {
+        tag = nil
+    }
+    RustLog.shared.queue.async {
+        if !callback(LogLevel(safeRawValue: level), tag, msg) {
+            RustLog.shared.state.disable()
+        }
+    }
+}
+
+// This implements everything, but without synchronization. It needs to be
+// guarded by a queue, which is done by the RustLog class.
+fileprivate class RustLogState {
+    var adapter: OpaquePointer?
+    var callback: LogCallback?
+
+    var isEnabled: Bool { return adapter != nil }
+
+    func enable(_ callback: @escaping LogCallback) throws {
+        if isEnabled {
+            throw RustLogError.alreadyEnabled
+        }
+        assert(self.callback == nil)
+        self.callback = callback
+        self.adapter = try rustCall { error in
+            rc_log_adapter_create(logCallbackFunc, error)
+        }
+    }
+
+    func disable() {
+        guard let adapter = self.adapter else {
+            return
+        }
+        self.adapter = nil
+        self.callback = nil
+        rc_log_adapter_destroy(adapter)
+    }
+
+    func tryEnable(_ callback: @escaping LogCallback) -> Bool {
+        if isEnabled {
+            return false
+        }
+        do {
+            try enable(callback)
+            return true
+        } catch let error {
+            let _ = callback(.error,
+                             "RustLog.swift",
+                             "RustLog.enable failed: \(error)")
+            return false
+        }
+    }
+}

--- a/megazords/ios/RustLog/RustLogFFI.h
+++ b/megazords/ios/RustLog/RustLogFFI.h
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#pragma once
+#include <stdint.h>
+#include <Foundation/NSObjCRuntime.h>
+
+typedef struct RcLogError {
+    int32_t code;
+    char *_Nullable message;
+} RcLogError;
+
+typedef void RustLogCallback(int32_t level,
+                             char const *_Nullable tag,
+                             char const *_Nonnull msg);
+
+typedef struct RustLogAdapter RustLogAdapter;
+
+RustLogAdapter *_Nullable rc_log_adapter_create(RustLogCallback *_Nonnull callback,
+                                                RcLogError *_Nonnull out_err);
+
+void rc_log_adapter_set_max_level(int32_t max_level,
+                                  RcLogError *_Nonnull out_err);
+
+void rc_log_adapter_destroy(RustLogAdapter *_Nonnull to_destroy);
+
+void rc_log_adapter_test__log_msg(char const *_Nonnull msg);
+
+// Only use for Error strings!
+void rc_log_adapter_destroy_string(char *_Nonnull msg);

--- a/megazords/ios/config/base.xcconfig
+++ b/megazords/ios/config/base.xcconfig
@@ -1,7 +1,7 @@
 #include "../../xcconfig/common.xcconfig"
 
 INFOPLIST_FILE = config/Info.plist
-HEADER_SEARCH_PATHS = "../../components/fxa-client/ios/FxAClient"  "../../components/logins/ios/Logins"
+HEADER_SEARCH_PATHS = "../../components/fxa-client/ios/FxAClient"  "../../components/logins/ios/Logins" "./RustLog"
 LIBRARY_SEARCH_PATHS = "../../target/universal/release" "../../libs/ios/universal/sqlcipher/lib"
 FRAMEWORK_SEARCH_PATHS = "../../Carthage/Build/iOS"
 SWIFT_OBJC_BRIDGING_HEADER = MozillaAppServices.h

--- a/megazords/ios/rust/Cargo.toml
+++ b/megazords/ios/rust/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["staticlib"]
 fxaclient_ffi = { path = "../../../components/fxa-client/ffi" }
 logins_ffi = { path = "../../../components/logins/ffi" }
 places-ffi = { path = "../../../components/places/ffi" }
+rc_log_ffi = { path = "../../../components/rc_log" }

--- a/megazords/ios/rust/src/lib.rs
+++ b/megazords/ios/rust/src/lib.rs
@@ -5,3 +5,4 @@
 pub extern crate fxaclient_ffi;
 pub extern crate logins_ffi;
 pub extern crate places_ffi;
+pub extern crate rc_log_ffi;


### PR DESCRIPTION
This also ended up changing how the android bindings works a little (mostly it moves them into their own file, since we don't need to jump through the same hoops / have the same limitations on iOS as android).

Flagging @linacambridge for reviewing the rust bits, and @garvankeeley for reviewing the swift/megazord build changes.

The test is a bit monolithic but I basically just ripped it directly from the android test.

Fixes #618