### PR TITLE
Use recommended -DHAVE_USLEEP=1 setting when building SQLCipher on iOS.

### DIFF
--- a/libs/build-sqlcipher-ios.sh
+++ b/libs/build-sqlcipher-ios.sh
@@ -58,6 +58,8 @@ CFLAGS="\
 # Match the SQLCIPHER_CFLAGS used in Firefox for iOS v15.x and earlier.
 # NOTE: iOS v15.x and earlier used -DSQLITE_THREADSAFE=2, but the
 # SQLCipher `configure` script seems to overwrite it to only be 0 or 1.
+# NOTE: iOS v16.x and earlier did not use -DHAVE_USLEEP=1, but it seems
+# like a safe setting since it prevents sleep with <1000ms precision.
 SQLCIPHER_CFLAGS=" \
   -DNDEBUG=1 \
   -DSQLITE_HAS_CODEC \
@@ -69,11 +71,11 @@ SQLCIPHER_CFLAGS=" \
   -DSQLITE_ENABLE_FTS3_PARENTHESIS \
   -DSQLITE_ENABLE_FTS4 \
   -DSQLITE_ENABLE_FTS5 \
+  -DHAVE_USLEEP=1 \
 "
 # These additional options are used on desktop, but are not currently
 # used on iOS until we can performance test them:
 #   -DSQLITE_SOUNDEX \
-#   -DHAVE_USLEEP=1 \
 #   -DSQLITE_ENABLE_MEMORY_MANAGEMENT=1 \
 #   -DSQLITE_ENABLE_LOAD_EXTENSION \
 #   -DSQLITE_ENABLE_COLUMN_METADATA \


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
