### PR TITLE
Bug 1547928 - prevent releases to be retriggered by editing their fields

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -132,7 +132,7 @@ tasks:
             - metadata:
                 name: Application Services - Decision task (master)
                 description: Schedules the build and test tasks for Application Services.
-        "tasks_for == 'github-release'":
+        "tasks_for == 'github-release' && event['action'] == 'published'":
           $let:
             beetmover_worker_type: appsv-beetmover-v1
             beetmover_bucket: maven-production


### PR DESCRIPTION
This it to prevent bugs such as https://bugzilla.mozilla.org/show_bug.cgi?id=1547928 where enditing a former release's description field retriggered the release because of https://developer.github.com/v3/activity/events/types/#releaseevent.

Trimming the event actions to merely publishing (that *excludes* draft releases or pre-releases) so that we don't hit this again.

It's scriptworker dependency has already been addressed generically (for all projects enabled theree) and deployed via https://github.com/mozilla-releng/scriptworker/pull/339