### PR TITLE
Append 1.0/sync/1.5 to the tokenserver url in sync rather than in fxa (fixes #604)

### DIFF
--- a/components/fxa-client/src/config.rs
+++ b/components/fxa-client/src/config.rs
@@ -129,7 +129,7 @@ impl Config {
             auth_url: format!("{}/", resp.auth_server_base_url),
             oauth_url: format!("{}/", resp.oauth_server_base_url),
             profile_url: format!("{}/", resp.profile_server_base_url),
-            token_server_endpoint_url: format!("{}/1.0/sync/1.5", resp.sync_tokenserver_base_url),
+            token_server_endpoint_url: format!("{}/", resp.sync_tokenserver_base_url),
             authorization_endpoint: openid_resp.authorization_endpoint,
             issuer: openid_resp.issuer,
             jwks_uri: openid_resp.jwks_uri,

--- a/components/sync15/src/client.rs
+++ b/components/sync15/src/client.rs
@@ -174,7 +174,7 @@ impl Sync15StorageClient {
             init_params.tokenserver_url,
             init_params.access_token,
             init_params.key_id,
-        );
+        )?;
         Ok(Sync15StorageClient { tsc })
     }
 

--- a/components/sync15/src/token.rs
+++ b/components/sync15/src/token.rs
@@ -52,12 +52,18 @@ struct TokenServerFetcher {
 }
 
 impl TokenServerFetcher {
-    fn new(server_url: Url, access_token: String, key_id: String) -> TokenServerFetcher {
-        TokenServerFetcher {
+    fn new(base_url: Url, access_token: String, key_id: String) -> Result<TokenServerFetcher> {
+        // base_url is the end-point as returned by .well-known/fxa-client-configuration,
+        // or as directly specified by self-hosters. As a result, it doesn't have
+        // the sync 1.5 suffix of "/1.0/sync/1.5" - so add it on here.
+        // (Note that base_url must end in a slash, or the last path element in
+        // the base url will be replaced with this suffix.)
+        let server_url = base_url.join("1.0/sync/1.5")?;
+        Ok(TokenServerFetcher {
             server_url,
             access_token,
             key_id,
-        }
+        })
     }
 }
 
@@ -365,11 +371,11 @@ pub struct TokenProvider {
 }
 
 impl TokenProvider {
-    pub fn new(url: Url, access_token: String, key_id: String) -> Self {
-        let fetcher = TokenServerFetcher::new(url, access_token, key_id);
-        Self {
+    pub fn new(url: Url, access_token: String, key_id: String) -> Result<Self> {
+        let fetcher = TokenServerFetcher::new(url, access_token, key_id)?;
+        Ok(Self {
             imp: TokenProviderImpl::new(fetcher),
-        }
+        })
     }
 
     pub fn hashed_uid(&self) -> Result<String> {


### PR DESCRIPTION
Do we need anything more than this?

(Note that if a self-hoster manages to arrange for us to get the base URL without a trailing /, it's not going to do the right thing, but I think that's fine. Our fxa code ensures this is the case.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
