### PR TITLE
Fix rc_crypto on platforms where `long` is 32 bits [ci full]

### DIFF
--- a/components/support/rc_crypto/src/hkdf.rs
+++ b/components/support/rc_crypto/src/hkdf.rs
@@ -9,7 +9,12 @@ use crate::{
     util::{ensure_nss_initialized, map_nss_secstatus},
 };
 use nss_sys::*;
-use std::{convert::TryFrom, mem, os::raw::c_uchar, ptr};
+use std::{
+    convert::TryFrom,
+    mem,
+    os::raw::{c_uchar, c_ulong},
+    ptr,
+};
 
 pub fn extract_and_expand(
     salt: &hmac::SigningKey,
@@ -41,7 +46,7 @@ pub fn expand(prk: &hmac::SigningKey, info: &[u8], out: &mut [u8]) -> Result<()>
         ulSaltLen: 0,
         bExpand: CK_TRUE,
         pInfo: info.as_ptr() as *mut u8,
-        ulInfoLen: u64::try_from(info.len())?,
+        ulInfoLen: c_ulong::try_from(info.len())?,
     };
     let mut params = SECItem {
         type_: SECItemType::siBuffer,


### PR DESCRIPTION

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
