### PR TITLE
bug: Normalize error messages

### DIFF
--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -47,7 +47,7 @@ pub extern "C" fn push_connection_new(
     error: &mut ExternError,
 ) -> u64 {
     MANAGER.insert_with_result(error, || {
-        log::debug!(
+        log::trace!(
             "push_connection_new {:?} {:?} -> {:?} {:?}=>{:?}",
             http_protocol,
             server_host,

--- a/components/push/src/communications.rs
+++ b/components/push/src/communications.rs
@@ -383,7 +383,7 @@ impl Connection for ConnectHttp {
         if &self.options.sender_id == "test" {
             return Ok(false);
         }
-        log::trace!(":::Getting Channel List");
+        log::debug!("Getting Channel List");
         let remote = self.channel_list()?;
         // verify both lists match. Either side could have lost it's mind.
         Ok(remote == channels.to_vec())

--- a/components/push/src/crypto.rs
+++ b/components/push/src/crypto.rs
@@ -9,7 +9,7 @@
 //! This uses prime256v1 EC encryption that should come from internal crypto calls. The "application-services"
 //! module compiles openssl, however, so might be enough to tie into that.
 
-use log::{debug, error};
+use log;
 use std::clone;
 use std::cmp;
 use std::fmt;
@@ -183,7 +183,7 @@ pub fn get_bytes(size: usize) -> error::Result<Vec<u8>> {
 fn extract_value(string: Option<&str>, target: &str) -> Option<Vec<u8>> {
     if let Some(val) = string {
         if !val.contains(&format!("{}=", target)) {
-            debug!("No sub-value found for {}", target);
+            log::debug!("No sub-value found for {}", target);
             return None;
         }
         let items: Vec<&str> = val.split(|c| c == ',' || c == ';').collect();
@@ -193,7 +193,7 @@ fn extract_value(string: Option<&str>, target: &str) -> Option<Vec<u8>> {
                 return match base64::decode_config(kv[1], base64::URL_SAFE_NO_PAD) {
                     Ok(v) => Some(v),
                     Err(e) => {
-                        error!("base64 failed for target:{}; {:?}", target, e);
+                        log::error!("base64 failed for target:{}; {:?}", target, e);
                         None
                     }
                 };


### PR DESCRIPTION
* to make finding log macros easier, make sure that things like `trace!`
  and `error!` are called from the `log` package

Issue #908

Pre-emptive to help out with that bug.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
