### PR TITLE
Android bootstrap script

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -207,9 +207,9 @@ def linux_build_task(name):
             rustup target add aarch64-linux-android
         """)
         .with_script("""
-            test -d $ANDROID_NDK_TOOLCHAIN_DIR/arm-$ANDROID_NDK_API_VERSION   || $ANDROID_NDK_HOME/build/tools/make_standalone_toolchain.py --arch="arm"   --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/arm-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
-            test -d $ANDROID_NDK_TOOLCHAIN_DIR/arm64-$ANDROID_NDK_API_VERSION || $ANDROID_NDK_HOME/build/tools/make_standalone_toolchain.py --arch="arm64" --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/arm64-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
-            test -d $ANDROID_NDK_TOOLCHAIN_DIR/x86-$ANDROID_NDK_API_VERSION   || $ANDROID_NDK_HOME/build/tools/make_standalone_toolchain.py --arch="x86"   --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/x86-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
+            test -d $ANDROID_NDK_TOOLCHAIN_DIR/arm-$ANDROID_NDK_API_VERSION   || $ANDROID_NDK_ROOT/build/tools/make_standalone_toolchain.py --arch="arm"   --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/arm-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
+            test -d $ANDROID_NDK_TOOLCHAIN_DIR/arm64-$ANDROID_NDK_API_VERSION || $ANDROID_NDK_ROOT/build/tools/make_standalone_toolchain.py --arch="arm64" --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/arm64-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
+            test -d $ANDROID_NDK_TOOLCHAIN_DIR/x86-$ANDROID_NDK_API_VERSION   || $ANDROID_NDK_ROOT/build/tools/make_standalone_toolchain.py --arch="x86"   --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/x86-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
         """)
         .with_repo()
     )

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -212,6 +212,9 @@ def linux_build_task(name):
             test -d $ANDROID_NDK_TOOLCHAIN_DIR/x86-$ANDROID_NDK_API_VERSION   || $ANDROID_NDK_ROOT/build/tools/make_standalone_toolchain.py --arch="x86"   --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/x86-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
         """)
         .with_repo()
+        .with_script("""
+            ./libs/verify-android-environment.sh
+        """)
     )
 
 def linux_target_macos_build_task(name):

--- a/automation/taskcluster/docker/build.dockerfile
+++ b/automation/taskcluster/docker/build.dockerfile
@@ -85,12 +85,12 @@ RUN curl -L https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_S
 # build OpenSSL.
 ENV ANDROID_NDK_VERSION "r15c"
 
-ENV ANDROID_NDK_HOME /build/android-ndk
+ENV ANDROID_NDK_ROOT /build/android-ndk
 
 RUN curl -L https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip > ndk.zip \
 	&& unzip -q ndk.zip -d /build \
 	&& rm ndk.zip \
-  && mv /build/android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_HOME}
+  && mv /build/android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_ROOT}
 
 ENV ANDROID_NDK_TOOLCHAIN_DIR /root/.android-ndk-r15c-toolchain
 ENV ANDROID_NDK_API_VERSION 21

--- a/docs/howtos/setup-android-build-environment.md
+++ b/docs/howtos/setup-android-build-environment.md
@@ -19,7 +19,7 @@ may need to repeat some steps (eg, rust updates should be done periodically)
 
 At the end of this process you should have the following environment variables set up.
 
-- `NDK_HOME`
+- `ANDROID_NDK_ROOT`
 - `ANDROID_NDK_TOOLCHAIN_DIR`
 - `ANDROID_NDK_API_VERSION`
 - `ANDROID_HOME`
