### PR TITLE
Some improvements and additional tests made when debugging iOS logins crash.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.1...master)
 
+## Logins
+
+### What's new
+
+- iOS only: Logins store has a new (static) `numOpenConnections` function, which can be used to detect leaks. ([#1070](https://github.com/mozilla/application-services/pull/1070))
+
 # v0.27.1 (_2019-04-26_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.0...v0.27.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,13 +733,16 @@ dependencies = [
 
 [[package]]
 name = "ffi-support"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -837,7 +840,7 @@ dependencies = [
  "ece 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "force-viaduct-reqwest 0.1.0",
  "hawk 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -864,7 +867,7 @@ name = "fxaclient_ffi"
 version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "fxa-client 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1160,7 +1163,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "force-viaduct-reqwest 0.1.0",
  "fxa-client 0.1.0",
  "interrupt 0.1.0",
@@ -1183,7 +1186,7 @@ version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins 0.1.0",
@@ -1568,7 +1571,7 @@ dependencies = [
  "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "find-places-db 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "force-viaduct-reqwest 0.1.0",
  "fxa-client 0.1.0",
@@ -1603,7 +1606,7 @@ version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "interrupt 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1718,7 +1721,7 @@ dependencies = [
  "error-support 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "force-viaduct-reqwest 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1741,7 +1744,7 @@ version = "0.1.0"
 dependencies = [
  "android_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "push 0.1.0",
@@ -1941,7 +1944,7 @@ name = "rc_log_ffi"
 version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2252,7 +2255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "sql-support"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "interrupt 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2722,7 +2725,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.3",
+ "ffi-support 0.3.4",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/logins/ffi/src/lib.rs
+++ b/components/logins/ffi/src/lib.rs
@@ -59,6 +59,11 @@ pub extern "C" fn sync15_passwords_state_new(
     })
 }
 
+#[no_mangle]
+pub extern "C" fn sync15_passwords_num_open_connections(error: &mut ExternError) -> u64 {
+    ffi_support::call_with_output(error, || ENGINES.len() as u64)
+}
+
 unsafe fn bytes_to_key_string(key_bytes: *const u8, len: usize) -> Option<String> {
     if len == 0 {
         log::info!("Opening/Creating unencrypted database!");

--- a/components/logins/ios/Logins/RustPasswordAPI.h
+++ b/components/logins/ios/Logins/RustPasswordAPI.h
@@ -27,6 +27,8 @@ typedef uint64_t Sync15PasswordEngineHandle;
 
 typedef struct Sync15PasswordsInterruptHandle Sync15PasswordsInterruptHandle;
 
+uint64_t sync15_passwords_num_open_connections(Sync15PasswordsError *_Nonnull error_out);
+
 Sync15PasswordEngineHandle sync15_passwords_state_new(char const *_Nonnull db_path,
                                                       char const *_Nonnull encryption_key,
                                                       Sync15PasswordsError *_Nonnull error_out);

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffi-support"
 edition = "2018"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 description = "A crate to help expose Rust functions over the FFI."
 repository = "https://github.com/mozilla/application-services"
@@ -26,3 +26,8 @@ failure_derive = "0.1.5"
 [dependencies.backtrace]
 optional = true
 version = "0.3.9"
+
+[dev-dependencies]
+rand = "0.6.5"
+rayon = "1.0.3"
+env_logger = "0.6.1"

--- a/components/support/ffi/src/handle_map.rs
+++ b/components/support/ffi/src/handle_map.rs
@@ -705,6 +705,23 @@ impl<T> ConcurrentHandleMap<T> {
         }
     }
 
+    /// Get the number of entries in the `ConcurrentHandleMap`.
+    ///
+    /// This takes the map's `read` lock.
+    #[inline]
+    pub fn len(&self) -> usize {
+        let map = self.map.read().unwrap();
+        map.len()
+    }
+
+    /// Returns true if the `ConcurrentHandleMap` is empty.
+    ///
+    /// This takes the map's `read` lock.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Insert an item into the map, returning the newly allocated handle to the
     /// item.
     ///
@@ -1018,6 +1035,7 @@ lazy_static::lazy_static! {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::sync::Arc;
 
     #[derive(PartialEq, Debug)]
     struct Foobar(usize);
@@ -1116,6 +1134,84 @@ mod test {
             let h1 = Handle::from_u64(h1u).unwrap();
             assert_eq!(map.get(h1).unwrap(), &Foobar(i + 1000));
         }
+    }
+
+    fn with_error<F: FnOnce(&mut ExternError) -> T, T>(callback: F) -> T {
+        let mut e = ExternError::success();
+        let result = callback(&mut e);
+        if let Some(m) = unsafe { e.get_and_consume_message() } {
+            panic!("unexpected error: {}", m);
+        }
+        result
+    }
+
+    struct DropChecking {
+        counter: Arc<AtomicUsize>,
+        id: usize,
+    }
+    impl Drop for DropChecking {
+        fn drop(&mut self) {
+            let val = self.counter.fetch_add(1, Ordering::SeqCst);
+            log::debug!("Dropped {} :: {}", self.id, val);
+        }
+    }
+    #[test]
+    fn test_concurrent_drop() {
+        use rand::prelude::*;
+        use rayon::prelude::*;
+        let _ = env_logger::try_init();
+        let drop_counter = Arc::new(AtomicUsize::new(0));
+        let id = Arc::new(AtomicUsize::new(1));
+        let map = ConcurrentHandleMap::new();
+        let count = 1000;
+        let mut handles = (0..count)
+            .into_par_iter()
+            .map(|_| {
+                let id = id.fetch_add(1, Ordering::SeqCst);
+                let handle = with_error(|e| {
+                    map.insert_with_output(e, || {
+                        log::debug!("Created {}", id);
+                        DropChecking {
+                            counter: drop_counter.clone(),
+                            id,
+                        }
+                    })
+                });
+                (id, handle)
+            })
+            .collect::<Vec<_>>();
+
+        handles.shuffle(&mut thread_rng());
+
+        assert_eq!(drop_counter.load(Ordering::SeqCst), 0);
+        handles.par_iter().for_each(|(id, h)| {
+            with_error(|e| {
+                map.call_with_output(e, *h, |val| {
+                    assert_eq!(val.id, *id);
+                })
+            });
+        });
+
+        assert_eq!(drop_counter.load(Ordering::SeqCst), 0);
+
+        handles.par_iter().for_each(|(id, h)| {
+            with_error(|e| {
+                map.call_with_output(e, *h, |val| {
+                    assert_eq!(val.id, *id);
+                })
+            });
+        });
+
+        handles.par_iter().for_each(|(id, h)| {
+            let item = map
+                .remove_u64(*h)
+                .expect("remove to succeed")
+                .expect("item to exist");
+            assert_eq!(item.id, *id);
+            let h = map.insert(item).into_u64();
+            map.delete_u64(h).expect("delete to succeed");
+        });
+        assert_eq!(drop_counter.load(Ordering::SeqCst), count);
     }
 
 }


### PR DESCRIPTION
It turns out that the error wasn't in the Rust code, but I wrote some tests and added some useful functionality to help track it down, and there's no reason not to land it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
    - This adds a new dev-dependency on [`rayon`](https://github.com/rayon-rs/rayon) to simplify concurrent testing. This is a well known and popular concurrency library, and used in m-c for parallel styling, webrender, etc.
    - This also adds a new dev-dependency to ffi_support on `rand` and `env_logger`, but these already existed as dev dependencies (and, in the case of `rand`, runtime dependencies) elsewhere in the tree.
