### PR TITLE
WIP - Ensure we reupload everything after a reset.

### DIFF
--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -1985,8 +1985,7 @@ mod tests {
                 IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(1.0));
             let outgoing = store.apply_incoming(incoming, &mut telemetry::EngineIncoming::new())?;
             let synced_ids: Vec<String> = outgoing.changes.iter().map(|c| c.id.clone()).collect();
-            println!("IDS {:?}", synced_ids); // hrmph - this prints ["menu", "bookmark2___"]
-            assert_eq!(synced_ids.len(), 5, "should be 4 roots + 1 outgoing item"); // <-------- this fails.
+            assert_eq!(synced_ids.len(), 5, "should be 4 roots + 1 outgoing item");
             store.sync_finished(ServerTimestamp(2.0), synced_ids)?;
         }
 


### PR DESCRIPTION
After a store reset we set the `syncChangeCounter=0` and
`syncStatus=SyncStatus::New` for all items. However, the query to determine
local items to upload looks only for `syncChangeCounter > 0`. This works fine
for new bookmarks because we create them with a change counter of 1, but on
reset we change them to 0.

This is easy to reproduce - execute:

% cargo run --example places-utils -- --database_path ./places.db sync --credentials credentials.json --wipe-all-remote

and you will see in the log that we fail to upload any items. doh!

My attempt at fixing this was simply to look for items with changeCounter == 0
OR status = New. Another option (which I didn't actually try) would be for
the reset to set the change counters to 1, although a downside of that is that
there may already be items in the wild with a change counter of 0 due to a
reset.

However, my new test still doesn't work - after a reset we end up with only
2 items to upload, whereas we should have all items. Sadly I ran out of time
to debug this further, so if @lina has any ideas, send them my way and I'll
finish the PR on Monday.
