### PR TITLE
chore(docs): Document manual mirroring of release artifacts from bintray to maven

### DIFF
--- a/docs/build-and-publish-pipeline.md
+++ b/docs/build-and-publish-pipeline.md
@@ -27,9 +27,11 @@ The key points:
     * [TaskCluster](../automation/taskcluster/README.md) is used to:
         * Build an Android binary release.
         * Upload Android library symbols to [Socorro](https://wiki.mozilla.org/Socorro).
-        * Publish it to the 'mozilla-appservices'organization on [bintray](https://bintray.com/),
+        * Publish it to the 'mozilla-appservices' organization on [bintray](https://bintray.com/),
           which mirrors it to [jcenter](https://bintray.com/bintray/jcenter).
            * (although this will soon change to publish to https://maven.mozilla.org).
+    * There is also a manual step where we mirror artifacts from bintray to maven.mozilla.org,
+      as a temporary measure until we can get automatic publishing set up correctly.
 
 For Android consumers these are the steps by which Application Services code becomes available,
 and the integrity-protection mechanisms that apply at each step:
@@ -56,7 +58,8 @@ and the integrity-protection mechanisms that apply at each step:
     * TODO: talk about how TC's "chain of trust" might be useful here.
 6. Bintray mirrors the built artifacts to [jcenter](https://bintray.com/bintray/jcenter).
     * TODO: as above, we're in the process of [moving this to maven.mozilla.org](https://github.com/mozilla/application-services/issues/252).
-6. Consumers fetch the published artifacts from bintray.
+7. On request, our operations team [manually mirrors artifacts to maven.mozilla.org](https://bugzilla.mozilla.org/show_bug.cgi?id=1540775).
+8. Consumers fetch the published artifacts from maven.mozilla.org.
 
 For iOS consumers the corresponding steps are:
 

--- a/docs/howtos/cut-a-new-release.md
+++ b/docs/howtos/cut-a-new-release.md
@@ -31,6 +31,9 @@ These are the steps needed to cut a new release.
     4. Note that the release is not avaliable until the taskcluster build completes for that tag.
         - Finding out that this takes a little navigation in the github UI. It's available at `https://github.com/mozilla/application-services/commits/v<VERSION NUMBER>` in the build status info (the emoji) next to the last commit.
         - If the taskcluster tag and/or release tasks fail, ping someone in slack and we'll figure out what to do.
+    5. Until [automated publishing to maven](https://github.com/mozilla/application-services/issues/252)
+       is available, file a bug to request manual mirroring of the release artifacts from bintray to maven.
+       You can use [Bug 1540775](https://bugzilla.mozilla.org/show_bug.cgi?id=1540775) as a template.
 5. If you need to manually produce the iOS build for some reason (for example, if CircleCI cannot), someone with a mac needs to do the following steps:
     1. If necessary, set up for performing iOS builds:
         ```


### PR DESCRIPTION
As described in [Nick's email to application-services](https://groups.google.com/a/mozilla.com/d/msg/application-services/V6dE7mQi1d4/FLCJRZteAgAJ), there's a manual mirroring step in our release process that will persist until we get maven builds sorted out. Let's write it down so we don't forget to do it.