### PR TITLE
Use same rust targets list everywhere

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,17 @@ if (System.getenv("CI")) {
     }
 }
 
+// The Cargo targets to invoke.  The mapping from short name to target
+// triple is defined by the `rust-android-gradle` plugin.
+ext.rustTargets = [
+    'linux-x86-64',
+    'darwin',
+    'win32-x86-64-gnu',
+    'arm',
+    'arm64',
+    'x86_64',
+    'x86',
+]
 // Configure some environment variables, per toolchain, that will apply during
 // the Cargo build.  We assume that the `libs/` directory has been populated
 // before invoking Gradle (or Cargo).

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -67,17 +67,7 @@ cargo {
 
     libname = 'fxaclient_ffi'
 
-    // The Cargo targets to invoke.  The mapping from short name to target
-    // triple is defined by the `rust-android-gradle` plugin.
-    targets = [
-        'linux-x86-64',
-        'darwin',
-        'win32-x86-64-gnu',
-        'arm',
-        'arm64',
-        'x86_64',
-        'x86',
-    ]
+    targets = rootProject.ext.rustTargets
 
     profile = rootProject.ext.nonMegazordProfile
 

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -60,17 +60,7 @@ cargo {
 
     libname = 'logins_ffi'
 
-    // The Cargo targets to invoke.  The mapping from short name to target
-    // triple is defined by the `rust-android-gradle` plugin.
-    targets = [
-        'linux-x86-64',
-        'darwin',
-        'win32-x86-64-gnu',
-        'arm',
-        'arm64',
-        'x86_64',
-        'x86',
-    ]
+    targets = rootProject.ext.rustTargets
 
     profile = rootProject.ext.nonMegazordProfile
 

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -67,17 +67,7 @@ cargo {
 
     libname = 'places_ffi'
 
-    // The Cargo targets to invoke.  The mapping from short name to target
-    // triple is defined by the `rust-android-gradle` plugin.
-    targets = [
-        'linux-x86-64',
-        'darwin',
-        'win32-x86-64-gnu',
-        'arm',
-        'arm64',
-        'x86_64',
-        'x86',
-    ]
+    targets = rootProject.ext.rustTargets
 
     profile = rootProject.ext.nonMegazordProfile
 

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -60,15 +60,7 @@ cargo {
 
     libname = 'push_ffi'
 
-    // The Cargo targets to invoke.  The mapping from short name to target
-    // triple is defined by the `rust-android-gradle` plugin.
-    targets = [
-        'arm',
-        'arm64',
-        'x86_64',
-        'x86',
-        'linux-x86-64',
-    ]
+    targets = rootProject.ext.rustTargets
 
     profile = rootProject.ext.nonMegazordProfile
 

--- a/components/rc_log/android/build.gradle
+++ b/components/rc_log/android/build.gradle
@@ -60,17 +60,7 @@ cargo {
 
     libname = 'rc_log_ffi'
 
-    // The Cargo targets to invoke.  The mapping from short name to target
-    // triple is defined by the `rust-android-gradle` plugin.
-    targets = [
-        'linux-x86-64',
-        'darwin',
-        'win32-x86-64-gnu',
-        'arm',
-        'arm64',
-        'x86_64',
-        'x86',
-    ]
+    targets = rootProject.ext.rustTargets
 
     profile = rootProject.ext.nonMegazordProfile
 


### PR DESCRIPTION
I noticed this was wrong for Push, so made this use a common list.
