### PR TITLE
iOS CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,9 @@ jobs:
           command: |
             brew outdated carthage || brew upgrade carthage
             bash build-carthage.sh MozillaAppServices.framework.zip
+      - store_artifacts:
+          path: raw_xcodebuild.log
+          destination: logs/raw_xcodebuild.log
       - save_cache:
           name: Save Rust cache
           key: rust-cache-{{ arch }}-{{ checksum "Cargo.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,7 +236,11 @@ jobs:
           destination: logs/raw_xcodebuild.log
       - save_cache:
           name: Save Rust cache
-          key: rust-cache-{{ arch }}-{{ checksum "Cargo.lock" }}
+          # We use {{ epoch }} to always upload a fresh cache:
+          # Of course, restore_cache will not find this exact key,
+          # but it will fall back to the closest key (aka the most recent).
+          # See https://discuss.circleci.com/t/add-mechanism-to-update-existing-cache-key/9014/13
+          key: rust-cache-{{ arch }}-{{ checksum "Cargo.lock" }}-{{ epoch }}
           paths:
             - "./target"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,14 @@ commands:
           command: cargo bench --all
 
 jobs:
+  Check Swift formatting:
+    macos:
+      xcode: "10.1.0"
+    steps:
+      - checkout
+      - run: brew install swiftlint swiftformat
+      - run: swiftlint --strict
+      - run: swiftformat --lint --swiftversion 4 --verbose megazords
   Check Rust formatting:
     docker:
       - image: circleci/rust:latest
@@ -295,6 +303,9 @@ jobs:
             popd
 workflows:
   version: 2
+  swiftlint:
+    jobs:
+      - Check Swift formatting
   check-formating:
     jobs:
       - Check Rust formatting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,13 @@
 version: 2.1
 
 commands:
+  install-xcpretty:
+    steps:
+      - run:
+          name: Install xcpretty
+          command: |
+            gem install --user-install xcpretty
+            echo 'export PATH="$HOME/.gem/ruby/2.3.0/bin:$PATH"' >> $BASH_ENV
   install-mdbook:
     steps:
       - run:
@@ -182,7 +189,7 @@ jobs:
       - image: circleci/rust:latest
     steps:
       - bench-all
-  Carthage build:
+  iOS build and test:
     macos:
       xcode: "10.1.0"
     steps:
@@ -197,12 +204,24 @@ jobs:
       - build-libs:
           platform: ios
       - run:
-          name: Build Carthage archive
+          name: Setup build environment
           command: |
             rustup target add aarch64-apple-ios x86_64-apple-ios
+            carthage bootstrap --platform iOS
             brew update
-            brew outdated carthage || brew upgrade carthage
             brew install swift-protobuf
+            # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
+            xcrun instruments -w "iPhone 7 (12.1) [" || true
+      - run:
+          name: Run XCode tests
+          command: bash run-ios-tests.sh
+      - store_artifacts:
+          path: raw_xcodetest.log
+          destination: logs/raw_xcodetest.log
+      - run:
+          name: Build Carthage archive
+          command: |
+            brew outdated carthage || brew upgrade carthage
             bash build-carthage.sh MozillaAppServices.framework.zip
       - save_cache:
           name: Save Rust cache
@@ -306,13 +325,13 @@ workflows:
       - Sync integration tests
   carthage-framework:
     jobs:
-      - Carthage build:
+      - iOS build and test:
           filters:  # required since `Release` has tag filters AND requires `Build`
             tags:
               only: /.*/
       - Carthage release:
           requires:
-            - Carthage build
+            - iOS build and test
           filters:
             branches:
               ignore: /.*/

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
   - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
   - `cargo fmt` does not produce any changes to the code
   - `./gradlew ktlint detekt` runs without emitting any warnings
+  - `swiftformat --lint --swiftversion 4 megazords && swiftlint` runs without emitting any warnings
   - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
 - [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
 - [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one

--- a/.gitignore
+++ b/.gitignore
@@ -21,11 +21,12 @@ xcuserdata
 # Protobuf Swift
 *.pb.swift
 
-# Carthage built artifacts
+# Carthage generated artifacts
 Carthage
+MozillaAppServices.framework.zip
+raw_xcodebuild.log
+raw_xcodetest.log
 
 # Generated debug symbols
 crashreporter-symbols*
 automation/symbols-generation/bin/
-
-MozillaAppServices.framework.zip

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,5 @@
+included: # paths to include during linting. `--path` is ignored if present.
+  - megazords
+excluded:
+  - Carthage
+  - "megazords/ios/MozillaAppServicesTests"

--- a/build-carthage.sh
+++ b/build-carthage.sh
@@ -12,7 +12,10 @@ carthage update --platform iOS --cache-builds swift-protobuf
 ## When https://github.com/Carthage/Carthage/issues/2623 is fixed,
 ## carthage build --archive should work to produce a zip
 
-carthage build --no-skip-current --platform iOS --verbose
+set -o pipefail && \
+carthage build --no-skip-current --platform iOS --verbose | \
+tee raw_xcodebuild.log | \
+xcpretty
 
 # Exclude SwiftProtobuf.
 rm -rf Carthage/Build/iOS/SwiftProtobuf.framework*

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -339,7 +339,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE9D202820914D0D00F1C8FA /* Build configuration list for PBXNativeTarget "MozillaAppServices" */;
 			buildPhases = (
-				CEEA12EF20AA1D630018998A /* Run Script */,
+				CEEA12EF20AA1D630018998A /* Build Rust libraries */,
 				CE9D201B20914D0D00F1C8FA /* Sources */,
 				CE9D201C20914D0D00F1C8FA /* Frameworks */,
 				CE9D201D20914D0D00F1C8FA /* Headers */,
@@ -429,14 +429,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		CEEA12EF20AA1D630018998A /* Run Script */ = {
+		CEEA12EF20AA1D630018998A /* Build Rust libraries */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Run Script";
+			name = "Build Rust libraries";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/megazords/ios/MozillaAppServicesTests/LogTest.swift
+++ b/megazords/ios/MozillaAppServicesTests/LogTest.swift
@@ -1,23 +1,22 @@
+import Foundation
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import XCTest
-import Foundation
 
 @testable import MozillaAppServices
 
 class LogTests: XCTestCase {
-
     func writeTestLog(_ message: String) {
         RustLog.shared.logTestMessage(message: message)
         // Wait for the log to come in. Cludgey but good enough.
         Thread.sleep(forTimeInterval: 0.1)
         // Force us to synchronize on the queue.
-        let _ = RustLog.shared.isEnabled
+        _ = RustLog.shared.isEnabled
     }
 
     func testLogging() {
-        var logs: [(LogLevel, String?, String)] = [];
+        var logs: [(LogLevel, String?, String)] = []
 
         assert(!RustLog.shared.isEnabled)
 
@@ -35,7 +34,7 @@ class LogTests: XCTestCase {
         writeTestLog("Test1")
         XCTAssertEqual(logs.count, 2)
         do {
-            try RustLog.shared.enable { _, _, _ in return true }
+            try RustLog.shared.enable { _, _, _ in true }
             XCTFail("Enable should fail")
         } catch let error as RustLogError {
             switch error {
@@ -44,11 +43,11 @@ class LogTests: XCTestCase {
             default:
                 XCTFail("Wrong RustLogError: \(error)")
             }
-        } catch let error {
+        } catch {
             XCTFail("Wrong error: \(error)")
         }
         // tryEnable should return false
-        XCTAssert(!RustLog.shared.tryEnable { _, _, _ in return true });
+        XCTAssert(!RustLog.shared.tryEnable { _, _, _ in true })
 
         // Adjust the max level so that the test log (which is logged at info level)
         // will not be present.
@@ -67,7 +66,7 @@ class LogTests: XCTestCase {
         writeTestLog("Test4")
 
         XCTAssertEqual(logs.count, 3)
-        var counter = 0;
+        var counter = 0
         let didEnable = RustLog.shared.tryEnable { level, tag, msg in
             let info = "Rust | Level: \(level) | tag: \(String(describing: tag)) | message: \(msg)"
             print(info)
@@ -94,6 +93,5 @@ class LogTests: XCTestCase {
         XCTAssertEqual(logs.count, 6)
         // Should be disabled now,
         XCTAssert(!RustLog.shared.isEnabled)
-
     }
 }

--- a/megazords/ios/MozillaAppServicesTests/PlacesTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/PlacesTests.swift
@@ -1,8 +1,8 @@
+@testable import MozillaAppServices
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import XCTest
-@testable import MozillaAppServices
 // some utility functions for the test code
 
 func dynCmp<T: Equatable>(_ optVal: T?, _ optDynVal: Any?) -> Bool {
@@ -90,8 +90,8 @@ func checkTree(_ n: BookmarkNode, _ want: [String: Any], checkChildren: CheckChi
             XCTAssertEqual(children.count, wantedChildren.count)
             let nextCheckChildren = checkChildren == .onlyGUIDsInChildren ? .onlyGUIDs : checkChildren
             // we need `i` for comparing position, or we'd just use zip().
-            for i in 0..<children.count {
-                let child = children[i];
+            for i in 0 ..< children.count {
+                let child = children[i]
                 XCTAssertEqual(child.guid, fn.childGUIDs[i])
                 XCTAssertEqual(child.parentGUID, fn.guid)
                 XCTAssertEqual(Int(child.position), i)
@@ -141,11 +141,11 @@ let DummyTree0: [String: Any] = [
         [
             "type": "bookmark",
             "url": "http://www.github.com/",
-            "title": "github"
+            "title": "github",
         ],
         [
             "type": "separator",
-            ],
+        ],
         [
             "type": "folder",
             "title": "cool folder",
@@ -153,22 +153,22 @@ let DummyTree0: [String: Any] = [
                 [
                     "type": "bookmark",
                     "title": "example0",
-                    "url": "https://www.example0.com/"
+                    "url": "https://www.example0.com/",
                 ],
                 [
                     "type": "folder",
                     "title": "empty folder",
-                    "children": EmptyChildren
+                    "children": EmptyChildren,
                 ],
                 [
                     "type": "bookmark",
                     "title": "example1",
-                    "url": "https://www.example1.com/"
+                    "url": "https://www.example1.com/",
                 ],
-            ]
+            ],
         ],
-    ]
-];
+    ],
+]
 
 class PlacesTests: XCTestCase {
     // XXX: We don't clean up PlacesAPIs properly (issue 749), so
@@ -179,7 +179,7 @@ class PlacesTests: XCTestCase {
         // This method is called before the invocation of each test method in the class.
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("testdb-\(UUID().uuidString).db")
-        self.api = try! PlacesAPI(path: url.path)
+        api = try! PlacesAPI(path: url.path)
     }
 
     override func tearDown() {
@@ -195,21 +195,21 @@ class PlacesTests: XCTestCase {
             "children": [
                 [
                     "guid": BookmarkRoots.MenuFolderGUID,
-                    "children": EmptyChildren
+                    "children": EmptyChildren,
                 ],
                 [
                     "guid": BookmarkRoots.ToolbarFolderGUID,
-                    "children": EmptyChildren
+                    "children": EmptyChildren,
                 ],
                 [
                     "guid": BookmarkRoots.UnfiledFolderGUID,
-                    "children": EmptyChildren
+                    "children": EmptyChildren,
                 ],
                 [
                     "guid": BookmarkRoots.MobileFolderGUID,
-                    "children": EmptyChildren
-                ]
-            ]
+                    "children": EmptyChildren,
+                ],
+            ],
         ])
 
         insertTree(db, parent: BookmarkRoots.MenuFolderGUID, tree: DummyTree0)
@@ -219,13 +219,13 @@ class PlacesTests: XCTestCase {
         checkTree(got, [
             "guid": BookmarkRoots.MenuFolderGUID,
             "type": "folder",
-            "children": [DummyTree0]
+            "children": [DummyTree0],
         ])
 
         // Check recursive: false
         let noGrandkids = try! db.getBookmarksTree(rootGUID: BookmarkRoots.MenuFolderGUID, recursive: false)! as! BookmarkFolder
 
-        let expectedChildGuids =  ((got as! BookmarkFolder).children![0] as! BookmarkFolder).childGUIDs;
+        let expectedChildGuids = ((got as! BookmarkFolder).children![0] as! BookmarkFolder).childGUIDs
 
         checkTree(noGrandkids, [
             "guid": BookmarkRoots.MenuFolderGUID,
@@ -234,12 +234,11 @@ class PlacesTests: XCTestCase {
                 [
                     "type": "folder",
                     "title": "my favorite bookmarks",
-                    "childGUIDs": expectedChildGuids
-                ]
-            ]
+                    "childGUIDs": expectedChildGuids,
+                ],
+            ],
         ], checkChildren: .onlyGUIDsInChildren)
     }
-
 
     func testGetBookmark() {
         let db = api.getWriter()
@@ -250,10 +249,7 @@ class PlacesTests: XCTestCase {
         checkTree(try! db.getBookmark(guid: BookmarkRoots.MenuFolderGUID)!, [
             "guid": BookmarkRoots.MenuFolderGUID,
             "type": "folder",
-            "childGUIDs": [newFolderGUID, sepGUID]
+            "childGUIDs": [newFolderGUID, sepGUID],
         ], checkChildren: .onlyGUIDs)
-
-
     }
-
 }

--- a/megazords/ios/RustLog/RustLog.swift
+++ b/megazords/ios/RustLog/RustLog.swift
@@ -70,7 +70,7 @@ public enum LogLevelFilter: Int32 {
 /// false if we should disable the logger. You cannot call `disable()`
 /// from inside the callback (it's protected by a dispatch queue you're
 /// already running on).
-public typealias LogCallback = (_ level: LogLevel, _ tag: String?, _ message: String) -> Bool;
+public typealias LogCallback = (_ level: LogLevel, _ tag: String?, _ message: String) -> Bool
 
 /// The public interface to Rust's logger.
 ///
@@ -166,7 +166,7 @@ public enum RustLogError: Error {
 }
 
 @discardableResult
-fileprivate func rustCall<T>(_ callback: (UnsafeMutablePointer<RcLogError>) throws -> T) throws -> T {
+private func rustCall<T>(_ callback: (UnsafeMutablePointer<RcLogError>) throws -> T) throws -> T {
     var err = RcLogError(code: 0, message: nil)
     let result = try callback(&err)
     if err.code != 0 {
@@ -183,7 +183,7 @@ fileprivate func rustCall<T>(_ callback: (UnsafeMutablePointer<RcLogError>) thro
 }
 
 // This is the function actually passed to Rust.
-fileprivate func logCallbackFunc(level: Int32, optTagP: UnsafePointer<CChar>?, msgP: UnsafePointer<CChar>) {
+private func logCallbackFunc(level: Int32, optTagP: UnsafePointer<CChar>?, msgP: UnsafePointer<CChar>) {
     guard let callback = RustLog.shared.state.callback else {
         return
     }
@@ -204,7 +204,7 @@ fileprivate func logCallbackFunc(level: Int32, optTagP: UnsafePointer<CChar>?, m
 
 // This implements everything, but without synchronization. It needs to be
 // guarded by a queue, which is done by the RustLog class.
-fileprivate class RustLogState {
+private class RustLogState {
     var adapter: OpaquePointer?
     var callback: LogCallback?
 
@@ -216,7 +216,7 @@ fileprivate class RustLogState {
         }
         assert(self.callback == nil)
         self.callback = callback
-        self.adapter = try rustCall { error in
+        adapter = try rustCall { error in
             rc_log_adapter_create(logCallbackFunc, error)
         }
     }
@@ -226,7 +226,7 @@ fileprivate class RustLogState {
             return
         }
         self.adapter = nil
-        self.callback = nil
+        callback = nil
         rc_log_adapter_destroy(adapter)
     }
 
@@ -237,10 +237,10 @@ fileprivate class RustLogState {
         do {
             try enable(callback)
             return true
-        } catch let error {
-            let _ = callback(.error,
-                             "RustLog.swift",
-                             "RustLog.enable failed: \(error)")
+        } catch {
+            _ = callback(.error,
+                         "RustLog.swift",
+                         "RustLog.enable failed: \(error)")
             return false
         }
     }

--- a/run-ios-tests.sh
+++ b/run-ios-tests.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euvx
+
+# Help out iOS folks who might want to run this but haven't
+# updated rust recently.
+rustup update stable
+
+set -o pipefail && \
+xcodebuild \
+  -workspace ./megazords/ios/MozillaAppServices.xcodeproj/project.xcworkspace \
+  -scheme MozillaAppServices \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone X' \
+  test | \
+tee raw_xcodetest.log | \
+xcpretty && exit "${PIPESTATUS[0]}"


### PR DESCRIPTION
Fixes #607 #842

The last commit (`Use {{ epoch }} in the rust target cache key`) makes sure our Rust `target/` cache doesn't grow too big (I've noticed it's 5Gb now and takes a while to restore) by always uploading a new cache entry and letting CircleCI pick the most recent one on further runs.