### PR TITLE
Provide custom Debug implementation for structs containing various secrets

### DIFF
--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -259,10 +259,18 @@ impl FirefoxAccount {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RefreshToken {
     pub token: String,
     pub scopes: HashSet<String>,
+}
+
+impl std::fmt::Debug for RefreshToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RefreshToken")
+            .field("scopes", &self.scopes)
+            .finish()
+    }
 }
 
 pub struct OAuthFlow {
@@ -270,12 +278,22 @@ pub struct OAuthFlow {
     pub code_verifier: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AccessTokenInfo {
     pub scope: String,
     pub token: String,
     pub key: Option<ScopedKey>,
     pub expires_at: u64, // seconds since epoch
+}
+
+impl std::fmt::Debug for AccessTokenInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AccessTokenInfo")
+            .field("scope", &self.scope)
+            .field("key", &self.key)
+            .field("expires_at", &self.expires_at)
+            .finish()
+    }
 }
 
 #[cfg(test)]

--- a/components/fxa-client/src/scoped_keys.rs
+++ b/components/fxa-client/src/scoped_keys.rs
@@ -18,7 +18,7 @@ impl FirefoxAccount {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ScopedKey {
     pub kty: String,
     pub scope: String,
@@ -30,6 +30,16 @@ pub struct ScopedKey {
 impl ScopedKey {
     pub fn key_bytes(&self) -> Result<Vec<u8>> {
         Ok(base64::decode_config(&self.k, base64::URL_SAFE_NO_PAD)?)
+    }
+}
+
+impl std::fmt::Debug for ScopedKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScopedKey")
+            .field("kty", &self.kty)
+            .field("scope", &self.scope)
+            .field("kid", &self.kid)
+            .finish()
     }
 }
 

--- a/components/push/src/crypto.rs
+++ b/components/push/src/crypto.rs
@@ -26,12 +26,18 @@ pub(crate) enum VersionnedKey {
     V1(KeyV1),
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct KeyV1 {
     p256key: EcKeyComponents,
     pub auth: Vec<u8>,
 }
 pub type Key = KeyV1;
+
+impl std::fmt::Debug for KeyV1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KeyV1").finish()
+    }
+}
 
 impl Key {
     // We define this method so the type-checker prevents us from

--- a/components/sync15/src/key_bundle.rs
+++ b/components/sync15/src/key_bundle.rs
@@ -8,10 +8,16 @@ use openssl::pkey::PKey;
 use openssl::sign::Signer;
 use openssl::{self, symm};
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct KeyBundle {
     enc_key: Vec<u8>,
     mac_key: Vec<u8>,
+}
+
+impl std::fmt::Debug for KeyBundle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KeyBundle").finish()
+    }
 }
 
 impl KeyBundle {

--- a/components/sync15/src/token.rs
+++ b/components/sync15/src/token.rs
@@ -16,7 +16,7 @@ const RETRY_AFTER_DEFAULT_MS: u64 = 10000;
 
 // The TokenserverToken is the token as received directly from the token server
 // and deserialized from JSON.
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Clone, PartialEq, Eq)]
 struct TokenserverToken {
     id: String,
     key: String,
@@ -24,6 +24,17 @@ struct TokenserverToken {
     uid: u64,
     duration: u64,
     hashed_fxa_uid: String,
+}
+
+impl std::fmt::Debug for TokenserverToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenserverToken")
+            .field("api_endpoint", &self.api_endpoint)
+            .field("uid", &self.uid)
+            .field("duration", &self.duration)
+            .field("hashed_fxa_uid", &self.hashed_fxa_uid)
+            .finish()
+    }
 }
 
 // The struct returned by the TokenFetcher - the token itself and the


### PR DESCRIPTION
This will hopefully make it less likely for said secrets to show up accidentally in logs.

We may lose some slight visibility into debug output (e.g. you can't look at two logged instances of a key and see if they're the same) but I think that's an OK tradeoff.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- ~~[ ] **Tests**: This PR includes thorough tests or an explanation of why it does not~~
- ~~[ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one~~
- ~~[ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)~~