### PR TITLE
URL parse errors from the FFI should be a places error, not a sync error

### DIFF
--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use places::api::matcher::{match_url, search_frecent, SearchParams};
 
 // indirection to help `?` figure out the target error type
-fn parse_url(url: &str) -> sync15::Result<url::Url> {
+fn parse_url(url: &str) -> places::Result<url::Url> {
     Ok(url::Url::parse(url)?)
 }
 


### PR DESCRIPTION
As found by @linacambridge. I suspect (but am not sure) that the current code will fail to turn a URL parse error into a `URL_PARSE_ERROR` in this scenario, but would for other parse errors in the lib.