### PR TITLE
Store i64 in sync15::ServerTimestamp

### DIFF
--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -577,7 +577,7 @@ impl LoginDb {
             "DELETE FROM loginsM",
             &format!("UPDATE loginsL SET sync_status = {}", SyncStatus::New as u8),
         ])?;
-        self.set_last_sync(ServerTimestamp(0.0))?;
+        self.set_last_sync(ServerTimestamp(0))?;
         match assoc {
             StoreSyncAssociation::Disconnected => {
                 self.delete_meta(schema::GLOBAL_SYNCID_META_KEY)?;
@@ -788,9 +788,8 @@ impl LoginDb {
     }
 
     fn get_last_sync(&self) -> Result<Option<ServerTimestamp>> {
-        Ok(self
-            .get_meta::<i64>(schema::LAST_SYNC_META_KEY)?
-            .map(|millis| ServerTimestamp(millis as f64 / 1000.0)))
+        let millis = self.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?.unwrap();
+        Ok(Some(ServerTimestamp(millis)))
     }
 
     pub fn set_global_state(&self, state: &Option<String>) -> Result<()> {

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -145,7 +145,7 @@ impl MirrorLogin {
         Ok(MirrorLogin {
             login: Login::from_row(row)?,
             is_overridden: row.get("is_overridden")?,
-            server_modified: ServerTimestamp(row.get::<_, i64>("server_modified")? as f64 / 1000.0),
+            server_modified: ServerTimestamp(row.get::<_, i64>("server_modified")?),
         })
     }
 }
@@ -235,7 +235,7 @@ impl_login!(LocalLogin {
 
 impl_login!(MirrorLogin {
     is_overridden: false,
-    server_modified: ServerTimestamp(0.0)
+    server_modified: ServerTimestamp(0)
 });
 
 // Stores data needed to do a 3-way merge

--- a/components/places/src/bookmark_sync/incoming.rs
+++ b/components/places/src/bookmark_sync/incoming.rs
@@ -404,7 +404,7 @@ mod tests {
     fn apply_incoming(api: &PlacesApi, records_json: Value) -> SyncConn<'_> {
         let conn = api.open_sync_connection().expect("should get a connection");
 
-        let server_timestamp = ServerTimestamp(0.0);
+        let server_timestamp = ServerTimestamp(0);
         let applicator = IncomingApplicator::new(&conn);
 
         match records_json {

--- a/components/places/src/bookmark_sync/tests/synced_item.rs
+++ b/components/places/src/bookmark_sync/tests/synced_item.rs
@@ -217,7 +217,7 @@ impl SyncedBookmarkItem {
             guid: SyncedBookmarkValue::Specified(row.get("guid")?),
             parent_guid: SyncedBookmarkValue::Specified(row.get("parentGuid")?),
             server_modified: SyncedBookmarkValue::Specified(ServerTimestamp(
-                row.get::<_, f64>("serverModified")?,
+                row.get::<_, i64>("serverModified")?,
             )),
             needs_merge: SyncedBookmarkValue::Specified(row.get("needsMerge")?),
             validity: SyncedBookmarkValue::Specified(

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -473,7 +473,7 @@ mod tests {
         let url = Url::parse("https://example.com")?;
 
         // 2 incoming records with the same URL.
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json!({
             "id": guid1,
             "title": "title",
@@ -482,7 +482,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts1), "type": 1}]
         }))?;
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let payload2 = Payload::from_json(json!({
             "id": guid2,
@@ -492,7 +492,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts2), "type": 1}]
         }))?;
-        incoming.changes.push((payload2, ServerTimestamp(0f64)));
+        incoming.changes.push((payload2, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -539,7 +539,7 @@ mod tests {
         apply_observation(&db, obs)?;
 
         // 2 incoming records with the same URL.
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json!({
             "id": guid1,
             "title": "title",
@@ -548,7 +548,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts1), "type": 1}]
         }))?;
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let payload2 = Payload::from_json(json!({
             "id": guid2,
@@ -558,7 +558,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts2), "type": 1}]
         }))?;
