### PR TITLE
Use clippy.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,14 @@ jobs:
       - run: rustup component add rustfmt
       - run: rustfmt --version
       - run: cargo fmt -- --check
+  Lint Rust with clippy:
+    docker:
+      - image: circleci/rust:latest
+    steps:
+      - checkout
+      - run: rustup component add clippy
+      - run: cargo clippy --version
+      - run: cargo clippy --all --all-targets --all-features -- -D warnings
   Rust tests - stable:
     docker:
       - image: circleci/rust:latest
@@ -198,6 +206,9 @@ workflows:
   check-formating:
     jobs:
       - Check Rust formatting
+  clippy:
+    jobs:
+      - Lint Rust with clippy
   run-tests:
     jobs:
       - Rust tests - stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,7 +419,7 @@ dependencies = [
  "ece 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -604,7 +604,7 @@ dependencies = [
 
 [[package]]
 name = "ffi-support"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -687,7 +687,7 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "hawk 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -712,7 +712,7 @@ name = "fxaclient_ffi"
 version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "fxa-client 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -995,7 +995,7 @@ dependencies = [
  "cli-support 0.1.0",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "fxa-client 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1016,7 +1016,7 @@ version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base16 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins 0.1.0",
@@ -1333,7 +1333,7 @@ dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "find-places-db 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxa-client 0.1.0",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1368,7 +1368,7 @@ version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "places 0.1.0",
@@ -1492,7 +1492,7 @@ version = "0.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1507,7 +1507,7 @@ dependencies = [
  "communications 0.1.0",
  "config 0.1.0",
  "crypto 0.1.0",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "push-errors 0.1.0",
@@ -1696,7 +1696,7 @@ name = "rc_log_ffi"
 version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.0",
+ "ffi-support 0.3.1",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,6 @@
+# Right now we just use the defaults. This file exists should we
+# want to change that, and to indicate to contributors that they
+# might want to run clippy.
+#
+# See https://rust-lang.github.io/rust-clippy/master/index.html for
+# the complete list of lints.

--- a/components/fxa-client/examples/oauth_flow.rs
+++ b/components/fxa-client/examples/oauth_flow.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use text_io::*;
 use url::Url;
 
-static CONTENT_SERVER: &'static str = "http://127.0.0.1:3030";
-static CLIENT_ID: &'static str = "7f368c6886429f19";
-static REDIRECT_URI: &'static str = "https://mozilla.github.io/notes/fxa/android-redirect.html";
-static SCOPES: &'static [&'static str] = &["https://identity.mozilla.com/apps/oldsync"];
+const CONTENT_SERVER: &str = "http://127.0.0.1:3030";
+const CLIENT_ID: &str = "7f368c6886429f19";
+const REDIRECT_URI: &str = "https://mozilla.github.io/notes/fxa/android-redirect.html";
+const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
 
 fn main() {
     let mut fxa = FirefoxAccount::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
@@ -17,8 +17,9 @@ fn main() {
     let redirect_uri: String = read!("{}\n");
     let redirect_uri = Url::parse(&redirect_uri).unwrap();
     let query_params: HashMap<_, _> = redirect_uri.query_pairs().into_owned().collect();
-    let code = query_params.get("code").unwrap();
-    let state = query_params.get("state").unwrap();
-    let oauth_info = fxa.complete_oauth_flow(&code, &state).unwrap();
+    let code = &query_params["code"];
+    let state = &query_params["state"];
+    fxa.complete_oauth_flow(&code, &state).unwrap();
+    let oauth_info = fxa.get_access_token(SCOPES[0]);
     println!("access_token: {:?}", oauth_info);
 }

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 use ffi_support::{
     define_bytebuffer_destructor, define_handle_map_deleter, define_string_destructor, ByteBuffer,
     ConcurrentHandleMap, ExternError, FfiStr,

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -150,7 +150,7 @@ pub extern "C" fn fxa_begin_pairing_flow(
     ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
         let pairing_url = pairing_url.as_str();
         let scope = scope.as_str();
-        let scopes: Vec<&str> = scope.split(" ").collect();
+        let scopes: Vec<&str> = scope.split(' ').collect();
         fxa.begin_pairing_flow(&pairing_url, &scopes)
     })
 }
@@ -179,7 +179,7 @@ pub extern "C" fn fxa_begin_oauth_flow(
     log::debug!("fxa_begin_oauth_flow");
     ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
         let scope = scope.as_str();
-        let scopes: Vec<&str> = scope.split(" ").collect();
+        let scopes: Vec<&str> = scope.split(' ').collect();
         fxa.begin_oauth_flow(&scopes, wants_keys)
     })
 }

--- a/components/fxa-client/src/browser_id.rs
+++ b/components/fxa-client/src/browser_id.rs
@@ -45,7 +45,7 @@ impl FirefoxAccount {
         }))
     }
 
