### PR TITLE
Replace .unwrap() with .unwrap_or_default() on duration_since. Fixes #413

### DIFF
--- a/components/places/src/history_sync/mod.rs
+++ b/components/places/src/history_sync/mod.rs
@@ -39,7 +39,7 @@ impl From<Timestamp> for ServerVisitTimestamp {
 impl From<SystemTime> for ServerVisitTimestamp {
     #[inline]
     fn from(st: SystemTime) -> Self {
-        let d = st.duration_since(UNIX_EPOCH).unwrap(); // hrmph - unwrap doesn't seem ideal
+        let d = st.duration_since(UNIX_EPOCH).unwrap_or_default();
         ServerVisitTimestamp(
             (d.as_secs() as u64) * 1_000_000 + (u64::from(d.subsec_nanos()) / 1_000),
         )


### PR DESCRIPTION
We seem to have spent far more time in meetings talking about this than the time it takes to fix it :)

This is the only offending call I can find - I think we had others, but they all either return `Option<Duration>` or already use `unwrap_or_default()`