### PR TITLE
Include dsym files in mac package

### DIFF
--- a/build-carthage.sh
+++ b/build-carthage.sh
@@ -9,13 +9,6 @@ carthage update --platform iOS --cache-builds swift-protobuf
 
 carthage build --no-skip-current --platform iOS --verbose
 
-ZIP_DIR=$(mktemp -d)
-mkdir -p $ZIP_DIR/Carthage/Build/iOS
-cp -r Carthage/Build/iOS/Static $ZIP_DIR/Carthage/Build/iOS
-cp -r Carthage/Build/iOS/*.framework $ZIP_DIR/Carthage/Build/iOS
-pushd $ZIP_DIR
 # Exclude SwiftProtobuf.
-rm -rf Carthage/Build/iOS/SwiftProtobuf.framework
+rm -rf Carthage/Build/iOS/SwiftProtobuf.framework*
 zip -r $FRAMEWORK_NAME Carthage/Build/iOS
-popd
-cp $ZIP_DIR/$FRAMEWORK_NAME $FRAMEWORK_NAME


### PR DESCRIPTION
As evidence, here is a snippet showing dsyms and bcsymbolmaps being added to the zip:
``` 
-- snip --
adding: Carthage/Build/iOS/Static/MozillaAppServices.framework/Modules/module.modulemap (deflated 42%)
  adding: Carthage/Build/iOS/Static/MozillaAppServices.framework/Info.plist (deflated 29%)
  adding: Carthage/Build/iOS/8F213E96-4749-36D9-9EB4-999831CBC7E4.bcsymbolmap (deflated 89%)
  adding: Carthage/Build/iOS/5EC84229-9A27-365D-B034-B5951F15FBF4.bcsymbolmap (deflated 89%)
  adding: Carthage/Build/iOS/FxAClient.framework.dSYM/ (stored 0%)
  adding: Carthage/Build/iOS/FxAClient.framework.dSYM/Contents/ (stored 0%)
  adding: Carthage/Build/iOS/FxAClient.framework.dSYM/Contents/Resources/ (stored 0%)
  adding: Carthage/Build/iOS/FxAClient.framework.dSYM/Contents/Resources/DWARF/ (stored 0%)
  adding: Carthage/Build/iOS/FxAClient.framework.dSYM/Contents/Resources/DWARF/FxAClient (deflated 73%)
  adding: Carthage/Build/iOS/FxAClient.framework.dSYM/Contents/Info.plist (deflated 52%)
  adding: Carthage/Build/iOS/Logins.framework/ (stored 0%)
  adding: Carthage/Build/iOS/Logins.framework/Headers/ (stored 0%)
  adding: Carthage/Build/iOS/Logins.framework/Headers/RustPasswordAPI.h (deflated 82%)
-- snip --
```