### PR TITLE
Store diverging structure for synced bookmarks

### DIFF
--- a/components/places/sql/create_shared_schema.sql
+++ b/components/places/sql/create_shared_schema.sql
@@ -203,10 +203,11 @@ CREATE TABLE IF NOT EXISTS moz_bookmarks_synced(
 -- also lets us catch disagreements between a folder's `children` and its
 -- childrens' `parentid`.
 CREATE TABLE IF NOT EXISTS moz_bookmarks_synced_structure(
-    guid TEXT NOT NULL PRIMARY KEY,
-    parentGuid TEXT NOT NULL REFERENCES moz_bookmarks_synced(guid)
-                             ON DELETE CASCADE,
-    position INTEGER NOT NULL
+    guid TEXT,
+    parentGuid TEXT REFERENCES moz_bookmarks_synced(guid)
+                    ON DELETE CASCADE,
+    position INTEGER NOT NULL,
+    PRIMARY KEY(parentGuid, guid)
 ) WITHOUT ROWID;
 
 -- This table holds tags for synced items.


### PR DESCRIPTION
This commit:

* Uses chunking to insert child GUIDs in `store_incoming_folder`.
* Changes the schema to store multiple parents, so that it can be
  passed to Dogear.
* Sorts synced items by GUID, so that diverging ones can be reparented
  in a deterministic order.
* Moves items with missing and invalid parents to `unfiled`.

This is a backport of
https://bugzilla.mozilla.org/show_bug.cgi?id=1540894.