### PR TITLE
Store i64 in sync15::ServerTimestamp

### DIFF
--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -575,7 +575,7 @@ impl LoginDb {
             "DELETE FROM loginsM",
             &format!("UPDATE loginsL SET sync_status = {}", SyncStatus::New as u8),
         ])?;
-        self.set_last_sync(ServerTimestamp(0.0))?;
+        self.set_last_sync(ServerTimestamp(0))?;
         match assoc {
             StoreSyncAssociation::Disconnected => {
                 self.delete_meta(schema::GLOBAL_SYNCID_META_KEY)?;
@@ -786,9 +786,8 @@ impl LoginDb {
     }
 
     fn get_last_sync(&self) -> Result<Option<ServerTimestamp>> {
-        Ok(self
-            .get_meta::<i64>(schema::LAST_SYNC_META_KEY)?
-            .map(|millis| ServerTimestamp(millis as f64 / 1000.0)))
+        let millis = self.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?.unwrap();
+        Ok(Some(ServerTimestamp(millis)))
     }
 
     pub fn set_global_state(&self, state: &Option<String>) -> Result<()> {

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -145,7 +145,7 @@ impl MirrorLogin {
         Ok(MirrorLogin {
             login: Login::from_row(row)?,
             is_overridden: row.get("is_overridden")?,
-            server_modified: ServerTimestamp(row.get::<_, i64>("server_modified")? as f64 / 1000.0),
+            server_modified: ServerTimestamp(row.get::<_, i64>("server_modified")?),
         })
     }
 }
@@ -235,7 +235,7 @@ impl_login!(LocalLogin {
 
 impl_login!(MirrorLogin {
     is_overridden: false,
-    server_modified: ServerTimestamp(0.0)
+    server_modified: ServerTimestamp(0)
 });
 
 // Stores data needed to do a 3-way merge

--- a/components/places/src/bookmark_sync/incoming.rs
+++ b/components/places/src/bookmark_sync/incoming.rs
@@ -404,7 +404,7 @@ mod tests {
     fn apply_incoming(api: &PlacesApi, records_json: Value) -> SyncConn<'_> {
         let conn = api.open_sync_connection().expect("should get a connection");
 
-        let server_timestamp = ServerTimestamp(0.0);
+        let server_timestamp = ServerTimestamp(0);
         let applicator = IncomingApplicator::new(&conn);
 
         match records_json {

--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -615,12 +615,10 @@ impl<'a> Store for BookmarksStore<'a> {
     }
 
     fn get_collection_request(&self) -> result::Result<CollectionRequest, failure::Error> {
-        let since = get_meta::<i64>(self.db, LAST_SYNC_META_KEY)?
-            .map(|millis| ServerTimestamp(millis as f64 / 1000.0))
-            .unwrap_or_default();
+        let since = get_meta::<i64>(self.db, LAST_SYNC_META_KEY)?.unwrap_or_default();
         Ok(CollectionRequest::new(self.collection_name())
             .full()
-            .newer_than(since))
+            .newer_than(ServerTimestamp(since)))
     }
 
     fn get_sync_assoc(&self) -> result::Result<StoreSyncAssociation, failure::Error> {
@@ -749,9 +747,7 @@ impl<'a> Merger<'a> {
         // of seconds before creating a ServerTimestamp and doing duration_since.
         let age = self
             .remote_time
-            .duration_since(ServerTimestamp(
-                row.get::<_, f64>("serverModified")? / 1000.0,
-            ))
+            .duration_since(ServerTimestamp(row.get::<_, i64>("serverModified")?))
             .unwrap_or_default();
         item.age = age.as_secs() as i64 * 1000 + i64::from(age.subsec_millis());
         item.needs_merge = row.get("needsMerge")?;
@@ -1149,18 +1145,18 @@ mod tests {
         let store = BookmarksStore::new(&conn, &interrupt_scope);
 
         let mut incoming =
-            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0.0));
+            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0));
 
         match records_json {
             Value::Array(records) => {
                 for record in records {
                     let payload = Payload::from_json(record).unwrap();
-                    incoming.changes.push((payload, ServerTimestamp(0.0)));
+                    incoming.changes.push((payload, ServerTimestamp(0)));
                 }
             }
             Value::Object(_) => {
                 let payload = Payload::from_json(records_json).unwrap();
-                incoming.changes.push((payload, ServerTimestamp(0.0)));
+                incoming.changes.push((payload, ServerTimestamp(0)));
             }
             _ => panic!("unexpected json value"),
         }
@@ -1217,18 +1213,18 @@ mod tests {
         let store = BookmarksStore::new(&conn, &interrupt_scope);
 
         let mut incoming =
-            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0.0));
+            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0));
 
         for record in records {
             let payload = Payload::from_json(record).unwrap();
-            incoming.changes.push((payload, ServerTimestamp(0.0)));
+            incoming.changes.push((payload, ServerTimestamp(0)));
         }
 
         store
             .stage_incoming(incoming, &mut telemetry::EngineIncoming::new())
             .expect("Should apply incoming and stage outgoing records");
 
-        let merger = Merger::new(&store, ServerTimestamp(0.0));
+        let merger = Merger::new(&store, ServerTimestamp(0));
 
         let tree = merger.fetch_remote_tree()?;
 
@@ -1297,7 +1293,7 @@ mod tests {
 
         let interrupt_scope = syncer.begin_interrupt_scope();
         let store = BookmarksStore::new(&syncer, &interrupt_scope);
-        let merger = Merger::new(&store, ServerTimestamp(0.0));
+        let merger = Merger::new(&store, ServerTimestamp(0));
 
         let tree = merger.fetch_local_tree()?;
 
@@ -1549,10 +1545,10 @@ mod tests {
         let store = BookmarksStore::new(&syncer, &interrupt_scope);
 
         let mut incoming =
-            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0.0));
+            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0));
         for record in records {
             let payload = Payload::from_json(record).unwrap();
-            incoming.changes.push((payload, ServerTimestamp(0.0)));
+            incoming.changes.push((payload, ServerTimestamp(0)));
         }
 
         let mut outgoing = store
