### PR TITLE
fix(config): Disable `doNotStrip` in viaduct build config.

### DIFF
--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -36,12 +36,8 @@ android {
         }
     }
 
-    // Help folks debugging by including symbols in our native libraries.  Yes, this makes the
-    // resulting AAR very large.  The Android ecosystem seems to be in flux around who is in charge
-    // of stripping native binaries, but for now let's provide symbols and see how consumers react.
-    packagingOptions {
-        doNotStrip "**/*.so"
-    }
+    // Uncomment to include debug symbols in native library builds.
+    // packagingOptions { doNotStrip "**/*.so" }
 }
 
 configurations {


### PR DESCRIPTION
This appears to have been missed when we disabled it in the other projects in #915, perhaps because the viaduct work was branched before but merged after that change.