### PR TITLE
config.yml iOS: build for 2 archs not 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
       - run:
           name: Build Carthage archive
           command: |
-            rustup target add aarch64-apple-ios armv7-apple-ios i386-apple-ios x86_64-apple-ios
+            rustup target add aarch64-apple-ios x86_64-apple-ios
             cargo lipo --help &>/dev/null || cargo install cargo-lipo
             brew update
             brew outdated carthage || brew upgrade carthage


### PR DESCRIPTION
The other 2 are older unsupported architectures.
