### PR TITLE
Pass an empty FxA UID instead of `null` to Kotlin

### DIFF
--- a/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
+++ b/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
@@ -41,6 +41,15 @@ data class SyncTelemetryPing(
     companion object {
         @JvmField val EMPTY_UID = "0".repeat(32)
 
+        fun empty(): SyncTelemetryPing {
+            return SyncTelemetryPing(
+                version = 1,
+                uid = EMPTY_UID,
+                events = emptyList(),
+                syncs = emptyList()
+            )
+        }
+
         fun fromJSON(jsonObject: JSONObject): SyncTelemetryPing {
             val events = unwrapFromJSON(jsonObject) {
                 it.getJSONArray("events")
@@ -88,8 +97,8 @@ data class SyncTelemetryPing(
 }
 
 data class SyncInfo(
-    val at: Int,
-    val took: Int,
+    val at: Long,
+    val took: Long,
     val engines: List<EngineInfo>,
     val failureReason: FailureReason?
 ) {
@@ -106,8 +115,8 @@ data class SyncInfo(
                 FailureReason.fromJSON(it)
             }
             return SyncInfo(
-                at = jsonObject.getInt("when"),
-                took = intOrZero(jsonObject, "took"),
+                at = jsonObject.getLong("when"),
+                took = longOrZero(jsonObject, "took"),
                 engines = engines,
                 failureReason = failureReason
             )
@@ -144,8 +153,8 @@ data class SyncInfo(
 
 data class EngineInfo(
     val name: String,
-    val at: Int,
-    val took: Int,
+    val at: Long,
+    val took: Long,
     val incoming: IncomingInfo?,
     val outgoing: List<OutgoingInfo>,
     val failureReason: FailureReason?,
@@ -175,8 +184,8 @@ data class EngineInfo(
             }
             return EngineInfo(
                 name = jsonObject.getString("name"),
-                at = jsonObject.getInt("when"),
-                took = intOrZero(jsonObject, "took"),
+                at = jsonObject.getLong("when"),
+                took = longOrZero(jsonObject, "took"),
                 incoming = incoming,
                 outgoing = outgoing,
                 failureReason = failureReason,
@@ -476,6 +485,12 @@ data class EventInfo(
             }
         }
     }
+}
+
+private fun longOrZero(jsonObject: JSONObject, key: String): Long {
+    return unwrapFromJSON(jsonObject) {
+        it.getLong(key)
+    } ?: 0
 }
 
 private fun intOrZero(jsonObject: JSONObject, key: String): Int {

--- a/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
+++ b/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
@@ -22,6 +22,7 @@ import org.json.JSONObject
  * Applications like Fenix that embed Glean will automatically submit these
  * pings.
  */
+
 enum class FailureName {
     Shutdown,
     Other,
@@ -33,11 +34,13 @@ enum class FailureName {
 
 data class SyncTelemetryPing(
     val version: Int,
-    val uid: String?,
+    val uid: String,
     val events: List<EventInfo>,
     val syncs: List<SyncInfo>
 ) {
     companion object {
+        @JvmField val EMPTY_UID = "0".repeat(32)
+
         fun fromJSON(jsonObject: JSONObject): SyncTelemetryPing {
             val events = unwrapFromJSON(jsonObject) {
                 it.getJSONArray("events")
@@ -51,7 +54,7 @@ data class SyncTelemetryPing(
             } ?: emptyList()
             return SyncTelemetryPing(
                 version = jsonObject.getInt("version"),
-                uid = stringOrNull(jsonObject, "uid"),
+                uid = stringOrNull(jsonObject, "uid") ?: EMPTY_UID,
                 events = events,
                 syncs = syncs
             )
@@ -65,9 +68,7 @@ data class SyncTelemetryPing(
     fun toJSON(): JSONObject {
         var result = JSONObject()
         result.put("version", version)
-        uid?.let {
-            result.put("uid", it)
-        }
+        result.put("uid", uid)
         if (!events.isEmpty()) {
             result.put("events", JSONArray().apply {
                 events.forEach {


### PR DESCRIPTION
Instead of making a-c do this for each ping. 😄

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
