### PR TITLE
Release 0.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 **See [the release process docs](docs/howtos/cut-a-new-release.md) for the steps to take when cutting a new release.**
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.20.0...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.20.1...master)
+
+# v0.20.1 (_2019-03-15_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.20.0...v0.20.1)
+
+- A error in the build.gradle file caused the v0.20.0 release to fail, this
+  release should not be meaningfully different from it.
 
 # v0.20.0 (_2019-03-14_)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.10'
 
     ext.library = [
-        version: '0.19.0'
+        version: '0.20.1'
     ]
 
     ext.build = [


### PR DESCRIPTION
This is my fault, I forgot to update the build.gradle to say 0.20.0 instead of 0.19.0. instead of attempting to yank the previous release / drop the tag, i'm just moving forward to 0.20.1 (which is how we've handled this sort of issue in the past)