### PR TITLE
bug: stop eating errors, allow verifyConnection() without subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.22.1...master)
 
+## Push
+
+### Breaking changes
+
+- the `PushManager` argument `socket_protocol` is now `http_protocol`
+  to correctly map its role. `socket_protocol` is reserved.
+
 # v0.22.1 (_2019-03-27_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.22.0...v0.22.1)

--- a/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
@@ -44,7 +44,7 @@ internal interface LibPushFFI : Library {
     /** Create a new push connection */
     fun push_connection_new(
         server_host: String,
-        socket_protocol: String?,
+        http_protocol: String?,
         bridge_type: String?,
         registration_id: String,
         sender_id: String?,

--- a/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
@@ -15,14 +15,14 @@ import mozilla.appservices.support.RustBuffer
  * An implementation of a [PushAPI] backed by a Rust Push library.
  *
  * @param serverHost the host name for the service (e.g. "push.service.mozilla.org").
- * @param socketProtocol the optional socket protocol (default: "https")
+ * @param httpProtocol the optional socket protocol (default: "https")
  * @param bridgeType the optional bridge protocol (default: "fcm")
  * @param registrationId the native OS messaging registration id
  */
 class PushManager(
     senderId: String,
     serverHost: String = "push.service.mozilla.com",
-    socketProtocol: String = "https",
+    httpProtocol: String = "https",
     bridgeType: BridgeTypes,
     registrationId: String,
     databasePath: String = "push.sqlite"
@@ -35,7 +35,7 @@ class PushManager(
         handle.set(rustCall { error ->
                 LibPushFFI.INSTANCE.push_connection_new(
                         serverHost,
-                        socketProtocol,
+                        httpProtocol,
                         bridgeType.toString(),
                         registrationId,
                         senderId,

--- a/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
+++ b/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
@@ -183,16 +183,20 @@ class PushTest {
     @Test
     fun testUpdate() {
         val manager = getPushManager()
+        // subscribe to at least one channel.
+        manager.subscribe(testChannelid, "foo")
         val result = manager.update("test-2")
-        // TODO: This changes the SenderID used by manager.conn, which is private.
-        // probably should add a call to return that for test checks.
         assertEquals("SenderID update", true, result)
     }
 
     @Test
     fun testVerifyConnection() {
         val manager = getPushManager()
+        // Client will call verifyConnection() on initial setup, before UAID set.
+        manager.verifyConnection()
+        // Register a subscription
         manager.subscribe(testChannelid, "foo")
+        // and call verifyConnection again to emulate a set value.
         val result = manager.verifyConnection()
         val vv = result[testChannelid].toString()
         assertEquals("Check changed endpoint", "http://push.example.com/test/obscure", vv)

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -142,7 +142,7 @@ pub extern "C" fn push_verify_connection(handle: u64, error: &mut ExternError) -
     MANAGER.call_with_result_mut(error, handle, |mgr| -> Result<_> {
         if !mgr.verify_connection()? {
             let new_endpoints = mgr.regenerate_endpoints()?;
-            if new_endpoints.is_empty() {
+            if !new_endpoints.is_empty() {
                 return serde_json::to_string(&new_endpoints).map_err(|e| {
                     push_errors::ErrorKind::TranscodingError(format!("{:?}", e)).into()
                 });

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -42,7 +42,7 @@ lazy_static::lazy_static! {
 #[no_mangle]
 pub extern "C" fn push_connection_new(
     server_host: FfiStr<'_>,
-    socket_protocol: FfiStr<'_>,
+    http_protocol: FfiStr<'_>,
     bridge_type: FfiStr<'_>,
     registration_id: FfiStr<'_>,
     sender_id: FfiStr<'_>,
@@ -52,7 +52,7 @@ pub extern "C" fn push_connection_new(
     MANAGER.insert_with_result(error, || {
         log::debug!(
             "push_connection_new {:?} {:?} -> {:?} {:?}=>{:?}",
-            socket_protocol,
+            http_protocol,
             server_host,
             bridge_type,
             sender_id,
@@ -61,7 +61,7 @@ pub extern "C" fn push_connection_new(
         // return this as a reference to the map since that map contains the actual handles that rust uses.
         // see ffi layer for details.
         let host = server_host.into_string();
-        let protocol = socket_protocol.into_opt_string();
+        let protocol = http_protocol.into_opt_string();
         let reg_id = registration_id.into_opt_string();
         let bridge = bridge_type.into_opt_string();
         let sender = sender_id.into_string();
@@ -140,14 +140,12 @@ pub extern "C" fn push_update(handle: u64, new_token: FfiStr<'_>, error: &mut Ex
 pub extern "C" fn push_verify_connection(handle: u64, error: &mut ExternError) -> *mut c_char {
     log::debug!("push_verify");
     MANAGER.call_with_result_mut(error, handle, |mgr| -> Result<_> {
-        if let Ok(r) = mgr.verify_connection() {
-            if !r {
-                if let Ok(new_endpoints) = mgr.regenerate_endpoints() {
-                    // use a `match` here to resolve return of <_>
-                    return serde_json::to_string(&new_endpoints).map_err(|e| {
-                        push_errors::ErrorKind::TranscodingError(format!("{:?}", e)).into()
-                    });
-                }
+        if !mgr.verify_connection()? {
+            let new_endpoints = mgr.regenerate_endpoints()?;
+            if new_endpoints.is_empty() {
+                return serde_json::to_string(&new_endpoints).map_err(|e| {
+                    push_errors::ErrorKind::TranscodingError(format!("{:?}", e)).into()
+                });
             }
         }
         Ok(String::from(""))
@@ -186,15 +184,15 @@ pub extern "C" fn push_dispatch_for_chid(
     log::debug!("push_dispatch_for_chid");
     MANAGER.call_with_result_mut(error, handle, |mgr| -> Result<String> {
         let chid = chid.as_str();
-        if let Some(record) = mgr.get_record_by_chid(chid)? {
-            let dispatch = json!({
-                "uaid": record.uaid,
-                "scope": record.scope,
-            });
-            Ok(dispatch.to_string())
-        } else {
-            // TODO: either Error or return Option
-            Ok(String::from(""))
+        match mgr.get_record_by_chid(chid)? {
+            Some(record) => {
+                let dispatch = json!({
+                    "uaid": record.uaid,
+                    "scope": record.scope,
+                });
+                Ok(dispatch.to_string())
+            }
+            None => Ok(String::from("")),
         }
     })
 }


### PR DESCRIPTION
* FFI layer was eating rust exceptions, those are now passed on
* allowing `verifyConnection()` after PushManager create so client can
  write simple bootstrapping code
* Now checking prior subscription status for other calls.

BREAKING CHANGE
* the argument `socket_protocol` is now `http_protocol` to correctly map
  it's role. `socket_protocol` will be used later for desktop websocket
  connections

Closes #873, #874

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
