### PR TITLE
Fix typo in the sql which upgrades db to version 8

### DIFF
--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -193,7 +193,7 @@ fn upgrade(db: &PlacesDb, from: i64) -> Result<()> {
             // Changing `moz_bookmarks_synced_structure` to store multiple
             // parents, so we need to re-download all synced bookmarks.
             &format!(
-                "DELETE FROM moz_meta WHERE key = {}",
+                "DELETE FROM moz_meta WHERE key = '{}'",
                 bookmark_sync::store::LAST_SYNC_META_KEY
             ),
             "DROP TABLE moz_bookmarks_synced",


### PR DESCRIPTION
Upgrading gives the error `Error executing SQL: no such column: bookmarks_last_sync_time`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
