### PR TITLE
Re-implement the FxA persist callbacks in Swift

### DIFF
--- a/components/fxa-client/ios/FxAClient.xcodeproj/project.pbxproj
+++ b/components/fxa-client/ios/FxAClient.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		CE3E9D3520A36B63001B4B14 /* libfxaclient_ffi.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE7B4B8A20A36B0500FC4422 /* libfxaclient_ffi.a */; };
 		CE9D202520914D0D00F1C8FA /* FxAClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CE9D202320914D0D00F1C8FA /* FxAClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE9D203120914D2600F1C8FA /* FirefoxAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9D202B20914D2600F1C8FA /* FirefoxAccount.swift */; };
-		CE9D203520914D2600F1C8FA /* fxa.h in Headers */ = {isa = PBXBuildFile; fileRef = CE9D202F20914D2600F1C8FA /* fxa.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CE9D203520914D2600F1C8FA /* RustFxAFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = CE9D202F20914D2600F1C8FA /* RustFxAFFI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE5A6AEF220E2FD300B7F1BC /* RustProtobuf.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5A6AEE220E2FD300B7F1BC /* RustProtobuf.swift */; };
 		CEBACFC4220E22C80078D41C /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEBACFC3220E22C80078D41C /* SwiftProtobuf.framework */; };
 		CECB395D20B5BE0200DB3ED4 /* RustPointer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECB395B20B5BE0200DB3ED4 /* RustPointer.swift */; };
@@ -42,7 +42,7 @@
 		CE9D202320914D0D00F1C8FA /* FxAClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FxAClient.h; sourceTree = "<group>"; };
 		CE9D202420914D0D00F1C8FA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CE9D202B20914D2600F1C8FA /* FirefoxAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirefoxAccount.swift; sourceTree = "<group>"; };
-		CE9D202F20914D2600F1C8FA /* fxa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fxa.h; sourceTree = "<group>"; };
+		CE9D202F20914D2600F1C8FA /* RustFxAFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RustFxAFFI.h; sourceTree = "<group>"; };
 		CEBACFC3220E22C80078D41C /* SwiftProtobuf.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftProtobuf.framework; path = ../../../Carthage/Build/iOS/SwiftProtobuf.framework; sourceTree = "<group>"; };
 		CECB395B20B5BE0200DB3ED4 /* RustPointer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustPointer.swift; sourceTree = "<group>"; };
 		CEE1087520C5ADF9007048AC /* FxAError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAError.swift; sourceTree = "<group>"; };
@@ -96,7 +96,7 @@
 				CE9D202320914D0D00F1C8FA /* FxAClient.h */,
 				CE9D202420914D0D00F1C8FA /* Info.plist */,
 				CE9D202B20914D2600F1C8FA /* FirefoxAccount.swift */,
-				CE9D202F20914D2600F1C8FA /* fxa.h */,
+				CE9D202F20914D2600F1C8FA /* RustFxAFFI.h */,
 			);
 			path = FxAClient;
 			sourceTree = "<group>";

--- a/components/fxa-client/ios/FxAClient/FxAClient.h
+++ b/components/fxa-client/ios/FxAClient/FxAClient.h
@@ -10,4 +10,4 @@ FOUNDATION_EXPORT double FxAClientVersionNumber;
 //! Project version string for FxAClient.
 FOUNDATION_EXPORT const unsigned char FxAClientVersionString[];
 
