### PR TITLE
Strip native code by default, document debugging process 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.23.0...master)
 
+## General
+
+- Native code builds are now stripped by default, reducing size by almost an
+  order of magnitude. ([#913](https://github.com/mozilla/application-services/issues/913))
+    - This is done rather than relying on consumers to strip them, which proved
+      more difficult than anticipated.
+
 ## Push
 
 ### What's new

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -36,12 +36,8 @@ android {
         }
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
 
 configurations {

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -29,12 +29,8 @@ android {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
 
 configurations {

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -36,12 +36,8 @@ android {
         }
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
 
 configurations {

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -29,12 +29,8 @@ android {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
 
 configurations {

--- a/components/rc_log/android/build.gradle
+++ b/components/rc_log/android/build.gradle
@@ -29,12 +29,8 @@ android {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
 
 configurations {

--- a/docs/howtos/exposing-rust-components-to-kotlin.md
+++ b/docs/howtos/exposing-rust-components-to-kotlin.md
@@ -144,3 +144,24 @@ However, it comes with the following downsides:
    [`ffi_support` docs](https://docs.rs/ffi-support/*/ffi_support/), but a
    major one is when to use `Pointer` vs `String` (getting this wrong will
    often work, but may corrupt memory).
+
+### How do I debug Rust code with the step-debugger in Android Studio
+
+1. Uncomment the `packagingOptions { doNotStrip "**/*.so" }` line from the
+   build.gradle file of the component you want to debug.
+2. In the rust code, either:
+    1. Cause something to crash where you want the breakpoint. Note: Panics
+        don't work here, unfortunately. (I have not found a convenient way to
+        set a breakpoint to rust code, so
+        `unsafe { std::ptr::write_volatile(0 as *const _, 1u8) }` usually is
+        what I do).
+    2. If you manage to get an LLDB prompt, you can set a breakpoint using
+       `breakpoint set --name foo`, or `breakpoint set --file foo.rs --line 123`.
+       I don't know how to bring up this prompt reliably, so I often do step 1 to
+       get it to appear, delete the crashing code, and then set the
+       breakpoint using the CLI. This is admittedly suboptimal.
+3. Click the Debug button in Android Studio, to display the "Select Deployment
+   Target" window.
+4. Make sure the debugger selection is set to "Both". This tends to unset
+   itself, so make sure.
+5. Click "Run", and debug away.

--- a/megazords/fenix/android/build.gradle
+++ b/megazords/fenix/android/build.gradle
@@ -25,12 +25,8 @@ android {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
 
 configurations {

--- a/megazords/lockbox/android/build.gradle
+++ b/megazords/lockbox/android/build.gradle
@@ -25,12 +25,8 @@ android {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
 
 configurations {

--- a/megazords/reference-browser/android/build.gradle
+++ b/megazords/reference-browser/android/build.gradle
@@ -25,12 +25,8 @@ android {
         test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
 
 configurations {


### PR DESCRIPTION
Fixes #913
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- ~[ ] **Tests**: This PR includes thorough tests or an explanation of why it does not~
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- ~[ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)~
