### PR TITLE
Several ffi_support improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,9 +629,6 @@ dependencies = [
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
  "ece 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -622,7 +622,7 @@ dependencies = [
 
 [[package]]
 name = "ffi-support"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -708,7 +708,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "hawk 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -733,7 +733,7 @@ name = "fxaclient_ffi"
 version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "fxa-client 0.1.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1015,7 +1015,7 @@ dependencies = [
  "cli-support 0.1.0",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "fxa-client 0.1.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1036,7 +1036,7 @@ version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base16 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins 0.1.0",
@@ -1352,7 +1352,7 @@ dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "find-places-db 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxa-client 0.1.0",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1386,7 +1386,7 @@ name = "places-ffi"
 version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "places 0.1.0",
@@ -1509,7 +1509,7 @@ version = "0.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1524,7 +1524,7 @@ dependencies = [
  "communications 0.1.0",
  "config 0.1.0",
  "crypto 0.1.0",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "push-errors 0.1.0",
@@ -1713,7 +1713,7 @@ name = "rc_log_ffi"
 version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.2.0",
+ "ffi-support 0.3.0",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,7 +24,7 @@ serde_derive = "1.0.79"
 serde_json = "1.0.28"
 untrusted = "0.6.2"
 url = "1.7.1"
-ffi-support = { path = "../support/ffi", features = ["prost_support"], optional = true }
+ffi-support = { path = "../support/ffi", optional = true }
 
 [dev-dependencies]
 text_io = "0.1.7"

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,7 +24,7 @@ serde_derive = "1.0.79"
 serde_json = "1.0.28"
 untrusted = "0.6.2"
 url = "1.7.1"
-ffi-support = { path = "../support/ffi", optional = true }
+ffi-support = { path = "../support/ffi" }
 
 [dev-dependencies]
 text_io = "0.1.7"
@@ -34,5 +34,4 @@ prost-build = "0.4"
 
 [features]
 browserid = ["openssl", "hawk"]
-ffi = ["ffi-support"]
-default = ["ffi"]
+default = []

--- a/components/fxa-client/ffi/Cargo.toml
+++ b/components/fxa-client/ffi/Cargo.toml
@@ -15,7 +15,6 @@ lazy_static = "1.2.0"
 
 [dependencies.fxa-client]
 path = "../"
-features = ["ffi"]
 
 [features]
 browserid = ["fxa-client/browserid"]

--- a/components/fxa-client/ffi/Cargo.toml
+++ b/components/fxa-client/ffi/Cargo.toml
@@ -9,7 +9,7 @@ name = "fxaclient_ffi"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-ffi-support = { path = "../../support/ffi", features = ["prost_support"] }
+ffi-support = { path = "../../support/ffi" }
 log = "0.4.6"
 lazy_static = "1.2.0"
 

--- a/components/fxa-client/src/ffi.rs
+++ b/components/fxa-client/src/ffi.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![cfg(feature = "ffi")]
-
 //! This module implement the traits and some types that make the FFI code easier to manage.
 //!
 //! Note that the FxA FFI is older than the other FFIs in application-services, and has (direct,

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -21,7 +21,6 @@ use url::Url;
 mod browser_id;
 mod config;
 pub mod errors;
-#[cfg(feature = "ffi")]
 pub mod ffi;
 // Include the `msg_types` module, which is generated from msg_types.proto.
 pub mod msg_types {

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 
 [features]
-ffi = ["ffi-support"]
 log_query_plans = ["sql-support/log_query_plans"]
 default = []
 
@@ -19,7 +18,7 @@ lazy_static = "1.1.0"
 url = "1.7.1"
 failure = "0.1.3"
 sql-support = { path = "../support/sql" }
-ffi-support = { path = "../support/ffi", optional = true }
+ffi-support = { path = "../support/ffi" }
 
 [dependencies.rusqlite]
 version = "0.16.0"

--- a/components/logins/ffi/Cargo.toml
+++ b/components/logins/ffi/Cargo.toml
@@ -21,7 +21,6 @@ features = ["sqlcipher"]
 
 [dependencies.logins]
 path = ".."
-features = ["ffi"]
 
 [dependencies.sync15]
 path = "../../sync15"

--- a/components/logins/src/ffi.rs
+++ b/components/logins/src/ffi.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![cfg(feature = "ffi")]
-
 // This module implement the traits that make the FFI code easier to manage.
 
 use crate::{Error, ErrorKind, Login};

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -12,7 +12,6 @@ pub mod schema;
 mod update_plan;
 mod util;
 
-#[cfg(feature = "ffi")]
 mod ffi;
 
 pub use crate::engine::*;

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -23,7 +23,7 @@ caseless = "0.2.1"
 unicode-normalization = "0.1.7"
 sql-support = { path = "../support/sql" }
 url_serde = "0.2.0"
-ffi-support = { path = "../support/ffi", optional = true, features = ["prost_support"] }
+ffi-support = { path = "../support/ffi", optional = true }
 bitflags = "1.0.4"
 idna = "0.1.5"
 memchr = "2.1.3"

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 authors = []
 
 [features]
-ffi = ["ffi-support"]
 log_query_plans = ["sql-support/log_query_plans"]
 default = []
 
@@ -23,7 +22,7 @@ caseless = "0.2.1"
 unicode-normalization = "0.1.7"
 sql-support = { path = "../support/sql" }
 url_serde = "0.2.0"
-ffi-support = { path = "../support/ffi", optional = true }
+ffi-support = { path = "../support/ffi" }
 bitflags = "1.0.4"
 idna = "0.1.5"
 memchr = "2.1.3"

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -24,7 +24,6 @@ path = "../../sync15"
 
 [dependencies.places]
 path = ".."
-features = ["ffi"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.7.0"

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -140,14 +140,15 @@ pub extern "C" fn places_query_autocomplete(
     error: &mut ExternError,
 ) -> *mut c_char {
     log::debug!("places_query_autocomplete");
-    CONNECTIONS.call_with_result(error, handle, |conn| {
-        search_frecent(
+    CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
+        let res = search_frecent(
             conn,
             SearchParams {
                 search_string: search.into_string(),
                 limit,
             },
-        )
+        )?;
+        Ok(serde_json::to_string(&res)?)
     })
 }
 

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -4,8 +4,7 @@
 
 use ffi_support::{
     define_box_destructor, define_bytebuffer_destructor, define_handle_map_deleter,
-    define_string_destructor, rust_str_from_c, rust_string_from_c, ByteBuffer, ConcurrentHandleMap,
-    ExternError,
+    define_string_destructor, ByteBuffer, ConcurrentHandleMap, ExternError, FfiStr,
 };
 use places::error::*;
 use places::{db::PlacesInterruptHandle, storage, ConnectionType, PlacesApi, PlacesDb};
@@ -42,16 +41,16 @@ lazy_static::lazy_static! {
 /// Instantiate a places API. Returned api must be freed with
 /// `places_api_destroy`. Returns null and logs on errors (for now).
 #[no_mangle]
-pub unsafe extern "C" fn places_api_new(
-    db_path: *const c_char,
-    encryption_key: *const c_char,
+pub extern "C" fn places_api_new(
+    db_path: FfiStr<'_>,
+    encryption_key: FfiStr<'_>,
     error: &mut ExternError,
 ) -> u64 {
     log::debug!("places_api_new");
     APIS.insert_with_result(error, || {
-        let path = ffi_support::rust_string_from_c(db_path);
-        let key = ffi_support::opt_rust_string_from_c(encryption_key);
-        PlacesApi::new(path, key.as_ref().map(|v| v.as_str()))
+        let path = db_path.as_str();
+        let key = encryption_key.as_opt_str();
+        PlacesApi::new(path, key)
     })
 }
 
@@ -60,7 +59,7 @@ pub unsafe extern "C" fn places_api_new(
 /// not destroy, or even close, connections already obtained from this
 /// object. Returns null and logs on errors (for now).
 #[no_mangle]
-pub unsafe extern "C" fn places_connection_new(
+pub extern "C" fn places_connection_new(
     handle: u64,
     conn_type_val: u8,
     error: &mut ExternError,
@@ -118,14 +117,14 @@ pub extern "C" fn places_interrupt(handle: &PlacesInterruptHandle, error: &mut E
 /// Add an observation to the database. The observation is a VisitObservation represented as JSON.
 /// Errors are logged.
 #[no_mangle]
-pub unsafe extern "C" fn places_note_observation(
+pub extern "C" fn places_note_observation(
     handle: u64,
-    json_observation: *const c_char,
+    json_observation: FfiStr<'_>,
     error: &mut ExternError,
 ) {
     log::debug!("places_note_observation");
     CONNECTIONS.call_with_result_mut(error, handle, |conn| {
-        let json = ffi_support::rust_str_from_c(json_observation);
+        let json = json_observation.as_str();
         let visit: places::VisitObservation = serde_json::from_str(&json)?;
         places::api::apply_observation(conn, visit)
     })
@@ -134,9 +133,9 @@ pub unsafe extern "C" fn places_note_observation(
 /// Execute a query, returning a `Vec<SearchResult>` as a JSON string. Returned string must be freed
 /// using `places_destroy_string`. Returns null and logs on errors (for now).
 #[no_mangle]
-pub unsafe extern "C" fn places_query_autocomplete(
+pub extern "C" fn places_query_autocomplete(
     handle: u64,
-    search: *const c_char,
+    search: FfiStr<'_>,
     limit: u32,
     error: &mut ExternError,
 ) -> *mut c_char {
@@ -145,7 +144,7 @@ pub unsafe extern "C" fn places_query_autocomplete(
         search_frecent(
             conn,
             SearchParams {
-                search_string: ffi_support::rust_string_from_c(search),
+                search_string: search.into_string(),
                 limit,
             },
         )
@@ -155,15 +154,13 @@ pub unsafe extern "C" fn places_query_autocomplete(
 /// Execute a query, returning a URL string or null. Returned string must be freed
 /// using `places_destroy_string`. Returns null if no match is found.
 #[no_mangle]
-pub unsafe extern "C" fn places_match_url(
+pub extern "C" fn places_match_url(
     handle: u64,
-    search: *const c_char,
+    search: FfiStr<'_>,
     error: &mut ExternError,
 ) -> *mut c_char {
     log::debug!("places_match_url");
-    CONNECTIONS.call_with_result(error, handle, |conn| {
-        match_url(conn, ffi_support::rust_string_from_c(search))
-    })
+    CONNECTIONS.call_with_result(error, handle, |conn| match_url(conn, search.as_str()))
 }
 
 #[no_mangle]
@@ -190,7 +187,7 @@ pub unsafe extern "C" fn places_get_visited(
             .iter()
             .enumerate()
             .filter_map(|(idx, &p)| {
-                let s = ffi_support::rust_str_from_c(p);
+                let s = FfiStr::from_raw(p).as_str();
                 url::Url::parse(s).ok().map(|url| (idx, url))
             })
             .collect::<Vec<_>>();
@@ -221,14 +218,10 @@ pub extern "C" fn places_get_visited_urls_in_range(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn places_delete_place(
-    handle: u64,
-    url: *const c_char,
-    error: &mut ExternError,
-) {
+pub extern "C" fn places_delete_place(handle: u64, url: FfiStr<'_>, error: &mut ExternError) {
     log::debug!("places_delete_place");
     CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
-        let url = parse_url(rust_str_from_c(url))?;
+        let url = parse_url(url.as_str())?;
         if let Some(guid) = storage::history::url_to_guid(conn, &url)? {
             storage::history::delete_place_by_guid(conn, &guid)?;
         }
@@ -255,9 +248,9 @@ pub extern "C" fn places_delete_visits_between(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn places_delete_visit(
+pub extern "C" fn places_delete_visit(
     handle: u64,
-    url: *const c_char,
+    url: FfiStr<'_>,
     timestamp: i64,
     error: &mut ExternError,
 ) {
@@ -265,7 +258,7 @@ pub unsafe extern "C" fn places_delete_visit(
     CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
         storage::history::delete_place_visit_at_time(
             conn,
-            &parse_url(rust_str_from_c(url))?,
+            &parse_url(url.as_str())?,
             places::Timestamp(timestamp.max(0) as u64),
         )?;
         Ok(())
@@ -273,19 +266,19 @@ pub unsafe extern "C" fn places_delete_visit(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn places_wipe_local(handle: u64, error: &mut ExternError) {
+pub extern "C" fn places_wipe_local(handle: u64, error: &mut ExternError) {
     log::debug!("places_wipe_local");
     CONNECTIONS.call_with_result(error, handle, |conn| storage::history::wipe_local(conn))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn places_run_maintenance(handle: u64, error: &mut ExternError) {
+pub extern "C" fn places_run_maintenance(handle: u64, error: &mut ExternError) {
     log::debug!("places_run_maintenance");
     CONNECTIONS.call_with_result(error, handle, |conn| storage::run_maintenance(conn))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn places_prune_destructively(handle: u64, error: &mut ExternError) {
+pub extern "C" fn places_prune_destructively(handle: u64, error: &mut ExternError) {
     log::debug!("places_prune_destructively");
     CONNECTIONS.call_with_result(error, handle, |conn| {
         storage::history::prune_destructively(conn)
@@ -293,7 +286,7 @@ pub unsafe extern "C" fn places_prune_destructively(handle: u64, error: &mut Ext
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn places_delete_everything(handle: u64, error: &mut ExternError) {
+pub extern "C" fn places_delete_everything(handle: u64, error: &mut ExternError) {
     log::debug!("places_delete_everything");
     CONNECTIONS.call_with_result(error, handle, |conn| {
         storage::history::delete_everything(conn)
@@ -301,7 +294,7 @@ pub unsafe extern "C" fn places_delete_everything(handle: u64, error: &mut Exter
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn places_get_visit_infos(
+pub extern "C" fn places_get_visit_infos(
     handle: u64,
     start_date: i64,
     end_date: i64,
@@ -318,12 +311,12 @@ pub unsafe extern "C" fn places_get_visit_infos(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn sync15_history_sync(
+pub extern "C" fn sync15_history_sync(
     handle: u64,
-    key_id: *const c_char,
-    access_token: *const c_char,
-    sync_key: *const c_char,
-    tokenserver_url: *const c_char,
+    key_id: FfiStr<'_>,
+    access_token: FfiStr<'_>,
+    sync_key: FfiStr<'_>,
+    tokenserver_url: FfiStr<'_>,
     error: &mut ExternError,
 ) {
     log::debug!("sync15_history_sync");
@@ -331,11 +324,11 @@ pub unsafe extern "C" fn sync15_history_sync(
         // Note that api.sync returns a SyncPing which we drop on the floor.
         api.sync(
             &sync15::Sync15StorageClientInit {
-                key_id: rust_string_from_c(key_id),
-                access_token: rust_string_from_c(access_token),
-                tokenserver_url: parse_url(rust_str_from_c(tokenserver_url))?,
+                key_id: key_id.into_string(),
+                access_token: access_token.into_string(),
+                tokenserver_url: parse_url(tokenserver_url.as_str())?,
             },
-            &sync15::KeyBundle::from_ksync_base64(rust_str_from_c(sync_key))?,
+            &sync15::KeyBundle::from_ksync_base64(sync_key.as_str())?,
         )?;
         Ok(())
     })

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#![cfg(feature = "ffi")]
-
 // This module implement the traits that make the FFI code easier to manage.
 
 use crate::api::matcher::SearchResult;

--- a/components/places/src/lib.rs
+++ b/components/places/src/lib.rs
@@ -7,7 +7,6 @@ pub mod error;
 pub mod types;
 // Making these all pub for now while we flesh out the API.
 pub mod db;
-#[cfg(feature = "ffi")]
 pub mod ffi;
 pub mod frecency;
 pub mod hash;

--- a/components/rc_log/src/lib.rs
+++ b/components/rc_log/src/lib.rs
@@ -19,7 +19,6 @@
 #![cfg_attr(test, allow(dead_code))]
 
 use std::ffi::CString;
-use std::os::raw::c_char;
 
 // Import this in tests (even on non-android builds / cases where the
 // force_android feature is not enabled) so we can check that it compiles
@@ -115,9 +114,9 @@ pub unsafe extern "C" fn rc_log_adapter_destroy(to_destroy: *mut imp::LogAdapter
 
 // Used just to allow tests to produce logs.
 #[no_mangle]
-pub unsafe extern "C" fn rc_log_adapter_test__log_msg(msg: *const c_char) {
+pub extern "C" fn rc_log_adapter_test__log_msg(msg: ffi_support::FfiStr<'_>) {
     ffi_support::abort_on_panic::call_with_output(|| {
-        log::info!("testing: {}", ffi_support::rust_str_from_c(msg));
+        log::info!("testing: {}", msg.as_str());
     });
 }
 

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffi-support"
 edition = "2018"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 description = "A crate to help expose Rust functions over the FFI."
 repository = "https://github.com/mozilla/application-services"

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -16,11 +16,8 @@ travis-ci = { repository = "mozilla/application-services" }
 [features]
 default = []
 log_backtraces = ["backtrace"]
-prost_support = ["prost"]
 
 [dependencies]
-serde_json = "1.0.32"
-serde = "1.0.79"
 log = "0.4"
 lazy_static = "1.2.0"
 failure = "0.1.5"
@@ -29,10 +26,3 @@ failure_derive = "0.1.5"
 [dependencies.backtrace]
 optional = true
 version = "0.3.9"
-
-[dependencies.prost]
-optional = true
-version = "0.4"
-
-[package.metadata.docs.rs]
-features = ["prost_support"]

--- a/components/support/ffi/src/error.rs
+++ b/components/support/ffi/src/error.rs
@@ -133,6 +133,7 @@ pub struct ExternError {
 }
 
 impl std::panic::UnwindSafe for ExternError {}
+impl std::panic::RefUnwindSafe for ExternError {}
 
 /// This is sound so long as our fields are private.
 unsafe impl Send for ExternError {}

--- a/components/support/ffi/src/error.rs
+++ b/components/support/ffi/src/error.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::string::{destroy_c_string, rust_str_from_c, rust_string_to_c};
+use crate::string::{destroy_c_string, rust_string_to_c};
 use std::os::raw::c_char;
 use std::{self, ptr};
 
@@ -170,17 +170,6 @@ impl ExternError {
     #[inline]
     pub fn get_raw_message(&self) -> *const c_char {
         self.message as *const _
-    }
-
-    /// Get the `message` property as something usable from rust. Unsafe because it reads from a raw
-    /// pointer.
-    #[inline]
-    pub unsafe fn get_message(&self) -> Option<&str> {
-        if self.message.is_null() {
-            None
-        } else {
-            Some(rust_str_from_c(self.message))
-        }
     }
 
     /// Manually release the memory behind this string. You probably don't want to call this.

--- a/components/support/ffi/src/ffistr.rs
+++ b/components/support/ffi/src/ffistr.rs
@@ -1,0 +1,236 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::ffi::CStr;
+use std::marker::PhantomData;
+use std::os::raw::c_char;
+
+/// `FfiStr<'a>` is a safe (`#[repr(transparent)]`) wrapper around a
+/// nul-terminated `*const c_char` (e.g. a C string). Conceptually, it is
+/// similar to [`std::ffi::CStr`], except that it may be used in the signatures
+/// of extern "C" functions.
+///
+/// Functions accepting strings should use this instead of accepting a C string
+/// directly. This allows us to write those functions using safe code without
+/// allowing safe Rust to cause memory unsafety.
+///
+/// A single function for constructing these from Rust ([`FfiStr::from_raw`])
+/// has been provided. Most of the time, this should not be necessary, and users
+/// should accept `FfiStr` in the parameter list directly.
+///
+/// ## Caveats
+///
+/// An effort has been made to make this struct hard to misuse, however it is
+/// still possible, if the `'static` lifetime is manually specified in the
+/// struct. E.g.
+///
+/// ```rust,no_run
+/// # use ffi_support::FfiStr;
+/// // NEVER DO THIS
+/// #[no_mangle]
+/// extern "C" fn never_do_this(s: FfiStr<'static>) {
+///     // save `s` somewhere, and access it after this
+///     // function returns.
+/// }
+/// ```
+///
+/// Instead, one of the following patterns should be used:
+///
+/// ```
+/// # use ffi_support::FfiStr;
+/// #[no_mangle]
+/// extern "C" fn valid_use_1(s: FfiStr<'_>) {
+///     // Use of `s` after this function returns is impossible
+/// }
+/// // Alternative:
+/// #[no_mangle]
+/// extern "C" fn valid_use_2(s: FfiStr) {
+///     // Use of `s` after this function returns is impossible
+/// }
+/// ```
+#[repr(transparent)]
+pub struct FfiStr<'a> {
+    cstr: *const c_char,
+    _boo: PhantomData<&'a ()>,
+}
+
+impl<'a> FfiStr<'a> {
+    /// Construct an `FfiStr` from a raw pointer.
+    ///
+    /// This should not be needed most of the time, and users should instead
+    /// accept `FfiStr` in function parameter lists.
+    #[inline]
+    pub unsafe fn from_raw(ptr: *const c_char) -> Self {
+        Self {
+            cstr: ptr,
+            _boo: PhantomData,
+        }
+    }
+
+    /// Construct a FfiStr from a `std::ffi::CStr`. This is provided for
+    /// completeness, as a safe method of producing an `FfiStr` in Rust.
+    #[inline]
+    pub fn from_cstr(cstr: &'a CStr) -> Self {
+        Self {
+            cstr: cstr.as_ptr(),
+            _boo: PhantomData,
+        }
+    }
+
+    /// Get an `&str` out of the `FfiStr`. This will panic in any case that
+    /// [`FfiStr::as_opt_str`] would return `None` (e.g. null pointer or invalid
+    /// UTF-8).
+    ///
+    /// If the string should be optional, you should use [`FfiStr::as_opt_str`]
+    /// instead. If an owned string is desired, use [`FfiStr::into_string`] or
+    /// [`FfiStr::into_opt_string`].
+    #[inline]
+    pub fn as_str(&self) -> &'a str {
+        self.as_opt_str()
+            .expect("Unexpected null string pointer passed to rust")
+    }
+
+    /// Get an `Option<&str>` out of the `FfiStr`. If this stores a null
+    /// pointer, then None will be returned. If a string containing invalid
+    /// UTF-8 was passed, then an error will be logged and `None` will be
+    /// returned.
+    ///
+    /// If the string is a required argument, use [`FfiStr::as_str`], or
+    /// [`FfiStr::into_string`] instead. If `Option<String>` is desired, use
+    /// [`FfiStr::into_opt_string`] (which will handle invalid UTF-8 by
+    /// replacing with the replacement character).
+    pub fn as_opt_str(&self) -> Option<&'a str> {
+        if self.cstr.is_null() {
+            return None;
+        }
+        unsafe {
+            match std::ffi::CStr::from_ptr(self.cstr).to_str() {
+                Ok(s) => Some(s),
+                Err(e) => {
+                    log::error!("Invalid UTF-8 was passed to rust! {:?}", e);
+                    None
+                }
+            }
+        }
+    }
+
+    /// Get an `Option<String>` out of the `FfiStr`. Returns `None` if this
+    /// `FfiStr` holds a null pointer. Note that unlike [`FfiStr::as_opt_str`],
+    /// invalid UTF-8 is replaced with the replacement character instead of
+    /// causing us to return None.
+    ///
+    /// If the string should be mandatory, you should use
+    /// [`FfiStr::into_string`] instead. If an owned string is not needed, you
+    /// may want to use [`FfiStr::as_str`] or [`FfiStr::as_opt_str`] instead,
+    /// (however, note the differnces in how invalid UTF-8 is handled, should
+    /// this be relevant to your use).
+    pub fn into_opt_string(self) -> Option<String> {
+        if !self.cstr.is_null() {
+            unsafe { Some(CStr::from_ptr(self.cstr).to_string_lossy().to_string()) }
+        } else {
+            None
+        }
+    }
+
+    /// Get a `String` out of a `FfiStr`. This function is essential a
+    /// convenience wrapper for `ffi_str.into_opt_string().unwrap()`, with a
+    /// message that indicates that a null argument was passed to rust when it
+    /// should be mandatory. As with [`FfiStr::into_opt_string`], invalid UTF-8
+    /// is replaced with the replacement character if encountered.
+    ///
+    /// If the string should *not* be mandatory, you should use
+    /// [`FfiStr::into_opt_string`] instead. If an owned string is not needed,
+    /// you may want to use [`FfiStr::as_str`] or [`FfiStr::as_opt_str`]
+    /// instead, (however, note the differnces in how invalid UTF-8 is handled,
+    /// should this be relevant to your use).
+    #[inline]
+    pub fn into_string(self) -> String {
+        self.into_opt_string()
+            .expect("Unexpected null string pointer passed to rust")
+    }
+}
+
+impl<'a> std::fmt::Debug for FfiStr<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if let Some(s) = self.as_opt_str() {
+            write!(f, "FfiStr({:?})", s)
+        } else {
+            write!(f, "FfiStr(null)")
+        }
+    }
+}
+
+// Conversions...
+
+impl<'a> From<FfiStr<'a>> for String {
+    #[inline]
+    fn from(f: FfiStr<'a>) -> Self {
+        f.into_string()
+    }
+}
+
+impl<'a> From<FfiStr<'a>> for Option<String> {
+    #[inline]
+    fn from(f: FfiStr<'a>) -> Self {
+        f.into_opt_string()
+    }
+}
+
+impl<'a> From<FfiStr<'a>> for Option<&'a str> {
+    #[inline]
+    fn from(f: FfiStr<'a>) -> Self {
+        f.as_opt_str()
+    }
+}
+
+impl<'a> From<FfiStr<'a>> for &'a str {
+    #[inline]
+    fn from(f: FfiStr<'a>) -> Self {
+        f.as_str()
+    }
+}
+
+// TODO: `AsRef<str>`?
+
+// Comparisons...
+
+// Compare FfiStr with eachother
+impl<'a> PartialEq for FfiStr<'a> {
+    #[inline]
+    fn eq(&self, other: &FfiStr<'a>) -> bool {
+        self.as_opt_str() == other.as_opt_str()
+    }
+}
+
+// Compare FfiStr with str
+impl<'a> PartialEq<str> for FfiStr<'a> {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.as_opt_str() == Some(other)
+    }
+}
+
+// Compare FfiStr with &str
+impl<'a, 'b> PartialEq<&'b str> for FfiStr<'a> {
+    #[inline]
+    fn eq(&self, other: &&'b str) -> bool {
+        self.as_opt_str() == Some(*other)
+    }
+}
+
+// rhs/lhs swap version of above
+impl<'a> PartialEq<FfiStr<'a>> for str {
+    #[inline]
+    fn eq(&self, other: &FfiStr<'a>) -> bool {
+        Some(self) == other.as_opt_str()
+    }
+}
+
+// rhs/lhs swap...
+impl<'a, 'b> PartialEq<FfiStr<'a>> for &'b str {
+    #[inline]
+    fn eq(&self, other: &FfiStr<'a>) -> bool {
+        Some(*self) == other.as_opt_str()
+    }
+}

--- a/components/support/ffi/src/handle_map.rs
+++ b/components/support/ffi/src/handle_map.rs
@@ -880,7 +880,7 @@ impl<T> ConcurrentHandleMap<T> {
         callback: F,
     ) -> R::Value
     where
-        F: FnOnce(&mut T) -> Result<R, E>,
+        F: std::panic::UnwindSafe + FnOnce(&mut T) -> Result<R, E>,
         ExternError: From<E>,
         R: IntoFfi,
     {
@@ -904,7 +904,7 @@ impl<T> ConcurrentHandleMap<T> {
         callback: F,
     ) -> R::Value
     where
-        F: FnOnce(&T) -> Result<R, E>,
+        F: std::panic::UnwindSafe + FnOnce(&T) -> Result<R, E>,
         ExternError: From<E>,
         R: IntoFfi,
     {
@@ -919,7 +919,7 @@ impl<T> ConcurrentHandleMap<T> {
         callback: F,
     ) -> R::Value
     where
-        F: FnOnce(&T) -> R,
+        F: std::panic::UnwindSafe + FnOnce(&T) -> R,
         R: IntoFfi,
     {
         self.call_with_result(out_error, h, |r| -> Result<_, HandleError> {
@@ -935,7 +935,7 @@ impl<T> ConcurrentHandleMap<T> {
         callback: F,
     ) -> R::Value
     where
-        F: FnOnce(&mut T) -> R,
+        F: std::panic::UnwindSafe + FnOnce(&mut T) -> R,
         R: IntoFfi,
     {
         self.call_with_result_mut(out_error, h, |r| -> Result<_, HandleError> {
@@ -948,7 +948,7 @@ impl<T> ConcurrentHandleMap<T> {
     /// `ExternError`).
     pub fn insert_with_result<E, F>(&self, out_error: &mut ExternError, constructor: F) -> u64
     where
-        F: FnOnce() -> Result<T, E>,
+        F: std::panic::UnwindSafe + FnOnce() -> Result<T, E>,
         ExternError: From<E>,
     {
         use crate::call_with_result;
@@ -969,7 +969,7 @@ impl<T> ConcurrentHandleMap<T> {
     /// clear that it contains a [`call_with_output`] internally.
     pub fn insert_with_output<F>(&self, out_error: &mut ExternError, constructor: F) -> u64
     where
-        F: FnOnce() -> T,
+        F: std::panic::UnwindSafe + FnOnce() -> T,
     {
         // The Err type isn't important here beyond being convertable to ExternError
         self.insert_with_result(out_error, || -> Result<_, HandleError> {

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -98,6 +98,7 @@ mod error;
 mod ffistr;
 pub mod handle_map;
 mod into_ffi;
+#[macro_use]
 mod macros;
 mod string;
 

--- a/components/support/ffi/src/macros.rs
+++ b/components/support/ffi/src/macros.rs
@@ -68,8 +68,6 @@ macro_rules! implement_into_ffi_by_json {
                 $crate::convert_to_json_string(&self)
             }
         }
-
-        impl $crate::IntoFfiJsonTag for $T {}
     )*}
 }
 

--- a/docs/howtos/when-to-use-what-in-the-ffi.md
+++ b/docs/howtos/when-to-use-what-in-the-ffi.md
@@ -81,8 +81,8 @@ good support for calling over the FFI), but it's our lowest common denominator.
 
 These we pass as nul-terminated UTF-8 C-strings.
 
-Specifically, `*mut c_char` or `*const c_char`, depending on whether or not it's
-a return value, or input, respectively.
+For return values, used `*mut c_char`, and for input, use
+[`ffi_support::FfiStr`](https://docs.rs/ffi-support/*/ffi_support/struct.FfiStr.html)
 
 1. If the string is returned from Rust to Kotlin/Swift, you need to expose a
    string destructor from your ffi crate. See
@@ -103,10 +103,10 @@ a return value, or input, respectively.
     to the destructor, it will allocate a temporary buffer, pass it to Rust, which
     we'll free, corrupting both heaps 💥. Oops!
 
-2. If the string is passed into Rust from Kotlin/Swift, it should work
-   more-or-less automatically. The Rust code should convert it using one of the
-   functions from ffi_support, such as `rust_string_from_c`, `rust_str_from_c`,
-   `opt_rust_string_from_c`, `opt_rust_str_from_c`, etc.
+2. If the string is passed into Rust from Kotlin/Swift, the rust code should
+   declare the parameter as a [`FfiStr<'_>`](https://docs.rs/ffi-support/*/ffi_support/struct.FfiStr.html).
+   and things should then work more or less automatically. The `FfiStr` has methods
+   for extracting it's data as `&str`, `Option<&str>`, `String`, and `Option<String>`.
 
 It's also completely fine to use Protobufs or JSON for this case!
 


### PR DESCRIPTION
- The main one here is the addition of the `FfiStr` type. This allows most of our ffi code to be written without any `unsafe`, unless it's doing something complex (in which case indicating this with `unsafe` is appropriate). The old functions are still present, but deprecated, mostly for documentation purposes.
- `ffi_support` now properly handles unwind-safety. In practice we already handle this properly, as almost everything uses HandleMaps now-a-days, so there's really no reason to default to the panic-unsafe thing. This also lets us remove a big block comment defending our current choice to do the dubious thing.
- It removes explicit dependencies on `serde`/`serde_json`/`prost` from `ffi_support` when they're only used in macros and the caller already needs dependencies on them for them for them to work. This removes the `prost_support` feature, since now those macros are just always available.
- And while I was at it: I've also removed the ability to compile the components without their `ffi.rs` module which generally jsut implements IntoFfi. Making this a feature causes unnecessary recompilation, and ffi_support is quite lightweight, so having the dependency doesn't hurt us at all.

In general, these changes should make things safer and build faster. The first two have been somethign I've wanted to do for a while, but submitting to rustconf made me remember that I should clean this up.
