### PR TITLE
Use resource_class large for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,13 +162,13 @@ jobs:
     docker:
       - image: circleci/rust:latest
     # We have to use a machine with more RAM for tests so we don't run out of memory.
-    resource_class: medium+
+    resource_class: large
     steps:
       - rust-tests
   Rust tests - beta:
     docker:
       - image: circleci/rust:latest
-    resource_class: medium+
+    resource_class: large
     steps:
       - rust-tests:
           rust-version: "beta"


### PR DESCRIPTION
I have no clue if this will work.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
