### PR TITLE
Cleanup, optimizations, and fixes for panic handling in ffi_support

### DIFF
--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -15,7 +15,8 @@ travis-ci = { repository = "mozilla/application-services" }
 
 [features]
 default = []
-log_backtraces = ["backtrace"]
+log_panics = []
+log_backtraces = ["log_panics", "backtrace"]
 
 [dependencies]
 log = "0.4"

--- a/components/support/ffi/src/error.rs
+++ b/components/support/ffi/src/error.rs
@@ -252,6 +252,7 @@ impl From<Box<dyn std::any::Any + Send + 'static>> for ExternError {
         } else {
             "Unknown panic!".to_string()
         };
+        log::error!("Caught a panic calling rust code: {:?}", message);
         ExternError::new_error(ErrorCode::PANIC, message)
     }
 }

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -174,10 +174,7 @@ pub use crate::handle_map::{ConcurrentHandleMap, Handle, HandleError, HandleMap}
 pub fn call_with_result<R, E, F>(out_error: &mut ExternError, callback: F) -> R::Value
 where
     F: panic::UnwindSafe + FnOnce() -> Result<R, E>,
-    // It would be nice to only require std::fmt::Debug if the `log_backtraces`
-    // feature is on, but there's not really a way to do that in stable rust (at least
-    // not in a way that wouldn't add more work for consumers of this lib).
-    E: Into<ExternError> + std::fmt::Debug,
+    E: Into<ExternError>,
     R: IntoFfi,
 {
     call_with_result_impl(out_error, callback)
@@ -208,7 +205,7 @@ where
 fn call_with_result_impl<R, E, F>(out_error: &mut ExternError, callback: F) -> R::Value
 where
     F: panic::UnwindSafe + FnOnce() -> Result<R, E>,
-    E: Into<ExternError> + std::fmt::Debug,
+    E: Into<ExternError>,
     R: IntoFfi,
 {
     *out_error = ExternError::success();

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -225,7 +225,6 @@ where
             o
         }
         Err(e) => {
-            log::error!("Caught a panic calling rust code: {:?}", e);
             *out_error = e.into();
             R::ffi_default()
         }

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -423,18 +423,12 @@ impl ByteBuffer {
     /// This will panic if the buffer length (`usize`) cannot fit into a `i64`.
     #[inline]
     pub fn from_vec(bytes: Vec<u8>) -> Self {
+        use std::convert::TryFrom;
         let mut buf = bytes.into_boxed_slice();
         let data = buf.as_mut_ptr();
-        let len = buf.len();
-        assert!(
-            len as i64 >= 0 && (len as u64) <= (i64::max_value() as u64),
-            "buffer length cannot fit into a i64."
-        );
+        let len = i64::try_from(buf.len()).expect("buffer length cannot fit into a i64.");
         std::mem::forget(buf);
-        Self {
-            data,
-            len: len as i64,
-        }
+        Self { data, len }
     }
 
     /// Convert this `ByteBuffer` into a Vec<u8>. This is the only way

--- a/components/support/ffi/src/macros.rs
+++ b/components/support/ffi/src/macros.rs
@@ -21,12 +21,12 @@ macro_rules! implement_into_ffi_by_pointer {
 
             #[inline]
             fn ffi_default() -> *mut $T {
-                ::std::ptr::null_mut()
+                std::ptr::null_mut()
             }
 
             #[inline]
             fn into_ffi_value(self) -> *mut $T {
-                ::std::boxed::Box::into_raw(::std::boxed::Box::new(self))
+                Box::into_raw(Box::new(self))
             }
         }
     )*}
@@ -64,13 +64,13 @@ macro_rules! implement_into_ffi_by_pointer {
 macro_rules! implement_into_ffi_by_json {
     ($($T:ty),* $(,)*) => {$(
         unsafe impl $crate::IntoFfi for $T where $T: serde::Serialize {
-            type Value = *mut ::std::os::raw::c_char;
+            type Value = *mut std::os::raw::c_char;
             #[inline]
-            fn ffi_default() -> *mut ::std::os::raw::c_char {
-                ::std::ptr::null_mut()
+            fn ffi_default() -> *mut std::os::raw::c_char {
+                std::ptr::null_mut()
             }
             #[inline]
-            fn into_ffi_value(self) -> *mut ::std::os::raw::c_char {
+            fn into_ffi_value(self) -> *mut std::os::raw::c_char {
                 // This panic is inside our catch_panic, so it should be fine.
                 // We've also documented the case where the IntoFfi impl that
                 // calls this panics, and it's rare enough that it shouldn't
@@ -183,7 +183,7 @@ macro_rules! define_string_destructor {
     ($mylib_destroy_string:ident) => {
         #[doc = "Public destructor for strings managed by the other side of the FFI."]
         #[no_mangle]
-        pub unsafe extern "C" fn $mylib_destroy_string(s: *mut ::std::os::raw::c_char) {
+        pub unsafe extern "C" fn $mylib_destroy_string(s: *mut std::os::raw::c_char) {
             if !s.is_null() {
                 $crate::destroy_c_string(s)
             }
@@ -217,7 +217,7 @@ macro_rules! define_box_destructor {
         #[no_mangle]
         pub unsafe extern "C" fn $destructor_name(v: *mut $T) {
             if !v.is_null() {
-                drop(::std::boxed::Box::from_raw(v))
+                drop(Box::from_raw(v))
             }
         }
     };
@@ -281,7 +281,7 @@ macro_rules! define_handle_map_deleter {
         pub extern "C" fn $destructor_name(v: u64, err: &mut $crate::ExternError) {
             $crate::call_with_result(err, || {
                 // Force type errors here.
-                let map: &ConcurrentHandleMap<_> = &*$HANDLE_MAP_NAME;
+                let map: &$crate::ConcurrentHandleMap<_> = &*$HANDLE_MAP_NAME;
                 map.delete_u64(v)
             })
         }


### PR DESCRIPTION
This is a mix of fairly small changes I've kind of wanted to do for a while, and some real bugs I noticed while doing those changes.

The actual bugs are:

- Not handling panics in the destruction functions (this is somewhat significant, as it can be a memory safety issue).
- Improper panic handling in `ConcurrentHandleMap::delete{,_u64}` (not huge in practice, since our dtors very rarely panic)
- Logging the panic message (previously we always logged 'Caught a panic calling rust code: Any', which is unhelpful).
- Not using `$crate::ConcurrentHandleMap` in define_handle_map_deleter (the downside of this is very minor and just means someone might need to `use ffi_support::ConcurrentHandleMap` for that macro to work.

The rest are small cleanups (and an optimization that probably doesn't matter in practice for our usage, although is somewhat significant).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