@@ -1633,7 +1629,7 @@ mod tests {
 
         store
             .sync_finished(
-                ServerTimestamp(0.0),
+                ServerTimestamp(0),
                 vec![
                     "bookmarkAAAA".into(),
                     "bookmarkBBBB".into(),
@@ -1694,10 +1690,10 @@ mod tests {
         let store = BookmarksStore::new(&syncer, &interrupt_scope);
 
         let mut incoming =
-            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0.0));
+            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0));
         for record in records {
             let payload = Payload::from_json(record).unwrap();
-            incoming.changes.push((payload, ServerTimestamp(0.0)));
+            incoming.changes.push((payload, ServerTimestamp(0)));
         }
 
         let outgoing = store
@@ -1712,7 +1708,7 @@ mod tests {
         assert_eq!(outgoing_ids, &["menu", "mobile", "toolbar", "unfiled"],);
 
         store
-            .sync_finished(ServerTimestamp(0.0), outgoing_ids)
+            .sync_finished(ServerTimestamp(0), outgoing_ids)
             .expect("Should push synced changes back to the store");
 
         update_bookmark(
@@ -1727,7 +1723,7 @@ mod tests {
 
         let outgoing = store
             .apply_incoming(
-                IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(1.0)),
+                IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(1000)),
                 &mut telemetry::EngineIncoming::new(),
             )
             .expect("Should fetch outgoing records after making local changes");
@@ -1823,10 +1819,10 @@ mod tests {
         let store = BookmarksStore::new(&syncer, &interrupt_scope);
 
         let mut incoming =
-            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0.0));
+            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(0));
         for record in records {
             let payload = Payload::from_json(record).unwrap();
-            incoming.changes.push((payload, ServerTimestamp(0.0)));
+            incoming.changes.push((payload, ServerTimestamp(0)));
         }
 
         let outgoing = store
@@ -1841,7 +1837,7 @@ mod tests {
         assert_eq!(outgoing_ids, &["menu", "mobile", "toolbar", "unfiled"],);
 
         store
-            .sync_finished(ServerTimestamp(0.0), outgoing_ids)
+            .sync_finished(ServerTimestamp(0), outgoing_ids)
             .expect("Should push synced changes back to the store");
 
         store.wipe().expect("Should wipe the store");
@@ -1886,10 +1882,10 @@ mod tests {
         });
 
         let mut incoming =
