### PR TITLE
fix(build): Set ANDROID_NDK_HOME so that gradle can strip native libs.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -29,3 +29,14 @@ not have a way to send just the new endpoint to the client PWA.)
 channel was already deleted. To delete all channels for a given user,
 call `PushManager.unsubscribeAll()`.
 [#889](https://github.com/mozilla/application-services/issues/889)
+
+## General
+
+### What's Fixed
+
+- Native libraries should now have debug symbols stripped by default,
+  resulting in significantly smaller package size for consuming
+  applications. A test was also added to CI to ensure that this
+  does not regress in future.
+  ([1107](https://github.com/mozilla/application-services/issues/1107))
+

--- a/automation/check_artifact_size.sh
+++ b/automation/check_artifact_size.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# A simple check that our release .aar files are a reasonable size.
+# If this fails then something has gone wrong with the build process,
+# such as pulling in unwanted dependencies or failing to strip debug symbols.
+
+set -eu
+
+if [ "$#" -ne 2 ]
+then
+    echo "Usage:"
+    echo "./automation/check_artifact_size.sh <buildDir> <artifactId>"
+    exit 1
+fi
+
+BUILD_DIR="$1"
+ARTIFACT_ID="$2"
+
+# Even our largest .aar should be less than 30M.
+# Seems like a lot? They include compiled rust code for 4 architectures.
+# We expect this size to decrease over time as we make changes to the way
+# we perform megazord builds, but at least it's an upper bound for now...
+LIMIT=30000000
+
+if [ -d $BUILD_DIR ]; then
+    for AAR_FILE in `find $BUILD_DIR -path "*/$ARTIFACT_ID/*" -name "*.aar"`; do
+        SIZE=`du -b $AAR_FILE | cut -f 1`
+        if [ $SIZE -gt $LIMIT ]; then
+            echo "ERROR: Build artifact is unacceptably large." >&2
+            du -h $AAR_FILE >&2
+            exit 1
+        fi
+    done
+fi

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -184,6 +184,7 @@ def gradle_module_task(libs_tasks, module_info, is_release):
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "testDebug")))
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "assembleRelease")))
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "publish")))
+        .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "checkMavenArtifacts")))
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "zipMavenArtifacts")))
     )
     for artifact_info in module_info['artifacts']:

--- a/automation/taskcluster/docker/build.dockerfile
+++ b/automation/taskcluster/docker/build.dockerfile
@@ -90,7 +90,9 @@ RUN curl -L https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_S
 # build OpenSSL.
 ENV ANDROID_NDK_VERSION "r15c"
 
+# $ANDROID_NDK_ROOT is the preferred name, but the android gradle plugin uses $ANDROID_NDK_HOME.
 ENV ANDROID_NDK_ROOT /build/android-ndk
+ENV ANDROID_NDK_HOME /build/android-ndk
 
 RUN curl -L https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip > ndk.zip \
 	&& unzip -q ndk.zip -d /build \

--- a/docs/howtos/setup-android-build-environment.md
+++ b/docs/howtos/setup-android-build-environment.md
@@ -20,6 +20,7 @@ may need to repeat some steps (eg, rust updates should be done periodically)
 At the end of this process you should have the following environment variables set up.
 
 - `ANDROID_NDK_ROOT`
+- `ANDROID_NDK_HOME`
 - `ANDROID_NDK_TOOLCHAIN_DIR`
 - `ANDROID_NDK_API_VERSION`
 - `ANDROID_HOME`
@@ -33,6 +34,8 @@ a rc file or similar so they persist between reboots etc.
    argument required to build OpenSSL against a v21 toolchain).
     - Extract it, put it somewhere (`$HOME/.android-ndk-r15c` is a reasonable
       choice, but it doesn't matter), and set `ANDROID_NDK_ROOT` to this location.
+    - Set `ANDROID_NDK_HOME` to match `ANDROID_NDK_ROOT`, for compatibility with
+      some android grandle plugins.
 
 2. Install `rustup` from https://rustup.rs:
     - If you already have it, run `rustup update`

--- a/libs/verify-android-environment.sh
+++ b/libs/verify-android-environment.sh
@@ -22,6 +22,16 @@ if [ -z "${ANDROID_NDK_ROOT}" ]; then
   exit 1
 fi
 
+if [ -z "${ANDROID_NDK_HOME}" ]; then
+  echo "Environment variable \$ANDROID_NDK_HOME is not set:"
+  echo "Please export ANDROID_NDK_HOME=\$ANDROID_NDK_ROOT for compatibility with the android gradle plugin."
+  exit 1
+elif [ "${ANDROID_NDK_HOME}" != "${ANDROID_NDK_ROOT}" ]; then
+  echo "Environment variable \$ANDROID_NDK_HOME is different from \$ANDROID_NDK_ROOT."
+  echo "Please adjust your environment variables to ensure they are the same."
+  exit 1
+fi
+
 INSTALLED_NDK_VERSION=$(sed -En -e 's/^Pkg.Revision[ \t]*=[ \t]*([0-9a-f]+).*/\1/p' ${ANDROID_NDK_ROOT}/source.properties)
 if [ "${INSTALLED_NDK_VERSION}" != ${NDK_VERSION} ]; then
   echo "Wrong Android NDK version:"

--- a/publish.gradle
+++ b/publish.gradle
@@ -208,6 +208,15 @@ ext.configurePublish = { jnaForTestConfiguration = null,
         }
     }
 
+    task checkMavenArtifacts
+
+    publishing.publications.withType(MavenPublication).each {publication ->
+        def checkFileSizeTask = task "checkLibSizeForMavenArtifact-${publication.artifactId}"(type: Exec) {
+            commandLine "${rootProject.projectDir}/automation/check_artifact_size.sh", project.buildDir, publication.artifactId
+        }
+        checkMavenArtifacts.dependsOn(checkFileSizeTask)
+    }
+
     task zipMavenArtifacts
 
     publishing.publications.withType(MavenPublication).each {publication ->


### PR DESCRIPTION
This is required in order for stripping of debug symbols to work correctly, since otherwise the gradle plugin doesn't know where to find the appropriate `strip` command.

I've also added a very coarse test to ensure that the size of the resulting release artifacts is sensible, which should help us check whether this works in CI and guard against future regressions.

Fixes https://github.com/mozilla/application-services/issues/1107.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- ~~[ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)~~
