### PR TITLE
Have our cmdline utilities use the stable_dev fxa environment

### DIFF
--- a/components/support/cli/src/fxa_creds.rs
+++ b/components/support/cli/src/fxa_creds.rs
@@ -70,7 +70,7 @@ fn create_fxa_creds(path: &str, cfg: Config) -> Result<FirefoxAccount> {
 // better with clap, so we could automagically support various args (such as
 // the config to use or filenames to read), but this will do for now.
 pub fn get_default_fxa_config() -> Config {
-    Config::release(CLIENT_ID, REDIRECT_URI)
+    Config::stable_dev(CLIENT_ID, REDIRECT_URI)
 }
 
 pub fn get_cli_fxa(config: Config, cred_file: &str) -> Result<CliFxa> {


### PR DESCRIPTION
Our cmdline utilities have been using the release FxA environment, which has recently stopped working for our configuration. Using stable_dev does work.

(Ideally we'd have the sync integration tests use our cli library, but that's a yak for another day)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
