### PR TITLE
feat(fxa): Add method for getting account-management URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@
   existence of `syncBookmarks`.
   ([#850](https://github.com/mozilla/application-services/issues/850))
 
+## FxA
+
+### What's New
+
+- New methods `getManageAccountURL` and `getManageDevicesURL` have been added,
+  which the application can use to direct the user to manage their account on the web.
+
 # v0.25.2 (_2018-04-11_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.24.0...v0.25.2)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "fxa-client 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "viaduct 0.1.0",
 ]
 

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -188,6 +188,34 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
     }
 
     /**
+     * Fetches the user's manage-account url.
+     *
+     * This performs network requests, and should not be used on the main thread.
+     *
+     * @throws FxaException.Unauthorized We couldn't find any suitable access token to identify the user.
+     * The caller should then start the OAuth Flow again with the "profile" scope.
+     */
+    fun getManageAccountURL(entrypoint: String): String {
+        return rustCallWithLock { e ->
+            LibFxAFFI.INSTANCE.fxa_get_manage_account_url(this.handle.get(), entrypoint, e)
+        }.getAndConsumeRustString()
+    }
+
+    /**
+     * Fetches the user's manage-devices url.
+     *
+     * This performs network requests, and should not be used on the main thread.
+     *
+     * @throws FxaException.Unauthorized We couldn't find any suitable access token to identify the user.
+     * The caller should then start the OAuth Flow again with the "profile" scope.
+     */
+    fun getManageDevicesURL(entrypoint: String): String {
+        return rustCallWithLock { e ->
+            LibFxAFFI.INSTANCE.fxa_get_manage_devices_url(this.handle.get(), entrypoint, e)
+        }.getAndConsumeRustString()
+    }
+
+    /**
      * Tries to fetch an access token for the given scope.
      *
      * This performs network requests, and should not be used on the main thread.

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -70,6 +70,8 @@ internal interface LibFxAFFI : Library {
 
     fun fxa_get_token_server_endpoint_url(fxa: FxaHandle, e: RustError.ByReference): Pointer?
     fun fxa_get_connection_success_url(fxa: FxaHandle, e: RustError.ByReference): Pointer?
+    fun fxa_get_manage_account_url(fxa: FxaHandle, entrypoint: String, e: RustError.ByReference): Pointer?
+    fun fxa_get_manage_devices_url(fxa: FxaHandle, entrypoint: String, e: RustError.ByReference): Pointer?
 
     fun fxa_complete_oauth_flow(fxa: FxaHandle, code: String, state: String, e: RustError.ByReference)
     fun fxa_get_access_token(fxa: FxaHandle, scope: String, e: RustError.ByReference): RustBuffer.ByValue

--- a/components/fxa-client/ffi/Cargo.toml
+++ b/components/fxa-client/ffi/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 ffi-support = { path = "../../support/ffi" }
 log = "0.4.6"
 lazy_static = "1.3.0"
+url = "1.7.1"
 viaduct = { path = "../../viaduct" }
 
 [dependencies.fxa-client]

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -13,6 +13,7 @@ use ffi_support::{
 };
 use fxa_client::FirefoxAccount;
 use std::os::raw::c_char;
+use url::Url;
 
 #[no_mangle]
 pub extern "C" fn fxa_enable_logcat_logging() {
@@ -113,7 +114,7 @@ pub extern "C" fn fxa_get_token_server_endpoint_url(
 ) -> *mut c_char {
     log::debug!("fxa_get_token_server_endpoint_url");
     ACCOUNTS.call_with_result(error, handle, |fxa| {
-        fxa.get_token_server_endpoint_url().map(|u| u.to_string())
+        fxa.get_token_server_endpoint_url().map(Url::into_string)
     })
 }
 
@@ -130,7 +131,45 @@ pub extern "C" fn fxa_get_connection_success_url(
 ) -> *mut c_char {
     log::debug!("fxa_get_connection_success_url");
     ACCOUNTS.call_with_result(error, handle, |fxa| {
-        fxa.get_connection_success_url().map(|u| u.to_string())
+        fxa.get_connection_success_url().map(Url::into_string)
+    })
+}
+
+/// Get the url to open the user's account-management page.
+///
+/// # Safety
+///
+/// A destructor [fxa_str_free] is provided for releasing the memory for this
+/// pointer type.
+#[no_mangle]
+pub extern "C" fn fxa_get_manage_account_url(
+    handle: u64,
+    entrypoint: FfiStr<'_>,
+    error: &mut ExternError,
+) -> *mut c_char {
+    log::debug!("fxa_get_manage_account_url");
+    ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
+        fxa.get_manage_account_url(entrypoint.as_str())
+            .map(Url::into_string)
+    })
+}
+
+/// Get the url to open the user's devices-management page.
+///
+/// # Safety
+///
+/// A destructor [fxa_str_free] is provided for releasing the memory for this
+/// pointer type.
+#[no_mangle]
+pub extern "C" fn fxa_get_manage_devices_url(
+    handle: u64,
+    entrypoint: FfiStr<'_>,
+    error: &mut ExternError,
+) -> *mut c_char {
+    log::debug!("fxa_get_manage_devices_url");
+    ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
+        fxa.get_manage_devices_url(entrypoint.as_str())
+            .map(Url::into_string)
     })
 }
 

--- a/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
@@ -170,6 +170,22 @@ open class FirefoxAccount {
         })
     }
 
+    open func getManageAccountURL(entrypoint: String) throws -> URL {
+        return try queue.sync(execute: {
+            return URL(string: String(freeingFxaString: try FirefoxAccountError.unwrap({err in
+                fxa_get_manage_account_url(self.raw, entrypoint, err)
+            })))!
+        })
+    }
+
+    open func getManageDevicesURL(entrypoint: String) throws -> URL {
+        return try queue.sync(execute: {
+            return URL(string: String(freeingFxaString: try FirefoxAccountError.unwrap({err in
+                fxa_get_manage_devices_url(self.raw, entrypoint, err)
+            })))!
+        })
+    }
+
     /// Request a OAuth token by starting a new OAuth flow.
     ///
     /// This function returns a URL string that the caller should open in a webview.

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -78,6 +78,14 @@ char *_Nullable fxa_get_token_server_endpoint_url(FirefoxAccountHandle handle,
 char *_Nullable fxa_get_connection_success_url(FirefoxAccountHandle handle,
                                                FxAError *_Nonnull out);
 
+char *_Nullable fxa_get_manage_account_url(FirefoxAccountHandle handle,
+                                           const char *_Nonnull entrypoint,
+                                           FxAError *_Nonnull out);
+
+char *_Nullable fxa_get_manage_devices_url(FirefoxAccountHandle handle,
+                                           const char *_Nonnull entrypoint,
+                                           FxAError *_Nonnull out);
+
 void fxa_str_free(char *_Nullable ptr);
 void fxa_free(FirefoxAccountHandle h, FxAError *_Nonnull out);
 void fxa_bytebuffer_free(FxARustBuffer buffer);


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/750.

This is my initial attempt at adding a `get_manage_account_url` method, which Fenix will need for its account-settings UI.  I wanted to get a bit of feedback before I pushed too much further ahead with this, @vladikoff or @eoger could you please take a look at the shape of it so far?

One thing that's not clear to me is how I should test that the Kotlin/Swift FFI pieces are working as intended. It looks like we don't have any automated tests for them in this repo. Should I be looking at adding some, perhaps along the lines of what's done for the logins component?

I'm also feeling the pain of https://github.com/mozilla/application-services/issues/483 a bit in this PR, because it needs to access the `uid` and `email` of the signed-in user.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- ~~[] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)~~