### PR TITLE
fix(libs): Pass RTLD_LAZY when checking whether we can link against NSS.

### DIFF
--- a/libs/bootstrap-desktop.sh
+++ b/libs/bootstrap-desktop.sh
@@ -32,8 +32,9 @@ else
   const LIB_NAME: &str = "libnss3.dylib";
   #[cfg(target_os = "linux")]
   const LIB_NAME: &str = "libnss3.so";
+  const RTLD_LAZY: c_int = 0x01;
   fn main() {
-    let result = unsafe { dlopen(CString::new(LIB_NAME).unwrap().as_ptr(), 0) };
+    let result = unsafe { dlopen(CString::new(LIB_NAME).unwrap().as_ptr(), RTLD_LAZY) };
     if result.is_null() { println!("Could not dlopen nss"); exit(1); }
   }
   ' > nsslibcheck.rs


### PR DESCRIPTION
Our little autoconf.rs script was failing to detect NSS for me. According to `man dlopen 3` one of `RTLD_LAZY` or `RTLD_NOW` *must* be passed in the flags argument, so I opted to pass `RTLD_LAZY`.

It's not clear to me whether this value might differ on different platforms, could someone please test on OSX to see if it continues to work there?