### PR TITLE
Replace `try!` with `unwrapOrLog` in ios places read conn deinit. Fixes #1111

### DIFF
--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -237,9 +237,8 @@ public class PlacesReadConnection {
         // Note: don't need to queue.sync in deinit -- no more references exist to us.
         let handle = self.takeHandle()
         if handle != 0 {
-            // In practice this can only fail if the rust code panics, which for this
-            // function would be quite bad.
-            try! PlacesError.tryUnwrap { err in
+            // In practice this can only fail if the rust code panics.
+            PlacesError.unwrapOrLog { err in
                 places_connection_destroy(handle, err)
             }
         }


### PR DESCRIPTION
If this is a bug, we'll see this error move to something else.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
