### PR TITLE
Add API for fetching the most recently bookmarked items. Fixes #1129

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,16 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.28.1...master)
+
+## Places
+
+### What's New
+
+- A new `getRecentBookmarks` API was added to return the list of most recently
+  added bookmark items ([#1129](https://github.com/mozilla/application-services/issues/1129)).
+
+### Breaking Changes
+- The addition of `getRecentBookmarks` is a breaking change for custom
+  implementation of `ReadableBookmarksConnection` on Android
+  ([#1129](https://github.com/mozilla/application-services/issues/1129)).
+

--- a/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
@@ -228,6 +228,20 @@ interface ReadableBookmarksConnection : InterruptibleConnection {
      * has its `interrupt()` method called on another thread.
      */
     fun searchBookmarks(query: String, limit: Int): List<BookmarkItem>
+
+    /**
+     * Returns the list of most recently added bookmarks.
+     *
+     * The result list be in order of time of addition, descending (more recent
+     * additions first), and will contain no folder or separator nodes.
+     *
+     * @param limit The maximum number of items to return.
+     * @return A list of recently added bookmarks.
+     *
+     * @throws OperationInterrupted if this database implements [InterruptibleConnection] and
+     * has its `interrupt()` method called on another thread.
+     */
+    fun getRecentBookmarks(limit: Int): List<BookmarkItem>
 }
 
 /**

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -229,6 +229,12 @@ internal interface LibPlacesFFI : Library {
         error: RustError.ByReference
     ): RustBuffer.ByValue
 
+    fun bookmarks_get_recent(
+        handle: PlacesConnectionHandle,
+        limit: Int,
+        error: RustError.ByReference
+    ): RustBuffer.ByValue
+
     // Returns newly inserted guid
     fun bookmarks_insert(
         handle: PlacesConnectionHandle,

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -332,6 +332,19 @@ open class PlacesReaderConnection internal constructor(connHandle: Long) :
             LibPlacesFFI.INSTANCE.places_destroy_bytebuffer(rustBuf)
         }
     }
+
+    override fun getRecentBookmarks(limit: Int): List<BookmarkItem> {
+        val rustBuf = rustCall { err ->
+            LibPlacesFFI.INSTANCE.bookmarks_get_recent(this.handle.get(), limit, err)
+        }
+
+        try {
+            val message = MsgTypes.BookmarkNodeList.parseFrom(rustBuf.asCodedInputStream()!!)
+            return unpackProtobufItemList(message)
+        } finally {
+            LibPlacesFFI.INSTANCE.places_destroy_bytebuffer(rustBuf)
+        }
+    }
 }
 
 fun visitTransitionSet(l: List<VisitType>): Int {

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -543,10 +543,24 @@ pub extern "C" fn bookmarks_search(
     limit: i32,
     error: &mut ExternError,
 ) -> ByteBuffer {
-    log::debug!("bookmarks_get_all_with_url");
+    log::debug!("bookmarks_search");
     CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
         Ok(BookmarkNodeList::from(
             bookmarks::public_node::search_bookmarks(conn, query.as_str(), limit as u32)?,
+        ))
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn bookmarks_get_recent(
+    handle: u64,
+    limit: i32,
+    error: &mut ExternError,
+) -> ByteBuffer {
+    log::debug!("bookmarks_get_recent");
+    CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
+        Ok(BookmarkNodeList::from(
+            bookmarks::public_node::recent_bookmarks(conn, limit as u32)?,
         ))
     })
 }

--- a/components/places/ios/Places/RustPlacesAPI.h
+++ b/components/places/ios/Places/RustPlacesAPI.h
@@ -162,6 +162,10 @@ PlacesRustBuffer bookmarks_search(PlacesConnectionHandle handle,
                                   int32_t limit,
                                   PlacesRustError *_Nonnull out_err);
 
+PlacesRustBuffer bookmarks_get_recent(PlacesConnectionHandle handle,
+                                      int32_t limit,
+                                      PlacesRustError *_Nonnull out_err);
+
 PlacesRustBuffer bookmarks_get_tree(PlacesConnectionHandle handle,
                                     char const *_Nullable root_guid,
                                     PlacesRustError *_Nonnull out_err);


### PR DESCRIPTION
I needed to do something other than the gradle work for a bit. My tests are still runinng for this but I wanted to get the PR up before the standup, for some reason.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
