### PR TITLE
WIP: login hostname / formSubmitURL fixup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
  "fxa-client 0.1.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -20,6 +20,7 @@ url = "1.7.1"
 failure = "0.1.3"
 sql-support = { path = "../support/sql" }
 ffi-support = { path = "../support/ffi", optional = true }
+memchr = "2.2.0"
 
 [dependencies.rusqlite]
 version = "0.16.0"

--- a/components/logins/src/engine.rs
+++ b/components/logins/src/engine.rs
@@ -136,7 +136,7 @@ mod test {
         let a = Login {
             id: "aaaaaaaaaaaa".into(),
             hostname: "https://www.example.com".into(),
-            form_submit_url: Some("https://www.example.com/login".into()),
+            form_submit_url: Some("https://login.example.com".into()),
             username: "coolperson21".into(),
             password: "p4ssw0rd".into(),
             username_field: "user_input".into(),

--- a/components/logins/src/fixup.rs
+++ b/components/logins/src/fixup.rs
@@ -220,3 +220,17 @@ pub fn try_fixup_origin_string(url_str: &str, allow_non_origin: bool, allow_empt
         tuple_origin => Some(tuple_origin.ascii_serialization()),
     }
 }
+
+pub fn fixup_record_for_database(login: &mut Login) {
+    if let Some(hostname) = try_fixup_origin_string(&login.hostname, true, false) {
+        login.hostname = hostname;
+    }
+
+    let maybe_url = login.form_submit_url.as_ref().map(|url| {
+        try_fixup_origin_string(url, true, true)
+    });
+
+    if let Some(Some(fixed_up_url)) = maybe_url {
+        login.form_submit_url = Some(fixed_up_url);
+    }
+}

--- a/components/logins/src/fixup.rs
+++ b/components/logins/src/fixup.rs
@@ -1,0 +1,222 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::db::LoginDb;
+use crate::login::Login;
+use crate::util;
+use url::{Origin, Url};
+use crate::error::Result;
+
+pub fn has_bad_character(field: &str) -> bool {
+    memchr::memchr3(b'\r', b'\n', b'\0', field.as_bytes()).is_some()
+}
+
+/// Fixes `l` in the following ways:
+///
+/// 1. If possible, ensure `hostname` is a sane origin.
+///     - Failing it being a sane origin, we tries to ensure it's a parsable URL
+///     - Failing that, leave it alone.
+///
+/// 2. Reconcile inconsistent or corrupted `formSubmitURL` and `httpRealm` values.
+///     - If neither are present, assume `form_submit_url` is actually ""
+///       and some client messed it up.
+///
+///     - If both are present, resolve in favor of `httpRealm` unless it's an
+///       empty string, or contains characters that cause desktop to barf
+///       (`\n`, `\r`, `\0`).
+///
+///     - If only `formSubmitURL` is present, or both are present but we don't want
+///       the httpRealm value, use `formSubmitURL`, possibly fixing it up
+///         - If it's an empty string, we use the empty string.
+///         - Otherwise, attempt to use it's origin, if we can get one.
+///         - If we can't, but we can get a parsable URL, use that.
+///         - Otherwise, use the (fixed up version of the) hostname.
+///
+///     - If only `httpRealm` is present and it only contains valid characters,
+///       take it.
+///
+///     - If only `httpRealm` is present and it contains `\r`, `\n`, or `\0`,
+///       replace them with spaces. (This is not likely to work for logging in,
+///       but seems better than discarding a password the user may not remember).
+///
+/// 3. If `username_field` or `password_field` contain characters that would break
+///    desktop, then set the fields to "". Those fields are optional and
+///    semi-deprecated anyway.
+///
+/// 4. Remove any `\0` that happen to exist in `username` or `password`. This is
+///    slightly dubious, but it's unclear to me what the better option is.
+///    Deletion seems bad, and it's likely to cause us problems in the FFI (at
+///    least, before we get around to using protobufs)
+fn fix_login(l: &Login) -> Login {
+    // Wasteful but whatever.
+    let mut fixed = l.clone();
+    let hostname = if let Some(fixed) = try_fixup_origin_string(&l.hostname, true, false) {
+        fixed
+    } else {
+        // Hostname is extremely important, but I'm just going to keep
+        // the original if we can't fix it.
+        l.hostname.clone()
+    };
+
+    if hostname != l.hostname {
+        log::trace!("  Fixing {} hostname", l.id);
+        fixed.hostname = hostname.into();
+    }
+
+    let (next_url, next_realm) = match (&l.form_submit_url, &l.http_realm) {
+        (None, None) => {
+            // If they're both missing, assume the empty form url is supposed to
+            // be the empty string and some client (maybe us in a previous version!)
+            // confused things.
+            (Some("".into()), None)
+        }
+
+        (Some(_), Some(realm)) if !realm.is_empty() && !has_bad_character(realm) => {
+            // If the realm exists and is valid, go with that over the form
+            // url unless it's empty.
+            (None, Some(realm.clone()))
+        }
+
+        // If the URL exists, and the realm doesn't or we can't use it,
+        // then use the url, possibly fixing it up and turning it into an
+        // origin as needed. In the case of a url that doesn't parse as
+        // such, either use the empty string (if it was empty/entirely
+        // whitespace), or the hostname.
+        (Some(url), _) => {
+            // No realm, or empty/corrupt realm.
+            let res_url = if let Some(s) = try_fixup_origin_string(url, true, true) {
+                s
+            } else {
+                // Can't borrow from fixed.hostname since we need
+                // to assign to it later
+                fixed.hostname.clone()
+            };
+            (Some(res_url), None)
+        }
+
+        // The 'only realm' case is straightforward, with the unfortunate
+        // caveat that if the realm is not valid, we try to replace the
+        // illegal characters with spaces. This probably won't actually work,
+        // seems better than throwing the record away and possibly losing
+        // a password that the user no longer remembers.
+        //
+        // In practice this should never happen, as 'invalid' means it has
+        // characters which aren't even allowed in HTTP headers to begin with.
+        (None, Some(realm)) => {
+            if has_bad_character(realm) {
+                log::trace!("  Fixup {}: Invalid realm", l.id);
+                let realm = realm.replace(|c| c == '\r' || c == '\n' || c == '\0', " ");
+                (None, Some(realm))
+            } else {
+                (None, Some(realm.clone()))
+            }
+        }
+    };
+
+    if next_url != l.form_submit_url {
+        log::trace!("  Fixup {}: Changed form_submit_url", l.id);
+        fixed.form_submit_url = next_url;
+    }
+    if next_realm != l.http_realm {
+        // already logged about this.
+        fixed.http_realm = next_realm.into();
+    }
+
+    // username_field and password_field are pseudo-deprecated (as far as I
+    // understand it), so if they're causing problems, then clear them.
+    if has_bad_character(&l.username_field) || l.username_field == "." {
+        log::trace!("  Fixup {}: Invalid username_field", l.id);
+        fixed.username_field.clear();
+    }
+    if has_bad_character(&l.password_field) {
+        log::trace!("  Fixup {}: Invalid password_field", l.id);
+        fixed.password_field.clear();
+    }
+
+    // This is wrong, but should be so rare that doesn't matter.
+    // Remove '\0' from the username and password, if present.
+    fixed.password = l.password.replace('\0', "");
+    fixed.username = l.username.replace('\0', "");
+
+    fixed
+}
+
+pub fn maybe_fixup_logins(db: &LoginDb) -> Result<()> {
+    // If we've ever done the fixup, don't bother doing it again. Eventually
+    // we might want to change that, but for now it should just be a 'run once'
+    // thing
+    if db.get_meta::<i64>(crate::schema::LAST_FIXUP_TIME_META_KEY)?.is_some() {
+        return Ok(());
+    }
+    log::info!("Running login fixup");
+    let now = util::system_time_ms_i64(std::time::SystemTime::now());
+    // Write it in advance. If something goes wrong, we don't want to
+    // keep trying this over and over again.
+    db.put_meta(crate::schema::LAST_FIXUP_TIME_META_KEY, &now)?;
+
+    let records = db.get_all()?.into_iter().filter_map(|record| {
+        let new_record = fix_login(&record);
+        if new_record != record {
+            Some(new_record)
+        } else {
+            None
+        }
+    });
+
+    // Not bothering with a transaction since these changes should all
+    // be improvements -- we dont want to roll back on failure.
+    for rec in records {
+        log::debug!("Applying change for record {}", rec.id);
+        db.update(rec)?;
+    }
+
+    log::info!("Fixup finished");
+    // Note: Arguably, we should dedupe here, but for now, we aren't, since we
+    // aren't in a good position to resolve any conflicts we find.
+    Ok(())
+}
+
+
+// `allow_non_origin` indicates if we're willing to take a non-origin if its a valid url but
+// that the URL spec has defined as having an opaque origin (includes all schemes
+// other than `"ftp" | "gopher" | "http" | "https" | "ws" | "wss"`)
+pub fn try_fixup_origin_string(url_str: &str, allow_non_origin: bool, allow_empty_string: bool) -> Option<String> {
+    let url_str = url_str
+        .trim()
+        .replace(|c| c == '\0' || c == '\r' || c == '\n', "");
+    if url_str == "" || url_str == "." {
+        return if allow_empty_string {
+            Some("".into())
+        } else {
+            None
+        };
+    }
+    let url = match Url::parse(&url_str) {
+        Ok(v) => v,
+        Err(_) => {
+            // try again with only the parts we actually want, in case
+            // some garbage is in the path or userinfo bits that we
+            // ignore. We also remove spaces from the result, in desperation.
+            let (prefix, hostport) = util::prefix_hostport(&url_str);
+            let to_parse = (prefix.to_string() + hostport).replace(|c| c == ' ' || c == '\t', "");
+            if to_parse.is_empty() && allow_empty_string {
+                return Some("".into());
+            }
+
+            Url::parse(&to_parse).ok()?
+        }
+    };
+    match url.origin() {
+        // All schemes other than a few well known ones come through as opaque,
+        // and stringify as "null" :|
+        Origin::Opaque(_) => {
+            if allow_non_origin {
+                Some(url.to_string())
+            } else {
+                None
+            }
+        }
+        tuple_origin => Some(tuple_origin.ascii_serialization()),
+    }
+}

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -8,6 +8,7 @@ mod login;
 
 mod db;
 mod engine;
+mod fixup;
 pub mod schema;
 mod update_plan;
 mod util;

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -15,10 +15,12 @@ pub struct Login {
     // TODO: consider `#[serde(rename = "id")] pub guid: String` to avoid confusion
     pub id: String,
 
+    /// Note: Despite it's name, this is an origin and not a hostname.
     pub hostname: String,
 
-    // rename_all = "camelCase" by default will do formSubmitUrl, but we can just
-    // override this one field.
+    /// Note: Despite it's name, this is an origin and not a URL.
+    ///
+    /// (It may also be the empty string)
     #[serde(rename = "formSubmitURL")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub form_submit_url: Option<String>,

--- a/components/logins/src/schema.rs
+++ b/components/logins/src/schema.rs
@@ -207,6 +207,7 @@ const UPDATE_MIRROR_TIMESTAMPS_TO_MILLIS_SQL: &'static str = "
 
 pub(crate) static LAST_SYNC_META_KEY: &'static str = "last_sync_time";
 pub(crate) static GLOBAL_STATE_META_KEY: &'static str = "global_state";
+pub(crate) static LAST_FIXUP_TIME_META_KEY: &'static str = "last_fixup_time";
 
 pub(crate) fn init(db: &Connection) -> Result<()> {
     let user_version = db.query_one::<i64>("PRAGMA user_version")?;

--- a/components/logins/src/update_plan.rs
+++ b/components/logins/src/update_plan.rs
@@ -5,7 +5,7 @@
 use crate::error::*;
 use crate::login::{LocalLogin, Login, MirrorLogin, SyncStatus};
 use crate::util;
-use rusqlite::{types::ToSql, Connection};
+use rusqlite::Connection;
 use std::time::SystemTime;
 use sync15::ServerTimestamp;
 
@@ -118,22 +118,19 @@ impl UpdatePlan {
         for (login, timestamp) in &self.mirror_updates {
             log::trace!("Updating mirror {:?}", login.guid_str());
             stmt.execute_named(&[
-                (":server_modified", timestamp as &ToSql),
-                (":http_realm", &login.http_realm as &ToSql),
-                (":form_submit_url", &login.form_submit_url as &ToSql),
-                (":username_field", &login.username_field as &ToSql),
-                (":password_field", &login.password_field as &ToSql),
-                (":password", &login.password as &ToSql),
-                (":hostname", &login.hostname as &ToSql),
-                (":username", &login.username as &ToSql),
-                (":times_used", &login.times_used as &ToSql),
-                (":time_last_used", &login.time_last_used as &ToSql),
-                (
-                    ":time_password_changed",
-                    &login.time_password_changed as &ToSql,
-                ),
-                (":time_created", &login.time_created as &ToSql),
-                (":guid", &login.guid_str() as &ToSql),
+                (":server_modified", timestamp),
+                (":http_realm", &login.http_realm),
+                (":form_submit_url", &login.form_submit_url),
+                (":username_field", &login.username_field),
+                (":password_field", &login.password_field),
+                (":password", &login.password),
+                (":hostname", &login.hostname),
+                (":username", &login.username),
+                (":times_used", &login.times_used),
+                (":time_last_used", &login.time_last_used),
+                (":time_password_changed", &login.time_password_changed),
+                (":time_created", &login.time_created),
+                (":guid", &login.guid_str()),
             ])?;
         }
         Ok(())
@@ -183,23 +180,20 @@ impl UpdatePlan {
         for (login, timestamp, is_overridden) in &self.mirror_inserts {
             log::trace!("Inserting mirror {:?}", login.guid_str());
             stmt.execute_named(&[
-                (":is_overridden", is_overridden as &ToSql),
-                (":server_modified", timestamp as &ToSql),
-                (":http_realm", &login.http_realm as &ToSql),
-                (":form_submit_url", &login.form_submit_url as &ToSql),
-                (":username_field", &login.username_field as &ToSql),
-                (":password_field", &login.password_field as &ToSql),
-                (":password", &login.password as &ToSql),
-                (":hostname", &login.hostname as &ToSql),
-                (":username", &login.username as &ToSql),
-                (":times_used", &login.times_used as &ToSql),
-                (":time_last_used", &login.time_last_used as &ToSql),
-                (
-                    ":time_password_changed",
-                    &login.time_password_changed as &ToSql,
-                ),
-                (":time_created", &login.time_created as &ToSql),
-                (":guid", &login.guid_str() as &ToSql),
+                (":is_overridden", is_overridden),
+                (":server_modified", timestamp),
+                (":http_realm", &login.http_realm),
+                (":form_submit_url", &login.form_submit_url),
+                (":username_field", &login.username_field),
+                (":password_field", &login.password_field),
+                (":password", &login.password),
+                (":hostname", &login.hostname),
+                (":username", &login.username),
+                (":times_used", &login.times_used),
+                (":time_last_used", &login.time_last_used),
+                (":time_password_changed", &login.time_password_changed),
+                (":time_created", &login.time_created),
+                (":guid", &login.guid_str()),
             ])?;
         }
         Ok(())
@@ -207,9 +201,8 @@ impl UpdatePlan {
 
     fn perform_local_updates(&self, conn: &Connection) -> Result<()> {
         let sql = format!(
-            "
-            UPDATE loginsL
-            SET local_modified      = :local_modified,
+            "UPDATE loginsL SET
+                local_modified      = :local_modified,
                 httpRealm           = :http_realm,
                 formSubmitURL       = :form_submit_url,
                 usernameField       = :username_field,
@@ -230,21 +223,18 @@ impl UpdatePlan {
         for l in &self.local_updates {
             log::trace!("Updating local {:?}", l.guid_str());
             stmt.execute_named(&[
-                (":local_modified", &local_ms as &ToSql),
-                (":http_realm", &l.login.http_realm as &ToSql),
-                (":form_submit_url", &l.login.form_submit_url as &ToSql),
-                (":username_field", &l.login.username_field as &ToSql),
-                (":password_field", &l.login.password_field as &ToSql),
-                (":password", &l.login.password as &ToSql),
-                (":hostname", &l.login.hostname as &ToSql),
-                (":username", &l.login.username as &ToSql),
-                (":time_last_used", &l.login.time_last_used as &ToSql),
-                (
-                    ":time_password_changed",
-                    &l.login.time_password_changed as &ToSql,
-                ),
-                (":times_used", &l.login.times_used as &ToSql),
-                (":guid", &l.guid_str() as &ToSql),
+                (":local_modified", &local_ms),
+                (":http_realm", &l.login.http_realm),
+                (":form_submit_url", &l.login.form_submit_url),
+                (":username_field", &l.login.username_field),
+                (":password_field", &l.login.password_field),
+                (":password", &l.login.password),
+                (":hostname", &l.login.hostname),
+                (":username", &l.login.username),
+                (":time_last_used", &l.login.time_last_used),
+                (":time_password_changed", &l.login.time_password_changed),
+                (":times_used", &l.login.times_used),
+                (":guid", &l.guid_str()),
             ])?;
         }
         Ok(())


### PR DESCRIPTION
This still needs to

- [ ] Expose some new errors to callers (probably)
- [ ] Probably fix integration tests, and android/ios tests
- [ ] Implement for the kotlin memory-only impl
- [ ] Note in changelog
- Possibly rename form_submit_url to form_action_origin (obviously the record field stays the same)
- More strongly consider deduping after the automatic fixup (I have a WIP of it but it feels really sketchy)

Last two I'm not sure about so they aren't getting checkboxes for now

Fixes #695.