### PR TITLE
Prevent matcher.rs panicing on an invalid URL

### DIFF
--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -27,8 +27,9 @@ where
         .inspect(|r| {
             if let Err(ref e) = *r {
                 log::warn!("Failed to perform a search: {}", e);
-                #[cfg(debug_assertions)]
-                panic!("Failed to perform a search: {}", e);
+                if cfg!(debug_assertions) {
+                    panic!("Failed to perform a search: {}", e);
+                }
             }
         })
         .flatten()
@@ -773,7 +774,10 @@ mod tests {
     // we are panicing where we think we are, note the 'expected' string.
     // (Not really clear this test offers much value, but seems worth having...)
     #[test]
-    #[should_panic(expected = "Failed to perform a search:")]
+    #[cfg_attr(
+        debug_assertions,
+        should_panic(expected = "Failed to perform a search:")
+    )]
     fn search_invalid_url() {
         use rusqlite::NO_PARAMS;
         let conn = new_mem_connection();


### PR DESCRIPTION
I think this is the last actionable thing from us to fix #1222 - another key part was in 89b79ba7bce9e2d11dfb0d9d64fc9579cce9b4d2 (although that commit doesn't appear to have an issue number in the message!)

I hope this was the fix Thom had in mind :)