### PR TITLE
NSS crypto backend for SHA-256 digest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,9 @@ commands:
             rustup default <<parameters.rust-version>>
             rustup update
             rustc --version
+  install-system-nss:
+    steps:
+      - run: sudo apt-get install libnss3-dev
   build-libs:
     parameters:
       platform:
@@ -59,6 +62,7 @@ commands:
         default: "stable"
     steps:
       - checkout
+      - install-system-nss
       - build-desktop-libs
       - setup-rust-toolchain:
           rust-version: <<parameters.rust-version>>
@@ -132,6 +136,7 @@ jobs:
     steps:
       - checkout
       - setup-rust-toolchain
+      - install-system-nss
       - run: rustup component add clippy
       - run: cargo clippy --version
       - run: cargo clippy --all --all-targets --all-features -- -D warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## General
 
+- Some cryptographic primitives are now backed by NSS. On reference-browser and fenix megazords the GeckoView NSS libs are used, otherwise these libraries are bundled. ([#891](https://github.com/mozilla/application-services/pull/891))
+
 ### What's Fixed
 
 - Megazords and requests should work again. ([#946](https://github.com/mozilla/application-services/pull/946))
@@ -19,6 +21,7 @@
 ## iOS
 
 - The individual components projects have been removed, please use the MozillaAppServices framework from now on. ([#932](https://github.com/mozilla/application-services/pull/932))
+- The NSS .dylibs must be included in your application project, see [instructions](https://github.com/mozilla/application-services/blob/30a1a57917c6e243c0c5d59fba24caa8de8f6b3a/docs/howtos/consuming-rust-components-on-ios.md#nss)
 
 ## Push
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,13 +94,13 @@ name = "backtrace-sys"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "base16"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -202,7 +202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -222,14 +222,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.32.0"
+version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -267,11 +267,11 @@ name = "communications"
 version = "0.1.0"
 dependencies = [
  "config 0.1.0",
- "crypto 0.1.0",
  "force-viaduct-reqwest 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "push-crypto 0.1.0",
  "push-errors 0.1.0",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -289,6 +289,34 @@ version = "0.1.0"
 name = "constant_time_eq"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cookie"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "core-foundation"
@@ -325,21 +353,23 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "criterion-plot 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion-plot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -349,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -428,24 +458,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto"
-version = "0.1.0"
-dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ece 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
- "hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "push-errors 0.1.0",
- "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,7 +500,7 @@ name = "ctor"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -595,6 +607,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,7 +629,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -743,6 +763,7 @@ dependencies = [
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rc_crypto 0.1.0",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -774,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -871,13 +892,13 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.25"
+version = "0.12.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -903,7 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -970,6 +991,15 @@ version = "0.2.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libloading"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,7 +1045,7 @@ name = "logins"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cli-support 0.1.0",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1040,7 +1070,7 @@ name = "logins_ffi"
 version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "base16 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.3",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1128,7 +1158,7 @@ name = "miniz_oxide_c_api"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1221,6 +1251,14 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "nss_sys"
+version = "0.1.0"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,7 +1307,7 @@ name = "openssl-sys"
 version = "0.9.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1373,9 +1411,9 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "caseless 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cli-support 0.1.0",
- "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "dogear 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1492,7 +1530,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1506,16 +1544,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "publicsuffix"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "push"
 version = "0.1.0"
 dependencies = [
  "communications 0.1.0",
  "config 0.1.0",
- "crypto 0.1.0",
+ "push-crypto 0.1.0",
  "push-errors 0.1.0",
  "push-ffi 0.1.0",
  "storage 0.1.0",
  "subscriber 0.1.0",
+]
+
+[[package]]
+name = "push-crypto"
+version = "0.1.0"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ece 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.3.3",
+ "hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "push-errors 0.1.0",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1539,10 +1607,10 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "communications 0.1.0",
  "config 0.1.0",
- "crypto 0.1.0",
  "ffi-support 0.3.3",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "push-crypto 0.1.0",
  "push-errors 0.1.0",
  "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1560,7 +1628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1726,6 +1794,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rc_crypto"
+version = "0.1.0"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nss_sys 0.1.0",
+]
+
+[[package]]
 name = "rc_log_ffi"
 version = "0.1.0"
 dependencies = [
@@ -1745,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.52"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1753,7 +1830,7 @@ name = "redox_termios"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "redox_syscall 0.1.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1764,7 +1841,7 @@ dependencies = [
  "argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1809,16 +1886,18 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie_store 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1827,6 +1906,7 @@ dependencies = [
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1841,7 +1921,7 @@ name = "ring"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1968,7 +2048,7 @@ version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2047,13 +2127,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "storage"
 version = "0.1.0"
 dependencies = [
- "crypto 0.1.0",
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "push-crypto 0.1.0",
  "push-errors 0.1.0",
  "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2068,7 +2148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2076,7 +2156,7 @@ name = "structopt"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2087,7 +2167,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2098,8 +2178,8 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "communications 0.1.0",
  "config 0.1.0",
- "crypto 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "push-crypto 0.1.0",
  "push-errors 0.1.0",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2117,7 +2197,7 @@ version = "0.15.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2141,7 +2221,7 @@ dependencies = [
 name = "sync15"
 version = "0.1.0"
 dependencies = [
- "base16 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hawk 2.0.0 (git+https://github.com/eoger/rust-hawk?branch=use-openssl)",
@@ -2161,7 +2241,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2183,7 +2263,7 @@ dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2212,13 +2292,13 @@ version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2238,7 +2318,7 @@ version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.52 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2264,6 +2344,7 @@ dependencies = [
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2376,6 +2457,14 @@ dependencies = [
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "try_from"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "typenum"
@@ -2499,7 +2588,7 @@ dependencies = [
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2607,7 +2696,7 @@ dependencies = [
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f106c02a3604afcdc0df5d36cc47b44b55917dbaf3d808f71c163a0ddba64637"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
-"checksum base16 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fd4a4949666bf485542a06de6795ccba71eeabc1f5e9db7a2d82edc3573f6a"
+"checksum base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5d608a38535c371b2a9149159f6dd2259af379f71e50c24d54a842de44bc5b19"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
@@ -2621,19 +2710,21 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum caseless 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "808dab3318747be122cb31d36de18d4d1c81277a76f8332a02b81a3d73463d7f"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
-"checksum cc 1.0.34 (registry+https://github.com/rust-lang/crates.io-index)" = "30f813bf45048a18eda9190fd3c6b78644146056740c43172a5a3699118588fd"
+"checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
-"checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
+"checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum colored 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6e9a455e156a4271e12fd0246238c380b1e223e3736663c7a18ed8b6362028a9"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
+"checksum cookie 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1465f8134efa296b4c19db34d909637cb2bf0f7aaf21299e23e18fa29ac557cf"
+"checksum cookie_store 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b0d2f2ecb21dce00e2453268370312978af9b8024020c7a37ae2cc6dbbe64685"
 "checksum core-foundation 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "286e0b41c3a20da26536c6000a280585d519fd07b3956b43aed8a79e9edce980"
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
-"checksum criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "1c6e5ee5b9652d4f851418c448af105642e1f99e9a2741a8ff45c0d2c911b1e0"
-"checksum criterion-plot 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4107e4a5abb94267e0149922b8ff49dc70a87cc202820fdbfc0d3e1edbdc4b16"
+"checksum criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0363053954f3e679645fc443321ca128b7b950a6fe288cf5f9335cc22ee58394"
+"checksum criterion-plot 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76f9212ddf2f4a9eb2d401635190600656a1f88a932ef53d06e7fa4c7e02fb8e"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
@@ -2658,6 +2749,7 @@ dependencies = [
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -2673,7 +2765,7 @@ dependencies = [
 "checksum futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "62941eff9507c8177d448bd83a44d9b9760856e184081d8cd79ba9f03dd24981"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
-"checksum h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "910a5e7be6283a9c91b3982fa5188368c8719cce2a3cf3b86048673bf9d9c36b"
+"checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum hawk 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ccb26fc177705af37f278bb3e31643650176d265cb4d233d651dde0660c17b8c"
 "checksum hawk 2.0.0 (git+https://github.com/eoger/rust-hawk?branch=use-openssl)" = "<none>"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
@@ -2683,7 +2775,7 @@ dependencies = [
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
-"checksum hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5b6658b016965ae301fa995306db965c93677880ea70765a84235a96eae896"
+"checksum hyper 0.12.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4f2777434f26af6e4ce4fdcdccd3bed9d861d11e87bcbe72c0f51ddaca8ff848"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
@@ -2694,6 +2786,7 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
+"checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum libsqlite3-sys 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3567bc1a0c84e2c0d71eeb4a1f08451babf7843babd733158777d9c686dad9f3"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
@@ -2740,8 +2833,9 @@ dependencies = [
 "checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
 "checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
 "checksum prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
+"checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
@@ -2759,13 +2853,13 @@ dependencies = [
 "checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
 "checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum redox_syscall 0.1.52 (registry+https://github.com/rust-lang/crates.io-index)" = "d32b3053e5ced86e4bc0411fec997389532bf56b000e66cb4884eeeb41413d69"
+"checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum regex 1.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "559008764a17de49a3146b234641644ed37d118d1ef641a0bb573d146edc6ce0"
 "checksum regex-syntax 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "dcfd8681eebe297b81d98498869d4aae052137651ad7b96822f09ceb690d0a96"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
-"checksum reqwest 0.9.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3c4ef83e0beb14bfe38b9f01330a5bc8e965a9f9628690aa28383746dac1e925"
+"checksum reqwest 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)" = "19c4c4990514fbd7a80380b826d81368ba6f6af61007ea142519ce47d72f6b0f"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6381ddfe91dbb659b4b132168da15985bc84162378cf4fcdc4eb99c857d063e2"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
@@ -2794,7 +2888,7 @@ dependencies = [
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
-"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
@@ -2805,7 +2899,7 @@ dependencies = [
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum textwrap 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "307686869c93e71f94da64286f9a9524c0f308a9e1c87a583de8e9c9039ad3f6"
+"checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tinytemplate 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7655088894274afb52b807bd3c87072daa1fedd155068b8705cabfd628956115"
@@ -2820,6 +2914,7 @@ dependencies = [
 "checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+"checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "components/support/sql",
     "components/support/ffi",
     "components/support/force-viaduct-reqwest",
+    "components/support/rc_crypto",
     "components/viaduct",
     "components/sync15",
     "components/rc_log",

--- a/automation/license-check.sh
+++ b/automation/license-check.sh
@@ -6,18 +6,18 @@
 IFS=$'\n'
 UNACCEPTABLE=
 for LINE in `cargo license -t | tail -n +2`; do
-  NAME=`echo $LINE | cut -f 1`
-  LICENSE=`echo $LINE | cut -f 5`
-  if [ "x$LICENSE" = "x" ]; then
+  NAME=`echo ${LINE} | cut -f 1`
+  LICENSE=`echo ${LINE} | cut -f 5`
+  if [ "x${LICENSE}" = "x" ]; then
     LICENSE="UNKNOWN"
   fi
-  if grep "^$LICENSE\$" >/dev/null < `dirname $0`/licenses.txt; then true; else
-    if grep "^=$NAME\$" > /dev/null < `dirname $0`/licenses.txt; then true; else
-      echo "Unacceptable license: $NAME $LICENSE"
+  if grep "^${LICENSE}\$" >/dev/null < `dirname ${0}`/licenses.txt; then true; else
+    if grep "^=${NAME}\$" > /dev/null < `dirname ${0}`/licenses.txt; then true; else
+      echo "Unacceptable license: ${NAME} ${LICENSE}"
       UNACCEPTABLE=1
     fi
   fi
 done
-if [ "x$UNACCEPTABLE" = "x1" ]; then
+if [ "x${UNACCEPTABLE}" = "x1" ]; then
   exit 1
 fi

--- a/automation/taskcluster/docker/build.dockerfile
+++ b/automation/taskcluster/docker/build.dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update -qq \
                           tclsh \
                           patch \
                           file \
+                          libnss3-dev \
     && apt-get clean
 
 RUN pip install --upgrade pip

--- a/automation/upload_android_symbols.sh
+++ b/automation/upload_android_symbols.sh
@@ -2,25 +2,25 @@
 
 set -euvx
 
-if [ "$#" -ne 1 ]
+if [ "${#}" -ne 1 ]
 then
     echo "Usage:"
     echo "./automation/upload_android_symbols.sh <project path>"
     exit 1
 fi
 
-PROJECT_PATH=$1
+PROJECT_PATH=${1}
 
 source "libs/android_defaults.sh"
 
 OUTPUT_FOLDER="crashreporter-symbols"
 DUMP_SYMS_DIR="automation/symbols-generation/bin"
 
-if [ ! -f "$DUMP_SYMS_DIR/dump_syms" ]; then
+if [ ! -f "${DUMP_SYMS_DIR}/dump_syms" ]; then
   tooltool.py --manifest=automation/symbols-generation/dump_syms.manifest --url=http://taskcluster/tooltool.mozilla-releng.net/ fetch
   chmod +x dump_syms
-  mkdir -p "$DUMP_SYMS_DIR"
-  mv dump_syms "$DUMP_SYMS_DIR"
+  mkdir -p "${DUMP_SYMS_DIR}"
+  mv dump_syms "${DUMP_SYMS_DIR}"
 fi
 
 # Keep the 3 in sync.
@@ -28,18 +28,18 @@ TARGET_ARCHS=("x86_64" "x86" "arm64" "arm")
 JNI_LIBS_TARGETS=("x86_64" "x86" "arm64-v8a" "armeabi-v7a")
 OBJCOPY_BINS=("x86_64-linux-android-objcopy" "i686-linux-android-objcopy" "aarch64-linux-android-objcopy" "arm-linux-androideabi-objcopy")
 
-rm -rf "$OUTPUT_FOLDER"
-mkdir -p "$OUTPUT_FOLDER"
+rm -rf "${OUTPUT_FOLDER}"
+mkdir -p "${OUTPUT_FOLDER}"
 
 # 1. Generate the symbols.
 for i in "${!TARGET_ARCHS[@]}"; do
-  export OBJCOPY="$ANDROID_NDK_TOOLCHAIN_DIR/${TARGET_ARCHS[$i]}-$ANDROID_NDK_API_VERSION/bin/${OBJCOPY_BINS[$i]}"
-  JNI_SO_PATH="$PROJECT_PATH/build/rustJniLibs/android/${JNI_LIBS_TARGETS[$i]}"
-  for sofile in "$JNI_SO_PATH"/*.so; do
-    python automation/symbols-generation/symbolstore.py -c -s . --vcs-info "$DUMP_SYMS_DIR"/dump_syms "$OUTPUT_FOLDER" "$sofile"
+  export OBJCOPY="${ANDROID_NDK_TOOLCHAIN_DIR}/${TARGET_ARCHS[${i}]}-${ANDROID_NDK_API_VERSION}/bin/${OBJCOPY_BINS[${i}]}"
+  JNI_SO_PATH="${PROJECT_PATH}/build/rustJniLibs/android/${JNI_LIBS_TARGETS[${i}]}"
+  for sofile in "${JNI_SO_PATH}"/*.so; do
+    python automation/symbols-generation/symbolstore.py -c -s . --vcs-info "${DUMP_SYMS_DIR}"/dump_syms "${OUTPUT_FOLDER}" "${sofile}"
   done
 done
 
 # 2. Upload them.
 pip install -r automation/symbols-generation/requirements.txt
-python automation/symbols-generation/upload_symbols.py "$OUTPUT_FOLDER"
+python automation/symbols-generation/upload_symbols.py "${OUTPUT_FOLDER}"

--- a/build-carthage.sh
+++ b/build-carthage.sh
@@ -11,4 +11,4 @@ carthage build --no-skip-current --platform iOS --verbose
 
 # Exclude SwiftProtobuf.
 rm -rf Carthage/Build/iOS/SwiftProtobuf.framework*
-zip -r $FRAMEWORK_NAME Carthage/Build/iOS
+zip -r ${FRAMEWORK_NAME} Carthage/Build/iOS

--- a/build-scripts/patch-libs-paths.sh
+++ b/build-scripts/patch-libs-paths.sh
@@ -6,11 +6,11 @@ set -euvx
 
 # It should be called inside XCode as it reads env variables set by it
 
-pushd $TARGET_BUILD_DIR/$TARGET_NAME.framework
+pushd ${TARGET_BUILD_DIR}/${TARGET_NAME}.framework
 for binary in *.dylib; do
-  install_name_tool -id @rpath/$binary $binary
+  install_name_tool -id @rpath/${binary} ${binary}
   for lib in *.dylib; do
-    install_name_tool -change @executable_path/$lib @rpath/$lib $binary
+    install_name_tool -change @executable_path/${lib} @rpath/${lib} ${binary}
   done
 done
 popd

--- a/build-scripts/patch-libs-paths.sh
+++ b/build-scripts/patch-libs-paths.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euvx
+
+# This script patches our NSS .dylibs to load each other using @rpath instead of
+# @executable_path which is incorrect.
+
+# It should be called inside XCode as it reads env variables set by it
+
+pushd $TARGET_BUILD_DIR/$TARGET_NAME.framework
+for binary in *.dylib; do
+  install_name_tool -id @rpath/$binary $binary
+  for lib in *.dylib; do
+    install_name_tool -change @executable_path/$lib @rpath/$lib $binary
+  done
+done
+popd

--- a/build-scripts/xc-universal-binary.sh
+++ b/build-scripts/xc-universal-binary.sh
@@ -46,6 +46,7 @@ for i in "${!LIBS_ARCHS[@]}"; do
     LIB_ARCH=${LIBS_ARCHS[$i]}
     env -i PATH="$PATH" \
         OPENSSL_STATIC=1 \
+        NSS_DIR=$LIBSDIR/ios/$LIB_ARCH/nss \
         OPENSSL_DIR=$LIBSDIR/ios/$LIB_ARCH/openssl \
         SQLCIPHER_LIB_DIR=$LIBSDIR/ios/$LIB_ARCH/sqlcipher/lib \
         SQLCIPHER_INCLUDE_DIR=$LIBSDIR/ios/$LIB_ARCH/sqlcipher/include \

--- a/build-scripts/xc-universal-binary.sh
+++ b/build-scripts/xc-universal-binary.sh
@@ -2,37 +2,37 @@
 set -euvx
 
 # This should be invoked from inside xcode, not manually
-if [ "$#" -ne 4 ]
+if [ "${#}" -ne 4 ]
 then
     echo "Usage (note: only call inside xcode!):"
     echo "path/to/build-scripts/xc-universal-binary.sh <STATIC_LIB_NAME> <FFI_TARGET> <APPSVC_ROOT_PATH> <buildvariant>"
     exit 1
 fi
 # e.g. liblogins_ffi.a
-STATIC_LIB_NAME=$1
+STATIC_LIB_NAME=${1}
 # what to pass to cargo build -p, e.g. logins_ffi
-FFI_TARGET=$2
+FFI_TARGET=${2}
 # path to app services root
-APPSVC_ROOT=$3
+APPSVC_ROOT=${3}
 # buildvariant from our xcconfigs
-BUILDVARIANT=$4
+BUILDVARIANT=${4}
 
 RELFLAG=
 RELDIR="debug"
-if [[ "$BUILDVARIANT" != "debug" ]]; then
+if [[ "${BUILDVARIANT}" != "debug" ]]; then
     RELFLAG=--release
     RELDIR=release
 fi
 
-LIBSDIR=$APPSVC_ROOT/libs
-TARGETDIR=$APPSVC_ROOT/target
+LIBSDIR=${APPSVC_ROOT}/libs
+TARGETDIR=${APPSVC_ROOT}/target
 
-# If the libs don't exist, or it's modification time is older than the last commit in $LIBSDIR/ios, wipe it out.
-if [ ! -d $LIBSDIR/ios ] || [ $(stat -f "%m" $LIBSDIR/ios) -lt $(git log -n 1 --pretty=format:%at -- $LIBSDIR) ]; then
+# If the libs don't exist, or it's modification time is older than the last commit in ${LIBSDIR}/ios, wipe it out.
+if [ ! -d ${LIBSDIR}/ios ] || [ $(stat -f "%m" ${LIBSDIR}/ios) -lt $(git log -n 1 --pretty=format:%at -- ${LIBSDIR}) ]; then
     echo "No iOS libs present, or they are stale"
-    pushd $LIBSDIR
+    pushd ${LIBSDIR}
     rm -rf ios
-    env -i PATH="$PATH" HOME="$HOME" ./build-all.sh ios
+    env -i PATH="${PATH}" HOME="${HOME}" ./build-all.sh ios
     popd
 else
     echo "iOS libs already present, not rebuilding"
@@ -43,31 +43,31 @@ fi
 LIBS_ARCHS=("x86_64" "arm64")
 IOS_TRIPLES=("x86_64-apple-ios" "aarch64-apple-ios")
 for i in "${!LIBS_ARCHS[@]}"; do
-    LIB_ARCH=${LIBS_ARCHS[$i]}
-    env -i PATH="$PATH" \
+    LIB_ARCH=${LIBS_ARCHS[${i}]}
+    env -i PATH="${PATH}" \
         OPENSSL_STATIC=1 \
-        NSS_DIR=$LIBSDIR/ios/$LIB_ARCH/nss \
-        OPENSSL_DIR=$LIBSDIR/ios/$LIB_ARCH/openssl \
-        SQLCIPHER_LIB_DIR=$LIBSDIR/ios/$LIB_ARCH/sqlcipher/lib \
-        SQLCIPHER_INCLUDE_DIR=$LIBSDIR/ios/$LIB_ARCH/sqlcipher/include \
-    $HOME/.cargo/bin/cargo build --locked -p $FFI_TARGET --lib $RELFLAG --target ${IOS_TRIPLES[$i]}
+        NSS_DIR=${LIBSDIR}/ios/${LIB_ARCH}/nss \
+        OPENSSL_DIR=${LIBSDIR}/ios/${LIB_ARCH}/openssl \
+        SQLCIPHER_LIB_DIR=${LIBSDIR}/ios/${LIB_ARCH}/sqlcipher/lib \
+        SQLCIPHER_INCLUDE_DIR=${LIBSDIR}/ios/${LIB_ARCH}/sqlcipher/include \
+    ${HOME}/.cargo/bin/cargo build --locked -p ${FFI_TARGET} --lib ${RELFLAG} --target ${IOS_TRIPLES[${i}]}
 done
 
-UNIVERSAL_BINARY=$TARGETDIR/universal/$RELDIR/$STATIC_LIB_NAME
+UNIVERSAL_BINARY=${TARGETDIR}/universal/${RELDIR}/${STATIC_LIB_NAME}
 NEED_LIPO=
 
 # if the universal binary doesnt exist, or if it's older than the static libs,
 # we need to run `lipo` again.
-if [[ ! -f "$UNIVERSAL_BINARY" ]]; then
+if [[ ! -f "${UNIVERSAL_BINARY}" ]]; then
     NEED_LIPO=1
-elif [[ $(stat -f "%m" $TARGETDIR/x86_64-apple-ios/$RELDIR/$STATIC_LIB_NAME) -gt $(stat -f "%m" $UNIVERSAL_BINARY) ]]; then
+elif [[ $(stat -f "%m" ${TARGETDIR}/x86_64-apple-ios/${RELDIR}/${STATIC_LIB_NAME}) -gt $(stat -f "%m" ${UNIVERSAL_BINARY}) ]]; then
     NEED_LIPO=1
-elif [[ $(stat -f "%m" $TARGETDIR/aarch64-apple-ios/$RELDIR/$STATIC_LIB_NAME) -gt $(stat -f "%m" $UNIVERSAL_BINARY) ]]; then
+elif [[ $(stat -f "%m" ${TARGETDIR}/aarch64-apple-ios/${RELDIR}/${STATIC_LIB_NAME}) -gt $(stat -f "%m" ${UNIVERSAL_BINARY}) ]]; then
     NEED_LIPO=1
 fi
-if [[ "$NEED_LIPO" = "1" ]]; then
-    mkdir -p $TARGETDIR/universal/$RELDIR
-    lipo -create -output "$UNIVERSAL_BINARY" \
-        $TARGETDIR/x86_64-apple-ios/$RELDIR/$STATIC_LIB_NAME \
-        $TARGETDIR/aarch64-apple-ios/$RELDIR/$STATIC_LIB_NAME
+if [[ "${NEED_LIPO}" = "1" ]]; then
+    mkdir -p ${TARGETDIR}/universal/${RELDIR}
+    lipo -create -output "${UNIVERSAL_BINARY}" \
+        ${TARGETDIR}/x86_64-apple-ios/${RELDIR}/${STATIC_LIB_NAME} \
+        ${TARGETDIR}/aarch64-apple-ios/${RELDIR}/${STATIC_LIB_NAME}
 fi

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath "com.android.tools.build:gradle:$properties.androidGradlePluginVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Publish.
@@ -72,6 +72,23 @@ subprojects {
                 name = "projectBuildDir"
                 url "file://${project.buildDir}/maven"
             }
+        }
+    }
+
+    apply plugin: NativeLibsPlugin
+    nativeLibs {
+        nss {
+            lib "libplc4.*"
+            lib "libplds4.*"
+            lib "libnspr4.*"
+            lib "*freebl3.*"
+            lib "*nss3.*"
+            lib "*nssckbi.*"
+            lib "*nssutil3.*"
+            lib "*softokn3.*"
+            lib "*smime3.*"
+            // We don't need SSL so we might as well save space.
+            // lib "libssl3.*"
         }
     }
 }
@@ -219,7 +236,7 @@ ext.cargoExec = { spec, toolchain ->
 detekt {
     // The version number is duplicated, please refer to plugins block for more details
     toolVersion = "1.0.0-RC14"
-    input = files("${projectDir}/components", "${projectDir}/gradle-plugin")
+    input = files("${projectDir}/components", "${projectDir}/gradle-plugin", "buildSrc")
     filters = ".*test.*,.*/resources/.*,.*/tmp/.*,.*/build/.*"
     config = files("${projectDir}/.detekt.yml")
     failFast = false
@@ -240,12 +257,12 @@ task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
     main = "com.github.shyiko.ktlint.Main"
-    args "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "!**/build", "buildSrc/**/*.kt"
+    args "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build"
 }
 
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
     main = "com.github.shyiko.ktlint.Main"
-    args "-F", "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt"
+    args "-F", "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build"
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+plugins {
+    `kotlin-dsl`
+}
+
+// Use the Android Gradle plugin version from the root project so they stay in sync.
+import java.util.Properties
+fun readProperties(propertiesFile: File) = Properties().apply {
+    propertiesFile.inputStream().use { fis ->
+        load(fis)
+    }
+}
+val properties = readProperties(File(rootDir.parentFile, "gradle.properties"))
+val androidGradlePluginVersion = properties["androidGradlePluginVersion"]
+
+dependencies {
+    "implementation"("com.android.tools.build:gradle:$androidGradlePluginVersion")
+}
+
+repositories {
+    google()
+    jcenter()
+}

--- a/buildSrc/src/main/java/NativeLibsPlugin.kt
+++ b/buildSrc/src/main/java/NativeLibsPlugin.kt
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*
+ * This gradle plugin generates a `copyNativeLibs` task in the project it is
+ * applied to.
+ * This task copies library files in the application-services libs/ folder
+ * inside the build dir nativeLibs/ folder and makes sure this folder is
+ * included in Android jniLibs sourcesets.
+ * It is the responsability of the consumer of this plugin to depend on that
+ * newly defined task, for example in the `generateDebugAssets` task.
+ * Example of usage:
+ * <pre>
+ *   apply plugin: NativeLibsPlugin
+ *   nativeLibs {
+ *     nss {
+ *       lib "libnss3.*" // Wildcards are supported, just like the Copy task `include` method.
+ *     }
+ *   }
+ *   tasks["generateDebugAssets"].dependsOn(tasks["copyNativeLibs"])
+ * </pre>
+ */
+
+import com.android.build.gradle.AppExtension
+import com.android.build.gradle.AppPlugin
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.LibraryPlugin
+import org.gradle.api.tasks.Copy
+import org.gradle.api.Project
+import org.gradle.api.Plugin
+import org.gradle.kotlin.dsl.delegateClosureOf
+import java.io.File
+// Needed to be able to call `DomainObjectCollection.all` instead of Kotlin's built-in `all` method.
+import kotlin.collections.all as ktAll // ktlint-disable no-unused-imports
+
+const val EXTENSION_NAME = "nativeLibs"
+val ARCHS_FOLDERS = arrayOf(
+    "android/armeabi-v7a",
+    "android/arm64-v8a",
+    "android/x86",
+    "android/x86_64",
+    "desktop/linux-x86-64",
+    "desktop/darwin",
+    "desktop/win32-x86-64"
+)
+
+data class NativeLib(
+    val name: String,
+    var libs: List<String>
+) {
+    constructor(name: String) : this(name, listOf<String>())
+
+    public fun lib(libName: String): NativeLib {
+        this.libs += libName
+        return this
+    }
+}
+
+open class NativeLibsPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        with(project) {
+            val nativeLibs = container(NativeLib::class.java)
+            extensions.add(EXTENSION_NAME, nativeLibs)
+
+            nativeLibs.all(delegateClosureOf<NativeLib>({
+                val nativeLib = this
+                afterEvaluate {
+                    var copyNativeLibsTask = tasks.maybeCreate("copyNativeLibs")
+                    ARCHS_FOLDERS.forEach { archFolder ->
+                        val copyLibsTask = tasks.maybeCreate("copyNativeLibs-$archFolder", Copy::class.java).apply {
+                            from("${rootProject.rootDir}/libs/$archFolder/${nativeLib.name}/lib/")
+                            into("$buildDir/nativeLibs/$archFolder")
+                            nativeLib.libs.forEach {
+                                include(it)
+                            }
+                        }
+                        copyNativeLibsTask.dependsOn(copyLibsTask)
+                    }
+                }
+            }))
+            afterEvaluate {
+                plugins.all(delegateClosureOf<Plugin<*>>({
+                    when (this) {
+                        is AppPlugin -> addToSourceSets<AppExtension>(project)
+                        is LibraryPlugin -> addToSourceSets<LibraryExtension>(project)
+                    }
+                }))
+            }
+        }
+    }
+    private inline fun <reified T : BaseExtension> addToSourceSets(project: Project): Unit = with(project) {
+        (extensions.findByName("android") as T).apply {
+            sourceSets.getByName("main").jniLibs.srcDir(File("$buildDir/nativeLibs/android"))
+            sourceSets.getByName("test").resources.srcDir(File("$buildDir/nativeLibs/desktop"))
+        }
+    }
+}

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -25,6 +25,7 @@ untrusted = "0.6.2"
 url = "1.7.1"
 ffi-support = { path = "../support/ffi" }
 viaduct = { path = "../viaduct" }
+rc_crypto = { path = "../support/rc_crypto" }
 
 [dev-dependencies]
 cli-support = { path = "../support/cli" }

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -28,6 +28,7 @@ android {
 
     sourceSets {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
+        test.resources.srcDirs += "$buildDir/nativeLibs/desktop"
 
         main {
             proto {
@@ -147,10 +148,12 @@ afterEvaluate {
         def buildType = "${variant.buildType.name.capitalize()}"
         if (variant.buildType.name != 'withoutLib') {
             tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+            tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["copyNativeLibs"])
         }
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
+        tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["copyNativeLibs"])
     }
 }
 

--- a/components/fxa-client/src/errors.rs
+++ b/components/fxa-client/src/errors.rs
@@ -135,6 +135,9 @@ pub enum ErrorKind {
         info: String,
     },
 
+    #[fail(display = "Crypto/NSS error: {}", _0)]
+    CryptoError(#[fail(cause)] rc_crypto::Error),
+
     // Basically reimplement error_chain's foreign_links. (Ugh, this sucks)
     #[fail(display = "Hex decode error: {}", _0)]
     HexDecodeError(#[fail(cause)] hex::FromHexError),
@@ -188,6 +191,7 @@ macro_rules! impl_from_error {
 }
 
 impl_from_error! {
+    (CryptoError, ::rc_crypto::Error),
     (HexDecodeError, ::hex::FromHexError),
     (Base64Decode, ::base64::DecodeError),
     (JsonError, ::serde_json::Error),

--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{errors::*, scoped_keys::ScopedKeysFlow, util, FirefoxAccount, RNG};
-use ring::digest;
+use rc_crypto::digest;
 use serde_derive::*;
 use std::{
     collections::HashSet,
@@ -121,7 +121,7 @@ impl FirefoxAccount {
     fn oauth_flow(&mut self, mut url: Url, scopes: &[&str], wants_keys: bool) -> Result<String> {
         let state = util::random_base64_url_string(&*RNG, 16)?;
         let code_verifier = util::random_base64_url_string(&*RNG, 43)?;
-        let code_challenge = digest::digest(&digest::SHA256, &code_verifier.as_bytes());
+        let code_challenge = digest::digest(&digest::SHA256, &code_verifier.as_bytes())?;
         let code_challenge = base64::encode_config(&code_challenge, base64::URL_SAFE_NO_PAD);
         url.query_pairs_mut()
             .append_pair("client_id", &self.state.config.client_id)

--- a/components/fxa-client/src/scoped_keys.rs
+++ b/components/fxa-client/src/scoped_keys.rs
@@ -4,7 +4,8 @@
 
 use crate::errors::*;
 use byteorder::{BigEndian, ByteOrder};
-use ring::{aead, agreement, agreement::EphemeralPrivateKey, digest, rand::SecureRandom};
+use rc_crypto::digest;
+use ring::{aead, agreement, agreement::EphemeralPrivateKey, rand::SecureRandom};
 use serde_json::{self, json};
 use untrusted::Input;
 
@@ -92,7 +93,7 @@ impl ScopedKeysFlow {
                 buf.extend_from_slice(&to_32b_buf(apv.len() as u32));
                 buf.extend_from_slice(apv.as_bytes());
                 buf.extend_from_slice(&to_32b_buf(256));
-                Ok(digest::digest(&digest::SHA256, &buf).as_ref()[0..32].to_vec())
+                Ok(digest::digest(&digest::SHA256, &buf)?)
             },
         )?;
 

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 
 [dependencies]
 communications={path="communications"}
-crypto={path="crypto"}
+push-crypto={path="crypto"}
 storage={path="storage"}
 subscriber={path="subscriber"}
 push-errors={path="error"}

--- a/components/push/communications/Cargo.toml
+++ b/components/push/communications/Cargo.toml
@@ -20,7 +20,7 @@ viaduct = { path = "../../viaduct" }
 
 storage = {path="../storage"}
 push-errors = {path="../error"}
-crypto = {path="../crypto"}
+push-crypto = {path="../crypto"}
 config = {path="../config"}
 
 [dev-dependencies]

--- a/components/push/communications/src/lib.rs
+++ b/components/push/communications/src/lib.rs
@@ -409,7 +409,7 @@ mod test {
     use mockito::{mock, server_address};
     use serde_json::json;
 
-    // use crypto::{get_bytes, Key};
+    // use push_crypto::{get_bytes, Key};
 
     const DUMMY_CHID: &str = "deadbeef00000000decafbad00000000";
     const DUMMY_UAID: &str = "abad1dea00000000aabbccdd00000000";
@@ -447,7 +447,7 @@ mod test {
             .with_body(body)
             .create();
             let mut conn = connect(config.clone(), None, None).unwrap();
-            let channel_id = hex::encode(crypto::get_bytes(16).unwrap());
+            let channel_id = hex::encode(push_crypto::get_bytes(16).unwrap());
             let response = conn.subscribe(&channel_id).unwrap();
             ap_mock.assert();
             assert_eq!(response.uaid, DUMMY_UAID);

--- a/components/push/crypto/Cargo.toml
+++ b/components/push/crypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "crypto"
+name = "push-crypto"
 version = "0.1.0"
 authors = ["jrconlin <me+crypt@jrconlin.com>"]
 edition = "2018"

--- a/components/push/ffi/Cargo.toml
+++ b/components/push/ffi/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = "1.3.0"
 base64 = "0.10"
 
 config = { path = "../config" }
-crypto = { path = "../crypto" }
+push-crypto = { path = "../crypto" }
 push-errors = {path = "../error" }
 subscriber ={ path = "../subscriber" }
 storage = { path = "../storage" }

--- a/components/push/prototype.md
+++ b/components/push/prototype.md
@@ -49,7 +49,7 @@ Notifier.process_notification(notification: Notification) {
     // get the pushrecord from storage.
     if let Some(pr) = storage.get_record(uaid, notification.channel_id) {
         let content = if ! pr.system_record {
-            crypto::decrypt(notification);
+            push_crypto::decrypt(notification);
         } else {
             notification.body
         };

--- a/components/push/src/lib.rs
+++ b/components/push/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(unknown_lints)]
 pub use communications;
 pub use config;
-pub use crypto;
+pub use push_crypto;
 pub use push_errors;
 pub use push_ffi;
 pub use storage;

--- a/components/push/storage/Cargo.toml
+++ b/components/push/storage/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "MPL-2.0"
 
 [dependencies]
-crypto = { path = "../crypto" }
+push-crypto = { path = "../crypto" }
 lazy_static = "1.2"
 log = "0.4"
 failure = "0.1.5"

--- a/components/push/storage/src/db.rs
+++ b/components/push/storage/src/db.rs
@@ -196,7 +196,7 @@ impl Storage for PushDb {
 
 #[cfg(test)]
 mod test {
-    use crypto::{Crypto, Cryptography};
+    use push_crypto::{Crypto, Cryptography};
     use push_errors::Result;
 
     use super::PushDb;

--- a/components/push/storage/src/record.rs
+++ b/components/push/storage/src/record.rs
@@ -1,6 +1,6 @@
 use rusqlite::Row;
 
-use crypto::Key;
+use push_crypto::Key;
 use push_errors::Result;
 
 use crate::types::Timestamp;

--- a/components/push/subscriber/Cargo.toml
+++ b/components/push/subscriber/Cargo.toml
@@ -14,5 +14,5 @@ serde_json = "1.0"
 communications = {path = "../communications"}
 storage = {path="../storage"}
 push-errors = {path="../error"}
-crypto = {path="../crypto"}
+push-crypto = {path="../crypto"}
 config = {path="../config"}

--- a/components/push/subscriber/src/lib.rs
+++ b/components/push/subscriber/src/lib.rs
@@ -7,14 +7,14 @@
 extern crate serde_json;
 
 extern crate communications;
-extern crate crypto;
+extern crate push_crypto;
 extern crate storage;
 
 use std::collections::HashMap;
 
 use communications::{connect, ConnectHttp, Connection, RegisterResponse};
 use config::PushConfiguration;
-use crypto::{Crypto, Cryptography, Key};
+use push_crypto::{Crypto, Cryptography, Key};
 use storage::{Storage, Store};
 
 use push_errors::{self as error, ErrorKind, Result};
@@ -178,7 +178,7 @@ mod test {
 
     //use serde_json::json;
 
-    // use crypto::{get_bytes, Key};
+    // use push_crypto::{get_bytes, Key};
 
     /*
     const DUMMY_CHID: &str = "deadbeef00000000decafbad00000000";

--- a/components/support/rc_crypto/Cargo.toml
+++ b/components/support/rc_crypto/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rc_crypto"
+version = "0.1.0"
+authors = ["Edouard Oger <eoger@fastmail.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["lib", "staticlib", "cdylib"]
+
+[dependencies]
+failure = "0.1.5"
+failure_derive = "0.1.5"
+nss_sys = { path = "nss_sys" }

--- a/components/support/rc_crypto/nss_sys/Cargo.toml
+++ b/components/support/rc_crypto/nss_sys/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nss_sys"
+version = "0.1.0"
+authors = ["Edouard Oger <eoger@fastmail.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["lib", "staticlib", "cdylib"]
+
+[dependencies]
+libloading = "0.5"
+lazy_static = "1.3.0"

--- a/components/support/rc_crypto/nss_sys/README.md
+++ b/components/support/rc_crypto/nss_sys/README.md
@@ -1,0 +1,9 @@
+## nss_sys
+
+NSS bindings for Rust.
+
+These bindings are implemented using `dlopen`/`dlsym` instead of linking against libnss.
+This is so we can re-use the NSS library shipped with GeckoView on Fenix and reference-browser.
+On Lockbox Android, or even in unit tests artifacts, we ship these library files ourselves alongside our compiled Rust library.
+
+On iOS the situation is different, we dynamically link because Apple [discourages using `dlopen`](https://github.com/nicklockwood/GZIP/issues/24).

--- a/components/support/rc_crypto/nss_sys/build.rs
+++ b/components/support/rc_crypto/nss_sys/build.rs
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::{
+    env,
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+fn env(name: &str) -> Option<OsString> {
+    println!("cargo:rerun-if-env-changed={}", name);
+    env::var_os(name)
+}
+
+fn main() {
+    // See https://kazlauskas.me/entries/writing-proper-buildrs-scripts.html.
+    let target_os = env::var("CARGO_CFG_TARGET_OS");
+    // Only iOS dynamically links with NSS. All the other platforms dlopen.
+    if let Ok("ios") = target_os.as_ref().map(|x| &**x) {
+        let (lib_dir, include_dir) = get_nss();
+        println!(
+            "cargo:rustc-link-search=native={}",
+            lib_dir.to_string_lossy()
+        );
+        println!("cargo:include={}", include_dir.to_string_lossy());
+    }
+}
+
+pub fn get_nss() -> (PathBuf, PathBuf) {
+    let nss_dir = env("NSS_DIR").expect("To build for iOS, NSS_DIR must be set!");
+    let nss_dir = Path::new(&nss_dir);
+    let lib_dir = nss_dir.join("lib");
+    let include_dir = nss_dir.join("include");
+    (lib_dir, include_dir)
+}

--- a/components/support/rc_crypto/nss_sys/src/lib.rs
+++ b/components/support/rc_crypto/nss_sys/src/lib.rs
@@ -1,0 +1,65 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
+
+mod types;
+
+use std::os::raw::{c_char, c_uchar};
+pub use types::nspr::*;
+pub use types::nss3::*;
+
+// This is the version this crate is claiming to be compatible with.
+// We check it at runtime using `NSS_VersionCheck`.
+pub const COMPATIBLE_NSS_VERSION: &str = "3.26";
+
+// Code adapted from https://stackoverflow.com/a/35591693. I am not this kind of smart.
+macro_rules! nss_exports {
+    () => {};
+    (
+        unsafe fn $fn_name:ident($($arg:ident: $argty:ty),*) -> $ret:ty;
+        $($tail:tt)*
+    ) => {
+        #[cfg(not(target_os = "ios"))]
+        lazy_static::lazy_static! {
+            pub static ref $fn_name: libloading::Symbol<'static, unsafe extern fn($($arg: $argty),*) -> $ret> = {
+                unsafe {
+                    LIBNSS3.get(stringify!($fn_name).as_bytes()).expect(stringify!(Could not get $fn_name handle))
+                }
+            };
+        }
+        #[cfg(target_os = "ios")]
+        extern "C" {
+            pub fn $fn_name($($arg: $argty),*) -> $ret;
+        }
+        nss_exports! { $($tail)* }
+    };
+    // Support for functions that don't return can be added by copy-pasting the above code and removing -> ref:ty.
+}
+
+#[cfg(not(target_os = "ios"))]
+lazy_static::lazy_static! {
+    // Lib handle.
+    static ref LIBNSS3: libloading::Library = {
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        const LIB_NAME: &str = "libnss3.dylib";
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        const LIB_NAME: &str = "libnss3.so";
+        #[cfg(target_os = "windows")]
+        const LIB_NAME: &str = "nss3.dll";
+        libloading::Library::new(LIB_NAME).expect("Cannot load libnss3.")
+    };
+}
+
+nss_exports! {
+    unsafe fn PR_GetError() -> PRErrorCode;
+    unsafe fn PR_GetErrorTextLength() -> PRInt32;
+    unsafe fn PR_GetErrorText(out: *mut c_uchar) -> PRInt32;
+    unsafe fn NSS_NoDB_Init(configdir: *const c_char) -> SECStatus;
+    unsafe fn NSS_InitContext(configdir: *const c_char, certPrefix: *const c_char, keyPrefix: *const c_char, secmodName: *const c_char, initParams: *mut NSSInitParameters, flags: PRUint32) -> *mut NSSInitContext;
+    unsafe fn NSS_IsInitialized() -> PRBool;
+    unsafe fn NSS_GetVersion() -> *const c_char;
+    unsafe fn NSS_VersionCheck(importedVersion: *const c_char) -> PRBool;
+    unsafe fn PK11_HashBuf(hashAlg: SECOidTag, out: *mut c_uchar, r#in: *const c_uchar, len: PRInt32) -> SECStatus;
+}

--- a/components/support/rc_crypto/nss_sys/src/types/mod.rs
+++ b/components/support/rc_crypto/nss_sys/src/types/mod.rs
@@ -1,0 +1,6 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub(crate) mod nspr;
+pub(crate) mod nss3;

--- a/components/support/rc_crypto/nss_sys/src/types/nspr.rs
+++ b/components/support/rc_crypto/nss_sys/src/types/nspr.rs
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![allow(non_camel_case_types)]
+
+pub type PRBool = PRIntn;
+pub const PR_TRUE: PRBool = 1;
+pub const PR_FALSE: PRBool = 0;
+pub type PRErrorCode = PRInt32;
+pub type PRInt32 = i32;
+pub type PRUint32 = u32;
+pub type PRIntn = std::os::raw::c_int;
+pub type PRUintn = std::os::raw::c_uint;
+
+#[repr(C)]
+pub enum PRThreadPriority {
+    PR_PRIORITY_LOW = 0,
+    PR_PRIORITY_NORMAL = 1,
+    PR_PRIORITY_HIGH = 2,
+    PR_PRIORITY_URGENT = 3,
+}
+
+#[repr(C)]
+pub enum PRThreadType {
+    PR_USER_THREAD,
+    PR_SYSTEM_THREAD,
+}

--- a/components/support/rc_crypto/nss_sys/src/types/nss3.rs
+++ b/components/support/rc_crypto/nss_sys/src/types/nss3.rs
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::nspr::*;
+use std::os::raw::{c_char, c_int, c_uint};
+
+#[repr(C)]
+pub enum SECStatus {
+    SECWouldBlock = -2,
+    SECFailure = -1,
+    SECSuccess = 0,
+}
+pub use SECStatus::*;
+
+#[repr(C)]
+pub enum SECOidTag {
+    // We only list the values we use here.
+    SEC_OID_UNKNOWN = 0,
+    SEC_OID_SHA256 = 191,
+}
+pub use SECOidTag::*;
+
+pub type NSSInitParameters = NSSInitParametersStr;
+#[repr(C)]
+pub struct NSSInitParametersStr {
+    length: c_uint,
+    passwordRequired: PRBool,
+    minPWLen: c_int,
+    manufactureID: *mut c_char,
+    libraryDescription: *mut c_char,
+    cryptoTokenDescription: *mut c_char,
+    dbTokenDescription: *mut c_char,
+    FIPSTokenDescription: *mut c_char,
+    cryptoSlotDescription: *mut c_char,
+    dbSlotDescription: *mut c_char,
+    FIPSSlotDescription: *mut c_char,
+}
+
+pub type NSSInitContext = NSSInitContextStr;
+#[repr(C)]
+pub struct NSSInitContextStr {
+    next: *mut NSSInitContext,
+    magic: PRUint32,
+}
+
+pub const NSS_INIT_READONLY: PRUint32 = 0x1;
+pub const NSS_INIT_NOCERTDB: PRUint32 = 0x2;
+pub const NSS_INIT_NOMODDB: PRUint32 = 0x4;
+pub const NSS_INIT_FORCEOPEN: PRUint32 = 0x8;
+pub const NSS_INIT_NOROOTINIT: PRUint32 = 0x10;
+pub const NSS_INIT_OPTIMIZESPACE: PRUint32 = 0x20;
+pub const NSS_INIT_PK11THREADSAFE: PRUint32 = 0x40;
+pub const NSS_INIT_PK11RELOAD: PRUint32 = 0x80;
+pub const NSS_INIT_NOPK11FINALIZE: PRUint32 = 0x100;
+pub const NSS_INIT_RESERVED: PRUint32 = 0x200;

--- a/components/support/rc_crypto/src/digest.rs
+++ b/components/support/rc_crypto/src/digest.rs
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{error::*, util::ensure_nss_initialized, util::map_nss_secstatus};
+
+pub enum Algorithm {
+    SHA256,
+}
+pub use Algorithm::*;
+
+impl Algorithm {
+    fn result_len(&self) -> usize {
+        match self {
+            Algorithm::SHA256 => 32,
+        }
+    }
+}
+
+impl From<&Algorithm> for nss_sys::SECOidTag {
+    fn from(alg: &Algorithm) -> Self {
+        match alg {
+            Algorithm::SHA256 => nss_sys::SEC_OID_SHA256,
+            // _ => nss_sys::SEC_OID_UNKNOWN,
+        }
+    }
+}
+
+pub fn digest(algorithm: &'static Algorithm, data: &[u8]) -> Result<Vec<u8>> {
+    let mut out_buf = vec![0u8; algorithm.result_len()];
+    ensure_nss_initialized();
+    map_nss_secstatus(|| unsafe {
+        nss_sys::PK11_HashBuf(
+            algorithm.into(),
+            out_buf.as_mut_ptr(),
+            data.as_ptr(),
+            data.len() as i32,
+        )
+    })?;
+    Ok(out_buf)
+}

--- a/components/support/rc_crypto/src/error.rs
+++ b/components/support/rc_crypto/src/error.rs
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use failure::{Backtrace, Context, Fail};
+use std::boxed::Box;
+use std::{self, fmt};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+pub struct Error(Box<Context<ErrorKind>>);
+
+impl Fail for Error {
+    #[inline]
+    fn cause(&self) -> Option<&Fail> {
+        self.0.cause()
+    }
+
+    #[inline]
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.0.backtrace()
+    }
+}
+
+impl fmt::Display for Error {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&*self.0, f)
+    }
+}
+
+impl Error {
+    #[inline]
+    pub fn kind(&self) -> &ErrorKind {
+        &*self.0.get_context()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    #[inline]
+    fn from(kind: ErrorKind) -> Error {
+        Error(Box::new(Context::new(kind)))
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    #[inline]
+    fn from(inner: Context<ErrorKind>) -> Error {
+        Error(Box::new(inner))
+    }
+}
+
+#[derive(Debug, Fail)]
+pub enum ErrorKind {
+    #[fail(display = "NSS could not be initialized")]
+    NSSInitFailure,
+    #[fail(display = "NSS error: {} {:?}", _0, _1)]
+    NSSError(i32, String),
+}

--- a/components/support/rc_crypto/src/lib.rs
+++ b/components/support/rc_crypto/src/lib.rs
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub mod digest;
+mod error;
+mod util;
+
+pub use crate::error::{Error, ErrorKind, Result};

--- a/components/support/rc_crypto/src/util.rs
+++ b/components/support/rc_crypto/src/util.rs
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::error::*;
+use nss_sys::*;
+use std::ffi::CString;
+use std::sync::Once;
+
+static NSS_INIT: Once = Once::new();
+
+pub fn ensure_nss_initialized() {
+    NSS_INIT.call_once(|| {
+        let version_ptr = CString::new(nss_sys::COMPATIBLE_NSS_VERSION).unwrap();
+        if unsafe { NSS_VersionCheck(version_ptr.as_ptr()) == PR_FALSE } {
+            panic!("Incompatible NSS version!")
+        }
+        if unsafe { NSS_IsInitialized() } == PR_FALSE {
+            let empty = CString::default();
+            let flags = NSS_INIT_READONLY
+                | NSS_INIT_NOCERTDB
+                | NSS_INIT_NOMODDB
+                | NSS_INIT_FORCEOPEN
+                | NSS_INIT_OPTIMIZESPACE;
+            let context = unsafe {
+                NSS_InitContext(
+                    empty.as_ptr(),
+                    empty.as_ptr(),
+                    empty.as_ptr(),
+                    empty.as_ptr(),
+                    std::ptr::null_mut(),
+                    flags,
+                )
+            };
+            if context.is_null() {
+                panic!("Could not initialize NSS!")
+            }
+        }
+    })
+}
+
+pub fn map_nss_secstatus<F>(callback: F) -> Result<()>
+where
+    F: FnOnce() -> SECStatus,
+{
+    if let SECSuccess = callback() {
+        return Ok(());
+    }
+    let error_code = unsafe { PR_GetError() };
+    let error_text_len = unsafe { PR_GetErrorTextLength() } as usize;
+    let mut out_str = vec![0u8; error_text_len + 1];
+    unsafe { PR_GetErrorText(out_str.as_mut_ptr()) };
+    let error_text: String = CString::new(&out_str[0..error_text_len])
+        .unwrap_or_else(|_| CString::default())
+        .to_str()
+        .unwrap_or_else(|_| "")
+        .to_owned();
+    Err(ErrorKind::NSSError(error_code, error_text).into())
+}

--- a/docs/howtos/consuming-rust-components-on-ios.md
+++ b/docs/howtos/consuming-rust-components-on-ios.md
@@ -26,6 +26,10 @@ Rather than using a tagged release version, one can grab the build from Circle-C
 
 The project has additional 3rd-party dependencies that a client must link against.
 
+### NSS
+
+- In your project, add all the .dylibs in the `../Carthage/Build/iOS/MozillaAppServices.framework` directory to both the "Embedded Binaries" and the "Linked Frameworks and Libraries" panels.
+
 ### Protobuf
 
 - *SwiftProtoBuf.framework* should be automatically downloaded by carthage while pulling in the application-services dependency.

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ libVcsUrl=https://github.com/mozilla/application-services.git
 
 libLicense=MPL-2.0
 libLicenseUrl=https://www.mozilla.org/en-US/MPL/2.0/
+androidGradlePluginVersion=3.2.1

--- a/libs/.gitignore
+++ b/libs/.gitignore
@@ -1,11 +1,10 @@
-bin/patchelf
-
 # Downloaded sources tarballs.
 *.tar.gz
 
 # Intermediate folders leftover on build failures.
 openssl-*
 sqlcipher-*
+nss-*
 
 # Final artifacts
 /android

--- a/libs/android_defaults.sh
+++ b/libs/android_defaults.sh
@@ -2,10 +2,10 @@
 
 if [ -z "${ANDROID_NDK_TOOLCHAIN_DIR:-}" ]; then
     export ANDROID_NDK_TOOLCHAIN_DIR="/tmp/android-ndk-toolchain"
-    echo "The ANDROID_NDK_TOOLCHAIN_DIR env variable is not set. Defaulting to $ANDROID_NDK_TOOLCHAIN_DIR"
+    echo "The ANDROID_NDK_TOOLCHAIN_DIR env variable is not set. Defaulting to ${ANDROID_NDK_TOOLCHAIN_DIR}"
 fi
 
 if [ -z "${ANDROID_NDK_API_VERSION:-}" ]; then
     export ANDROID_NDK_API_VERSION=21
-    echo "The ANDROID_NDK_API_VERSION env variable is not set. Defaulting to $ANDROID_NDK_API_VERSION"
+    echo "The ANDROID_NDK_API_VERSION env variable is not set. Defaulting to ${ANDROID_NDK_API_VERSION}"
 fi

--- a/libs/bootstrap-desktop.sh
+++ b/libs/bootstrap-desktop.sh
@@ -15,7 +15,7 @@ else
   export SQLCIPHER_LIB_DIR="$APPSERVICES_PLATFORM_DIR/sqlcipher/lib"
   export SQLCIPHER_INCLUDE_DIR="$APPSERVICES_PLATFORM_DIR/sqlcipher/include"
   export OPENSSL_DIR="$APPSERVICES_PLATFORM_DIR/openssl"
-  if [ ! -d "$SQLCIPHER_LIB_DIR" -o ! -d "$OPENSSL_DIR" ]; then
+  if [ ! -d "$SQLCIPHER_LIB_DIR" -o ! -d "$OPENSSL_DIR" -o ! -d "$APPSERVICES_PLATFORM_DIR/nss" ]; then
     pushd libs && ./build-all.sh desktop && popd
   fi;
 fi

--- a/libs/bootstrap-desktop.sh
+++ b/libs/bootstrap-desktop.sh
@@ -12,10 +12,10 @@ else
   else
     APPSERVICES_PLATFORM_DIR="$(pwd)/libs/desktop/linux-x86-64"
   fi
-  export SQLCIPHER_LIB_DIR="$APPSERVICES_PLATFORM_DIR/sqlcipher/lib"
-  export SQLCIPHER_INCLUDE_DIR="$APPSERVICES_PLATFORM_DIR/sqlcipher/include"
-  export OPENSSL_DIR="$APPSERVICES_PLATFORM_DIR/openssl"
-  if [ ! -d "$SQLCIPHER_LIB_DIR" -o ! -d "$OPENSSL_DIR" -o ! -d "$APPSERVICES_PLATFORM_DIR/nss" ]; then
+  export SQLCIPHER_LIB_DIR="${APPSERVICES_PLATFORM_DIR}/sqlcipher/lib"
+  export SQLCIPHER_INCLUDE_DIR="${APPSERVICES_PLATFORM_DIR}/sqlcipher/include"
+  export OPENSSL_DIR="${APPSERVICES_PLATFORM_DIR}/openssl"
+  if [ ! -d "${SQLCIPHER_LIB_DIR}" -o ! -d "${OPENSSL_DIR}" -o ! -d "${APPSERVICES_PLATFORM_DIR}/nss" ]; then
     pushd libs && ./build-all.sh desktop && popd
   fi;
 fi

--- a/libs/build-all-android.sh
+++ b/libs/build-all-android.sh
@@ -2,9 +2,6 @@
 
 set -euvx
 
-abspath () { case "$1" in /*)printf "%s\\n" "$1";; *)printf "%s\\n" "$PWD/$1";; esac; }
-export -f abspath
-
 # Our short-names for the architectures.
 TARGET_ARCHS=("x86_64" "x86" "arm64" "arm")
 # The directories required for the Android-Gradle plugin and APK
@@ -15,16 +12,29 @@ TARGET_ARCHS_TOOLCHAINS=("x86_64-linux-android" "i686-linux-android" "aarch64-li
 
 # End of configuration.
 
-if [ "$#" -ne 2 ]
+if [ "$#" -ne 3 ]
 then
     echo "Usage:"
-    echo "./build-all-android.sh <OPENSSL_SRC_PATH> <SQLCIPHER_SRC_PATH>"
+    echo "./build-all-android.sh <OPENSSL_SRC_PATH> <SQLCIPHER_SRC_PATH> <NSS_SRC_PATH>"
     exit 1
 fi
 
 source "$(dirname "$0")/android_defaults.sh"
 OPENSSL_SRC_PATH=$1
 SQLCIPHER_SRC_PATH=$2
+NSS_SRC_PATH=$3
+
+echo "# Building NSS"
+for i in "${!TARGET_ARCHS[@]}"; do
+  ARCH=${TARGET_ARCHS[$i]}
+  DIST=${TARGET_ARCHS_DISTS[$i]}
+  DIST_DIR=$(abspath "android/${DIST}/nss")
+  if [ -d "${DIST_DIR}" ]; then
+    echo "${DIST_DIR} already exists. Skipping building nss."
+  else
+    ./build-nss-android.sh "${NSS_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" "${TARGET_ARCHS_TOOLCHAINS[$i]}" "${ANDROID_NDK_API_VERSION}" || exit 1
+  fi
+done
 
 echo "# Building openssl"
 for i in "${!TARGET_ARCHS[@]}"; do

--- a/libs/build-all-android.sh
+++ b/libs/build-all-android.sh
@@ -12,51 +12,51 @@ TARGET_ARCHS_TOOLCHAINS=("x86_64-linux-android" "i686-linux-android" "aarch64-li
 
 # End of configuration.
 
-if [ "$#" -ne 3 ]
+if [ "${#}" -ne 3 ]
 then
     echo "Usage:"
     echo "./build-all-android.sh <OPENSSL_SRC_PATH> <SQLCIPHER_SRC_PATH> <NSS_SRC_PATH>"
     exit 1
 fi
 
-source "$(dirname "$0")/android_defaults.sh"
-OPENSSL_SRC_PATH=$1
-SQLCIPHER_SRC_PATH=$2
-NSS_SRC_PATH=$3
+source "$(dirname "${0}")/android_defaults.sh"
+OPENSSL_SRC_PATH=${1}
+SQLCIPHER_SRC_PATH=${2}
+NSS_SRC_PATH=${3}
 
 echo "# Building NSS"
 for i in "${!TARGET_ARCHS[@]}"; do
-  ARCH=${TARGET_ARCHS[$i]}
-  DIST=${TARGET_ARCHS_DISTS[$i]}
+  ARCH=${TARGET_ARCHS[${i}]}
+  DIST=${TARGET_ARCHS_DISTS[${i}]}
   DIST_DIR=$(abspath "android/${DIST}/nss")
   if [ -d "${DIST_DIR}" ]; then
     echo "${DIST_DIR} already exists. Skipping building nss."
   else
-    ./build-nss-android.sh "${NSS_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" "${TARGET_ARCHS_TOOLCHAINS[$i]}" "${ANDROID_NDK_API_VERSION}" || exit 1
+    ./build-nss-android.sh "${NSS_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" "${TARGET_ARCHS_TOOLCHAINS[${i}]}" "${ANDROID_NDK_API_VERSION}" || exit 1
   fi
 done
 
 echo "# Building openssl"
 for i in "${!TARGET_ARCHS[@]}"; do
-  ARCH=${TARGET_ARCHS[$i]}
-  DIST=${TARGET_ARCHS_DISTS[$i]}
-  DIST_DIR=$(abspath "android/""$DIST""/openssl")
-  if [ -d "$DIST_DIR" ]; then
-    echo "$DIST_DIR already exists. Skipping building openssl."
+  ARCH=${TARGET_ARCHS[${i}]}
+  DIST=${TARGET_ARCHS_DISTS[${i}]}
+  DIST_DIR=$(abspath "android/""${DIST}""/openssl")
+  if [ -d "${DIST_DIR}" ]; then
+    echo "${DIST_DIR} already exists. Skipping building openssl."
   else
-    ./build-openssl-android.sh "$OPENSSL_SRC_PATH" "$DIST_DIR" "$ANDROID_NDK_TOOLCHAIN_DIR/$ARCH-$ANDROID_NDK_API_VERSION" "${TARGET_ARCHS_TOOLCHAINS[$i]}" "$ANDROID_NDK_API_VERSION" || exit 1
+    ./build-openssl-android.sh "${OPENSSL_SRC_PATH}" "${DIST_DIR}" "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" "${TARGET_ARCHS_TOOLCHAINS[${i}]}" "${ANDROID_NDK_API_VERSION}" || exit 1
   fi
 done
 
 echo "# Building sqlcipher"
 for i in "${!TARGET_ARCHS[@]}"; do
-  ARCH=${TARGET_ARCHS[$i]}
-  DIST=${TARGET_ARCHS_DISTS[$i]}
-  OPENSSL_DIR=$(abspath "android/""$DIST""/openssl")
-  DIST_DIR=$(abspath "android/""$DIST""/sqlcipher")
-  if [ -d "$DIST_DIR" ]; then
-    echo "$DIST_DIR already exists. Skipping building sqlcipher."
+  ARCH=${TARGET_ARCHS[${i}]}
+  DIST=${TARGET_ARCHS_DISTS[${i}]}
+  OPENSSL_DIR=$(abspath "android/""${DIST}""/openssl")
+  DIST_DIR=$(abspath "android/""${DIST}""/sqlcipher")
+  if [ -d "${DIST_DIR}" ]; then
+    echo "${DIST_DIR} already exists. Skipping building sqlcipher."
   else
-    ./build-sqlcipher-android.sh "$SQLCIPHER_SRC_PATH" "$DIST_DIR" "$ANDROID_NDK_TOOLCHAIN_DIR/$ARCH-$ANDROID_NDK_API_VERSION" "${TARGET_ARCHS_TOOLCHAINS[$i]}" "$ANDROID_NDK_API_VERSION" "$OPENSSL_DIR" || exit 1
+    ./build-sqlcipher-android.sh "${SQLCIPHER_SRC_PATH}" "${DIST_DIR}" "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" "${TARGET_ARCHS_TOOLCHAINS[${i}]}" "${ANDROID_NDK_API_VERSION}" "${OPENSSL_DIR}" || exit 1
   fi
 done

--- a/libs/build-all-ios.sh
+++ b/libs/build-all-ios.sh
@@ -6,28 +6,29 @@ IOS_MIN_SDK_VERSION="11.0"
 # Our short-names for the architectures.
 TARGET_ARCHS=("x86_64" "arm64")
 
-if [ "$#" -ne 2 ]
+if [ "$#" -ne 3 ]
 then
     echo "Usage:"
-    echo "./build-all-ios.sh <OPENSSL_SRC_PATH> <SQLCIPHER_SRC_PATH>"
+    echo "./build-all-ios.sh <OPENSSL_SRC_PATH> <SQLCIPHER_SRC_PATH> <NSS_SRC_PATH>"
     exit 1
 fi
 
 OPENSSL_SRC_PATH=$1
 SQLCIPHER_SRC_PATH=$2
+NSS_SRC_PATH=$3
 
 function universal_lib() {
   DIR_NAME=$1
   LIB_NAME=$2
-  UNIVERSAL_DIR="ios/universal/""$DIR_NAME"
-  LIB_PATH=$UNIVERSAL_DIR"/lib/"$LIB_NAME
+  UNIVERSAL_DIR="ios/universal/$DIR_NAME"
+  LIB_PATH="$UNIVERSAL_DIR/lib/$LIB_NAME"
   if [ ! -e "$LIB_PATH" ]; then
-    mkdir -p "$UNIVERSAL_DIR""/lib"
+    mkdir -p "$UNIVERSAL_DIR/lib"
     CMD="lipo"
     for ARCH in "${TARGET_ARCHS[@]}"; do
-      CMD="$CMD"" -arch ""$ARCH"" ios/""$ARCH""/""$DIR_NAME""/lib/""$LIB_NAME"
+      CMD="$CMD -arch $ARCH ios/$ARCH/$DIR_NAME/lib/$LIB_NAME"
     done
-    CMD="$CMD"" -output ""$LIB_PATH"" -create"
+    CMD="$CMD -output $LIB_PATH -create"
     ${CMD}
   fi
 }
@@ -57,6 +58,27 @@ for i in "${!TARGET_ARCHS[@]}"; do
 done
 universal_lib "sqlcipher" "libsqlcipher.a"
 
+echo "# Building NSS"
+for i in "${!TARGET_ARCHS[@]}"; do
+  ARCH=${TARGET_ARCHS[$i]}
+  DIST_DIR=$(abspath "ios/$ARCH/nss")
+  if [ -d "$DIST_DIR" ]; then
+    echo "$DIST_DIR already exists. Skipping building nss."
+  else
+    ./build-nss-ios.sh "$NSS_SRC_PATH" "$DIST_DIR" "$ARCH" "$IOS_MIN_SDK_VERSION" || exit 1
+  fi
+done
+universal_lib "nss" "libplc4.dylib"
+universal_lib "nss" "libplds4.dylib"
+universal_lib "nss" "libnspr4.dylib"
+universal_lib "nss" "libfreebl3.dylib"
+universal_lib "nss" "libnss3.dylib"
+universal_lib "nss" "libnssckbi.dylib"
+universal_lib "nss" "libnssutil3.dylib"
+universal_lib "nss" "libsmime3.dylib"
+universal_lib "nss" "libsoftokn3.dylib"
+universal_lib "nss" "libssl3.dylib"
+
 HEADER_DIST_DIR="ios/universal/openssl/include/openssl"
 if [ ! -e "$HEADER_DIST_DIR" ]; then
   mkdir -p $HEADER_DIST_DIR
@@ -70,5 +92,13 @@ if [ ! -e "$HEADER_DIST_DIR" ]; then
   mkdir -p $HEADER_DIST_DIR
   # Choice of arm64 is arbitrary, it shouldn't matter.
   HEADER_SRC_DIR=$(abspath "ios/arm64/sqlcipher/include/sqlcipher")
+  cp -L "$HEADER_SRC_DIR"/*.h "$HEADER_DIST_DIR"
+fi
+
+HEADER_DIST_DIR="ios/universal/nss/include/nss"
+if [ ! -e "$HEADER_DIST_DIR" ]; then
+  mkdir -p $HEADER_DIST_DIR
+  # Choice of arm64 is arbitrary, it shouldn't matter.
+  HEADER_SRC_DIR=$(abspath "ios/arm64/nss/include/nss")
   cp -L "$HEADER_SRC_DIR"/*.h "$HEADER_DIST_DIR"
 fi

--- a/libs/build-all-ios.sh
+++ b/libs/build-all-ios.sh
@@ -6,41 +6,41 @@ IOS_MIN_SDK_VERSION="11.0"
 # Our short-names for the architectures.
 TARGET_ARCHS=("x86_64" "arm64")
 
-if [ "$#" -ne 3 ]
+if [ "${#}" -ne 3 ]
 then
     echo "Usage:"
     echo "./build-all-ios.sh <OPENSSL_SRC_PATH> <SQLCIPHER_SRC_PATH> <NSS_SRC_PATH>"
     exit 1
 fi
 
-OPENSSL_SRC_PATH=$1
-SQLCIPHER_SRC_PATH=$2
-NSS_SRC_PATH=$3
+OPENSSL_SRC_PATH=${1}
+SQLCIPHER_SRC_PATH=${2}
+NSS_SRC_PATH=${3}
 
 function universal_lib() {
-  DIR_NAME=$1
-  LIB_NAME=$2
-  UNIVERSAL_DIR="ios/universal/$DIR_NAME"
-  LIB_PATH="$UNIVERSAL_DIR/lib/$LIB_NAME"
-  if [ ! -e "$LIB_PATH" ]; then
-    mkdir -p "$UNIVERSAL_DIR/lib"
+  DIR_NAME=${1}
+  LIB_NAME=${2}
+  UNIVERSAL_DIR="ios/universal/${DIR_NAME}"
+  LIB_PATH="${UNIVERSAL_DIR}/lib/${LIB_NAME}"
+  if [ ! -e "${LIB_PATH}" ]; then
+    mkdir -p "${UNIVERSAL_DIR}/lib"
     CMD="lipo"
     for ARCH in "${TARGET_ARCHS[@]}"; do
-      CMD="$CMD -arch $ARCH ios/$ARCH/$DIR_NAME/lib/$LIB_NAME"
+      CMD="${CMD} -arch ${ARCH} ios/${ARCH}/${DIR_NAME}/lib/${LIB_NAME}"
     done
-    CMD="$CMD -output $LIB_PATH -create"
+    CMD="${CMD} -output ${LIB_PATH} -create"
     ${CMD}
   fi
 }
 
 echo "# Building openssl"
 for i in "${!TARGET_ARCHS[@]}"; do
-  ARCH=${TARGET_ARCHS[$i]}
-  DIST_DIR=$(abspath "ios/""$ARCH""/openssl")
-  if [ -d "$DIST_DIR" ]; then
-    echo "$DIST_DIR already exists. Skipping building openssl."
+  ARCH=${TARGET_ARCHS[${i}]}
+  DIST_DIR=$(abspath "ios/""${ARCH}""/openssl")
+  if [ -d "${DIST_DIR}" ]; then
+    echo "${DIST_DIR} already exists. Skipping building openssl."
   else
-    ./build-openssl-ios.sh "$OPENSSL_SRC_PATH" "$DIST_DIR" "$ARCH" "$IOS_MIN_SDK_VERSION" || exit 1
+    ./build-openssl-ios.sh "${OPENSSL_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${IOS_MIN_SDK_VERSION}" || exit 1
   fi
 done
 universal_lib "openssl" "libssl.a"
@@ -48,24 +48,24 @@ universal_lib "openssl" "libcrypto.a"
 
 echo "# Building sqlcipher"
 for i in "${!TARGET_ARCHS[@]}"; do
-  ARCH=${TARGET_ARCHS[$i]}
-  DIST_DIR=$(abspath "ios/""$ARCH""/sqlcipher")
-  if [ -d "$DIST_DIR" ]; then
-    echo "$DIST_DIR already exists. Skipping building sqlcipher."
+  ARCH=${TARGET_ARCHS[${i}]}
+  DIST_DIR=$(abspath "ios/""${ARCH}""/sqlcipher")
+  if [ -d "${DIST_DIR}" ]; then
+    echo "${DIST_DIR} already exists. Skipping building sqlcipher."
   else
-    ./build-sqlcipher-ios.sh "$SQLCIPHER_SRC_PATH" "$DIST_DIR" "$ARCH" "$IOS_MIN_SDK_VERSION" || exit 1
+    ./build-sqlcipher-ios.sh "${SQLCIPHER_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${IOS_MIN_SDK_VERSION}" || exit 1
   fi
 done
 universal_lib "sqlcipher" "libsqlcipher.a"
 
 echo "# Building NSS"
 for i in "${!TARGET_ARCHS[@]}"; do
-  ARCH=${TARGET_ARCHS[$i]}
-  DIST_DIR=$(abspath "ios/$ARCH/nss")
-  if [ -d "$DIST_DIR" ]; then
-    echo "$DIST_DIR already exists. Skipping building nss."
+  ARCH=${TARGET_ARCHS[${i}]}
+  DIST_DIR=$(abspath "ios/${ARCH}/nss")
+  if [ -d "${DIST_DIR}" ]; then
+    echo "${DIST_DIR} already exists. Skipping building nss."
   else
-    ./build-nss-ios.sh "$NSS_SRC_PATH" "$DIST_DIR" "$ARCH" "$IOS_MIN_SDK_VERSION" || exit 1
+    ./build-nss-ios.sh "${NSS_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${IOS_MIN_SDK_VERSION}" || exit 1
   fi
 done
 universal_lib "nss" "libplc4.dylib"
@@ -80,25 +80,25 @@ universal_lib "nss" "libsoftokn3.dylib"
 universal_lib "nss" "libssl3.dylib"
 
 HEADER_DIST_DIR="ios/universal/openssl/include/openssl"
-if [ ! -e "$HEADER_DIST_DIR" ]; then
-  mkdir -p $HEADER_DIST_DIR
-  cp -L "$OPENSSL_SRC_PATH"/include/openssl/*.h "$HEADER_DIST_DIR"
+if [ ! -e "${HEADER_DIST_DIR}" ]; then
+  mkdir -p ${HEADER_DIST_DIR}
+  cp -L "${OPENSSL_SRC_PATH}"/include/openssl/*.h "${HEADER_DIST_DIR}"
   # The following file is generated during compilation, we pick the one in arm64.
-  cp -L "$PWD"/ios/arm64/openssl/include/openssl/opensslconf.h "$HEADER_DIST_DIR"
+  cp -L "${PWD}"/ios/arm64/openssl/include/openssl/opensslconf.h "${HEADER_DIST_DIR}"
 fi
 
 HEADER_DIST_DIR="ios/universal/sqlcipher/include/sqlcipher"
-if [ ! -e "$HEADER_DIST_DIR" ]; then
-  mkdir -p $HEADER_DIST_DIR
+if [ ! -e "${HEADER_DIST_DIR}" ]; then
+  mkdir -p ${HEADER_DIST_DIR}
   # Choice of arm64 is arbitrary, it shouldn't matter.
   HEADER_SRC_DIR=$(abspath "ios/arm64/sqlcipher/include/sqlcipher")
-  cp -L "$HEADER_SRC_DIR"/*.h "$HEADER_DIST_DIR"
+  cp -L "${HEADER_SRC_DIR}"/*.h "${HEADER_DIST_DIR}"
 fi
 
 HEADER_DIST_DIR="ios/universal/nss/include/nss"
-if [ ! -e "$HEADER_DIST_DIR" ]; then
-  mkdir -p $HEADER_DIST_DIR
+if [ ! -e "${HEADER_DIST_DIR}" ]; then
+  mkdir -p ${HEADER_DIST_DIR}
   # Choice of arm64 is arbitrary, it shouldn't matter.
   HEADER_SRC_DIR=$(abspath "ios/arm64/nss/include/nss")
-  cp -L "$HEADER_SRC_DIR"/*.h "$HEADER_DIST_DIR"
+  cp -L "${HEADER_SRC_DIR}"/*.h "${HEADER_DIST_DIR}"
 fi

--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -8,6 +8,11 @@ OPENSSL_SHA256="fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41
 SQLCIPHER_VERSION="4.0.0"
 SQLCIPHER_SHA256="c8f5fc6d800aae6107bf23900144804db5510c2676c93fbb269e4a0700837d68"
 
+NSS="nss-3.43"
+NSS_ARCHIVE="nss-3.43-with-nspr-4.21.tar.gz"
+NSS_URL="http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_43_RTM/src/$NSS_ARCHIVE"
+NSS_SHA256="fb2d54d507ceb185bac73f492cce7086a462d41977c2378aba9dd10e04448cf3"
+
 # End of configuration.
 
 if [ "$#" -ne 1 ]
@@ -22,47 +27,56 @@ PLATFORM=$1
 abspath () { case "$1" in /*)printf "%s\\n" "$1";; *)printf "%s\\n" "$PWD/$1";; esac; }
 export -f abspath
 
-OPENSSL="openssl-${OPENSSL_VERSION}"
-rm -rf "${OPENSSL}"
-if [ ! -e "${OPENSSL}.tar.gz" ]; then
-  echo "Downloading ${OPENSSL}.tar.gz"
-  curl -L -O "https://www.openssl.org/source/""${OPENSSL}"".tar.gz"
+OPENSSL="openssl-$OPENSSL_VERSION"
+rm -rf "$OPENSSL"
+if [ ! -e "$OPENSSL.tar.gz" ]; then
+  echo "Downloading $OPENSSL.tar.gz"
+  curl -L -O "https://www.openssl.org/source/$OPENSSL.tar.gz"
 else
-  echo "Using ${OPENSSL}.tar.gz"
+  echo "Using $OPENSSL.tar.gz"
 fi
-
-echo "${OPENSSL_SHA256}  ${OPENSSL}.tar.gz" | shasum -a 256 -c - || exit 2
-
-tar xfz "${OPENSSL}.tar.gz"
+echo "$OPENSSL_SHA256  $OPENSSL.tar.gz" | shasum -a 256 -c - || exit 2
+tar xfz "$OPENSSL.tar.gz"
 OPENSSL_SRC_PATH=$(abspath $OPENSSL)
 
-
-SQLCIPHER="v${SQLCIPHER_VERSION}"
-rm -rf "${SQLCIPHER}"
-if [ ! -e "${SQLCIPHER}.tar.gz" ]; then
-  echo "Downloading ${SQLCIPHER}.tar.gz"
-  curl -L -O "https://github.com/sqlcipher/sqlcipher/archive/""${SQLCIPHER}"".tar.gz"
+SQLCIPHER="v$SQLCIPHER_VERSION"
+rm -rf "$SQLCIPHER"
+if [ ! -e "$SQLCIPHER.tar.gz" ]; then
+  echo "Downloading $SQLCIPHER.tar.gz"
+  curl -L -O "https://github.com/sqlcipher/sqlcipher/archive/$SQLCIPHER.tar.gz"
 else
-  echo "Using ${SQLCIPHER}.tar.gz"
+  echo "Using $SQLCIPHER.tar.gz"
 fi
+echo "$SQLCIPHER_SHA256  $SQLCIPHER.tar.gz" | shasum -a 256 -c - || exit 2
+tar xfz "$SQLCIPHER.tar.gz"
+SQLCIPHER_SRC_PATH=$(abspath "sqlcipher-$SQLCIPHER_VERSION")
 
-echo "${SQLCIPHER_SHA256}  ${SQLCIPHER}.tar.gz" | shasum -a 256 -c - || exit 2
-
-tar xfz "${SQLCIPHER}.tar.gz"
-SQLCIPHER_SRC_PATH=$(abspath "sqlcipher-${SQLCIPHER_VERSION}")
+rm -rf "$NSS"
+if [ ! -e "$NSS_ARCHIVE" ]; then
+  echo "Downloading $NSS_ARCHIVE"
+  curl -L -O "$NSS_URL"
+else
+  echo "Using $NSS_ARCHIVE"
+fi
+echo "$NSS_SHA256  $NSS_ARCHIVE" | shasum -a 256 -c - || exit 2
+tar xfz "$NSS_ARCHIVE"
+NSS_SRC_PATH=$(abspath "$NSS")
+./patch-nss-src.sh "${NSS_SRC_PATH}"
 
 if [ "$PLATFORM" == "ios" ]
 then
-  ./build-all-ios.sh "$OPENSSL_SRC_PATH" "$SQLCIPHER_SRC_PATH"
+  ./build-all-ios.sh "$OPENSSL_SRC_PATH" "$SQLCIPHER_SRC_PATH" "$NSS_SRC_PATH"
 elif [ "$PLATFORM" == "android" ]
 then
-  ./build-all-android.sh "$OPENSSL_SRC_PATH" "$SQLCIPHER_SRC_PATH"
+  ./build-all-android.sh "$OPENSSL_SRC_PATH" "$SQLCIPHER_SRC_PATH" "$NSS_SRC_PATH"
 elif [ "$PLATFORM" == "desktop" ]
 then
+  ./build-nss-desktop.sh "$NSS_SRC_PATH"
   ./build-openssl-desktop.sh "$OPENSSL_SRC_PATH"
   ./build-sqlcipher-desktop.sh "$SQLCIPHER_SRC_PATH"
 elif [ "$PLATFORM" == "darwin" -o "$PLATFORM" == "win32-x86-64" ]
 then
+  ./build-nss-desktop.sh "$NSS_SRC_PATH" "$PLATFORM"
   ./build-openssl-desktop.sh "$OPENSSL_SRC_PATH" "$PLATFORM"
   ./build-sqlcipher-desktop.sh "$SQLCIPHER_SRC_PATH" "$PLATFORM"
 else
@@ -73,5 +87,6 @@ fi
 echo "Cleaning up"
 rm -rf "$OPENSSL_SRC_PATH"
 rm -rf "$SQLCIPHER_SRC_PATH"
+rm -rf "$NSS_SRC_PATH"
 
 echo "Done"

--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -10,83 +10,83 @@ SQLCIPHER_SHA256="c8f5fc6d800aae6107bf23900144804db5510c2676c93fbb269e4a0700837d
 
 NSS="nss-3.43"
 NSS_ARCHIVE="nss-3.43-with-nspr-4.21.tar.gz"
-NSS_URL="http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_43_RTM/src/$NSS_ARCHIVE"
+NSS_URL="http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_43_RTM/src/${NSS_ARCHIVE}"
 NSS_SHA256="fb2d54d507ceb185bac73f492cce7086a462d41977c2378aba9dd10e04448cf3"
 
 # End of configuration.
 
-if [ "$#" -ne 1 ]
+if [ "${#}" -ne 1 ]
 then
     echo "Usage:"
     echo "./build-all.sh [ios|android|desktop]"
     exit 1
 fi
 
-PLATFORM=$1
+PLATFORM="${1}"
 
-abspath () { case "$1" in /*)printf "%s\\n" "$1";; *)printf "%s\\n" "$PWD/$1";; esac; }
+abspath () { case "${1}" in /*)printf "%s\\n" "${1}";; *)printf "%s\\n" "${PWD}/${1}";; esac; }
 export -f abspath
 
-OPENSSL="openssl-$OPENSSL_VERSION"
-rm -rf "$OPENSSL"
-if [ ! -e "$OPENSSL.tar.gz" ]; then
-  echo "Downloading $OPENSSL.tar.gz"
-  curl -L -O "https://www.openssl.org/source/$OPENSSL.tar.gz"
+OPENSSL="openssl-${OPENSSL_VERSION}"
+rm -rf "${OPENSSL}"
+if [ ! -e "${OPENSSL}.tar.gz" ]; then
+  echo "Downloading ${OPENSSL}.tar.gz"
+  curl -L -O "https://www.openssl.org/source/${OPENSSL}.tar.gz"
 else
-  echo "Using $OPENSSL.tar.gz"
+  echo "Using ${OPENSSL}.tar.gz"
 fi
-echo "$OPENSSL_SHA256  $OPENSSL.tar.gz" | shasum -a 256 -c - || exit 2
-tar xfz "$OPENSSL.tar.gz"
-OPENSSL_SRC_PATH=$(abspath $OPENSSL)
+echo "${OPENSSL_SHA256}  ${OPENSSL}.tar.gz" | shasum -a 256 -c - || exit 2
+tar xfz "${OPENSSL}.tar.gz"
+OPENSSL_SRC_PATH=$(abspath ${OPENSSL})
 
-SQLCIPHER="v$SQLCIPHER_VERSION"
-rm -rf "$SQLCIPHER"
-if [ ! -e "$SQLCIPHER.tar.gz" ]; then
-  echo "Downloading $SQLCIPHER.tar.gz"
-  curl -L -O "https://github.com/sqlcipher/sqlcipher/archive/$SQLCIPHER.tar.gz"
+SQLCIPHER="v${SQLCIPHER_VERSION}"
+rm -rf "${SQLCIPHER}"
+if [ ! -e "${SQLCIPHER}.tar.gz" ]; then
+  echo "Downloading ${SQLCIPHER}.tar.gz"
+  curl -L -O "https://github.com/sqlcipher/sqlcipher/archive/${SQLCIPHER}.tar.gz"
 else
-  echo "Using $SQLCIPHER.tar.gz"
+  echo "Using ${SQLCIPHER}.tar.gz"
 fi
-echo "$SQLCIPHER_SHA256  $SQLCIPHER.tar.gz" | shasum -a 256 -c - || exit 2
-tar xfz "$SQLCIPHER.tar.gz"
-SQLCIPHER_SRC_PATH=$(abspath "sqlcipher-$SQLCIPHER_VERSION")
+echo "${SQLCIPHER_SHA256}  ${SQLCIPHER}.tar.gz" | shasum -a 256 -c - || exit 2
+tar xfz "${SQLCIPHER}.tar.gz"
+SQLCIPHER_SRC_PATH=$(abspath "sqlcipher-${SQLCIPHER_VERSION}")
 
-rm -rf "$NSS"
-if [ ! -e "$NSS_ARCHIVE" ]; then
-  echo "Downloading $NSS_ARCHIVE"
-  curl -L -O "$NSS_URL"
+rm -rf "${NSS}"
+if [ ! -e "${NSS_ARCHIVE}" ]; then
+  echo "Downloading ${NSS_ARCHIVE}"
+  curl -L -O "${NSS_URL}"
 else
-  echo "Using $NSS_ARCHIVE"
+  echo "Using ${NSS_ARCHIVE}"
 fi
-echo "$NSS_SHA256  $NSS_ARCHIVE" | shasum -a 256 -c - || exit 2
-tar xfz "$NSS_ARCHIVE"
-NSS_SRC_PATH=$(abspath "$NSS")
+echo "${NSS_SHA256}  ${NSS_ARCHIVE}" | shasum -a 256 -c - || exit 2
+tar xfz "${NSS_ARCHIVE}"
+NSS_SRC_PATH=$(abspath "${NSS}")
 ./patch-nss-src.sh "${NSS_SRC_PATH}"
 
-if [ "$PLATFORM" == "ios" ]
+if [ "${PLATFORM}" == "ios" ]
 then
-  ./build-all-ios.sh "$OPENSSL_SRC_PATH" "$SQLCIPHER_SRC_PATH" "$NSS_SRC_PATH"
-elif [ "$PLATFORM" == "android" ]
+  ./build-all-ios.sh "${OPENSSL_SRC_PATH}" "${SQLCIPHER_SRC_PATH}" "${NSS_SRC_PATH}"
+elif [ "${PLATFORM}" == "android" ]
 then
-  ./build-all-android.sh "$OPENSSL_SRC_PATH" "$SQLCIPHER_SRC_PATH" "$NSS_SRC_PATH"
-elif [ "$PLATFORM" == "desktop" ]
+  ./build-all-android.sh "${OPENSSL_SRC_PATH}" "${SQLCIPHER_SRC_PATH}" "${NSS_SRC_PATH}"
+elif [ "${PLATFORM}" == "desktop" ]
 then
-  ./build-nss-desktop.sh "$NSS_SRC_PATH"
-  ./build-openssl-desktop.sh "$OPENSSL_SRC_PATH"
-  ./build-sqlcipher-desktop.sh "$SQLCIPHER_SRC_PATH"
-elif [ "$PLATFORM" == "darwin" -o "$PLATFORM" == "win32-x86-64" ]
+  ./build-nss-desktop.sh "${NSS_SRC_PATH}"
+  ./build-openssl-desktop.sh "${OPENSSL_SRC_PATH}"
+  ./build-sqlcipher-desktop.sh "${SQLCIPHER_SRC_PATH}"
+elif [ "${PLATFORM}" == "darwin" -o "${PLATFORM}" == "win32-x86-64" ]
 then
-  ./build-nss-desktop.sh "$NSS_SRC_PATH" "$PLATFORM"
-  ./build-openssl-desktop.sh "$OPENSSL_SRC_PATH" "$PLATFORM"
-  ./build-sqlcipher-desktop.sh "$SQLCIPHER_SRC_PATH" "$PLATFORM"
+  ./build-nss-desktop.sh "${NSS_SRC_PATH}" "${PLATFORM}"
+  ./build-openssl-desktop.sh "${OPENSSL_SRC_PATH}" "${PLATFORM}"
+  ./build-sqlcipher-desktop.sh "${SQLCIPHER_SRC_PATH}" "${PLATFORM}"
 else
   echo "Unrecognized platform"
   exit 1
 fi
 
 echo "Cleaning up"
-rm -rf "$OPENSSL_SRC_PATH"
-rm -rf "$SQLCIPHER_SRC_PATH"
-rm -rf "$NSS_SRC_PATH"
+rm -rf "${OPENSSL_SRC_PATH}"
+rm -rf "${SQLCIPHER_SRC_PATH}"
+rm -rf "${NSS_SRC_PATH}"
 
 echo "Done"

--- a/libs/build-nss-android.sh
+++ b/libs/build-nss-android.sh
@@ -4,19 +4,19 @@
 
 set -euvx
 
-if [ "$#" -ne 6 ]
+if [ "${#}" -ne 6 ]
 then
     echo "Usage:"
     echo "./build-nss-android.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <TOOLCHAIN_PATH> <TOOLCHAIN> <ANDROID_NDK_API_VERSION>"
     exit 1
 fi
 
-NSS_SRC_DIR=$1
-DIST_DIR=$2
-ARCH=$3
-TOOLCHAIN_PATH=$4
-TOOLCHAIN=$5
-ANDROID_NDK_API_VERSION=$6
+NSS_SRC_DIR=${1}
+DIST_DIR=${2}
+ARCH=${3}
+TOOLCHAIN_PATH=${4}
+TOOLCHAIN=${5}
+ANDROID_NDK_API_VERSION=${6}
 
 if [ -d "${DIST_DIR}" ]; then
   echo "${DIST_DIR}"" folder already exists. Skipping build."

--- a/libs/build-nss-android.sh
+++ b/libs/build-nss-android.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# This script cross-compiles the NSS library for Android.
+
+set -euvx
+
+if [ "$#" -ne 6 ]
+then
+    echo "Usage:"
+    echo "./build-nss-android.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <TOOLCHAIN_PATH> <TOOLCHAIN> <ANDROID_NDK_API_VERSION>"
+    exit 1
+fi
+
+NSS_SRC_DIR=$1
+DIST_DIR=$2
+ARCH=$3
+TOOLCHAIN_PATH=$4
+TOOLCHAIN=$5
+ANDROID_NDK_API_VERSION=$6
+
+if [ -d "${DIST_DIR}" ]; then
+  echo "${DIST_DIR}"" folder already exists. Skipping build."
+  exit 0
+fi
+
+PLATFORM_PATH="${ANDROID_NDK_ROOT}/platforms/android-${ANDROID_NDK_API_VERSION}/arch-${ARCH}"
+USE_64=""
+if [ "${TOOLCHAIN}" == "x86_64-linux-android" ]
+then
+  CONFIGURE_ARCH="android64-x86_64"
+  CPU_ARCH="x86_64"
+  LDFLAGS="-L${PLATFORM_PATH}/usr/lib64"
+  USE_64=1
+elif [ "${TOOLCHAIN}" == "i686-linux-android" ]
+then
+  CONFIGURE_ARCH="android-x86"
+  CPU_ARCH="x86"
+elif [ "${TOOLCHAIN}" == "aarch64-linux-android" ]
+then
+  CONFIGURE_ARCH="android-arm64"
+  CPU_ARCH="arm"
+  USE_64=1
+elif [ "${TOOLCHAIN}" == "arm-linux-androideabi" ]
+then
+  CONFIGURE_ARCH="android-arm"
+  CPU_ARCH="arm"
+else
+  echo "Unknown toolchain"
+  exit 1
+fi
+NSPR_64=""
+NSS_64=""
+if [[ -n "${USE_64}" ]]; then
+  NSPR_64="--enable-64bit"
+  NSS_64="USE_64=1"
+fi
+LDFLAGS=${LDFLAGS:-}
+
+# Build NSPR
+NSPR_BUILD_DIR=$(mktemp -d)
+pushd "${NSPR_BUILD_DIR}"
+"${NSS_SRC_DIR}"/nspr/configure \
+  LDFLAGS="${LDFLAGS}" \
+  ${NSPR_64} \
+  --target="${TOOLCHAIN}" \
+  --with-android-ndk="${ANDROID_NDK_ROOT}" \
+  --with-android-toolchain="${TOOLCHAIN_PATH}" \
+  --with-android-platform="${PLATFORM_PATH}" \
+   --disable-debug \
+   --enable-optimize
+make
+popd
+
+# Build NSS
+BUILD_DIR=$(mktemp -d)
+# The ANDROID_ vars are just set so the Makefile doesn't complain.
+make \
+  CROSS_COMPILE=1 \
+  ANDROID_NDK=${ANDROID_NDK_ROOT} \
+  ANDROID_TOOLCHAIN_VERSION=${ANDROID_NDK_API_VERSION} \
+  CC="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-clang" \
+  CCC="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-clang++" \
+  RANLIB="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-ranlib" \
+  OS_TARGET=Android \
+  ${NSS_64} \
+  LDFLAGS="${LDFLAGS}" \
+  CPU_ARCH="${CPU_ARCH}" \
+  ARCHFLAG="-D__ANDROID_API__=${ANDROID_NDK_API_VERSION}" \
+  BUILD_OPT=1 \
+  NSS_DISABLE_CHACHAPOLY=1 \
+  NSS_DISABLE_DBM=1 \
+  BUILD_TREE="${BUILD_DIR}" \
+  SOURCE_PREFIX="${BUILD_DIR}/dist" \
+  SOURCE_MD_DIR="${BUILD_DIR}/dist" \
+  DIST="${BUILD_DIR}/dist" \
+  SOURCE_MDHEADERS_DIR="${NSPR_BUILD_DIR}/dist/include/nspr" \
+  NSPR_INCLUDE_DIR="${NSPR_BUILD_DIR}/dist/include/nspr" \
+  NSPR_LIB_DIR="${NSPR_BUILD_DIR}/dist/lib" \
+  NSINSTALL="${NSPR_BUILD_DIR}/config/nsinstall" \
+  -C "${NSS_SRC_DIR}/nss"
+
+mkdir -p "${DIST_DIR}/include/nss"
+mkdir -p "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libfreebl3.so "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libnss3.so "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libnssckbi.so "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libnssutil3.so "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libsmime3.so "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libsoftokn3.so "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libssl3.so "${DIST_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist"/lib/libplc4.so "${DIST_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist"/lib/libplds4.so "${DIST_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist"/lib/libnspr4.so "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/public/nss/* "${DIST_DIR}/include/nss"

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+# This script builds the NSS3 library (with NSPR) for Desktop.
+
+set -euvx
+
+if [ "$#" -lt 1 -o "$#" -gt 2 ]
+then
+  echo "Usage:"
+  echo "./build-nss-desktop.sh <NSS_SRC_PATH> [CROSS_COMPILE_TARGET]"
+  exit 1
+fi
+
+NSS_SRC_PATH=$1
+# Whether to cross compile from Linux to a different target.  Really
+# only intended for automation.
+CROSS_COMPILE_TARGET=${2-}
+
+if [ -n "${CROSS_COMPILE_TARGET}" -a $(uname -s) != "Linux" ]; then
+  echo "Can only cross compile from 'Linux'; 'uname -s' is $(uname -s)"
+  exit 1
+fi
+
+if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
+  NSS_DIR=$(abspath "desktop/win32-x86-64/nss")
+elif [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
+  NSS_DIR=$(abspath "desktop/darwin/nss")
+elif [ -n "${CROSS_COMPILE_TARGET}" ]; then
+  echo "Cannot build NSS for unrecognized target OS ${CROSS_COMPILE_TARGET}"
+  exit 1
+elif [ $(uname -s) == "Darwin" ]; then
+  NSS_DIR=$(abspath "desktop/darwin/nss")
+elif [ $(uname -s) == "Linux" ]; then
+  # This is a JNA weirdness: "x86-64" rather than "x86_64".
+  NSS_DIR=$(abspath "desktop/linux-x86-64/nss")
+else
+   echo "Cannot build NSS on unrecognized host OS $(uname -s)"
+   exit 1
+fi
+
+if [ -d "${NSS_DIR}" ]; then
+  echo "${NSS_DIR} folder already exists. Skipping build."
+  exit 0
+fi
+
+NSPR_BUILD_DIR=$(mktemp -d)
+BUILD_DIR=$(mktemp -d)
+
+EXTRA_MAKE_ARGS=()
+# Build NSPR.
+pushd "${NSPR_BUILD_DIR}"
+if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
+  # TODO cross compile ourselves, I lost my sanity over this and gave up.
+  curl -L -O "https://s3-us-west-2.amazonaws.com/fxa-dev-bucket/nss/nss-dist.tar.bz2"
+  SHA256="e744a4e0ea7daad75b28eef63d6ced0acd8a993a850998018916e0cad82dc382"
+  echo "$SHA256  nss-dist.tar.bz2" | shasum -a 256 -c - || exit 2
+  tar xvjf nss-dist.tar.bz2
+  mkdir -p "${NSS_DIR}/include/nss"
+  mkdir -p "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libnss3.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libnssutil3.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libfreebl3.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libnssckbi.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libsmime3.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libsoftokn3.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libssl3.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libplc4.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libplds4.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/Debug/lib/libnspr4.dylib "${NSS_DIR}/lib"
+  cp -p -L dist/public/nss/*.h "${NSS_DIR}/include/nss"
+  rm -rf dist && rm -f nss-dist.tar.bz2
+  exit 0
+
+elif [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
+  # Build NSPR.
+  "${NSS_SRC_PATH}"/nspr/configure \
+    --target x86_64-w64-mingw32 \
+    --enable-64bit \
+    --disable-debug \
+    --enable-optimize
+  EXTRA_MAKE_ARGS+=('OS_ARCH=WINNT')
+  EXTRA_MAKE_ARGS+=('OS_TARGET=WIN95')
+  EXTRA_MAKE_ARGS+=('NS_USE_GCC=1')
+  EXTRA_MAKE_ARGS+=('CC=x86_64-w64-mingw32-gcc')
+  EXTRA_MAKE_ARGS+=('CCC=x86_64-w64-mingw32-gcc')
+  EXTRA_MAKE_ARGS+=('RC=x86_64-w64-mingw32-windres -O coff --use-temp-file')
+elif [ "$(uname -s)" == "Darwin" -o "$(uname -s)" == "Linux" ]; then
+  "${NSS_SRC_PATH}"/nspr/configure \
+    --enable-64bit \
+    --disable-debug \
+    --enable-optimize
+fi
+make
+popd
+
+# Build NSS.
+make \
+  ${EXTRA_MAKE_ARGS[@]+"${EXTRA_MAKE_ARGS[@]}"} \
+  USE_64=1 \
+  BUILD_OPT=1 \
+  NSS_DISABLE_CHACHAPOLY=1 \
+  NSS_DISABLE_DBM=1 \
+  SOURCE_MDHEADERS_DIR="${NSPR_BUILD_DIR}/dist/include/nspr" \
+  NSPR_INCLUDE_DIR="${NSPR_BUILD_DIR}/dist/include/nspr" \
+  NSPR_LIB_DIR="${NSPR_BUILD_DIR}/dist/lib" \
+  NSINSTALL="${NSPR_BUILD_DIR}/config/nsinstall" \
+  BUILD_TREE="${BUILD_DIR}" \
+  SOURCE_PREFIX="${BUILD_DIR}/dist" \
+  SOURCE_MD_DIR="${BUILD_DIR}/dist" \
+  DIST="${BUILD_DIR}/dist" \
+  -C ${NSS_SRC_PATH}/nss
+
+mkdir -p "${NSS_DIR}/include/nss"
+mkdir -p "${NSS_DIR}/lib"
+
+if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
+  EXT="dll"
+  PREFIX=""
+elif [ "$(uname -s)" == "Darwin" -o "$(uname -s)" == "Linux" ]; then
+  [[ "$(uname -s)" == "Darwin" ]] && EXT="dylib" || EXT="so"
+  PREFIX="lib"
+fi
+
+cp -p -L "${BUILD_DIR}/dist"/lib/"${PREFIX}"freebl3."${EXT}" "${NSS_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/"${PREFIX}"nss3."${EXT}" "${NSS_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/"${PREFIX}"nssckbi."${EXT}" "${NSS_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/"${PREFIX}"nssutil3."${EXT}" "${NSS_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/"${PREFIX}"smime3."${EXT}" "${NSS_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/"${PREFIX}"softokn3."${EXT}" "${NSS_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/"${PREFIX}"ssl3."${EXT}" "${NSS_DIR}/lib"
+# For some reason the NSPR libs always have the "lib" prefix even on Windows.
+cp -p -L "${NSPR_BUILD_DIR}/dist"/lib/libplc4."${EXT}" "${NSS_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist"/lib/libplds4."${EXT}" "${NSS_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist"/lib/libnspr4."${EXT}" "${NSS_DIR}/lib"
+
+cp -p -L "${BUILD_DIR}/dist"/public/nss/* "${NSS_DIR}/include/nss"

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -4,14 +4,14 @@
 
 set -euvx
 
-if [ "$#" -lt 1 -o "$#" -gt 2 ]
+if [ "${#}" -lt 1 -o "${#}" -gt 2 ]
 then
   echo "Usage:"
   echo "./build-nss-desktop.sh <NSS_SRC_PATH> [CROSS_COMPILE_TARGET]"
   exit 1
 fi
 
-NSS_SRC_PATH=$1
+NSS_SRC_PATH=${1}
 # Whether to cross compile from Linux to a different target.  Really
 # only intended for automation.
 CROSS_COMPILE_TARGET=${2-}
@@ -53,7 +53,7 @@ if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   # TODO cross compile ourselves, I lost my sanity over this and gave up.
   curl -L -O "https://s3-us-west-2.amazonaws.com/fxa-dev-bucket/nss/nss-dist.tar.bz2"
   SHA256="e744a4e0ea7daad75b28eef63d6ced0acd8a993a850998018916e0cad82dc382"
-  echo "$SHA256  nss-dist.tar.bz2" | shasum -a 256 -c - || exit 2
+  echo "${SHA256}  nss-dist.tar.bz2" | shasum -a 256 -c - || exit 2
   tar xvjf nss-dist.tar.bz2
   mkdir -p "${NSS_DIR}/include/nss"
   mkdir -p "${NSS_DIR}/lib"

--- a/libs/build-nss-ios.sh
+++ b/libs/build-nss-ios.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# This script cross-compiles the NSS library for iOS.
+
+set -euvx
+
+if [ "$#" -ne 4 ]
+then
+    echo "Usage:"
+    echo "./build-nss-ios.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <IOS_MIN_SDK_VERSION>"
+    exit 1
+fi
+
+NSS_SRC_DIR=$1
+DIST_DIR=$2
+ARCH=$3
+IOS_MIN_SDK_VERSION=$4
+
+if [ -d "${DIST_DIR}" ]; then
+  echo "${DIST_DIR}"" folder already exists. Skipping build."
+  exit 0
+fi
+
+if [[ "${ARCH}" == "i386" || "${ARCH}" == "x86_64" ]]; then
+  OS_COMPILER="iPhoneSimulator"
+  TARGET="x86_64-apple-darwin"
+elif [[ "${ARCH}" == "armv7" || "${ARCH}" == "arm64" ]]; then
+  OS_COMPILER="iPhoneOS"
+  TARGET="aarch64-apple-darwin"
+else
+  echo "Unsupported architecture"
+  exit 1
+fi
+
+DEVELOPER=$(xcode-select -print-path)
+CROSS_TOP="$DEVELOPER/Platforms/$OS_COMPILER.platform/Developer"
+CROSS_SDK="$OS_COMPILER.sdk"
+TOOLCHAIN_BIN="$DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+ISYSROOT="$CROSS_TOP/SDKs/$CROSS_SDK"
+CC="${TOOLCHAIN_BIN}/clang -arch ${ARCH} -isysroot ${ISYSROOT} -lc++ -mios-version-min=${IOS_MIN_SDK_VERSION}"
+CPU_ARCH="arm" # Static on purpose as NSS's Makefiles don't try to do anything funny when CPU_ARCH == "arm".
+
+# Build NSPR
+NSPR_BUILD_DIR=$(mktemp -d)
+pushd "${NSPR_BUILD_DIR}"
+"${NSS_SRC_DIR}"/nspr/configure \
+  STRIP="${TOOLCHAIN_BIN}/strip" \
+  RANLIB="${TOOLCHAIN_BIN}/ranlib" \
+  AR="${TOOLCHAIN_BIN}/ar" \
+  AS="${TOOLCHAIN_BIN}/as" \
+  LD="${TOOLCHAIN_BIN}/ld -arch arm64" \
+  CC="${CC}" \
+  CCC="${CC}" \
+  --target aarch64-apple-darwin \
+  --enable-64bit \
+  --disable-debug \
+  --enable-optimize
+make
+popd
+
+# Build NSS
+BUILD_DIR=$(mktemp -d)
+make \
+  CROSS_COMPILE=1 \
+  STRIP="${TOOLCHAIN_BIN}/strip" \
+  RANLIB="${TOOLCHAIN_BIN}/ranlib" \
+  AR="${TOOLCHAIN_BIN}/ar cr"' $@' \
+  AS="${TOOLCHAIN_BIN}/as -arch ${ARCH} -isysroot ${ISYSROOT}" \
+  LINK="${TOOLCHAIN_BIN}/ld -arch ${ARCH}" \
+  CC="${CC}" \
+  CCC="${CC}" \
+  OS_ARCH=Darwin \
+  OS_TEST="${CPU_ARCH}" \
+  CPU_ARCH="${CPU_ARCH}" \
+  USE_64=1 \
+  BUILD_OPT=1 \
+  NSS_DISABLE_CHACHAPOLY=1 \
+  NSS_DISABLE_DBM=1 \
+  BUILD_TREE="${BUILD_DIR}" \
+  SOURCE_PREFIX="${BUILD_DIR}/dist" \
+  SOURCE_MD_DIR="${BUILD_DIR}/dist" \
+  DIST="${BUILD_DIR}/dist" \
+  SOURCE_MDHEADERS_DIR="${NSPR_BUILD_DIR}/dist/include/nspr" \
+  NSPR_INCLUDE_DIR="${NSPR_BUILD_DIR}/dist/include/nspr" \
+  NSPR_LIB_DIR="${NSPR_BUILD_DIR}/dist/lib" \
+  NSINSTALL="${NSPR_BUILD_DIR}/config/nsinstall" \
+  -C "$NSS_SRC_DIR/nss"
+
+mkdir -p "${DIST_DIR}/include/nss"
+mkdir -p "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libfreebl3.dylib "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libnss3.dylib "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libnssckbi.dylib "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libnssutil3.dylib "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libsmime3.dylib "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libsoftokn3.dylib "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/lib/libssl3.dylib "${DIST_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist"/lib/libplc4.dylib "${DIST_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist"/lib/libplds4.dylib "${DIST_DIR}/lib"
+cp -p -L "${NSPR_BUILD_DIR}/dist"/lib/libnspr4.dylib "${DIST_DIR}/lib"
+cp -p -L "${BUILD_DIR}/dist"/public/nss/* "${DIST_DIR}/include/nss"

--- a/libs/build-nss-ios.sh
+++ b/libs/build-nss-ios.sh
@@ -4,17 +4,17 @@
 
 set -euvx
 
-if [ "$#" -ne 4 ]
+if [ "${#}" -ne 4 ]
 then
     echo "Usage:"
     echo "./build-nss-ios.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <IOS_MIN_SDK_VERSION>"
     exit 1
 fi
 
-NSS_SRC_DIR=$1
-DIST_DIR=$2
-ARCH=$3
-IOS_MIN_SDK_VERSION=$4
+NSS_SRC_DIR=${1}
+DIST_DIR=${2}
+ARCH=${3}
+IOS_MIN_SDK_VERSION=${4}
 
 if [ -d "${DIST_DIR}" ]; then
   echo "${DIST_DIR}"" folder already exists. Skipping build."
@@ -33,10 +33,10 @@ else
 fi
 
 DEVELOPER=$(xcode-select -print-path)
-CROSS_TOP="$DEVELOPER/Platforms/$OS_COMPILER.platform/Developer"
-CROSS_SDK="$OS_COMPILER.sdk"
-TOOLCHAIN_BIN="$DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-ISYSROOT="$CROSS_TOP/SDKs/$CROSS_SDK"
+CROSS_TOP="${DEVELOPER}/Platforms/${OS_COMPILER}.platform/Developer"
+CROSS_SDK="${OS_COMPILER}.sdk"
+TOOLCHAIN_BIN="${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+ISYSROOT="${CROSS_TOP}/SDKs/${CROSS_SDK}"
 CC="${TOOLCHAIN_BIN}/clang -arch ${ARCH} -isysroot ${ISYSROOT} -lc++ -mios-version-min=${IOS_MIN_SDK_VERSION}"
 CPU_ARCH="arm" # Static on purpose as NSS's Makefiles don't try to do anything funny when CPU_ARCH == "arm".
 
@@ -84,7 +84,7 @@ make \
   NSPR_INCLUDE_DIR="${NSPR_BUILD_DIR}/dist/include/nspr" \
   NSPR_LIB_DIR="${NSPR_BUILD_DIR}/dist/lib" \
   NSINSTALL="${NSPR_BUILD_DIR}/config/nsinstall" \
-  -C "$NSS_SRC_DIR/nss"
+  -C "${NSS_SRC_DIR}/nss"
 
 mkdir -p "${DIST_DIR}/include/nss"
 mkdir -p "${DIST_DIR}/lib"

--- a/libs/build-openssl-android.sh
+++ b/libs/build-openssl-android.sh
@@ -4,43 +4,43 @@
 
 set -euvx
 
-if [ "$#" -ne 5 ]
+if [ "${#}" -ne 5 ]
 then
     echo "Usage:"
     echo "./build-openssl-android.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <TOOLCHAIN_PATH> <TOOLCHAIN> <ANDROID_NDK_API_VERSION>"
     exit 1
 fi
 
-OPENSSL_DIR=$1
-DIST_DIR=$2
-TOOLCHAIN_PATH=$3
-TOOLCHAIN=$4
-ANDROID_NDK_API_VERSION=$5
+OPENSSL_DIR=${1}
+DIST_DIR=${2}
+TOOLCHAIN_PATH=${3}
+TOOLCHAIN=${4}
+ANDROID_NDK_API_VERSION=${5}
 
-if [ -d "$DIST_DIR" ]; then
-  echo "$DIST_DIR"" folder already exists. Skipping build."
+if [ -d "${DIST_DIR}" ]; then
+  echo "${DIST_DIR}"" folder already exists. Skipping build."
   exit 0
 fi
 
 cd "${OPENSSL_DIR}"
 
-export CFLAGS="-D__ANDROID_API__=$ANDROID_NDK_API_VERSION"
-export ANDROID_NDK="$TOOLCHAIN_PATH"
-export PATH="$TOOLCHAIN_PATH/bin:$PATH"
+export CFLAGS="-D__ANDROID_API__=${ANDROID_NDK_API_VERSION}"
+export ANDROID_NDK="${TOOLCHAIN_PATH}"
+export PATH="${TOOLCHAIN_PATH}/bin:${PATH}"
 
-OPENSSL_OUTPUT_PATH="/tmp/openssl-$TOOLCHAIN"_$$
-mkdir -p "$OPENSSL_OUTPUT_PATH"
+OPENSSL_OUTPUT_PATH="/tmp/openssl-${TOOLCHAIN}_${$}"
+mkdir -p "${OPENSSL_OUTPUT_PATH}"
 
-if [ "$TOOLCHAIN" == "x86_64-linux-android" ]
+if [ "${TOOLCHAIN}" == "x86_64-linux-android" ]
 then
   CONFIGURE_ARCH="android64-x86_64"
-elif [ "$TOOLCHAIN" == "i686-linux-android" ]
+elif [ "${TOOLCHAIN}" == "i686-linux-android" ]
 then
   CONFIGURE_ARCH="android-x86"
-elif [ "$TOOLCHAIN" == "aarch64-linux-android" ]
+elif [ "${TOOLCHAIN}" == "aarch64-linux-android" ]
 then
   CONFIGURE_ARCH="android-arm64"
-elif [ "$TOOLCHAIN" == "arm-linux-androideabi" ]
+elif [ "${TOOLCHAIN}" == "arm-linux-androideabi" ]
 then
   CONFIGURE_ARCH="android-arm"
 else
@@ -49,15 +49,15 @@ else
 fi
 
 make clean || true
-./Configure "$CONFIGURE_ARCH" shared --prefix="$OPENSSL_OUTPUT_PATH" || exit 1
+./Configure "${CONFIGURE_ARCH}" shared --prefix="${OPENSSL_OUTPUT_PATH}" || exit 1
 make -j6
 make install_sw
-mkdir -p "$DIST_DIR""/include/openssl"
-mkdir -p "$DIST_DIR""/lib"
-cp -p "$OPENSSL_OUTPUT_PATH"/lib/libssl.a "$DIST_DIR"/lib
-cp -p "$OPENSSL_OUTPUT_PATH"/lib/libcrypto.a "$DIST_DIR"/lib
-cp -L "$PWD"/include/openssl/*.h "${DIST_DIR}/include/openssl"
+mkdir -p "${DIST_DIR}""/include/openssl"
+mkdir -p "${DIST_DIR}""/lib"
+cp -p "${OPENSSL_OUTPUT_PATH}"/lib/libssl.a "${DIST_DIR}"/lib
+cp -p "${OPENSSL_OUTPUT_PATH}"/lib/libcrypto.a "${DIST_DIR}"/lib
+cp -L "${PWD}"/include/openssl/*.h "${DIST_DIR}/include/openssl"
 # For some reason the created binaries are -w.
-chmod +w "$DIST_DIR"/lib/libssl.a
-chmod +w "$DIST_DIR"/lib/libcrypto.a
-rm -rf "$OPENSSL_OUTPUT_PATH"
+chmod +w "${DIST_DIR}"/lib/libssl.a
+chmod +w "${DIST_DIR}"/lib/libcrypto.a
+rm -rf "${OPENSSL_OUTPUT_PATH}"

--- a/libs/build-openssl-desktop.sh
+++ b/libs/build-openssl-desktop.sh
@@ -2,9 +2,6 @@
 
 set -euvx
 
-abspath () { case "$1" in /*)printf "%s\\n" "$1";; *)printf "%s\\n" "$PWD/$1";; esac; }
-export -f abspath
-
 # End of configuration.
 
 if [ "$#" -lt 1 -o "$#" -gt 2 ]

--- a/libs/build-openssl-desktop.sh
+++ b/libs/build-openssl-desktop.sh
@@ -4,27 +4,27 @@ set -euvx
 
 # End of configuration.
 
-if [ "$#" -lt 1 -o "$#" -gt 2 ]
+if [ "${#}" -lt 1 -o "${#}" -gt 2 ]
 then
   echo "Usage:"
   echo "./build-openssl-desktop.sh <OPENSSL_SRC_PATH> [CROSS_COMPILE_TARGET]"
   exit 1
 fi
 
-OPENSSL_SRC_PATH=$1
+OPENSSL_SRC_PATH=${1}
 CROSS_COMPILE_TARGET=${2-}
 
-if [ -n "$CROSS_COMPILE_TARGET" -a $(uname -s) != "Linux" ]; then
+if [ -n "${CROSS_COMPILE_TARGET}" -a $(uname -s) != "Linux" ]; then
   echo "Can only cross compile from 'Linux'; 'uname -s' is $(uname -s)"
   exit 1
 fi
 
-if [[ "$CROSS_COMPILE_TARGET" =~ "win32-x86-64" ]]; then
+if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
   OPENSSL_DIR=$(abspath "desktop/win32-x86-64/openssl")
-elif [[ "$CROSS_COMPILE_TARGET" =~ "darwin" ]]; then
+elif [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   OPENSSL_DIR=$(abspath "desktop/darwin/openssl")
-elif [ -n "$CROSS_COMPILE_TARGET" ]; then
-  echo "Cannot build OpenSSL for unrecognized target OS $CROSS_COMPILE_TARGET"
+elif [ -n "${CROSS_COMPILE_TARGET}" ]; then
+  echo "Cannot build OpenSSL for unrecognized target OS ${CROSS_COMPILE_TARGET}"
   exit 1
 elif [ $(uname -s) == "Darwin" ]; then
   OPENSSL_DIR=$(abspath "desktop/darwin/openssl")
@@ -36,21 +36,21 @@ else
    exit 1
 fi
 
-if [ -d "$OPENSSL_DIR" ]; then
-  echo "$OPENSSL_DIR folder already exists. Skipping build."
+if [ -d "${OPENSSL_DIR}" ]; then
+  echo "${OPENSSL_DIR} folder already exists. Skipping build."
   exit 0
 fi
 
 echo "# Building openssl"
-OPENSSL_OUTPUT_PATH="/tmp/openssl"_$$
+OPENSSL_OUTPUT_PATH="/tmp/openssl_${$}"
 pushd "${OPENSSL_SRC_PATH}"
-mkdir -p "$OPENSSL_OUTPUT_PATH"
+mkdir -p "${OPENSSL_OUTPUT_PATH}"
 
-if [[ "$CROSS_COMPILE_TARGET" =~ "darwin" ]]; then
+if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   # OpenSSL's configure script isn't very robust: it appears to look
-  # in $PATH.  This is all cribbed from
+  # in ${PATH}.  This is all cribbed from
   # https://searchfox.org/mozilla-central/rev/8848b9741fc4ee4e9bc3ae83ea0fc048da39979f/build/macosx/cross-mozconfig.common.
-  export PATH=/tmp/clang/bin:/tmp/cctools/bin:$PATH
+  export PATH=/tmp/clang/bin:/tmp/cctools/bin:${PATH}
 
   export CC=/tmp/clang/bin/clang
 
@@ -66,42 +66,42 @@ if [[ "$CROSS_COMPILE_TARGET" =~ "darwin" ]]; then
     '-isysroot /tmp/MacOSX10.11.sdk' \
     '-Wl,-syslibroot,/tmp/MacOSX10.11.sdk' \
     '-Wl,-dead_strip' \
-    --prefix="$OPENSSL_OUTPUT_PATH"
+    --prefix="${OPENSSL_OUTPUT_PATH}"
 
   sed -i.orig 's/-arch x86_64//' Makefile
 
   # See https://searchfox.org/mozilla-central/rev/8848b9741fc4ee4e9bc3ae83ea0fc048da39979f/build/macosx/cross-mozconfig.common#12-13.
   export LD_LIBRARY_PATH=/tmp/clang/lib
-elif [[ "$CROSS_COMPILE_TARGET" =~ "win32-x86-64" ]]; then
+elif [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
     # Force 64 bits on Windows..
     ./Configure --cross-compile-prefix=x86_64-w64-mingw32- mingw64 \
       shared \
-      --prefix="$OPENSSL_OUTPUT_PATH"
+      --prefix="${OPENSSL_OUTPUT_PATH}"
 elif [ $(uname -s) == "Darwin" ]; then
     # Force 64 bits on macOS.
     ./Configure darwin64-x86_64-cc \
       shared \
-      --prefix="$OPENSSL_OUTPUT_PATH"
+      --prefix="${OPENSSL_OUTPUT_PATH}"
 elif [ $(uname -s) == "Linux" ]; then
     ./config shared \
-      --prefix="$OPENSSL_OUTPUT_PATH"
+      --prefix="${OPENSSL_OUTPUT_PATH}"
 fi
 
 make clean || true
 make -j6
 make install_sw
 
-mkdir -p "$OPENSSL_DIR""/include/openssl"
-mkdir -p "$OPENSSL_DIR""/lib"
-cp -p "$OPENSSL_OUTPUT_PATH"/lib/libssl.a "$OPENSSL_DIR""/lib"
-cp -p "$OPENSSL_OUTPUT_PATH"/lib/libcrypto.a "$OPENSSL_DIR""/lib"
-cp -L "$PWD"/include/openssl/*.h "${OPENSSL_DIR}/include/openssl"
-rm -rf "$OPENSSL_OUTPUT_PATH"
+mkdir -p "${OPENSSL_DIR}""/include/openssl"
+mkdir -p "${OPENSSL_DIR}""/lib"
+cp -p "${OPENSSL_OUTPUT_PATH}"/lib/libssl.a "${OPENSSL_DIR}""/lib"
+cp -p "${OPENSSL_OUTPUT_PATH}"/lib/libcrypto.a "${OPENSSL_DIR}""/lib"
+cp -L "${PWD}"/include/openssl/*.h "${OPENSSL_DIR}/include/openssl"
+rm -rf "${OPENSSL_OUTPUT_PATH}"
 
-if [[ "$CROSS_COMPILE_TARGET" =~ "win32-x86-64" ]]; then
+if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
   # See https://www.wagner.pp.ru/~vitus/articles/openssl-mingw.html.
-  mv "$OPENSSL_DIR/lib/libssl.a" "$OPENSSL_DIR/lib/libssl.lib"
-  mv "$OPENSSL_DIR/lib/libcrypto.a" "$OPENSSL_DIR/lib/libcrypto.lib"
+  mv "${OPENSSL_DIR}/lib/libssl.a" "${OPENSSL_DIR}/lib/libssl.lib"
+  mv "${OPENSSL_DIR}/lib/libcrypto.a" "${OPENSSL_DIR}/lib/libcrypto.lib"
 fi
 
 popd

--- a/libs/build-openssl-ios.sh
+++ b/libs/build-openssl-ios.sh
@@ -16,30 +16,22 @@ DIST_DIR=$2
 ARCH=$3
 IOS_MIN_SDK_VERSION=$4
 
-if [ -d "$DIST_DIR" ]; then
-  echo "$DIST_DIR"" folder already exists. Skipping build."
+if [ -d "${DIST_DIR}" ]; then
+  echo "${DIST_DIR} folder already exists. Skipping build."
   exit 0
 fi
 
 cd "${OPENSSL_DIR}"
 
-OPENSSL_OUTPUT_PATH="/tmp/openssl-""$ARCH"_$$
-mkdir -p "$OPENSSL_OUTPUT_PATH"
+OPENSSL_OUTPUT_PATH="/tmp/openssl-${ARCH}_${$}"
+mkdir -p "${OPENSSL_OUTPUT_PATH}"
 
-if [[ "${ARCH}" == "i386" || "${ARCH}" == "x86_64" ]]; then
+if [[ "${ARCH}" == "x86_64" ]]; then
   OS_COMPILER="iPhoneSimulator"
-  if [[ "${ARCH}" == "x86_64" ]]; then
-    HOST="darwin64-x86_64-cc"
-  else
-    HOST="darwin-i386-cc"
-  fi
-elif [[ "${ARCH}" == "armv7" || "${ARCH}" == "arm64" ]]; then
+  HOST="darwin64-x86_64-cc"
+elif [[ "${ARCH}" == "arm64" ]]; then
   OS_COMPILER="iPhoneOS"
-  if [[ "${ARCH}" == "arm64" ]]; then
-    HOST="ios64-cross"
-  else
-    HOST="ios-cross"
-  fi
+  HOST="ios64-cross"
 else
   echo "Unsupported architecture"
   exit 1
@@ -57,9 +49,9 @@ if [[ "${OS_COMPILER}" == "iPhoneSimulator" ]]; then
 fi
 make -j6
 make install_sw
-mkdir -p "$DIST_DIR""/include/openssl"
-mkdir -p "$DIST_DIR""/lib"
-cp -p "$OPENSSL_OUTPUT_PATH"/lib/libssl.a "$DIST_DIR""/lib"
-cp -p "$OPENSSL_OUTPUT_PATH"/lib/libcrypto.a "$DIST_DIR""/lib"
-cp -L "$PWD"/include/openssl/*.h "${DIST_DIR}/include/openssl"
-rm -rf "$OPENSSL_OUTPUT_PATH"
+mkdir -p "${DIST_DIR}/include/openssl"
+mkdir -p "${DIST_DIR}/lib"
+cp -p "${OPENSSL_OUTPUT_PATH}"/lib/libssl.a "${DIST_DIR}/lib"
+cp -p "${OPENSSL_OUTPUT_PATH}"/lib/libcrypto.a "${DIST_DIR}/lib"
+cp -L "${PWD}"/include/openssl/*.h "${DIST_DIR}/include/openssl"
+rm -rf "${OPENSSL_OUTPUT_PATH}"

--- a/libs/build-openssl-ios.sh
+++ b/libs/build-openssl-ios.sh
@@ -4,17 +4,17 @@
 
 set -euvx
 
-if [ "$#" -ne 4 ]
+if [ "${#}" -ne 4 ]
 then
     echo "Usage:"
     echo "./build-openssl-ios.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <IOS_MIN_SDK_VERSION>"
     exit 1
 fi
 
-OPENSSL_DIR=$1
-DIST_DIR=$2
-ARCH=$3
-IOS_MIN_SDK_VERSION=$4
+OPENSSL_DIR=${1}
+DIST_DIR=${2}
+ARCH=${3}
+IOS_MIN_SDK_VERSION=${4}
 
 if [ -d "${DIST_DIR}" ]; then
   echo "${DIST_DIR} folder already exists. Skipping build."
@@ -43,7 +43,7 @@ export CROSS_SDK="${OS_COMPILER}.sdk"
 export CROSS_COMPILE="${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin/"
 
 make clean || true
-./Configure $HOST "-arch $ARCH -fembed-bitcode" no-asm no-ssl3 no-comp no-hw no-engine no-async --prefix="$OPENSSL_OUTPUT_PATH" || exit 1
+./Configure ${HOST} "-arch ${ARCH} -fembed-bitcode" no-asm no-ssl3 no-comp no-hw no-engine no-async --prefix="${OPENSSL_OUTPUT_PATH}" || exit 1
 if [[ "${OS_COMPILER}" == "iPhoneSimulator" ]]; then
   sed -ie "s!^CFLAGS=!CFLAGS=-isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} -mios-version-min=${IOS_MIN_SDK_VERSION} !" "Makefile"
 fi

--- a/libs/build-sqlcipher-android.sh
+++ b/libs/build-sqlcipher-android.sh
@@ -4,48 +4,48 @@
 
 set -euvx
 
-if [ "$#" -ne 6 ]
+if [ "${#}" -ne 6 ]
 then
     echo "Usage:"
     echo "./build-sqlcipher-android.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <TOOLCHAIN_PATH> <TOOLCHAIN> <ANDROID_NDK_API_VERSION> <OPENSSL_DIR>"
     exit 1
 fi
 
-SQLCIPHER_DIR=$1
-DIST_DIR=$2
-TOOLCHAIN_PATH=$3
-TOOLCHAIN=$4
-ANDROID_NDK_API_VERSION=$5
-OPENSSL_DIR=$6
+SQLCIPHER_DIR=${1}
+DIST_DIR=${2}
+TOOLCHAIN_PATH=${3}
+TOOLCHAIN=${4}
+ANDROID_NDK_API_VERSION=${5}
+OPENSSL_DIR=${6}
 
-if [ -d "$DIST_DIR" ]; then
-  echo "$DIST_DIR"" folder already exists. Skipping build."
+if [ -d "${DIST_DIR}" ]; then
+  echo "${DIST_DIR}"" folder already exists. Skipping build."
   exit 0
 fi
 
 cd "${SQLCIPHER_DIR}"
 
-export TOOLCHAIN_BIN="$TOOLCHAIN_PATH""/bin/"
-export CC="$TOOLCHAIN_BIN""$TOOLCHAIN""-gcc"
-export CXX="$TOOLCHAIN_BIN""$TOOLCHAIN""-g++"
-export RANLIB="$TOOLCHAIN_BIN""$TOOLCHAIN""-ranlib"
-export LD="$TOOLCHAIN_BIN""$TOOLCHAIN""-ld"
-export AR="$TOOLCHAIN_BIN""$TOOLCHAIN""-ar"
-export CFLAGS="-D__ANDROID_API__=$ANDROID_NDK_API_VERSION"
+export TOOLCHAIN_BIN="${TOOLCHAIN_PATH}""/bin/"
+export CC="${TOOLCHAIN_BIN}""${TOOLCHAIN}""-gcc"
+export CXX="${TOOLCHAIN_BIN}""${TOOLCHAIN}""-g++"
+export RANLIB="${TOOLCHAIN_BIN}""${TOOLCHAIN}""-ranlib"
+export LD="${TOOLCHAIN_BIN}""${TOOLCHAIN}""-ld"
+export AR="${TOOLCHAIN_BIN}""${TOOLCHAIN}""-ar"
+export CFLAGS="-D__ANDROID_API__=${ANDROID_NDK_API_VERSION}"
 
-SQLCIPHER_OUTPUT_PATH="/tmp/sqlcipher-""$TOOLCHAIN"_$$
-mkdir -p "$SQLCIPHER_OUTPUT_PATH"
+SQLCIPHER_OUTPUT_PATH="/tmp/sqlcipher-""${TOOLCHAIN}_${$}"
+mkdir -p "${SQLCIPHER_OUTPUT_PATH}"
 
-if [ "$TOOLCHAIN" == "x86_64-linux-android" ]
+if [ "${TOOLCHAIN}" == "x86_64-linux-android" ]
 then
   HOST="x86_64-linux"
-elif [ "$TOOLCHAIN" == "i686-linux-android" ]
+elif [ "${TOOLCHAIN}" == "i686-linux-android" ]
 then
   HOST="i686-linux"
-elif [ "$TOOLCHAIN" == "aarch64-linux-android" ]
+elif [ "${TOOLCHAIN}" == "aarch64-linux-android" ]
 then
   HOST="arm-linux"
-elif [ "$TOOLCHAIN" == "arm-linux-androideabi" ]
+elif [ "${TOOLCHAIN}" == "arm-linux-androideabi" ]
 then
   HOST="arm-linux"
 else
@@ -90,16 +90,16 @@ make clean || true
   --enable-tempstore=always \
   CFLAGS="${CFLAGS} ${SQLCIPHER_CFLAGS} -I${OPENSSL_DIR}/include -L${OPENSSL_DIR}/lib" \
   LIBS="-lcrypto -llog -lm" \
-  LDFLAGS="$OPENSSL_DIR/lib/libcrypto.a "
+  LDFLAGS="${OPENSSL_DIR}/lib/libcrypto.a "
 
 make -j6
 make install
 
-mkdir -p "$DIST_DIR""/include/sqlcipher"
-mkdir -p "$DIST_DIR""/lib"
+mkdir -p "${DIST_DIR}""/include/sqlcipher"
+mkdir -p "${DIST_DIR}""/lib"
 
-cp -p "$SQLCIPHER_OUTPUT_PATH"/lib/libsqlcipher.a "$DIST_DIR"/lib/libsqlcipher.a
+cp -p "${SQLCIPHER_OUTPUT_PATH}"/lib/libsqlcipher.a "${DIST_DIR}"/lib/libsqlcipher.a
 
 # Just in case, ensure that the created binaries are not -w.
-chmod +w "$DIST_DIR"/lib/libsqlcipher.a
-rm -rf "$SQLCIPHER_OUTPUT_PATH"
+chmod +w "${DIST_DIR}"/lib/libsqlcipher.a
+rm -rf "${SQLCIPHER_OUTPUT_PATH}"

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -2,9 +2,6 @@
 
 set -euvx
 
-abspath () { case "$1" in /*)printf "%s\\n" "$1";; *)printf "%s\\n" "$PWD/$1";; esac; }
-export -f abspath
-
 if [ "$#" -lt 1 -o "$#" -gt 2 ]
 then
   echo "Usage:"

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -2,31 +2,31 @@
 
 set -euvx
 
-if [ "$#" -lt 1 -o "$#" -gt 2 ]
+if [ "${#}" -lt 1 -o "${#}" -gt 2 ]
 then
   echo "Usage:"
   echo "./build-sqlcipher-desktop.sh <SQLCIPHER_SRC_PATH> [CROSS_COMPILE_TARGET]"
   exit 1
 fi
 
-SQLCIPHER_SRC_PATH=$1
+SQLCIPHER_SRC_PATH=${1}
 # Whether to cross compile from Linux to a different target.  Really
 # only intended for automation.
 CROSS_COMPILE_TARGET=${2-}
 
-if [ -n "$CROSS_COMPILE_TARGET" -a $(uname -s) != "Linux" ]; then
+if [ -n "${CROSS_COMPILE_TARGET}" -a $(uname -s) != "Linux" ]; then
   echo "Can only cross compile from 'Linux'; 'uname -s' is $(uname -s)"
   exit 1
 fi
 
-if [[ "$CROSS_COMPILE_TARGET" =~ "win32-x86-64" ]]; then
+if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
   SQLCIPHER_DIR=$(abspath "desktop/win32-x86-64/sqlcipher")
   OPENSSL_DIR=$(abspath "desktop/win32-x86-64/openssl")
-elif [[ "$CROSS_COMPILE_TARGET" =~ "darwin" ]]; then
+elif [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   SQLCIPHER_DIR=$(abspath "desktop/darwin/sqlcipher")
   OPENSSL_DIR=$(abspath "desktop/darwin/openssl")
-elif [ -n "$CROSS_COMPILE_TARGET" ]; then
-  echo "Cannot build SQLCipher for unrecognized target OS $CROSS_COMPILE_TARGET"
+elif [ -n "${CROSS_COMPILE_TARGET}" ]; then
+  echo "Cannot build SQLCipher for unrecognized target OS ${CROSS_COMPILE_TARGET}"
   exit 1
 elif [ $(uname -s) == "Darwin" ]; then
   SQLCIPHER_DIR=$(abspath "desktop/darwin/sqlcipher")
@@ -40,8 +40,8 @@ else
    exit 1
 fi
 
-if [ -d "$SQLCIPHER_DIR" ]; then
-  echo "$SQLCIPHER_DIR folder already exists. Skipping build."
+if [ -d "${SQLCIPHER_DIR}" ]; then
+  echo "${SQLCIPHER_DIR} folder already exists. Skipping build."
   exit 0
 fi
 
@@ -77,9 +77,9 @@ SQLCIPHER_CFLAGS=" \
   -DSQLITE_MAX_DEFAULT_PAGE_SIZE=32768 \
 "
 
-rm -rf "$SQLCIPHER_SRC_PATH/build-desktop"
-mkdir -p "$SQLCIPHER_SRC_PATH/build-desktop/install-prefix"
-pushd "$SQLCIPHER_SRC_PATH/build-desktop"
+rm -rf "${SQLCIPHER_SRC_PATH}/build-desktop"
+mkdir -p "${SQLCIPHER_SRC_PATH}/build-desktop/install-prefix"
+pushd "${SQLCIPHER_SRC_PATH}/build-desktop"
 
 make clean || true
 
@@ -90,7 +90,7 @@ make clean || true
 # We achieve that by forcing PIC (even for the .a) and disabling the
 # shared library (.so) entirely.
 
-if [[ "$CROSS_COMPILE_TARGET" =~ "darwin" ]]; then
+if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   export CC=/tmp/clang/bin/clang
 
   export AR=/tmp/cctools/bin/x86_64-apple-darwin11-ar
@@ -111,7 +111,7 @@ if [[ "$CROSS_COMPILE_TARGET" =~ "darwin" ]]; then
   # See https://searchfox.org/mozilla-central/rev/8848b9741fc4ee4e9bc3ae83ea0fc048da39979f/build/macosx/cross-mozconfig.common#12-13.
   export LD_LIBRARY_PATH=/tmp/clang/lib
 
-  ../configure --prefix="$PWD/install-prefix" \
+  ../configure --prefix="${PWD}/install-prefix" \
     --with-pic \
     --disable-shared \
     --host=x86_64-apple-darwin \
@@ -121,7 +121,7 @@ if [[ "$CROSS_COMPILE_TARGET" =~ "darwin" ]]; then
     CFLAGS="${CFLAGS} ${SQLCIPHER_CFLAGS} -I${OPENSSL_DIR}/include -L${OPENSSL_DIR}/lib" \
     LDFLAGS="${LDFLAGS} -L${OPENSSL_DIR}/lib" \
     LIBS="-lcrypto"
-elif [[ "$CROSS_COMPILE_TARGET" =~ "win32-x86-64" ]]; then
+elif [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
 
 pushd ..
 
@@ -151,7 +151,7 @@ EOF
 patch --forward --ignore-whitespace < Makefile.in-patch
 popd
 
-  ../configure --prefix="$PWD/install-prefix" \
+  ../configure --prefix="${PWD}/install-prefix" \
     --with-pic \
     --disable-shared \
     --build=x86_64 \
@@ -164,7 +164,7 @@ popd
     LDFLAGS="-L${OPENSSL_DIR}/lib" \
     LIBS="-llibcrypto -lgdi32 -lws2_32"
 elif [ $(uname -s) == "Darwin" ]; then
-  ../configure --prefix="$PWD/install-prefix" \
+  ../configure --prefix="${PWD}/install-prefix" \
     --with-pic \
     --disable-shared \
     --enable-tempstore=yes \
@@ -174,7 +174,7 @@ elif [ $(uname -s) == "Darwin" ]; then
     LDFLAGS="-L${OPENSSL_DIR}/lib" \
     LIBS="-lcrypto"
 elif [ $(uname -s) == "Linux" ]; then
-  ../configure --prefix="$PWD/install-prefix" \
+  ../configure --prefix="${PWD}/install-prefix" \
     --with-pic \
     --disable-shared \
     --enable-tempstore=yes \
@@ -188,14 +188,14 @@ fi
 make -j6
 make install
 
-mkdir -p "$SQLCIPHER_DIR/lib"
-cp -r "install-prefix/include" "$SQLCIPHER_DIR"
-cp -p "install-prefix/lib/libsqlcipher.a" "$SQLCIPHER_DIR/lib/libsqlcipher.a"
+mkdir -p "${SQLCIPHER_DIR}/lib"
+cp -r "install-prefix/include" "${SQLCIPHER_DIR}"
+cp -p "install-prefix/lib/libsqlcipher.a" "${SQLCIPHER_DIR}/lib/libsqlcipher.a"
 
-chmod +w "$SQLCIPHER_DIR/lib/libsqlcipher.a"
+chmod +w "${SQLCIPHER_DIR}/lib/libsqlcipher.a"
 
-if [[ "$CROSS_COMPILE_TARGET" =~ "win32-x86-64" ]]; then
-  mv "$SQLCIPHER_DIR/lib/libsqlcipher.a" "$SQLCIPHER_DIR/lib/sqlcipher.lib"
+if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
+  mv "${SQLCIPHER_DIR}/lib/libsqlcipher.a" "${SQLCIPHER_DIR}/lib/sqlcipher.lib"
 fi
 
 popd

--- a/libs/build-sqlcipher-ios.sh
+++ b/libs/build-sqlcipher-ios.sh
@@ -25,14 +25,10 @@ SQLCIPHER_IOS="$SQLCIPHER_SRC_DIR/build-ios-""$ARCH"_$$
 mkdir -p "$SQLCIPHER_IOS"
 pushd "$SQLCIPHER_IOS"
 
-if [[ "${ARCH}" == "i386" || "${ARCH}" == "x86_64" ]]; then
+if [[ "$ARCH" == "x86_64" ]]; then
   OS_COMPILER="iPhoneSimulator"
-  if [[ "${ARCH}" == "x86_64" ]]; then
-    HOST="x86_64-apple-darwin"
-  else
-    HOST="x86-apple-darwin"
-  fi
-elif [[ "${ARCH}" == "armv7" || "${ARCH}" == "arm64" ]]; then
+  HOST="x86_64-apple-darwin"
+elif [[ "$ARCH" == "arm64" ]]; then
   OS_COMPILER="iPhoneOS"
   HOST="arm-apple-darwin"
 else
@@ -41,22 +37,22 @@ else
 fi
 
 DEVELOPER=$(xcode-select -print-path)
-export CROSS_TOP="${DEVELOPER}/Platforms/${OS_COMPILER}.platform/Developer"
-export CROSS_SDK="${OS_COMPILER}.sdk"
-TOOLCHAIN_BIN="${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-export CC="${TOOLCHAIN_BIN}/clang"
-export AR="${TOOLCHAIN_BIN}/ar"
-export RANLIB="${TOOLCHAIN_BIN}/ranlib"
-export STRIP="${TOOLCHAIN_BIN}/strip"
-export LIBTOOL="${TOOLCHAIN_BIN}/libtool"
-export NM="${TOOLCHAIN_BIN}/nm"
-export LD="${TOOLCHAIN_BIN}/ld"
+export CROSS_TOP="$DEVELOPER/Platforms/$OS_COMPILER.platform/Developer"
+export CROSS_SDK="$OS_COMPILER.sdk"
+TOOLCHAIN_BIN="$DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+export CC="$TOOLCHAIN_BIN/clang"
+export AR="$TOOLCHAIN_BIN/ar"
+export RANLIB="$TOOLCHAIN_BIN/ranlib"
+export STRIP="$TOOLCHAIN_BIN/strip"
+export LIBTOOL="$TOOLCHAIN_BIN/libtool"
+export NM="$TOOLCHAIN_BIN/nm"
+export LD="$TOOLCHAIN_BIN/ld"
 
 CFLAGS="\
   -fembed-bitcode \
-  -arch ${ARCH} \
-  -isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} \
-  -mios-version-min=${IOS_MIN_SDK_VERSION} \
+  -arch $ARCH \
+  -isysroot $CROSS_TOP/SDKs/$CROSS_SDK \
+  -mios-version-min=$IOS_MIN_SDK_VERSION \
 "
 
 # Match the SQLCIPHER_CFLAGS used in Firefox for iOS v15.x and earlier.
@@ -104,7 +100,7 @@ SQLCIPHER_CFLAGS=" \
   --enable-tempstore=yes \
   --enable-threadsafe=yes \
   --disable-editline \
-  CFLAGS="${CFLAGS} ${SQLCIPHER_CFLAGS}" \
+  CFLAGS="$CFLAGS $SQLCIPHER_CFLAGS" \
   LDFLAGS="-framework Security -framework Foundation"
 
 # Make all fails because it tries to build the command line program.

--- a/libs/build-sqlcipher-ios.sh
+++ b/libs/build-sqlcipher-ios.sh
@@ -4,31 +4,31 @@
 
 set -euvx
 
-if [ "$#" -ne 4 ]
+if [ "${#}" -ne 4 ]
 then
     echo "Usage:"
     echo "./build-sqlcipher-ios.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <IOS_MIN_SDK_VERSION>"
     exit 1
 fi
 
-SQLCIPHER_SRC_DIR=$1
-DIST_DIR=$2
-ARCH=$3
-IOS_MIN_SDK_VERSION=$4
+SQLCIPHER_SRC_DIR=${1}
+DIST_DIR=${2}
+ARCH=${3}
+IOS_MIN_SDK_VERSION=${4}
 
-if [ -d "$DIST_DIR" ]; then
-  echo "$DIST_DIR"" folder already exists. Skipping build."
+if [ -d "${DIST_DIR}" ]; then
+  echo "${DIST_DIR}"" folder already exists. Skipping build."
   exit 0
 fi
 
-SQLCIPHER_IOS="$SQLCIPHER_SRC_DIR/build-ios-""$ARCH"_$$
-mkdir -p "$SQLCIPHER_IOS"
-pushd "$SQLCIPHER_IOS"
+SQLCIPHER_IOS="${SQLCIPHER_SRC_DIR}/build-ios-""${ARCH}_${$}"
+mkdir -p "${SQLCIPHER_IOS}"
+pushd "${SQLCIPHER_IOS}"
 
-if [[ "$ARCH" == "x86_64" ]]; then
+if [[ "${ARCH}" == "x86_64" ]]; then
   OS_COMPILER="iPhoneSimulator"
   HOST="x86_64-apple-darwin"
-elif [[ "$ARCH" == "arm64" ]]; then
+elif [[ "${ARCH}" == "arm64" ]]; then
   OS_COMPILER="iPhoneOS"
   HOST="arm-apple-darwin"
 else
@@ -37,22 +37,22 @@ else
 fi
 
 DEVELOPER=$(xcode-select -print-path)
-export CROSS_TOP="$DEVELOPER/Platforms/$OS_COMPILER.platform/Developer"
-export CROSS_SDK="$OS_COMPILER.sdk"
-TOOLCHAIN_BIN="$DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-export CC="$TOOLCHAIN_BIN/clang"
-export AR="$TOOLCHAIN_BIN/ar"
-export RANLIB="$TOOLCHAIN_BIN/ranlib"
-export STRIP="$TOOLCHAIN_BIN/strip"
-export LIBTOOL="$TOOLCHAIN_BIN/libtool"
-export NM="$TOOLCHAIN_BIN/nm"
-export LD="$TOOLCHAIN_BIN/ld"
+export CROSS_TOP="${DEVELOPER}/Platforms/${OS_COMPILER}.platform/Developer"
+export CROSS_SDK="${OS_COMPILER}.sdk"
+TOOLCHAIN_BIN="${DEVELOPER}/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+export CC="${TOOLCHAIN_BIN}/clang"
+export AR="${TOOLCHAIN_BIN}/ar"
+export RANLIB="${TOOLCHAIN_BIN}/ranlib"
+export STRIP="${TOOLCHAIN_BIN}/strip"
+export LIBTOOL="${TOOLCHAIN_BIN}/libtool"
+export NM="${TOOLCHAIN_BIN}/nm"
+export LD="${TOOLCHAIN_BIN}/ld"
 
 CFLAGS="\
   -fembed-bitcode \
-  -arch $ARCH \
-  -isysroot $CROSS_TOP/SDKs/$CROSS_SDK \
-  -mios-version-min=$IOS_MIN_SDK_VERSION \
+  -arch ${ARCH} \
+  -isysroot ${CROSS_TOP}/SDKs/${CROSS_SDK} \
+  -mios-version-min=${IOS_MIN_SDK_VERSION} \
 "
 
 # Match the SQLCIPHER_CFLAGS used in Firefox for iOS v15.x and earlier.
@@ -94,13 +94,13 @@ SQLCIPHER_CFLAGS=" \
 ../configure \
   --with-pic \
   --disable-tcl \
-  --host="$HOST" \
+  --host="${HOST}" \
   --verbose \
   --with-crypto-lib=commoncrypto \
   --enable-tempstore=yes \
   --enable-threadsafe=yes \
   --disable-editline \
-  CFLAGS="$CFLAGS $SQLCIPHER_CFLAGS" \
+  CFLAGS="${CFLAGS} ${SQLCIPHER_CFLAGS}" \
   LDFLAGS="-framework Security -framework Foundation"
 
 # Make all fails because it tries to build the command line program.
@@ -115,13 +115,13 @@ make sqlite3.h
 make sqlite3ext.h
 make libsqlcipher.la
 
-mkdir -p "$DIST_DIR/include/sqlcipher"
-mkdir -p "$DIST_DIR/lib"
+mkdir -p "${DIST_DIR}/include/sqlcipher"
+mkdir -p "${DIST_DIR}/lib"
 
-cp -p "$SQLCIPHER_IOS/sqlite3.h" "$DIST_DIR/include/sqlcipher"
-cp -p "$SQLCIPHER_IOS/sqlite3ext.h" "$DIST_DIR/include/sqlcipher"
-cp -p "$SQLCIPHER_IOS/.libs/libsqlcipher.a" "$DIST_DIR/lib"
+cp -p "${SQLCIPHER_IOS}/sqlite3.h" "${DIST_DIR}/include/sqlcipher"
+cp -p "${SQLCIPHER_IOS}/sqlite3ext.h" "${DIST_DIR}/include/sqlcipher"
+cp -p "${SQLCIPHER_IOS}/.libs/libsqlcipher.a" "${DIST_DIR}/lib"
 
 popd
 
-rm -rf $SQLCIPHER_IOS
+rm -rf ${SQLCIPHER_IOS}

--- a/libs/patch-nss-src.sh
+++ b/libs/patch-nss-src.sh
@@ -5,14 +5,14 @@
 
 set -euvx
 
-if [ "$#" -ne 1 ]
+if [ "${#}" -ne 1 ]
 then
     echo "Usage:"
     echo "./patch-nss-src.sh <NSS_SRC_PATH>"
     exit 1
 fi
 
-NSS_SRC_PATH=$1
+NSS_SRC_PATH=${1}
 
 # Remove once NSS 3.44 is out (see bug 1540205 for context).
 echo '\
@@ -34,7 +34,7 @@ echo '\
 
  SECStatus
  ChaCha20Poly1305_Seal(const ChaCha20Poly1305Context *ctx, unsigned char *output,
-' | patch $NSS_SRC_PATH/nss/lib/freebl/chacha20poly1305.c
+' | patch ${NSS_SRC_PATH}/nss/lib/freebl/chacha20poly1305.c
 
 # TODO: file bug to get this upstream.
 echo '\
@@ -53,7 +53,7 @@ echo '\
  arm-linux*-android*|*-linuxandroid*)
      android_tool_prefix="arm-linux-androideabi"
      ;;
-' | patch $NSS_SRC_PATH/nspr/configure
+' | patch ${NSS_SRC_PATH}/nspr/configure
 
 # TODO: file bug to get this upstream.
 echo '\
@@ -70,7 +70,7 @@ echo '\
  ifdef USE_PTHREADS
  	DEFINES		+= -D_REENTRANT
  endif
-' | patch $NSS_SRC_PATH/nss/coreconf/Linux.mk
+' | patch ${NSS_SRC_PATH}/nss/coreconf/Linux.mk
 
 # TODO: file bug to get this upstream.
 # This param makes mingw32 gcc trip.

--- a/libs/patch-nss-src.sh
+++ b/libs/patch-nss-src.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# This script patches the NSS/NSPR source code so we can cross-compile
+# them properly until the fixes are merged upstream and released.
+
+set -euvx
+
+if [ "$#" -ne 1 ]
+then
+    echo "Usage:"
+    echo "./patch-nss-src.sh <NSS_SRC_PATH>"
+    exit 1
+fi
+
+NSS_SRC_PATH=$1
+
+# Remove once NSS 3.44 is out (see bug 1540205 for context).
+echo '\
+--- chacha20poly1305.c	2019-03-15 20:25:08.000000000 -0400
++++ chacha20poly1305.c.patched	2019-03-29 17:24:37.000000000 -0400
+@@ -157,6 +157,7 @@
+ #endif
+ }
+
++#ifndef NSS_DISABLE_CHACHAPOLY
+ void
+ ChaCha20Xor(uint8_t *output, uint8_t *block, uint32_t len, uint8_t *k,
+             uint8_t *nonce, uint32_t ctr)
+@@ -167,6 +168,7 @@
+         Hacl_Chacha20_chacha20(output, block, len, k, nonce, ctr);
+     }
+ }
++#endif
+
+ SECStatus
+ ChaCha20Poly1305_Seal(const ChaCha20Poly1305Context *ctx, unsigned char *output,
+' | patch $NSS_SRC_PATH/nss/lib/freebl/chacha20poly1305.c
+
+# TODO: file bug to get this upstream.
+echo '\
+--- configure	2019-03-07 05:04:05.000000000 -0500
++++ configure.patched	2019-04-02 15:04:27.000000000 -0400
+@@ -2641,6 +2641,12 @@
+ 
+ 
+ case "$target" in
++x86_64-linux*-android*)
++    android_tool_prefix="x86_64-linux-android"
++    ;;
++aarch64-linux*-android*)
++    android_tool_prefix="aarch64-linux-android"
++    ;;
+ arm-linux*-android*|*-linuxandroid*)
+     android_tool_prefix="arm-linux-androideabi"
+     ;;
+' | patch $NSS_SRC_PATH/nspr/configure
+
+# TODO: file bug to get this upstream.
+echo '\
+--- Linux.mk	2019-04-02 14:55:31.000000000 -0400
++++ Linux.mk.patched	2019-04-02 14:55:32.000000000 -0400
+@@ -135,6 +135,10 @@
+ endif
+ OS_LIBS			= $(OS_PTHREAD) -ldl -lc
+
++ifeq ($(OS_TARGET),Android)
++	OS_LIBS		+= -llog
++endif
++
+ ifdef USE_PTHREADS
+ 	DEFINES		+= -D_REENTRANT
+ endif
+' | patch $NSS_SRC_PATH/nss/coreconf/Linux.mk
+
+# TODO: file bug to get this upstream.
+# This param makes mingw32 gcc trip.
+sed -i -e '/w44996/d' "${NSS_SRC_PATH}"/nss/lib/sqlite/Makefile
+
+# We probably don't want to upstream this.
+# Only build NSS lib and skip tests
+sed -i -e '/^DIRS = /s/ cmd cpputil gtests$//' "${NSS_SRC_PATH}"/nss/manifest.mn

--- a/libs/setup_toolchains_local.sh
+++ b/libs/setup_toolchains_local.sh
@@ -9,48 +9,48 @@ TARGET_ARCHS=("x86_64" "x86" "arm64" "arm")
 RUST_TARGETS=("x86_64-linux-android" "i686-linux-android" "aarch64-linux-android" "armv7-linux-androideabi")
 CLANG_BINS=("x86_64-linux-android-clang" "i686-linux-android-clang" "aarch64-linux-android-clang" "arm-linux-androideabi-clang")
 
-ANDROID_NDK_ROOT="${1:-$ANDROID_NDK_ROOT}"
+ANDROID_NDK_ROOT="${1:-${ANDROID_NDK_ROOT}}"
 
-if [ -z "$ANDROID_NDK_ROOT" ]; then
+if [ -z "${ANDROID_NDK_ROOT}" ]; then
     echo "Usage:"
     echo "./setup_toolchains_local.sh <ANDROID_NDK_ROOT>"
     exit 1
 fi
 
-source "$(dirname "$0")/android_defaults.sh"
-mkdir -p $ANDROID_NDK_TOOLCHAIN_DIR
+source "$(dirname "${0}")/android_defaults.sh"
+mkdir -p ${ANDROID_NDK_TOOLCHAIN_DIR}
 echo "Installing toolchains for the following architectures: ${TARGET_ARCHS[@]}."
-echo "The toolchains will be installed in $ANDROID_NDK_TOOLCHAIN_DIR (ANDROID_NDK_TOOLCHAIN_DIR)."
-echo "The Android API version is set to $ANDROID_NDK_API_VERSION (ANDROID_NDK_API_VERSION)."
+echo "The toolchains will be installed in ${ANDROID_NDK_TOOLCHAIN_DIR} (ANDROID_NDK_TOOLCHAIN_DIR)."
+echo "The Android API version is set to ${ANDROID_NDK_API_VERSION} (ANDROID_NDK_API_VERSION)."
 echo ""
 
 # Toolchains installation
 for ARCH in "${TARGET_ARCHS[@]}"; do
-  if [ ! -d "$ANDROID_NDK_TOOLCHAIN_DIR/$ARCH-$ANDROID_NDK_API_VERSION" ]; then
-    echo "Installing $ARCH toolchain..."
-    python "$ANDROID_NDK_ROOT/build/tools/make_standalone_toolchain.py" --arch="$ARCH" --api="$ANDROID_NDK_API_VERSION" --install-dir="$ANDROID_NDK_TOOLCHAIN_DIR/$ARCH-$ANDROID_NDK_API_VERSION" --deprecated-headers --force
+  if [ ! -d "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" ]; then
+    echo "Installing ${ARCH} toolchain..."
+    python "${ANDROID_NDK_ROOT}/build/tools/make_standalone_toolchain.py" --arch="${ARCH}" --api="${ANDROID_NDK_API_VERSION}" --install-dir="${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" --deprecated-headers --force
   else
-    echo "$ARCH toolchain already exists. Skipping installation."
+    echo "${ARCH} toolchain already exists. Skipping installation."
   fi
 done
 
 # Setup cargo linkers
-CONFIG_FILE="$(dirname "$0")/../.cargo/config"
+CONFIG_FILE="$(dirname "${0}")/../.cargo/config"
 read -p "Would you like to set-up the toolchain linkers in .cargo/config? (you should say yes) " -n 1 -r
 echo ""
-if [[ ! $REPLY =~ ^[Yy]$ ]]
+if [[ ! ${REPLY} =~ ^[Yy]$ ]]
 then
   exit 0
 fi
 
-mkdir -p "$(dirname "$0")/../.cargo"
-echo -n "" > $CONFIG_FILE # Clear the file first
+mkdir -p "$(dirname "${0}")/../.cargo"
+echo -n "" > ${CONFIG_FILE} # Clear the file first
 for i in "${!TARGET_ARCHS[@]}"; do
-  ARCH=${TARGET_ARCHS[$i]}
-  RUST_TARGET=${RUST_TARGETS[$i]}
-  CLANG_BIN=${CLANG_BINS[$i]}
-  echo "[target.$RUST_TARGET]
-linker = \"$ANDROID_NDK_TOOLCHAIN_DIR/$ARCH-$ANDROID_NDK_API_VERSION/bin/$CLANG_BIN\"
-" >> $CONFIG_FILE
+  ARCH=${TARGET_ARCHS[${i}]}
+  RUST_TARGET=${RUST_TARGETS[${i}]}
+  CLANG_BIN=${CLANG_BINS[${i}]}
+  echo "[target.${RUST_TARGET}]
+linker = \"${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}/bin/${CLANG_BIN}\"
+" >> ${CONFIG_FILE}
 done
-echo "Cargo config written to $CONFIG_FILE."
+echo "Cargo config written to ${CONFIG_FILE}."

--- a/libs/verify-android-environment.sh
+++ b/libs/verify-android-environment.sh
@@ -10,36 +10,36 @@ if [ ! -f "$(pwd)/libs/build-all.sh" ]; then
   exit 1
 fi
 
-if [ -z "$ANDROID_HOME" ]; then
+if [ -z "${ANDROID_HOME}" ]; then
   echo "Could not find Android SDK:"
   echo 'Please install the Android SDK and then set ANDROID_HOME.'
   exit 1
 fi
 
-if [ -z "$ANDROID_NDK_ROOT" ]; then
+if [ -z "${ANDROID_NDK_ROOT}" ]; then
   echo "Could not find Android NDK:"
   echo 'Please install the Android NDK r15c and then set ANDROID_NDK_ROOT.'
   exit 1
 fi
 
-INSTALLED_NDK_VERSION=$(sed -En -e 's/^Pkg.Revision[ \t]*=[ \t]*([0-9a-f]+).*/\1/p' $ANDROID_NDK_ROOT/source.properties)
-if [ "$INSTALLED_NDK_VERSION" != $NDK_VERSION ]; then
+INSTALLED_NDK_VERSION=$(sed -En -e 's/^Pkg.Revision[ \t]*=[ \t]*([0-9a-f]+).*/\1/p' ${ANDROID_NDK_ROOT}/source.properties)
+if [ "${INSTALLED_NDK_VERSION}" != ${NDK_VERSION} ]; then
   echo "Wrong Android NDK version:"
-  echo "Expected version $NDK_VERSION, got $INSTALLED_NDK_VERSION"
+  echo "Expected version ${NDK_VERSION}, got ${INSTALLED_NDK_VERSION}"
   exit 1
 fi
 
 INSTALLED_RUST_TARGETS=$(rustup target list)
 for TARGET in "${RUST_TARGETS[@]}"
 do
-  if ! [ "$(echo "$INSTALLED_RUST_TARGETS" | grep "$TARGET")" ]; then
-    echo "Missing Rust target: $TARGET"
+  if ! [ "$(echo "${INSTALLED_RUST_TARGETS}" | grep "${TARGET}")" ]; then
+    echo "Missing Rust target: ${TARGET}"
     echo "Installing the required target, please hold on."
-    rustup target add $TARGET
+    rustup target add ${TARGET}
   fi
 done
 
-if [ -z "$ANDROID_NDK_TOOLCHAIN_DIR" ]; then
+if [ -z "${ANDROID_NDK_TOOLCHAIN_DIR}" ]; then
   echo "Could not find Android NDK toolchain directory:"
   echo "1. Create a directory where to set up the toolchains (e.g. ~/.ndk-standalone-toolchains)."
   echo "2. Set ANDROID_NDK_TOOLCHAIN_DIR to this newly created directory."

--- a/megazords/fenix/android/build.gradle
+++ b/megazords/fenix/android/build.gradle
@@ -25,6 +25,7 @@ android {
 
     sourceSets {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
+        test.resources.srcDirs += "$buildDir/nativeLibs/desktop"
     }
 
     // Uncomment to include debug symbols in native library builds.
@@ -101,9 +102,11 @@ afterEvaluate {
         }
         def buildType = "${variant.buildType.name.capitalize()}"
         tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        // Don't depend on copyNativeLibs here as NSS libs are shipped with GeckoView.
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
+        tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["copyNativeLibs"])
     }
 }
 

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -30,6 +30,15 @@
 		CDC0089F2236CAD100893800 /* places_msg_types.proto in Sources */ = {isa = PBXBuildFile; fileRef = CDC0089E2236CAD100893800 /* places_msg_types.proto */; };
 		CDC21B14221DCE3700AA71E5 /* RustLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDC21B12221DCE3700AA71E5 /* RustLog.swift */; };
 		CDC21B15221DCE3700AA71E5 /* RustLogFFI.h in Headers */ = {isa = PBXBuildFile; fileRef = CDC21B13221DCE3700AA71E5 /* RustLogFFI.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CE18A85122580A32002BB8A1 /* libfreebl3.dylib in Resources */ = {isa = PBXBuildFile; fileRef = CE18A84422580A1F002BB8A1 /* libfreebl3.dylib */; };
+		CE18A85222580A32002BB8A1 /* libnspr4.dylib in Resources */ = {isa = PBXBuildFile; fileRef = CE18A83F22580A1F002BB8A1 /* libnspr4.dylib */; };
+		CE18A85322580A32002BB8A1 /* libnss3.dylib in Resources */ = {isa = PBXBuildFile; fileRef = CE18A84522580A1F002BB8A1 /* libnss3.dylib */; };
+		CE18A85422580A32002BB8A1 /* libnssckbi.dylib in Resources */ = {isa = PBXBuildFile; fileRef = CE18A84722580A1F002BB8A1 /* libnssckbi.dylib */; };
+		CE18A85522580A32002BB8A1 /* libnssutil3.dylib in Resources */ = {isa = PBXBuildFile; fileRef = CE18A84122580A1F002BB8A1 /* libnssutil3.dylib */; };
+		CE18A85622580A32002BB8A1 /* libplc4.dylib in Resources */ = {isa = PBXBuildFile; fileRef = CE18A84322580A1F002BB8A1 /* libplc4.dylib */; };
+		CE18A85722580A32002BB8A1 /* libplds4.dylib in Resources */ = {isa = PBXBuildFile; fileRef = CE18A84022580A1F002BB8A1 /* libplds4.dylib */; };
+		CE18A85822580A32002BB8A1 /* libsmime3.dylib in Resources */ = {isa = PBXBuildFile; fileRef = CE18A84222580A1F002BB8A1 /* libsmime3.dylib */; };
+		CE18A85922580A32002BB8A1 /* libsoftokn3.dylib in Resources */ = {isa = PBXBuildFile; fileRef = CE18A84622580A1F002BB8A1 /* libsoftokn3.dylib */; };
 		CE1ADA9722249FDA00E89714 /* Data+RustBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1ADA9622249FDA00E89714 /* Data+RustBuffer.swift */; };
 		CE3A2F38225BDE5300EA569C /* PlacesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3A2F37225BDE5300EA569C /* PlacesTests.swift */; };
 		D05434A1225680D900FDE4EF /* MozillaAppServices.h in Headers */ = {isa = PBXBuildFile; fileRef = C852EEF2220A3C6800A6E79A /* MozillaAppServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -104,6 +113,15 @@
 		CDC0089E2236CAD100893800 /* places_msg_types.proto */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.protobuf; name = places_msg_types.proto; path = ../../src/places_msg_types.proto; sourceTree = "<group>"; };
 		CDC21B12221DCE3700AA71E5 /* RustLog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RustLog.swift; sourceTree = "<group>"; };
 		CDC21B13221DCE3700AA71E5 /* RustLogFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RustLogFFI.h; sourceTree = "<group>"; };
+		CE18A83F22580A1F002BB8A1 /* libnspr4.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libnspr4.dylib; path = ../../libs/ios/universal/nss/lib/libnspr4.dylib; sourceTree = "<group>"; };
+		CE18A84022580A1F002BB8A1 /* libplds4.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libplds4.dylib; path = ../../libs/ios/universal/nss/lib/libplds4.dylib; sourceTree = "<group>"; };
+		CE18A84122580A1F002BB8A1 /* libnssutil3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libnssutil3.dylib; path = ../../libs/ios/universal/nss/lib/libnssutil3.dylib; sourceTree = "<group>"; };
+		CE18A84222580A1F002BB8A1 /* libsmime3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsmime3.dylib; path = ../../libs/ios/universal/nss/lib/libsmime3.dylib; sourceTree = "<group>"; };
+		CE18A84322580A1F002BB8A1 /* libplc4.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libplc4.dylib; path = ../../libs/ios/universal/nss/lib/libplc4.dylib; sourceTree = "<group>"; };
+		CE18A84422580A1F002BB8A1 /* libfreebl3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libfreebl3.dylib; path = ../../libs/ios/universal/nss/lib/libfreebl3.dylib; sourceTree = "<group>"; };
+		CE18A84522580A1F002BB8A1 /* libnss3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libnss3.dylib; path = ../../libs/ios/universal/nss/lib/libnss3.dylib; sourceTree = "<group>"; };
+		CE18A84622580A1F002BB8A1 /* libsoftokn3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsoftokn3.dylib; path = ../../libs/ios/universal/nss/lib/libsoftokn3.dylib; sourceTree = "<group>"; };
+		CE18A84722580A1F002BB8A1 /* libnssckbi.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.bundle"; name = libnssckbi.dylib; path = ../../libs/ios/universal/nss/lib/libnssckbi.dylib; sourceTree = "<group>"; };
 		CE1ADA9622249FDA00E89714 /* Data+RustBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data+RustBuffer.swift"; sourceTree = "<group>"; };
 		CE3A2F37225BDE5300EA569C /* PlacesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlacesTests.swift; sourceTree = "<group>"; };
 		CE9D202020914D0D00F1C8FA /* MozillaAppServices.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MozillaAppServices.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -279,6 +297,15 @@
 		CE9D203720914D4800F1C8FA /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				CE18A84422580A1F002BB8A1 /* libfreebl3.dylib */,
+				CE18A83F22580A1F002BB8A1 /* libnspr4.dylib */,
+				CE18A84522580A1F002BB8A1 /* libnss3.dylib */,
+				CE18A84722580A1F002BB8A1 /* libnssckbi.dylib */,
+				CE18A84122580A1F002BB8A1 /* libnssutil3.dylib */,
+				CE18A84322580A1F002BB8A1 /* libplc4.dylib */,
+				CE18A84022580A1F002BB8A1 /* libplds4.dylib */,
+				CE18A84222580A1F002BB8A1 /* libsmime3.dylib */,
+				CE18A84622580A1F002BB8A1 /* libsoftokn3.dylib */,
 				EB7DE84C2214D30B00E7CF17 /* SwiftProtobuf.framework */,
 				C852EE9D220A283200A6E79A /* libsqlcipher.a */,
 				C852EEEE220A2E9400A6E79A /* libmegazord_ios.a */,
@@ -336,11 +363,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE9D202820914D0D00F1C8FA /* Build configuration list for PBXNativeTarget "MozillaAppServices" */;
 			buildPhases = (
-				CEEA12EF20AA1D630018998A /* ShellScript */,
+				CEEA12EF20AA1D630018998A /* Run Script */,
 				CE9D201B20914D0D00F1C8FA /* Sources */,
 				CE9D201C20914D0D00F1C8FA /* Frameworks */,
 				CE9D201D20914D0D00F1C8FA /* Headers */,
 				CE9D201E20914D0D00F1C8FA /* Resources */,
+				CE18A85A225BB893002BB8A1 /* ShellScript */,
 			);
 			buildRules = (
 				EB7DE84A2214D28C00E7CF17 /* PBXBuildRule */,
@@ -413,6 +441,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE18A85122580A32002BB8A1 /* libfreebl3.dylib in Resources */,
+				CE18A85222580A32002BB8A1 /* libnspr4.dylib in Resources */,
+				CE18A85322580A32002BB8A1 /* libnss3.dylib in Resources */,
+				CE18A85422580A32002BB8A1 /* libnssckbi.dylib in Resources */,
+				CE18A85522580A32002BB8A1 /* libnssutil3.dylib in Resources */,
+				CE18A85622580A32002BB8A1 /* libplc4.dylib in Resources */,
+				CE18A85722580A32002BB8A1 /* libplds4.dylib in Resources */,
+				CE18A85822580A32002BB8A1 /* libsmime3.dylib in Resources */,
+				CE18A85922580A32002BB8A1 /* libsoftokn3.dylib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -426,13 +463,31 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		CEEA12EF20AA1D630018998A /* ShellScript */ = {
+		CE18A85A225BB893002BB8A1 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "bash $PWD/../../build-scripts/patch-libs-paths.sh\n";
+		};
+		CEEA12EF20AA1D630018998A /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
+			name = "Run Script";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/megazords/lockbox/android/build.gradle
+++ b/megazords/lockbox/android/build.gradle
@@ -25,6 +25,7 @@ android {
 
     sourceSets {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
+        test.resources.srcDirs += "$buildDir/nativeLibs/desktop"
     }
 
     // Uncomment to include debug symbols in native library builds.
@@ -101,9 +102,11 @@ afterEvaluate {
         }
         def buildType = "${variant.buildType.name.capitalize()}"
         tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["copyNativeLibs"])
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
+        tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["copyNativeLibs"])
     }
 }
 

--- a/megazords/reference-browser/android/build.gradle
+++ b/megazords/reference-browser/android/build.gradle
@@ -25,6 +25,7 @@ android {
 
     sourceSets {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
+        test.resources.srcDirs += "$buildDir/nativeLibs/desktop"
     }
 
     // Uncomment to include debug symbols in native library builds.
@@ -103,9 +104,11 @@ afterEvaluate {
         }
         def buildType = "${variant.buildType.name.capitalize()}"
         tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        // Don't depend on copyNativeLibs here as NSS libs are shipped with GeckoView.
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
+        tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["copyNativeLibs"])
     }
 }
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -55,9 +55,14 @@ ext.configurePublish = { jnaForTestConfiguration = null,
         def forUnitTestsJarTask = task forUnitTestsJar(type: Jar) {
             from extractJnaResources
             from "$buildDir/rustJniLibs/desktop"
+            from "$buildDir/nativeLibs/desktop"
         }
 
         project.afterEvaluate {
+            def copyNativeLibsTask = tasks.findByName("copyNativeLibs")
+            if (copyNativeLibsTask != null) {
+                forUnitTestsJarTask.dependsOn(copyNativeLibsTask)
+            }
             forUnitTestsJarTask.dependsOn(tasks["cargoBuild"])
         }
     }


### PR DESCRIPTION
## Notes
- We introduce the new `crypto` crate in `support/crypto`, and replace 2 calls from FxAClient from ring to our new crate for `SHA-256` digest.
- On iOS we link dynamically against NSS.
- On every other platform we `dlopen` against either geckoview's NSS or our own provided libs.
- On Android for unit testing (since there's no GV), we bundle the relevant NSS libs in the `forUnitTests` JAR artifact.
- Use the NSS system installed lib for local building/testing (see TC/CircleCI changes) so we don't have to mess with `ld_library_path` on our dev machines.
- We cross-compile NSS for every single platform, except one: Linux-> MacOS. I lost hope and gave up. Thankfully it's only used in unit tests so we can fix it later (we still download the relevant libs from the NSS project CI).
- There's a plugin implemented with kotlin-dsl to handle the new `nativeLibs` extension: it makes sure the libs (nss and friends) we specify are included in the artifacts we produce. I have high hopes that the new Android megazord spec will make it easier.
- We need to kill the iOS non-megazords projects for this to work. (tracked in https://github.com/mozilla/application-services/pull/932).
- We rename the push `crypto` crate to `push_crypto`.

## New dependencies

Libloading is a new dependency. The code is [pretty simple](https://github.com/nagisa/rust_libloading) and can be audited in a reasonable time, while providing good wrappers around dlopen and friends. It is [vendored in Firefox](https://searchfox.org/mozilla-central/search?q=libloading) and MPL-2 compatible (ISC is similar to BSD/MIT).