### PR TITLE
Fix #1058 - syncBookmarks API on iOS is private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Breaking Changes
 
 - It is no longer possible to create an encrypted places database. ([#950](https://github.com/mozilla/application-services/issues/950))
+- `syncBookmarks()` API is now marked `open` to be accessible outside the framework. ([#1058](https://github.com/mozilla/application-services/issues/1058))
 
 ### What's Fixed
 

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -103,7 +103,7 @@ public class PlacesAPI {
     /**
      * Sync the bookmarks collection.
      */
-    func syncBookmarks(unlockInfo: SyncUnlockInfo) throws {
+    open func syncBookmarks(unlockInfo: SyncUnlockInfo) throws {
         return try queue.sync {
             try PlacesError.unwrap { err in
                 sync15_bookmarks_sync(handle, unlockInfo.kid, unlockInfo.fxaAccessToken, unlockInfo.syncKey, unlockInfo.tokenserverURL, err)


### PR DESCRIPTION
One-liner and updated the changelog.