### PR TITLE
Update rusqlite to 0.18.0, getting us off of my branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,8 +1102,8 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.13.0"
-source = "git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled#2e6e055890ca39b6b609cdb3f38dc2dfef106d48"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1159,7 +1159,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
+ "rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1178,7 +1178,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins 0.1.0",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
+ "rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "sync15 0.1.0",
@@ -1573,7 +1573,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
+ "rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1715,7 +1715,7 @@ dependencies = [
  "mockito 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc_crypto 0.1.0",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
+ "rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1734,7 +1734,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "push 0.1.0",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
+ "rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sync15 0.1.0",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2053,13 +2053,13 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.17.0"
-source = "git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled#2e6e055890ca39b6b609cdb3f38dc2dfef106d48"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.13.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
+ "libsqlite3-sys 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2244,7 +2244,7 @@ dependencies = [
  "interrupt 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)",
+ "rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2944,7 +2944,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
-"checksum libsqlite3-sys 0.13.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)" = "<none>"
+"checksum libsqlite3-sys 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e310445ab028c374b9efaaed4b7a52a14e3b8ad5a1351b4bbd46dec03ffce717"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
@@ -3022,7 +3022,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)" = "943b9f85622f53bcf71721e0996f23688e3942e51fc33766c2e24a959316767b"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
-"checksum rusqlite 0.17.0 (git+https://github.com/thomcc/rusqlite?branch=sqlcipher-and-bundled)" = "<none>"
+"checksum rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "700720c977deb8b91c9d881dcbe3309c254d414078ca3856ea6647e569be3b66"
 "checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,10 +29,3 @@ members = [
 opt-level = "s"
 debug = true
 lto = true
-
-[patch.crates-io]
-# Until https://github.com/jgallagher/rusqlite/pull/511 lands and is in a release.
-# Note: this uses a different branchname than that PR, to work around issues with
-# various caches we have in CI (basically, the other branch got force pushed to,
-# and our CI was never the same)
-rusqlite = { git = "https://github.com/thomcc/rusqlite", branch = "sqlcipher-and-bundled" }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -24,7 +24,7 @@ ffi-support = { path = "../support/ffi" }
 interrupt = { path = "../support/interrupt" }
 
 [dependencies.rusqlite]
-version = "0.17.0"
+version = "0.18.0"
 features = ["sqlcipher", "limits"]
 
 [dev-dependencies]

--- a/components/logins/ffi/Cargo.toml
+++ b/components/logins/ffi/Cargo.toml
@@ -23,7 +23,7 @@ viaduct = { path = "../../viaduct" }
 sql-support = { path = "../../support/sql" }
 
 [dependencies.rusqlite]
-version = "0.17.0"
+version = "0.18.0"
 features = ["sqlcipher"]
 
 [dependencies.logins]

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -33,7 +33,7 @@ dogear = "0.2.2"
 interrupt = { path = "../support/interrupt" }
 
 [dependencies.rusqlite]
-version = "0.17.0"
+version = "0.18.0"
 features = ["functions", "bundled"]
 
 [dev-dependencies]

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -20,7 +20,7 @@ ece = "0.1.3"
 failure = "0.1.5"
 failure_derive = "0.1.5"
 log = "0.4.6"
-rusqlite = { version = "0.17.0", features = ["bundled"] }
+rusqlite = { version = "0.18.0", features = ["bundled"] }
 url = "1.7.2"
 viaduct = { path = "../viaduct" }
 ffi-support = { path = "../support/ffi" }

--- a/components/push/ffi/Cargo.toml
+++ b/components/push/ffi/Cargo.toml
@@ -20,7 +20,7 @@ push = { path = ".." }
 viaduct = { path = "../../viaduct" }
 
 [dependencies.rusqlite]
-version = "0.17.0"
+version = "0.18.0"
 features = ["limits", "functions"]
 
 [dependencies.sync15]

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -16,5 +16,5 @@ interrupt = { path = "../interrupt" }
 ffi-support = { path = "../ffi" }
 
 [dependencies.rusqlite]
-version = "0.17.0"
+version = "0.18.0"
 features = ["functions", "limits"]


### PR DESCRIPTION
#1047 moved us onto my local branch of rusqlite, which is undesirable for obvious reasons. This fixes that.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