-    fn to_married(&mut self) -> Option<&MarriedState> {
+    fn advance_to_married(&mut self) -> Option<&MarriedState> {
         self.advance();
         match self.state.login_state {
             LoginState::Married(ref married) => Some(married),
@@ -73,7 +73,7 @@ impl FirefoxAccount {
     }
 
     pub fn generate_assertion(&mut self, audience: &str) -> Result<String> {
-        let married = match self.to_married() {
+        let married = match self.advance_to_married() {
             Some(married) => married,
             None => return Err(ErrorKind::NotMarried.into()),
         };
@@ -87,7 +87,7 @@ impl FirefoxAccount {
     }
 
     pub fn get_sync_keys(&mut self) -> Result<SyncKeys> {
-        let married = match self.to_married() {
+        let married = match self.advance_to_married() {
             Some(married) => married,
             None => return Err(ErrorKind::NotMarried.into()),
         };
@@ -97,7 +97,7 @@ impl FirefoxAccount {
 
     pub fn sign_out(mut self) {
         self.client.sign_out();
-        self.state.login_state = self.state.login_state.to_separated();
+        self.state.login_state = self.state.login_state.into_separated();
     }
 }
 

--- a/components/fxa-client/src/config.rs
+++ b/components/fxa-client/src/config.rs
@@ -71,6 +71,8 @@ impl Config {
         }
     }
 
+    // FIXME
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn init(
         content_url: String,
         auth_url: String,

--- a/components/fxa-client/src/http_client/browser_id/hawk_request.rs
+++ b/components/fxa-client/src/http_client/browser_id/hawk_request.rs
@@ -12,16 +12,16 @@ use url::Url;
 
 const KEY_LENGTH: usize = 32;
 
-pub struct HAWKRequestBuilder<'a> {
+pub struct HawkRequestBuilder<'a> {
     url: Url,
     method: Method,
     body: Option<String>,
-    hkdf_sha256_key: &'a Vec<u8>,
+    hkdf_sha256_key: &'a [u8],
 }
 
-impl<'a> HAWKRequestBuilder<'a> {
-    pub fn new(method: Method, url: Url, hkdf_sha256_key: &'a Vec<u8>) -> Self {
-        HAWKRequestBuilder {
+impl<'a> HawkRequestBuilder<'a> {
+    pub fn new(method: Method, url: Url, hkdf_sha256_key: &'a [u8]) -> Self {
+        HawkRequestBuilder {
             url,
             method,
             body: None,

--- a/components/fxa-client/src/http_client/browser_id/jwt_utils.rs
+++ b/components/fxa-client/src/http_client/browser_id/jwt_utils.rs
@@ -17,7 +17,8 @@ pub fn create_assertion(
     let since_epoch = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Something is very wrong.");
-    let issued_at = since_epoch.as_secs() * 1000 + since_epoch.subsec_nanos() as u64 / 1_000_000;
+    let issued_at =
+        since_epoch.as_secs() * 1000 + u64::from(since_epoch.subsec_nanos()) / 1_000_000;
     let expires_at = issued_at + DEFAULT_ASSERTION_DURATION;
     let issuer = DEFAULT_ASSERTION_ISSUER;
     create_assertion_full(
@@ -142,7 +143,7 @@ mod tests {
     }
 
     fn decode(token: &str, key_pair: &BrowserIDKeyPair) -> Result<String> {
-        let segments: Vec<&str> = token.split(".").collect();
+        let segments: Vec<&str> = token.split('.').collect();
         let message = format!("{}.{}", &segments[0], &segments[1]);
         let message_bytes = message.as_bytes();
         let signature = base64::decode_config(&segments[2], base64::URL_SAFE_NO_PAD)?;
@@ -187,7 +188,7 @@ mod tests {
 
         let issuer = "127.0.0.1";
         let audience = "http://localhost:8080";
-        let iat: u64 = 1352995809210;
+        let iat: u64 = 1_352_995_809_210;
         let dur: u64 = 60 * 60 * 1000;
         let exp: u64 = iat + dur;
 

--- a/components/fxa-client/src/http_client/browser_id/rsa.rs
+++ b/components/fxa-client/src/http_client/browser_id/rsa.rs
@@ -89,6 +89,7 @@ impl fmt::Debug for RSABrowserIDKeyPair {
 }
 
 impl Serialize for RSABrowserIDKeyPair {
+    #[allow(clippy::many_single_char_names)] // FIXME
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -201,7 +202,7 @@ impl<'de> Deserialize<'de> for RSABrowserIDKeyPair {
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("struct RSABrowserIDKeyPair")
             }
-
+            #[allow(clippy::many_single_char_names)] // FIXME
             fn visit_map<V>(self, mut map: V) -> std::result::Result<RSABrowserIDKeyPair, V::Error>
             where
                 V: MapAccess<'de>,
@@ -302,7 +303,7 @@ impl<'de> Deserialize<'de> for RSABrowserIDKeyPair {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &["n", "e", "d", "p", "q", "dmp1", "dmq1", "iqmp"];
+        const FIELDS: &[&str] = &["n", "e", "d", "p", "q", "dmp1", "dmq1", "iqmp"];
         deserializer.deserialize_struct("RSABrowserIDKeyPair", FIELDS, RSABrowserIDKeyPairVisitor)
     }
 }

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 #[cfg(feature = "browserid")]
 pub use crate::browser_id::{SyncKeys, WebChannelResponse};
 #[cfg(feature = "browserid")]

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -104,6 +104,7 @@ impl FirefoxAccount {
     }
 
     #[cfg(test)]
+    #[allow(dead_code)] // FIXME
     pub(crate) fn set_client(&mut self, client: Arc<FxAClient>) {
         self.client = client;
     }

--- a/components/fxa-client/src/login_sm.rs
+++ b/components/fxa-client/src/login_sm.rs
@@ -277,7 +277,7 @@ impl MarriedState {
 }
 
 impl LoginState {
-    pub fn to_separated(self) -> Self {
+    pub fn into_separated(self) -> Self {
         use self::LoginState::*;
         match self {
             Married(state) => Separated(state.token_keys_and_key_pair.token_and_keys.base),

--- a/components/fxa-client/src/profile.rs
+++ b/components/fxa-client/src/profile.rs
@@ -6,7 +6,7 @@ pub use crate::http_client::ProfileResponse as Profile;
 use crate::{errors::*, scopes, util, CachedResponse, FirefoxAccount};
 
 // A cached profile response is considered fresh for `PROFILE_FRESHNESS_THRESHOLD` ms.
-const PROFILE_FRESHNESS_THRESHOLD: u64 = 120000; // 2 minutes
+const PROFILE_FRESHNESS_THRESHOLD: u64 = 120_000; // 2 minutes
 
 impl FirefoxAccount {
     /// Fetch the profile for the user.

--- a/components/fxa-client/src/scoped_keys.rs
+++ b/components/fxa-client/src/scoped_keys.rs
@@ -48,7 +48,7 @@ impl ScopedKeysFlow {
     }
 
     pub fn decrypt_keys_jwe(self, jwe: &str) -> Result<String> {
-        let segments: Vec<&str> = jwe.split(".").collect();
+        let segments: Vec<&str> = jwe.split('.').collect();
         let header = base64::decode_config(&segments[0], base64::URL_SAFE_NO_PAD)?;
         let protected_header: serde_json::Value = serde_json::from_slice(&header)?;
         assert_eq!(protected_header["epk"]["kty"], "EC");

--- a/components/fxa-client/src/scopes.rs
+++ b/components/fxa-client/src/scopes.rs
@@ -2,4 +2,4 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub const PROFILE: &'static str = "profile";
+pub const PROFILE: &str = "profile";

--- a/components/fxa-client/src/state_persistence.rs
+++ b/components/fxa-client/src/state_persistence.rs
@@ -12,7 +12,7 @@ type State = StateV2;
 
 pub(crate) fn state_from_json(data: &str) -> Result<State> {
     let stored_state: PersistedState = serde_json::from_str(data)?;
-    return upgrade_state(stored_state);
+    upgrade_state(stored_state)
 }
 
 pub(crate) fn state_to_json(state: &State) -> Result<String> {
@@ -29,10 +29,10 @@ enum PersistedState {
 }
 
 fn upgrade_state(in_state: PersistedState) -> Result<State> {
-    return match in_state {
+    match in_state {
         PersistedState::V1(state) => state.into(),
         PersistedState::V2(state) => Ok(state),
-    };
+    }
 }
 
 // Migrations

--- a/components/fxa-client/src/state_persistence.rs
+++ b/components/fxa-client/src/state_persistence.rs
@@ -145,10 +145,7 @@ mod tests {
             .scopes
             .contains("https://identity.mozilla.com/apps/lockbox"));
         assert_eq!(state.scoped_keys.len(), 2);
-        let oldsync_key = state
-            .scoped_keys
-            .get("https://identity.mozilla.com/apps/oldsync")
-            .unwrap();
+        let oldsync_key = &state.scoped_keys["https://identity.mozilla.com/apps/oldsync"];
         assert_eq!(oldsync_key.kid, "1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ");
         assert_eq!(oldsync_key.k, "kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg");
         assert_eq!(oldsync_key.kty, "oct");
@@ -156,10 +153,8 @@ mod tests {
             oldsync_key.scope,
             "https://identity.mozilla.com/apps/oldsync"
         );
-        let lockbox_key = state
-            .scoped_keys
-            .get("https://identity.mozilla.com/apps/lockbox")
-            .unwrap();
+        let lockbox_key = &state.scoped_keys["https://identity.mozilla.com/apps/lockbox"];
+
         assert_eq!(lockbox_key.kid, "1231014287-KDVj0DFaO3wGpPJD8oPwVg");
         assert_eq!(lockbox_key.k, "Qk4K4xF2PgQ6XvBXW8X7B7AWwWgW2bHQov9NHNd4v-k");
         assert_eq!(lockbox_key.kty, "oct");

--- a/components/fxa-client/src/util.rs
+++ b/components/fxa-client/src/util.rs
@@ -11,7 +11,7 @@ pub fn now() -> u64 {
     let since_epoch = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Something is very wrong.");
-    since_epoch.as_secs() * 1000 + since_epoch.subsec_nanos() as u64 / 1_000_000
+    since_epoch.as_secs() * 1000 + u64::from(since_epoch.subsec_nanos()) / 1_000_000
 }
 
 pub fn now_secs() -> u64 {

--- a/components/logins/examples/sync_pass_sql.rs
+++ b/components/logins/examples/sync_pass_sql.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![recursion_limit = "4096"]
+#![allow(unknown_lints)]
 
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
 use cli_support::prompt::{prompt_string, prompt_usize};

--- a/components/logins/examples/sync_pass_sql.rs
+++ b/components/logins/examples/sync_pass_sql.rs
@@ -26,7 +26,7 @@ fn read_login() -> Login {
     let username_field = prompt_string("username_field").unwrap_or_default();
     let password_field = prompt_string("password_field").unwrap_or_default();
     let record = Login {
-        id: sync15::random_guid().unwrap().into(),
+        id: sync15::random_guid().unwrap(),
         username,
         password,
         username_field,
@@ -141,7 +141,6 @@ fn show_sql(e: &PasswordEngine, sql: &str) -> Result<()> {
 
     let rows = stmt.query_map(NO_PARAMS, |row| {
         (0..len)
-            .into_iter()
             .map(|idx| match row.get::<_, Value>(idx) {
                 Value::Null => Cell::new("null").style_spec("Fd"),
                 Value::Integer(i) => Cell::new(&i.to_string()).style_spec("Fb"),
@@ -235,6 +234,7 @@ fn init_logging() {
     env_logger::init_from_env(env_logger::Env::default().filter_or("RUST_LOG", spec));
 }
 
+#[allow(clippy::cyclomatic_complexity)] // FIXME
 fn main() -> Result<()> {
     init_logging();
     std::env::set_var("RUST_BACKTRACE", "1");

--- a/components/logins/ffi/src/lib.rs
+++ b/components/logins/ffi/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 use ffi_support::ConcurrentHandleMap;
 use ffi_support::{define_handle_map_deleter, define_string_destructor, ExternError, FfiStr};
 use logins::{Login, PasswordEngine, Result};

--- a/components/logins/ffi/src/lib.rs
+++ b/components/logins/ffi/src/lib.rs
@@ -105,7 +105,7 @@ pub extern "C" fn sync15_passwords_sync(
     log::debug!("sync15_passwords_sync");
     ENGINES.call_with_result(error, handle, |state| -> Result<()> {
         let mut sync_ping = telemetry::SyncTelemetryPing::new();
-        let result = state.sync(
+        state.sync(
             &sync15::Sync15StorageClientInit {
                 key_id: key_id.into_string(),
                 access_token: access_token.into_string(),
@@ -113,8 +113,7 @@ pub extern "C" fn sync15_passwords_sync(
             },
             &sync15::KeyBundle::from_ksync_base64(sync_key.as_str())?,
             &mut sync_ping,
-        );
-        result
+        )
     })
 }
 

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -775,13 +775,14 @@ impl Store for LoginDb {
         new_timestamp: ServerTimestamp,
         records_synced: &[String],
     ) -> result::Result<(), failure::Error> {
-        Ok(self.mark_as_synchronized(
+        self.mark_as_synchronized(
             &records_synced
                 .iter()
                 .map(|r| r.as_str())
                 .collect::<Vec<_>>(),
             new_timestamp,
-        )?)
+        )?;
+        Ok(())
     }
 
     fn get_collection_request(&self) -> result::Result<CollectionRequest, failure::Error> {

--- a/components/logins/src/engine.rs
+++ b/components/logins/src/engine.rs
@@ -97,7 +97,7 @@ impl PasswordEngine {
         );
         self.db.set_global_state(global_state.replace(None))?;
         let failures = result?;
-        if failures.len() == 0 {
+        if failures.is_empty() {
             Ok(())
         } else {
             assert_eq!(failures.len(), 1);

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 #[macro_use]
 mod error;
 mod login;

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -337,6 +337,7 @@ macro_rules! merge_field {
 }
 
 impl LoginDelta {
+    #[allow(clippy::cyclomatic_complexity)] // Looks like clippy considers this after macro-expansion...
     pub fn merge(self, mut b: LoginDelta, b_is_newer: bool) -> LoginDelta {
         let mut merged = self;
         merge_field!(merged, b, b_is_newer, hostname);

--- a/components/logins/src/schema.rs
+++ b/components/logins/src/schema.rs
@@ -114,7 +114,7 @@ pub const VERSION: i64 = 4;
 /// (of `loginsM`) are stored as milliseconds as well both on firefox-ios and
 /// here (and so they do not need to be updated with the `timeLastUsed`/
 /// `timePasswordChanged`/`timeCreated` timestamps.
-pub const COMMON_COLS: &'static str = "
+pub const COMMON_COLS: &str = "
     guid,
     username,
     password,
@@ -129,7 +129,7 @@ pub const COMMON_COLS: &'static str = "
     timesUsed
 ";
 
-const COMMON_SQL: &'static str = "
+const COMMON_SQL: &str = "
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     hostname            TEXT NOT NULL,
     -- Exactly one of httpRealm or formSubmitURL should be set
@@ -172,41 +172,41 @@ lazy_static! {
         format!("PRAGMA user_version = {version}", version = VERSION);
 }
 
-const CREATE_META_TABLE_SQL: &'static str = "
+const CREATE_META_TABLE_SQL: &str = "
     CREATE TABLE IF NOT EXISTS loginsSyncMeta (
         key TEXT PRIMARY KEY,
         value NOT NULL
     )
 ";
 
-const CREATE_OVERRIDE_HOSTNAME_INDEX_SQL: &'static str = "
+const CREATE_OVERRIDE_HOSTNAME_INDEX_SQL: &str = "
     CREATE INDEX IF NOT EXISTS idx_loginsM_is_overridden_hostname
     ON loginsM (is_overridden, hostname)
 ";
 
-const CREATE_DELETED_HOSTNAME_INDEX_SQL: &'static str = "
+const CREATE_DELETED_HOSTNAME_INDEX_SQL: &str = "
     CREATE INDEX IF NOT EXISTS idx_loginsL_is_deleted_hostname
     ON loginsL (is_deleted, hostname)
 ";
 
 // As noted above, we use these when updating from schema v3 (firefox-ios's
 // last schema) to convert from microsecond timestamps to milliseconds.
-const UPDATE_LOCAL_TIMESTAMPS_TO_MILLIS_SQL: &'static str = "
+const UPDATE_LOCAL_TIMESTAMPS_TO_MILLIS_SQL: &str = "
     UPDATE loginsL
     SET timeCreated = timeCreated / 1000,
         timeLastUsed = timeLastUsed / 1000,
         timePasswordChanged = timePasswordChanged / 1000
 ";
 
-const UPDATE_MIRROR_TIMESTAMPS_TO_MILLIS_SQL: &'static str = "
+const UPDATE_MIRROR_TIMESTAMPS_TO_MILLIS_SQL: &str = "
     UPDATE loginsM
     SET timeCreated = timeCreated / 1000,
         timeLastUsed = timeLastUsed / 1000,
         timePasswordChanged = timePasswordChanged / 1000
 ";
 
-pub(crate) static LAST_SYNC_META_KEY: &'static str = "last_sync_time";
-pub(crate) static GLOBAL_STATE_META_KEY: &'static str = "global_state";
+pub(crate) static LAST_SYNC_META_KEY: &str = "last_sync_time";
+pub(crate) static GLOBAL_STATE_META_KEY: &str = "global_state";
 
 pub(crate) fn init(db: &Connection) -> Result<()> {
     let user_version = db.query_one::<i64>("PRAGMA user_version")?;

--- a/components/logins/src/util.rs
+++ b/components/logins/src/util.rs
@@ -25,7 +25,7 @@ pub fn system_time_millis_from_row(row: &Row, col_name: &str) -> Result<time::Sy
 }
 
 pub fn duration_ms_i64(d: time::Duration) -> i64 {
-    (d.as_secs() as i64) * 1000 + ((d.subsec_nanos() as i64) / 1_000_000)
+    (d.as_secs() as i64) * 1000 + (i64::from(d.subsec_nanos()) / 1_000_000)
 }
 
 pub fn system_time_ms_i64(t: time::SystemTime) -> i64 {

--- a/components/places/benches/match_impl.rs
+++ b/components/places/benches/match_impl.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints)]
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use places::match_impl::{AutocompleteMatch, MatchBehavior, SearchBehavior};
 

--- a/components/places/benches/search.rs
+++ b/components/places/benches/search.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints)]
+
 use criterion::{criterion_group, criterion_main, Criterion};
 use places::api::{
     matcher::{match_url, search_frecent, SearchParams},

--- a/components/places/examples/autocomplete.rs
+++ b/components/places/examples/autocomplete.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 use clap::value_t;
 use failure::bail;
 use places::{PlacesDb, VisitObservation, VisitTransition};

--- a/components/places/examples/places-utils.rs
+++ b/components/places/examples/places-utils.rs
@@ -74,11 +74,7 @@ fn convert_node(dm: DesktopItem) -> Option<BookmarkTreeNode> {
             date_added: dm.date_added.map(|v| Timestamp(v / 1000)),
             last_modified: dm.last_modified.map(|v| Timestamp(v / 1000)),
             title: dm.title,
-            children: dm
-                .children
-                .into_iter()
-                .filter_map(|c| convert_node(c))
-                .collect(),
+            children: dm.children.into_iter().filter_map(convert_node).collect(),
         }
         .into(),
     })

--- a/components/places/examples/places-utils.rs
+++ b/components/places/examples/places-utils.rs
@@ -169,7 +169,7 @@ fn sync(
     // markh got a bit ahead of himself here :)
     // This should move to using PlacesApi.
     let client_info = Cell::new(None);
-    let stores = if engine_names.len() == 0 {
+    let stores = if engine_names.is_empty() {
         vec![HistoryStore::new(db, &client_info)]
     } else {
         assert!(engine_names.len() == 1 && engine_names[0] == "history");

--- a/components/places/examples/places-utils.rs
+++ b/components/places/examples/places-utils.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
 use places::history_sync::store::HistoryStore;
 use places::storage::bookmarks::{

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 use ffi_support::{
     define_box_destructor, define_bytebuffer_destructor, define_handle_map_deleter,
     define_string_destructor, ByteBuffer, ConcurrentHandleMap, ExternError, FfiStr,

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -128,7 +128,7 @@ pub fn split_after_host_and_port(href: &str) -> (&str, &str) {
         .map(|i| i + 1)
         .unwrap_or(0);
     let remainder = &remainder[start..];
-    let end = memchr::memchr3(b'/', b'?', b'#', remainder.as_bytes()).unwrap_or(remainder.len());
+    let end = memchr::memchr3(b'/', b'?', b'#', remainder.as_bytes()).unwrap_or_else(|| remainder.len());
     remainder.split_at(end)
 }
 
@@ -318,7 +318,7 @@ impl<'query> OriginOrUrl<'query> {
     }
 }
 
-const URL_SQL: &'static str = "
+const URL_SQL: &str = "
     SELECT h.url as url,
             :host || :remainder AS strippedURL,
             h.frecency as frecency,
@@ -347,7 +347,7 @@ const URL_SQL: &'static str = "
     ORDER BY h.frecency DESC, h.id DESC
     LIMIT 1
 ";
-const ORIGIN_SQL: &'static str = "
+const ORIGIN_SQL: &str = "
     SELECT IFNULL(:prefix, prefix) || moz_origins.host || '/' AS url,
             moz_origins.host || '/' AS displayURL,
             frecency,

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -128,7 +128,8 @@ pub fn split_after_host_and_port(href: &str) -> (&str, &str) {
         .map(|i| i + 1)
         .unwrap_or(0);
     let remainder = &remainder[start..];
-    let end = memchr::memchr3(b'/', b'?', b'#', remainder.as_bytes()).unwrap_or_else(|| remainder.len());
+    let end =
+        memchr::memchr3(b'/', b'?', b'#', remainder.as_bytes()).unwrap_or_else(|| remainder.len());
     remainder.split_at(end)
 }
 
@@ -579,7 +580,7 @@ mod tests {
 
     #[test]
     fn search() {
-        let mut conn = new_mem_connection();
+        let conn = new_mem_connection();
 
         let url = Url::parse("http://example.com/123").unwrap();
         let visit = VisitObservation::new(url.clone())
@@ -587,7 +588,7 @@ mod tests {
             .with_visit_type(VisitTransition::Typed)
             .with_at(Timestamp::now());
 
-        apply_observation(&mut conn, visit).expect("Should apply visit");
+        apply_observation(&conn, visit).expect("Should apply visit");
 
         let by_origin = search_frecent(
             &conn,
@@ -602,7 +603,7 @@ mod tests {
             .any(|result| result.search_string == "example.com"
                 && result.title == "example.com/"
                 && result.url.as_str() == "http://example.com/"
-                && result.reasons == &[MatchReason::Origin]));
+                && result.reasons == [MatchReason::Origin]));
 
         let by_url_without_path = search_frecent(
             &conn,
@@ -616,7 +617,7 @@ mod tests {
             .iter()
             .any(|result| result.title == "example.com/"
                 && result.url.as_str() == "http://example.com/"
-                && result.reasons == &[MatchReason::Url]));
+                && result.reasons == [MatchReason::Url]));
 
         let by_url_with_path = search_frecent(
             &conn,
@@ -630,7 +631,7 @@ mod tests {
             .iter()
             .any(|result| result.title == "example.com/123"
                 && result.url.as_str() == "http://example.com/123"
-                && result.reasons == &[MatchReason::Url]));
+                && result.reasons == [MatchReason::Url]));
 
         accept_result(
             &conn,
@@ -657,7 +658,7 @@ mod tests {
             .iter()
             .any(|result| result.search_string == "ample"
                 && result.url == url
-                && result.reasons == &[MatchReason::PreviousUse]));
+                && result.reasons == [MatchReason::PreviousUse]));
 
         let with_limit = search_frecent(
             &conn,
@@ -681,7 +682,7 @@ mod tests {
     }
     #[test]
     fn search_unicode() {
-        let mut conn = new_mem_connection();
+        let conn = new_mem_connection();
 
         let url = Url::parse("http://exämple.com/123").unwrap();
         let visit = VisitObservation::new(url.clone())
@@ -689,7 +690,7 @@ mod tests {
             .with_visit_type(VisitTransition::Typed)
             .with_at(Timestamp::now());
 
-        apply_observation(&mut conn, visit).expect("Should apply visit");
+        apply_observation(&conn, visit).expect("Should apply visit");
 
         let by_url_without_path = search_frecent(
             &conn,
@@ -704,7 +705,7 @@ mod tests {
             // Should we consider un-punycoding the title? (firefox desktop doesn't...)
             .any(|result| result.title == "xn--exmple-cua.com/"
                 && result.url.as_str() == "http://xn--exmple-cua.com/"
-                && result.reasons == &[MatchReason::Url]));
+                && result.reasons == [MatchReason::Url]));
 
         let by_url_with_path = search_frecent(
             &conn,
@@ -719,7 +720,7 @@ mod tests {
                 .iter()
                 .any(|result| result.title == "xn--exmple-cua.com/123"
                     && result.url.as_str() == "http://xn--exmple-cua.com/123"
-                    && result.reasons == &[MatchReason::Url]),
+                    && result.reasons == [MatchReason::Url]),
             "{:?}",
             by_url_with_path
         );

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -38,7 +38,7 @@ impl ConnectionType {
 }
 
 impl ConnectionType {
-    pub fn rusqlite_flags(&self) -> OpenFlags {
+    pub fn rusqlite_flags(self) -> OpenFlags {
         let common_flags = OpenFlags::SQLITE_OPEN_NO_MUTEX | OpenFlags::SQLITE_OPEN_URI;
         match self {
             ConnectionType::ReadOnly => common_flags | OpenFlags::SQLITE_OPEN_READ_ONLY,

--- a/components/places/src/db/mod.rs
+++ b/components/places/src/db/mod.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // We don't want 'db.rs' as a sub-module. We could move the contents here? Or something else?
+#[allow(clippy::module_inception)] // FIXME
 pub mod db;
 mod interrupt;
 mod schema;

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -34,9 +34,9 @@ lazy_static::lazy_static! {
 }
 
 // Keys in the moz_meta table.
-pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_COUNT: &'static str = "origin_frecency_count";
-pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM: &'static str = "origin_frecency_sum";
-pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM_OF_SQUARES: &'static str =
+pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_COUNT: &str = "origin_frecency_count";
+pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM: &str = "origin_frecency_sum";
+pub(crate) static MOZ_META_KEY_ORIGIN_FRECENCY_SUM_OF_SQUARES: &str =
     "origin_frecency_sum_of_squares";
 
 fn update_origin_frecency_stats(op: &str) -> String {

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -39,7 +39,7 @@ pub mod error_codes {
     // (if they happen accidentally) will come through as unexpected.
 
     /// `InvalidParent`: Attempt to add a child to a non-folder.
-    pub const INVALID_PLACE_INFO_INVALID_PARENT: i32 = 64 + 0;
+    pub const INVALID_PLACE_INFO_INVALID_PARENT: i32 = 64;
 
     /// `NoItem`: The GUID provided does not exist.
     pub const INVALID_PLACE_INFO_NO_ITEM: i32 = 64 + 1;

--- a/components/places/src/hash.rs
+++ b/components/places/src/hash.rs
@@ -93,7 +93,7 @@ mod tests {
             ("place", 0xf434),
         ];
         for &(prefix, top16bits) in test_values {
-            let expected_lo = (top16bits as u64) << 32;
+            let expected_lo = u64::from(top16bits) << 32;
             let expected_hi = expected_lo | 0xffff_ffffu64;
             assert_eq!(
                 hash_url_prefix(prefix, PrefixMode::Lo),

--- a/components/places/src/hash.rs
+++ b/components/places/src/hash.rs
@@ -15,12 +15,12 @@ const MAX_BYTES_TO_HASH: usize = 1500;
 /// returned hash will be a 32 bit hash.
 pub fn hash_url(spec: &str) -> u64 {
     let max_len_to_hash = spec.len().min(MAX_BYTES_TO_HASH);
-    let str_hash = hash_string(&spec[..max_len_to_hash]) as u64;
+    let str_hash = u64::from(hash_string(&spec[..max_len_to_hash]));
     let str_head = &spec[..spec.len().min(50)];
     // We should be using memchr -- there's almost no chance we aren't
     // already pulling it in transitively and it's supposedly *way* faster.
     if let Some(pos) = str_head.as_bytes().iter().position(|&b| b == b':') {
-        let prefix_hash = (hash_string(&spec[..pos]) & 0x0000_ffff) as u64;
+        let prefix_hash = u64::from(hash_string(&spec[..pos]) & 0x0000_ffff);
         (prefix_hash << 32).wrapping_add(str_hash)
     } else {
         str_hash
@@ -47,8 +47,8 @@ pub fn hash_url_prefix(spec_prefix: &str, mode: PrefixMode) -> u64 {
     let to_hash = &spec_prefix[..spec_prefix.len().min(MAX_BYTES_TO_HASH)];
 
     // Keep 16 bits
-    let unshifted_hash = hash_string(to_hash) & 0x0000ffff;
-    let hash = (unshifted_hash as u64) << 32;
+    let unshifted_hash = hash_string(to_hash) & 0x0000_ffff;
+    let hash = u64::from(unshifted_hash) << 32;
     if mode == PrefixMode::Hi {
         hash.wrapping_add(0xffff_ffffu64)
     } else {
@@ -57,7 +57,7 @@ pub fn hash_url_prefix(spec_prefix: &str, mode: PrefixMode) -> u64 {
 }
 
 // mozilla::kGoldenRatioU32
-const GOLDEN_RATIO: u32 = 0x9E3779B9;
+const GOLDEN_RATIO: u32 = 0x9E37_79B9;
 
 // mozilla::AddU32ToHash
 #[inline]
@@ -71,7 +71,7 @@ pub fn hash_string(string: &str) -> u32 {
     string
         .as_bytes()
         .iter()
-        .fold(0u32, |hash, &cur| add_u32_to_hash(hash, cur as u32))
+        .fold(0u32, |hash, &cur| add_u32_to_hash(hash, u32::from(cur)))
 }
 
 #[cfg(test)]

--- a/components/places/src/history_sync/mod.rs
+++ b/components/places/src/history_sync/mod.rs
@@ -14,7 +14,7 @@ pub mod store;
 const MAX_INCOMING_PLACES: usize = 5000;
 const MAX_OUTGOING_PLACES: usize = 5000;
 const MAX_VISITS: usize = 20;
-pub const HISTORY_TTL: u32 = 5184000; // 60 days in milliseconds
+pub const HISTORY_TTL: u32 = 5_184_000; // 60 days in milliseconds
 
 /// Visit timestamps on the server are *microseconds* since the epoch.
 #[derive(
@@ -40,7 +40,9 @@ impl From<SystemTime> for ServerVisitTimestamp {
     #[inline]
     fn from(st: SystemTime) -> Self {
         let d = st.duration_since(UNIX_EPOCH).unwrap(); // hrmph - unwrap doesn't seem ideal
-        ServerVisitTimestamp((d.as_secs() as u64) * 1_000_000 + ((d.subsec_nanos() as u64) / 1_000))
+        ServerVisitTimestamp(
+            (d.as_secs() as u64) * 1_000_000 + (u64::from(d.subsec_nanos()) / 1_000),
+        )
     }
 }
 

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -300,13 +300,12 @@ mod tests {
         let result: Result<Option<u32>> = conn.try_query_row(
             "SELECT COUNT(*) from moz_places_tombstones;",
             &[],
-            |row| Ok(row.get_checked::<_, u32>(0)?.clone()),
+            |row| Ok(row.get_checked::<_, u32>(0)?),
             true,
         );
         result
             .expect("should have worked")
             .expect("should have got a value")
-            .into()
     }
 
     fn get_sync(conn: &PlacesDb, url: &Url) -> (SyncStatus, u32) {
@@ -326,7 +325,6 @@ mod tests {
         guid_result
             .expect("should have worked")
             .expect("should have got values")
-            .into()
     }
 
     #[test]
@@ -396,14 +394,14 @@ mod tests {
     #[test]
     fn test_plan_dupe_visit_same_guid() -> Result<()> {
         let _ = env_logger::try_init();
-        let mut conn = PlacesDb::open_in_memory(None).expect("no memory db");
+        let conn = PlacesDb::open_in_memory(None).expect("no memory db");
         let now = SystemTime::now();
         let url = Url::parse("https://example.com").expect("is valid");
         // add it locally
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
             .with_at(Some(now.into()));
-        apply_observation(&mut conn, obs).expect("should apply");
+        apply_observation(&conn, obs).expect("should apply");
         // should be New with a change counter.
         assert_eq!(get_sync(&conn, &url), (SyncStatus::New, 1));
 
@@ -433,14 +431,14 @@ mod tests {
     #[test]
     fn test_plan_dupe_visit_different_guid_no_visits() {
         let _ = env_logger::try_init();
-        let mut conn = PlacesDb::open_in_memory(None).expect("no memory db");
+        let conn = PlacesDb::open_in_memory(None).expect("no memory db");
         let now = SystemTime::now();
         let url = Url::parse("https://example.com").expect("is valid");
         // add it locally
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
             .with_at(Some(now.into()));
-        apply_observation(&mut conn, obs).expect("should apply");
+        apply_observation(&conn, obs).expect("should apply");
 
         assert_eq!(get_sync(&conn, &url), (SyncStatus::New, 1));
 
@@ -523,7 +521,7 @@ mod tests {
         // but they are yet to be synced - the local guid should change and
         // all visits should be applied.
         let _ = env_logger::try_init();
-        let mut db = PlacesDb::open_in_memory(None)?;
+        let db = PlacesDb::open_in_memory(None)?;
 
         let guid1 = SyncGuid::new();
         let ts1: Timestamp = (SystemTime::now() - Duration::new(5, 0)).into();
@@ -535,8 +533,8 @@ mod tests {
         let ts_local: Timestamp = (SystemTime::now() - Duration::new(10, 0)).into();
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
-            .with_at(Some(ts_local.into()));
-        apply_observation(&mut db, obs)?;
+            .with_at(Some(ts_local));
+        apply_observation(&db, obs)?;
 
         // 2 incoming records with the same URL.
         let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
@@ -580,7 +578,7 @@ mod tests {
         // and they have been synced - the existing guid should not change,
         // although all visits should still be applied.
         let _ = env_logger::try_init();
-        let mut db = PlacesDb::open_in_memory(None)?;
+        let db = PlacesDb::open_in_memory(None)?;
 
         let guid1 = SyncGuid::new();
         let ts1: Timestamp = (SystemTime::now() - Duration::new(5, 0)).into();
@@ -592,8 +590,8 @@ mod tests {
         let ts_local: Timestamp = (SystemTime::now() - Duration::new(10, 0)).into();
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
-            .with_at(Some(ts_local.into()));
-        apply_observation(&mut db, obs)?;
+            .with_at(Some(ts_local));
+        apply_observation(&db, obs)?;
 
         // 2 incoming records with the same URL.
         let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
@@ -641,7 +639,7 @@ mod tests {
             "histUri": "http://example.com",
             "sortindex": 0,
             "ttl": 100,
-            "visits": [ {"date": 15423493234840000000u64, "type": 1}]
+            "visits": [ {"date": 15_423_493_234_840_000_000u64, "type": 1}]
         });
         let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
         let payload = Payload::from_json(json).unwrap();
@@ -757,13 +755,13 @@ mod tests {
     #[test]
     fn test_apply_plan_outgoing_new() -> Result<()> {
         let _ = env_logger::try_init();
-        let mut db = PlacesDb::open_in_memory(None)?;
+        let db = PlacesDb::open_in_memory(None)?;
         let url = Url::parse("https://example.com")?;
         let now = SystemTime::now();
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
             .with_at(Some(now.into()));
-        apply_observation(&mut db, obs)?;
+        apply_observation(&db, obs)?;
 
         let incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
         let outgoing = apply_plan(&db, incoming, &mut telemetry::EngineIncoming::new())?;
@@ -775,7 +773,7 @@ mod tests {
     #[test]
     fn test_simple_visit_reconciliation() -> Result<()> {
         let _ = env_logger::try_init();
-        let mut db = PlacesDb::open_in_memory(None)?;
+        let db = PlacesDb::open_in_memory(None)?;
         let ts: Timestamp = (SystemTime::now() - Duration::new(5, 0)).into();
         let url = Url::parse("https://example.com")?;
 
@@ -783,7 +781,7 @@ mod tests {
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
             .with_at(Some(ts));
-        apply_observation(&mut db, obs)?;
+        apply_observation(&db, obs)?;
         // Sync status should be "new" and have a change recorded.
         assert_eq!(get_sync(&db, &url), (SyncStatus::New, 1));
 
@@ -817,7 +815,7 @@ mod tests {
     #[test]
     fn test_simple_visit_incoming_and_outgoing() -> Result<()> {
         let _ = env_logger::try_init();
-        let mut db = PlacesDb::open_in_memory(None)?;
+        let db = PlacesDb::open_in_memory(None)?;
         let ts1: Timestamp = (SystemTime::now() - Duration::new(5, 0)).into();
         let ts2: Timestamp = SystemTime::now().into();
         let url = Url::parse("https://example.com")?;
@@ -826,7 +824,7 @@ mod tests {
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
             .with_at(Some(ts1));
-        apply_observation(&mut db, obs)?;
+        apply_observation(&db, obs)?;
 
         let guid = get_existing_guid(&db, &url);
 
@@ -872,12 +870,12 @@ mod tests {
     #[test]
     fn test_incoming_tombstone_local_new() -> Result<()> {
         let _ = env_logger::try_init();
-        let mut db = PlacesDb::open_in_memory(None)?;
+        let db = PlacesDb::open_in_memory(None)?;
         let url = Url::parse("https://example.com")?;
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
             .with_at(Some(SystemTime::now().into()));
-        apply_observation(&mut db, obs)?;
+        apply_observation(&db, obs)?;
         assert_eq!(get_sync(&db, &url), (SyncStatus::New, 1));
 
         let guid = get_existing_guid(&db, &url);
@@ -901,12 +899,12 @@ mod tests {
     #[test]
     fn test_incoming_tombstone_local_normal() -> Result<()> {
         let _ = env_logger::try_init();
-        let mut db = PlacesDb::open_in_memory(None)?;
+        let db = PlacesDb::open_in_memory(None)?;
         let url = Url::parse("https://example.com")?;
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
             .with_at(Some(SystemTime::now().into()));
-        apply_observation(&mut db, obs)?;
+        apply_observation(&db, obs)?;
         let guid = get_existing_guid(&db, &url);
 
         // Set the status to normal
@@ -936,12 +934,12 @@ mod tests {
     #[test]
     fn test_outgoing_tombstone() -> Result<()> {
         let _ = env_logger::try_init();
-        let mut db = PlacesDb::open_in_memory(None)?;
+        let db = PlacesDb::open_in_memory(None)?;
         let url = Url::parse("https://example.com")?;
         let obs = VisitObservation::new(url.clone())
             .with_visit_type(VisitTransition::Link)
             .with_at(Some(SystemTime::now().into()));
-        apply_observation(&mut db, obs)?;
+        apply_observation(&db, obs)?;
         let guid = get_existing_guid(&db, &url);
 
         // Set the status to normal

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -27,7 +27,7 @@ use url::Url;
 // XXX - there's probably a case to be made for this being, say, 5 years ago -
 // then all requests earlier than that are collapsed into a single visit at
 // this timestamp.
-const EARLIEST_TIMESTAMP: Timestamp = Timestamp(727747200000);
+const EARLIEST_TIMESTAMP: Timestamp = Timestamp(727_747_200_000);
 
 /// Clamps a history visit date between the current date and the earliest
 /// sensible date.
@@ -39,7 +39,7 @@ fn clamp_visit_date(visit_date: Timestamp) -> Timestamp {
     if visit_date < EARLIEST_TIMESTAMP {
         return EARLIEST_TIMESTAMP;
     }
-    return visit_date;
+    visit_date
 }
 
 /// This is the action we will take *locally* for each incoming record.
@@ -83,12 +83,12 @@ fn plan_incoming_record(conn: &PlacesDb, record: HistoryRecord, max_visits: usiz
                 return IncomingPlan::Skip;
             }
         }
-        Err(e) => return IncomingPlan::Failed(e.into()),
+        Err(e) => return IncomingPlan::Failed(e),
     }
     // Let's get what we know about it, if anything - last 20, like desktop?
     let visit_tuple = match fetch_visits(conn, &url, max_visits) {
         Ok(v) => v,
-        Err(e) => return IncomingPlan::Failed(e.into()),
+        Err(e) => return IncomingPlan::Failed(e),
     };
 
     // This all seems more messy than it should be - struggling to find the
@@ -115,7 +115,7 @@ fn plan_incoming_record(conn: &PlacesDb, record: HistoryRecord, max_visits: usiz
             Some(t) => t,
             None => continue,
         };
-        let date_use = clamp_visit_date(visit.visit_date.into());
+        let date_use = clamp_visit_date(visit.visit_date);
         cur_visit_map.insert((transition, date_use));
     }
     // If we already have MAX_RECORDS visits, then we will ignore incoming
@@ -154,7 +154,7 @@ fn plan_incoming_record(conn: &PlacesDb, record: HistoryRecord, max_visits: usiz
     // Now we need to check the other attributes.
     // Check if we should update title? For now, assume yes. It appears
     // as though desktop always updates it.
-    if guid_changed || to_apply.len() != 0 {
+    if guid_changed || !to_apply.is_empty() {
         let new_title = Some(record.title);
         IncomingPlan::Apply {
             url: url.clone(),

--- a/components/places/src/history_sync/store.rs
+++ b/components/places/src/history_sync/store.rs
@@ -21,8 +21,8 @@ use sync15::{
 use super::plan::{apply_plan, finish_plan};
 use super::MAX_INCOMING_PLACES;
 
-static LAST_SYNC_META_KEY: &'static str = "history_last_sync_time";
-static GLOBAL_STATE_META_KEY: &'static str = "history_global_state";
+const LAST_SYNC_META_KEY: &str = "history_last_sync_time";
+const GLOBAL_STATE_META_KEY: &str = "history_global_state";
 
 // A HistoryStore is short-lived and constructed each sync by something which
 // owns the connection and ClientInfo.
@@ -112,7 +112,7 @@ impl<'a> HistoryStore<'a> {
         );
         self.set_global_state(global_state.replace(None))?;
         let failures = result?;
-        if failures.len() == 0 {
+        if failures.is_empty() {
             Ok(())
         } else {
             assert_eq!(failures.len(), 1);
@@ -149,7 +149,8 @@ impl<'a> Store for HistoryStore<'a> {
         new_timestamp: ServerTimestamp,
         records_synced: &[String],
     ) -> result::Result<(), failure::Error> {
-        Ok(self.do_sync_finished(new_timestamp, records_synced)?)
+        self.do_sync_finished(new_timestamp, records_synced)?;
+        Ok(())
     }
 
     fn get_collection_request(&self) -> result::Result<CollectionRequest, failure::Error> {

--- a/components/places/src/lib.rs
+++ b/components/places/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 pub mod api;
 pub mod error;
 pub mod types;

--- a/components/places/src/match_impl.rs
+++ b/components/places/src/match_impl.rs
@@ -59,7 +59,7 @@ impl ToSql for MatchBehavior {
 bitflags! {
     pub struct SearchBehavior: u32 {
         /// Search through history.
-        const HISTORY = 1 << 0;
+        const HISTORY = 1;
 
         /// Search through bookmarks.
         const BOOKMARK = 1 << 1;
@@ -257,7 +257,10 @@ fn next_codepoint_lower(s: &str) -> (char, usize) {
     // this should be more efficient than this implementation is)
     let mut indices = s.char_indices();
     let (_, next_char) = indices.next().unwrap();
-    let next_index = indices.next().map(|(index, _)| index).unwrap_or(s.len());
+    let next_index = indices
+        .next()
+        .map(|(index, _)| index)
+        .unwrap_or_else(|| s.len());
     (char_to_lower_single(next_char), next_index)
 }
 
@@ -300,7 +303,7 @@ pub fn find_in_string(token: &str, src: &str, only_boundary: bool) -> bool {
         }
         cur_offset += next_offset_in_cur;
     }
-    return false;
+    false
 }
 
 // Places splits on ascii whitespace, so we do too. str::split_ascii_whitespace is

--- a/components/places/src/match_impl.rs
+++ b/components/places/src/match_impl.rs
@@ -479,40 +479,34 @@ mod test {
         //
         // It also checks that U+0130 is the only single codepoint that lower cases
         // to multiple characters.
-        for c in 128..0x110000 {
-            match char::from_u32(c) {
-                Some(ch) => {
-                    // Not quite the same (because codepoints aren't characters), but
-                    // should serve the same purpose.
-                    let mut li = ch.to_lowercase();
-                    let lc = li.next().unwrap();
-                    if c != 304 && c != 8490 {
-                        assert!(
-                            (lc as u32) >= 128,
-                            "Lower case of non-ascii '{}' ({}) was unexpectedly ascii",
-                            ch,
-                            c
-                        );
-                        // This one we added (it's an implicit assumption in the utilities the
-                        // places code uses).
-                        assert!(
-                            li.next().is_none(),
-                            "Lower case of '{}' ({}) produced multiple codepoints unexpectedly",
-                            ch,
-                            c
-                        );
-                    } else {
-                        assert!(
-                            (lc as u32) < 128,
-                            "Lower case of non-ascii '{}' ({}) was unexpectedly not ascii",
-                            ch,
-                            c
-                        );
-                    }
-                }
-                _ => {
-                    // We're being overly broad with what `c` iterates over to keep this fairly
-                    // simple.
+        for c in 128..0x11_0000 {
+            if let Some(ch) = char::from_u32(c) {
+                // Not quite the same (because codepoints aren't characters), but
+                // should serve the same purpose.
+                let mut li = ch.to_lowercase();
+                let lc = li.next().unwrap();
+                if c != 304 && c != 8490 {
+                    assert!(
+                        (lc as u32) >= 128,
+                        "Lower case of non-ascii '{}' ({}) was unexpectedly ascii",
+                        ch,
+                        c
+                    );
+                    // This one we added (it's an implicit assumption in the utilities the
+                    // places code uses).
+                    assert!(
+                        li.next().is_none(),
+                        "Lower case of '{}' ({}) produced multiple codepoints unexpectedly",
+                        ch,
+                        c
+                    );
+                } else {
+                    assert!(
+                        (lc as u32) < 128,
+                        "Lower case of non-ascii '{}' ({}) was unexpectedly not ascii",
+                        ch,
+                        c
+                    );
                 }
             }
         }
@@ -530,7 +524,7 @@ mod test {
             );
         }
 
-        for c in (b'a'..=b'z').into_iter().chain(b'A'..=b'Z') {
+        for c in (b'a'..=b'z').chain(b'A'..=b'Z') {
             assert_eq!(
                 dubious_to_ascii_lower(c),
                 c.to_ascii_lowercase(),

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -1920,7 +1920,6 @@ mod tests {
                 })
                 .expect("should work")
                 .map(|v| v.unwrap())
-                .into_iter()
                 .collect();
 
             assert_eq!(
@@ -1943,7 +1942,6 @@ mod tests {
                 })
                 .expect("should work")
                 .map(|v| v.unwrap())
-                .into_iter()
                 .collect();
 
             assert_eq!(

--- a/components/places/src/storage/bookmarks/conversions.rs
+++ b/components/places/src/storage/bookmarks/conversions.rs
@@ -152,7 +152,7 @@ impl msg_types::BookmarkNode {
         let value = self.node_type.unwrap();
         // Check that the cast wouldn't truncate first.
         assert!(
-            value >= 0 && value <= std::u8::MAX as i32,
+            value >= 0 && value <= i32::from(std::u8::MAX),
             "wildly illegal node_type: {}",
             value
         );
@@ -245,7 +245,7 @@ impl BookmarkUpdateInfo {
             (None, None) => UpdateTreeLocation::None,
             (None, Some(pos)) => UpdateTreeLocation::Position(BookmarkPosition::Specific(pos)),
             (Some(parent_guid), pos) => UpdateTreeLocation::Parent(
-                SyncGuid::from(parent_guid),
+                parent_guid,
                 pos.map_or(BookmarkPosition::Append, BookmarkPosition::Specific),
             ),
         };

--- a/components/places/src/storage/bookmarks/root_guid.rs
+++ b/components/places/src/storage/bookmarks/root_guid.rs
@@ -61,15 +61,15 @@ impl BookmarkRootGuid {
         self.guid().clone()
     }
 
-    pub fn from_str(guid: &str) -> Option<Self> {
+    pub fn well_known(guid: &str) -> Option<Self> {
         GUIDS
             .iter()
-            .find(|(_, sync_guid)| &sync_guid.0 == guid)
+            .find(|(_, sync_guid)| sync_guid.0 == guid)
             .map(|(root, _)| *root)
     }
 
     pub fn from_guid(guid: &SyncGuid) -> Option<Self> {
-        Self::from_str(&guid.0)
+        Self::well_known(&guid.0)
     }
 }
 
@@ -82,26 +82,26 @@ impl From<BookmarkRootGuid> for SyncGuid {
 // Allow comparisons between BookmarkRootGuid and SyncGuids
 impl PartialEq<BookmarkRootGuid> for SyncGuid {
     fn eq(&self, other: &BookmarkRootGuid) -> bool {
-        &self.0 == other.as_str()
+        self.0 == other.as_str()
     }
 }
 
 impl PartialEq<SyncGuid> for BookmarkRootGuid {
     fn eq(&self, other: &SyncGuid) -> bool {
-        &other.0 == self.as_str()
+        other.0 == self.as_str()
     }
 }
 
 // Even if we have a reference to &SyncGuid
 impl<'a> PartialEq<BookmarkRootGuid> for &'a SyncGuid {
     fn eq(&self, other: &BookmarkRootGuid) -> bool {
-        &self.0 == other.as_str()
+        self.0 == other.as_str()
     }
 }
 
 impl<'a> PartialEq<&'a SyncGuid> for BookmarkRootGuid {
     fn eq(&self, other: &&'a SyncGuid) -> bool {
-        &other.0 == self.as_str()
+        other.0 == self.as_str()
     }
 }
 

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -54,7 +54,7 @@ impl ToSql for RowId {
 
 impl FromSql for RowId {
     fn column_result(value: ValueRef) -> FromSqlResult<Self> {
-        value.as_i64().map(|v| RowId(v))
+        value.as_i64().map(RowId)
     }
 }
 

--- a/components/places/src/storage/tags.rs
+++ b/components/places/src/storage/tags.rs
@@ -14,7 +14,7 @@ use url::Url;
 pub fn validate_tag(t: &str) -> Result<&str> {
     // Drop empty and oversized tags.
     let t = t.trim();
-    if t.len() == 0 || t.len() > TAG_LENGTH_MAX || t.find(|c: char| c.is_whitespace()).is_some() {
+    if t.is_empty() || t.len() > TAG_LENGTH_MAX || t.find(|c: char| c.is_whitespace()).is_some() {
         Err(InvalidPlaceInfo::InvalidTag.into())
     } else {
         Ok(t)

--- a/components/push/communications/src/lib.rs
+++ b/components/push/communications/src/lib.rs
@@ -246,7 +246,7 @@ impl Connection for ConnectHttp {
             )
             .send()
         {
-            Ok(_) => return Ok(true),
+            Ok(_) => Ok(true),
             Err(e) => {
                 Err(CommunicationServerError(format!("Could not unsubscribe: {:?}", e)).into())
             }
@@ -412,11 +412,11 @@ mod test {
 
     // use crypto::{get_bytes, Key};
 
-    const DUMMY_CHID: &'static str = "deadbeef00000000decafbad00000000";
-    const DUMMY_UAID: &'static str = "abad1dea00000000aabbccdd00000000";
+    const DUMMY_CHID: &str = "deadbeef00000000decafbad00000000";
+    const DUMMY_UAID: &str = "abad1dea00000000aabbccdd00000000";
     // Local test SENDER_ID ("test*" reserved for Kotlin testing.)
-    const SENDER_ID: &'static str = "FakeSenderID";
-    const SECRET: &'static str = "SuP3rS1kRet";
+    const SENDER_ID: &str = "FakeSenderID";
+    const SECRET: &str = "SuP3rS1kRet";
 
     #[test]
     fn test_communications() {

--- a/components/push/communications/src/lib.rs
+++ b/components/push/communications/src/lib.rs
@@ -6,6 +6,8 @@
  * In the future, it could be using gRPC and QUIC, or quantum relay.
  */
 
+#![allow(unknown_lints)]
+
 extern crate config;
 extern crate http;
 extern crate reqwest;
@@ -448,7 +450,7 @@ mod test {
             .with_body(body)
             .create();
             let mut conn = connect(config.clone()).unwrap();
-            let channel_id = String::from(hex::encode(crypto::get_bytes(16).unwrap()));
+            let channel_id = hex::encode(crypto::get_bytes(16).unwrap());
             let response = conn.subscribe(&channel_id).unwrap();
             ap_mock.assert();
             assert_eq!(response.uaid, DUMMY_UAID);

--- a/components/push/config/src/lib.rs
+++ b/components/push/config/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints)]
+
 #[derive(Clone, Debug)]
 pub struct PushConfiguration {
     // host name:port

--- a/components/push/crypto/src/lib.rs
+++ b/components/push/crypto/src/lib.rs
@@ -137,7 +137,7 @@ impl Key {
             }
         };
         Ok(Key {
-            private: private,
+            private,
             public: pubkey,
             auth: auth.to_vec(),
         })
@@ -206,7 +206,7 @@ fn extract_value(string: Option<&str>, target: &str) -> Option<Vec<u8>> {
             }
         }
     }
-    return None;
+    None
 }
 
 impl Cryptography for Crypto {

--- a/components/push/crypto/src/lib.rs
+++ b/components/push/crypto/src/lib.rs
@@ -8,6 +8,7 @@
  * This uses prime256v1 EC encryption that should come from internal crypto calls. The "application-services"
  * module compiles openssl, however, so might be enough to tie into that.
  */
+#![allow(unknown_lints)]
 use base64;
 use log::{debug, error};
 use std::clone;

--- a/components/push/delivery_mgr/src/lib.rs
+++ b/components/push/delivery_mgr/src/lib.rs
@@ -5,7 +5,7 @@
  * While this leans havily on data in Storage, the functions are separated out so that
  * Storage is only focused on actual data storage and retrieval.
  */
-
+#![allow(unknown_lints)]
 extern crate storage;
 
 use storage::Storage;

--- a/components/push/error/src/lib.rs
+++ b/components/push/error/src/lib.rs
@@ -12,7 +12,7 @@ use ffi_support;
 use lazy_static;
 
 lazy_static::lazy_static! {
-    pub static ref ERROR_CODE: ffi_support::ErrorCode = ffi_support::ErrorCode::new(-8675309);
+    pub static ref ERROR_CODE: ffi_support::ErrorCode = ffi_support::ErrorCode::new(-867_5309);
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/components/push/error/src/lib.rs
+++ b/components/push/error/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 use std::fmt;
 use std::result;
 

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 use ffi_support::{
     define_bytebuffer_destructor, define_handle_map_deleter, define_string_destructor,
     ConcurrentHandleMap, ExternError, FfiStr,

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -103,7 +103,7 @@ pub extern "C" fn push_subscribe(
                                                 base64::URL_SAFE_NO_PAD)
             }
         });
-        return Ok(subscription_info.to_string());
+        Ok(subscription_info.to_string())
     })
 }
 
@@ -139,7 +139,7 @@ pub extern "C" fn push_verify_connection(handle: u64, error: &mut ExternError) -
     log::debug!("push_verify");
     MANAGER.call_with_result_mut(error, handle, |mgr| -> Result<_> {
         if let Ok(r) = mgr.verify_connection() {
-            if r == false {
+            if !r {
                 if let Ok(new_endpoints) = mgr.regenerate_endpoints() {
                     // use a `match` here to resolve return of <_>
                     return serde_json::to_string(&new_endpoints).map_err(|e| {

--- a/components/push/notifier/src/lib.rs
+++ b/components/push/notifier/src/lib.rs
@@ -4,6 +4,7 @@
  *
  * Called from the Connection Manager.
  */
+#![allow(unknown_lints)]
 extern crate storage;
 
 pub struct NotifierError;

--- a/components/push/src/lib.rs
+++ b/components/push/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints)]
 pub use communications;
 pub use config;
 pub use crypto;

--- a/components/push/storage/src/db.rs
+++ b/components/push/storage/src/db.rs
@@ -57,7 +57,7 @@ impl Deref for PushDb {
 
 impl ConnExt for PushDb {
     fn conn(&self) -> &Connection {
-        *&self
+        &self.db
     }
 }
 
@@ -172,7 +172,7 @@ mod test {
     use super::PushDb;
     use crate::{db::Storage, record::PushRecord};
 
-    const DUMMY_UAID: &'static str = "abad1dea00000000aabbccdd00000000";
+    const DUMMY_UAID: &str = "abad1dea00000000aabbccdd00000000";
 
     fn prec() -> PushRecord {
         PushRecord::new(

--- a/components/push/storage/src/lib.rs
+++ b/components/push/storage/src/lib.rs
@@ -5,6 +5,7 @@
  * Handle Push data storage
  */
 
+#![allow(unknown_lints)]
 mod db;
 mod record;
 mod schema;

--- a/components/push/storage/src/schema.rs
+++ b/components/push/storage/src/schema.rs
@@ -5,9 +5,9 @@ use push_errors::Result;
 
 const VERSION: i64 = 1;
 
-const CREATE_TABLE_PUSH_SQL: &'static str = include_str!("schema.sql");
+const CREATE_TABLE_PUSH_SQL: &str = include_str!("schema.sql");
 
-pub const COMMON_COLS: &'static str = "
+pub const COMMON_COLS: &str = "
     uaid,
     channel_id,
     endpoint,

--- a/components/push/storage/src/types.rs
+++ b/components/push/storage/src/types.rs
@@ -27,7 +27,7 @@ impl From<Timestamp> for u64 {
 impl From<SystemTime> for Timestamp {
     fn from(st: SystemTime) -> Self {
         let d = st.duration_since(UNIX_EPOCH).unwrap_or_default();
-        Timestamp((d.as_secs() as u64) * 1000 + ((d.subsec_nanos() as u64) / 1_000_000))
+        Timestamp((d.as_secs() as u64) * 1000 + (u64::from(d.subsec_nanos()) / 1_000_000))
     }
 }
 

--- a/components/push/subscriber/src/lib.rs
+++ b/components/push/subscriber/src/lib.rs
@@ -155,11 +155,11 @@ mod test {
     // use crypto::{get_bytes, Key};
 
     /*
-    const DUMMY_CHID: &'static str = "deadbeef00000000decafbad00000000";
-    const DUMMY_UAID: &'static str = "abad1dea00000000aabbccdd00000000";
+    const DUMMY_CHID: &str = "deadbeef00000000decafbad00000000";
+    const DUMMY_UAID: &str = "abad1dea00000000aabbccdd00000000";
     // Local test SENDER_ID
-    const SENDER_ID: &'static str = "308358850242";
-    const SECRET: &'static str = "SuP3rS1kRet";
+    const SENDER_ID: &str = "308358850242";
+    const SECRET: &str = "SuP3rS1kRet";
     */
 
     #[test]

--- a/components/push/subscriber/src/lib.rs
+++ b/components/push/subscriber/src/lib.rs
@@ -2,6 +2,8 @@
  * "priviledged" system calls may require additional handling and should be flagged as such.
  */
 
+#![allow(unknown_lints)]
+
 extern crate serde_json;
 
 extern crate communications;

--- a/components/rc_log/src/android.rs
+++ b/components/rc_log/src/android.rs
@@ -129,6 +129,7 @@ impl log::Log for LogSink {
 }
 
 impl LogAdapterState {
+    #[allow(clippy::mutex_atomic)]
     pub fn init(callback: LogCallback) -> Self {
         // This uses a mutex (instead of an atomic bool) to avoid a race condition
         // where `stopped` gets set by another thread between when we read it and

--- a/components/rc_log/src/lib.rs
+++ b/components/rc_log/src/lib.rs
@@ -14,6 +14,7 @@
 //! it does not allow users to change loggers after the first initialization. We
 //! work around this using our `settable_log` module.
 
+#![allow(unknown_lints)]
 // We always include both modules when doing test builds, so for test builds,
 // allow dead code.
 #![cfg_attr(test, allow(dead_code))]

--- a/components/support/cli/src/fxa_creds.rs
+++ b/components/support/cli/src/fxa_creds.rs
@@ -45,7 +45,7 @@ fn create_fxa_creds(path: &str, cfg: Config) -> Result<FirefoxAccount> {
     let mut acct = FirefoxAccount::with_config(cfg);
     let oauth_uri = acct.begin_oauth_flow(&[SYNC_SCOPE], true)?;
 
-    if let Err(_) = webbrowser::open(&oauth_uri.as_ref()) {
+    if webbrowser::open(&oauth_uri.as_ref()).is_err() {
         log::warn!("Failed to open a web browser D:");
         println!("Please visit this URL, sign in, and then copy-paste the final URL below.");
         println!("\n    {}\n", oauth_uri);
@@ -53,7 +53,7 @@ fn create_fxa_creds(path: &str, cfg: Config) -> Result<FirefoxAccount> {
         println!("Please paste the final URL below:\n");
     }
 
-    let final_url = url::Url::parse(&prompt_string("Final URL").unwrap_or(String::new()))?;
+    let final_url = url::Url::parse(&prompt_string("Final URL").unwrap_or_default())?;
     let query_params = final_url
         .query_pairs()
         .into_owned()
@@ -81,8 +81,8 @@ pub fn get_cli_fxa(config: Config, cred_file: &str) -> Result<CliFxa> {
     // `scope` could be a param, but I can't see it changing.
     let token_info: AccessTokenInfo = match acct.get_access_token(SYNC_SCOPE) {
         Ok(t) => t,
-        Err(_) => {
-            panic!("No creds - run some other tool to set them up.");
+        Err(e) => {
+            panic!("No creds - run some other tool to set them up. {}", e);
         }
     };
     let key = token_info.key.unwrap();

--- a/components/support/cli/src/lib.rs
+++ b/components/support/cli/src/lib.rs
@@ -2,5 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 pub mod fxa_creds;
 pub mod prompt;

--- a/components/support/cli/src/prompt.rs
+++ b/components/support/cli/src/prompt.rs
@@ -16,7 +16,7 @@ pub fn prompt_string<S: AsRef<str>>(prompt: S) -> Option<String> {
     if let Some('\r') = s.chars().next_back() {
         s.pop();
     }
-    if s.len() == 0 {
+    if s.is_empty() {
         None
     } else {
         Some(s)

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffi-support"
 edition = "2018"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 description = "A crate to help expose Rust functions over the FFI."
 repository = "https://github.com/mozilla/application-services"

--- a/components/support/ffi/src/error.rs
+++ b/components/support/ffi/src/error.rs
@@ -256,7 +256,7 @@ impl ErrorCode {
 
     /// Returns whether or not this is a success code.
     #[inline]
-    pub fn is_success(&self) -> bool {
+    pub fn is_success(self) -> bool {
         self.code() == 0
     }
 }

--- a/components/support/ffi/src/handle_map.rs
+++ b/components/support/ffi/src/handle_map.rs
@@ -241,6 +241,12 @@ impl<T> HandleMap<T> {
         self.num_entries
     }
 
+    /// Returns true if the HandleMap is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Returns the number of slots allocated in the handle map.
     #[inline]
     pub fn capacity(&self) -> usize {
@@ -342,10 +348,10 @@ impl<T> HandleMap<T> {
             free_indices[ni].1 = true;
 
             match &self.entries[ni].state {
-                &EntryState::InFreeList(ref next_index) => next = *next_index,
-                &EntryState::EndOfFreeList => break,
+                EntryState::InFreeList(next_index) => next = *next_index,
+                EntryState::EndOfFreeList => break,
                 // Hitting `Active` here is probably not possible because of the checks above, but who knows.
-                &EntryState::Active(..) => panic!("Bug: Active item in free list at {}", next),
+                EntryState::Active(..) => unreachable!("Bug: Active item in free list at {}", next),
             }
         }
         let mut occupied_count = 0;
@@ -565,12 +571,12 @@ impl Handle {
     /// Most uses of this will be automatic due to our [`IntoFfi`] implementation.
     #[inline]
     pub fn into_u64(self) -> u64 {
-        let map_id = self.map_id as u64;
-        let version = self.version as u64;
-        let index = self.index as u64;
+        let map_id = u64::from(self.map_id);
+        let version = u64::from(self.version);
+        let index = u64::from(self.index);
         // SOMEDAY: we could also use this as a sort of CRC if we were really paranoid.
         // e.g. `magic = combine_to_u16(map_id, version, index)`.
-        let magic = HANDLE_MAGIC as u64;
+        let magic = u64::from(HANDLE_MAGIC);
         (magic << 48) | (map_id << 32) | (index << 16) | version
     }
 
@@ -603,7 +609,7 @@ impl Handle {
     /// encoded [`Handle`].
     #[inline]
     pub fn is_valid(v: u64) -> bool {
-        (v >> 48) == (HANDLE_MAGIC as u64) &&
+        (v >> 48) == u64::from(HANDLE_MAGIC) &&
         // The "bottom" field is the version. We increment it both when
         // inserting and removing, and they're all initially 1. So, all valid
         // handles that we returned should have an even version.
@@ -978,6 +984,13 @@ impl<T> ConcurrentHandleMap<T> {
     }
 }
 
+impl<T> Default for ConcurrentHandleMap<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Returns the next map_id.
 fn next_handle_map_id() -> u16 {
     let id = HANDLE_MAP_ID_COUNTER
@@ -1014,12 +1027,12 @@ mod test {
         assert_eq!(Handle::from_u64(0), Err(HandleError::NullHandle));
         // Valid except `version` is odd
         assert_eq!(
-            Handle::from_u64(((HANDLE_MAGIC as u64) << 48) | 0x1234_0012_0001),
+            Handle::from_u64((u64::from(HANDLE_MAGIC) << 48) | 0x1234_0012_0001),
             Err(HandleError::InvalidHandle)
         );
 
         assert_eq!(
-            Handle::from_u64(((HANDLE_MAGIC as u64) << 48) | 0x1234_0012_0002),
+            Handle::from_u64((u64::from(HANDLE_MAGIC) << 48) | 0x1234_0012_0002),
             Ok(Handle {
                 version: 0x0002,
                 index: 0x0012,

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -160,7 +160,7 @@ pub use crate::handle_map::{ConcurrentHandleMap, Handle, HandleError, HandleMap}
 ///     // to avoid a case where a panic occurs.
 ///     ffi_support::call_with_result(error, || {
 ///         let s = thing_to_print.as_str();
-///         if s.len() == 0 {
+///         if s.is_empty() {
 ///             // This is a silly example!
 ///             return Err(BadEmptyString);
 ///         }

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![deny(missing_docs)]
+#![allow(unknown_lints)]
 
 //! # FFI Support
 //!

--- a/components/support/sql/src/lib.rs
+++ b/components/support/sql/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 mod conn_ext;
 mod each_chunk;
 mod maybe_cached;

--- a/components/support/sql/src/query_plan.rs
+++ b/components/support/sql/src/query_plan.rs
@@ -40,7 +40,7 @@ impl QueryPlan {
     }
 
     pub fn print_pretty_tree(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        if self.plan.len() == 0 {
+        if self.plan.is_empty() {
             return writeln!(f, "<no query plan>");
         }
         writeln!(f, "QUERY PLAN")?;

--- a/components/support/sql/src/repeat.rs
+++ b/components/support/sql/src/repeat.rs
@@ -44,7 +44,7 @@ where
 ///            "(0,?),(1,?),(2,?)");
 /// ```
 #[inline]
-pub fn repeat_display<'a, F>(count: usize, sep: &'a str, fmt_one: F) -> RepeatDisplay<'a, F>
+pub fn repeat_display<F>(count: usize, sep: &str, fmt_one: F) -> RepeatDisplay<F>
 where
     F: Fn(usize, &mut fmt::Formatter) -> fmt::Result,
 {

--- a/components/sync15/src/bso_record.rs
+++ b/components/sync15/src/bso_record.rs
@@ -70,7 +70,7 @@ impl<T> BsoRecord<T> {
     pub fn new_record(id: String, coll: String, payload: T) -> BsoRecord<T> {
         BsoRecord {
             id,
-            collection: coll.into(),
+            collection: coll,
             ttl: None,
             sortindex: None,
             modified: ServerTimestamp::default(),
@@ -178,9 +178,9 @@ pub struct Payload {
     pub data: Map<String, JsonValue>,
 }
 
-// `#[serde(skip_if)]` only allows a function (not an expression).
-// Is there a builtin way to do this?
+// TODO: Move skip_if_default from places to something shared
 #[inline]
+#[allow(clippy::trivially_copy_pass_by_ref)]
 fn is_false(b: &bool) -> bool {
     !*b
 }
@@ -307,7 +307,7 @@ impl From<Payload> for JsonValue {
             id,
             deleted,
         } = cleartext;
-        data.insert("id".to_string(), JsonValue::String(id.into()));
+        data.insert("id".to_string(), JsonValue::String(id));
         if deleted {
             data.insert("deleted".to_string(), JsonValue::Bool(true));
         }

--- a/components/sync15/src/bso_record.rs
+++ b/components/sync15/src/bso_record.rs
@@ -447,7 +447,7 @@ mod tests {
         let record: BsoRecord<EncryptedPayload> = serde_json::from_str(serialized).unwrap();
         assert_eq!(&record.id, "1234");
         assert_eq!(&record.collection, "passwords");
-        assert_eq!(record.modified.0, 12344321.0);
+        assert!((record.modified.0 - 1234_4321.0).abs() < std::f64::EPSILON);
         assert_eq!(record.sortindex, None);
         assert_eq!(&record.payload.iv, "aaaaa");
         assert_eq!(&record.payload.hmac, "bbbbb");

--- a/components/sync15/src/key_bundle.rs
+++ b/components/sync15/src/key_bundle.rs
@@ -58,7 +58,7 @@ impl KeyBundle {
     pub fn from_base64(enc: &str, mac: &str) -> Result<KeyBundle> {
         let enc_bytes = base64::decode(&enc)?;
         let mac_bytes = base64::decode(&mac)?;
-        KeyBundle::new(enc_bytes.into(), mac_bytes.into())
+        KeyBundle::new(enc_bytes, mac_bytes)
     }
 
     #[inline]
@@ -117,7 +117,7 @@ impl KeyBundle {
         // robust and avoids an allocation.
         let mut decoded_hmac = [0u8; 32];
 
-        if let Err(_) = base16::decode_slice(expected_hmac, &mut decoded_hmac) {
+        if base16::decode_slice(expected_hmac, &mut decoded_hmac).is_err() {
             log::warn!("Garbage HMAC verification string: contained non base16 characters");
             return Ok(false);
         }
@@ -171,13 +171,12 @@ impl KeyBundle {
 mod test {
     use super::*;
 
-    static HMAC_B16: &'static str =
-        "b1e6c18ac30deb70236bc0d65a46f7a4dce3b8b0e02cf92182b914e3afa5eebc";
-    static IV_B64: &'static str = "GX8L37AAb2FZJMzIoXlX8w==";
-    static HMAC_KEY_B64: &'static str = "MMntEfutgLTc8FlTLQFms8/xMPmCldqPlq/QQXEjx70=";
-    static ENC_KEY_B64: &'static str = "9K/wLdXdw+nrTtXo4ZpECyHFNr4d7aYHqeg3KW9+m6Q=";
+    const HMAC_B16: &str = "b1e6c18ac30deb70236bc0d65a46f7a4dce3b8b0e02cf92182b914e3afa5eebc";
+    const IV_B64: &str = "GX8L37AAb2FZJMzIoXlX8w==";
+    const HMAC_KEY_B64: &str = "MMntEfutgLTc8FlTLQFms8/xMPmCldqPlq/QQXEjx70=";
+    const ENC_KEY_B64: &str = "9K/wLdXdw+nrTtXo4ZpECyHFNr4d7aYHqeg3KW9+m6Q=";
 
-    static CIPHERTEXT_B64_PIECES: &'static [&'static str] = &[
+    const CIPHERTEXT_B64_PIECES: &[&str] = &[
         "NMsdnRulLwQsVcwxKW9XwaUe7ouJk5Wn80QhbD80l0HEcZGCynh45qIbeYBik0lgcHbK",
         "mlIxTJNwU+OeqipN+/j7MqhjKOGIlvbpiPQQLC6/ffF2vbzL0nzMUuSyvaQzyGGkSYM2",
         "xUFt06aNivoQTvU2GgGmUK6MvadoY38hhW2LCMkoZcNfgCqJ26lO1O0sEO6zHsk3IVz6",
@@ -187,7 +186,7 @@ mod test {
         "jOoRSLx7GG86wT59QZw=",
     ];
 
-    static CLEARTEXT_B64_PIECES: &'static [&'static str] = &[
+    const CLEARTEXT_B64_PIECES: &[&str] = &[
         "eyJpZCI6IjVxUnNnWFdSSlpYciIsImhpc3RVcmkiOiJmaWxlOi8vL1VzZXJzL2phc29u",
         "L0xpYnJhcnkvQXBwbGljYXRpb24lMjBTdXBwb3J0L0ZpcmVmb3gvUHJvZmlsZXMva3Nn",
         "ZDd3cGsuTG9jYWxTeW5jU2VydmVyL3dlYXZlL2xvZ3MvIiwidGl0bGUiOiJJbmRleCBv",

--- a/components/sync15/src/lib.rs
+++ b/components/sync15/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 mod bso_record;
 mod changeset;
 mod client;

--- a/components/sync15/src/request.rs
+++ b/components/sync15/src/request.rs
@@ -29,9 +29,9 @@ impl fmt::Display for RequestOrder {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            &RequestOrder::Oldest => f.write_str("oldest"),
-            &RequestOrder::Newest => f.write_str("newest"),
-            &RequestOrder::Index => f.write_str("index"),
+            RequestOrder::Oldest => f.write_str("oldest"),
+            RequestOrder::Newest => f.write_str("newest"),
+            RequestOrder::Index => f.write_str("index"),
         }
     }
 }
@@ -126,10 +126,10 @@ impl CollectionRequest {
         if self.limit > 0 {
             pairs.append_pair("limit", &format!("{}", self.limit));
         }
-        if let &Some(ref ids) = &self.ids {
+        if let Some(ids) = &self.ids {
             pairs.append_pair("ids", &ids.join(","));
         }
-        if let &Some(ref batch) = &self.batch {
+        if let Some(batch) = &self.batch {
             pairs.append_pair("batch", &batch);
         }
         if self.commit {
@@ -192,7 +192,7 @@ impl LimitTracker {
     pub fn can_add_record(&self, payload_size: usize) -> bool {
         // Desktop does the cur_bytes check as exclusive, but we shouldn't see any servers that
         // don't have https://github.com/mozilla-services/server-syncstorage/issues/73
-        self.cur_records + 1 <= self.max_records && self.cur_bytes + payload_size <= self.max_bytes
+        self.cur_records < self.max_records && self.cur_bytes + payload_size <= self.max_bytes
     }
 
     pub fn can_never_add(&self, record_size: usize) -> bool {
@@ -392,7 +392,7 @@ impl PostResponseHandler for NormalResponseHandler {
                 .into());
             }
         }
-        if r.result.failed.len() > 0 && !self.allow_failed {
+        if !r.result.failed.is_empty() && !self.allow_failed {
             return Err(ErrorKind::RecordUploadFailed.into());
         }
         for id in r.result.success.iter() {
@@ -436,7 +436,7 @@ where
     #[inline]
     fn in_batch(&self) -> bool {
         match &self.batch {
-            &BatchState::Unsupported | &BatchState::NoBatch => false,
+            BatchState::Unsupported | BatchState::NoBatch => false,
             _ => true,
         }
     }
@@ -520,7 +520,7 @@ where
     }
 
     pub fn flush(&mut self, want_commit: bool) -> Result<()> {
-        if self.queued.len() == 0 {
+        if self.queued.is_empty() {
             assert!(
                 !self.in_batch(),
                 "Bug: Somehow we're in a batch but have no queued records"
@@ -532,11 +532,11 @@ where
         self.queued.push(b']');
         let batch_id = match &self.batch {
             // Not the first post and we know we have no batch semantics.
-            &BatchState::Unsupported => None,
+            BatchState::Unsupported => None,
             // First commit in possible batch
-            &BatchState::NoBatch => Some("true".into()),
+            BatchState::NoBatch => Some("true".into()),
             // In a batch and we have a batch id.
-            &BatchState::InBatch(ref s) => Some(s.clone()),
+            BatchState::InBatch(ref s) => Some(s.clone()),
         };
 
         log::info!(
@@ -545,7 +545,7 @@ where
             self.queued.len()
         );
 
-        let is_commit = want_commit && !batch_id.is_none();
+        let is_commit = want_commit && batch_id.is_some();
         // Weird syntax for calling a function object that is a property.
         let resp_or_error =
             self.poster
@@ -607,11 +607,11 @@ where
             .clone();
 
         match &self.batch {
-            &BatchState::Unsupported => {
+            BatchState::Unsupported => {
                 log::warn!("Server changed it's mind about supporting batching mid-batch...");
             }
 
-            &BatchState::InBatch(ref cur_id) => {
+            BatchState::InBatch(ref cur_id) => {
                 if cur_id != &batch_id {
                     return Err(ErrorKind::ServerBatchProblem(
                         "Invalid server response: 202 without a batch ID",

--- a/components/sync15/src/request.rs
+++ b/components/sync15/src/request.rs
@@ -983,7 +983,7 @@ mod test {
             max_record_payload_bytes: 1000,
             ..InfoConfiguration::default()
         };
-        let time = 11111111.0;
+        let time = 11_111_111.0;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
@@ -1012,7 +1012,7 @@ mod test {
             max_request_bytes: 250,
             ..InfoConfiguration::default()
         };
-        let time = 11111111.0;
+        let time = 11_111_111.0;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
@@ -1061,7 +1061,7 @@ mod test {
             max_request_bytes: 350,
             ..InfoConfiguration::default()
         };
-        let time = 11111111.0;
+        let time = 11_111_111.0;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
@@ -1095,7 +1095,7 @@ mod test {
     #[test]
     fn test_pq_single_batch() {
         let cfg = InfoConfiguration::default();
-        let time = 11111111.0;
+        let time = 11_111_111.0;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
@@ -1133,7 +1133,7 @@ mod test {
             max_post_bytes: 200,
             ..InfoConfiguration::default()
         };
-        let time = 11111111.0;
+        let time = 11_111_111.0;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
@@ -1182,7 +1182,7 @@ mod test {
             max_post_records: 3,
             ..InfoConfiguration::default()
         };
-        let time = 11111111.0;
+        let time = 11_111_111.0;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
@@ -1241,13 +1241,14 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::cyclomatic_complexity)]
     fn test_pq_multi_post_multi_batch_records() {
         let cfg = InfoConfiguration {
             max_post_records: 3,
             max_total_records: 5,
             ..InfoConfiguration::default()
         };
-        let time = 11111111.0;
+        let time = 11_111_111.0;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
@@ -1323,14 +1324,28 @@ mod test {
         );
     }
 
+    macro_rules! assert_feq {
+        ($a:expr, $b:expr) => {
+            let a = $a;
+            let b = $b;
+            assert!(
+                (a - b).abs() < std::f64::EPSILON,
+                "assert_feq failure: {} != {}",
+                a,
+                b
+            )
+        };
+    }
+
     #[test]
+    #[allow(clippy::cyclomatic_complexity)]
     fn test_pq_multi_post_multi_batch_bytes() {
         let cfg = InfoConfiguration {
             max_post_bytes: 300,
             max_total_bytes: 500,
             ..InfoConfiguration::default()
         };
-        let time = 11111111.0;
+        let time = 11_111_111.0;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
@@ -1345,22 +1360,22 @@ mod test {
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
-        assert_eq!(pq.last_modified.0, time);
+        assert_feq!(pq.last_modified.0, time);
         // POST
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
         // POST + COMMIT
         pq.enqueue(&make_record(100)).unwrap();
-        assert_eq!(pq.last_modified.0, time + 100.0);
+        assert_feq!(pq.last_modified.0, time + 100.0);
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
 
         // POST
         pq.enqueue(&make_record(100)).unwrap();
-        assert_eq!(pq.last_modified.0, time + 100.0);
+        assert_feq!(pq.last_modified.0, time + 100.0);
         pq.flush(true).unwrap(); // COMMIT
 
-        assert_eq!(pq.last_modified.0, time + 200.0);
+        assert_feq!(pq.last_modified.0, time + 200.0);
 
         let t = tester.borrow();
         assert!(t.cur_batch.is_none());

--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -175,8 +175,8 @@ fn engine_state_changes_from_new_global(
 
     // Reset engines with sync ID changes.
     for name in new_engine_names.intersection(&previous_engine_names) {
-        let previous_engine = previous_global.engines.get(*name).unwrap();
-        let new_engine = new_global.engines.get(*name).unwrap();
+        let previous_engine = &previous_global.engines[*name];
+        let new_engine = &new_global.engines[*name];
         if previous_engine.sync_id != new_engine.sync_id {
             changes.push(EngineStateChange::Reset(name.to_string()));
         }
@@ -523,7 +523,7 @@ impl<'client, 'keys> SetupStateMachine<'client, 'keys> {
     }
 
     /// Runs through the state machine to the ready state.
-    pub fn to_ready(&mut self, state: GlobalState) -> error::Result<GlobalState> {
+    pub fn run_to_ready(&mut self, state: GlobalState) -> error::Result<GlobalState> {
         let mut s = InitialWithLiveToken(state);
         loop {
             let label = &s.label();
@@ -737,7 +737,7 @@ mod tests {
                         },
                     )]
                     .into_iter()
-                    .map(|(key, value)| (key.to_owned(), value.into()))
+                    .map(|(key, value)| (key.to_owned(), value))
                     .collect(),
                     declined: vec![],
                 },
@@ -748,7 +748,7 @@ mod tests {
         let state = GlobalState::default();
         let mut state_machine = SetupStateMachine::for_full_sync(&client, &root_key);
         assert!(
-            state_machine.to_ready(state).is_ok(),
+            state_machine.run_to_ready(state).is_ok(),
             "Should drive state machine to ready"
         );
         assert_eq!(

--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -113,7 +113,7 @@ pub fn sync_multiple(
         let mut state_machine =
             SetupStateMachine::for_full_sync(&client_info.client, &root_sync_key);
         log::info!("Advancing state machine to ready (full)");
-        global_state = state_machine.to_ready(global_state)?;
+        global_state = state_machine.run_to_ready(global_state)?;
         sync_ping.uid(client_info.client.hashed_uid()?);
     }
 
@@ -151,7 +151,7 @@ pub fn sync_multiple(
             Err(e) => {
                 log::warn!("Sync of {} failed! {:?}", name, e);
                 let f = telemetry::sync_failure_from_error(&e);
-                failures.insert(name.into(), e.into());
+                failures.insert(name.into(), e);
                 telem_engine.failure(f);
             }
         }

--- a/components/sync15/src/telemetry.rs
+++ b/components/sync15/src/telemetry.rs
@@ -211,7 +211,7 @@ mod test_events {
         let l = "abcdefghijk";
         let mut e = Event::new("Object", "Method");
         for i in 0..l.len() {
-            e = e.extra(&l[i..i + 1], "v".to_string());
+            e = e.extra(&l[i..=i], "v".to_string());
         }
     }
 

--- a/components/sync15/src/telemetry.rs
+++ b/components/sync15/src/telemetry.rs
@@ -49,6 +49,12 @@ enum Stopwatch {
     Finished(WhenTook),
 }
 
+impl Default for Stopwatch {
+    fn default() -> Self {
+        Stopwatch::new()
+    }
+}
+
 impl Stopwatch {
     fn new() -> Self {
         Stopwatch::Started(time::SystemTime::now(), time::Instant::now())
@@ -68,7 +74,7 @@ impl Stopwatch {
                 let when = std.as_secs() as f64; // we don't want sub-sec accuracy. Do we need to write a float?
 
                 let sid = si.elapsed();
-                let took = sid.as_secs() * 1000 + (sid.subsec_nanos() as u64) / 1_000_000;
+                let took = sid.as_secs() * 1000 + (u64::from(sid.subsec_nanos()) / 1_000_000);
                 Stopwatch::Finished(WhenTook { when, took })
             }
             _ => {
@@ -507,7 +513,7 @@ mod engine_tests {
 }
 
 /// A single sync. May have many engines, may have its own failure.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Default)]
 pub struct SyncTelemetry {
     #[serde(flatten)]
     when_took: Stopwatch,
@@ -522,11 +528,7 @@ pub struct SyncTelemetry {
 
 impl SyncTelemetry {
     pub fn new() -> Self {
-        Self {
-            when_took: Stopwatch::new(),
-            engines: Vec::new(),
-            failure: None,
-        }
+        Default::default()
     }
 
     pub fn engine(&mut self, mut e: Engine) {

--- a/components/sync15/src/token.rs
+++ b/components/sync15/src/token.rs
@@ -469,7 +469,7 @@ mod tests {
             })
         };
 
-        let tsc = make_tsc(fetch, || SystemTime::now());
+        let tsc = make_tsc(fetch, SystemTime::now);
 
         let e = tsc.api_endpoint(&make_client()).expect("should work");
         assert_eq!(e, "api_endpoint".to_string());
@@ -487,7 +487,7 @@ mod tests {
         let fetch = || {
             counter.set(counter.get() + 1);
             let when = SystemTime::now() + Duration::from_millis(10000);
-            return Err(error::Error::from(ErrorKind::BackoffError(when)));
+            Err(error::Error::from(ErrorKind::BackoffError(when)))
         };
         let now: Cell<SystemTime> = Cell::new(SystemTime::now());
         let tsc = make_tsc(fetch, || now.get());

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,6 +50,7 @@ Patches should be submitted as [pull requests](https://help.github.com/articles/
 Before submitting a PR:
 - Your code must run and pass all the automated tests before you submit your PR for review. "Work in progress" pull requests are allowed to be submitted, but should be clearly labeled as such and should not be merged until all tests pass and the code has been reviewed.
   - Run `cargo test --all` to make sure all tests still pass and no warnings are emitted.
+  - Run `cargo clippy --all-targets --all-features` to make sure that linting passes (You may need to `rustup component add clippy` first).
   - Run `cargo fmt` to ensure the code is formatted correctly.
 - Your patch should include new tests that cover your changes. It is your and your reviewer's responsibility to ensure your patch includes adequate tests.
 
@@ -57,7 +58,7 @@ When submitting a PR:
 - You agree to license your code under the project's open source license ([MPL 2.0](/LICENSE)).
 - Base your branch off the current `master` (see below for an example workflow).
 - Add both your code and new tests if relevant.
-- Run `cargo test` to make sure your code passes linting and tests.
+- Run `cargo test` and `cargo clippy` to make sure your code passes linting and tests.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
 
 ## Code Review ##

--- a/megazords/fenix/src/lib.rs
+++ b/megazords/fenix/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 pub extern crate fxaclient_ffi;
 pub extern crate places_ffi;
 pub extern crate push_ffi;

--- a/megazords/ios/rust/src/lib.rs
+++ b/megazords/ios/rust/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 pub extern crate fxaclient_ffi;
 pub extern crate logins_ffi;
 pub extern crate places_ffi;

--- a/megazords/lockbox/src/lib.rs
+++ b/megazords/lockbox/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 pub extern crate fxaclient_ffi;
 pub extern crate logins_ffi;
 pub extern crate rc_log_ffi;

--- a/megazords/reference-browser/src/lib.rs
+++ b/megazords/reference-browser/src/lib.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#![allow(unknown_lints)]
+
 pub extern crate fxaclient_ffi;
 pub extern crate logins_ffi;
 pub extern crate places_ffi;

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -1,6 +1,8 @@
 /* Any copyright is dedicated to the Public Domain.
 http://creativecommons.org/publicdomain/zero/1.0/ */
 
+#![allow(unknown_lints)]
+
 use structopt::StructOpt;
 
 mod auth;

--- a/testing/sync-test/src/testing.rs
+++ b/testing/sync-test/src/testing.rs
@@ -14,9 +14,6 @@ pub struct TestGroup {
 
 impl TestGroup {
     pub fn new(name: &'static str, tests: Vec<Test>) -> Self {
-        Self {
-            name,
-            tests: tests.into(),
-        }
+        Self { name, tests }
     }
 }


### PR DESCRIPTION
Fixes #812.

This is a large change-set but is almost entirely mechanical. Anything nontrivial I just added #[allow(clippy::blah)] with a FIXME. I'll file a followup for those but in bulk.

Note: `#[allow(unknown_lints)]` is only needed in crates that actually specify clippy lints, but I added it to everything just for completeness.