### PR TITLE
Bump android-gradle plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,9 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        // If this gets out-of-sync with our downstream consumers, module substitution
+        // workflow may no longer function correctly.
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Publish.


### PR DESCRIPTION
We're using 3.3.2 in Fenix, and this change makes module substitution workflow
work.