### PR TITLE
Bump rusqlite to 0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,16 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fenix"
 version = "0.1.0"
 dependencies = [
@@ -978,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.11.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1033,7 +1043,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1052,7 +1062,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins 0.1.0",
- "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sync15 0.1.0",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1408,7 +1418,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1433,7 +1443,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "places 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sync15 0.1.0",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1548,7 +1558,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mockito 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1567,7 +1577,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "push 0.1.0",
- "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sync15 0.1.0",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1884,12 +1894,15 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2065,7 +2078,7 @@ version = "0.1.0"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2670,6 +2683,8 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
+"checksum fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 "checksum find-places-db 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "156072cf5b7e3974da51941bf050f5b8ab5a8df56ad5c1adbd8c07e9d9455b95"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f87e68aa82b2de08a6e037f1385455759df6e445a8df5e005b4297191dbf18aa"
@@ -2704,7 +2719,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
-"checksum libsqlite3-sys 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3567bc1a0c84e2c0d71eeb4a1f08451babf7843babd733158777d9c686dad9f3"
+"checksum libsqlite3-sys 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44c0ae64aa0fc0c81fc1ddc9eae833e617e900677f83a72907b5535f08913d99"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -2778,7 +2793,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)" = "19c4c4990514fbd7a80380b826d81368ba6f6af61007ea142519ce47d72f6b0f"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
-"checksum rusqlite 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6381ddfe91dbb659b4b132168da15985bc84162378cf4fcdc4eb99c857d063e2"
+"checksum rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8ef7411f02f83d4ce1b9c6c043013ed141f01aa1a77c665fb6d72042a3705cf"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -23,7 +23,7 @@ sql-support = { path = "../support/sql" }
 ffi-support = { path = "../support/ffi" }
 
 [dependencies.rusqlite]
-version = "0.16.0"
+version = "0.17.0"
 features = ["sqlcipher", "limits"]
 
 [dev-dependencies]

