### PR TITLE
Add wipeLocal, ensureUnlocked, and ensureLocked to swift logins. Fixes #854

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.22.0...master)
 
+## Logins
+
+### What's New
+
+- iOS Logins storage now has `ensureLocked`, `ensureUnlocked`, and `wipeLocal`
+  methods, equivalent to those provided in the android API.
+  ([#854](https://github.com/mozilla/application-services/issues/854))
+
 # v0.22.0 (_2019-03-22_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.21.0...v0.22.0)

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -88,6 +88,16 @@ open class LoginsStorage {
         })
     }
 
+    /// equivalent to `unlock(withEncryptionKey:)`, but does not throw if the
+    /// database is already unlocked.
+    open func ensureUnlocked(withEncryptionKey key: String) throws {
+        try queue.sync(execute: {
+            self.raw = try LoginsStoreError.unwrap({ err in
+                sync15_passwords_state_new(self.dbPath, key, err)
+            })
+        })
+    }
+
     /// Lock the database.
     ///
     /// Throws `LockError.mismatched` if the database is already locked.
@@ -98,6 +108,13 @@ open class LoginsStorage {
             }
             self.doDestroy()
         })
+    }
+
+    /// Locks the database, but does not throw in the case that the database is
+    /// already locked. This is an alias for `close()`, provided for convenience
+    /// (and consistency with Android)
+    open func ensureLocked() {
+        close()
     }
 
     /// Synchronize with the server.
@@ -138,6 +155,15 @@ open class LoginsStorage {
             let engine = try self.getUnlocked()
             try LoginsStoreError.unwrap({ err in
                 sync15_passwords_wipe(engine, err)
+            })
+        })
+    }
+
+    open func wipeLocal() throws {
+        try queue.sync(execute: {
+            let engine = try self.getUnlocked()
+            try LoginsStoreError.unwrap({ err in
+                sync15_passwords_wipe_local(engine, err)
             })
         })
     }

--- a/components/logins/ios/Logins/RustPasswordAPI.h
+++ b/components/logins/ios/Logins/RustPasswordAPI.h
@@ -57,6 +57,9 @@ void sync15_passwords_sync(Sync15PasswordEngineHandle handle,
 void sync15_passwords_wipe(Sync15PasswordEngineHandle handle,
                            Sync15PasswordsError *_Nonnull error);
 
+void sync15_passwords_wipe_local(Sync15PasswordEngineHandle handle,
+                                 Sync15PasswordsError *_Nonnull error);
+
 void sync15_passwords_disable_mem_security(Sync15PasswordEngineHandle handle,
                                            Sync15PasswordsError *_Nonnull error);
 


### PR DESCRIPTION
I was going to do this later but I have some builds running and nothing to do until they finish, and this is trivial.