### PR TITLE
chore(ci): Send notification email when a release publishing task fails.

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -238,6 +238,7 @@ def android_multiarch_release():
                     "project:mozilla:application-services:releng:beetmover:bucket:{}".format(bucket_name),
                     "project:mozilla:application-services:releng:beetmover:action:push-to-maven"
                 )
+                .with_routes("notify.email.a-s-ci-failures@mozilla.com.on-failed")
                 .create()
             )
 

--- a/docs/build-and-publish-pipeline.md
+++ b/docs/build-and-publish-pipeline.md
@@ -28,6 +28,8 @@ The key points:
         * Build an Android binary release.
         * Upload Android library symbols to [Socorro](https://wiki.mozilla.org/Socorro).
         * Publish it to the [maven.mozilla.org](https://maven.mozilla.org).
+* Notifications about build failures are sent to a mailing list at
+  [a-s-ci-failures@mozilla.com](https://groups.google.com/a/mozilla.com/forum/#!forum/a-s-ci-failures)
 
 For Android consumers these are the steps by which Application Services code becomes available,
 and the integrity-protection mechanisms that apply at each step:


### PR DESCRIPTION
I copied what appeared to be notification logic for failures in the build tasks, so that it will also notify us on failures of release-publishing tasks such as https://github.com/mozilla/application-services/issues/1155

I also joined the secret "a-s-ci-failures" mailing list, and added it to the docs in case future collaborators want to do the same.