### PR TITLE
Mention Firefox Send in FxA service list

### DIFF
--- a/docs/product-portal/accounts/faq.md
+++ b/docs/product-portal/accounts/faq.md
@@ -5,7 +5,7 @@ sidebar_label: Frequently Asked Questions
 ---
 
 ## Am I required to create a Firefox Account to use Firefox?
-No. A Firefox Account is only required for Mozilla Services that require authentication, such as Firefox Sync and advanced features on Firefox Marketplace like purchasing paid apps, adding app reviews etc.
+No. A Firefox Account is only required for Mozilla Services that require authentication, such as Firefox Sync and advanced features on addons.mozilla.org like posting reviews, publishing new add-ons, etc.
 
 ## Why does Firefox Accounts require me to choose a password?
 One of the primary services that uses Firefox Accounts is Firefox Sync, which encrypts all your data client-side before submitting it to the server. The password is used to securely derive an encryption key.

--- a/docs/product-portal/accounts/welcome.md
+++ b/docs/product-portal/accounts/welcome.md
@@ -23,7 +23,7 @@ Firefox Accounts integration is currently recommended only for Mozilla-hosted se
 
 All reliers need to register the following information with Firefox Accounts:
 
-*   **name** \- a user friendly name for your service, e.g., "Firefox Marketplace".
+*   **name** \- a user friendly name for your service, e.g., "Firefox Send".
 *   **redirect_uri** - a HTTPS endpoint on your service, to which we can return the user after authentication has completed.
 
 In return, your service will be allocated a set of OAuth client credentials:
@@ -227,8 +227,6 @@ Below is a list of current and future Mozilla services that delegate authenticat
 
 *   [Firefox Send](https://send.firefox.com/)
 *   [Firefox Sync](https://www.mozilla.org/en-US/firefox/sync/) (since Firefox 29)
-*   [Find My Device](https://wiki.mozilla.org/CloudServices/FindMyDevice)
-*   [Firefox Marketplace](/en-US/Marketplace)
 *   [addons.mozilla.org](https://addons.mozilla.org)
 *   [Mozilla IAM](https://github.com/mozilla-iam/mozilla-iam) (since [June 2018](https://discourse.mozilla.org/t/announcing-firefox-accounts-in-mozilla-iam/29218))
 

--- a/docs/product-portal/accounts/welcome.md
+++ b/docs/product-portal/accounts/welcome.md
@@ -225,6 +225,7 @@ Below is a list of current and future Mozilla services that delegate authenticat
 
 ### Current
 
+*   [Firefox Send](https://send.firefox.com/)
 *   [Firefox Sync](https://www.mozilla.org/en-US/firefox/sync/) (since Firefox 29)
 *   [Find My Device](https://wiki.mozilla.org/CloudServices/FindMyDevice)
 *   [Firefox Marketplace](/en-US/Marketplace)


### PR DESCRIPTION
A minor change to the FxA documentation, to list Firefox Send in the list of FxA services as well.