### PR TITLE
Revert "Enable SQLITE_DBCONFIG_DEFENSIVE for places and logins db connections"

### DIFF
--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -9,7 +9,6 @@ use crate::update_plan::UpdatePlan;
 use crate::util;
 use lazy_static::lazy_static;
 use rusqlite::{
-    config::DbConfig,
     named_params,
     types::{FromSql, ToSql},
     Connection, NO_PARAMS,
@@ -59,7 +58,6 @@ impl LoginDb {
         // https://github.com/mozilla/mentat/issues/505. Ideally we'd only
         // do this on Android, or allow caller to configure it.
         db.set_pragma("temp_store", 2)?;
-        db.set_db_config(DbConfig::SQLITE_DBCONFIG_DEFENSIVE, true)?;
 
         let mut logins = Self {
             db,

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -5,7 +5,7 @@
 use super::schema;
 use crate::api::places_api::ConnectionType;
 use crate::error::*;
-use rusqlite::{config::DbConfig, Connection};
+use rusqlite::Connection;
 use sql_support::{ConnExt, SqlInterruptHandle, SqlInterruptScope};
 use std::ops::Deref;
 use std::path::Path;
@@ -69,7 +69,6 @@ impl PlacesDb {
         ";
 
         db.execute_batch(initial_pragmas)?;
-        db.set_db_config(DbConfig::SQLITE_DBCONFIG_DEFENSIVE, true)?;
         define_functions(&db)?;
         let res = Self {
             db,


### PR DESCRIPTION
Reverts mozilla/application-services#1194

I did this from the github UI, so I don't have the template.