### PR TITLE
Enable `rust_2018_idioms` lints everywhere

### DIFF
--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 // Let's allow these in the FFI code, since it's usually just a coincidence if
 // the closure is small.
 #![allow(clippy::redundant_closure)]

--- a/components/fxa-client/src/errors.rs
+++ b/components/fxa-client/src/errors.rs
@@ -14,7 +14,7 @@ pub struct Error(Box<Context<ErrorKind>>);
 
 impl Fail for Error {
     #[inline]
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.0.cause()
     }
 
@@ -26,7 +26,7 @@ impl Fail for Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.0, f)
     }
 }

--- a/components/fxa-client/src/http_client/browser_id.rs
+++ b/components/fxa-client/src/http_client/browser_id.rs
@@ -56,7 +56,7 @@ pub trait FxABrowserIDClient: http_client::FxAClient {
         &self,
         config: &Config,
         session_token: &[u8],
-        key_pair: &BrowserIDKeyPair,
+        key_pair: &dyn BrowserIDKeyPair,
     ) -> Result<SignResponse>;
 }
 
@@ -160,7 +160,7 @@ impl FxABrowserIDClient for http_client::Client {
         &self,
         config: &Config,
         session_token: &[u8],
-        key_pair: &BrowserIDKeyPair,
+        key_pair: &dyn BrowserIDKeyPair,
     ) -> Result<SignResponse> {
         let public_key_json = key_pair.to_json(false)?;
         let parameters = json!({

--- a/components/fxa-client/src/http_client/browser_id/jwt_utils.rs
+++ b/components/fxa-client/src/http_client/browser_id/jwt_utils.rs
@@ -10,7 +10,7 @@ const DEFAULT_ASSERTION_ISSUER: &str = "127.0.0.1";
 const DEFAULT_ASSERTION_DURATION: u64 = 60 * 60 * 1000;
 
 pub fn create_assertion(
-    key_pair: &BrowserIDKeyPair,
+    key_pair: &dyn BrowserIDKeyPair,
     certificate: &str,
     audience: &str,
 ) -> Result<String> {
@@ -32,7 +32,7 @@ pub fn create_assertion(
 }
 
 pub fn create_assertion_full(
-    key_pair: &BrowserIDKeyPair,
+    key_pair: &dyn BrowserIDKeyPair,
     certificate: &str,
     audience: &str,
     issuer: &str,
@@ -46,7 +46,7 @@ pub fn create_assertion_full(
 }
 
 struct SignedJWTBuilder<'keypair> {
-    key_pair: &'keypair BrowserIDKeyPair,
+    key_pair: &'keypair dyn BrowserIDKeyPair,
     issuer: String,
     issued_at: u64,
     expires_at: u64,
@@ -56,7 +56,7 @@ struct SignedJWTBuilder<'keypair> {
 
 impl<'keypair> SignedJWTBuilder<'keypair> {
     fn new(
-        key_pair: &'keypair BrowserIDKeyPair,
+        key_pair: &'keypair dyn BrowserIDKeyPair,
         issuer: &str,
         issued_at: u64,
         expires_at: u64,
@@ -106,7 +106,7 @@ impl<'keypair> SignedJWTBuilder<'keypair> {
     }
 }
 
-fn encode_and_sign(payload: &str, key_pair: &BrowserIDKeyPair) -> Result<String> {
+fn encode_and_sign(payload: &str, key_pair: &dyn BrowserIDKeyPair) -> Result<String> {
     let headers_str = json!({"alg": key_pair.get_algo()}).to_string();
     let encoded_header = base64::encode_config(headers_str.as_bytes(), base64::URL_SAFE_NO_PAD);
     let encoded_payload = base64::encode_config(payload.as_bytes(), base64::URL_SAFE_NO_PAD);
@@ -128,7 +128,7 @@ mod tests {
         issuer: &str,
         issued_at: u64,
         expires_at: u64,
-        key_pair: &BrowserIDKeyPair,
+        key_pair: &dyn BrowserIDKeyPair,
     ) -> Result<String> {
         let principal = json!({ "email": email });
         let payload = json!({
@@ -142,7 +142,7 @@ mod tests {
         )
     }
 
-    fn decode(token: &str, key_pair: &BrowserIDKeyPair) -> Result<String> {
+    fn decode(token: &str, key_pair: &dyn BrowserIDKeyPair) -> Result<String> {
         let segments: Vec<&str> = token.split('.').collect();
         let message = format!("{}.{}", &segments[0], &segments[1]);
         let message_bytes = message.as_bytes();
@@ -158,7 +158,7 @@ mod tests {
     // These tests are copied directly from Firefox for Android's TestJSONWebTokenUtils.
     // They could probably be improved a lot.
 
-    fn do_test_encode_decode(key_pair: &BrowserIDKeyPair) {
+    fn do_test_encode_decode(key_pair: &dyn BrowserIDKeyPair) {
         let payload = json!({"key": "value"}).to_string();
 
         let token = encode_and_sign(&payload, key_pair).unwrap();

--- a/components/fxa-client/src/http_client/browser_id/rsa.rs
+++ b/components/fxa-client/src/http_client/browser_id/rsa.rs
@@ -83,7 +83,7 @@ impl Clone for RSABrowserIDKeyPair {
 }
 
 impl fmt::Debug for RSABrowserIDKeyPair {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "<rsa_key_pair>")
     }
 }
@@ -168,7 +168,7 @@ impl<'de> Deserialize<'de> for RSABrowserIDKeyPair {
                 impl<'de> Visitor<'de> for FieldVisitor {
                     type Value = Field;
 
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                         formatter.write_str("`n`, `e`, `d`, `p`, `q`, `dmp1`, `dmq1`, `iqmp`")
                     }
 
@@ -199,7 +199,7 @@ impl<'de> Deserialize<'de> for RSABrowserIDKeyPair {
         impl<'de> Visitor<'de> for RSABrowserIDKeyPairVisitor {
             type Value = RSABrowserIDKeyPair;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("struct RSABrowserIDKeyPair")
             }
             #[allow(clippy::many_single_char_names)] // FIXME

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -43,9 +43,9 @@ lazy_static! {
 }
 
 #[cfg(feature = "browserid")]
-type FxAClient = http_client::browser_id::FxABrowserIDClient + Sync + Send;
+type FxAClient = dyn http_client::browser_id::FxABrowserIDClient + Sync + Send;
 #[cfg(not(feature = "browserid"))]
-type FxAClient = http_client::FxAClient + Sync + Send;
+type FxAClient = dyn http_client::FxAClient + Sync + Send;
 
 pub struct FirefoxAccount {
     client: Arc<FxAClient>,

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 #[cfg(feature = "browserid")]
 pub use crate::browser_id::{SyncKeys, WebChannelResponse};

--- a/components/fxa-client/src/login_sm.rs
+++ b/components/fxa-client/src/login_sm.rs
@@ -13,14 +13,14 @@ use std::sync::Arc;
 
 pub struct LoginStateMachine<'a> {
     config: &'a Config,
-    client: Arc<http_client::browser_id::FxABrowserIDClient>,
+    client: Arc<dyn http_client::browser_id::FxABrowserIDClient>,
 }
 
 impl<'a> LoginStateMachine<'a> {
     pub fn new(
         config: &'a Config,
-        client: Arc<http_client::browser_id::FxABrowserIDClient>,
-    ) -> LoginStateMachine {
+        client: Arc<dyn http_client::browser_id::FxABrowserIDClient>,
+    ) -> LoginStateMachine<'_> {
         LoginStateMachine { config, client }
     }
 

--- a/components/fxa-client/src/scoped_keys.rs
+++ b/components/fxa-client/src/scoped_keys.rs
@@ -19,7 +19,7 @@ pub struct ScopedKeysFlow {
 /// In the past, we chose cjose to do that job, but it added three C dependencies to build and link
 /// against: jansson, openssl and cjose itself.
 impl ScopedKeysFlow {
-    pub fn with_random_key(rng: &SecureRandom) -> Result<ScopedKeysFlow> {
+    pub fn with_random_key(rng: &dyn SecureRandom) -> Result<ScopedKeysFlow> {
         let private_key = EphemeralPrivateKey::generate(&agreement::ECDH_P256, rng)
             .map_err(|_| ErrorKind::KeyGenerationFailed)?;
         Ok(ScopedKeysFlow { private_key })

--- a/components/fxa-client/src/util.rs
+++ b/components/fxa-client/src/util.rs
@@ -21,7 +21,7 @@ pub fn now_secs() -> u64 {
     since_epoch.as_secs()
 }
 
-pub fn random_base64_url_string(rng: &SecureRandom, len: usize) -> Result<String> {
+pub fn random_base64_url_string(rng: &dyn SecureRandom, len: usize) -> Result<String> {
     let mut out = vec![0u8; len];
     rng.fill(&mut out).map_err(|_| ErrorKind::RngFailure)?;
     Ok(base64::encode_config(&out, base64::URL_SAFE_NO_PAD))

--- a/components/logins/examples/sync_pass_sql.rs
+++ b/components/logins/examples/sync_pass_sql.rs
@@ -4,6 +4,7 @@
 
 #![recursion_limit = "4096"]
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
 use cli_support::prompt::{prompt_string, prompt_usize};

--- a/components/logins/ffi/src/lib.rs
+++ b/components/logins/ffi/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 // Let's allow these in the FFI code, since it's usually just a coincidence if
 // the closure is small.
 #![allow(clippy::redundant_closure)]

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -22,7 +22,7 @@ pub struct Error(Box<Context<ErrorKind>>);
 
 impl Fail for Error {
     #[inline]
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.0.cause()
     }
 
@@ -34,7 +34,7 @@ impl Fail for Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.0, f)
     }
 }

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 #[macro_use]
 mod error;

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -53,7 +53,7 @@ pub struct Login {
     pub times_used: i64,
 }
 
-fn string_or_default(row: &Row, col: &str) -> Result<String> {
+fn string_or_default(row: &Row<'_>, col: &str) -> Result<String> {
     Ok(row.get::<_, Option<String>>(col)?.unwrap_or_default())
 }
 
@@ -87,7 +87,7 @@ impl Login {
         Ok(())
     }
 
-    pub(crate) fn from_row(row: &Row) -> Result<Login> {
+    pub(crate) fn from_row(row: &Row<'_>) -> Result<Login> {
         Ok(Login {
             id: row.get("guid")?,
             password: row.get("password")?,
@@ -126,7 +126,7 @@ impl MirrorLogin {
         self.login.guid_str()
     }
 
-    pub(crate) fn from_row(row: &Row) -> Result<MirrorLogin> {
+    pub(crate) fn from_row(row: &Row<'_>) -> Result<MirrorLogin> {
         Ok(MirrorLogin {
             login: Login::from_row(row)?,
             is_overridden: row.get("is_overridden")?,
@@ -170,7 +170,7 @@ impl LocalLogin {
         self.login.guid_str()
     }
 
-    pub(crate) fn from_row(row: &Row) -> Result<LocalLogin> {
+    pub(crate) fn from_row(row: &Row<'_>) -> Result<LocalLogin> {
         Ok(LocalLogin {
             login: Login::from_row(row)?,
             sync_status: SyncStatus::from_u8(row.get("sync_status")?)?,

--- a/components/logins/src/update_plan.rs
+++ b/components/logins/src/update_plan.rs
@@ -118,22 +118,22 @@ impl UpdatePlan {
         for (login, timestamp) in &self.mirror_updates {
             log::trace!("Updating mirror {:?}", login.guid_str());
             stmt.execute_named(&[
-                (":server_modified", timestamp as &ToSql),
-                (":http_realm", &login.http_realm as &ToSql),
-                (":form_submit_url", &login.form_submit_url as &ToSql),
-                (":username_field", &login.username_field as &ToSql),
-                (":password_field", &login.password_field as &ToSql),
-                (":password", &login.password as &ToSql),
-                (":hostname", &login.hostname as &ToSql),
-                (":username", &login.username as &ToSql),
-                (":times_used", &login.times_used as &ToSql),
-                (":time_last_used", &login.time_last_used as &ToSql),
+                (":server_modified", timestamp as &dyn ToSql),
+                (":http_realm", &login.http_realm as &dyn ToSql),
+                (":form_submit_url", &login.form_submit_url as &dyn ToSql),
+                (":username_field", &login.username_field as &dyn ToSql),
+                (":password_field", &login.password_field as &dyn ToSql),
+                (":password", &login.password as &dyn ToSql),
+                (":hostname", &login.hostname as &dyn ToSql),
+                (":username", &login.username as &dyn ToSql),
+                (":times_used", &login.times_used as &dyn ToSql),
+                (":time_last_used", &login.time_last_used as &dyn ToSql),
                 (
                     ":time_password_changed",
-                    &login.time_password_changed as &ToSql,
+                    &login.time_password_changed as &dyn ToSql,
                 ),
-                (":time_created", &login.time_created as &ToSql),
-                (":guid", &login.guid_str() as &ToSql),
+                (":time_created", &login.time_created as &dyn ToSql),
+                (":guid", &login.guid_str() as &dyn ToSql),
             ])?;
         }
         Ok(())
@@ -183,23 +183,23 @@ impl UpdatePlan {
         for (login, timestamp, is_overridden) in &self.mirror_inserts {
             log::trace!("Inserting mirror {:?}", login.guid_str());
             stmt.execute_named(&[
-                (":is_overridden", is_overridden as &ToSql),
-                (":server_modified", timestamp as &ToSql),
-                (":http_realm", &login.http_realm as &ToSql),
-                (":form_submit_url", &login.form_submit_url as &ToSql),
-                (":username_field", &login.username_field as &ToSql),
-                (":password_field", &login.password_field as &ToSql),
-                (":password", &login.password as &ToSql),
-                (":hostname", &login.hostname as &ToSql),
-                (":username", &login.username as &ToSql),
-                (":times_used", &login.times_used as &ToSql),
-                (":time_last_used", &login.time_last_used as &ToSql),
+                (":is_overridden", is_overridden as &dyn ToSql),
+                (":server_modified", timestamp as &dyn ToSql),
+                (":http_realm", &login.http_realm as &dyn ToSql),
+                (":form_submit_url", &login.form_submit_url as &dyn ToSql),
+                (":username_field", &login.username_field as &dyn ToSql),
+                (":password_field", &login.password_field as &dyn ToSql),
+                (":password", &login.password as &dyn ToSql),
+                (":hostname", &login.hostname as &dyn ToSql),
+                (":username", &login.username as &dyn ToSql),
+                (":times_used", &login.times_used as &dyn ToSql),
+                (":time_last_used", &login.time_last_used as &dyn ToSql),
                 (
                     ":time_password_changed",
-                    &login.time_password_changed as &ToSql,
+                    &login.time_password_changed as &dyn ToSql,
                 ),
-                (":time_created", &login.time_created as &ToSql),
-                (":guid", &login.guid_str() as &ToSql),
+                (":time_created", &login.time_created as &dyn ToSql),
+                (":guid", &login.guid_str() as &dyn ToSql),
             ])?;
         }
         Ok(())
@@ -230,21 +230,21 @@ impl UpdatePlan {
         for l in &self.local_updates {
             log::trace!("Updating local {:?}", l.guid_str());
             stmt.execute_named(&[
-                (":local_modified", &local_ms as &ToSql),
-                (":http_realm", &l.login.http_realm as &ToSql),
-                (":form_submit_url", &l.login.form_submit_url as &ToSql),
-                (":username_field", &l.login.username_field as &ToSql),
-                (":password_field", &l.login.password_field as &ToSql),
-                (":password", &l.login.password as &ToSql),
-                (":hostname", &l.login.hostname as &ToSql),
-                (":username", &l.login.username as &ToSql),
-                (":time_last_used", &l.login.time_last_used as &ToSql),
+                (":local_modified", &local_ms as &dyn ToSql),
+                (":http_realm", &l.login.http_realm as &dyn ToSql),
+                (":form_submit_url", &l.login.form_submit_url as &dyn ToSql),
+                (":username_field", &l.login.username_field as &dyn ToSql),
+                (":password_field", &l.login.password_field as &dyn ToSql),
+                (":password", &l.login.password as &dyn ToSql),
+                (":hostname", &l.login.hostname as &dyn ToSql),
+                (":username", &l.login.username as &dyn ToSql),
+                (":time_last_used", &l.login.time_last_used as &dyn ToSql),
                 (
                     ":time_password_changed",
-                    &l.login.time_password_changed as &ToSql,
+                    &l.login.time_password_changed as &dyn ToSql,
                 ),
-                (":times_used", &l.login.times_used as &ToSql),
-                (":guid", &l.guid_str() as &ToSql),
+                (":times_used", &l.login.times_used as &dyn ToSql),
+                (":guid", &l.guid_str() as &dyn ToSql),
             ])?;
         }
         Ok(())

--- a/components/logins/src/util.rs
+++ b/components/logins/src/util.rs
@@ -17,7 +17,7 @@ pub fn url_host_port(url_str: &str) -> Option<String> {
     })
 }
 
-pub fn system_time_millis_from_row(row: &Row, col_name: &str) -> Result<time::SystemTime> {
+pub fn system_time_millis_from_row(row: &Row<'_>, col_name: &str) -> Result<time::SystemTime> {
     let time_ms = row.get::<_, Option<i64>>(col_name)?.unwrap_or_default() as u64;
     Ok(time::UNIX_EPOCH + time::Duration::from_millis(time_ms))
 }

--- a/components/places/benches/match_impl.rs
+++ b/components/places/benches/match_impl.rs
@@ -1,4 +1,5 @@
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use places::match_impl::{AutocompleteMatch, MatchBehavior, SearchBehavior};

--- a/components/places/benches/search.rs
+++ b/components/places/benches/search.rs
@@ -1,4 +1,5 @@
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use places::api::{

--- a/components/places/examples/autocomplete.rs
+++ b/components/places/examples/autocomplete.rs
@@ -100,7 +100,7 @@ struct LegacyPlace {
 }
 
 impl LegacyPlace {
-    pub fn from_row(row: &rusqlite::Row) -> Self {
+    pub fn from_row(row: &rusqlite::Row<'_>) -> Self {
         Self {
             id: row.get_unwrap("place_id"),
             guid: row.get_unwrap("place_guid"),

--- a/components/places/examples/autocomplete.rs
+++ b/components/places/examples/autocomplete.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 use clap::value_t;
 use failure::bail;

--- a/components/places/examples/places-utils.rs
+++ b/components/places/examples/places-utils.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
 use places::bookmark_sync::store::BookmarksStore;

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 // Let's allow these in the FFI code, since it's usually just a coincidence if
 // the closure is small.
 #![allow(clippy::redundant_closure)]

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -184,7 +184,7 @@ pub struct SearchResult {
 impl SearchResult {
     /// Default search behaviors from Desktop: HISTORY, BOOKMARK, OPENPAGE, SEARCHES.
     /// Default match behavior: MATCH_BOUNDARY_ANYWHERE.
-    pub fn from_adaptive_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
+    pub fn from_adaptive_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
         let mut reasons = vec![MatchReason::PreviousUse];
 
         let search_string = row.get::<_, String>("searchString")?;
@@ -216,7 +216,7 @@ impl SearchResult {
         })
     }
 
-    pub fn from_suggestion_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
+    pub fn from_suggestion_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
         let mut reasons = vec![MatchReason::Bookmark];
 
         let search_string = row.get::<_, String>("searchString")?;
@@ -244,7 +244,7 @@ impl SearchResult {
         })
     }
 
-    pub fn from_origin_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
+    pub fn from_origin_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
         let search_string = row.get::<_, String>("searchString")?;
         let url = row.get::<_, String>("url")?;
         let display_url = row.get::<_, String>("displayURL")?;
@@ -262,7 +262,7 @@ impl SearchResult {
         })
     }
 
-    pub fn from_url_row(row: &rusqlite::Row) -> rusqlite::Result<Self> {
+    pub fn from_url_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Self> {
         let search_string = row.get::<_, String>("searchString")?;
         let href = row.get::<_, String>("url")?;
         let stripped_url = row.get::<_, String>("strippedURL")?;

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -187,7 +187,7 @@ impl PlacesApi {
         }
     }
 
-    pub fn open_sync_connection(&self) -> Result<SyncConn> {
+    pub fn open_sync_connection(&self) -> Result<SyncConn<'_>> {
         let prev_value = self
             .sync_conn_active
             .compare_and_swap(false, true, Ordering::SeqCst);

--- a/components/places/src/bookmark_sync/incoming.rs
+++ b/components/places/src/bookmark_sync/incoming.rs
@@ -394,7 +394,7 @@ mod tests {
     use serde_json::{json, Value};
     use sync15::Payload;
 
-    fn apply_incoming(api: &PlacesApi, records_json: Value) -> SyncConn {
+    fn apply_incoming(api: &PlacesApi, records_json: Value) -> SyncConn<'_> {
         let conn = api.open_sync_connection().expect("should get a connection");
 
         let server_timestamp = ServerTimestamp(0.0);

--- a/components/places/src/bookmark_sync/mod.rs
+++ b/components/places/src/bookmark_sync/mod.rs
@@ -99,7 +99,7 @@ impl From<SyncedBookmarkKind> for dogear::Kind {
 }
 
 impl ToSql for SyncedBookmarkKind {
-    fn to_sql(&self) -> RusqliteResult<ToSqlOutput> {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(*self as u8))
     }
 }
@@ -144,7 +144,7 @@ impl From<SyncedBookmarkValidity> for dogear::Validity {
 }
 
 impl ToSql for SyncedBookmarkValidity {
-    fn to_sql(&self) -> RusqliteResult<ToSqlOutput> {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(*self as u8))
     }
 }

--- a/components/places/src/bookmark_sync/record.rs
+++ b/components/places/src/bookmark_sync/record.rs
@@ -104,7 +104,7 @@ impl<'de> Deserialize<'de> for BookmarkRecordId {
         impl<'de> Visitor<'de> for V {
             type Value = BookmarkRecordId;
 
-            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str("a bookmark record ID")
             }
 

--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -106,8 +106,8 @@ impl<'a> BookmarksStore<'a> {
     fn update_local_items<'t>(
         &self,
         descendants: Vec<MergedDescendant<'t>>,
-        deletions: Vec<Deletion>,
-        _tx: &mut PlacesTransaction,
+        deletions: Vec<Deletion<'_>>,
+        _tx: &mut PlacesTransaction<'_>,
     ) -> Result<()> {
         // First, insert rows for all merged descendants.
         sql_support::each_sized_chunk(
@@ -558,7 +558,7 @@ struct Merger<'a> {
 }
 
 impl<'a> Merger<'a> {
-    fn new(store: &'a BookmarksStore, remote_time: ServerTimestamp) -> Self {
+    fn new(store: &'a BookmarksStore<'_>, remote_time: ServerTimestamp) -> Self {
         Self {
             store,
             remote_time,
@@ -578,7 +578,7 @@ impl<'a> Merger<'a> {
     }
 
     /// Creates a local tree item from a row in the `localItems` CTE.
-    fn local_row_to_item(&self, row: &Row) -> Result<Item> {
+    fn local_row_to_item(&self, row: &Row<'_>) -> Result<Item> {
         let guid = row.get::<_, SyncGuid>("guid")?;
         let kind = SyncedBookmarkKind::from_u8(row.get("kind")?)?;
         let mut item = Item::new(guid.into(), kind.into());
@@ -593,7 +593,7 @@ impl<'a> Merger<'a> {
     }
 
     /// Creates a remote tree item from a row in `moz_bookmarks_synced`.
-    fn remote_row_to_item(&self, row: &Row) -> Result<Item> {
+    fn remote_row_to_item(&self, row: &Row<'_>) -> Result<Item> {
         let guid = row.get::<_, SyncGuid>("guid")?;
         let kind = SyncedBookmarkKind::from_u8(row.get("kind")?)?;
         let mut item = Item::new(guid.into(), kind.into());
@@ -852,7 +852,7 @@ impl<'a> dogear::Store<Error> for Merger<'a> {
 struct LocalItemsFragment<'a>(&'a str);
 
 impl<'a> fmt::Display for LocalItemsFragment<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{name}(id, guid, parentId, parentGuid, position, type, title, parentTitle,
@@ -892,7 +892,7 @@ struct ItemKindFragment {
 }
 
 impl fmt::Display for ItemKindFragment {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "(CASE {typ}
@@ -931,7 +931,7 @@ enum UrlOrPlaceIdFragment {
 }
 
 impl fmt::Display for UrlOrPlaceIdFragment {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             UrlOrPlaceIdFragment::Url(s) => write!(f, "{}", s),
             UrlOrPlaceIdFragment::PlaceId(s) => {
@@ -946,7 +946,7 @@ impl fmt::Display for UrlOrPlaceIdFragment {
 struct RootsFragment<'a>(&'a [BookmarkRootGuid]);
 
 impl<'a> fmt::Display for RootsFragment<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("(")?;
         for (i, guid) in self.0.iter().enumerate() {
             if i != 0 {

--- a/components/places/src/bookmark_sync/tests/synced_item.rs
+++ b/components/places/src/bookmark_sync/tests/synced_item.rs
@@ -170,7 +170,7 @@ impl SyncedBookmarkItem {
 
     // Return a new SyncedBookmarkItem from a database row. All values will
     // be SyncedBookmarkValue::Specified.
-    fn from_row(row: &Row) -> Result<Self> {
+    fn from_row(row: &Row<'_>) -> Result<Self> {
         let mut tags = row
             .get::<_, Option<String>>("tags")?
             .map(|tags| {

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -230,14 +230,14 @@ mod sql_fns {
     use rusqlite::{functions::Context, types::ValueRef, Error, Result};
 
     // Helpers for define_functions
-    fn get_raw_str<'a>(ctx: &'a Context, fname: &'static str, idx: usize) -> Result<&'a str> {
+    fn get_raw_str<'a>(ctx: &'a Context<'_>, fname: &'static str, idx: usize) -> Result<&'a str> {
         ctx.get_raw(idx).as_str().map_err(|e| {
             Error::UserFunctionError(format!("Bad arg {} to '{}': {}", idx, fname, e).into())
         })
     }
 
     fn get_raw_opt_str<'a>(
-        ctx: &'a Context,
+        ctx: &'a Context<'_>,
         fname: &'static str,
         idx: usize,
     ) -> Result<Option<&'a str>> {
@@ -256,7 +256,7 @@ mod sql_fns {
     // #[inline(never)] ensures they show up in profiles.
 
     #[inline(never)]
-    pub fn hash(ctx: &Context) -> rusqlite::Result<Option<i64>> {
+    pub fn hash(ctx: &Context<'_>) -> rusqlite::Result<Option<i64>> {
         Ok(match ctx.len() {
             1 => {
                 // This is a deterministic function, which means sqlite
@@ -295,7 +295,7 @@ mod sql_fns {
     }
 
     #[inline(never)]
-    pub fn autocomplete_match(ctx: &Context) -> Result<bool> {
+    pub fn autocomplete_match(ctx: &Context<'_>) -> Result<bool> {
         let search_str = get_raw_str(ctx, "autocomplete_match", 0)?;
         let url_str = get_raw_str(ctx, "autocomplete_match", 1)?;
         let title_str = get_raw_opt_str(ctx, "autocomplete_match", 2)?.unwrap_or_default();
@@ -323,7 +323,7 @@ mod sql_fns {
     }
 
     #[inline(never)]
-    pub fn reverse_host(ctx: &Context) -> Result<String> {
+    pub fn reverse_host(ctx: &Context<'_>) -> Result<String> {
         // We reuse this memory so no need for get_raw.
         let mut host = ctx.get::<String>(0)?;
         debug_assert!(host.is_ascii(), "Hosts must be Punycoded");
@@ -340,21 +340,21 @@ mod sql_fns {
     }
 
     #[inline(never)]
-    pub fn get_prefix(ctx: &Context) -> Result<String> {
+    pub fn get_prefix(ctx: &Context<'_>) -> Result<String> {
         let href = get_raw_str(ctx, "get_prefix", 0)?;
         let (prefix, _) = split_after_prefix(&href);
         Ok(prefix.to_owned())
     }
 
     #[inline(never)]
-    pub fn get_host_and_port(ctx: &Context) -> Result<String> {
+    pub fn get_host_and_port(ctx: &Context<'_>) -> Result<String> {
         let href = get_raw_str(ctx, "get_host_and_port", 0)?;
         let (host_and_port, _) = split_after_host_and_port(&href);
         Ok(host_and_port.to_owned())
     }
 
     #[inline(never)]
-    pub fn strip_prefix_and_userinfo(ctx: &Context) -> Result<String> {
+    pub fn strip_prefix_and_userinfo(ctx: &Context<'_>) -> Result<String> {
         let href = get_raw_str(ctx, "strip_prefix_and_userinfo", 0)?;
         let (host_and_port, remainder) = split_after_host_and_port(&href);
         let mut res = String::with_capacity(host_and_port.len() + remainder.len() + 1);
@@ -364,12 +364,12 @@ mod sql_fns {
     }
 
     #[inline(never)]
-    pub fn now(_ctx: &Context) -> Result<Timestamp> {
+    pub fn now(_ctx: &Context<'_>) -> Result<Timestamp> {
         Ok(Timestamp::now())
     }
 
     #[inline(never)]
-    pub fn generate_guid(_ctx: &Context) -> Result<SyncGuid> {
+    pub fn generate_guid(_ctx: &Context<'_>) -> Result<SyncGuid> {
         Ok(SyncGuid::new())
     }
 }

--- a/components/places/src/db/tx/coop_transaction.rs
+++ b/components/places/src/db/tx/coop_transaction.rs
@@ -53,7 +53,7 @@ use std::time::{Duration, Instant};
 impl PlacesDb {
     /// Begin a ChunkedCoopTransaction. Must be called from the
     /// sync connection, see module doc for details.
-    pub(super) fn chunked_coop_trransaction(&self) -> Result<ChunkedCoopTransaction> {
+    pub(super) fn chunked_coop_trransaction(&self) -> Result<ChunkedCoopTransaction<'_>> {
         // Note: if there's actually a reason for a write conn to take this, we
         // can consider relaxing this. It's not required for correctness, just happens
         // to be the right choice for everything we expose and plan on exposing.
@@ -75,7 +75,7 @@ impl PlacesDb {
 
     /// Begin a "coop" transaction. Must be called from the write connection, see
     /// module doc for details.
-    pub(super) fn coop_transaction(&self) -> Result<UncheckedTransaction> {
+    pub(super) fn coop_transaction(&self) -> Result<UncheckedTransaction<'_>> {
         // Only validate tranaction types for ConnectionType::ReadWrite.
         assert_eq!(
             self.conn_type(),
@@ -196,7 +196,7 @@ impl<'conn> ConnExt for ChunkedCoopTransaction<'conn> {
 
 // A helper that attempts to get an Immediate lock on the DB. If it fails with
 // a "busy" or "locked" error, it does exactly 1 retry.
-fn get_tx_with_retry_on_locked(conn: &Connection) -> Result<UncheckedTransaction> {
+fn get_tx_with_retry_on_locked(conn: &Connection) -> Result<UncheckedTransaction<'_>> {
     let behavior = TransactionBehavior::Immediate;
     match UncheckedTransaction::new(conn, behavior) {
         Ok(tx) => Ok(tx),

--- a/components/places/src/db/tx/mod.rs
+++ b/components/places/src/db/tx/mod.rs
@@ -73,7 +73,7 @@ impl super::PlacesDb {
     /// - for ReadWrite connections, begins a normal coop transaction
     /// - for ReadOnly connections, panics in debug builds, and
     ///   logs an error (before opening a (pointless) in release builds.
-    pub fn begin_transaction(&self) -> Result<PlacesTransaction> {
+    pub fn begin_transaction(&self) -> Result<PlacesTransaction<'_>> {
         Ok(PlacesTransaction(match self.conn_type() {
             ConnectionType::Sync => {
                 PlacesTransactionRepr::Chunked(self.chunked_coop_trransaction()?)

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -18,7 +18,7 @@ pub struct Error(Box<Context<ErrorKind>>);
 
 impl Fail for Error {
     #[inline]
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.0.cause()
     }
 
@@ -30,7 +30,7 @@ impl Fail for Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.0, f)
     }
 }

--- a/components/places/src/history_sync/mod.rs
+++ b/components/places/src/history_sync/mod.rs
@@ -48,7 +48,7 @@ impl From<SystemTime> for ServerVisitTimestamp {
 
 impl fmt::Display for ServerVisitTimestamp {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/components/places/src/history_sync/store.rs
+++ b/components/places/src/history_sync/store.rs
@@ -38,7 +38,7 @@ impl<'a> HistoryStore<'a> {
         Self { db }
     }
 
-    fn put_meta(&self, key: &str, value: &ToSql) -> Result<()> {
+    fn put_meta(&self, key: &str, value: &dyn ToSql) -> Result<()> {
         crate::storage::put_meta(self.db, key, value)
     }
 

--- a/components/places/src/lib.rs
+++ b/components/places/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 pub mod api;
 pub mod error;

--- a/components/places/src/match_impl.rs
+++ b/components/places/src/match_impl.rs
@@ -36,7 +36,7 @@ pub enum MatchBehavior {
 
 impl FromSql for MatchBehavior {
     #[inline]
-    fn column_result(value: ValueRef) -> FromSqlResult<Self> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         Ok(match value.as_i64()? {
             0 => MatchBehavior::Anywhere,
             1 => MatchBehavior::BoundaryAnywhere,
@@ -51,7 +51,7 @@ impl FromSql for MatchBehavior {
 
 impl ToSql for MatchBehavior {
     #[inline]
-    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(*self as u32))
     }
 }
@@ -111,7 +111,7 @@ impl SearchBehavior {
 
 impl FromSql for SearchBehavior {
     #[inline]
-    fn column_result(value: ValueRef) -> FromSqlResult<Self> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         SearchBehavior::from_bits(u32::column_result(value)?)
             .ok_or_else(|| FromSqlError::InvalidType)
     }
@@ -119,7 +119,7 @@ impl FromSql for SearchBehavior {
 
 impl ToSql for SearchBehavior {
     #[inline]
-    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput> {
+    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(self.bits()))
     }
 }

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -47,7 +47,7 @@ fn create_root(
         ",
         BookmarkRootGuid::Root.as_guid().as_ref()
     );
-    let params: Vec<(&str, &ToSql)> = vec![
+    let params: Vec<(&str, &dyn ToSql)> = vec![
         (":item_type", &BookmarkType::Folder),
         (":item_position", &position),
         (":item_title", &title),
@@ -1077,7 +1077,7 @@ struct FetchedTreeRow {
 }
 
 impl FetchedTreeRow {
-    pub fn from_row(row: &Row) -> Result<Self> {
+    pub fn from_row(row: &Row<'_>) -> Result<Self> {
         let url = row.get::<_, Option<String>>("url")?;
         Ok(Self {
             level: row.get("level")?,
@@ -1264,7 +1264,7 @@ pub(crate) struct RawBookmark {
 }
 
 impl RawBookmark {
-    pub fn from_row(row: &Row) -> Result<Self> {
+    pub fn from_row(row: &Row<'_>) -> Result<Self> {
         let place_id = row.get::<_, Option<RowId>>("fk")?;
         Ok(Self {
             row_id: row.get("_id")?,

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -49,7 +49,7 @@ pub fn apply_observation_direct(
     };
     let mut update_change_counter = false;
     let mut update_frec = false;
-    let mut updates: Vec<(&str, &str, &ToSql)> = Vec::new();
+    let mut updates: Vec<(&str, &str, &dyn ToSql)> = Vec::new();
 
     if let Some(ref title) = visit_ob.title {
         page_info.title = crate::util::slice_up_to(title, super::TITLE_LENGTH_MAX).into();
@@ -92,7 +92,7 @@ pub fn apply_observation_direct(
     }
 
     if !updates.is_empty() {
-        let mut params: Vec<(&str, &ToSql)> = Vec::with_capacity(updates.len() + 1);
+        let mut params: Vec<(&str, &dyn ToSql)> = Vec::with_capacity(updates.len() + 1);
         let mut sets: Vec<String> = Vec::with_capacity(updates.len());
         for (col, name, val) in updates {
             sets.push(format!("{} = {}", col, name));
@@ -250,7 +250,7 @@ pub fn wipe_local(db: &PlacesDb) -> Result<()> {
     Ok(())
 }
 
-fn wipe_local_in_tx(db: &PlacesDb, tx: crate::db::PlacesTransaction) -> Result<()> {
+fn wipe_local_in_tx(db: &PlacesDb, tx: crate::db::PlacesTransaction<'_>) -> Result<()> {
     use crate::frecency::DEFAULT_FRECENCY_SETTINGS;
     db.execute_all(&[
         "DELETE FROM moz_places WHERE foreign_count == 0",
@@ -437,7 +437,7 @@ struct PageToClean {
 }
 
 impl PageToClean {
-    pub fn from_row(row: &Row) -> Result<Self> {
+    pub fn from_row(row: &Row<'_>) -> Result<Self> {
         Ok(Self {
             id: row.get("id")?,
             has_foreign: row.get("has_foreign")?,
@@ -525,7 +525,7 @@ pub mod history_sync {
     }
 
     impl FetchedVisit {
-        pub fn from_row(row: &Row) -> Result<Self> {
+        pub fn from_row(row: &Row<'_>) -> Result<Self> {
             Ok(Self {
                 is_local: row.get("is_local")?,
                 visit_date: row
@@ -547,7 +547,7 @@ pub mod history_sync {
     }
 
     impl FetchedVisitPage {
-        pub fn from_row(row: &Row) -> Result<Self> {
+        pub fn from_row(row: &Row<'_>) -> Result<Self> {
             Ok(Self {
                 url: Url::parse(&row.get::<_, String>("url")?)?,
                 guid: row.get::<_, String>("guid")?.into(),

--- a/components/places/src/storage/tags.rs
+++ b/components/places/src/storage/tags.rs
@@ -43,7 +43,7 @@ impl<'a> ValidatedTag<'a> {
 }
 
 /// Checks the validity of the specified tag.
-pub fn validate_tag(tag: &str) -> ValidatedTag {
+pub fn validate_tag(tag: &str) -> ValidatedTag<'_> {
     // Drop empty and oversized tags.
     let t = tag.trim();
     if t.is_empty() || t.len() > TAG_LENGTH_MAX || t.find(char::is_whitespace).is_some() {

--- a/components/places/src/types.rs
+++ b/components/places/src/types.rs
@@ -52,20 +52,20 @@ impl From<SyncGuid> for dogear::Guid {
 }
 
 impl ToSql for SyncGuid {
-    fn to_sql(&self) -> RusqliteResult<ToSqlOutput> {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(self.0.clone())) // cloning seems wrong?
     }
 }
 
 impl FromSql for SyncGuid {
-    fn column_result(value: ValueRef) -> FromSqlResult<Self> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         value.as_str().map(|v| SyncGuid(v.to_string()))
     }
 }
 
 impl fmt::Display for SyncGuid {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
@@ -127,19 +127,19 @@ impl From<u64> for Timestamp {
 
 impl fmt::Display for Timestamp {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
 impl ToSql for Timestamp {
-    fn to_sql(&self) -> RusqliteResult<ToSqlOutput> {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(self.0 as i64)) // hrm - no u64 in rusqlite
     }
 }
 
 impl FromSql for Timestamp {
-    fn column_result(value: ValueRef) -> FromSqlResult<Self> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         value.as_i64().map(|v| Timestamp(v as u64)) // hrm - no u64
     }
 }
@@ -168,7 +168,7 @@ pub enum VisitTransition {
 }
 
 impl ToSql for VisitTransition {
-    fn to_sql(&self) -> RusqliteResult<ToSqlOutput> {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(*self as u8))
     }
 }
@@ -195,7 +195,7 @@ struct VisitTransitionSerdeVisitor;
 impl<'de> serde::de::Visitor<'de> for VisitTransitionSerdeVisitor {
     type Value = VisitTransition;
 
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("positive integer representing VisitTransition")
     }
 
@@ -235,7 +235,7 @@ pub enum BookmarkType {
 }
 
 impl FromSql for BookmarkType {
-    fn column_result(value: ValueRef) -> FromSqlResult<Self> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         let v = value.as_i64()?;
         if v < 0 || v > i64::from(u8::max_value()) {
             return Err(FromSqlError::OutOfRange(v));
@@ -272,7 +272,7 @@ impl BookmarkType {
 }
 
 impl ToSql for BookmarkType {
-    fn to_sql(&self) -> RusqliteResult<ToSqlOutput> {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(*self as u8))
     }
 }
@@ -320,7 +320,7 @@ impl SyncStatus {
 }
 
 impl ToSql for SyncStatus {
-    fn to_sql(&self) -> RusqliteResult<ToSqlOutput> {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(*self as u8))
     }
 }

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 use ffi_support::{
     define_bytebuffer_destructor, define_handle_map_deleter, define_string_destructor,

--- a/components/push/src/crypto.rs
+++ b/components/push/src/crypto.rs
@@ -46,7 +46,7 @@ impl clone::Clone for Key {
 }
 
 impl fmt::Debug for Key {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{{private: {:?}, public: {:?}, auth: {:?}}}",

--- a/components/push/src/error.rs
+++ b/components/push/src/error.rs
@@ -15,7 +15,7 @@ pub struct Error(Box<Context<ErrorKind>>);
 
 impl Fail for Error {
     #[inline]
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.0.cause()
     }
 
@@ -27,7 +27,7 @@ impl Fail for Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.0, f)
     }
 }

--- a/components/push/src/lib.rs
+++ b/components/push/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 pub mod communications;
 pub mod config;

--- a/components/push/src/storage/record.rs
+++ b/components/push/src/storage/record.rs
@@ -67,7 +67,7 @@ impl PushRecord {
         }
     }
 
-    pub(crate) fn from_row(row: &Row) -> Result<Self> {
+    pub(crate) fn from_row(row: &Row<'_>) -> Result<Self> {
         Ok(PushRecord {
             uaid: row.get("uaid")?,
             channel_id: row.get("channel_id")?,

--- a/components/push/src/storage/types.rs
+++ b/components/push/src/storage/types.rs
@@ -47,19 +47,19 @@ impl From<u64> for Timestamp {
 }
 
 impl fmt::Display for Timestamp {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
 impl ToSql for Timestamp {
-    fn to_sql(&self) -> RusqliteResult<ToSqlOutput> {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(self.0 as i64)) // hrm - no u64 in rusqlite
     }
 }
 
 impl FromSql for Timestamp {
-    fn column_result(value: ValueRef) -> FromSqlResult<Self> {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         value.as_i64().map(|v| Timestamp(v as u64)) // hrm - no u64
     }
 }

--- a/components/rc_log/src/android.rs
+++ b/components/rc_log/src/android.rs
@@ -103,13 +103,13 @@ pub struct LogSink {
 }
 
 impl log::Log for LogSink {
-    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+    fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
         // Really this could just be Acquire but whatever
         !self.disabled.load(Ordering::SeqCst)
     }
 
     fn flush(&self) {}
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &log::Record<'_>) {
         // Important: we check stopped before writing, which means
         // it must be set before
         if self.disabled.load(Ordering::SeqCst) {

--- a/components/rc_log/src/ios.rs
+++ b/components/rc_log/src/ios.rs
@@ -38,12 +38,12 @@ struct Logger {
 }
 
 impl log::Log for Logger {
-    fn enabled(&self, _metadata: &log::Metadata) -> bool {
+    fn enabled(&self, _metadata: &log::Metadata<'_>) -> bool {
         !self.stop.load(Ordering::SeqCst)
     }
 
     fn flush(&self) {}
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &log::Record<'_>) {
         if self.stop.load(Ordering::SeqCst) {
             // Note: `enabled` is not automatically called.
             return;

--- a/components/rc_log/src/lib.rs
+++ b/components/rc_log/src/lib.rs
@@ -15,6 +15,7 @@
 //! work around this using our `settable_log` module.
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 // We always include both modules when doing test builds, so for test builds,
 // allow dead code.
 #![cfg_attr(test, allow(dead_code))]

--- a/components/rc_log/src/settable_log.rs
+++ b/components/rc_log/src/settable_log.rs
@@ -30,7 +30,7 @@ impl SettableLog {
 }
 
 impl Log for SettableLog {
-    fn enabled(&self, metadata: &log::Metadata) -> bool {
+    fn enabled(&self, metadata: &log::Metadata<'_>) -> bool {
         let inner = self.inner.read().unwrap();
         if let Some(log) = &*inner {
             log.enabled(metadata)
@@ -46,7 +46,7 @@ impl Log for SettableLog {
         }
     }
 
-    fn log(&self, record: &log::Record) {
+    fn log(&self, record: &log::Record<'_>) {
         let inner = self.inner.read().unwrap();
         if let Some(log) = &*inner {
             log.log(record);

--- a/components/support/cli/src/lib.rs
+++ b/components/support/cli/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 pub mod fxa_creds;
 pub mod prompt;

--- a/components/support/ffi/src/error.rs
+++ b/components/support/ffi/src/error.rs
@@ -218,8 +218,8 @@ impl Default for ExternError {
 
 // This is the `Err` of std::thread::Result, which is what
 // `panic::catch_unwind` returns.
-impl From<Box<std::any::Any + Send + 'static>> for ExternError {
-    fn from(e: Box<std::any::Any + Send + 'static>) -> Self {
+impl From<Box<dyn std::any::Any + Send + 'static>> for ExternError {
+    fn from(e: Box<dyn std::any::Any + Send + 'static>) -> Self {
         // The documentation suggests that it will *usually* be a str or String.
         let message = if let Some(s) = e.downcast_ref::<&'static str>() {
             s.to_string()

--- a/components/support/ffi/src/ffistr.rs
+++ b/components/support/ffi/src/ffistr.rs
@@ -152,7 +152,7 @@ impl<'a> FfiStr<'a> {
 }
 
 impl<'a> std::fmt::Debug for FfiStr<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(s) = self.as_opt_str() {
             write!(f, "FfiStr({:?})", s)
         } else {

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -4,6 +4,7 @@
 
 #![deny(missing_docs)]
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 //! # FFI Support
 //!

--- a/components/support/rc_crypto/src/error.rs
+++ b/components/support/rc_crypto/src/error.rs
@@ -13,7 +13,7 @@ pub struct Error(Box<Context<ErrorKind>>);
 
 impl Fail for Error {
     #[inline]
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.0.cause()
     }
 
@@ -25,7 +25,7 @@ impl Fail for Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.0, f)
     }
 }

--- a/components/support/sql/src/lib.rs
+++ b/components/support/sql/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 mod conn_ext;
 mod each_chunk;

--- a/components/support/sql/src/query_plan.rs
+++ b/components/support/sql/src/query_plan.rs
@@ -39,7 +39,7 @@ impl QueryPlan {
         })
     }
 
-    pub fn print_pretty_tree(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    pub fn print_pretty_tree(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.plan.is_empty() {
             return writeln!(f, "<no query plan>");
         }
@@ -58,7 +58,7 @@ impl QueryPlan {
 
     fn print_tree(
         &self,
-        f: &mut std::fmt::Formatter,
+        f: &mut std::fmt::Formatter<'_>,
         entry: &QueryPlanStep,
         prefix: &str,
         last_child: bool,
@@ -84,7 +84,7 @@ impl QueryPlan {
 }
 
 impl std::fmt::Display for QueryPlan {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "### QUERY PLAN")?;
         writeln!(f, "#### SQL:\n{}\n#### PLAN:", self.query)?;
         self.print_pretty_tree(f)?;

--- a/components/support/sql/src/repeat.rs
+++ b/components/support/sql/src/repeat.rs
@@ -16,9 +16,9 @@ pub struct RepeatDisplay<'a, F> {
 
 impl<'a, F> fmt::Display for RepeatDisplay<'a, F>
 where
-    F: Fn(usize, &mut fmt::Formatter) -> fmt::Result,
+    F: Fn(usize, &mut fmt::Formatter<'_>) -> fmt::Result,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for i in 0..self.count {
             if i != 0 {
                 f.write_str(self.sep)?;
@@ -44,9 +44,9 @@ where
 ///            "(0,?),(1,?),(2,?)");
 /// ```
 #[inline]
-pub fn repeat_display<F>(count: usize, sep: &str, fmt_one: F) -> RepeatDisplay<F>
+pub fn repeat_display<F>(count: usize, sep: &str, fmt_one: F) -> RepeatDisplay<'_, F>
 where
-    F: Fn(usize, &mut fmt::Formatter) -> fmt::Result,
+    F: Fn(usize, &mut fmt::Formatter<'_>) -> fmt::Result,
 {
     RepeatDisplay {
         count,

--- a/components/sync15/src/client.rs
+++ b/components/sync15/src/client.rs
@@ -238,7 +238,7 @@ impl Sync15StorageClient {
             match status {
                 404 => Sync15ClientResponse::NotFound { route },
                 401 => Sync15ClientResponse::Unauthorized { route },
-                500...600 => Sync15ClientResponse::ServerError { route, status },
+                500..=600 => Sync15ClientResponse::ServerError { route, status },
                 _ => Sync15ClientResponse::RequestFailed { route, status },
             }
         })

--- a/components/sync15/src/coll_state.rs
+++ b/components/sync15/src/coll_state.rs
@@ -61,7 +61,7 @@ pub struct LocalCollStateMachine<'state> {
 }
 
 impl<'state> LocalCollStateMachine<'state> {
-    fn advance(&self, from: LocalCollState, store: &Store) -> error::Result<LocalCollState> {
+    fn advance(&self, from: LocalCollState, store: &dyn Store) -> error::Result<LocalCollState> {
         let name = &store.collection_name().to_string();
         let meta_global = &self.global_state.global;
         match from {
@@ -113,7 +113,7 @@ impl<'state> LocalCollStateMachine<'state> {
     // A little whimsy - a portmanteau of far and fast
     fn run_and_run_as_farst_as_you_can(
         &mut self,
-        store: &Store,
+        store: &dyn Store,
     ) -> error::Result<Option<CollState>> {
         let mut s = LocalCollState::Unknown {
             assoc: store.get_sync_assoc()?,
@@ -156,7 +156,7 @@ impl<'state> LocalCollStateMachine<'state> {
     }
 
     pub fn get_state(
-        store: &Store,
+        store: &dyn Store,
         global_state: &'state GlobalState,
     ) -> error::Result<Option<CollState>> {
         let mut gingerbread_man = Self { global_state };

--- a/components/sync15/src/error.rs
+++ b/components/sync15/src/error.rs
@@ -14,7 +14,7 @@ pub struct Error(Box<Context<ErrorKind>>);
 
 impl Fail for Error {
     #[inline]
-    fn cause(&self) -> Option<&Fail> {
+    fn cause(&self) -> Option<&dyn Fail> {
         self.0.cause()
     }
 
@@ -26,7 +26,7 @@ impl Fail for Error {
 
 impl fmt::Display for Error {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&*self.0, f)
     }
 }

--- a/components/sync15/src/lib.rs
+++ b/components/sync15/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 mod bso_record;
 mod changeset;

--- a/components/sync15/src/request.rs
+++ b/components/sync15/src/request.rs
@@ -22,7 +22,7 @@ pub enum RequestOrder {
 
 impl fmt::Display for RequestOrder {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RequestOrder::Oldest => f.write_str("oldest"),
             RequestOrder::Newest => f.write_str("newest"),
@@ -114,7 +114,7 @@ impl CollectionRequest {
         self
     }
 
-    fn build_query(&self, pairs: &mut Serializer<UrlQuery>) {
+    fn build_query(&self, pairs: &mut Serializer<UrlQuery<'_>>) {
         if self.full {
             pairs.append_pair("full", "1");
         }

--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -117,7 +117,7 @@ fn new_global(pgs: &PersistedGlobalState) -> error::Result<MetaGlobalRecord> {
 }
 
 pub struct SetupStateMachine<'a> {
-    client: &'a SetupStorageClient,
+    client: &'a dyn SetupStorageClient,
     root_key: &'a KeyBundle,
     pgs: &'a mut PersistedGlobalState,
     // `allowed_states` is designed so that we can arrange for the concept of
@@ -137,7 +137,7 @@ impl<'a> SetupStateMachine<'a> {
     /// all states, including uploading a fresh `meta/global` and `crypto/keys`
     /// after a node reassignment.
     pub fn for_full_sync(
-        client: &'a SetupStorageClient,
+        client: &'a dyn SetupStorageClient,
         root_key: &'a KeyBundle,
         pgs: &'a mut PersistedGlobalState,
     ) -> SetupStateMachine<'a> {
@@ -163,7 +163,7 @@ impl<'a> SetupStateMachine<'a> {
     /// important to get to ready as quickly as possible, like syncing before
     /// sleep, or when conserving time or battery life.
     pub fn for_fast_sync(
-        client: &'a SetupStorageClient,
+        client: &'a dyn SetupStorageClient,
         root_key: &'a KeyBundle,
         pgs: &'a mut PersistedGlobalState,
     ) -> SetupStateMachine<'a> {
@@ -179,7 +179,7 @@ impl<'a> SetupStateMachine<'a> {
     /// upload `meta/global` or `crypto/keys`. Useful for clients that only
     /// sync specific collections, like Lockbox.
     pub fn for_readonly_sync(
-        client: &'a SetupStorageClient,
+        client: &'a dyn SetupStorageClient,
         root_key: &'a KeyBundle,
         pgs: &'a mut PersistedGlobalState,
     ) -> SetupStateMachine<'a> {
@@ -200,7 +200,7 @@ impl<'a> SetupStateMachine<'a> {
     }
 
     fn with_allowed_states(
-        client: &'a SetupStorageClient,
+        client: &'a dyn SetupStorageClient,
         root_key: &'a KeyBundle,
         pgs: &'a mut PersistedGlobalState,
         allowed_states: Vec<&'static str>,

--- a/components/sync15/src/sync.rs
+++ b/components/sync15/src/sync.rs
@@ -51,7 +51,7 @@ pub trait Store {
 pub fn synchronize(
     client: &Sync15StorageClient,
     global_state: &GlobalState,
-    store: &Store,
+    store: &dyn Store,
     fully_atomic: bool,
     telem_engine: &mut telemetry::Engine,
 ) -> Result<(), Error> {

--- a/components/sync15/src/token.rs
+++ b/components/sync15/src/token.rs
@@ -116,7 +116,7 @@ struct TokenContext {
 
 // hawk::Credentials doesn't implement debug -_-
 impl fmt::Debug for TokenContext {
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         f.debug_struct("TokenContext")
             .field("token", &self.token)
             .field("credentials", &"(omitted)")

--- a/components/sync15/src/util.rs
+++ b/components/sync15/src/util.rs
@@ -50,7 +50,7 @@ impl FromStr for ServerTimestamp {
 
 impl fmt::Display for ServerTimestamp {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/components/viaduct/src/headers.rs
+++ b/components/viaduct/src/headers.rs
@@ -85,7 +85,7 @@ impl Header {
 }
 
 impl std::fmt::Display for Header {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}: {}", self.name, self.value)
     }
 }

--- a/components/viaduct/src/headers/name.rs
+++ b/components/viaduct/src/headers/name.rs
@@ -98,7 +98,7 @@ impl HeaderName {
 }
 
 impl std::fmt::Display for HeaderName {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
 }

--- a/components/viaduct/src/lib.rs
+++ b/components/viaduct/src/lib.rs
@@ -52,7 +52,7 @@ impl Method {
 }
 
 impl std::fmt::Display for Method {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -242,7 +242,7 @@ impl Response {
 
     /// Get the body as a string. Assumes UTF-8 encoding. Any non-utf8 bytes
     /// are replaced with the replacement character.
-    pub fn text(&self) -> std::borrow::Cow<str> {
+    pub fn text(&self) -> std::borrow::Cow<'_, str> {
         String::from_utf8_lossy(&self.body)
     }
 

--- a/components/viaduct/src/lib.rs
+++ b/components/viaduct/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 use url::Url;
 #[macro_use]

--- a/megazords/fenix/src/lib.rs
+++ b/megazords/fenix/src/lib.rs
@@ -4,8 +4,8 @@
 
 #![allow(unknown_lints)]
 
-pub extern crate fxaclient_ffi;
-pub extern crate places_ffi;
-pub extern crate push_ffi;
-pub extern crate rc_log_ffi;
-pub extern crate viaduct;
+pub use fxaclient_ffi;
+pub use places_ffi;
+pub use push_ffi;
+pub use rc_log_ffi;
+pub use viaduct;

--- a/megazords/fenix/src/lib.rs
+++ b/megazords/fenix/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 pub use fxaclient_ffi;
 pub use places_ffi;

--- a/megazords/ios/rust/src/lib.rs
+++ b/megazords/ios/rust/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![allow(unknown_lints)]
 
-pub extern crate fxaclient_ffi;
-pub extern crate logins_ffi;
-pub extern crate places_ffi;
-pub extern crate rc_log_ffi;
+pub use fxaclient_ffi;
+pub use logins_ffi;
+pub use places_ffi;
+pub use rc_log_ffi;

--- a/megazords/ios/rust/src/lib.rs
+++ b/megazords/ios/rust/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 pub use fxaclient_ffi;
 pub use logins_ffi;

--- a/megazords/lockbox/src/lib.rs
+++ b/megazords/lockbox/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![allow(unknown_lints)]
 
-pub extern crate fxaclient_ffi;
-pub extern crate logins_ffi;
-pub extern crate rc_log_ffi;
-pub extern crate viaduct;
+pub use fxaclient_ffi;
+pub use logins_ffi;
+pub use rc_log_ffi;
+pub use viaduct;

--- a/megazords/lockbox/src/lib.rs
+++ b/megazords/lockbox/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 pub use fxaclient_ffi;
 pub use logins_ffi;

--- a/megazords/reference-browser/src/lib.rs
+++ b/megazords/reference-browser/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 pub use fxaclient_ffi;
 pub use logins_ffi;

--- a/megazords/reference-browser/src/lib.rs
+++ b/megazords/reference-browser/src/lib.rs
@@ -4,9 +4,9 @@
 
 #![allow(unknown_lints)]
 
-pub extern crate fxaclient_ffi;
-pub extern crate logins_ffi;
-pub extern crate places_ffi;
-pub extern crate push_ffi;
-pub extern crate rc_log_ffi;
-pub extern crate viaduct;
+pub use fxaclient_ffi;
+pub use logins_ffi;
+pub use places_ffi;
+pub use push_ffi;
+pub use rc_log_ffi;
+pub use viaduct;

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -2,6 +2,7 @@
 http://creativecommons.org/publicdomain/zero/1.0/ */
 
 #![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
 
 use structopt::StructOpt;
 


### PR DESCRIPTION
The only one of these I actually care about is `&SomeTrait` => `&dyn SomeTrait` (which I feel makes what we're doing much clearer -- are we passing a reference to data, or to functionality), but it feels better to be able to say our code is ✨idiomatic✨.

This was generated largely by `cargo fix --edition-idioms`, so rebases/merges should be able to just rerun that if there's anything tricky.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