--- a/components/logins/examples/sync_pass_sql.rs
+++ b/components/logins/examples/sync_pass_sql.rs
@@ -142,14 +142,16 @@ fn show_sql(e: &PasswordEngine, sql: &str) -> Result<()> {
 
     let rows = stmt.query_map(NO_PARAMS, |row| {
         (0..len)
-            .map(|idx| match row.get::<_, Value>(idx) {
-                Value::Null => Cell::new("null").style_spec("Fd"),
-                Value::Integer(i) => Cell::new(&i.to_string()).style_spec("Fb"),
-                Value::Real(r) => Cell::new(&r.to_string()).style_spec("Fb"),
-                Value::Text(s) => Cell::new(&s.to_string()).style_spec("Fr"),
-                Value::Blob(b) => Cell::new(&format!("{}b blob", b.len())),
+            .map(|idx| {
+                Ok(match row.get::<_, Value>(idx)? {
+                    Value::Null => Cell::new("null").style_spec("Fd"),
+                    Value::Integer(i) => Cell::new(&i.to_string()).style_spec("Fb"),
+                    Value::Real(r) => Cell::new(&r.to_string()).style_spec("Fb"),
+                    Value::Text(s) => Cell::new(&s.to_string()).style_spec("Fr"),
+                    Value::Blob(b) => Cell::new(&format!("{}b blob", b.len())),
+                })
             })
-            .collect::<Vec<_>>()
+            .collect::<std::result::Result<Vec<_>, _>>()
     })?;
 
     for row in rows {

--- a/components/logins/ffi/Cargo.toml
+++ b/components/logins/ffi/Cargo.toml
@@ -21,7 +21,7 @@ lazy_static = "1.3.0"
 viaduct = { path = "../../viaduct" }
 
 [dependencies.rusqlite]
-version = "0.16.0"
+version = "0.17.0"
 features = ["sqlcipher"]
 
 [dependencies.logins]

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -225,12 +225,12 @@ impl LoginDb {
                 let mut stmt = self.db.prepare(&query)?;
 
                 let rows = stmt.query_and_then(chunk, |row| {
-                    let guid_idx_i = row.get_checked::<_, i64>("guid_idx")?;
+                    let guid_idx_i = row.get::<_, i64>("guid_idx")?;
                     // Hitting this means our math is wrong...
                     assert!(guid_idx_i >= 0);
 
                     let guid_idx = guid_idx_i as usize;
-                    let is_mirror: bool = row.get_checked("is_mirror")?;
+                    let is_mirror: bool = row.get("is_mirror")?;
                     if is_mirror {
                         sync_data[guid_idx].set_mirror(MirrorLogin::from_row(row)?)?;
                     } else {
@@ -698,8 +698,8 @@ impl LoginDb {
             synced = SyncStatus::Synced as u8
         ))?;
         let rows = stmt.query_and_then(NO_PARAMS, |row| {
-            Ok(if row.get_checked::<_, bool>("is_deleted")? {
-                Payload::new_tombstone(row.get_checked::<_, String>("guid")?)
+            Ok(if row.get::<_, bool>("is_deleted")? {
+                Payload::new_tombstone(row.get::<_, String>("guid")?)
                     .with_sortindex(TOMBSTONE_SORTINDEX)
             } else {
                 let login = Login::from_row(row)?;
@@ -734,7 +734,7 @@ impl LoginDb {
         Ok(self.try_query_row(
             "SELECT value FROM loginsSyncMeta WHERE key = :key",
             &[(":key", &key as &ToSql)],
-            |row| Ok::<_, Error>(row.get_checked(0)?),
+            |row| Ok::<_, Error>(row.get(0)?),
             true,
         )?)
     }

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -54,9 +54,7 @@ pub struct Login {
 }
 
 fn string_or_default(row: &Row, col: &str) -> Result<String> {
-    Ok(row
-        .get_checked::<_, Option<String>>(col)?
-        .unwrap_or_default())
+    Ok(row.get::<_, Option<String>>(col)?.unwrap_or_default())
 }
 
 impl Login {
@@ -91,26 +89,26 @@ impl Login {
 
     pub(crate) fn from_row(row: &Row) -> Result<Login> {
         Ok(Login {
-            id: row.get_checked("guid")?,
-            password: row.get_checked("password")?,
+            id: row.get("guid")?,
+            password: row.get("password")?,
             username: string_or_default(row, "username")?,
 
-            hostname: row.get_checked("hostname")?,
-            http_realm: row.get_checked("httpRealm")?,
+            hostname: row.get("hostname")?,
+            http_realm: row.get("httpRealm")?,
 
-            form_submit_url: row.get_checked("formSubmitURL")?,
+            form_submit_url: row.get("formSubmitURL")?,
 
             username_field: string_or_default(row, "usernameField")?,
             password_field: string_or_default(row, "passwordField")?,
 
-            time_created: row.get_checked("timeCreated")?,
+            time_created: row.get("timeCreated")?,
             // Might be null
             time_last_used: row
-                .get_checked::<_, Option<i64>>("timeLastUsed")?
+                .get::<_, Option<i64>>("timeLastUsed")?
                 .unwrap_or_default(),
 
-            time_password_changed: row.get_checked("timePasswordChanged")?,
-            times_used: row.get_checked("timesUsed")?,
+            time_password_changed: row.get("timePasswordChanged")?,
+            times_used: row.get("timesUsed")?,
         })
     }
 }
@@ -131,10 +129,8 @@ impl MirrorLogin {
     pub(crate) fn from_row(row: &Row) -> Result<MirrorLogin> {
         Ok(MirrorLogin {
             login: Login::from_row(row)?,
-            is_overridden: row.get_checked("is_overridden")?,
-            server_modified: ServerTimestamp(
-                row.get_checked::<_, i64>("server_modified")? as f64 / 1000.0,
-            ),
+            is_overridden: row.get("is_overridden")?,
+            server_modified: ServerTimestamp(row.get::<_, i64>("server_modified")? as f64 / 1000.0),
         })
     }
 }
@@ -177,8 +173,8 @@ impl LocalLogin {
     pub(crate) fn from_row(row: &Row) -> Result<LocalLogin> {
         Ok(LocalLogin {
             login: Login::from_row(row)?,
-            sync_status: SyncStatus::from_u8(row.get_checked("sync_status")?)?,
-            is_deleted: row.get_checked("is_deleted")?,
+            sync_status: SyncStatus::from_u8(row.get("sync_status")?)?,
+            is_deleted: row.get("is_deleted")?,
             local_modified: util::system_time_millis_from_row(row, "local_modified")?,
         })
     }

--- a/components/logins/src/util.rs
+++ b/components/logins/src/util.rs
@@ -18,9 +18,7 @@ pub fn url_host_port(url_str: &str) -> Option<String> {
 }
 
 pub fn system_time_millis_from_row(row: &Row, col_name: &str) -> Result<time::SystemTime> {
-    let time_ms = row
-        .get_checked::<_, Option<i64>>(col_name)?
-        .unwrap_or_default() as u64;
+    let time_ms = row.get::<_, Option<i64>>(col_name)?.unwrap_or_default() as u64;
     Ok(time::UNIX_EPOCH + time::Duration::from_millis(time_ms))
 }
 

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -32,7 +32,7 @@ bytes = "0.4.11"
 dogear = "0.2.2"
 
 [dependencies.rusqlite]
-version = "0.16.0"
+version = "0.17.0"
 features = ["sqlcipher", "functions"]
 
 [dev-dependencies]

--- a/components/places/examples/autocomplete.rs
+++ b/components/places/examples/autocomplete.rs
@@ -102,21 +102,21 @@ struct LegacyPlace {
 impl LegacyPlace {
     pub fn from_row(row: &rusqlite::Row) -> Self {
         Self {
-            id: row.get("place_id"),
-            guid: row.get("place_guid"),
-            title: row.get("place_title"),
-            url: row.get("place_url"),
-            description: row.get("place_description"),
-            preview_image_url: row.get("place_preview_image_url"),
-            typed: row.get("place_typed"),
-            hidden: row.get("place_hidden"),
-            visit_count: row.get("place_visit_count"),
-            last_visit_date: row.get("place_last_visit_date"),
+            id: row.get_unwrap("place_id"),
+            guid: row.get_unwrap("place_guid"),
+            title: row.get_unwrap("place_title"),
+            url: row.get_unwrap("place_url"),
+            description: row.get_unwrap("place_description"),
+            preview_image_url: row.get_unwrap("place_preview_image_url"),
+            typed: row.get_unwrap("place_typed"),
+            hidden: row.get_unwrap("place_hidden"),
+            visit_count: row.get_unwrap("place_visit_count"),
+            last_visit_date: row.get_unwrap("place_last_visit_date"),
             visits: vec![LegacyPlaceVisit {
-                id: row.get("visit_id"),
-                date: row.get("visit_date"),
-                visit_type: row.get("visit_type"),
-                from_visit: row.get("visit_from_visit"),
+                id: row.get_unwrap("visit_id"),
+                date: row.get_unwrap("visit_date"),
+                visit_type: row.get_unwrap("visit_type"),
+                from_visit: row.get_unwrap("visit_from_visit"),
             }],
         }
     }
@@ -149,13 +149,13 @@ fn import_places(
     let (place_count, visit_count) = {
         let mut stmt = old.prepare("SELECT count(*) FROM moz_places").unwrap();
         let mut rows = stmt.query(NO_PARAMS).unwrap();
-        let ps: i64 = rows.next().unwrap()?.get(0);
+        let ps: i64 = rows.next()?.unwrap().get_unwrap(0);
 
         let mut stmt = old
             .prepare("SELECT count(*) FROM moz_historyvisits")
             .unwrap();
         let mut rows = stmt.query(NO_PARAMS).unwrap();
-        let vs: i64 = rows.next().unwrap()?.get(0);
+        let vs: i64 = rows.next()?.unwrap().get_unwrap(0);
         (ps, vs)
     };
 
@@ -205,15 +205,14 @@ fn import_places(
         place_counter, place_count
     );
     let _ = std::io::stdout().flush();
-    while let Some(row_or_error) = rows.next() {
-        let row = row_or_error?;
-        let id: i64 = row.get("place_id");
+    while let Some(row) = rows.next()? {
+        let id: i64 = row.get("place_id")?;
         if current_place.id == id {
             current_place.visits.push(LegacyPlaceVisit {
-                id: row.get("visit_id"),
-                date: row.get("visit_date"),
-                visit_type: row.get("visit_type"),
-                from_visit: row.get("visit_from_visit"),
+                id: row.get("visit_id")?,
+                date: row.get("visit_date")?,
+                visit_type: row.get("visit_type")?,
+                from_visit: row.get("visit_from_visit")?,
             });
             continue;
         }

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -24,7 +24,7 @@ bytes = "0.4.12"
 viaduct = { path = "../../viaduct" }
 
 [dependencies.rusqlite]
-version = "0.16.0"
+version = "0.17.0"
 features = ["sqlcipher", "limits", "functions"]
 
 [dependencies.sync15]

--- a/components/places/src/api/history.rs
+++ b/components/places/src/api/history.rs
@@ -97,18 +97,14 @@ mod tests {
         let row = result.expect("expect anything");
 
         assert_eq!(
-            row.get_checked::<_, String>("url").expect("should work"),
+            row.get::<_, String>("url").expect("should work"),
             "http://example.com/"
         ); // hrmph - note trailing slash
         assert_eq!(
-            row.get_checked::<_, Timestamp>("visit_date")
-                .expect("should work"),
+            row.get::<_, Timestamp>("visit_date").expect("should work"),
             date
         );
-        assert_ne!(
-            row.get_checked::<_, i32>("frecency").expect("should work"),
-            0
-        );
+        assert_ne!(row.get::<_, i32>("frecency").expect("should work"), 0);
         // XXX - check more.
     }
 }

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -187,17 +187,17 @@ impl SearchResult {
     pub fn from_adaptive_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
         let mut reasons = vec![MatchReason::PreviousUse];
 
-        let search_string = row.get_checked::<_, String>("searchString")?;
-        let _place_id = row.get_checked::<_, i64>("id")?;
-        let url = row.get_checked::<_, String>("url")?;
-        let history_title = row.get_checked::<_, Option<String>>("title")?;
-        let bookmarked = row.get_checked::<_, bool>("bookmarked")?;
-        let bookmark_title = row.get_checked::<_, Option<String>>("btitle")?;
-        let frecency = row.get_checked::<_, i64>("frecency")?;
+        let search_string = row.get::<_, String>("searchString")?;
+        let _place_id = row.get::<_, i64>("id")?;
+        let url = row.get::<_, String>("url")?;
+        let history_title = row.get::<_, Option<String>>("title")?;
+        let bookmarked = row.get::<_, bool>("bookmarked")?;
+        let bookmark_title = row.get::<_, Option<String>>("btitle")?;
+        let frecency = row.get::<_, i64>("frecency")?;
 
         let title = bookmark_title.or_else(|| history_title).unwrap_or_default();
 
-        let tags = row.get_checked::<_, Option<String>>("tags")?;
+        let tags = row.get::<_, Option<String>>("tags")?;
         if let Some(tags) = tags {
             reasons.push(MatchReason::Tags(tags));
         }
@@ -219,20 +219,20 @@ impl SearchResult {
     pub fn from_suggestion_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
         let mut reasons = vec![MatchReason::Bookmark];
 
-        let search_string = row.get_checked::<_, String>("searchString")?;
-        let url = row.get_checked::<_, String>("url")?;
+        let search_string = row.get::<_, String>("searchString")?;
+        let url = row.get::<_, String>("url")?;
 
-        let history_title = row.get_checked::<_, Option<String>>("title")?;
-        let bookmark_title = row.get_checked::<_, Option<String>>("btitle")?;
+        let history_title = row.get::<_, Option<String>>("title")?;
+        let bookmark_title = row.get::<_, Option<String>>("btitle")?;
         let title = bookmark_title.or_else(|| history_title).unwrap_or_default();
 
-        let tags = row.get_checked::<_, Option<String>>("tags")?;
+        let tags = row.get::<_, Option<String>>("tags")?;
         if let Some(tags) = tags {
             reasons.push(MatchReason::Tags(tags));
         }
         let url = Url::parse(&url).expect("Invalid URL in Places");
 
-        let frecency = row.get_checked::<_, i64>("frecency")?;
+        let frecency = row.get::<_, i64>("frecency")?;
 
         Ok(Self {
             search_string,
@@ -245,10 +245,10 @@ impl SearchResult {
     }
 
     pub fn from_origin_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
-        let search_string = row.get_checked::<_, String>("searchString")?;
-        let url = row.get_checked::<_, String>("url")?;
-        let display_url = row.get_checked::<_, String>("displayURL")?;
-        let frecency = row.get_checked::<_, i64>("frecency")?;
+        let search_string = row.get::<_, String>("searchString")?;
+        let url = row.get::<_, String>("url")?;
+        let display_url = row.get::<_, String>("displayURL")?;
+        let frecency = row.get::<_, i64>("frecency")?;
 
         let url = Url::parse(&url).expect("Invalid URL in Places");
 
@@ -263,11 +263,11 @@ impl SearchResult {
     }
 
     pub fn from_url_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
-        let search_string = row.get_checked::<_, String>("searchString")?;
-        let href = row.get_checked::<_, String>("url")?;
-        let stripped_url = row.get_checked::<_, String>("strippedURL")?;
-        let frecency = row.get_checked::<_, i64>("frecency")?;
-        let bookmarked = row.get_checked::<_, bool>("bookmarked")?;
+        let search_string = row.get::<_, String>("searchString")?;
+        let href = row.get::<_, String>("url")?;
+        let stripped_url = row.get::<_, String>("strippedURL")?;
+        let frecency = row.get::<_, i64>("frecency")?;
+        let bookmarked = row.get::<_, bool>("bookmarked")?;
 
         let mut reasons = vec![MatchReason::Url];
         if bookmarked {

--- a/components/places/src/bookmark_sync/tests/synced_item.rs
+++ b/components/places/src/bookmark_sync/tests/synced_item.rs
@@ -172,7 +172,7 @@ impl SyncedBookmarkItem {
     // be SyncedBookmarkValue::Specified.
     fn from_row(row: &Row) -> Result<Self> {
         let mut tags = row
-            .get_checked::<_, Option<String>>("tags")?
+            .get::<_, Option<String>>("tags")?
             .map(|tags| {
                 tags.split(',')
                     .map(ToString::to_string)
@@ -181,35 +181,32 @@ impl SyncedBookmarkItem {
             .unwrap_or_default();
         tags.sort();
         Ok(Self {
-            id: SyncedBookmarkValue::Specified(row.get_checked("id")?),
-            guid: SyncedBookmarkValue::Specified(row.get_checked("guid")?),
-            parent_guid: SyncedBookmarkValue::Specified(row.get_checked("parentGuid")?),
+            id: SyncedBookmarkValue::Specified(row.get("id")?),
+            guid: SyncedBookmarkValue::Specified(row.get("guid")?),
+            parent_guid: SyncedBookmarkValue::Specified(row.get("parentGuid")?),
             server_modified: SyncedBookmarkValue::Specified(ServerTimestamp(
-                row.get_checked::<_, f64>("serverModified")?,
+                row.get::<_, f64>("serverModified")?,
             )),
-            needs_merge: SyncedBookmarkValue::Specified(row.get_checked("needsMerge")?),
+            needs_merge: SyncedBookmarkValue::Specified(row.get("needsMerge")?),
             validity: SyncedBookmarkValue::Specified(
-                SyncedBookmarkValidity::from_u8(row.get_checked("validity")?)
-                    .expect("a valid validity"),
+                SyncedBookmarkValidity::from_u8(row.get("validity")?).expect("a valid validity"),
             ),
-            deleted: SyncedBookmarkValue::Specified(row.get_checked("isDeleted")?),
+            deleted: SyncedBookmarkValue::Specified(row.get("isDeleted")?),
             kind: SyncedBookmarkValue::Specified(
                 // tombstones have a kind of -1, so get it from the db as i8
-                SyncedBookmarkKind::from_u8(row.get_checked::<_, i8>("kind")? as u8).ok(),
+                SyncedBookmarkKind::from_u8(row.get::<_, i8>("kind")? as u8).ok(),
             ),
-            date_added: SyncedBookmarkValue::Specified(row.get_checked("dateAdded")?),
-            title: SyncedBookmarkValue::Specified(row.get_checked("title")?),
-            place_id: SyncedBookmarkValue::Specified(row.get_checked("placeId")?),
-            keyword: SyncedBookmarkValue::Specified(row.get_checked("keyword")?),
-            description: SyncedBookmarkValue::Specified(row.get_checked("description")?),
-            load_in_sidebar: SyncedBookmarkValue::Specified(row.get_checked("loadInSidebar")?),
-            smart_bookmark_name: SyncedBookmarkValue::Specified(
-                row.get_checked("smartBookmarkName")?,
-            ),
-            feed_url: SyncedBookmarkValue::Specified(row.get_checked("feedUrl")?),
-            site_url: SyncedBookmarkValue::Specified(row.get_checked("siteUrl")?),
+            date_added: SyncedBookmarkValue::Specified(row.get("dateAdded")?),
+            title: SyncedBookmarkValue::Specified(row.get("title")?),
+            place_id: SyncedBookmarkValue::Specified(row.get("placeId")?),
+            keyword: SyncedBookmarkValue::Specified(row.get("keyword")?),
+            description: SyncedBookmarkValue::Specified(row.get("description")?),
+            load_in_sidebar: SyncedBookmarkValue::Specified(row.get("loadInSidebar")?),
+            smart_bookmark_name: SyncedBookmarkValue::Specified(row.get("smartBookmarkName")?),
+            feed_url: SyncedBookmarkValue::Specified(row.get("feedUrl")?),
+            site_url: SyncedBookmarkValue::Specified(row.get("siteUrl")?),
             url: SyncedBookmarkValue::Specified(
-                row.get_checked::<_, Option<String>>("url")?
+                row.get::<_, Option<String>>("url")?
                     .and_then(|s| Url::parse(&s).ok()),
             ),
             tags: SyncedBookmarkValue::Specified(tags),

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -226,7 +226,7 @@ mod tests {
             "SELECT COUNT(*) from moz_places_tombstones
                      WHERE guid = :guid",
             &[(":guid", guid)],
-            |row| Ok(row.get_checked::<_, u32>(0)?),
+            |row| Ok(row.get::<_, u32>(0)?),
             true,
         );
         count.unwrap().unwrap() == 1
@@ -347,7 +347,7 @@ mod tests {
 
     fn select_simple_int(conn: &PlacesDb, stmt: &str) -> u32 {
         let count: Result<Option<u32>> =
-            conn.try_query_row(stmt, &[], |row| Ok(row.get_checked::<_, u32>(0)?), false);
+            conn.try_query_row(stmt, &[], |row| Ok(row.get::<_, u32>(0)?), false);
         count.unwrap().unwrap()
     }
 
@@ -356,7 +356,7 @@ mod tests {
             "SELECT foreign_count from moz_places
                      WHERE guid = :guid",
             &[(":guid", guid)],
-            |row| Ok(row.get_checked::<_, u32>(0)?),
+            |row| Ok(row.get::<_, u32>(0)?),
             true,
         );
         count.unwrap().unwrap()

--- a/components/places/src/frecency.rs
+++ b/components/places/src/frecency.rs
@@ -142,11 +142,11 @@ impl<'db, 's> FrecencyComputation<'db, 's> {
             FROM moz_places
             WHERE id = :page_id
         ", &[(":page_id", &page_id)], |row| {
-            let typed: i32 = row.get("typed");
-            let visit_count: i32 = row.get("visit_count");
-            let foreign_count: i32 = row.get("foreign_count");
-            let is_query: bool = row.get("is_query");
-            (typed, visit_count, foreign_count, is_query)
+            let typed: i32 = row.get("typed")?;
+            let visit_count: i32 = row.get("visit_count")?;
+            let foreign_count: i32 = row.get("foreign_count")?;
+            let is_query: bool = row.get("is_query")?;
+            Ok((typed, visit_count, foreign_count, is_query))
         })?;
 
         Ok(Self {
@@ -193,11 +193,9 @@ impl<'db, 's> FrecencyComputation<'db, 's> {
         let row_iter = stmt.query_and_then_named(
             &[(":page_id", &self.page_id)],
             |row| -> rusqlite::Result<_> {
-                let visit_type = row.get_checked::<_, Option<u8>>("visit_type")?.unwrap_or(0);
-                let target_visit_type = row
-                    .get_checked::<_, Option<u8>>("target_visit_type")?
-                    .unwrap_or(0);
-                let age_in_days: f64 = row.get_checked("age_in_days")?;
+                let visit_type = row.get::<_, Option<u8>>("visit_type")?.unwrap_or(0);
+                let target_visit_type = row.get::<_, Option<u8>>("target_visit_type")?.unwrap_or(0);
+                let age_in_days: f64 = row.get("age_in_days")?;
                 Ok((
                     VisitTransition::from_primitive(visit_type),
                     VisitTransition::from_primitive(target_visit_type),

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -298,7 +298,7 @@ mod tests {
         let result: Result<Option<u32>> = conn.try_query_row(
             "SELECT COUNT(*) from moz_places_tombstones;",
             &[],
-            |row| Ok(row.get_checked::<_, u32>(0)?),
+            |row| Ok(row.get::<_, u32>(0)?),
             true,
         );
         result
@@ -314,8 +314,8 @@ mod tests {
             &[(":url", &url.clone().into_string())],
             |row| {
                 Ok((
-                    SyncStatus::from_u8(row.get_checked::<_, u8>(0)?),
-                    row.get_checked::<_, u32>(1)?,
+                    SyncStatus::from_u8(row.get::<_, u8>(0)?),
+                    row.get::<_, u32>(1)?,
                 ))
             },
             true,

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -1078,23 +1078,22 @@ struct FetchedTreeRow {
 
 impl FetchedTreeRow {
     pub fn from_row(row: &Row) -> Result<Self> {
-        let url = row.get_checked::<_, Option<String>>("url")?;
+        let url = row.get::<_, Option<String>>("url")?;
         Ok(Self {
-            level: row.get_checked("level")?,
-            id: row.get_checked::<_, RowId>("id")?,
-            guid: row.get_checked::<_, String>("guid")?.into(),
-            parent: row.get_checked::<_, Option<RowId>>("parent")?,
+            level: row.get("level")?,
+            id: row.get::<_, RowId>("id")?,
+            guid: row.get::<_, String>("guid")?.into(),
+            parent: row.get::<_, Option<RowId>>("parent")?,
             parent_guid: row
-                .get_checked::<_, Option<String>>("parentGuid")?
+                .get::<_, Option<String>>("parentGuid")?
                 .map(SyncGuid::from),
-            node_type: BookmarkType::from_u8_with_valid_url(
-                row.get_checked::<_, u8>("type")?,
-                || url.is_some(),
-            ),
-            position: row.get_checked("position")?,
-            title: row.get_checked::<_, Option<String>>("title")?,
-            date_added: row.get_checked("dateAdded")?,
-            last_modified: row.get_checked("lastModified")?,
+            node_type: BookmarkType::from_u8_with_valid_url(row.get::<_, u8>("type")?, || {
+                url.is_some()
+            }),
+            position: row.get("position")?,
+            title: row.get::<_, Option<String>>("title")?,
+            date_added: row.get("dateAdded")?,
+            last_modified: row.get("lastModified")?,
             url,
         })
     }
@@ -1266,31 +1265,30 @@ pub(crate) struct RawBookmark {
 
 impl RawBookmark {
     pub fn from_row(row: &Row) -> Result<Self> {
-        let place_id = row.get_checked::<_, Option<RowId>>("fk")?;
+        let place_id = row.get::<_, Option<RowId>>("fk")?;
         Ok(Self {
-            row_id: row.get_checked("_id")?,
+            row_id: row.get("_id")?,
             place_id,
-            bookmark_type: BookmarkType::from_u8_with_valid_url(
-                row.get_checked::<_, u8>("type")?,
-                || place_id.is_some(),
-            ),
-            parent_id: row.get_checked("_parentId")?,
-            parent_guid: row.get_checked("parentGuid")?,
-            position: row.get_checked("position")?,
-            title: row.get_checked::<_, Option<String>>("title")?,
-            url: match row.get_checked::<_, Option<String>>("url")? {
+            bookmark_type: BookmarkType::from_u8_with_valid_url(row.get::<_, u8>("type")?, || {
+                place_id.is_some()
+            }),
+            parent_id: row.get("_parentId")?,
+            parent_guid: row.get("parentGuid")?,
+            position: row.get("position")?,
+            title: row.get::<_, Option<String>>("title")?,
+            url: match row.get::<_, Option<String>>("url")? {
                 Some(s) => Some(Url::parse(&s)?),
                 None => None,
             },
-            date_added: row.get_checked("dateAdded")?,
-            date_modified: row.get_checked("lastModified")?,
-            guid: row.get_checked::<_, String>("guid")?.into(),
-            sync_status: SyncStatus::from_u8(row.get_checked::<_, u8>("_syncStatus")?),
+            date_added: row.get("dateAdded")?,
+            date_modified: row.get("lastModified")?,
+            guid: row.get::<_, String>("guid")?.into(),
+            sync_status: SyncStatus::from_u8(row.get::<_, u8>("_syncStatus")?),
             sync_change_counter: row
-                .get_checked::<_, Option<u32>>("syncChangeCounter")?
+                .get::<_, Option<u32>>("syncChangeCounter")?
                 .unwrap_or_default(),
-            child_count: row.get_checked("_childCount")?,
-            grandparent_id: row.get_checked("_grandparentId")?,
+            child_count: row.get("_childCount")?,
+            grandparent_id: row.get("_grandparentId")?,
         })
     }
 }
@@ -1861,7 +1859,7 @@ mod tests {
             let mut stmt = conn.prepare(sql).expect("sql is ok");
             let got_guids: HashSet<String> = stmt
                 .query_and_then(NO_PARAMS, |row| -> rusqlite::Result<_> {
-                    Ok(row.get_checked::<_, String>(0)?)
+                    Ok(row.get::<_, String>(0)?)
                 })
                 .expect("should work")
                 .map(std::result::Result::unwrap)
@@ -1883,7 +1881,7 @@ mod tests {
             let mut stmt = conn.prepare(sql).expect("sql is ok");
             let got_guids: HashSet<String> = stmt
                 .query_and_then(NO_PARAMS, |row| -> rusqlite::Result<_> {
-                    Ok(row.get_checked::<_, String>(0)?)
+                    Ok(row.get::<_, String>(0)?)
                 })
                 .expect("should work")
                 .map(std::result::Result::unwrap)

--- a/components/places/src/storage/bookmarks/public_node.rs
+++ b/components/places/src/storage/bookmarks/public_node.rs
@@ -107,7 +107,7 @@ fn get_child_guids(db: &PlacesDb, parent: RowId) -> Result<Vec<SyncGuid>> {
          WHERE parent = :parent
          ORDER BY position ASC",
         &[(":parent", &parent)],
-        |row| row.get_checked(0),
+        |row| row.get(0),
     )?)
 }
 
@@ -200,7 +200,7 @@ pub fn update_bookmark_from_message(db: &PlacesDb, msg: ProtoBookmark) -> Result
     let node_type: BookmarkType = db.query_row_and_then_named(
         "SELECT type FROM moz_bookmarks WHERE guid = :guid",
         &[(":guid", &info.guid)],
-        |r| r.get_checked(0),
+        |r| r.get(0),
         true,
     )?;
     let (guid, updatable) = info.into_updatable(node_type)?;
@@ -238,12 +238,7 @@ pub fn fetch_public_tree(db: &PlacesDb, item_guid: &SyncGuid) -> Result<Option<P
         let (parent_guid, position) = db.query_row_and_then_named(
             sql,
             &[(":guid", &item_guid)],
-            |row| -> Result<_> {
-                Ok((
-                    row.get_checked::<_, Option<SyncGuid>>(0)?,
-                    row.get_checked::<_, u32>(1)?,
-                ))
-            },
+            |row| -> Result<_> { Ok((row.get::<_, Option<SyncGuid>>(0)?, row.get::<_, u32>(1)?)) },
             true,
         )?;
         proto.parent_guid = parent_guid;
@@ -261,14 +256,14 @@ pub fn search_bookmarks(db: &PlacesDb, search: &str, limit: u32) -> Result<Vec<P
             scope.err_if_interrupted()?;
             Ok(PublicNode {
                 node_type: BookmarkType::Bookmark,
-                guid: row.get_checked("guid")?,
-                parent_guid: row.get_checked("parentGuid")?,
-                position: row.get_checked("position")?,
-                date_added: row.get_checked("dateAdded")?,
-                last_modified: row.get_checked("lastModified")?,
-                title: row.get_checked("title")?,
+                guid: row.get("guid")?,
+                parent_guid: row.get("parentGuid")?,
+                position: row.get("position")?,
+                date_added: row.get("dateAdded")?,
+                last_modified: row.get("lastModified")?,
+                title: row.get("title")?,
                 url: row
-                    .get_checked::<_, Option<String>>("url")?
+                    .get::<_, Option<String>>("url")?
                     .map(|href| url::Url::parse(&href))
                     .transpose()?,
                 child_guids: None,

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -78,29 +78,27 @@ pub struct PageInfo {
 impl PageInfo {
     pub fn from_row(row: &Row) -> Result<Self> {
         Ok(Self {
-            url: Url::parse(&row.get_checked::<_, String>("url")?)?,
-            guid: row.get_checked::<_, String>("guid")?.into(),
-            row_id: row.get_checked("id")?,
-            title: row
-                .get_checked::<_, Option<String>>("title")?
-                .unwrap_or_default(),
-            hidden: row.get_checked("hidden")?,
-            typed: row.get_checked("typed")?,
+            url: Url::parse(&row.get::<_, String>("url")?)?,
+            guid: row.get::<_, String>("guid")?.into(),
+            row_id: row.get("id")?,
+            title: row.get::<_, Option<String>>("title")?.unwrap_or_default(),
+            hidden: row.get("hidden")?,
+            typed: row.get("typed")?,
 
-            frecency: row.get_checked("frecency")?,
-            visit_count_local: row.get_checked("visit_count_local")?,
-            visit_count_remote: row.get_checked("visit_count_remote")?,
+            frecency: row.get("frecency")?,
+            visit_count_local: row.get("visit_count_local")?,
+            visit_count_remote: row.get("visit_count_remote")?,
 
             last_visit_date_local: row
-                .get_checked::<_, Option<Timestamp>>("last_visit_date_local")?
+                .get::<_, Option<Timestamp>>("last_visit_date_local")?
                 .unwrap_or_default(),
             last_visit_date_remote: row
-                .get_checked::<_, Option<Timestamp>>("last_visit_date_remote")?
+                .get::<_, Option<Timestamp>>("last_visit_date_remote")?
                 .unwrap_or_default(),
 
-            sync_status: SyncStatus::from_u8(row.get_checked::<_, u8>("sync_status")?),
+            sync_status: SyncStatus::from_u8(row.get::<_, u8>("sync_status")?),
             sync_change_counter: row
-                .get_checked::<_, Option<u32>>("sync_change_counter")?
+                .get::<_, Option<u32>>("sync_change_counter")?
                 .unwrap_or_default(),
         })
     }
@@ -119,7 +117,7 @@ impl FetchedPageInfo {
     pub fn from_row(row: &Row) -> Result<Self> {
         Ok(Self {
             page: PageInfo::from_row(row)?,
-            last_visit_id: row.get_checked::<_, Option<RowId>>("last_visit_id")?,
+            last_visit_id: row.get::<_, Option<RowId>>("last_visit_id")?,
         })
     }
 }
@@ -177,15 +175,15 @@ fn new_page_info(db: &PlacesDb, url: &Url, new_guid: Option<SyncGuid>) -> Result
 
 impl HistoryVisitInfo {
     pub(crate) fn from_row(row: &rusqlite::Row) -> Result<Self> {
-        let visit_type = VisitTransition::from_primitive(row.get_checked::<_, u8>("visit_type")?)
+        let visit_type = VisitTransition::from_primitive(row.get::<_, u8>("visit_type")?)
             // Do we have an existing error we use for this? For now they
             // probably don't care too much about VisitTransition, so this
             // is fine.
             .unwrap_or(VisitTransition::Link);
-        let visit_date: Timestamp = row.get_checked("visit_date")?;
+        let visit_date: Timestamp = row.get("visit_date")?;
         Ok(Self {
-            url: row.get_checked("url")?,
-            title: row.get_checked("title")?,
+            url: row.get("url")?,
+            title: row.get("title")?,
             timestamp: visit_date.0 as i64,
             visit_type: visit_type as i32,
         })

--- a/components/places/src/storage/tags.rs
+++ b/components/places/src/storage/tags.rs
@@ -189,8 +189,7 @@ pub fn get_urls_with_tag(db: &PlacesDb, tag: &str) -> Result<Vec<Url>> {
          ORDER BY p.frecency",
     )?;
 
-    let rows =
-        stmt.query_and_then_named(&[(":tag", &tag)], |row| row.get_checked::<_, String>("url"))?;
+    let rows = stmt.query_and_then_named(&[(":tag", &tag)], |row| row.get::<_, String>("url"))?;
     let mut urls = Vec::new();
     for row in rows {
         urls.push(Url::parse(&row?)?);
@@ -220,7 +219,7 @@ pub fn get_tags_for_url(db: &PlacesDb, url: &Url) -> Result<Vec<String>> {
          ORDER BY t.lastModified DESC",
     )?;
     let rows = stmt.query_and_then_named(&[(":url", &url.as_str())], |row| {
-        row.get_checked::<_, String>("tag")
+        row.get::<_, String>("tag")
     })?;
     let mut tags = Vec::new();
     for row in rows {
@@ -255,7 +254,7 @@ mod tests {
              FROM moz_places
              WHERE url = :url",
             &[(":url", &url.as_str())],
-            |row| Ok(row.get_checked::<_, i32>(0)?),
+            |row| Ok(row.get::<_, i32>(0)?),
             false,
         );
         count.expect("should work").expect("should get a value")
@@ -340,14 +339,14 @@ mod tests {
         let count: Result<Option<u32>> = conn.try_query_row(
             "SELECT COUNT(*) from moz_tags",
             &[],
-            |row| Ok(row.get_checked::<_, u32>(0)?),
+            |row| Ok(row.get::<_, u32>(0)?),
             true,
         );
         assert_eq!(count.unwrap().unwrap(), 0);
         let count: Result<Option<u32>> = conn.try_query_row(
             "SELECT COUNT(*) from moz_tags_relation",
             &[],
-            |row| Ok(row.get_checked::<_, u32>(0)?),
+            |row| Ok(row.get::<_, u32>(0)?),
             true,
         );
         assert_eq!(count.unwrap().unwrap(), 0);

--- a/components/places/src/tests.rs
+++ b/components/places/src/tests.rs
@@ -55,10 +55,10 @@ pub fn check_positions(conn: &PlacesDb) {
     let parents: Vec<_> = stmt
         .query_and_then(NO_PARAMS, |row| -> rusqlite::Result<_> {
             Ok((
-                row.get_checked::<_, i64>(0)?,
-                row.get_checked::<_, String>(1)?,
-                row.get_checked::<_, Option<String>>(2)?,
-                row.get_checked::<_, u32>(3)?,
+                row.get::<_, i64>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, u32>(3)?,
             ))
         })
         .expect("should work")

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -20,7 +20,7 @@ ece = "0.1.3"
 failure = "0.1.5"
 failure_derive = "0.1.5"
 log = "0.4.6"
-rusqlite = "0.16.0"
+rusqlite = "0.17.0"
 url = "1.7.2"
 viaduct = { path = "../viaduct" }
 ffi-support = { path = "../support/ffi" }

--- a/components/push/ffi/Cargo.toml
+++ b/components/push/ffi/Cargo.toml
@@ -20,7 +20,7 @@ push = { path = ".." }
 viaduct = { path = "../../viaduct" }
 
 [dependencies.rusqlite]
-version = "0.16.0"
+version = "0.17.0"
 features = ["sqlcipher", "limits", "functions"]
 
 [dependencies.sync15]

--- a/components/push/src/storage/db.rs
+++ b/components/push/src/storage/db.rs
@@ -160,7 +160,7 @@ impl Storage for PushDb {
         self.query_rows_and_then_named(
             "SELECT channel_id FROM push_record WHERE uaid = :uaid",
             &[(":uaid", &uaid)],
-            |row| -> Result<String> { Ok(row.get_checked(0)?) },
+            |row| -> Result<String> { Ok(row.get(0)?) },
         )
     }
 

--- a/components/push/src/storage/record.rs
+++ b/components/push/src/storage/record.rs
@@ -69,14 +69,14 @@ impl PushRecord {
 
     pub(crate) fn from_row(row: &Row) -> Result<Self> {
         Ok(PushRecord {
-            uaid: row.get_checked("uaid")?,
-            channel_id: row.get_checked("channel_id")?,
-            endpoint: row.get_checked("endpoint")?,
-            scope: row.get_checked("scope")?,
-            key: row.get_checked("key")?,
-            ctime: row.get_checked("ctime")?,
-            app_server_key: row.get_checked("app_server_key")?,
-            native_id: row.get_checked("native_id")?,
+            uaid: row.get("uaid")?,
+            channel_id: row.get("channel_id")?,
+            endpoint: row.get("endpoint")?,
+            scope: row.get("scope")?,
+            key: row.get("key")?,
+            ctime: row.get("ctime")?,
+            app_server_key: row.get("app_server_key")?,
+            native_id: row.get("native_id")?,
         })
     }
 }

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -12,8 +12,8 @@ log_query_plans = []
 
 [dependencies]
 log = "0.4"
-lazy_static = "1.1.0"
+lazy_static = "1.3.0"
 
 [dependencies.rusqlite]
-version = "0.16.0"
+version = "0.17.0"
 features = ["functions", "limits"]

--- a/components/support/sql/src/query_plan.rs
+++ b/components/support/sql/src/query_plan.rs
@@ -26,10 +26,10 @@ impl QueryPlan {
         let plan = stmt
             .query_and_then_named(params, |row| -> SqlResult<_> {
                 Ok(QueryPlanStep {
-                    node_id: row.get_checked(0)?,
-                    parent_id: row.get_checked(1)?,
-                    aux: row.get_checked(2)?,
-                    detail: row.get_checked(3)?,
+                    node_id: row.get(0)?,
+                    parent_id: row.get(1)?,
+                    aux: row.get(2)?,
+                    detail: row.get(3)?,
                 })
             })?
             .collect::<Result<Vec<QueryPlanStep>, _>>()?;


### PR DESCRIPTION
Felt like doing this even though it's not due til may.

This applies on top of #974, so that needs to land first and then I'll rebase on top of master. I will also wait for the other outstanding patches (sync refactor, and bookmarks sync) land as not to bog them down. No urgency for reviews.

Fixes #799.

The biggest changes y'all will hit after this lands:

- `get_checked` was renamed to `get`. 
- `get` was renamed to `get_unwrap`.
- `Rows::next()` returns `Result<Option<Row>>` and not `Option<Result<Row>>`, since that's way more ergonomic.

There were also a lot of nice things that got added, like the `params![stuff, here]` and `named_params!{ ":key": thing, ":other_thing": etc }` macros, a nicer API for setting pragmas, etc (not to mention it does far fewer unnecessary string copies), but I didn't change things that weren't busted to avoid big diffs.

The rest are https://github.com/jgallagher/rusqlite/releases/tag/0.17.0.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
