### PR TITLE
Recalculate synced bookmark frecencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.0...master)
 
+## Places
+
+### What's New
+
+- Frecencies are now recalculated for bookmarked URLs after a sync.
+  ([#847](https://github.com/mozilla/application-services/issues/847))
+
 # v0.27.0 (_2019-04-22_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.26.2...v0.27.0)

--- a/components/places/src/frecency.rs
+++ b/components/places/src/frecency.rs
@@ -170,19 +170,19 @@ impl<'db, 's> FrecencyComputation<'db, 's> {
         // In case the visit is a redirect target, calculate the frecency
         // as if the original page was visited.
         // If it's a redirect source, we may want to use a lower bonus.
-        let get_recent_visits = format!("
-            SELECT
-                IFNULL(origin.visit_type, v.visit_type) AS visit_type,
-                target.visit_type AS target_visit_type,
-                ROUND((strftime('%s','now','localtime','utc') - v.visit_date/1000000)/86400) AS age_in_days
-            FROM moz_historyvisits v
-            LEFT JOIN moz_historyvisits origin ON origin.id = v.from_visit
-                AND v.visit_type BETWEEN {redirect_permanent} AND {redirect_temporary}
-            LEFT JOIN moz_historyvisits target ON v.id = target.from_visit
-                AND target.visit_type BETWEEN {redirect_permanent} AND {redirect_temporary}
-            WHERE v.place_id = :page_id
-            ORDER BY v.visit_date DESC
-            LIMIT {max_visits}",
+        let get_recent_visits = format!(
+            "SELECT
+                 IFNULL(origin.visit_type, v.visit_type) AS visit_type,
+                 target.visit_type AS target_visit_type,
+                 ROUND((now() - v.visit_date)/86400000) AS age_in_days
+             FROM moz_historyvisits v
+             LEFT JOIN moz_historyvisits origin ON origin.id = v.from_visit
+                 AND v.visit_type BETWEEN {redirect_permanent} AND {redirect_temporary}
+             LEFT JOIN moz_historyvisits target ON v.id = target.from_visit
+                 AND target.visit_type BETWEEN {redirect_permanent} AND {redirect_temporary}
+             WHERE v.place_id = :page_id
+             ORDER BY v.visit_date DESC
+             LIMIT {max_visits}",
             redirect_permanent = VisitTransition::RedirectPermanent as u8,
             redirect_temporary = VisitTransition::RedirectTemporary as u8,
             max_visits = self.settings.num_visits,


### PR DESCRIPTION
This commit recalculates stale frecencies for synced bookmark URLs,
chunking them to allow transactions on the main connection to interrupt
frecency calculation.

This commit also changes `score_recent_visits` to use the correct
timestamp unit: `now()` and `v.visit_date` are in milliseconds, not
microseconds as on Desktop.

Closes #847.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
