### PR TITLE
Fix return type of sync15_passwords_destroy_string in RustPasswordsApi.h, clean up headers a little

### DIFF
--- a/components/fxa-client/ios/FxAClient/fxa.h
+++ b/components/fxa-client/ios/FxAClient/fxa.h
@@ -55,14 +55,6 @@ typedef struct SyncKeysC {
     const char *const _Nonnull xcs;
 } SyncKeysC;
 
-typedef struct ProfileC {
-    const char *const _Nonnull uid;
-    const char *const _Nonnull email;
-    const char *const _Nullable avatar;
-    const uint8_t avatar_default;
-    const char *const _Nullable display_name;
-} ProfileC;
-
 typedef uint64_t FirefoxAccountHandle;
 
 char *_Nonnull fxa_begin_oauth_flow(FirefoxAccountHandle handle,

--- a/components/logins/ios/Logins/RustPasswordAPI.h
+++ b/components/logins/ios/Logins/RustPasswordAPI.h
@@ -33,18 +33,19 @@ Sync15PasswordEngineHandle sync15_passwords_state_new_with_hex_key(char const *_
                                                                    uint32_t encryption_key_len,
                                                                    Sync15PasswordsError *_Nonnull error_out);
 
-void sync15_passwords_state_destroy(Sync15PasswordEngineHandle handle, Sync15PasswordsError *_Nonnull error_out);
+void sync15_passwords_state_destroy(Sync15PasswordEngineHandle handle,
+                                    Sync15PasswordsError *_Nonnull error_out);
 
-char *sync15_passwords_get_by_id(Sync15PasswordEngineHandle handle,
-                                 char const *_Nonnull id,
-                                 Sync15PasswordsError *_Nonnull error_out);
+char *_Nullable sync15_passwords_get_by_id(Sync15PasswordEngineHandle handle,
+                                          char const *_Nonnull id,
+                                          Sync15PasswordsError *_Nonnull error_out);
 
-char *sync15_passwords_get_by_id(Sync15PasswordEngineHandle handle,
-                                 char const *_Nonnull id,
-                                 Sync15PasswordsError *_Nonnull error_out);
+char *_Nullable sync15_passwords_get_by_id(Sync15PasswordEngineHandle handle,
+                                          char const *_Nonnull id,
+                                          Sync15PasswordsError *_Nonnull error_out);
 
-char *sync15_passwords_get_all(Sync15PasswordEngineHandle handle,
-                               Sync15PasswordsError *_Nonnull error_out);
+char *_Nullable sync15_passwords_get_all(Sync15PasswordEngineHandle handle,
+                                         Sync15PasswordsError *_Nonnull error_out);
 
 void sync15_passwords_sync(Sync15PasswordEngineHandle handle,
                            char const *_Nonnull key_id,
@@ -67,12 +68,12 @@ uint8_t sync15_passwords_delete(Sync15PasswordEngineHandle handle,
                                 char const *_Nonnull id,
                                 Sync15PasswordsError *_Nonnull error);
 
-char *sync15_passwords_add(Sync15PasswordEngineHandle handle,
-                           char const *_Nonnull json,
-                           Sync15PasswordsError *_Nonnull error);
+char *_Nullable sync15_passwords_add(Sync15PasswordEngineHandle handle,
+                                     char const *_Nonnull json,
+                                     Sync15PasswordsError *_Nonnull error);
 
 void sync15_passwords_update(Sync15PasswordEngineHandle handle,
                              char const *_Nonnull json,
                              Sync15PasswordsError *_Nonnull error);
 
-char *sync15_passwords_destroy_string(char const *_Nonnull str);
+void sync15_passwords_destroy_string(char const *_Nonnull str);


### PR DESCRIPTION
Fixes #697.