-        incoming.changes.push((payload2, ServerTimestamp(0f64)));
+        incoming.changes.push((payload2, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -601,7 +601,7 @@ mod tests {
         apply_observation(&db, obs)?;
 
         // 2 incoming records with the same URL.
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json!({
             "id": guid1,
             "title": "title",
@@ -610,7 +610,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts1), "type": 1}]
         }))?;
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let payload2 = Payload::from_json(json!({
             "id": guid2,
@@ -620,7 +620,7 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(ts2), "type": 1}]
         }))?;
-        incoming.changes.push((payload2, ServerTimestamp(0f64)));
+        incoming.changes.push((payload2, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -653,9 +653,9 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": 15_423_493_234_840_000_000u64, "type": 1}]
         });
-        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        result.changes.push((payload, ServerTimestamp(0f64)));
+        result.changes.push((payload, ServerTimestamp(0i64)));
 
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let outgoing = apply_plan(
@@ -688,9 +688,9 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": -123, "type": 1}]
         });
-        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        result.changes.push((payload, ServerTimestamp(0f64)));
+        result.changes.push((payload, ServerTimestamp(0i64)));
 
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let outgoing = apply_plan(
@@ -740,9 +740,9 @@ mod tests {
             "ttl": 100,
             "visits": [ {"date": ServerVisitTimestamp::from(now), "type": 1}]
         });
-        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut result = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        result.changes.push((payload, ServerTimestamp(0f64)));
+        result.changes.push((payload, ServerTimestamp(0i64)));
 
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let outgoing = apply_plan(
@@ -790,7 +790,7 @@ mod tests {
             .with_at(Some(now.into()));
         apply_observation(&db, obs)?;
 
-        let incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let outgoing = apply_plan(
             &db,
             incoming,
@@ -829,9 +829,9 @@ mod tests {
             "visits": [ {"date": ServerVisitTimestamp::from(ts), "type": 1}]
         });
 
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         apply_plan(
             &db,
@@ -875,9 +875,9 @@ mod tests {
             "visits": [ {"date": ServerVisitTimestamp::from(ts2), "type": 1}]
         });
 
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -928,9 +928,9 @@ mod tests {
             "deleted": true,
         });
 
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -957,7 +957,7 @@ mod tests {
         // Set the status to normal
         apply_plan(
             &db,
-            IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64)),
+            IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64)),
             &mut telemetry::EngineIncoming::new(),
             &NeverInterrupts,
         )?;
@@ -970,9 +970,9 @@ mod tests {
             "deleted": true,
         });
 
-        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64));
+        let mut incoming = IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64));
         let payload = Payload::from_json(json).unwrap();
-        incoming.changes.push((payload, ServerTimestamp(0f64)));
+        incoming.changes.push((payload, ServerTimestamp(0i64)));
 
         let outgoing = apply_plan(
             &db,
@@ -998,7 +998,7 @@ mod tests {
         // Set the status to normal
         apply_plan(
             &db,
-            IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64)),
+            IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64)),
             &mut telemetry::EngineIncoming::new(),
             &NeverInterrupts,
         )?;
