### PR TITLE
bug: Only use Auth header if auth provided by server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.25.2...master)
 
+## Push
+
+### Breaking Change
+
+- `PushAPI.subscribe()` now returns a `SubscriptionResponse` that contains the server supplied `channelID` and the
+   `subscriptionInfo` block previously returned. Please note: the server supplied `channelID` may differ from the
+   supplied `channelID` argument. This is definitely true when an empty channelID value is provided to `subscribe()`,
+   or if the channelID is not a proper UUID.
+   The returned `channelID` value is authoritative and will be the value associated with the subscription and future
+   subscription updates. As before, the `subscriptionResponse.subscriptionInfo` can be JSON serialized and returned to 
+   the application.
+ 
 # v0.25.2 (_2018-04-11_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.24.0...v0.25.2)

--- a/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
+++ b/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
@@ -183,11 +183,13 @@ class PushTest {
     fun testNewSubscription() {
         val manager = getPushManager()
 
-        val subscriptionInfo = manager.subscribe(testChannelid, "foo")
+        val subscriptionResponse = manager.subscribe(testChannelid, "foo")
         // These are mock values, but it's important that they exist.
-        assertEquals("Auth Check", auth_raw, subscriptionInfo.keys.auth)
-        assertEquals("p256 Check", public_key_raw, subscriptionInfo.keys.p256dh)
-        assertEquals("endpoint Check", "http://push.example.com/test/opaque", subscriptionInfo.endpoint)
+        assertEquals("ChannelID Check", testChannelid, subscriptionResponse.channelID)
+        assertEquals("Auth Check", auth_raw, subscriptionResponse.subscriptionInfo.keys.auth)
+        assertEquals("p256 Check", public_key_raw, subscriptionResponse.subscriptionInfo.keys.p256dh)
+        assertEquals("endpoint Check", "http://push.example.com/test/opaque",
+            subscriptionResponse.subscriptionInfo.endpoint)
     }
 
     @Test
@@ -224,7 +226,7 @@ class PushTest {
     fun testDispatchForChid() {
         val manager = getPushManager()
 
-        val subscriptionInfo = manager.subscribe(testChannelid, "foo")
+        manager.subscribe(testChannelid, "foo")
         val dispatch = manager.dispatchForChid(testChannelid)
         assertEquals("uaid", "abad1d3a00000000aabbccdd00000000", dispatch.uaid)
         assertEquals("scope", "foo", dispatch.scope)
@@ -242,5 +244,18 @@ class PushTest {
         } catch (e: PushError) {
             assert(e is StorageError)
         }
+    }
+
+    @Test
+    fun testDuplicateSubscription() {
+        val manager = getPushManager()
+
+        val testChannelId = "deadbeef00000000decafbad00000000"
+        val response1 = manager.subscribe(testChannelid, "foo")
+        val response2 = manager.subscribe(testChannelid, "foo")
+        assertEquals(response1.channelID, response2.channelID)
+        assertEquals(response1.subscriptionInfo.endpoint, response2.subscriptionInfo.endpoint)
+        assertEquals(response1.subscriptionInfo.keys.auth, response2.subscriptionInfo.keys.auth)
+        assertEquals(response1.subscriptionInfo.keys.p256dh, response2.subscriptionInfo.keys.p256dh)
     }
 }

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -92,17 +92,21 @@ pub extern "C" fn push_subscribe(
         // Don't auto add the subscription to the db.
         // (endpoint updates also call subscribe and should be lighter weight)
         let (info, subscription_key) = mgr.subscribe(channel, scope_s)?;
-        // store the channelid => auth + subscription_key
-        let subscription_info = json!({
-            "endpoint": info.endpoint,
-            "keys": {
-                "auth": base64::encode_config(&subscription_key.auth,
-                                              base64::URL_SAFE_NO_PAD),
-                "p256dh": base64::encode_config(&subscription_key.public,
-                                                base64::URL_SAFE_NO_PAD)
+        // it is possible for the
+        // store the channel_id => auth + subscription_key
+        let subscription_response = json!({
+            "channel_id": info.channel_id,
+            "subscription_info": {
+                "endpoint": info.endpoint,
+                "keys": {
+                    "auth": base64::encode_config(&subscription_key.auth,
+                                                  base64::URL_SAFE_NO_PAD),
+                    "p256dh": base64::encode_config(&subscription_key.public,
+                                                    base64::URL_SAFE_NO_PAD)
+                }
             }
         });
-        Ok(subscription_info.to_string())
+        Ok(subscription_response.to_string())
     })
 }
 
@@ -131,8 +135,8 @@ pub extern "C" fn push_update(handle: u64, new_token: FfiStr<'_>, error: &mut Ex
 }
 
 // verify connection using channel list
-// Returns a JSON containing the new channelids => endpoints
-// NOTE: AC should notify processes associated with channelIDs of new endpoint
+// Returns a JSON containing the new channel_ids => endpoints
+// NOTE: AC should notify processes associated with channel_ids of new endpoint
 #[no_mangle]
 pub extern "C" fn push_verify_connection(handle: u64, error: &mut ExternError) -> *mut c_char {
     log::debug!("push_verify");

--- a/components/push/src/subscriber.rs
+++ b/components/push/src/subscriber.rs
@@ -4,7 +4,7 @@
 
 //! Handle external Push Subscription Requests.
 //!
-//! "priviledged" system calls may require additional handling and should be flagged as such.
+//! "privileged" system calls may require additional handling and should be flagged as such.
 
 use std::collections::HashMap;
 
@@ -53,10 +53,10 @@ impl PushManager {
         } else {
             subscription_key = Crypto::generate_key().unwrap();
         }
-        // store the channelid => auth + subscription_key
+        // store the channel_id => auth + subscription_key
         let mut record = crate::storage::PushRecord::new(
             &info.uaid,
-            &channel_id,
+            &info.channel_id,
             &info.endpoint,
             scope,
             subscription_key.clone(),
@@ -67,8 +67,6 @@ impl PushManager {
         // store the meta information if we've not yet done that.
         if self.store.get_meta("uaid")?.is_none() {
             self.store.set_meta("uaid", &info.uaid)?;
-        }
-        if self.store.get_meta("auth")?.is_none() {
             if let Some(secret) = &info.secret {
                 self.store.set_meta("auth", &secret)?;
             }
@@ -132,7 +130,7 @@ impl PushManager {
                 };
                 Err(ErrorKind::StorageError(format!(
                     "No record for uaid:chid {:?}:{:?}",
-                    self.conn.uaid, chid
+                    uaid, chid
                 ))
                 .into())
             }


### PR DESCRIPTION
This also includes fixes noted during client build:

* return authoritative, server provided ChannelID to Kotlin layer
* use authoritative ChannelID when storing records
* normalize "channel_id" var names where appropriate
* fix missspellings in comments
* double check that fetching subscriptions w/ same UAID&CHID return same sub info
* tests more closely match real usage (use GUID like values)
* deleting all subscriptions also deletes UAID and Auth from meta-data
* bottleneck db in tests so we can switch between file and memory based

Closes #978, #980

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
