### PR TITLE
Publish all Maven artifacts to a single bintray package.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.jvmargs=-Xmx1536m
 
 libGroupId=org.mozilla.appservices
 libRepositoryName=application-services
-libProjectName=application-services
+libProjectName=org.mozilla.appservices
 libProjectDescription=Firefox Application Services
 libUrl=https://github.com/mozilla/application-services
 libVcsUrl=https://github.com/mozilla/application-services.git

--- a/publish.gradle
+++ b/publish.gradle
@@ -5,6 +5,7 @@
 def libLicense = properties.libLicense
 def libLicenseUrl = properties.libLicenseUrl
 def libRepositoryName = properties.libRepositoryName
+def libProjectName = properties.libProjectName
 def libUrl = properties.libUrl
 def libVcsUrl = properties.libVcsUrl
 
@@ -227,8 +228,7 @@ ext.configurePublish = { groupIdArg, artifactIdArg, descriptionArg,
 
         pkg {
             repo = libRepositoryName
-            name = artifactIdArg
-            desc = descriptionArg
+            name = libProjectName
             websiteUrl = libUrl
             vcsUrl = libVcsUrl
             if (project.ext.has('vcsTag')) {


### PR DESCRIPTION
Right now, we publish each Maven artifact "cluster" -- for "logins",
say, that is "logins", "logins-withoutLibs", and "logins-forUnitTests"
-- to a single bintray package named like the Maven artifact ID (say,
"logins").

This seems to be common, but bintray mirrors packages to jcenter, and
bintray packages don't map directly to Maven coordinates.  AFAICT,
that is the thing that requires somebody (right now, me -- nalexander)
to push the "mirror to jcenter" button in the bintray UI.

If we instead have a single bintray "package" (say,
"org.mozilla.appservices") and then publish many Maven artifacts to
that package, we should get automatic jcenter mirroring for everything
that we have under it.  Let's try!

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one

There shouldn't be any change for consumers, if all goes well.