### PR TITLE
Use root project rust targets for megazords [ci full]

### DIFF
--- a/megazords/fenix/android/build.gradle
+++ b/megazords/fenix/android/build.gradle
@@ -63,15 +63,7 @@ cargo {
 
     // The Cargo targets to invoke.  The mapping from short name to target
     // triple is defined by the `rust-android-gradle` plugin.
-    targets = [
-        'linux-x86-64',
-        'darwin',
-        'win32-x86-64-gnu',
-        'arm',
-        'arm64',
-        'x86_64',
-        'x86',
-    ]
+    targets = rootProject.ext.rustTargets
 
     // Perform release builds (which should have debug info, due to
     // `debug = true` in Cargo.toml).

--- a/megazords/lockbox/android/build.gradle
+++ b/megazords/lockbox/android/build.gradle
@@ -64,15 +64,7 @@ cargo {
 
     // The Cargo targets to invoke.  The mapping from short name to target
     // triple is defined by the `rust-android-gradle` plugin.
-    targets = [
-        'linux-x86-64',
-        'darwin',
-        'win32-x86-64-gnu',
-        'arm',
-        'arm64',
-        'x86_64',
-        'x86',
-    ]
+    targets = rootProject.ext.rustTargets
 
     // Perform release builds (which should have debug info, due to
     // `debug = true` in Cargo.toml).

--- a/megazords/reference-browser/android/build.gradle
+++ b/megazords/reference-browser/android/build.gradle
@@ -63,15 +63,7 @@ cargo {
 
     // The Cargo targets to invoke.  The mapping from short name to target
     // triple is defined by the `rust-android-gradle` plugin.
-    targets = [
-        'linux-x86-64',
-        'darwin',
-        'win32-x86-64-gnu',
-        'arm',
-        'arm64',
-        'x86_64',
-        'x86',
-    ]
+    targets = rootProject.ext.rustTargets
 
     // Perform release builds (which should have debug info, due to
     // `debug = true` in Cargo.toml).


### PR DESCRIPTION
Looks like I missed some stuff in https://github.com/mozilla/application-services/pull/1028.