### PR TITLE
Replace excluded character in task name

### DIFF
--- a/buildSrc/src/main/java/NativeLibsPlugin.kt
+++ b/buildSrc/src/main/java/NativeLibsPlugin.kt
@@ -69,7 +69,8 @@ open class NativeLibsPlugin : Plugin<Project> {
                 afterEvaluate {
                     var copyNativeLibsTask = tasks.maybeCreate("copyNativeLibs")
                     ARCHS_FOLDERS.forEach { archFolder ->
-                        val copyLibsTask = tasks.maybeCreate("copyNativeLibs-$archFolder", Copy::class.java).apply {
+                        val taskName = archFolder.replace("/", "-")
+                        val copyLibsTask = tasks.maybeCreate("copyNativeLibs-$taskName", Copy::class.java).apply {
                             from("${rootProject.rootDir}/libs/$archFolder/${nativeLib.name}/lib/")
                             into("$buildDir/nativeLibs/$archFolder")
                             nativeLib.libs.forEach {


### PR DESCRIPTION
Fixes this error:
```
* What went wrong:
A problem occurred configuring project ':application-services:as-support-library'.
> Could not create task ':application-services:as-support-library:copyNativeLibs-android/armeabi-v7a'.
   > The task name 'copyNativeLibs-android/armeabi-v7a' must not contain any of the following characters: [/, \, :, <, >, ", ?, *, |].
```
Checklist not applicable.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
