### PR TITLE
Ensure we PUT and POST non-collection resources with the correct x-if…

### DIFF
--- a/components/sync15/src/client.rs
+++ b/components/sync15/src/client.rs
@@ -109,7 +109,7 @@ impl SetupStorageClient for Sync15StorageClient {
     fn fetch_crypto_keys(&self) -> error::Result<TimestampedResponse<EncryptedBso>> {
         let mut keys_resp = self.relative_storage_request(Method::GET, "storage/crypto/keys")?;
         let record: EncryptedBso = keys_resp.json()?;
-        let last_modified = get_response_timestamp(&mut keys_resp)?;
+        let last_modified = get_response_timestamp(&keys_resp)?;
         Ok(TimestampedResponse {
             last_modified,
             record,
@@ -232,7 +232,7 @@ impl Sync15StorageClient {
     {
         let mut resp = self.relative_storage_request(Method::GET, path)?;
         let record: T = resp.json()?;
-        let last_modified = get_response_timestamp(&mut resp)?;
+        let last_modified = get_response_timestamp(&resp)?;
         Ok(TimestampedResponse {
             last_modified,
             record,

--- a/components/sync15/src/request.rs
+++ b/components/sync15/src/request.rs
@@ -23,7 +23,7 @@ pub enum RequestOrder {
 }
 
 pub const X_IF_UNMODIFIED_SINCE: &str = "X-If-Unmodified-Since";
-const X_LAST_MODIFIED: &str = "X-Last-Modified";
+pub const X_LAST_MODIFIED: &str = "X-Last-Modified";
 
 impl fmt::Display for RequestOrder {
     #[inline]


### PR DESCRIPTION
…-unmodified-since header

Even though we don't attempt to overwrite these resources (ie, we only upload them when we think they are new), there's still a risk we will race with another client even in that case.