### PR TITLE
Remove reqwest backend from megazords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### What's Fixed
 
-- Megazords and requests should work again.
+- Megazords and requests should work again. ([#946](https://github.com/mozilla/application-services/pull/946))
+- The vestigial `reqwest` backend is no longer compiled into the megazords ([#937](https://github.com/mozilla/application-services/pull/937)).
+    - Note that prior to this it was present, but unused.
 
 ## iOS
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ version = "0.1.0"
 dependencies = [
  "config 0.1.0",
  "crypto 0.1.0",
+ "force-viaduct-reqwest 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -671,6 +672,13 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "force-viaduct-reqwest"
+version = "0.1.0"
+dependencies = [
+ "viaduct 0.1.0",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +734,7 @@ dependencies = [
  "cli-support 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.3",
+ "force-viaduct-reqwest 0.1.0",
  "hawk 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -947,11 +956,6 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1016,6 +1020,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.3",
+ "force-viaduct-reqwest 0.1.0",
  "fxa-client 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1376,6 +1381,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.3",
  "find-places-db 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "force-viaduct-reqwest 0.1.0",
  "fxa-client 0.1.0",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1428,19 +1434,6 @@ dependencies = [
  "ctor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "prettytable-rs"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2150,14 +2143,11 @@ version = "0.1.0"
 dependencies = [
  "base16 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "fxa-client 0.1.0",
  "hawk 2.0.0 (git+https://github.com/eoger/rust-hawk?branch=use-openssl)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2196,15 +2186,6 @@ dependencies = [
  "redox_syscall 0.1.52 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "term"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2710,7 +2691,6 @@ dependencies = [
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
@@ -2754,7 +2734,6 @@ dependencies = [
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
-"checksum prettytable-rs 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "34dc1f4f6dddab3bf008ecfd4fd2a631b585fbf0af123f34c1324f51a034ff5f"
 "checksum prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5511ca4c805aa35f0abff6be7923231d664408b60c09f44ef715f2bce106cd9e"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
@@ -2823,7 +2802,6 @@ dependencies = [
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
-"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "components/support/cli",
     "components/support/sql",
     "components/support/ffi",
+    "components/support/force-viaduct-reqwest",
     "components/viaduct",
     "components/sync15",
     "components/rc_log",

--- a/automation/check_megazord.sh
+++ b/automation/check_megazord.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euvx
+
+if [ "$#" -ne 1 ]
+then
+    echo "Usage:"
+    echo "./automation/check_megazord.sh <megazord_name>"
+    exit 1
+fi
+
+MEGAZORD_NAME=$1
+
+TARGET_ARCHS=("x86_64" "x86" "arm64" "arm")
+JNI_LIBS_TARGETS=("x86_64" "x86" "arm64-v8a" "armeabi-v7a")
+NM_BINS=("x86_64-linux-android-nm" "i686-linux-android-nm" "aarch64-linux-android-nm" "arm-linux-androideabi-nm")
+RUST_TRIPLES=("x86_64-linux-android" "i686-linux-android" "aarch64-linux-android" "armv7-linux-androideabi")
+
+FORBIDDEN_SYMBOL="viaduct_detect_reqwest_backend"
+for i in "${!TARGET_ARCHS[@]}"; do
+    NM="$ANDROID_NDK_TOOLCHAIN_DIR/${TARGET_ARCHS[$i]}-$ANDROID_NDK_API_VERSION/bin/${NM_BINS[$i]}"
+    MEGAZORD_PATH="./target/${RUST_TRIPLES[i]}/release/lib$MEGAZORD_NAME.so"
+    echo "\nTesting if $MEGAZORD_PATH contains the legacy/test-only HTTP stack\n"
+    # Returns error status on failure, which will cause us to exit because of set -e.
+    ./testing/err-if-symbol.sh "$NM" "$MEGAZORD_PATH" "$FORBIDDEN_SYMBOL"
+done

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -157,6 +157,8 @@ def gradle_module_task(libs_tasks, module_info, is_release):
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "publish")))
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "zipMavenArtifacts")))
     )
+    if module.endswith("-megazord"):
+        task.with_script("./automation/check_megazords.sh {}".format(module[0:-9]))
     for artifact_info in module_info['artifacts']:
         task.with_artifacts(artifact_info['artifact'])
     if is_release:

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -28,10 +28,12 @@ viaduct = { path = "../viaduct" }
 
 [dev-dependencies]
 cli-support = { path = "../support/cli" }
+force-viaduct-reqwest = { path = "../support/force-viaduct-reqwest" }
 
 [build-dependencies]
 prost-build = "0.5"
 
 [features]
 browserid = ["openssl", "hawk"]
+reqwest = ["viaduct/reqwest"]
 default = []

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -68,6 +68,10 @@ cargo {
     profile = rootProject.ext.nonMegazordProfile
 
     exec = rootProject.ext.cargoExec
+
+    features {
+        defaultAnd("reqwest")
+    }
 }
 
 configurations {

--- a/components/fxa-client/ffi/Cargo.toml
+++ b/components/fxa-client/ffi/Cargo.toml
@@ -20,7 +20,7 @@ path = "../"
 
 [features]
 browserid = ["fxa-client/browserid"]
-rust-http-stack = ["viaduct/rust-http-stack"]
+reqwest = ["viaduct/reqwest", "fxa-client/reqwest"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.7.0"

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 
 [features]
 log_query_plans = ["sql-support/log_query_plans"]
+reqwest = ["sync15/reqwest"]
 default = []
 
 [dependencies]
@@ -33,3 +34,4 @@ fxa-client = { path = "../fxa-client" }
 chrono = "0.4.6"
 clap = "2.32.0"
 cli-support = { path = "../support/cli" }
+force-viaduct-reqwest = { path = "../support/force-viaduct-reqwest" }

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -61,6 +61,11 @@ cargo {
     profile = rootProject.ext.nonMegazordProfile
 
     exec = rootProject.ext.cargoExec
+
+    features {
+        defaultAnd("reqwest")
+    }
+
 }
 
 configurations {

--- a/components/logins/ffi/Cargo.toml
+++ b/components/logins/ffi/Cargo.toml
@@ -10,7 +10,7 @@ name = "logins_ffi"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [features]
-rust-http-stack = ["viaduct/rust-http-stack"]
+reqwest = ["viaduct/reqwest", "logins/reqwest"]
 
 [dependencies]
 serde_json = "1.0.28"

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 
 [features]
 log_query_plans = ["sql-support/log_query_plans"]
+reqwest = ["sync15/reqwest"]
 default = []
 
 [dependencies]
@@ -47,6 +48,7 @@ criterion = "0.2.9"
 tempdir = "0.3.7"
 cli-support = { path = "../support/cli" }
 pretty_assertions = "0.6.1"
+force-viaduct-reqwest = { path = "../support/force-viaduct-reqwest" }
 
 [build-dependencies]
 prost-build = "0.5.0"

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -68,6 +68,10 @@ cargo {
     profile = rootProject.ext.nonMegazordProfile
 
     exec = rootProject.ext.cargoExec
+
+    features {
+        defaultAnd("reqwest")
+    }
 }
 
 configurations {

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -10,7 +10,8 @@ name = "places_ffi"
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [features]
-rust-http-stack = ["viaduct/rust-http-stack"]
+reqwest = ["viaduct/reqwest", "places/reqwest"]
+default = []
 
 [dependencies]
 serde_json = "1.0.28"

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -5,6 +5,10 @@ version = "0.1.0"
 authors = ["jrconlin <me+crypt@jrconlin.com>", "Phil Jenvey <pjenvey@underboss.org>"]
 license = "MPL-2.0"
 
+[features]
+reqwest = ["communications/reqwest", "push-ffi/reqwest"]
+default = []
+
 [dependencies]
 communications={path="communications"}
 crypto={path="crypto"}

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -61,6 +61,10 @@ cargo {
     profile = rootProject.ext.nonMegazordProfile
 
     exec = rootProject.ext.cargoExec
+
+    features {
+        defaultAnd("reqwest")
+    }
 }
 
 configurations {

--- a/components/push/communications/Cargo.toml
+++ b/components/push/communications/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["jrconlin <me+crypt@jrconlin.com>", "Phil Jenvey <pjenvey@underboss.o
 edition = "2018"
 license = "MPL-2.0"
 
+[features]
+reqwest = ["viaduct/reqwest"]
+default = []
+
 [dependencies]
 hex = "0.3"
 log = "0.4"
@@ -21,3 +25,4 @@ config = {path="../config"}
 
 [dev-dependencies]
 mockito = "0.15"
+force-viaduct-reqwest = { path = "../../support/force-viaduct-reqwest" }

--- a/components/push/ffi/Cargo.toml
+++ b/components/push/ffi/Cargo.toml
@@ -33,9 +33,7 @@ features = ["sqlcipher", "limits", "functions"]
 path = "../../sync15"
 
 [features]
-rust-http-stack = ["viaduct/rust-http-stack"]
-
-
+reqwest = ["viaduct/reqwest", "communications/reqwest"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_logger = "0.7.0"

--- a/components/support/force-viaduct-reqwest/Cargo.toml
+++ b/components/support/force-viaduct-reqwest/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "force-viaduct-reqwest"
+version = "0.1.0"
+authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+# This is a hack we use to allow tests to force-enable the "reqwest" feature of
+# viaduct. You should only depend on it as a dev-dependency, and only if your
+# tests need to make network requests.
+
+[dependencies]
+viaduct = { path = "../../viaduct", features = ["reqwest"] }

--- a/components/support/force-viaduct-reqwest/src/lib.rs
+++ b/components/support/force-viaduct-reqwest/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -5,6 +5,10 @@ version = "0.1.0"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 license = "MPL-2.0"
 
+[features]
+reqwest = ["viaduct/reqwest"]
+default = []
+
 [dependencies]
 base64 = "0.9.3"
 serde = "1.0.79"
@@ -18,8 +22,3 @@ lazy_static = "1.0"
 base16 = "0.1.1"
 failure = "0.1.3"
 viaduct = { path = "../viaduct" }
-
-[dev-dependencies]
-env_logger = "0.5"
-prettytable-rs = "0.6"
-fxa-client = { path = "../fxa-client" }

--- a/components/viaduct/Cargo.toml
+++ b/components/viaduct/Cargo.toml
@@ -9,9 +9,7 @@ license = "MPL-2.0"
 crate-type = ["lib", "cdylib"]
 
 [features]
-# Unfortunate, but required to make our tests work.
-default = ["rust-http-stack"]
-rust-http-stack = ["reqwest"]
+default = []
 
 [dependencies]
 failure = "0.1.5"

--- a/components/viaduct/src/backend.rs
+++ b/components/viaduct/src/backend.rs
@@ -4,7 +4,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 
-#[cfg(feature = "rust-http-stack")]
+#[cfg(feature = "reqwest")]
 mod reqwest;
 
 mod ffi;
@@ -21,15 +21,30 @@ pub fn force_enable_ffi_backend(v: bool) {
     FFI_FORCED.store(v, Ordering::SeqCst)
 }
 
+pub(crate) fn note_backend(which: &str) {
+    // If trace logs are enabled: log on every request. Otherwise, just log on
+    // the first request at `info` level. We remember if the Once was triggered
+    // to avoid logging twice in the first case.
+    static NOTE_BACKEND_ONCE: std::sync::Once = std::sync::Once::new();
+    let mut called = false;
+    NOTE_BACKEND_ONCE.call_once(|| {
+        log::info!("Using HTTP backend {}", which);
+        called = true;
+    });
+    if !called {
+        log::trace!("Using HTTP backend {}", which);
+    }
+}
+
 pub fn send(request: crate::Request) -> Result<crate::Response, crate::Error> {
     if ffi_is_forced() {
         return self::ffi::send(request);
     }
-    #[cfg(feature = "rust-http-stack")]
+    #[cfg(feature = "reqwest")]
     {
         self::reqwest::send(request)
     }
-    #[cfg(not(feature = "rust-http-stack"))]
+    #[cfg(not(feature = "reqwest"))]
     {
         self::ffi::send(request)
     }

--- a/components/viaduct/src/backend/ffi.rs
+++ b/components/viaduct/src/backend/ffi.rs
@@ -41,6 +41,7 @@ macro_rules! backend_error {
 pub fn send(request: crate::Request) -> Result<crate::Response, Error> {
     use ffi_support::IntoFfi;
     use prost::Message;
+    super::note_backend("FFI (trusted)");
 
     let method = request.method;
     let fetch = callback_holder::get_callback().ok_or_else(|| Error::BackendNotInitialized)?;
@@ -197,7 +198,7 @@ pub unsafe extern "C" fn viaduct_initialize(callback: FetchCallback) -> u8 {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn viaduct_force_enable_ffi_backend(v: u8) {
+pub extern "C" fn viaduct_force_enable_ffi_backend(v: u8) {
     ffi_support::abort_on_panic::call_with_output(|| super::force_enable_ffi_backend(v != 0));
 }
 

--- a/components/viaduct/src/backend/reqwest.rs
+++ b/components/viaduct/src/backend/reqwest.rs
@@ -55,6 +55,7 @@ impl crate::Request {
 }
 
 pub fn send(request: crate::Request) -> Result<crate::Response, crate::Error> {
+    super::note_backend("reqwest (untrusted)");
     let request_method = request.method;
     let req = request.into_reqwest()?;
     let mut resp = CLIENT.execute(req).map_err(|e| {

--- a/components/viaduct/src/backend/reqwest.rs
+++ b/components/viaduct/src/backend/reqwest.rs
@@ -94,3 +94,12 @@ pub fn send(request: crate::Request) -> Result<crate::Response, crate::Error> {
         headers,
     })
 }
+
+/// A dummy symbol we include so that we can detect whether or not the reqwest
+/// backend got compiled in.
+#[no_mangle]
+pub extern "C" fn viaduct_detect_reqwest_backend() {
+    ffi_support::abort_on_panic::call_with_output(|| {
+        println!("Nothing to see here (reqwest backend available).");
+    });
+}

--- a/megazords/reference-browser/Cargo.toml
+++ b/megazords/reference-browser/Cargo.toml
@@ -14,4 +14,4 @@ logins_ffi = { path = "../../components/logins/ffi" }
 places-ffi = { path = "../../components/places/ffi" }
 push-ffi = { path = "../../components/push/ffi" }
 rc_log_ffi = { path = "../../components/rc_log" }
-viaduct = { path = "../../components/viaduct", default-features = false }
+viaduct = { path = "../../components/viaduct" }

--- a/testing/err-if-symbol.sh
+++ b/testing/err-if-symbol.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euvx
+
+if [ "$#" -ne 3 ]
+then
+    echo "Usage: <path/to/relevant/nm> <path/to/relevant/library> <symbol_name>"
+    echo "Example Usage:"
+    echo "$ bash testing/err-if-symbol.sh \\"
+    echo "    \$ANDROID_NDK_TOOLCHAIN_DIR/x86-$ANDROID_NDK_API_VERSION/bin/i686-linux-android-nm \\"
+    echo "    target/i686-linux-android/release/librc_log_ffi.so \\"
+    echo "    viaduct_detect_reqwest_backend"
+    exit 1
+fi
+
+NM=$1
+LIBRARY=$2
+SYMBOL=$3
+
+if [[ ! -f "$LIBRARY" ]]; then
+    echo "Library arg \"$LIBRARY\" does not exist"
+    exit 1
+fi
+
+PATTERN="\\b$SYMBOL\\b"
+
+# Split up for better error detection/reporting
+ALLSYMS=$($NM -g $LIBRARY)
+
+# Note: grep always returns an error when it gets 0 matches, so make sure it
+# always has enough matches so what we don't have to silence it's errors (which
+# might be about other things too...)
+
+FOUND=$(echo "$ALLSYMS $SYMBOL" | grep -cE $PATTERN)
+
+if [[ "$FOUND" -ne 1 ]]; then
+    echo "Error: Found unexpected symbol in \"$LIBRARY\": \"$SYMBOL\""
+    exit 1
+else
+    echo "PASS $LIBRARY"
+fi

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 license = "MPL-2.0"
 
 [dependencies]
-logins = { path = "../../components/logins" }
-sync15 = { path = "../../components/sync15" }
-fxa-client = { path = "../../components/fxa-client" }
+logins = { path = "../../components/logins", features = ["reqwest"] }
+sync15 = { path = "../../components/sync15", features = ["reqwest"] }
+fxa-client = { path = "../../components/fxa-client", features = ["reqwest"] }
 url = "1.7.1"
 env_logger = "0.6.0"
 log = "0.4.6"


### PR DESCRIPTION
Someone in the Rust discord suggested of a workaround for the cargo issues I was hitting before, so we don't have to block this on removing non-megazords (which we should still do!). I don't fully understand why this works while the other version doesn't, but I've added a taskcluster task that verifies that the megazords don't have the symbol `viaduct_detect_reqwest_backend` (which is only compiled in if the reqwest backend is present).

### Pull Request checklist ###
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
     - This has automated tests, but I have not manually tested this change yet.
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
