### PR TITLE
Release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,31 @@
 
 **See [the release process docs](docs/howtos/cut-a-new-release.md) for the steps to take when cutting a new release.**
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.19.0...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.20.0...master)
+
+# v0.20.0 (_2019-03-14_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.19.0...v0.20.0)
+
+## General
+
+- The previous release had an issue with the megazords, and so another
+  release was needed. This is version 0.4.2 of the megazord plugin.
+  ([#775](https://github.com/mozilla/application-services/pull/775))
+
+### Breaking Changes
+
+- All package names have been normalized. The gradle packages should all be
+  `org.mozilla.appservices:component`, and the java namespaces should be
+  `mozilla.appservices.component`. ([#776](https://github.com/mozilla/application-services/pull/776))
+
+## Logins
+
+### Breaking Changes
+
+- The gradle package for logins has been changed from
+  `'org.mozilla.sync15:logins'` to `org.mozilla.appservices:logins`.
+  ([#776](https://github.com/mozilla/application-services/pull/776))
 
 ## Places
 
@@ -16,6 +40,22 @@
     - `WritablePlacesConnectionInterface` => `WritableHistoryConnection`
     - `ReadablePlacesConnection` => `PlacesReaderConnection`
     - `WritablePlacesConnection` => `PlacesWriterConnection`
+
+- The java namespace used in places has changed from `org.mozilla.places` to
+  `mozilla.appservices.places`
+  ([#776](https://github.com/mozilla/application-services/pull/776))
+
+- The gradle package for places has been changed from
+  `'org.mozilla.places:places'` to `org.mozilla.appservices:places`.
+  ([#776](https://github.com/mozilla/application-services/pull/776))
+
+## FxA
+
+### Breaking Changes
+
+- The gradle package for fxa-client has been changed from
+  `'org.mozilla.fxaclient:fxaclient'` to `org.mozilla.appservices:fxaclient`.
+  ([#776](https://github.com/mozilla/application-services/pull/776))
 
 # 0.19.0 (_2019-03-13_)
 

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.3.10'
-    ext.plugin_version = '0.4.1'
+    ext.plugin_version = '0.4.2'
 
     repositories {
         google()


### PR DESCRIPTION
There were gradle plugin problems that makes the previous release unusable so this needs to happen even though we released yesterday.