-#import "fxa.h"
+#import "RustFxAFFI.h"

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -77,13 +77,6 @@ FirefoxAccountHandle fxa_from_json(const char *_Nonnull json,
 char *_Nullable fxa_to_json(FirefoxAccountHandle handle,
                             FxAErrorC *_Nonnull out);
 
-void fxa_register_persist_callback(FirefoxAccountHandle handle,
-                                   void (*_Nonnull callback_fn)(const char *_Nonnull json),
-                                   FxAErrorC *_Nonnull out);
-
-void fxa_unregister_persist_callback(FirefoxAccountHandle handle,
-                                     FxAErrorC *_Nonnull out);
-
 FirefoxAccountHandle fxa_new(const char *_Nonnull content_base,
                              const char *_Nonnull client_id,
                              const char *_Nonnull redirect_uri,

--- a/components/fxa-client/src/profile.rs
+++ b/components/fxa-client/src/profile.rs
@@ -9,6 +9,13 @@ use crate::{errors::*, scopes, util, CachedResponse, FirefoxAccount};
 const PROFILE_FRESHNESS_THRESHOLD: u64 = 120000; // 2 minutes
 
 impl FirefoxAccount {
+    /// Fetch the profile for the user.
+    /// This method will error-out if the `profile` scope is not
+    /// authorized for the current refresh token or or if we do
+    /// not have a valid refresh token.
+    ///
+    /// * `ignore_cache` - If set to true, bypass the in-memory cache
+    /// and fetch the entire profile data from the server.
     pub fn get_profile(&mut self, ignore_cache: bool) -> Result<Profile> {
         let profile_access_token = self.get_access_token(scopes::PROFILE)?.token;
         let mut etag = None;

--- a/megazords/ios/MozillaAppServices.h
+++ b/megazords/ios/MozillaAppServices.h
@@ -7,6 +7,6 @@
 FOUNDATION_EXPORT double MegazordClientVersionNumber;
 FOUNDATION_EXPORT const unsigned char MegazordClientVersionString[];
 
-#import <fxa.h>
+#import <RustFxAFFI.h>
 #import <RustPasswordAPI.h>
 #import <RustLogFFI.h>

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -65,7 +65,7 @@
 		C852EEDC220A2A2B00A6E79A /* RustPointer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustPointer.swift; sourceTree = "<group>"; };
 		C852EEDD220A2A2B00A6E79A /* FirefoxAccount.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirefoxAccount.swift; sourceTree = "<group>"; };
 		C852EEDF220A2A2B00A6E79A /* String+Free_FxAClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Free_FxAClient.swift"; sourceTree = "<group>"; };
-		C852EEE0220A2A2B00A6E79A /* fxa.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fxa.h; sourceTree = "<group>"; };
+		C852EEE0220A2A2B00A6E79A /* RustFxAFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RustFxAFFI.h; sourceTree = "<group>"; };
 		C852EEE3220A2A2B00A6E79A /* FxAError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAError.swift; sourceTree = "<group>"; };
 		C852EEEE220A2E9400A6E79A /* libmegazord_ios.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmegazord_ios.a; path = ../../target/universal/release/libmegazord_ios.a; sourceTree = "<group>"; };
 		C852EEF2220A3C6800A6E79A /* MozillaAppServices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MozillaAppServices.h; sourceTree = "<group>"; };
@@ -155,7 +155,7 @@
 				C852EEDB220A2A2B00A6E79A /* Rust */,
 				C852EEDD220A2A2B00A6E79A /* FirefoxAccount.swift */,
 				C852EEDE220A2A2B00A6E79A /* Extensions */,
-				C852EEE0220A2A2B00A6E79A /* fxa.h */,
+				C852EEE0220A2A2B00A6E79A /* RustFxAFFI.h */,
 				C852EEE2220A2A2B00A6E79A /* Errors */,
 			);
 			name = FxAClient;

--- a/samples/sandvich-ios/Example/FxAView.swift
+++ b/samples/sandvich-ios/Example/FxAView.swift
@@ -67,13 +67,13 @@ class FxAView: UIViewController, WKNavigationDelegate {
         if let state_json = UserDefaults.standard.string(forKey: stateKey) {
             self.fxa = try! FirefoxAccount.fromJSON(state: state_json)
             persistor.persist(json: (try! fxa?.toJSON())!) // Persist the FxA state right after its creation in case something goes wrong.
-            try! fxa!.registerPersistCallback(persistor) // After this, mutating changes will be persisted automatically.
+            fxa!.registerPersistCallback(persistor) // After this, mutating changes will be persisted automatically.
             self.tryGetProfile()
         } else {
             let config = FxAConfig.release(clientId: ClientID, redirectUri: RedirectURL)
             self.fxa = try! FirefoxAccount(config: config)
             persistor.persist(json: (try! self.fxa?.toJSON())!)
-            try! self.fxa!.registerPersistCallback(persistor)
+            self.fxa!.registerPersistCallback(persistor)
             self.tryGetProfile()
         }
     }


### PR DESCRIPTION
**Motivation:**
Callbacks across the FFI can be unsafe (especially w/ Rust<>JVM ) and for our use case
it is just easier to document which Rust methods modify the internal FxA state
and trigger the persist callbacks from the Swift side after calling them.

@garvankeeley  do you mind reviewing the Swift parts?
@rfk I got carried away after adding the `💾 This method alters the persisted account state` doc and ended up documenting all the other methods in `FirefoxAccount`. It's not quite complete but it's a good start, do you mind doing a review of these?