### PR TITLE
Use a 10s request timeout on iOS

### DIFF
--- a/components/viaduct/src/settings.rs
+++ b/components/viaduct/src/settings.rs
@@ -23,10 +23,16 @@ pub(crate) struct Settings {
     _priv: (),
 }
 
+#[cfg(target_os = "ios")]
+const TIMEOUT_DURATION: Duration = Duration::from_secs(30);
+
+#[cfg(not(target_os = "ios"))]
+const TIMEOUT_DURATION: Duration = Duration::from_secs(10);
+
 // The singleton instance of our settings.
 pub(crate) static GLOBAL_SETTINGS: &Settings = &Settings {
-    read_timeout: Some(Duration::from_secs(30)),
-    connect_timeout: Some(Duration::from_secs(30)),
+    read_timeout: Some(TIMEOUT_DURATION),
+    connect_timeout: Some(TIMEOUT_DURATION),
     follow_redirects: true,
     include_cookies: false,
     use_caches: false,


### PR DESCRIPTION
Requested on slack, apparently a lot of crashes are happening.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
