### PR TITLE
cleanup: Apply Kotlin style guide to push component

### DIFF
--- a/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
@@ -8,7 +8,6 @@ import android.util.Log
 import com.sun.jna.Library
 import com.sun.jna.Native
 import com.sun.jna.Pointer
-import com.sun.jna.PointerType
 import java.lang.reflect.Proxy
 
 import mozilla.appservices.support.RustBuffer
@@ -30,8 +29,7 @@ internal interface LibPushFFI : Library {
         } catch (e: UnsatisfiedLinkError) {
             Proxy.newProxyInstance(
                 LibPushFFI::class.java.classLoader,
-                arrayOf(LibPushFFI::class.java))
-            { _, _, _ ->
+                arrayOf(LibPushFFI::class.java)) { _, _, _ ->
                 throw RuntimeException("Push functionality not available", e)
             } as LibPushFFI
         }
@@ -43,39 +41,39 @@ internal interface LibPushFFI : Library {
 
     /** Create a new push connection */
     fun push_connection_new(
-            server_host: String,
-            socket_protocol: String?,
-            bridge_type: String?,
-            registration_id: String,
-            sender_id: String?,
-            database_path: String,
-            out_err: RustError.ByReference
+        server_host: String,
+        socket_protocol: String?,
+        bridge_type: String?,
+        registration_id: String,
+        sender_id: String?,
+        database_path: String,
+        out_err: RustError.ByReference
     ): PushManagerHandle
 
     /** Returns JSON string, which you need to free with push_destroy_string */
     fun push_subscribe(
-            mgr: PushManagerHandle,
-            channel_id: String,
-            scope: String,
-            out_err: RustError.ByReference
+        mgr: PushManagerHandle,
+        channel_id: String,
+        scope: String,
+        out_err: RustError.ByReference
     ): Pointer?
 
     /** Returns bool */
     fun push_unsubscribe(
-            mgr: PushManagerHandle,
-            channel_id: String,
-            out_err: RustError.ByReference
+        mgr: PushManagerHandle,
+        channel_id: String,
+        out_err: RustError.ByReference
     ): Byte
 
     fun push_update(
-            mgr: PushManagerHandle,
-            new_token: String,
-            out_err: RustError.ByReference
+        mgr: PushManagerHandle,
+        new_token: String,
+        out_err: RustError.ByReference
     ): Byte
 
     fun push_verify_connection(
-            mgr: PushManagerHandle,
-            out_err: RustError.ByReference
+        mgr: PushManagerHandle,
+        out_err: RustError.ByReference
     ): Pointer?
 
     fun push_decrypt(
@@ -102,7 +100,6 @@ internal interface LibPushFFI : Library {
 
     /** Destroy connection created using `push_connection_new` */
     fun push_connection_destroy(obj: PushManagerHandle, out_err: RustError.ByReference)
-
 }
 
 internal typealias PushManagerHandle = Long

--- a/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
@@ -40,7 +40,7 @@ internal interface LibPushFFI : Library {
     // free them).
 
     /** Create a new push connection */
-    fun push_connection_new(
+    fun push_new_connection(
         server_host: String,
         socket_protocol: String?,
         bridge_type: String?,
@@ -50,7 +50,7 @@ internal interface LibPushFFI : Library {
         out_err: RustError.ByReference
     ): PushManagerHandle
 
-    /** Returns JSON string, which you need to free with push_destroy_string */
+    /** Returns JSON string, which you need to free with destroyString */
     fun push_subscribe(
         mgr: PushManagerHandle,
         channel_id: String,
@@ -65,7 +65,7 @@ internal interface LibPushFFI : Library {
         out_err: RustError.ByReference
     ): Byte
 
-    fun push_update(
+    fun push_update_registration_token(
         mgr: PushManagerHandle,
         new_token: String,
         out_err: RustError.ByReference
@@ -98,8 +98,8 @@ internal interface LibPushFFI : Library {
     /** Destroy a buffer value returned from the decrypt ffi call */
     fun push_destroy_buffer(s: RustBuffer.ByValue)
 
-    /** Destroy connection created using `push_connection_new` */
-    fun push_connection_destroy(obj: PushManagerHandle, out_err: RustError.ByReference)
+    /** Destroy connection created using `newConnection` */
+    fun push_destroy_connection(obj: PushManagerHandle, out_err: RustError.ByReference)
 }
 
 internal typealias PushManagerHandle = Long

--- a/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
@@ -11,7 +11,6 @@ import org.json.JSONArray
 
 import mozilla.appservices.support.RustBuffer
 
-
 /**
  * An implementation of a [PushAPI] backed by a Rust Push library.
  *
@@ -26,22 +25,23 @@ class PushManager(
     socket_protocol: String = "https",
     bridge_type: BridgeTypes,
     registration_id: String,
-    database_path: String = "push.sqlite") : PushAPI, AutoCloseable {
+    database_path: String = "push.sqlite"
+) : PushAPI, AutoCloseable {
 
     private var handle: AtomicLong = AtomicLong(0)
 
     init {
         try {
-	    handle.set(rustCall { error ->
+            handle.set(rustCall { error ->
                 LibPushFFI.INSTANCE.push_connection_new(
-                        server_host,
-                        socket_protocol,
-                        bridge_type.toString(),
-                        registration_id,
-                        sender_id,
-                        database_path,
-                        error)
-            })
+                    server_host,
+                    socket_protocol,
+                    bridge_type.toString(),
+                    registration_id,
+                    sender_id,
+                    database_path,
+                    error)
+                })
         } catch (e: InternalPanic) {
             // Do local error handling?
 
@@ -54,7 +54,7 @@ class PushManager(
         val handle = this.handle.getAndSet(0L)
         if (handle != 0L) {
             rustCall { error ->
-		LibPushFFI.INSTANCE.push_connection_destroy(handle, error)
+                LibPushFFI.INSTANCE.push_connection_destroy(handle, error)
             }
         }
     }
@@ -85,7 +85,6 @@ class PushManager(
         }.toInt() == 1
     }
 
-
     override fun verifyConnection(): Map<String, String> {
         val newEndpoints: MutableMap<String, String> = linkedMapOf()
         val response = rustCallForString { error ->
@@ -106,20 +105,21 @@ class PushManager(
         body: String,
         encoding: String,
         salt: String,
-        dh: String): ByteArray {
-            val result = rustCallForString{ error ->
-            LibPushFFI.INSTANCE.push_decrypt(
-                this.handle.get(), channelID, body, encoding, salt, dh, error
-            )}
-            val jarray = JSONArray(result)
-            val retarray = ByteArray(jarray.length())
-            // `for` is inclusive.
-            val end = jarray.length()-1
-            for (i in 0 .. end) {
-                retarray[i] = jarray.getInt(i).toByte()
-            }
-            return retarray
+        dh: String
+    ): ByteArray {
+        val result = rustCallForString { error ->
+        LibPushFFI.INSTANCE.push_decrypt(
+            this.handle.get(), channelID, body, encoding, salt, dh, error
+        ) }
+        val jarray = JSONArray(result)
+        val retarray = ByteArray(jarray.length())
+        // `for` is inclusive.
+        val end = jarray.length() - 1
+        for (i in 0..end) {
+            retarray[i] = jarray.getInt(i).toByte()
         }
+        return retarray
+    }
 
     override fun dispatch_for_chid(channelID: String): DispatchInfo {
         val json = rustCallForString { error ->
@@ -141,7 +141,9 @@ class PushManager(
         }
     }
 
-    private inline fun rustCallForString(callback: (RustError.ByReference) -> Pointer?): String {
+    private inline fun rustCallForString(
+        callback: (RustError.ByReference) -> Pointer?
+    ): String {
         val cstring = rustCall(callback)
                 ?: throw RuntimeException("Bug: Don't use this function when you can return" +
                         " null on success.")
@@ -152,7 +154,9 @@ class PushManager(
         }
     }
 
-    private inline fun rustCallForBuffer(callback: (RustError.ByReference) -> RustBuffer.ByValue?): ByteArray {
+    private inline fun rustCallForBuffer(
+        callback: (RustError.ByReference) -> RustBuffer.ByValue?
+    ): ByteArray {
         val cbuff = rustCall(callback)
                 ?: throw RuntimeException("Bug: Don't use this function when you can return" +
                 "null on success.")
@@ -185,42 +189,40 @@ enum class BridgeTypes {
  * probably want a way of sharing these.
  */
 
-class KeyInfo (
+class KeyInfo(
     var auth: String,
     var p256dh: String
 )
 
 class SubscriptionInfo constructor (
-        val endpoint:String,
-        val keys: KeyInfo)
-{
-
-
+    val endpoint: String,
+    val keys: KeyInfo
+) {
     companion object {
-        internal fun fromString(msg: String) : SubscriptionInfo {
+        internal fun fromString(msg: String): SubscriptionInfo {
             val obj = JSONObject(msg)
             val keyObj = obj.getJSONObject("keys")
             return SubscriptionInfo(
                     endpoint = obj.getString("endpoint"),
                     keys = KeyInfo(
-                            auth = keyObj.getString("auth"),
-                            p256dh = keyObj.getString("p256dh"))
+                        auth = keyObj.getString("auth"),
+                        p256dh = keyObj.getString("p256dh"))
             )
         }
     }
- }
+}
 
 class DispatchInfo constructor (
-        val uaid: String,
-        val scope: String)
-{
+    val uaid: String,
+    val scope: String
+) {
     companion object {
-        internal fun fromString(msg: String) : DispatchInfo {
+        internal fun fromString(msg: String): DispatchInfo {
             val obj = JSONObject(msg)
             return DispatchInfo(
                 uaid = obj.getString("uaid"),
-               scope = obj.getString("scope")
-           )
+                scope = obj.getString("scope")
+            )
         }
     }
 }
@@ -290,12 +292,12 @@ interface PushAPI {
      * @return Decrypted message body.
      */
     fun decrypt(
-                channelID: String,
-                body: String,
-                encoding: String,
-                salt: String,
-                dh: String): ByteArray
+        channelID: String,
+        body: String,
+        encoding: String,
+        salt: String,
+        dh: String
+    ): ByteArray
 
     fun dispatch_for_chid(channelID: String): DispatchInfo
-
 }

--- a/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
@@ -33,7 +33,7 @@ class PushManager(
     init {
         try {
             handle.set(rustCall { error ->
-                LibPushFFI.INSTANCE.push_connection_new(
+                LibPushFFI.INSTANCE.push_new_connection(
                     server_host,
                     socket_protocol,
                     bridge_type.toString(),
@@ -54,7 +54,7 @@ class PushManager(
         val handle = this.handle.getAndSet(0L)
         if (handle != 0L) {
             rustCall { error ->
-                LibPushFFI.INSTANCE.push_connection_destroy(handle, error)
+                LibPushFFI.INSTANCE.push_destroy_connection(handle, error)
             }
         }
     }
@@ -78,9 +78,9 @@ class PushManager(
         }.toInt() == 1
     }
 
-    override fun update(registrationToken: String): Boolean {
+    override fun updateRegistrationToken(registrationToken: String): Boolean {
         return rustCall { error ->
-            LibPushFFI.INSTANCE.push_update(
+            LibPushFFI.INSTANCE.push_update_registration_token(
                 this.handle.get(), registrationToken, error)
         }.toInt() == 1
     }
@@ -121,7 +121,7 @@ class PushManager(
         return retarray
     }
 
-    override fun dispatch_for_chid(channelID: String): DispatchInfo {
+    override fun dispatchForCHID(channelID: String): DispatchInfo {
         val json = rustCallForString { error ->
             LibPushFFI.INSTANCE.push_dispatch_for_chid(
                 this.handle.get(), channelID, error)
@@ -258,7 +258,7 @@ interface PushAPI {
      * @param registrationToken the new Native OS push registration ID.
      * @return bool
      */
-    fun update(registrationToken: String): Boolean
+    fun updateRegistrationToken(registrationToken: String): Boolean
 
     /**
      * Verifies the connection state. NOTE: If the internal check fails,
@@ -299,5 +299,5 @@ interface PushAPI {
         dh: String
     ): ByteArray
 
-    fun dispatch_for_chid(channelID: String): DispatchInfo
+    fun dispatchForCHID(channelID: String): DispatchInfo
 }

--- a/components/push/android/src/main/java/mozilla/appservices/push/RustError.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/RustError.kt
@@ -13,19 +13,19 @@ import com.sun.jna.Structure
 import java.util.Arrays
 
 // Mirror the Rust errors from push/error/lib.rs
-open class PushError(msg: String): Exception(msg)
-open class InternalPanic(msg: String): PushError(msg)
-open class OpenSSLError(msg: String): PushError(msg)
-open class CommunicationError(msg: String): PushError(msg)
-open class CommunicationServerError(msg: String): PushError(msg)
-open class AlreadyRegisteredError: PushError(
+open class PushError(msg: String) : Exception(msg)
+open class InternalPanic(msg: String) : PushError(msg)
+open class OpenSSLError(msg: String) : PushError(msg)
+open class CommunicationError(msg: String) : PushError(msg)
+open class CommunicationServerError(msg: String) : PushError(msg)
+open class AlreadyRegisteredError : PushError(
         "This channelID is already registered.")
-open class StorageError(msg: String): PushError(msg)
-open class MissingRegistrationTokenError: PushError(
+open class StorageError(msg: String) : PushError(msg)
+open class MissingRegistrationTokenError : PushError(
         "Missing Registration Token. Please register with OS first.")
-open class StorageSqlError(msg: String): PushError(msg)
-open class TranscodingError(msg: String): PushError(msg)
-open class EncryptionError(msg: String): PushError(msg)
+open class StorageSqlError(msg: String) : PushError(msg)
+open class TranscodingError(msg: String) : PushError(msg)
+open class EncryptionError(msg: String) : PushError(msg)
 
 /**
  * This should be considered private, but it needs to be public for JNA.
@@ -61,10 +61,10 @@ open class RustError : Structure() {
             // ever hit! (But we shouldn't ever hit it?)
             throw RuntimeException("[Bug] intoException called on non-failure!")
         }
-        val message = this.consumeErrorMessage();
+        val message = this.consumeErrorMessage()
         when (code) {
             24 -> return OpenSSLError(message)
-            25-> return CommunicationError(message)
+            25 -> return CommunicationError(message)
             26 -> return CommunicationServerError(message)
             27 -> return AlreadyRegisteredError()
             28 -> return StorageError(message)

--- a/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
+++ b/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
@@ -184,7 +184,7 @@ class PushTest {
     @Test
     fun testUpdate() {
         val manager = getPushManager()
-        val result = manager.update("test-2")
+        val result = manager.updateRegistrationToken("test-2")
         // TODO: This changes the SenderID used by manager.conn, which is private.
         // probably should add a call to return that for test checks.
         assertEquals("SenderID update", true, result)
@@ -200,11 +200,11 @@ class PushTest {
     }
 
     @Test
-    fun testDispatchForChid() {
+    fun testDispatchForCHID() {
         val manager = getPushManager()
 
         val subscriptionInfo = manager.subscribe(testChannelid, "foo")
-        val dispatch = manager.dispatch_for_chid(testChannelid)
+        val dispatch = manager.dispatchForCHID(testChannelid)
         assertEquals("uaid", "abad1d3a00000000aabbccdd00000000", dispatch.uaid)
         assertEquals("scope", "foo", dispatch.scope)
     }

--- a/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
+++ b/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
@@ -1,6 +1,5 @@
 package mozilla.appservices.push
 
-import java.io.File
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -8,7 +7,7 @@ import org.robolectric.annotation.Config
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
 import java.nio.charset.Charset
 
 @RunWith(RobolectricTestRunner::class)
@@ -137,10 +136,10 @@ class PushTest {
         // These values should come from the delivered message content.
         val result = manager.decrypt(
                 channelID = testChannelid,
-                body=aesgcmBlock["body"].toString(),
-                encoding=aesgcmBlock["enc"].toString(),
-                salt=aesgcmBlock["salt"].toString(),
-                dh=aesgcmBlock["dh"].toString()
+                body = aesgcmBlock["body"].toString(),
+                encoding = aesgcmBlock["enc"].toString(),
+                salt = aesgcmBlock["salt"].toString(),
+                dh = aesgcmBlock["dh"].toString()
         )
         val sresult = result.toString(Charset.forName("UTF-8"))
         assertEquals("Result", plaintext, sresult)
@@ -153,10 +152,10 @@ class PushTest {
         manager.subscribe(testChannelid, "foo")
         val result = manager.decrypt(
                 channelID = testChannelid,
-                body=aes128gcmBlock["body"].toString(),
-                encoding=aes128gcmBlock["enc"].toString(),
-                salt=aes128gcmBlock["salt"].toString(),
-                dh=aes128gcmBlock["dh"].toString()
+                body = aes128gcmBlock["body"].toString(),
+                encoding = aes128gcmBlock["enc"].toString(),
+                salt = aes128gcmBlock["salt"].toString(),
+                dh = aes128gcmBlock["dh"].toString()
         )
         val sresult = result.toString(Charset.forName("UTF-8"))
         assertEquals("Result", plaintext, sresult)
@@ -170,11 +169,12 @@ class PushTest {
         // These are mock values, but it's important that they exist.
         assertEquals("Auth Check", auth_raw, subscriptionInfo.keys.auth)
         assertEquals("p256 Check", public_key_raw, subscriptionInfo.keys.p256dh)
-        assertEquals("endpoint Check", "http://push.example.com/test/opaque", subscriptionInfo.endpoint)
+        assertEquals("endpoint Check", "http://push.example.com/test/opaque",
+                subscriptionInfo.endpoint)
     }
 
     @Test
-    fun testUnsubscribe(){
+    fun testUnsubscribe() {
         val manager = getPushManager()
         manager.subscribe(testChannelid, "foo")
         val result = manager.unsubscribe(testChannelid)
@@ -182,7 +182,7 @@ class PushTest {
     }
 
     @Test
-    fun testUpdate(){
+    fun testUpdate() {
         val manager = getPushManager()
         val result = manager.update("test-2")
         // TODO: This changes the SenderID used by manager.conn, which is private.
@@ -191,7 +191,7 @@ class PushTest {
     }
 
     @Test
-    fun testVerifyConnection(){
+    fun testVerifyConnection() {
         val manager = getPushManager()
         manager.subscribe(testChannelid, "foo")
         val result = manager.verifyConnection()
@@ -204,7 +204,7 @@ class PushTest {
         val manager = getPushManager()
 
         val subscriptionInfo = manager.subscribe(testChannelid, "foo")
-        val dispatch = manager.dispatch_for_chid(testChannelid);
+        val dispatch = manager.dispatch_for_chid(testChannelid)
         assertEquals("uaid", "abad1d3a00000000aabbccdd00000000", dispatch.uaid)
         assertEquals("scope", "foo", dispatch.scope)
     }

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -50,7 +50,7 @@ pub extern "C" fn push_new_connection(
     error: &mut ExternError,
 ) -> u64 {
     MANAGER.insert_with_result(error, || {
-        log::debug!(
+        log::trace!(
             "newConnection {:?} {:?} -> {:?} {:?}=>{:?}",
             socket_protocol,
             server_host,


### PR DESCRIPTION
Using `ktlint -a --format --color android/**/*.kt`
to apply Android formatting (-a), with autocorrection (--format) styling
the manual input required warnings with (--color)

Issue: #818

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo clean; cargo test --all` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - *First run with `ktclean`*
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
   _formatting cleanup, no code changes_ 
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - ~Any breaking changes to Swift or Kotlin binding APIs are noted explicitly~
