### PR TITLE
Do not inject the appservices bintray repo in the gradle-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.25.2...master)
 
+## Gradle plugin
+
+- Removed the appservices bintray repo from the plugin
+
 ## Push
 
 ### Breaking Change

--- a/gradle-plugin/src/main/kotlin/mozilla/appservices/AppServicesPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/mozilla/appservices/AppServicesPlugin.kt
@@ -16,11 +16,9 @@ import org.gradle.api.artifacts.DependencySubstitutions
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
-import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import java.net.URI
 
 open class AppServicesPlugin : Plugin<Project> {
     internal lateinit var appServicesExtension: AppServicesExtension
@@ -123,25 +121,6 @@ open class AppServicesPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         with(project) {
             appServicesExtension = extensions.create("appservices", AppServicesExtension::class.java, project)
-
-            // This is somewhat temporary: https://github.com/mozilla/application-services isn't publishing to
-            // maven.mozilla.org yet, so we need a non-standard URL.  But we probably want to force
-            // https://maven.mozilla.org/maven2 in the future anyway... so it's probably not worth making this
-            // configurable.  See https://github.com/mozilla/application-services/issues/252.
-            val customName = "appservices"
-            val customURI = URI.create("https://dl.bintray.com/mozilla-appservices/application-services")
-            // If there's already a Maven repo with the right URL, or even the right name, roll with it.
-            // The name gives the opportunity to customize, if it helps in the wild.
-            val existing = project.repositories.find {
-                (it is MavenArtifactRepository) && (it.url == customURI || it.name == customName)
-            }
-            if (existing == null) {
-                logger.info("adding '$customName' Maven repository with url '${customURI.toASCIIString()}'")
-                project.repositories.maven {
-                    it.name = customName
-                    it.url = customURI
-                }
-            }
 
             project.pluginManager.withPlugin("com.android.application") {
                 var android = project.extensions.getByType(AppExtension::class.java)


### PR DESCRIPTION
Fixes #899

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [] ~~**Tests**: This PR includes thorough tests or an explanation of why it does not~~
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] ~~**Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)~~
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
