### PR TITLE
Add the ability to update bookmarks

### DIFF
--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -60,6 +60,9 @@ pub enum ErrorKind {
     #[fail(display = "Invalid place info: {}", _0)]
     InvalidPlaceInfo(InvalidPlaceInfo),
 
+    #[fail(display = "The store is corrupt: {}", _0)]
+    Corruption(Corruption),
+
     #[fail(display = "Error synchronizing: {}", _0)]
     SyncAdapterError(#[fail(cause)] sync15::Error),
 
@@ -101,7 +104,8 @@ impl_from_error! {
     (JsonError, serde_json::Error),
     (UrlParseError, url::ParseError),
     (SqlError, rusqlite::Error),
-    (InvalidPlaceInfo, InvalidPlaceInfo)
+    (InvalidPlaceInfo, InvalidPlaceInfo),
+    (Corruption, Corruption)
 }
 
 #[derive(Debug, Fail)]
@@ -116,11 +120,27 @@ pub enum InvalidPlaceInfo {
     #[fail(display = "No such item: {}", _0)]
     NoItem(String),
 
-    #[fail(display = "Invalid bookmark type specified")]
-    InvalidBookmarkType,
+    #[fail(
+        display = "Can't update a bookmark of type {} with one of type {}",
+        _0, _1
+    )]
+    MismatchedBookmarkType(u8, u8),
 
     // Only returned when attempting to insert a bookmark --
     // for history we just ignore it.
     #[fail(display = "URL too long")]
     UrlTooLong,
+}
+
+// Error types used when we can't continue due to corruption.
+// Note that this is currently only for "logical" corruption. Should we
+// consider mapping sqlite error codes which mean a lower-level of corruption
+// into an enum value here?
+#[derive(Debug, Fail)]
+pub enum Corruption {
+    #[fail(
+        display = "Bookmark '{}' has a parent of '{}' which does not exist",
+        _0, _1
+    )]
+    NoParent(String, String),
 }

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -113,6 +113,12 @@ pub enum InvalidPlaceInfo {
     #[fail(display = "Invalid parent: {}", _0)]
     InvalidParent(String),
 
+    #[fail(display = "No such item: {}", _0)]
+    NoItem(String),
+
+    #[fail(display = "Invalid bookmark type specified")]
+    InvalidBookmarkType,
+
     // Only returned when attempting to insert a bookmark --
     // for history we just ignore it.
     #[fail(display = "URL too long")]

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -34,6 +34,9 @@ pub mod error_codes {
 
     /// The requested operation failed because it was interrupted
     pub const DATABASE_INTERRUPTED: i32 = 5;
+
+    /// The requested operation failed because the store is corrupt
+    pub const DATABASE_CORRUPT: i32 = 6;
 }
 
 fn get_code(err: &Error) -> ErrorCode {
@@ -64,6 +67,10 @@ fn get_code(err: &Error) -> ErrorCode {
             // Can't unify with the above ... :(
             log::info!("Operation interrupted");
             ErrorCode::new(error_codes::DATABASE_INTERRUPTED)
+        }
+        ErrorKind::Corruption(e) => {
+            log::info!("The store is corrupt: {}", e);
+            ErrorCode::new(error_codes::DATABASE_CORRUPT)
         }
 
         err => {

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -635,7 +635,7 @@ fn update_bookmark_in_tx(db: &impl ConnExt, guid: &SyncGuid, item: &UpdatableIte
             (":fk", &place_id),
             (":parent", &parent_id),
             (":position", &position),
-            (":title", &title),
+            (":title", &maybe_truncate_title(&title)),
             (":now", &now),
             (":change_incr", &(change_incr as u32)),
             (":id", &existing.row_id),


### PR DESCRIPTION
I figured that it makes sense to add some edit/update ability for bookmarks before working on sync. This exposes a public API for updating bookmarks, including their position, but excluding "internal" fields, such as the guid or dateAdded/lastModified etc fields.

It doesn't handle updating lastModified for parent items which it should, and it probably needs more tests for the syncStatus/syncChangeCounter etc (although I *think* it implements that correctly), but I thought I'd get it up for comment first.