### PR TITLE
Note clippy in pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,8 @@
 ### Pull Request checklist ###
 <!-- Before submitting the PR, please address each item -->
 - [ ] **Quality**: This PR builds and tests run cleanly
-  - `cargo clean; cargo test --all` runs without emitting any warnings
+  - `cargo test --all` produces no test failures
+  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
   - `cargo fmt` does not produce any changes to the code
   - `./gradlew ktlint detekt` runs without emitting any warnings
 - [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not


### PR DESCRIPTION
`cargo clippy --all-targets` will catch any warnings emitted during testing, as well as other things. I do wish there were a shorter command than `cargo clippy --all --all-targets --all-features`... (the --all can be omitted depending on your directory, I guess, but ehh...)