### PR TITLE
Get rustup-init without curl bash piping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,14 @@ commands:
       - run:
           name: Install Rust
           command: |
-            curl https://sh.rustup.rs -sSf | sh -s -- -y
+            RUSTUP_PLATFORM=x86_64-apple-darwin
+            RUSTUP_VERSION=1.17.0
+            RUSTUP_SHA256=f5da97b1854844fd7d61c52af8d78238c022fdc0ff0eeaf804baa0b9f7ff59d3
+            curl -O -s --retry 5 "https://static.rust-lang.org/rustup/archive/$RUSTUP_VERSION/$RUSTUP_PLATFORM/rustup-init"
+            echo "${RUSTUP_SHA256} *rustup-init" | shasum -a 256 -c -
+            chmod +x rustup-init
+            ./rustup-init -y --no-modify-path
+            rm rustup-init
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
   setup-rust-toolchain:
     parameters:


### PR DESCRIPTION
I think @rfk had a small concern about doing curl bash piping in CircleCI. It's pretty easy to fix so let's just do that.