### PR TITLE
feat: Add LiveTest code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,8 +323,8 @@ dependencies = [
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -380,8 +380,8 @@ dependencies = [
  "rand_xoshiro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tinytemplate 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -494,7 +494,7 @@ dependencies = [
  "csv-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -573,6 +573,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ece"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ece"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -816,8 +831,8 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sync15 0.1.0",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1113,8 +1128,8 @@ dependencies = [
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "sync15 0.1.0",
@@ -1510,8 +1525,8 @@ dependencies = [
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1639,7 +1654,7 @@ name = "push"
 version = "0.1.0"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ece 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ece 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1652,8 +1667,8 @@ dependencies = [
  "mockito 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1950,7 +1965,7 @@ dependencies = [
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2089,12 +2104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2109,7 +2124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2119,7 +2134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2249,8 +2264,8 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "viaduct 0.1.0",
@@ -2369,7 +2384,7 @@ name = "tinytemplate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2585,7 +2600,7 @@ name = "url_serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2631,7 +2646,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2820,6 +2835,7 @@ dependencies = [
 "checksum dogear 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "30ac4a8e8f834f02deb2266b1f279aa5494e990c625d8be8f2988a7c708ba1f8"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum ece 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f40068e2a282e5c6fc8c8881d191c3d1ffa10ada2aac0201e274e57a91004851"
+"checksum ece 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4407b4c6ff148e63f1e7b5f78782dcea90f0b891edf0fc640420d74ffbb1dc79"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
@@ -2958,8 +2974,8 @@ dependencies = [
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
-"checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
+"checksum serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "a72e9b96fa45ce22a4bc23da3858dfccfd60acd28a25bcd328a98fdd6bea43fd"
+"checksum serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)" = "101b495b109a3e3ca8c4cbe44cf62391527cdfb6ba15821c5ce80bcd5ea23f9f"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -10,13 +10,13 @@ reqwest = ["viaduct/reqwest"]
 default = []
 
 [dependencies]
-serde = "1.0.90"
-serde_derive = "1.0.90"
+serde = "1.0.91"
+serde_derive = "1.0.91"
 serde_json = "1.0.39"
 lazy_static = "1.3.0"
-openssl = "= 0.10.20"
+openssl = "0.10.20"
 base64 = "0.10.1"
-ece = "0.1.3"
+ece = "0.2.0"
 failure = "0.1.5"
 failure_derive = "0.1.5"
 log = "0.4.6"
@@ -29,7 +29,7 @@ error-support = { path = "../support/error" }
 
 [dev-dependencies]
 env_logger = "0.6.1"
-mockito = "0.17.0"
+mockito = "0.17.1"
 hex = "0.3.2"
 force-viaduct-reqwest = { path = "../support/force-viaduct-reqwest" }
 

--- a/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
+++ b/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
@@ -249,7 +249,6 @@ class PushTest {
     fun testDuplicateSubscription() {
         val manager = getPushManager()
 
-        val testChannelId = "deadbeef00000000decafbad00000000"
         val response1 = manager.subscribe(testChannelid, "foo")
         val response2 = manager.subscribe(testChannelid, "foo")
         assertEquals(response1.channelID, response2.channelID)

--- a/components/push/examples/livetest.rs
+++ b/components/push/examples/livetest.rs
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use hex;
+
+use push::communications::Connection;
+use push::config::PushConfiguration;
+use push::crypto::get_bytes;
+use push::error::Result;
+use push::subscriber::PushManager;
+
+/** Perform a "Live" test against a locally configured push server
+ *
+ * See https://autopush.readthedocs.io/en/latest/testing.html on
+ * setting up a local push server. This will also create a local
+ * test database under "/tmp". This database should be deleted before
+ * you re-run this test.
+ *
+ * NOTE: if you wish to do a "live" test inside of the kotlin layer,
+ * See `PushTest.kt` and look for "LIVETEST".
+ */
+
+fn dummy_uuid() -> Result<String> {
+    // Use easily findable "test" UUIDs
+    Ok(format!(
+        "deadbeef-{}-{}-{}-{}",
+        hex::encode(&get_bytes(2)?),
+        hex::encode(&get_bytes(2)?),
+        hex::encode(&get_bytes(2)?),
+        hex::encode(&get_bytes(6)?),
+    ))
+}
+
+fn test_live_server() -> Result<()> {
+    let config = PushConfiguration {
+        http_protocol: Some("http".to_owned()),
+        server_host: "localhost:8082".to_owned(),
+        sender_id: "fir-bridgetest".to_owned(),
+        bridge_type: Some("fcm".to_owned()),
+        registration_id: Some("SomeRegistrationValue".to_owned()),
+        ..Default::default()
+    };
+
+    let mut pm = PushManager::new(config)?;
+    let channel1 = dummy_uuid()?;
+    let channel2 = dummy_uuid()?;
+
+    println!("Channels: [{}, {}]", channel1, channel2);
+
+    println!("\n == Subscribing channels");
+    let sub1 = pm.subscribe(&channel1, "").expect("subscribe failed");
+    // These are normally opaque values, displayed here for debug.
+    println!("Connection info: {:?}", (&pm.conn.uaid, &pm.conn.auth));
+    println!("## Subscription 1: {:?}", sub1);
+    let sub2 = pm.subscribe(&channel2, "")?;
+    println!("## Subscription 2: {:?}", sub2);
+
+    // You don't need to do this, normally. This is just for
+    // debugging and analysis.
+    println!("\n == Fetching channel list 1");
+    let ll = pm.conn.channel_list().expect("channel list failed");
+    println!("Server Known channels: {:?}", ll);
+
+    println!("\n == Unsubscribing single channel");
+    pm.unsubscribe(Some(&channel1)).expect("chid unsub failed");
+    println!("\n == Fetching channel list 2");
+    let ll = pm.conn.channel_list().expect("channel list failed");
+    println!("Server Known channels: {:?}", ll);
+
+    // the list of known channels should come from whatever is
+    // holding the index of channels to recipient applications.
+    println!("Verify: {:?}", pm.verify_connection());
+
+    println!("\n == Fetching channel list 3");
+    let ll = pm.conn.channel_list().expect("channel list failed");
+    println!("Server Known channels: {:?}", ll);
+
+    println!("\n == Unsubscribing all.");
+    // Unsubscribe all channels.
+    pm.unsubscribe(None)?;
+
+    println!("Done");
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    test_live_server()
+}

--- a/components/push/src/subscriber.rs
+++ b/components/push/src/subscriber.rs
@@ -193,6 +193,7 @@ impl PushManager {
 #[cfg(test)]
 mod test {
     use super::*;
+    use openssl::rand::rand_bytes;
 
     #[test]
     fn basic() -> Result<()> {
@@ -218,14 +219,13 @@ mod test {
     #[test]
     fn full() -> Result<()> {
         use ece;
-        use openssl::rand::rand_bytes;
         use serde_json;
 
         let data_string = b"Mary had a little lamb, with some nice mint jelly";
         let test_channel_id = "deadbeef00000000decafbad00000000";
         let test_config = PushConfiguration {
             sender_id: "test".to_owned(),
-            database_path: Some("/tmp/test.db".to_owned()),
+            // database_path: Some("test.db"),
             ..Default::default()
         };
         let mut pm = PushManager::new(test_config)?;


### PR DESCRIPTION
Look for "LIVETEST" to enable. This codifies stub code that I tend to
use to test against a "live" server.
* Update to use rust-ece 1.2
* Adds a full subscription/description unit test to subscriber
* fixes livetest stub in communications.

Closes #1094

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one - NA
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
