### PR TITLE
[ci full] Build rust targets only for Android and the host platform by default

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -161,6 +161,8 @@ def gradle_module_task(libs_tasks, module_info, is_release):
     else:
         task_title = "{} - Build and test".format(module)
     task = android_task(task_title, libs_tasks)
+    # This is important as by default the Rust plugin will only cross-compile for Android + host platform.
+    task.with_script('echo "rust.targets=arm,arm64,x86_64,x86,darwin,linux-x86-64,win32-x86-64-gnu\n" > local.properties')
     if not is_release: # Makes builds way faster.
         task.with_script('echo "application-services.nonmegazord-profile=debug" >> local.properties')
     (

--- a/build.gradle
+++ b/build.gradle
@@ -213,15 +213,28 @@ if (localProperties != null) {
 
 // The Cargo targets to invoke.  The mapping from short name to target
 // triple is defined by the `rust-android-gradle` plugin.
+// They can be overwritten in `local.properties` by the `rust.targets`
+// attribute.
 ext.rustTargets = [
-    'linux-x86-64',
-    'darwin',
-    'win32-x86-64-gnu',
     'arm',
     'arm64',
     'x86_64',
     'x86',
 ]
+
+// Generate libs for our current platform so we can run unit tests.
+switch (DefaultPlatform.RESOURCE_PREFIX) {
+    case 'darwin':
+        ext.rustTargets += 'darwin'
+        break
+    case 'linux-x86-64':
+        ext.rustTargets += 'linux-x86-64'
+        break
+    case 'win32-x86-64':
+        ext.rustTargets += 'win32-x86-64-gnu'
+        break
+}
+
 // Configure some environment variables, per toolchain, that will apply during
 // the Cargo build.  We assume that the `libs/` directory has been populated
 // before invoking Gradle (or Cargo).


### PR DESCRIPTION
This has been bothering me for a while and @linacambridge hit the problem again today.
This should decrease the pain of new Android contributors.