### PR TITLE
feat: alter `verify_connection` to just return boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@
 - iOS: Sync metadata can be reset using the `resetBookmarksMetadata` method
   ([#1092](https://github.com/mozilla/application-services/pull/1092))
 
+## Push
+
+### Breaking Changes
+
+- `PushManager.verify_connection()` now returns a boolean. `true`
+  indicates the connection is valid and no action required, `false`
+indicates that the connection is invalid. All existing subscriptions
+have been dropped. The caller should send a `pushsubscriptionchange`
+to all known apps. (This is due to the fact that the Push API does
+not have a way to send just the new endpoint to the client PWA.)
+
 # v0.27.1 (_2019-04-26_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.0...v0.27.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,16 +22,6 @@
 - iOS: Sync metadata can be reset using the `resetBookmarksMetadata` method
   ([#1092](https://github.com/mozilla/application-services/pull/1092))
 
-## Push
-
-### Breaking Changes
-
-- `PushManager.verify_connection()` now returns a boolean. `true`
-  indicates the connection is valid and no action required, `false`
-indicates that the connection is invalid. All existing subscriptions
-have been dropped. The caller should send a `pushsubscriptionchange`
-to all known apps. (This is due to the fact that the Push API does
-not have a way to send just the new endpoint to the client PWA.)
 
 # v0.27.1 (_2019-04-26_)
 

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -4,3 +4,14 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.2...master)
 
+## Push
+
+### Breaking Changes
+
+- `PushManager.verifyConnection()` now returns a boolean. `true`
+  indicates the connection is valid and no action required, `false`
+indicates that the connection is invalid. All existing subscriptions
+have been dropped. The caller should send a `pushsubscriptionchange`
+to all known apps. (This is due to the fact that the Push API does
+not have a way to send just the new endpoint to the client PWA.) 
+[#1114](https://github.com/mozilla/application-services/issues/1114) 

--- a/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
@@ -75,7 +75,7 @@ internal interface LibPushFFI : Library {
     fun push_verify_connection(
         mgr: PushManagerHandle,
         out_err: RustError.ByReference
-    ): Pointer?
+    ): Byte
 
     fun push_decrypt(
         mgr: PushManagerHandle,

--- a/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
+++ b/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
@@ -218,8 +218,7 @@ class PushTest {
         manager.subscribe(testChannelid, "foo")
         // and call verifyConnection again to emulate a set value.
         val result = manager.verifyConnection()
-        val vv = result[testChannelid].toString()
-        assertEquals("Check changed endpoint", "http://push.example.com/test/obscure", vv)
+        assertEquals("Check changed endpoint", false, result)
     }
 
     @Test


### PR DESCRIPTION
Closes #1114

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
