### PR TITLE
Make less log noise when syncing a history record with no visits

### DIFF
--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -845,7 +845,10 @@ pub mod history_sync {
                 continue;
             }
             if visits.is_empty() {
-                log::info!(
+                // This will be true for things like bookmarks which haven't
+                // had visits locally applied, and if we later prune old visits
+                // we'll also hit it, so don't make much log noise.
+                log::trace!(
                     "Page {:?} is flagged to be uploaded, but has no visits - skipping",
                     &page.guid
                 );


### PR DESCRIPTION
I noticed the log line `Page SyncGuid("_9tl7BO0yHVh") is flagged to be uploaded, but has no visits - skipping` spamming logcat when syncing history, and a common case for that is a bookmark with no local visits, so the message doesn't really have much value. This commit changes the level to "trace"