### PR TITLE
Cut release 0.27.2 and move to the new changelog / pending format

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 0.27.1
+libraryVersion: 0.27.2
 groupId: org.mozilla.appservices
 projects:
   fxa-client-library:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
-# Unreleased Changes
+# v0.27.2 (_2019-05-08_)
 
-**See [the release process docs](docs/howtos/cut-a-new-release.md) for the steps to take when cutting a new release.**
-
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.1...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.1...v0.27.2)
 
 ## Logins
 

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -1,0 +1,6 @@
+**See [the release process docs](docs/howtos/cut-a-new-release.md) for the steps to take when cutting a new release.**
+
+# Unreleased Changes
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.27.2...master)
+

--- a/docs/howtos/cut-a-new-release.md
+++ b/docs/howtos/cut-a-new-release.md
@@ -3,24 +3,25 @@
 These are the steps needed to cut a new release.
 
 1. Update the changelog.
+    1. Copy the contents from `CHANGES_UNRELEASED.md` into the top of `CHANGELOG.md`, except for the part that links to this document.
+    2. In `CHANGELOG.md`:
+        1. Replace `# Unreleased Changes` with `# v<new-version-number> (_<current date>_)`.
+        2. Replace `master` in the Full Changelog link (which you pasted in from `CHANGES_UNRELEASED.md`) to be `v<new-version-number>`. E.g. if you are releasing 0.13.2, the link should be
+            ```
+            [Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.1...v0.13.2)
+            ```
+            Note that this needs three dots (`...`) between the two tags (two dots is different). Yes, the second tag doesn't exist yet, you'll make it later.
+        3. Optionally, go over the commits between the past release and this one and see if anything is worth including.
+        4. Make sure the changelog follows the format of the other changelog entries. If you have access, [this document](https://docs.google.com/document/d/1oxdGm7OQcsy78NzXjMQKTbfzn21tl9Nopmvo8NCMWmU) is fairly comprehensive. For a concrete example, at the time of this writing, see the [0.13.0](https://github.com/mozilla/application-services/blob/master/CHANGELOG.md#0130-2019-01-09) release notes.
+            - Note that we try to provide PR or issue numbers (and links) for each change. Please add these if they are missing.
 
-    1. Add a new header between the "Full Changelog" and "See the release process docs..." lines with the version number and date of the next release.
-    2. Replace `master` in the Full Changelog link to be `v<new-version-number>`. E.g. if you are releasing 0.13.2, the link should be
-
-        ```
-        [Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.1...v0.13.2)
-        ```
-
-        Note that this needs three dots (`...`) between the two tags (two dots is different). Yes, the second tag doesn't exist yet, you'll make it later.
-
-    3. Add a new "Full Changelog" link that starts at your new version and continues to master. E.g. for 0.13.2 this would be
-        ```
-        [Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.2...master)
-        ```
-        Again, this needs 3 dots.
-    4. Optionally, go over the commits between the past release and this one and see if anything is worth including.
-    5. Make sure the changelog follows the format of the other changelog entries. If you have access, [this document](https://docs.google.com/document/d/1oxdGm7OQcsy78NzXjMQKTbfzn21tl9Nopmvo8NCMWmU) is fairly comprehensive. For a concrete example, at the time of this writing, see the [0.13.0](https://github.com/mozilla/application-services/blob/master/CHANGELOG.md#0130-2019-01-09) release notes.
-        - Note that we try to provide PR or issue numbers (and links) for each change. Please add these if they are missing.
+    3. In `CHANGES_UNRELEASED.md`:
+        1. Delete the list of changes that are now in the changelog.
+        2. Update the "Full Changelog" link so that it starts at your new version and continues to master. E.g. for 0.13.2 this would be
+            ```
+            [Full Changelog](https://github.com/mozilla/application-services/compare/v0.13.2...master)
+            ```
+            Again, this needs 3 dots.
 
 2. Bump `libraryVersion` in the top-level [.buildconfig-android.yml](https://github.com/mozilla/application-services/blob/master/.buildconfig-android.yml) file. Be sure you're following semver, and if in doubt, ask.
 3. Land the commits that perform the steps above. This takes a PR, typically, because of branch protection on master.


### PR DESCRIPTION
This moves to the changelog/pending format as discussed in meetings, fixes #919.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
