### PR TITLE
fix(docs): use correct param names in regex delimiters

### DIFF
--- a/docs/product-portal/accounts/metrics.md
+++ b/docs/product-portal/accounts/metrics.md
@@ -41,8 +41,8 @@ By following these instructions you provide both of our teams with data needed t
 |Name|Description|Example Values|Validation regex|Amplitude Chart Example|
 |----|-----------|--------------|----------------|-----------------------|
 |`entrypoint`|The specific page or browser UI element containing the first step of the FxA sign-in/sign-up process (e.g., enter email form)|`firstrun`|<!--begin-validation-entrypoint-->^[\w.:-]+$<!--end-validation-entrypoint-->|[Firstrun form views](https://analytics.amplitude.com/mozilla-corp/chart/n8cd9no)|
-|`entrypoint_experiment`|Identifier for the experiment the user is part of (if any)||<!--begin-validation-entrypoint-experiment-->^[\w.:-]+$<!--end-validation-entrypoint-experiment-->||
-|`entrypoint_variation`|Identifier for the experiment variation the user is part of (if any)||<!--begin-validation-entrypoint-variation-->^[\w.:-]+$<!--end-validation-entrypoint-variation-->||
+|`entrypoint_experiment`|Identifier for the experiment the user is part of (if any)||<!--begin-validation-entrypoint_experiment-->^[\w.:-]+$<!--end-validation-entrypoint_experiment-->||
+|`entrypoint_variation`|Identifier for the experiment variation the user is part of (if any)||<!--begin-validation-entrypoint_variation-->^[\w.:-]+$<!--end-validation-entrypoint_variation-->||
 |`form_type`|For self-hosted forms only (see above) the type of form that the user submits to begin the FxA flow|either: `email` if the form captures the user's email, otherwise `other`||NA|
 |`utm_source`|Unambiguous identifier of site or browser UI element that linked to the page containing the beginning of the FxA sign-in/sign-up process |`blog.mozilla.org`|<!--begin-validation-utm_source-->^[\w\/.%-]+$<!--end-validation-utm_source-->|[Registration form views segmented by utm_source](https://analytics.amplitude.com/mozilla-corp/chart/f5sz7kt)|
 |`utm_campaign`|More general label for the campaign that the site is part of|`firstrun`|<!--begin-validation-utm_campaign-->^[\w\/.%-]+$<!--end-validation-utm_campaign-->|TBD|


### PR DESCRIPTION
I added validation regexes for these parameters in #1009 but gave them hyphens instead of underscores, so the tests are failing in my content server branch.

@mozilla/fxa-devs r?