### PR TITLE
Allow begin_transaction for read-only methods

### DIFF
--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -363,6 +363,23 @@ pub mod test {
             .open_connection(ConnectionType::ReadWrite)
             .expect("should get a connection")
     }
+
+    pub struct MemConnections {
+        pub read: PlacesDb,
+        pub write: PlacesDb,
+        pub api: Arc<PlacesApi>,
+    }
+
+    pub fn new_mem_connections() -> MemConnections {
+        let api = new_mem_api();
+        let read = api
+            .open_connection(ConnectionType::ReadOnly)
+            .expect("should get a read connection");
+        let write = api
+            .open_connection(ConnectionType::ReadWrite)
+            .expect("should get a write connection");
+        MemConnections { api, read, write }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We use this in a couple places in bookmarks. Initially I was going to take them out, but they actually are required for correctness, So I made things allow them.

https://www.sqlite.org/lang_transaction.html indicates that the first read will acquire a SHARED lock which will prevent other writes, which seems like what we want.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
