### PR TITLE
Use NSS with rust-hawk. Fixes #959

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,15 +105,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "base64"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -626,14 +617,6 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "error-chain"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -791,7 +774,6 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ffi-support 0.3.3",
  "force-viaduct-reqwest 0.1.0",
- "hawk 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,27 +844,13 @@ dependencies = [
 
 [[package]]
 name = "hawk"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hawk"
 version = "2.0.0"
-source = "git+https://github.com/eoger/rust-hawk?branch=use-openssl#721c7d72fb3c34d855c8563ca453e77f8e1ee9a9"
+source = "git+https://github.com/thomcc/rust-hawk?branch=config-crypto#3494003fd04fccedc6976fd22c73a04330c43dc8"
 dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1365,6 +1333,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,15 +1683,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1870,7 +1837,9 @@ version = "0.1.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hawk 2.0.0 (git+https://github.com/thomcc/rust-hawk?branch=config-crypto)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nss_sys 0.1.0",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2037,11 +2006,6 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "safemem"
-version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2271,7 +2235,6 @@ dependencies = [
  "base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "hawk 2.0.0 (git+https://github.com/eoger/rust-hawk?branch=use-openssl)",
  "interrupt 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2760,7 +2723,6 @@ dependencies = [
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5d608a38535c371b2a9149159f6dd2259af379f71e50c24d54a842de44bc5b19"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bindgen 0.49.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33e1b67a27bca31fd12a683b2a3618e275311117f48cfcc892e18403ff889026"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
@@ -2814,7 +2776,6 @@ dependencies = [
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b61fa891024a945da30a9581546e8cfaf5602c7b3f4c137a2805cf388f92075a"
-"checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
@@ -2836,8 +2797,7 @@ dependencies = [
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
-"checksum hawk 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ccb26fc177705af37f278bb3e31643650176d265cb4d233d651dde0660c17b8c"
-"checksum hawk 2.0.0 (git+https://github.com/eoger/rust-hawk?branch=use-openssl)" = "<none>"
+"checksum hawk 2.0.0 (git+https://github.com/thomcc/rust-hawk?branch=config-crypto)" = "<none>"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a89c4638cf4e02d9db29750659d2af13d9001b508716f77d4693ec8a1f8bda8"
@@ -2883,6 +2843,7 @@ dependencies = [
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
+"checksum once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "532c29a261168a45ce28948f9537ddd7a5dd272cc513b3017b1e82a88f962c37"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)" = "5a0d6b781aac4ac1bd6cafe2a2f0ad8c16ae8e1dd5184822a16c50139f8838d9"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
@@ -2909,7 +2870,6 @@ dependencies = [
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
-"checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -2939,7 +2899,6 @@ dependencies = [
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
-"checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -10,7 +10,6 @@ base64 = "0.10.1"
 byteorder = "1.3.1"
 bytes = "0.4"
 failure = "0.1.3"
-hawk = { version = "1.0.5", optional = true }
 hex = "0.3.2"
 lazy_static = "1.0.0"
 log = "0.4"
@@ -35,6 +34,6 @@ force-viaduct-reqwest = { path = "../support/force-viaduct-reqwest" }
 prost-build = "0.5"
 
 [features]
-browserid = ["openssl", "hawk"]
+browserid = ["openssl", "rc_crypto/hawk"]
 reqwest = ["viaduct/reqwest"]
 default = []

--- a/components/support/rc_crypto/Cargo.toml
+++ b/components/support/rc_crypto/Cargo.toml
@@ -11,6 +11,14 @@ crate-type = ["lib", "staticlib", "cdylib"]
 [dependencies]
 failure = "0.1.5"
 failure_derive = "0.1.5"
+log = "0.4.6"
+
+[dependencies.hawk]
+# Until https://github.com/taskcluster/rust-hawk/pull/23 lands
+git = "https://github.com/thomcc/rust-hawk"
+branch = "config-crypto"
+default-features = false
+optional = true
 
 [target.'cfg(not(target_os = "ios"))'.dependencies]
 nss_sys = { path = "nss_sys" }

--- a/components/support/rc_crypto/src/hawk_crypto.rs
+++ b/components/support/rc_crypto/src/hawk_crypto.rs
@@ -1,0 +1,162 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{digest, hmac, rand};
+use hawk::crypto as hc;
+use std::convert::{TryFrom, TryInto};
+
+impl From<crate::Error> for hc::CryptoError {
+    // Our errors impl `Fail`, so we can do this.
+    fn from(e: crate::Error) -> Self {
+        hc::CryptoError::Other(e.into())
+    }
+}
+
+pub(crate) struct NssCryptographer;
+
+impl hc::HmacKey for crate::hmac::SigningKey {
+    fn sign(&self, data: &[u8]) -> Result<Vec<u8>, hc::CryptoError> {
+        let digest = hmac::sign(&self, data)?;
+        Ok(digest.as_ref().into())
+    }
+}
+
+// I don't really see a reason to bother doing incremental hashing here. A
+// one-shot is going to be faster in many cases anyway, and the higher memory
+// usage probably doesn't matter given our usage.
+struct NssHasher {
+    buffer: Vec<u8>,
+    algorithm: &'static digest::Algorithm,
+}
+
+impl hc::Hasher for NssHasher {
+    fn update(&mut self, data: &[u8]) -> Result<(), hc::CryptoError> {
+        self.buffer.extend_from_slice(data);
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<Vec<u8>, hc::CryptoError> {
+        let digest = digest::digest(self.algorithm, &self.buffer)?;
+        let bytes: &[u8] = digest.as_ref();
+        Ok(bytes.to_owned())
+    }
+}
+
+impl hc::Cryptographer for NssCryptographer {
+    fn rand_bytes(&self, output: &mut [u8]) -> Result<(), hc::CryptoError> {
+        rand::fill(output)?;
+        Ok(())
+    }
+
+    fn new_key(
+        &self,
+        algorithm: hawk::DigestAlgorithm,
+        key: &[u8],
+    ) -> Result<Box<dyn hc::HmacKey>, hc::CryptoError> {
+        let k = hmac::SigningKey::new(algorithm.try_into()?, key);
+        Ok(Box::new(k))
+    }
+
+    fn constant_time_compare(&self, a: &[u8], b: &[u8]) -> bool {
+        crate::constant_time::verify_slices_are_equal(a, b).is_ok()
+    }
+
+    fn new_hasher(
+        &self,
+        algorithm: hawk::DigestAlgorithm,
+    ) -> Result<Box<dyn hc::Hasher>, hc::CryptoError> {
+        Ok(Box::new(NssHasher {
+            algorithm: algorithm.try_into()?,
+            buffer: vec![],
+        }))
+    }
+}
+
+impl TryFrom<hawk::DigestAlgorithm> for &'static digest::Algorithm {
+    type Error = hc::CryptoError;
+    fn try_from(algorithm: hawk::DigestAlgorithm) -> Result<Self, hc::CryptoError> {
+        match algorithm {
+            hawk::DigestAlgorithm::Sha256 => Ok(&digest::SHA256),
+            algo => {
+                log::warn!("Unsupported algorithm: {:?}", algo);
+                Err(hc::CryptoError::UnsupportedDigest(algo))
+            }
+        }
+    }
+}
+
+// Note: this doesn't initialize NSS!
+pub(crate) fn init() {
+    hawk::crypto::set_cryptographer(&crate::hawk_crypto::NssCryptographer)
+        .expect("Failed to initialize `hawk` cryptographer!")
+}
+
+#[cfg(test)]
+mod test {
+
+    // Based on rust-hawk's hash_consistency. This fails if we've messed up the hashing.
+    #[test]
+    fn test_hawk_hashing() {
+        crate::init_once();
+        let mut hasher1 = hawk::PayloadHasher::new("text/plain", hawk::SHA256).unwrap();
+        hasher1.update("pày").unwrap();
+        hasher1.update("load").unwrap();
+        let hash1 = hasher1.finish().unwrap();
+
+        let mut hasher2 = hawk::PayloadHasher::new("text/plain", hawk::SHA256).unwrap();
+        hasher2.update("pàyload").unwrap();
+        let hash2 = hasher2.finish().unwrap();
+
+        let hash3 = hawk::PayloadHasher::hash("text/plain", hawk::SHA256, "pàyload").unwrap();
+
+        let hash4 = // "pàyload" as utf-8 bytes
+            hawk::PayloadHasher::hash("text/plain", hawk::SHA256, &[112, 195, 160, 121, 108, 111, 97, 100]).unwrap();
+
+        assert_eq!(
+            hash1,
+            &[
+                228, 238, 241, 224, 235, 114, 158, 112, 211, 254, 118, 89, 25, 236, 87, 176, 181,
+                54, 61, 135, 42, 223, 188, 103, 194, 59, 83, 36, 136, 31, 198, 50
+            ]
+        );
+        assert_eq!(hash2, hash1);
+        assert_eq!(hash3, hash1);
+        assert_eq!(hash4, hash1);
+    }
+
+    // Based on rust-hawk's test_make_mac. This fails if we've messed up the signing.
+    #[test]
+    fn test_hawk_signing() {
+        crate::init_once();
+        let key = hawk::Key::new(
+            &[
+                11u8, 19, 228, 209, 79, 189, 200, 59, 166, 47, 86, 254, 235, 184, 120, 197, 75,
+                152, 201, 79, 115, 61, 111, 242, 219, 187, 173, 14, 227, 108, 60, 232,
+            ],
+            hawk::SHA256,
+        )
+        .unwrap();
+
+        let mac = hawk::mac::Mac::new(
+            hawk::mac::MacType::Header,
+            &key,
+            std::time::UNIX_EPOCH + std::time::Duration::new(1000, 100),
+            "nonny",
+            "POST",
+            "mysite.com",
+            443,
+            "/v1/api",
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            mac.as_ref(),
+            &[
+                192, 227, 235, 121, 157, 185, 197, 79, 189, 214, 235, 139, 9, 232, 99, 55, 67, 30,
+                68, 0, 150, 187, 192, 238, 21, 200, 209, 107, 245, 159, 243, 178
+            ]
+        );
+    }
+}

--- a/components/support/rc_crypto/src/util.rs
+++ b/components/support/rc_crypto/src/util.rs
@@ -36,6 +36,10 @@ pub fn ensure_nss_initialized() {
                 panic!("Could not initialize NSS: {}", error);
             }
         }
+        #[cfg(feature = "hawk")]
+        {
+            crate::hawk_crypto::init();
+        }
     })
 }
 

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -16,11 +16,10 @@ serde_derive = "1.0.79"
 serde_json = "1.0.28"
 url = "1.7.1"
 openssl = "0.10.12"
-hawk = { git = "https://github.com/eoger/rust-hawk", branch = "use-openssl" }
 log = "0.4"
 lazy_static = "1.0"
 base16 = "0.1.1"
 failure = "0.1.3"
-rc_crypto = { path = "../support/rc_crypto" }
+rc_crypto = { path = "../support/rc_crypto", features = ["hawk"] }
 viaduct = { path = "../viaduct" }
 interrupt = { path = "../support/interrupt" }

--- a/components/sync15/src/client.rs
+++ b/components/sync15/src/client.rs
@@ -170,6 +170,7 @@ impl SetupStorageClient for Sync15StorageClient {
 
 impl Sync15StorageClient {
     pub fn new(init_params: Sync15StorageClientInit) -> error::Result<Sync15StorageClient> {
+        rc_crypto::init_once();
         let tsc = token::TokenProvider::new(
             init_params.tokenserver_url,
             init_params.access_token,

--- a/components/sync15/src/token.rs
+++ b/components/sync15/src/token.rs
@@ -4,6 +4,7 @@
 
 use crate::error::{self, ErrorKind, Result};
 use crate::util::ServerTimestamp;
+use rc_crypto::hawk;
 use serde_derive::*;
 use std::borrow::{Borrow, Cow};
 use std::cell::RefCell;
@@ -230,6 +231,9 @@ struct TokenProviderImpl<TF: TokenFetcher> {
 
 impl<TF: TokenFetcher> TokenProviderImpl<TF> {
     fn new(fetcher: TF) -> Self {
+        // We check this at the real entrypoint of the application, but tests
+        // can/do bypass that, so check this here too.
+        rc_crypto::init_once();
         TokenProviderImpl {
             fetcher,
             current_state: RefCell::new(TokenState::NoToken),
@@ -245,7 +249,7 @@ impl<TF: TokenFetcher> TokenProviderImpl<TF> {
 
         let credentials = hawk::Credentials {
             id: token.id.clone(),
-            key: hawk::Key::new(token.key.as_bytes(), hawk::Digest::sha256())?,
+            key: hawk::Key::new(token.key.as_bytes(), hawk::SHA256)?,
         };
 
         Ok(TokenContext::new(


### PR DESCRIPTION
Probably shouldn't land until a rust-hawk release with https://github.com/taskcluster/rust-hawk/pull/23 goes out.

Note: Since we expect integration tests to fail here (#1033), I'll note that I've run them locally and they pass.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
