### PR TITLE
Fix open_connection panic when syncing

### DIFF
--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -226,12 +226,12 @@ impl PlacesApi {
     }
 
     fn get_disk_persisted_state(&self) -> Result<Option<String>> {
-        let conn = self.open_connection(ConnectionType::Sync)?;
+        let conn = self.open_sync_connection()?;
         Ok(get_meta::<String>(&conn, GLOBAL_STATE_META_KEY)?)
     }
 
     fn set_disk_persisted_state(&self, state: &Option<String>) -> Result<()> {
-        let conn = self.open_connection(ConnectionType::Sync)?;
+        let conn = self.open_sync_connection()?;
         match state {
             Some(ref s) => put_meta(&conn, GLOBAL_STATE_META_KEY, s),
             None => delete_meta(&conn, GLOBAL_STATE_META_KEY),


### PR DESCRIPTION
This was basically a mid-air collision between the transaction patch and the sync-manager-lite

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