-            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(1.0));
+            IncomingChangeset::new(store.collection_name().to_string(), ServerTimestamp(1000));
         incoming.changes.push((
             Payload::from_json(record_for_f).unwrap(),
-            ServerTimestamp(1.0),
+            ServerTimestamp(1000),
         ));
 
         let outgoing = store

--- a/components/places/src/bookmark_sync/tests/synced_item.rs
+++ b/components/places/src/bookmark_sync/tests/synced_item.rs
@@ -217,7 +217,7 @@ impl SyncedBookmarkItem {
             guid: SyncedBookmarkValue::Specified(row.get("guid")?),
             parent_guid: SyncedBookmarkValue::Specified(row.get("parentGuid")?),
             server_modified: SyncedBookmarkValue::Specified(ServerTimestamp(
-                row.get::<_, f64>("serverModified")?,
+                row.get::<_, i64>("serverModified")?,
             )),
             needs_merge: SyncedBookmarkValue::Specified(row.get("needsMerge")?),
             validity: SyncedBookmarkValue::Specified(

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -473,7 +473,7 @@ mod tests {
         let url = Url::parse("https://example.com")?;
 
         // 2 incoming records with the same URL.
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json!({
             "id": guid1,
             "title": "title",
@@ -482,7 +482,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts1), "type": 1}]
         }))?;
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let payload2 = Payload::from_json(json!({
             "id": guid2,
@@ -492,7 +492,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts2), "type": 1}]
         }))?;
-        incoming.changes.push((payload2, ServerTimestamp(0f64)));
+        incoming.changes.push((payload2, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -539,7 +539,7 @@ mod tests {
         apply_observation(&db, obs)?;
 
         // 2 incoming records with the same URL.
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json!({
             "id": guid1,
             "title": "title",
@@ -548,7 +548,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts1), "type": 1}]
         }))?;
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let payload2 = Payload::from_json(json!({
             "id": guid2,
@@ -558,7 +558,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts2), "type": 1}]
         }))?;
-        incoming.changes.push((payload2, ServerTimestamp(0f64)));
+        incoming.changes.push((payload2, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -601,7 +601,7 @@ mod tests {
         apply_observation(&db, obs)?;
 
         // 2 incoming records with the same URL.
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json!({
             "id": guid1,
             "title": "title",
@@ -610,7 +610,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts1), "type": 1}]
         }))?;
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let payload2 = Payload::from_json(json!({
             "id": guid2,
@@ -620,7 +620,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts2), "type": 1}]
         }))?;
-        incoming.changes.push((payload2, ServerTimestamp(0f64)));
+        incoming.changes.push((payload2, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -653,9 +653,9 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": 15_423_493_234_840_000_000u64, "type": 1}]
         });
-        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        result.changes.push((payload, ServerTimestamp(0f64)));
+        result.changes.push((payload, ServerTimestamp(0i64)));
 
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let outgoing = apply_plan(
@@ -688,9 +688,9 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": -123, "type": 1}]
         });
-        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        result.changes.push((payload, ServerTimestamp(0f64)));
+        result.changes.push((payload, ServerTimestamp(0i64)));
 
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let outgoing = apply_plan(
@@ -740,9 +740,9 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(now), "type": 1}]
         });
-        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        result.changes.push((payload, ServerTimestamp(0f64)));
+        result.changes.push((payload, ServerTimestamp(0i64)));
 
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let outgoing = apply_plan(
@@ -790,7 +790,7 @@ mod tests {
             .with_at(Some(now.into()));
         apply_observation(&db, obs)?;
 
-        let incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let outgoing = apply_plan(
             &db,
             incoming,
@@ -829,9 +829,9 @@ mod tests {
             "visits": [ {"date": ServerVisitTimestamp::from(ts), "type": 1}]
         });
 
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         apply_plan(
             &db,
@@ -875,9 +875,9 @@ mod tests {
             "visits": [ {"date": ServerVisitTimestamp::from(ts2), "type": 1}]
         });
 
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -928,9 +928,9 @@ mod tests {
             "deleted": true,
         });
 
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -957,7 +957,7 @@ mod tests {
         // Set the status to normal
         apply_plan(
             &db,
-            IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64)),
+            IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64)),
             &mut telemetry::EngineIncoming::new(),
             &NeverInterrupts,
         )?;
