### PR TITLE
Fix cli-support's ability to use prod

### DIFF
--- a/components/support/cli/src/fxa_creds.rs
+++ b/components/support/cli/src/fxa_creds.rs
@@ -19,8 +19,8 @@ type Result<T> = std::result::Result<T, failure::Error>;
 
 // Defaults - not clear they are the best option, but they are a currently
 // working option.
-const CLIENT_ID: &str = "3c49430b43dfba77";
-const REDIRECT_URI: &str = "https://stable.dev.lcip.org/oauth/success/3c49430b43dfba77";
+const CLIENT_ID: &str = "e7ce535d93522896";
+const REDIRECT_URI: &str = "https://lockbox.firefox.com/fxa/android-redirect.html";
 const SYNC_SCOPE: &str = "https://identity.mozilla.com/apps/oldsync";
 
 fn load_fxa_creds(path: &str) -> Result<FirefoxAccount> {


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
