### PR TITLE
Separate Rust HTTP init from megazord init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.1...master)
 
+## Megazords
+
+### Breaking Changes
+
+- Megazord initialization is now separate from the initialization of the http client. ([#1066](https://github.com/mozilla/application-services/issues/1066))
+    - This is done to allow application that wish to defer initializing JNA
+      (which can be costly) until later. Now, you should use the `RustHttpConfig.setClient()` function from `org.mozilla.appservices:httpconfig`:
+
+        In `build.gradle`:
+        ```groovy
+        dependencies {
+            // ...
+            implementation "org.mozilla.appservices:httpconfig:${app_services_version}"
+            // ...
+        }
+        ```
+
+        In Kotlin:
+        ```kotlin
+        import mozilla.appservices.httpconfig.RustHttpConfig
+        // At some point after megazord init.
+        RustHttpConfig.setClient(lazy { /* your http client here */ })
+        ```
+
+        Note: The megazord init no longer takes the http client, so should look like either
+        ```kotlin
+        // Was: MyMegazord.init(lazy { /* your http client */ })
+        MyMegazord.init()
+        ```
+
+        Or, if you use reflection to allow substitions to function:
+        ```kotlin
+        // This was a more complex expression you can see below in the v0.24.0 changelog.
+        val megazordClass = Class.forName("mozilla.appservices.MyCoolMegazord")
+        val megazordInitMethod = megazordClass.getDeclaredMethod("init")
+        megazordInitMethod.invoke(megazordClass)
+        ```
+
+        Note that while RustHttpConfig does not work for non-megazord builds,
+        it's also harmless to initialize it in that case.
+
 # v0.27.1 (_2019-04-26_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.0...v0.27.1)

--- a/megazords/fenix/android/build.gradle
+++ b/megazords/fenix/android/build.gradle
@@ -80,9 +80,7 @@ dependencies {
     api project(path: ':push-library', configuration: 'withoutLib')
     api project(path: ':rustlog-library', configuration: 'withoutLib')
     api project(path: ':viaduct-library', configuration: 'withoutLib')
-    compile project(path: ':viaduct-library')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    api "org.mozilla.components:concept-fetch:$android_components_version"
 
     jnaForTest "net.java.dev.jna:jna:$jna_version@jar"
 }

--- a/megazords/fenix/android/src/main/java/mozilla/appservices/FenixMegazord.kt
+++ b/megazords/fenix/android/src/main/java/mozilla/appservices/FenixMegazord.kt
@@ -4,19 +4,15 @@
 
 package mozilla.appservices
 
-import mozilla.appservices.httpconfig.RustHttpConfig
-import mozilla.components.concept.fetch.Client
-
 class FenixMegazord {
     companion object {
         @JvmStatic
-        fun init(client: Lazy<Client>) {
+        fun init() {
             System.setProperty("mozilla.appservices.fxaclient_ffi_lib_name", "fenix")
             System.setProperty("mozilla.appservices.places_ffi_lib_name", "fenix")
             System.setProperty("mozilla.appservices.push_ffi_lib_name", "fenix")
             System.setProperty("mozilla.appservices.rc_log_ffi_lib_name", "fenix")
             System.setProperty("mozilla.appservices.viaduct_lib_name", "fenix")
-            RustHttpConfig.setClient(client)
         }
     }
 }

--- a/megazords/lockbox/android/build.gradle
+++ b/megazords/lockbox/android/build.gradle
@@ -80,10 +80,8 @@ dependencies {
     api project(path: ':logins-library', configuration: 'withoutLib')
     api project(path: ':rustlog-library', configuration: 'withoutLib')
     api project(path: ':viaduct-library', configuration: 'withoutLib')
-    compile project(path: ':viaduct-library')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    api "org.mozilla.components:concept-fetch:$android_components_version"
 
     jnaForTest "net.java.dev.jna:jna:$jna_version@jar"
 }

--- a/megazords/lockbox/android/src/main/java/mozilla/appservices/LockboxMegazord.kt
+++ b/megazords/lockbox/android/src/main/java/mozilla/appservices/LockboxMegazord.kt
@@ -4,18 +4,14 @@
 
 package mozilla.appservices
 
-import mozilla.appservices.httpconfig.RustHttpConfig
-import mozilla.components.concept.fetch.Client
-
 class LockboxMegazord {
     companion object {
         @JvmStatic
-        fun init(client: Lazy<Client>) {
+        fun init() {
             System.setProperty("mozilla.appservices.fxaclient_ffi_lib_name", "lockbox")
             System.setProperty("mozilla.appservices.logins_ffi_lib_name", "lockbox")
             System.setProperty("mozilla.appservices.rc_log_ffi_lib_name", "lockbox")
             System.setProperty("mozilla.appservices.viaduct_lib_name", "lockbox")
-            RustHttpConfig.setClient(client)
         }
     }
 }

--- a/megazords/reference-browser/android/build.gradle
+++ b/megazords/reference-browser/android/build.gradle
@@ -81,10 +81,8 @@ dependencies {
     api project(path: ':push-library', configuration: 'withoutLib')
     api project(path: ':rustlog-library', configuration: 'withoutLib')
     api project(path: ':viaduct-library', configuration: 'withoutLib')
-    compile project(path: ':viaduct-library')
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    api "org.mozilla.components:concept-fetch:$android_components_version"
 
     jnaForTest "net.java.dev.jna:jna:$jna_version@jar"
 }

--- a/megazords/reference-browser/android/src/main/java/mozilla/appservices/ReferenceBrowserMegazord.kt
+++ b/megazords/reference-browser/android/src/main/java/mozilla/appservices/ReferenceBrowserMegazord.kt
@@ -4,20 +4,16 @@
 
 package mozilla.appservices
 
-import mozilla.appservices.httpconfig.RustHttpConfig
-import mozilla.components.concept.fetch.Client
-
 class ReferenceBrowserMegazord {
     companion object {
         @JvmStatic
-        fun init(client: Lazy<Client>) {
+        fun init() {
             System.setProperty("mozilla.appservices.fxaclient_ffi_lib_name", "reference_browser")
             System.setProperty("mozilla.appservices.logins_ffi_lib_name", "reference_browser")
             System.setProperty("mozilla.appservices.places_ffi_lib_name", "reference_browser")
             System.setProperty("mozilla.appservices.push_ffi_lib_name", "reference_browser")
             System.setProperty("mozilla.appservices.rc_log_ffi_lib_name", "reference_browser")
             System.setProperty("mozilla.appservices.viaduct_lib_name", "reference_browser")
-            RustHttpConfig.setClient(client)
         }
     }
 }


### PR DESCRIPTION
Fixes #1066
Fixes #967 too, although that's not the point.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
    - I'll check this box when I finish manual testing.
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
