### PR TITLE
Bump version to 0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 **See [the release process docs](docs/howtos/cut-a-new-release.md) for the steps to take when cutting a new release.**
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.20.1...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.20.2...master)
+
+# v0.20.2 (_2019-03-15_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.20.1...v0.20.2)
+
+- An automation problem with the previous release, forcing a version bump. No functional changes.
+- Local development: non-megazord builds are now `debug` be default, improving local build times
+and working around subtle build issues.
+- Override this via a flag in `local.properties`: `application-services.nonmegazord-profile=release`
 
 # v0.20.1 (_2019-03-15_)
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.10'
 
     ext.library = [
-        version: '0.20.1'
+        version: '0.20.2'
     ]
 
     ext.build = [


### PR DESCRIPTION
Automation stack is requiring a version bump for things to be published correctly; no API/functional changes. Minor change relating to local development.