### PR TITLE
iOS bookmarks reset and interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### What's new
 
 - iOS only: Logins store has a new (static) `numOpenConnections` function, which can be used to detect leaks. ([#1070](https://github.com/mozilla/application-services/pull/1070))
+
 ## Places
 
 ### What's New
@@ -18,6 +19,10 @@
   only be called for non-sync users, as syncing the bookmarks over will result
   in better handling of sync metadata, among other things.
   ([#1078](https://github.com/mozilla/application-services/pull/1078))
+- iOS: Sync can now be interrupted using the `interrupt` method
+  ([#1092](https://github.com/mozilla/application-services/pull/1092))
+- iOS: Sync metadata can be reset using the `resetBookmarksMetadata` method
+  ([#1092](https://github.com/mozilla/application-services/pull/1092))
 
 # v0.27.1 (_2019-04-26_)
 

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -108,6 +108,11 @@ internal interface LibPlacesFFI : Library {
         out_err: RustError.ByReference
     ): RawPlacesInterruptHandle?
 
+    fun places_new_sync_conn_interrupt_handle(
+        api: PlacesApiHandle,
+        out_err: RustError.ByReference
+    ): RawPlacesInterruptHandle?
+
     fun places_interrupt(
         conn: RawPlacesInterruptHandle,
         out_err: RustError.ByReference

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -176,7 +176,7 @@ internal interface LibPlacesFFI : Library {
     ): Long
 
     fun sync15_history_sync(
-        handle: PlacesConnectionHandle,
+        handle: PlacesApiHandle,
         key_id: String,
         access_token: String,
         sync_key: String,
@@ -185,11 +185,16 @@ internal interface LibPlacesFFI : Library {
     )
 
     fun sync15_bookmarks_sync(
-        handle: PlacesConnectionHandle,
+        handle: PlacesApiHandle,
         key_id: String,
         access_token: String,
         sync_key: String,
         tokenserver_url: String,
+        out_err: RustError.ByReference
+    )
+
+    fun places_api_reset_bookmarks(
+        handle: PlacesApiHandle,
         out_err: RustError.ByReference
     )
 

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -115,6 +115,15 @@ pub extern "C" fn places_api_return_write_conn(
     })
 }
 
+#[no_mangle]
+pub extern "C" fn places_api_reset_bookmarks(api_handle: u64, error: &mut ExternError) {
+    log::debug!("places_api_reset_bookmarks");
+    APIS.call_with_result(error, api_handle, |api| -> places::Result<_> {
+        api.reset_bookmarks()?;
+        Ok(())
+    })
+}
+
 /// Get the interrupt handle for a connection. Must be destroyed with
 /// `places_interrupt_handle_destroy`.
 #[no_mangle]

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -58,10 +58,18 @@ pub extern "C" fn places_api_new(db_path: FfiStr<'_>, error: &mut ExternError) -
     })
 }
 
-/// Instantiate a places connection. Returned connection must be freed with
-/// `places_connection_destroy`, although it should be noted that this will
-/// not destroy, or even close, connections already obtained from this
-/// object. Returns null and logs on errors (for now).
+/// Get an interrupt handle for the PlacesApi's sync connection.
+#[no_mangle]
+pub extern "C" fn places_new_sync_conn_interrupt_handle(
+    handle: u64,
+    error: &mut ExternError,
+) -> *mut SqlInterruptHandle {
+    log::debug!("places_new_sync_conn_interrupt_handle");
+    APIS.call_with_result(error, handle, |api| -> places::Result<_> {
+        api.new_sync_conn_interrupt_handle()
+    })
+}
+
 #[no_mangle]
 pub extern "C" fn places_connection_new(
     handle: u64,

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -148,6 +148,24 @@ public class PlacesAPI {
             }
         }
     }
+
+    /**
+     * Reset sync metadata for the bookmarks collection.
+     *
+     * - Throws:
+     *     - `PlacesError.unexpected`: When an error that has not specifically been exposed
+     *                                 to Swift is encountered (for example IO errors from
+     *                                 the database code, etc).
+     *     - `PlacesError.panic`: If the rust code panics while completing this
+     *                            operation. (If this occurs, please let us know).
+     */
+    open func resetBookmarksMetadata() throws {
+        return try queue.sync {
+            try PlacesError.unwrap { err in
+                places_api_reset_bookmarks(handle, err)
+            }
+        }
+    }
 }
 
 /**

--- a/components/places/ios/Places/RustPlacesAPI.h
+++ b/components/places/ios/Places/RustPlacesAPI.h
@@ -125,19 +125,22 @@ PlacesRustBuffer places_get_visit_infos(PlacesConnectionHandle handle,
                                         int32_t exclude_types,
                                         PlacesRustError *_Nonnull out_err);
 
-void sync15_history_sync(PlacesConnectionHandle handle,
+void sync15_history_sync(PlacesAPIHandle handle,
                          char const *_Nonnull key_id,
                          char const *_Nonnull access_token,
                          char const *_Nonnull sync_key,
                          char const *_Nonnull tokenserver_url,
                          PlacesRustError *_Nonnull out_err);
 
-void sync15_bookmarks_sync(PlacesConnectionHandle handle,
+void sync15_bookmarks_sync(PlacesAPIHandle handle,
                            char const *_Nonnull key_id,
                            char const *_Nonnull access_token,
                            char const *_Nonnull sync_key,
                            char const *_Nonnull tokenserver_url,
                            PlacesRustError *_Nonnull out_err);
+
+void places_api_reset_bookmarks(PlacesAPIHandle handle,
+                                PlacesRustError *_Nonnull out_err);
 
 // MARK: Bookmarks APIs
 

--- a/components/places/ios/Places/RustPlacesAPI.h
+++ b/components/places/ios/Places/RustPlacesAPI.h
@@ -142,6 +142,10 @@ void sync15_bookmarks_sync(PlacesAPIHandle handle,
 void places_api_reset_bookmarks(PlacesAPIHandle handle,
                                 PlacesRustError *_Nonnull out_err);
 
+RawPlacesInterruptHandle *_Nullable
+places_new_sync_conn_interrupt_handle(PlacesAPIHandle handle,
+                                      PlacesRustError *_Nonnull out_err);
+
 // MARK: Bookmarks APIs
 
 PlacesRustBuffer bookmarks_get_by_guid(PlacesConnectionHandle handle,

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -10,6 +10,7 @@ use crate::storage::{delete_meta, get_meta, put_meta};
 use crate::util::normalize_path;
 use lazy_static::lazy_static;
 use rusqlite::OpenFlags;
+use sql_support::SqlInterruptHandle;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::fs;
@@ -326,6 +327,15 @@ impl PlacesApi {
         store.reset(&sync15::StoreSyncAssociation::Disconnected)?;
 
         Ok(())
+    }
+
+    /// Get a new interrupt handle for the sync connection.
+    pub fn new_sync_conn_interrupt_handle(&self) -> Result<SqlInterruptHandle> {
+        // Probably not necessary to lock here, since this should only get
+        // called in startup.
+        let _guard = self.sync_state.lock().unwrap();
+        let conn = self.open_sync_connection()?;
+        Ok(conn.new_interrupt_handle())
     }
 }
 


### PR DESCRIPTION
Fixes #1084. 

This also exposes interrupt, which was never actually exposed from #883.

This is iOS only at the moment, although I added the FFI defs to the LibPlacesFFI.kt file to simplify exposing it in the future.

I also fixed a couple places where we used PlacesConnectionHandle that should be PlacesApiHandle. these are both type aliases for a 64 bit int type, so it doesn't matter, but this is more clear.

Additionally, I made sure we report errors during sync() as the correct type of error. Previously, they'd always come through as unknown errors.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --lint --swiftversion 4 megazords && swiftlint` runs without emitting any warnings
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
    - Interrupt is very hard to test, reset is covered by existing tests.
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
