### PR TITLE
Do not depend on cargoBuild for assembleRelease in CI 

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -9,7 +9,8 @@ from decisionlib import *
 
 def main(task_for, mock=False):
     if task_for == "github-pull-request":
-        android_linux_x86_64()
+        #android_linux_x86_64() #TODO: remove me
+        android_multiarch()
     elif task_for == "github-push":
         android_multiarch()
     elif task_for == "github-release":

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -145,7 +145,15 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        if (variant.buildType.name != 'withoutLib') {
+        // The "CI" check is a terrible hack:
+        // In our decision task we execute `testDebug` then `assembleRelease`.
+        // The rust-android-gradle plugin relies on cargo to not re-build already
+        // built rust artifacts, however because of different feature sets, these
+        // two tasks will end up re-compiling the rust crates two times.
+        // Since the Rust crates will be created during `testDebug` (which depends on
+        // ...UnitTestJavaRes), we remove the `cargoBuild` dependency in `...Assets`
+        // (which `assembleRelease` depends on).
+        if (variant.buildType.name != 'withoutLib' && !System.getenv("CI")) {
             tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
         }
 

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -114,7 +114,17 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        // The "CI" check is a terrible hack:
+        // In our decision task we execute `testDebug` then `assembleRelease`.
+        // The rust-android-gradle plugin relies on cargo to not re-build already
+        // built rust artifacts, however because of different feature sets, these
+        // two tasks will end up re-compiling the rust crates two times.
+        // Since the Rust crates will be created during `testDebug` (which depends on
+        // ...UnitTestJavaRes), we remove the `cargoBuild` dependency in `...Assets`
+        // (which `assembleRelease` depends on).
+        if (variant.buildType.name != 'withoutLib' && !System.getenv("CI")) {
+            tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        }
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -144,7 +144,15 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        if (variant.buildType.name != 'withoutLib') {
+        // The "CI" check is a terrible hack:
+        // In our decision task we execute `testDebug` then `assembleRelease`.
+        // The rust-android-gradle plugin relies on cargo to not re-build already
+        // built rust artifacts, however because of different feature sets, these
+        // two tasks will end up re-compiling the rust crates two times.
+        // Since the Rust crates will be created during `testDebug` (which depends on
+        // ...UnitTestJavaRes), we remove the `cargoBuild` dependency in `...Assets`
+        // (which `assembleRelease` depends on).
+        if (variant.buildType.name != 'withoutLib' && !System.getenv("CI")) {
             tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
         }
 

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -112,7 +112,15 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        if (variant.buildType.name != 'withoutLib') {
+        // The "CI" check is a terrible hack:
+        // In our decision task we execute `testDebug` then `assembleRelease`.
+        // The rust-android-gradle plugin relies on cargo to not re-build already
+        // built rust artifacts, however because of different feature sets, these
+        // two tasks will end up re-compiling the rust crates two times.
+        // Since the Rust crates will be created during `testDebug` (which depends on
+        // ...UnitTestJavaRes), we remove the `cargoBuild` dependency in `...Assets`
+        // (which `assembleRelease` depends on).
+        if (variant.buildType.name != 'withoutLib' && !System.getenv("CI")) {
             tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
         }
 

--- a/components/rc_log/android/build.gradle
+++ b/components/rc_log/android/build.gradle
@@ -118,7 +118,17 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        // The "CI" check is a terrible hack:
+        // In our decision task we execute `testDebug` then `assembleRelease`.
+        // The rust-android-gradle plugin relies on cargo to not re-build already
+        // built rust artifacts, however because of different feature sets, these
+        // two tasks will end up re-compiling the rust crates two times.
+        // Since the Rust crates will be created during `testDebug` (which depends on
+        // ...UnitTestJavaRes), we remove the `cargoBuild` dependency in `...Assets`
+        // (which `assembleRelease` depends on).
+        if (variant.buildType.name != 'withoutLib' && !System.getenv("CI")) {
+            tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        }
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])

--- a/megazords/fenix/android/build.gradle
+++ b/megazords/fenix/android/build.gradle
@@ -98,7 +98,17 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        // The "CI" check is a terrible hack:
+        // In our decision task we execute `testDebug` then `assembleRelease`.
+        // The rust-android-gradle plugin relies on cargo to not re-build already
+        // built rust artifacts, however because of different feature sets, these
+        // two tasks will end up re-compiling the rust crates two times.
+        // Since the Rust crates will be created during `testDebug` (which depends on
+        // ...UnitTestJavaRes), we remove the `cargoBuild` dependency in `...Assets`
+        // (which `assembleRelease` depends on).
+        if (variant.buildType.name != 'withoutLib' && !System.getenv("CI")) {
+            tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        }
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])

--- a/megazords/lockbox/android/build.gradle
+++ b/megazords/lockbox/android/build.gradle
@@ -97,7 +97,17 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        // The "CI" check is a terrible hack:
+        // In our decision task we execute `testDebug` then `assembleRelease`.
+        // The rust-android-gradle plugin relies on cargo to not re-build already
+        // built rust artifacts, however because of different feature sets, these
+        // two tasks will end up re-compiling the rust crates two times.
+        // Since the Rust crates will be created during `testDebug` (which depends on
+        // ...UnitTestJavaRes), we remove the `cargoBuild` dependency in `...Assets`
+        // (which `assembleRelease` depends on).
+        if (variant.buildType.name != 'withoutLib' && !System.getenv("CI")) {
+            tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        }
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])

--- a/megazords/reference-browser/android/build.gradle
+++ b/megazords/reference-browser/android/build.gradle
@@ -99,7 +99,17 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        // The "CI" check is a terrible hack:
+        // In our decision task we execute `testDebug` then `assembleRelease`.
+        // The rust-android-gradle plugin relies on cargo to not re-build already
+        // built rust artifacts, however because of different feature sets, these
+        // two tasks will end up re-compiling the rust crates two times.
+        // Since the Rust crates will be created during `testDebug` (which depends on
+        // ...UnitTestJavaRes), we remove the `cargoBuild` dependency in `...Assets`
+        // (which `assembleRelease` depends on).
+        if (variant.buildType.name != 'withoutLib' && !System.getenv("CI")) {
+            tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        }
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])


### PR DESCRIPTION
It's an unfortunate hack but I don't know what else we can do here.
If I'm correct it should cut our full builds time by about 20-30min.