@@ -1013,7 +1013,7 @@ mod tests {
 
         let outgoing = apply_plan(
             &db,
-            IncomingChangeset::new("history".to_string(), ServerTimestamp(0f64)),
+            IncomingChangeset::new("history".to_string(), ServerTimestamp(0i64)),
             &mut telemetry::EngineIncoming::new(),
             &NeverInterrupts,
         )?;

--- a/components/places/src/history_sync/store.rs
+++ b/components/places/src/history_sync/store.rs
@@ -165,11 +165,10 @@ impl<'a> Store for HistoryStore<'a> {
     fn get_collection_request(&self) -> result::Result<CollectionRequest, failure::Error> {
         let since = self
             .get_meta::<i64>(LAST_SYNC_META_KEY)?
-            .map(|millis| ServerTimestamp(millis as f64 / 1000.0))
             .unwrap_or_default();
         Ok(CollectionRequest::new("history")
             .full()
-            .newer_than(since)
+            .newer_than(ServerTimestamp(since))
             .limit(MAX_INCOMING_PLACES))
     }
 

--- a/components/sync15/src/bso_record.rs
+++ b/components/sync15/src/bso_record.rs
@@ -225,7 +225,7 @@ impl Payload {
         CleartextBso {
             id,
             collection,
-            modified: 0.0.into(), // Doesn't matter.
+            modified: 0.into(), // Doesn't matter.
             sortindex,
             ttl,
             payload: self,
@@ -446,7 +446,7 @@ mod tests {
         let record: BsoRecord<EncryptedPayload> = serde_json::from_str(serialized).unwrap();
         assert_eq!(&record.id, "1234");
         assert_eq!(&record.collection, "passwords");
-        assert!((record.modified.0 - 1234_4321.0).abs() < std::f64::EPSILON);
+        assert_eq!((record.modified.0 - 12_344_321_000).abs(), 0);
         assert_eq!(record.sortindex, None);
         assert_eq!(&record.payload.iv, "aaaaa");
         assert_eq!(&record.payload.hmac, "bbbbb");
@@ -473,7 +473,7 @@ mod tests {
         let goal = r#"{"id":"1234","collection":"passwords","payload":"{\"IV\":\"aaaaa\",\"hmac\":\"bbbbb\",\"ciphertext\":\"ccccc\"}"}"#;
         let record = BsoRecord {
             id: "1234".into(),
-            modified: ServerTimestamp(999.0), // shouldn't be serialized by client no matter what it's value is
+            modified: ServerTimestamp(999), // shouldn't be serialized by client no matter what it's value is
             collection: "passwords".into(),
             sortindex: None,
             ttl: None,

--- a/components/sync15/src/collection_keys.rs
+++ b/components/sync15/src/collection_keys.rs
@@ -20,7 +20,7 @@ impl CollectionKeys {
     pub fn new_random() -> Result<CollectionKeys> {
         let default = KeyBundle::new_random()?;
         Ok(CollectionKeys {
-            timestamp: 0.0.into(),
+            timestamp: 0.into(),
             default,
             collections: HashMap::new(),
         })

--- a/components/sync15/src/request.rs
+++ b/components/sync15/src/request.rs
@@ -685,8 +685,8 @@ mod test {
             .full()
             .limit(10)
             .sort_by(RequestOrder::Oldest)
-            .older_than(ServerTimestamp(9876.54))
-            .newer_than(ServerTimestamp(1234.56))
+            .older_than(ServerTimestamp(9_876_540))
+            .newer_than(ServerTimestamp(1_234_560))
             .build_url(base.clone())
             .unwrap();
         assert_eq!(complex.as_str(),
@@ -868,7 +868,7 @@ mod test {
 
     fn pq_test_setup(
         cfg: InfoConfiguration,
-        lm: f64,
+        lm: i64,
         resps: Vec<PostResponse>,
     ) -> (MockedPostQueue, TestPosterRef) {
         let tester = TestPoster::new(&cfg, resps);
@@ -876,7 +876,7 @@ mod test {
         (pq, tester)
     }
 
-    fn fake_response<'a, T: Into<Option<&'a str>>>(status: u16, lm: f64, batch: T) -> PostResponse {
+    fn fake_response<'a, T: Into<Option<&'a str>>>(status: u16, lm: i64, batch: T) -> PostResponse {
         assert!(status_codes::is_success_code(status));
         Sync15ClientResponse::Success {
             status,
@@ -905,7 +905,7 @@ mod test {
             let val = serde_json::to_value(BsoRecord {
                 id: "".into(),
                 collection: "".into(),
-                modified: ServerTimestamp(0.0),
+                modified: ServerTimestamp(0),
                 sortindex: None,
                 ttl: None,
                 payload: EncryptedPayload {
@@ -932,7 +932,7 @@ mod test {
         BsoRecord {
             id: "".into(),
             collection: "".into(),
-            modified: ServerTimestamp(0.0),
+            modified: ServerTimestamp(0),
             sortindex: None,
             ttl: None,
             payload: EncryptedPayload {
@@ -957,11 +957,11 @@ mod test {
             max_record_payload_bytes: 1000,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
-            vec![fake_response(status_codes::OK, time + 100.0, None)],
+            vec![fake_response(status_codes::OK, time + 100_000, None)],
         );
 
         pq.enqueue(&make_record(100)).unwrap();
@@ -986,13 +986,13 @@ mod test {
             max_request_bytes: 250,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
-                fake_response(status_codes::OK, time + 100.0, None),
-                fake_response(status_codes::OK, time + 200.0, None),
+                fake_response(status_codes::OK, time + 100_000, None),
+                fake_response(status_codes::OK, time + 200_000, None),
             ],
         );
 
@@ -1035,13 +1035,13 @@ mod test {
             max_request_bytes: 350,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
-                fake_response(status_codes::OK, time + 100.0, None),
-                fake_response(status_codes::OK, time + 200.0, None),
+                fake_response(status_codes::OK, time + 100_000, None),
+                fake_response(status_codes::OK, time + 200_000, None),
             ],
         );
 
@@ -1069,13 +1069,13 @@ mod test {
     #[test]
     fn test_pq_single_batch() {
         let cfg = InfoConfiguration::default();
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![fake_response(
                 status_codes::ACCEPTED,
-                time + 100.0,
+                time + 100_000,
                 Some("1234"),
             )],
         );
@@ -1107,13 +1107,13 @@ mod test {
             max_post_bytes: 200,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("1234")),
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("1234")),
             ],
         );
 
@@ -1156,14 +1156,14 @@ mod test {
             max_post_records: 3,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("1234")),
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("1234")),
             ],
         );
 
@@ -1222,15 +1222,15 @@ mod test {
             max_total_records: 5,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("abcd")),
-                fake_response(status_codes::ACCEPTED, time + 200.0, Some("abcd")),
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("1234")),
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("abcd")),
+                fake_response(status_codes::ACCEPTED, time + 200_000, Some("abcd")),
             ],
         );
 
@@ -1298,19 +1298,6 @@ mod test {
         );
     }
 
-    macro_rules! assert_feq {
-        ($a:expr, $b:expr) => {
-            let a = $a;
-            let b = $b;
-            assert!(
-                (a - b).abs() < std::f64::EPSILON,
-                "assert_feq failure: {} != {}",
-                a,
-                b
-            )
-        };
-    }
-
     #[test]
     #[allow(clippy::cognitive_complexity)]
     fn test_pq_multi_post_multi_batch_bytes() {
@@ -1319,37 +1306,37 @@ mod test {
             max_total_bytes: 500,
             ..InfoConfiguration::default()
         };
-        let time = 11_111_111.0;
+        let time = 11_111_111_000;
         let (mut pq, tester) = pq_test_setup(
             cfg,
             time,
             vec![
                 fake_response(status_codes::ACCEPTED, time, Some("1234")),
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("1234")), // should commit
-                fake_response(status_codes::ACCEPTED, time + 100.0, Some("abcd")),
-                fake_response(status_codes::ACCEPTED, time + 200.0, Some("abcd")), // should commit
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("1234")), // should commit
+                fake_response(status_codes::ACCEPTED, time + 100_000, Some("abcd")),
+                fake_response(status_codes::ACCEPTED, time + 200_000, Some("abcd")), // should commit
             ],
         );
 
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
-        assert_feq!(pq.last_modified.0, time);
+        assert_eq!(pq.last_modified.0, time);
         // POST
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
         // POST + COMMIT
         pq.enqueue(&make_record(100)).unwrap();
-        assert_feq!(pq.last_modified.0, time + 100.0);
+        assert_eq!(pq.last_modified.0, time + 100_000);
         pq.enqueue(&make_record(100)).unwrap();
         pq.enqueue(&make_record(100)).unwrap();
 
         // POST
         pq.enqueue(&make_record(100)).unwrap();
-        assert_feq!(pq.last_modified.0, time + 100.0);
+        assert_eq!(pq.last_modified.0, time + 100_000);
         pq.flush(true).unwrap(); // COMMIT
 
-        assert_feq!(pq.last_modified.0, time + 200.0);
+        assert_eq!(pq.last_modified.0, time + 200_000);
 
         let t = tester.borrow();
         assert!(t.cur_batch.is_none());

--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -536,7 +536,7 @@ mod tests {
             xius: ServerTimestamp,
             _global: &MetaGlobalRecord,
         ) -> error::Result<()> {
-            assert_eq!(xius, ServerTimestamp(999.9));
+            assert_eq!(xius, ServerTimestamp(999_900));
             Err(ErrorKind::StorageHttpError(ErrorResponse::ServerError {
                 status: 500,
                 route: "meta/global".to_string(),
@@ -560,7 +560,7 @@ mod tests {
             xius: ServerTimestamp,
             _keys: &EncryptedBso,
         ) -> error::Result<()> {
-            assert_eq!(xius, ServerTimestamp(888.8));
+            assert_eq!(xius, ServerTimestamp(888_800));
             Err(ErrorKind::StorageHttpError(ErrorResponse::ServerError {
                 status: 500,
                 route: "crypto/keys".to_string(),
@@ -573,7 +573,7 @@ mod tests {
         }
     }
 
-    fn mocked_success_ts<T>(t: T, ts: f64) -> error::Result<Sync15ClientResponse<T>> {
+    fn mocked_success_ts<T>(t: T, ts: i64) -> error::Result<Sync15ClientResponse<T>> {
         Ok(Sync15ClientResponse::Success {
             status: 200,
             record: t,
@@ -583,7 +583,7 @@ mod tests {
     }
 
     fn mocked_success<T>(t: T) -> error::Result<Sync15ClientResponse<T>> {
-        mocked_success_ts(t, 0.0)
+        mocked_success_ts(t, 0)
     }
 
     // for tests, we want a BSO with a specific timestamp, which we never
@@ -614,14 +614,14 @@ mod tests {
     fn test_state_machine_ready_from_empty() {
         let root_key = KeyBundle::new_random().unwrap();
         let keys = CollectionKeys {
-            timestamp: 123.4.into(),
+            timestamp: 123_400.into(),
             default: KeyBundle::new_random().unwrap(),
             collections: HashMap::new(),
         };
         let client = InMemoryClient {
             info_configuration: mocked_success(InfoConfiguration::default()),
             info_collections: mocked_success(InfoCollections::new(
-                vec![("meta", 123.456), ("crypto", 145.0)]
+                vec![("meta", 123_456), ("crypto", 145_000)]
                     .into_iter()
                     .map(|(key, value)| (key.to_owned(), value.into()))
                     .collect(),
@@ -642,12 +642,12 @@ mod tests {
                     .collect(),
                     declined: vec![],
                 },
-                999.0,
+                999_000,
             ),
             crypto_keys: mocked_success_ts(
-                keys.to_encrypted_bso_with_timestamp(&root_key, 888.0.into())
+                keys.to_encrypted_bso_with_timestamp(&root_key, 888_000.into())
                     .expect("should always work in this test"),
-                888.0,
+                888_000,
             ),
         };
         let mut pgs = PersistedGlobalState::V2 { declined: None };

--- a/components/sync15/src/token.rs
+++ b/components/sync15/src/token.rs
@@ -455,7 +455,7 @@ mod tests {
                     duration: 1000,
                     hashed_fxa_uid: "hash".to_string(),
                 },
-                server_timestamp: ServerTimestamp(0f64),
+                server_timestamp: ServerTimestamp(0i64),
             })
         };
 
@@ -513,7 +513,7 @@ mod tests {
                     duration: 10,
                     hashed_fxa_uid: "hash".to_string(),
                 },
-                server_timestamp: ServerTimestamp(0f64),
+                server_timestamp: ServerTimestamp(0i64),
             })
         };
         let now: Cell<SystemTime> = Cell::new(SystemTime::now());


### PR DESCRIPTION
Store an i64 instead of f64 in sync15::ServerTimestamp.
Issue #815 