@@ -970,9 +970,9 @@ mod tests {
             "deleted": true,
         });
 
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -998,7 +998,7 @@ mod tests {
         // Set the status to normal
         apply_plan(
             &db,
-            IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64)),
+            IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64)),
             &mut telemetry::EngineIncoming::new(),
             &NeverInterrupts,
         )?;
@@ -1013,7 +1013,7 @@ mod tests {
 
         let outgoing = apply_plan(
             &db,
-            IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64)),
+            IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64)),
             &mut telemetry::EngineIncoming::new(),
             &NeverInterrupts,
         )?;

--- a/components/places/src/history_sync/store.rs
+++ b/components/places/src/history_sync/store.rs
@@ -193,11 +193,10 @@ impl<'a> Store for HistoryStore<'a> {
     fn get_collection_request(&self) -> result::Result<CollectionRequest, failure::Error> {
         let since = self
             .get_meta::<i64>(LAST_SYNC_META_KEY)?
-            .map(|millis| ServerTimestamp(millis as f64 / 1000.0))
             .unwrap_or_default();
         Ok(CollectionRequest::new("history")
             .full()
-            .newer_than(since)
+            .newer_than(ServerTimestamp(since))
             .limit(MAX_INCOMING_PLACES))
     }
 

--- a/components/sync15/src/bso_record.rs
+++ b/components/sync15/src/bso_record.rs
@@ -225,7 +225,7 @@ impl Payload {
         CleartextBso {
             id,
             collection,
-            modified: 0.0.into(), // Doesn't matter.
+            modified: 0.into(), // Doesn't matter.
             sortindex,
             ttl,
             payload: self,
@@ -440,13 +440,13 @@ mod tests {
         let serialized = r#"{
             "id": "1234",
             "collection": "passwords",
-            "modified": 12344321.0,
+            "modified": 12344321,
             "payload": "{\"IV\": \"aaaaa\", \"hmac\": \"bbbbb\", \"ciphertext\": \"ccccc\"}"
         }"#;
         let record: BsoRecord<EncryptedPayload> = serde_json::from_str(serialized).unwrap();
         assert_eq!(&record.id, "1234");
         assert_eq!(&record.collection, "passwords");
-        assert!((record.modified.0 - 1234_4321.0).abs() < std::f64::EPSILON);
+        assert_eq!((record.modified.0 - 1234_4321).abs(), 0);
         assert_eq!(record.sortindex, None);
         assert_eq!(&record.payload.iv, "aaaaa");
         assert_eq!(&record.payload.hmac, "bbbbb");
@@ -458,7 +458,7 @@ mod tests {
         let serialized = r#"{
             "id": "1234",
             "collection": "passwords",
-            "modified": 12344321.0,
+            "modified": 12344321,
             "sortindex": 100,
             "ttl": 99,
             "payload": "{\"IV\": \"aaaaa\", \"hmac\": \"bbbbb\", \"ciphertext\": \"ccccc\"}"
@@ -473,7 +473,7 @@ mod tests {
         let goal = r#"{"id":"1234","collection":"passwords","payload":"{\"IV\":\"aaaaa\",\"hmac\":\"bbbbb\",\"ciphertext\":\"ccccc\"}"}"#;
         let record = BsoRecord {
             id: "1234".into(),
-            modified: ServerTimestamp(999.0), // shouldn't be serialized by client no matter what it's value is
+            modified: ServerTimestamp(999), // shouldn't be serialized by client no matter what it's value is
             collection: "passwords".into(),
             sortindex: None,
             ttl: None,

--- a/components/sync15/src/collection_keys.rs
+++ b/components/sync15/src/collection_keys.rs
@@ -20,7 +20,7 @@ impl CollectionKeys {
     pub fn new_random() -> Result<CollectionKeys> {
         let default = KeyBundle::new_random()?;
         Ok(CollectionKeys {
-            timestamp: 0.0.into(),
+            timestamp: 0.into(),
             default,
             collections: HashMap::new(),
         })

--- a/components/sync15/src/request.rs
+++ b/components/sync15/src/request.rs
@@ -716,12 +716,12 @@ mod test {
             .full()
             .limit(10)
             .sort_by(RequestOrder::Oldest)
-            .older_than(ServerTimestamp(9876.54))
-            .newer_than(ServerTimestamp(1234.56))
+            .older_than(ServerTimestamp(9_876_540))
+            .newer_than(ServerTimestamp(1_234_560))
             .build_url(base.clone())
             .unwrap();
         assert_eq!(complex.as_str(),
-            "https://example.com/sync/storage/specific?full=1&limit=10&older=9876.54&newer=1234.56&sort=oldest");
+            "https://example.com/sync/storage/specific?full=1&limit=10&older=9876540&newer=1234560&sort=oldest");
     }
 
     #[derive(Debug, Clone)]
@@ -892,7 +892,7 @@ mod test {
 
     fn pq_test_setup(
         cfg: InfoConfiguration,
-        lm: f64,
+        lm: i64,
         resps: Vec<PostResponse>,
     ) -> (MockedPostQueue, TestPosterRef) {
         let tester = TestPoster::new(&cfg, resps);
@@ -900,7 +900,7 @@ mod test {
         (pq, tester)
     }
 
-    fn fake_response<'a, T: Into<Option<&'a str>>>(status: u16, lm: f64, batch: T) -> PostResponse {
+    fn fake_response<'a, T: Into<Option<&'a str>>>(status: u16, lm: i64, batch: T) -> PostResponse {
         PostResponse {
             status,
             last_modified: ServerTimestamp(lm),
@@ -927,7 +927,7 @@ mod test {
             let val = serde_json::to_value(BsoRecord {
                 id: "".into(),
                 collection: "".into(),
-                modified: ServerTimestamp(0.0),
+                modified: ServerTimestamp(0),
                 sortindex: None,
                 ttl: None,
                 payload: EncryptedPayload {
@@ -954,7 +954,7 @@ mod test {
         BsoRecord {
             id: "".into(),
             collection: "".into(),
-            modified: ServerTimestamp(0.0),
+            modified: ServerTimestamp(0),
             sortindex: None,
             ttl: None,
             payload: EncryptedPayload {
@@ -979,11 +979,11 @@ mod test {
             max_record_payload_bytes: 1000,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
-            vec![fake_response(status_codes::OK, time + 100.0, None)],
+            vec![fake_response(status_codes::OK, time + 100_000, None)],
         );
 
         pq.enqueue(&make_record(100)).unwrap();
@@ -1008,13 +1008,13 @@ mod test {
             max_request_bytes: 250,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
-                fake_response(status_codes::OK, time + 100.0, None),
-                fake_response(status_codes::OK, time + 200.0, None),
+                fake_response(status_codes::OK, time + 100_000, None),
+                fake_response(status_codes::OK, time + 200_000, None),
             ],
         );
 
@@ -1057,13 +1057,13 @@ mod test {
             max_request_bytes: 350,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
-                fake_response(status_codes::OK, time + 100.0, None),
-                fake_response(status_codes::OK, time + 200.0, None),
+                fake_response(status_codes::OK, time + 100_000, None),
+                fake_response(status_codes::OK, time + 200_000, None),
             ],
         );
 
@@ -1091,13 +1091,13 @@ mod test {
     #[test]
     fn test_pq_single_batch() {
         let cfg = InfoConfiguration::default();
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![fake_response(
                 status_codes::ACCEPTED,
-                time + 100.0,
+                time + 100_000,
                 Some("1234"),
             )],
         );
@@ -1129,13 +1129,13 @@ mod test {
             max_post_bytes: 200,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("1234")),
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("1234")),
             ],
         );
 
@@ -1178,14 +1178,14 @@ mod test {
             max_post_records: 3,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("1234")),
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("1234")),
             ],
         );
 
@@ -1244,15 +1244,15 @@ mod test {
             max_total_records: 5,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("abcd")),
-                fake_response(status_codes::ACCEPTED, time + 200.0, Some("abcd")),
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("1234")),
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("abcd")),
+                fake_response(status_codes::ACCEPTED, time + 200_000, Some("abcd")),
             ],
         );
 
@@ -1320,19 +1320,6 @@ mod test {
         );
     }
 
-    macro_rules! assert_feq {
-        ($a:expr, $b:expr) => {
-            let a = $a;
-            let b = $b;
-            assert!(
-                (a - b).abs() < std::f64::EPSILON,
-                "assert_feq failure: {} != {}",
-                a,
-                b
-            )
-        };
-    }
-
     #[test]
     #[allow(clippy::cyclomatic_complexity)]
     fn test_pq_multi_post_multi_batch_bytes() {
@@ -1341,37 +1328,37 @@ mod test {
             max_total_bytes: 500,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("1234")), // should commit
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("abcd")),
-                fake_response(status_codes::ACCEPTED, time + 200.0, Some("abcd")), // should commit
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("1234")), // should commit
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("abcd")),
+                fake_response(status_codes::ACCEPTED, time + 200_000, Some("abcd")), // should commit
             ],
         );
 
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
-        assert_feq!(pq.last_modified.0, time);
+        assert_eq!(pq.last_modified.0, time);
         // POST
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
         // POST + COMMIT
         pq.enqueue(&make_record(100)).unwrap();
-        assert_feq!(pq.last_modified.0, time + 100.0);
+        assert_eq!(pq.last_modified.0, time + 100_000);
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
 
         // POST
         pq.enqueue(&make_record(100)).unwrap();
-        assert_feq!(pq.last_modified.0, time + 100.0);
+        assert_eq!(pq.last_modified.0, time + 100_000);
         pq.flush(true).unwrap(); // COMMIT
 
-        assert_feq!(pq.last_modified.0, time + 200.0);
+        assert_eq!(pq.last_modified.0, time + 200_000);
 
         let t = tester.borrow();
         assert!(t.cur_batch.is_none());

--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -528,7 +528,7 @@ mod tests {
             xius: ServerTimestamp,
             _global: &MetaGlobalRecord,
         ) -> error::Result<()> {
-            assert_eq!(xius, ServerTimestamp(999.9));
+            assert_eq!(xius, ServerTimestamp(999_900));
             Err(ErrorKind::StorageHttpError {
                 code: 500,
                 route: "meta/global".to_string(),
@@ -552,7 +552,7 @@ mod tests {
             xius: ServerTimestamp,
             _keys: &EncryptedBso,
         ) -> error::Result<()> {
-            assert_eq!(xius, ServerTimestamp(888.8));
+            assert_eq!(xius, ServerTimestamp(888_800));
             Err(ErrorKind::StorageHttpError {
                 code: 500,
                 route: "crypto/keys".to_string(),
@@ -565,7 +565,7 @@ mod tests {
         }
     }
 
-    fn mocked_success_ts<T>(t: T, ts: f64) -> error::Result<Sync15ClientResponse<T>> {
+    fn mocked_success_ts<T>(t: T, ts: i64) -> error::Result<Sync15ClientResponse<T>> {
         Ok(Sync15ClientResponse::Success {
             record: t,
             last_modified: ServerTimestamp(ts),
@@ -574,7 +574,7 @@ mod tests {
     }
 
     fn mocked_success<T>(t: T) -> error::Result<Sync15ClientResponse<T>> {
-        mocked_success_ts(t, 0.0)
+        mocked_success_ts(t, 0)
     }
 
     // for tests, we want a BSO with a specific timestamp, which we never
@@ -605,14 +605,14 @@ mod tests {
     fn test_state_machine_ready_from_empty() {
         let root_key = KeyBundle::new_random().unwrap();
         let keys = CollectionKeys {
-            timestamp: 123.4.into(),
+            timestamp: 123_400.into(),
             default: KeyBundle::new_random().unwrap(),
             collections: HashMap::new(),
         };
         let client = InMemoryClient {
             info_configuration: mocked_success(InfoConfiguration::default()),
             info_collections: mocked_success(InfoCollections::new(
-                vec![("meta", 123.456), ("crypto", 145.0)]
+                vec![("meta", 123_456), ("crypto", 145_000)]
                     .into_iter()
                     .map(|(key, value)| (key.to_owned(), value.into()))
                     .collect(),
@@ -633,12 +633,12 @@ mod tests {
                     .collect(),
                     declined: vec![],
                 },
-                999.0,
+                999_000,
             ),
             crypto_keys: mocked_success_ts(
-                keys.to_encrypted_bso_with_timestamp(&root_key, 888.0.into())
+                keys.to_encrypted_bso_with_timestamp(&root_key, 888_000.into())
                     .expect("should always work in this test"),
-                888.0,
+                888_000,
             ),
         };
         let mut pgs = PersistedGlobalState::V2 { declined: None };

--- a/components/sync15/src/token.rs
+++ b/components/sync15/src/token.rs
@@ -455,7 +455,7 @@ mod tests {
                     duration: 1000,
                     hashed_fxa_uid: "hash".to_string(),
                 },
-                server_timestamp: ServerTimestamp(0f64),
+                server_timestamp: ServerTimestamp(0i64),
             })
         };
 
@@ -513,7 +513,7 @@ mod tests {
                     duration: 10,
                     hashed_fxa_uid: "hash".to_string(),
                 },
-                server_timestamp: ServerTimestamp(0f64),
+                server_timestamp: ServerTimestamp(0i64),
             })
         };
         let now: Cell<SystemTime> = Cell::new(SystemTime::now());

--- a/components/sync15/src/util.rs
+++ b/components/sync15/src/util.rs
@@ -16,35 +16,28 @@ pub fn random_guid() -> Result<String, openssl::error::ErrorStack> {
 
 /// Typesafe way to manage server timestamps without accidentally mixing them up with
 /// local ones.
-///
-/// TODO: We should probably store this as milliseconds (or something) for stability and to get
-/// Eq/Ord. The server guarantees that these are formatted to the hundreds place (not sure if this
-/// is documented but the code does it intentionally...). This would also let us throw out negative
-/// and NaN timestamps, which the server certainly won't send, but the guarantee would make me feel
-/// better.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Deserialize, Serialize, Default)]
-pub struct ServerTimestamp(pub f64);
+pub struct ServerTimestamp(pub i64);
 
-impl From<ServerTimestamp> for f64 {
+impl From<ServerTimestamp> for i64 {
     #[inline]
     fn from(ts: ServerTimestamp) -> Self {
         ts.0
     }
 }
 
-impl From<f64> for ServerTimestamp {
+impl From<i64> for ServerTimestamp {
     #[inline]
-    fn from(ts: f64) -> Self {
-        assert!(ts >= 0.0);
+    fn from(ts: i64) -> Self {
         ServerTimestamp(ts)
     }
 }
 
 // This lets us use these in hyper header! blocks.
 impl FromStr for ServerTimestamp {
-    type Err = num::ParseFloatError;
+    type Err = num::ParseIntError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(ServerTimestamp(f64::from_str(s)?))
+        Ok(ServerTimestamp(i64::from_str(s)?))
     }
 }
 
@@ -55,7 +48,7 @@ impl fmt::Display for ServerTimestamp {
     }
 }
 
-pub const SERVER_EPOCH: ServerTimestamp = ServerTimestamp(0.0);
+pub const SERVER_EPOCH: ServerTimestamp = ServerTimestamp(0);
 
 impl ServerTimestamp {
     /// Returns None if `other` is later than `self` (Duration may not represent
@@ -63,21 +56,17 @@ impl ServerTimestamp {
     #[inline]
     pub fn duration_since(self, other: ServerTimestamp) -> Option<Duration> {
         let delta = self.0 - other.0;
-        if delta < 0.0 {
+        if delta < 0 {
             None
         } else {
-            let secs = delta.floor();
-            // We don't want to round here, since it could round up, and
-            // Duration::new will panic if it rounds up to 1e9 nanoseconds.
-            let nanos = ((delta - secs) * 1_000_000_000.0).floor() as u32;
-            Some(Duration::new(secs as u64, nanos))
+            Some(Duration::from_millis(delta as u64))
         }
     }
 
     /// Get the milliseconds for the timestamp.
     #[inline]
-    pub fn as_millis(self) -> u64 {
-        (self.0 * 1000.0).floor() as u64
+    pub fn as_millis(self) -> i64 {
+        self.0
     }
 }
 
@@ -88,8 +77,8 @@ mod test {
 
     #[test]
     fn test_server_timestamp() {
-        let t0 = ServerTimestamp(10300.15);
-        let t1 = ServerTimestamp(10100.05);
+        let t0 = ServerTimestamp(10_300_150);
+        let t1 = ServerTimestamp(10_100_050);
         assert!(t1.duration_since(t0).is_none());
         assert!(t0.duration_since(t1).is_some());
         let dur = t0.duration_since(t1).unwrap();


### PR DESCRIPTION
Store an i64 instead of f64 in sync15::ServerTimestamp.

Signed-off-by: YLyu <lyuyuan92@gmail.com>

Issue #815