### PR TITLE
Use `bundled` feature of rusqlite where we don't need encryption. [ci full]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,7 +667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fallible-iterator"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1060,8 +1060,9 @@ dependencies = [
 [[package]]
 name = "libsqlite3-sys"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic#3099db5689dfdee830b4ae8bf7c7e130e85ef0e6"
 dependencies = [
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1115,7 +1116,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1134,7 +1135,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins 0.1.0",
- "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "sync15 0.1.0",
@@ -1524,7 +1525,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1550,7 +1551,6 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "places 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "sync15 0.1.0",
@@ -1667,7 +1667,7 @@ dependencies = [
  "mockito 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc_crypto 0.1.0",
- "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1686,7 +1686,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "push 0.1.0",
- "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sync15 0.1.0",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2006,12 +2006,12 @@ dependencies = [
 [[package]]
 name = "rusqlite"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic#3099db5689dfdee830b4ae8bf7c7e130e85ef0e6"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.13.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2196,7 +2196,7 @@ dependencies = [
  "interrupt 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
 ]
 
 [[package]]
@@ -2820,7 +2820,7 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-"checksum fallible-iterator 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eb7217124812dc5672b7476d0c2d20cfe9f7c0f1ba0904b674a9762a0212f72e"
+"checksum fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 "checksum fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 "checksum find-places-db 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "156072cf5b7e3974da51941bf050f5b8ab5a8df56ad5c1adbd8c07e9d9455b95"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
@@ -2858,7 +2858,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
-"checksum libsqlite3-sys 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44c0ae64aa0fc0c81fc1ddc9eae833e617e900677f83a72907b5535f08913d99"
+"checksum libsqlite3-sys 0.13.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)" = "<none>"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -2935,7 +2935,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "943b9f85622f53bcf71721e0996f23688e3942e51fc33766c2e24a959316767b"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
-"checksum rusqlite 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8ef7411f02f83d4ce1b9c6c043013ed141f01aa1a77c665fb6d72042a3705cf"
+"checksum rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)" = "<none>"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "libsqlite3-sys"
 version = "0.13.0"
-source = "git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic#3099db5689dfdee830b4ae8bf7c7e130e85ef0e6"
+source = "git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled#2e6e055890ca39b6b609cdb3f38dc2dfef106d48"
 dependencies = [
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1116,7 +1116,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1135,7 +1135,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins 0.1.0",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "sync15 0.1.0",
@@ -1525,7 +1525,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1667,7 +1667,7 @@ dependencies = [
  "mockito 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc_crypto 0.1.0",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1686,7 +1686,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "push 0.1.0",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sync15 0.1.0",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2006,12 +2006,12 @@ dependencies = [
 [[package]]
 name = "rusqlite"
 version = "0.17.0"
-source = "git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic#3099db5689dfdee830b4ae8bf7c7e130e85ef0e6"
+source = "git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled#2e6e055890ca39b6b609cdb3f38dc2dfef106d48"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.13.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
+ "libsqlite3-sys 0.13.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2196,7 +2196,7 @@ dependencies = [
  "interrupt 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)",
+ "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
 ]
 
 [[package]]
@@ -2858,7 +2858,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
-"checksum libsqlite3-sys 0.13.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)" = "<none>"
+"checksum libsqlite3-sys 0.13.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)" = "<none>"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -2935,7 +2935,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "943b9f85622f53bcf71721e0996f23688e3942e51fc33766c2e24a959316767b"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
-"checksum rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=no-sqlcipher-bundled-panic)" = "<none>"
+"checksum rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)" = "<none>"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ members = [
 opt-level = "s"
 debug = true
 lto = true
+
+[patch.crates-io]
+# Until https://github.com/jgallagher/rusqlite/pull/511 lands and is in a release.
+rusqlite = { git = "https://github.com/thomcc/rusqlite", branch = "no-sqlcipher-bundled-panic" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,7 @@ lto = true
 
 [patch.crates-io]
 # Until https://github.com/jgallagher/rusqlite/pull/511 lands and is in a release.
-rusqlite = { git = "https://github.com/thomcc/rusqlite", branch = "no-sqlcipher-bundled-panic" }
+# Note: this uses a different branchname than that PR, to work around issues with
+# various caches we have in CI (basically, the other branch got force pushed to,
+# and our CI was never the same)
+rusqlite = { git = "https://github.com/thomcc/rusqlite", branch = "sqlcipher-and-bundled" }

--- a/build.gradle
+++ b/build.gradle
@@ -236,18 +236,25 @@ switch (DefaultPlatform.RESOURCE_PREFIX) {
         break
 }
 
+// Use in-tree libs from the source directory in CI or if the git SHA is unset; otherwise use
+// downloaded libs.
+def libsRootDir = (System.getenv('CI') || ext.libsGitSha == null) ? rootProject.rootDir : rootProject.buildDir
+
 // Configure some environment variables, per toolchain, that will apply during
 // the Cargo build.  We assume that the `libs/` directory has been populated
 // before invoking Gradle (or Cargo).
 ext.cargoExec = { spec, toolchain ->
     spec.environment("OPENSSL_STATIC", "1")
-
-    // Use in-tree libs from the source directory in CI or if the git SHA is unset; otherwise use
-    // downloaded libs.
-    def libsRootDir = (System.getenv('CI') || ext.libsGitSha == null) ? rootProject.rootDir : rootProject.buildDir
-
     spec.environment("NSS_DIR",               new File(libsRootDir, "libs/${toolchain.folder}/nss").absolutePath)
     spec.environment("OPENSSL_DIR",           new File(libsRootDir, "libs/${toolchain.folder}/openssl").absolutePath)
+}
+// Strictly speaking, we could always specify `SQLCIPHER_LIB_DIR` and
+// `SQLCIPHER_INCLUDE_DIR`, and so long as everything else is configured right,
+// we wouldn't bring it in. That said, by only specifying it when we expect it
+// to be needed, we force a compilation (well, linking) failure if the
+// configuration is otherwise wrong.
+ext.cargoExecWithSQLCipher = { spec, toolchain ->
+    ext.cargoExec(spec, toolchain)
     spec.environment("SQLCIPHER_LIB_DIR",     new File(libsRootDir, "libs/${toolchain.folder}/sqlcipher/lib").absolutePath)
     spec.environment("SQLCIPHER_INCLUDE_DIR", new File(libsRootDir, "libs/${toolchain.folder}/sqlcipher/include").absolutePath)
 }

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -60,7 +60,7 @@ cargo {
 
     profile = rootProject.ext.nonMegazordProfile
 
-    exec = rootProject.ext.cargoExec
+    exec = rootProject.ext.cargoExecWithSQLCipher
 
     features {
         defaultAnd("reqwest")

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -34,7 +34,7 @@ interrupt = { path = "../support/interrupt" }
 
 [dependencies.rusqlite]
 version = "0.17.0"
-features = ["sqlcipher", "functions"]
+features = ["functions", "bundled"]
 
 [dev-dependencies]
 more-asserts = "0.2.1"

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -25,10 +25,6 @@ viaduct = { path = "../../viaduct" }
 interrupt = { path = "../../support/interrupt" }
 sql-support = { path = "../../support/sql" }
 
-[dependencies.rusqlite]
-version = "0.17.0"
-features = ["sqlcipher", "limits", "functions"]
-
 [dependencies.sync15]
 path = "../../sync15"
 

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -20,7 +20,7 @@ ece = "0.1.3"
 failure = "0.1.5"
 failure_derive = "0.1.5"
 log = "0.4.6"
-rusqlite = "0.17.0"
+rusqlite = { version = "0.17.0", features = ["bundled"] }
 url = "1.7.2"
 viaduct = { path = "../viaduct" }
 ffi-support = { path = "../support/ffi" }

--- a/components/push/ffi/Cargo.toml
+++ b/components/push/ffi/Cargo.toml
@@ -21,7 +21,7 @@ viaduct = { path = "../../viaduct" }
 
 [dependencies.rusqlite]
 version = "0.17.0"
-features = ["sqlcipher", "limits", "functions"]
+features = ["limits", "functions"]
 
 [dependencies.sync15]
 path = "../../sync15"

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -6,8 +6,7 @@ authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 license = "MPL-2.0"
 
 [features]
-default = ["sqlcipher"]
-sqlcipher = ["rusqlite/sqlcipher"]
+default = []
 log_query_plans = []
 
 [dependencies]

--- a/megazords/lockbox/android/build.gradle
+++ b/megazords/lockbox/android/build.gradle
@@ -70,7 +70,7 @@ cargo {
     // `debug = true` in Cargo.toml).
     profile = "release"
 
-    exec = rootProject.ext.cargoExec
+    exec = rootProject.ext.cargoExecWithSQLCipher
 }
 
 dependencies {

--- a/megazords/reference-browser/android/build.gradle
+++ b/megazords/reference-browser/android/build.gradle
@@ -69,7 +69,7 @@ cargo {
     // `debug = true` in Cargo.toml).
     profile = "release"
 
-    exec = rootProject.ext.cargoExec
+    exec = rootProject.ext.cargoExecWithSQLCipher
 }
 
 dependencies {


### PR DESCRIPTION
Fixes #760

This uses my branch of rusqlite until https://github.com/jgallagher/rusqlite/pull/511 lands / is usable in a release.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