@@ -32,7 +32,7 @@ a rc file or similar so they persist between reboots etc.
    (yes, this sucks, but newer versions don't understand the `--deprecated-headers`
    argument required to build OpenSSL against a v21 toolchain).
     - Extract it, put it somewhere (`$HOME/.android-ndk-r15c` is a reasonable
-      choice, but it doesn't matter), and set `NDK_HOME` to this location.
+      choice, but it doesn't matter), and set `ANDROID_NDK_ROOT` to this location.
 
 2. Install `rustup` from https://rustup.rs:
     - If you already have it, run `rustup update`
@@ -46,7 +46,7 @@ a rc file or similar so they persist between reboots etc.
         - `mkdir -p ~/.ndk-standalone-toolchains`
         - `export ANDROID_NDK_TOOLCHAIN_DIR=$HOME/.ndk-standalone-toolchains`
     - `cd path/to/application-services/libs`
-    - `./setup_toolchains_local.sh $NDK_HOME`
+    - `./setup_toolchains_local.sh $ANDROID_NDK_ROOT`
         - Say yes if/when prompted.
         - When this is done, it should have set `$ANDROID_NDK_API_VERSION` (to 21),
           but you should add this to an rcfile as above.

--- a/libs/setup_toolchains_local.sh
+++ b/libs/setup_toolchains_local.sh
@@ -11,10 +11,10 @@ CLANG_BINS=("i686-linux-android-clang" "arm-linux-androideabi-clang" "aarch64-li
 
 if [ "$#" -ne 1 ]; then
     echo "Usage:"
-    echo "./setup_toolchains_local.sh <ANDROID_NDK_HOME>"
+    echo "./setup_toolchains_local.sh <ANDROID_NDK_ROOT>"
     exit 1
 fi
-ANDROID_NDK_HOME=$1
+ANDROID_NDK_ROOT=$1
 
 source "$(dirname "$0")/android_defaults.sh"
 mkdir -p $ANDROID_NDK_TOOLCHAIN_DIR
@@ -27,7 +27,7 @@ echo ""
 for ARCH in "${TARGET_ARCHS[@]}"; do
   if [ ! -d "$ANDROID_NDK_TOOLCHAIN_DIR/$ARCH-$ANDROID_NDK_API_VERSION" ]; then
     echo "Installing $ARCH toolchain..."
-    python "$ANDROID_NDK_HOME/build/tools/make_standalone_toolchain.py" --arch="$ARCH" --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/$ARCH-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
+    python "$ANDROID_NDK_ROOT/build/tools/make_standalone_toolchain.py" --arch="$ARCH" --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/$ARCH-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
   else
     echo "$ARCH toolchain already exists. Skipping installation."
   fi

--- a/libs/setup_toolchains_local.sh
+++ b/libs/setup_toolchains_local.sh
@@ -9,12 +9,13 @@ TARGET_ARCHS=("x86" "arm64" "arm")
 RUST_TARGETS=("i686-linux-android" "armv7-linux-androideabi" "aarch64-linux-android")
 CLANG_BINS=("i686-linux-android-clang" "arm-linux-androideabi-clang" "aarch64-linux-android-clang")
 
-if [ "$#" -ne 1 ]; then
+ANDROID_NDK_ROOT="${1:-$ANDROID_NDK_ROOT}"
+
+if [ -z "$ANDROID_NDK_ROOT" ]; then
     echo "Usage:"
     echo "./setup_toolchains_local.sh <ANDROID_NDK_ROOT>"
     exit 1
 fi
-ANDROID_NDK_ROOT=$1
 
 source "$(dirname "$0")/android_defaults.sh"
 mkdir -p $ANDROID_NDK_TOOLCHAIN_DIR

--- a/libs/verify-android-environment.sh
+++ b/libs/verify-android-environment.sh
@@ -1,0 +1,50 @@
+# Ensure the build toolchains are set up correctly for android builds.
+#
+# This file should be used via `./libs/verify-android-environment.sh`.
+
+NDK_VERSION=15
+RUST_TARGETS=("aarch64-linux-android" "armv7-linux-androideabi" "i686-linux-android")
+
+if [ ! -f "$(pwd)/libs/build-all.sh" ]; then
+  echo "ERROR: verify-android-environment.sh should be run from the root directory of the repo"
+  exit 1
+fi
+
+if [ -z "$ANDROID_HOME" ]; then
+  echo "Could not find Android SDK:"
+  echo 'Please install the Android SDK and then set ANDROID_HOME.'
+  exit 1
+fi
+
+if [ -z "$ANDROID_NDK_ROOT" ]; then
+  echo "Could not find Android NDK:"
+  echo 'Please install the Android NDK r15c and then set ANDROID_NDK_ROOT.'
+  exit 1
+fi
+
+INSTALLED_NDK_VERSION=$(sed -En -e 's/^Pkg.Revision[ \t]*=[ \t]*([0-9a-f]+).*/\1/p' $ANDROID_NDK_ROOT/source.properties)
+if [ "$INSTALLED_NDK_VERSION" != $NDK_VERSION ]; then
+  echo "Wrong Android NDK version:"
+  echo "Expected version $NDK_VERSION, got $INSTALLED_NDK_VERSION"
+  exit 1
+fi
+
+INSTALLED_RUST_TARGETS=$(rustup target list)
+for TARGET in "${RUST_TARGETS[@]}"
+do
+  if ! [ "$(echo "$INSTALLED_RUST_TARGETS" | grep "$TARGET")" ]; then
+    echo "Missing Rust target: $TARGET"
+    echo "Installing the required target, please hold on."
+    rustup target add $TARGET
+  fi
+done
+
+if [ -z "$ANDROID_NDK_TOOLCHAIN_DIR" ]; then
+  echo "Could not find Android NDK toolchain directory:"
+  echo "1. Create a directory where to set up the toolchains (e.g. ~/.ndk-standalone-toolchains)."
+  echo "2. Set ANDROID_NDK_TOOLCHAIN_DIR to this newly created directory."
+  echo "3. Run setup_toolchains_local.sh in the libs/ directory."
+  exit 1
+fi
+
+echo "Looks good! cd to libs/ and run ./build-all.sh android"


### PR DESCRIPTION
Fixes #707

This script is not quite like `bootstrap-desktop.sh` which sets up variables and ensures you can `cargo build`.
Instead it is more like "if you can run it entirely, you should be fine developing with Android studio".
Let know if we can make this script more clever.