### PR TITLE
Better handling of invalid access tokens

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,25 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.31.0...master)
+
+## FxA Client
+
+### What's new
+
+- Added a new method to help recover from invalid access tokens. If the application receives an
+  an authentication exception while using a token obtained through `FirefoxAccount.getAccessToken`,
+  it should:
+  - Call `FirefoxAccount.clearAccessTokenCache` to remove the invalid token from the internal cache.
+  - Retry the operation after obtaining fresh access token via `FirefoxAccount.getAccessToken`.
+  - If the retry also fails with an authentication exception, then the user will need to reconnect
+    their account via a fresh OAuth flow.
+- `FirefoxAccount.getProfile` now performs the above retry logic automagically. An authentication
+  error while calling `getProfile` indicates that the user needs to reconnect their account.
+
+## Logins
+
+### Breaking Changes
+
+- iOS: LoginsStoreError enum variants have their name `lowerCamelCased`
+  instead of `UpperCamelCased`, to better fit with common Swift code style.
+  ([#1042](https://github.com/mozilla/application-services/issues/1042))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -675,9 +675,9 @@ name = "failure_derive"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -822,6 +822,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mockiato 0.7.0 (git+https://github.com/myelin-ai/mockiato.git?rev=bfd8d83a64d41d26ef593b304c183fb7c4ba61be)",
  "openssl 0.10.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1263,6 +1264,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockiato"
+version = "0.7.0"
+source = "git+https://github.com/myelin-ai/mockiato.git?rev=bfd8d83a64d41d26ef593b304c183fb7c4ba61be#bfd8d83a64d41d26ef593b304c183fb7c4ba61be"
+dependencies = [
+ "mockiato-codegen 0.7.0 (git+https://github.com/myelin-ai/mockiato.git?rev=bfd8d83a64d41d26ef593b304c183fb7c4ba61be)",
+ "nameof 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nearly_eq 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mockiato-codegen"
+version = "0.7.0"
+source = "git+https://github.com/myelin-ai/mockiato.git?rev=bfd8d83a64d41d26ef593b304c183fb7c4ba61be#bfd8d83a64d41d26ef593b304c183fb7c4ba61be"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mockito"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1312,11 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "nameof"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "native-tls"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,6 +1332,11 @@ dependencies = [
  "security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "nearly_eq"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "net2"
@@ -1579,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1619,9 +1653,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1699,7 +1733,7 @@ name = "quote"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2112,9 +2146,9 @@ name = "serde_derive"
 version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2215,9 +2249,9 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2227,10 +2261,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.15.33"
+version = "0.15.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2277,9 +2311,9 @@ name = "synstructure"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2897,10 +2931,14 @@ dependencies = [
 "checksum miniz_oxide_c_api 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab"
 "checksum mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)" = "71646331f2619b1026cc302f87a2b8b648d5c6dd6937846a16cc8ce0f347f432"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum mockiato 0.7.0 (git+https://github.com/myelin-ai/mockiato.git?rev=bfd8d83a64d41d26ef593b304c183fb7c4ba61be)" = "<none>"
+"checksum mockiato-codegen 0.7.0 (git+https://github.com/myelin-ai/mockiato.git?rev=bfd8d83a64d41d26ef593b304c183fb7c4ba61be)" = "<none>"
 "checksum mockito 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d303c060b18db22e0a9ac12133c32f927c3f980b6f70004bc0cb2f8accc94704"
 "checksum more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 "checksum multimap 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
+"checksum nameof 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d070df66b835aae5a33cbc9df3d8213dc9daaed6b1b7fe47c9663b007587efd"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
+"checksum nearly_eq 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a629868a433328c35d654e1e1fb4648a68a042e3c71de4e507a9bcf4602c5635"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -2926,7 +2964,7 @@ dependencies = [
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum prettytable-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5511ca4c805aa35f0abff6be7923231d664408b60c09f44ef715f2bce106cd9e"
-"checksum proc-macro2 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)" = "64c827cea7a7ab30ce4593e5e04d7a11617ad6ece2fa230605a78b00ff965316"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
 "checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
 "checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
@@ -2991,7 +3029,7 @@ dependencies = [
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)" = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836"
+"checksum syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)" = "641e117d55514d6d918490e47102f7e08d096fdde360247e4a10f7a91a8478d3"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ce2fe9db64b842314052e2421ac61a73ce41b898dc8e3750398b219c5fc1e0"

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -34,6 +34,8 @@ cli-support = { path = "../support/cli" }
 force-viaduct-reqwest = { path = "../support/force-viaduct-reqwest" }
 dialoguer = "0.3.0"
 webbrowser = "0.4.0"
+# Use unreleased `mockiato` with support for `returns_once`.
+mockiato = { git = "https://github.com/myelin-ai/mockiato.git", rev = "bfd8d83a64d41d26ef593b304c183fb7c4ba61be" }
 
 [build-dependencies]
 prost-build = "0.5"

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -241,6 +241,19 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
     }
 
     /**
+     * This method should be called when a request made with
+     * an OAuth token failed with an authentication error.
+     * It clears the internal cache of OAuth access tokens,
+     * so the caller can try to call `getAccessToken` or `getProfile`
+     * again.
+     */
+    fun clearAccessTokenCache() {
+        rustCallWithLock { e ->
+            LibFxAFFI.INSTANCE.fxa_clear_access_token_cache(this.handle.get(), e)
+        }
+    }
+
+    /**
      * Migrate from a logged-in Firefox Account.
      *
      * Modifies the FirefoxAccount state.

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -76,6 +76,7 @@ internal interface LibFxAFFI : Library {
 
     fun fxa_complete_oauth_flow(fxa: FxaHandle, code: String, state: String, e: RustError.ByReference)
     fun fxa_get_access_token(fxa: FxaHandle, scope: String, e: RustError.ByReference): RustBuffer.ByValue
+    fun fxa_clear_access_token_cache(fxa: FxaHandle, e: RustError.ByReference)
 
     fun fxa_set_push_subscription(
         fxa: FxaHandle,

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -289,6 +289,17 @@ pub extern "C" fn fxa_get_access_token(
     })
 }
 
+/// This method should be called when a request made with
+/// an OAuth token failed with an authentication error.
+/// It clears the internal cache of OAuth access tokens,
+/// so the caller can try to call `fxa_get_access_token` or `fxa_profile`
+/// again.
+#[no_mangle]
+pub extern "C" fn fxa_clear_access_token_cache(handle: u64, error: &mut ExternError) {
+    log::debug!("fxa_clear_access_token_cache");
+    ACCOUNTS.call_with_output_mut(error, handle, |fxa| fxa.clear_access_token_cache())
+}
+
 /// Update the Push subscription information for the current device.
 #[no_mangle]
 pub extern "C" fn fxa_set_push_subscription(

--- a/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
@@ -253,6 +253,24 @@ open class FirefoxAccount {
             }
         }
     }
+
+    /// This method should be called when a request made with
+    /// an OAuth token failed with an authentication error.
+    /// It clears the internal cache of OAuth access tokens,
+    /// so the caller can try to call `getAccessToken` or `getProfile`
+    /// again.
+    open func clearAccessTokenCache(completionHandler: @escaping (Void, Error?) -> Void) {
+        queue.async {
+            do {
+                try FirefoxAccountError.unwrap { err in
+                    fxa_clear_access_token_cache(self.raw, err)
+                }
+                DispatchQueue.main.async { completionHandler((), nil) }
+            } catch {
+                DispatchQueue.main.async { completionHandler((), error) }
+            }
+        }
+    }
 }
 
 public struct ScopedKey {

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -57,6 +57,9 @@ FxARustBuffer fxa_get_access_token(FirefoxAccountHandle handle,
                                    const char *_Nonnull scope,
                                    FxAError *_Nonnull out);
 
+FxARustBuffer fxa_clear_access_token_cache(FirefoxAccountHandle handle,
+                                             FxAError *_Nonnull out);
+
 FirefoxAccountHandle fxa_from_json(const char *_Nonnull json,
                                    FxAError *_Nonnull out);
 

--- a/components/fxa-client/src/http_client.rs
+++ b/components/fxa-client/src/http_client.rs
@@ -11,6 +11,7 @@ use viaduct::{header_names, status_codes, Method, Request, Response};
 
 pub(crate) mod browser_id;
 
+#[cfg_attr(test, mockiato::mockable)]
 pub trait FxAClient {
     fn oauth_token_with_code(
         &self,

--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -124,6 +124,7 @@ impl FirefoxAccount {
     }
 
     fn oauth_flow(&mut self, mut url: Url, scopes: &[&str], wants_keys: bool) -> Result<String> {
+        self.clear_access_token_cache();
         let state = util::random_base64_url_string(&*RNG, 16)?;
         let code_verifier = util::random_base64_url_string(&*RNG, 43)?;
         let code_challenge = digest::digest(&digest::SHA256, &code_verifier.as_bytes());
@@ -161,6 +162,7 @@ impl FirefoxAccount {
     ///
     /// **💾 This method alters the persisted account state.**
     pub fn complete_oauth_flow(&mut self, code: &str, state: &str) -> Result<()> {
+        self.clear_access_token_cache();
         let oauth_flow = match self.flow_store.remove(state) {
             Some(oauth_flow) => oauth_flow,
             None => return Err(ErrorKind::UnknownOAuthState.into()),
@@ -256,6 +258,10 @@ impl FirefoxAccount {
             }
         }
         Ok(())
+    }
+
+    pub fn clear_access_token_cache(&mut self) {
+        self.access_token_cache.clear();
     }
 }
 

--- a/components/fxa-client/src/profile.rs
+++ b/components/fxa-client/src/profile.rs
@@ -17,6 +17,22 @@ impl FirefoxAccount {
     /// * `ignore_cache` - If set to true, bypass the in-memory cache
     /// and fetch the entire profile data from the server.
     pub fn get_profile(&mut self, ignore_cache: bool) -> Result<Profile> {
+        match self.get_profile_helper(ignore_cache) {
+            Ok(res) => Ok(res),
+            Err(e) => match e.kind() {
+                ErrorKind::RemoteError { code: 401, .. } => {
+                    log::warn!(
+                        "Access token rejected, clearing the tokens cache and trying again."
+                    );
+                    self.clear_access_token_cache();
+                    self.get_profile_helper(ignore_cache)
+                }
+                _ => Err(e),
+            },
+        }
+    }
+
+    fn get_profile_helper(&mut self, ignore_cache: bool) -> Result<Profile> {
         let mut etag = None;
         if let Some(ref cached_profile) = self.profile_cache {
             if !ignore_cache && util::now() < cached_profile.cached_at + PROFILE_FRESHNESS_THRESHOLD
@@ -65,130 +81,47 @@ impl FirefoxAccount {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{http_client::*, oauth::AccessTokenInfo, Config};
-    use std::{collections::HashMap, sync::Arc};
-
-    struct FakeClient {
-        pub is_success: bool, // Can't clone Result<T, error>.
-        pub profile_response: Option<ResponseAndETag<ProfileResponse>>,
-    }
+    use crate::{
+        http_client::*,
+        oauth::{AccessTokenInfo, RefreshToken},
+    };
+    use std::sync::Arc;
 
     impl FirefoxAccount {
-        fn add_token(&mut self, scope: &str, token_info: AccessTokenInfo) {
+        fn add_cached_token(&mut self, scope: &str, token_info: AccessTokenInfo) {
             self.access_token_cache
                 .insert(scope.to_string(), token_info);
         }
     }
 
-    impl FxAClient for FakeClient {
-        fn oauth_token_with_code(
-            &self,
-            _: &Config,
-            _: &str,
-            _: &str,
-        ) -> Result<OAuthTokenResponse> {
-            unimplemented!()
-        }
-        fn oauth_token_with_refresh_token(
-            &self,
-            _: &Config,
-            _: &str,
-            _: &[&str],
-        ) -> Result<OAuthTokenResponse> {
-            unimplemented!()
-        }
-        fn oauth_token_from_session_token(
-            &self,
-            _: &Config,
-            _: &[u8],
-            _: &[&str],
-        ) -> Result<OAuthTokenResponse> {
-            unimplemented!()
-        }
-        fn duplicate_session(
-            &self,
-            _config: &Config,
-            _token: &[u8],
-        ) -> Result<DuplicateTokenResponse> {
-            unimplemented!()
-        }
-        fn destroy_oauth_token(&self, _config: &Config, _token: &str) -> Result<()> {
-            unimplemented!()
-        }
-        fn scoped_key_data(
-            &self,
-            _: &Config,
-            _: &[u8],
-            _: &str,
-        ) -> Result<HashMap<String, ScopedKeyDataResponse>> {
-            unimplemented!()
-        }
-        fn profile(
-            &self,
-            _: &Config,
-            _: &str,
-            _: Option<String>,
-        ) -> Result<Option<ResponseAndETag<ProfileResponse>>> {
-            if self.is_success {
-                Ok(self.profile_response.clone())
-            } else {
-                panic!("Not implemented yet")
-            }
-        }
-        fn pending_commands(
-            &self,
-            _: &Config,
-            _: &str,
-            _: u64,
-            _: Option<u64>,
-        ) -> Result<PendingCommandsResponse> {
-            unimplemented!("Not implemented yet")
-        }
-        fn invoke_command(
-            &self,
-            _: &Config,
-            _: &str,
-            _: &str,
-            _: &str,
-            _: &serde_json::Value,
-        ) -> Result<()> {
-            unimplemented!("Not implemented yet")
-        }
-        fn devices(&self, _: &Config, _: &str) -> Result<Vec<GetDeviceResponse>> {
-            unimplemented!("Not implemented yet")
-        }
-        fn update_device(
-            &self,
-            _: &Config,
-            _: &str,
-            _: DeviceUpdateRequest<'_>,
-        ) -> Result<UpdateDeviceResponse> {
-            unimplemented!("Not implemented yet")
-        }
-
-        fn destroy_device(&self, _: &Config, _: &str, _: &str) -> Result<()> {
-            unimplemented!("Not implemented yet")
-        }
-    }
+    // FIXME: https://github.com/myelin-ai/mockiato/issues/106.
+    unsafe impl<'a> Send for FxAClientMock<'a> {}
+    unsafe impl<'a> Sync for FxAClientMock<'a> {}
 
     #[test]
     fn test_fetch_profile() {
         let mut fxa =
             FirefoxAccount::new("https://stable.dev.lcip.org", "12345678", "https://foo.bar");
 
-        fxa.add_token(
+        fxa.add_cached_token(
             "profile",
             AccessTokenInfo {
                 scope: "profile".to_string(),
-                token: "toktok".to_string(),
+                token: "profiletok".to_string(),
                 key: None,
                 expires_at: u64::max_value(),
             },
         );
 
-        let client = Arc::new(FakeClient {
-            is_success: true,
-            profile_response: Some(ResponseAndETag {
+        let mut client = FxAClientMock::new();
+        client
+            .expect_profile(
+                mockiato::Argument::any,
+                |token| token.partial_eq("profiletok"),
+                mockiato::Argument::any,
+            )
+            .times(1)
+            .returns_once(Ok(Some(ResponseAndETag {
                 response: ProfileResponse {
                     uid: "12345ab".to_string(),
                     email: "foo@bar.com".to_string(),
@@ -200,9 +133,87 @@ mod tests {
                     two_factor_authentication: false,
                 },
                 etag: None,
-            }),
+            })));
+        fxa.set_client(Arc::new(client));
+
+        let p = fxa.get_profile(false).unwrap();
+        assert_eq!(p.email, "foo@bar.com");
+    }
+
+    #[test]
+    fn test_expired_access_token_refetch() {
+        let mut fxa =
+            FirefoxAccount::new("https://stable.dev.lcip.org", "12345678", "https://foo.bar");
+
+        fxa.add_cached_token(
+            "profile",
+            AccessTokenInfo {
+                scope: "profile".to_string(),
+                token: "bad_access_token".to_string(),
+                key: None,
+                expires_at: u64::max_value(),
+            },
+        );
+        let mut refresh_token_scopes = std::collections::HashSet::new();
+        refresh_token_scopes.insert("profile".to_owned());
+        fxa.state.refresh_token = Some(RefreshToken {
+            token: "refreshtok".to_owned(),
+            scopes: refresh_token_scopes,
         });
-        fxa.set_client(client);
+
+        let mut client = FxAClientMock::new();
+        // First call to profile() we fail with 401.
+        client
+            .expect_profile(
+                mockiato::Argument::any,
+                |token| token.partial_eq("bad_access_token"),
+                mockiato::Argument::any,
+            )
+            .times(1)
+            .returns_once(Err(ErrorKind::RemoteError{
+                code: 401,
+                errno: 110,
+                error: "Unauthorized".to_owned(),
+                message: "Invalid authentication token in request signature".to_owned(),
+                info: "https://github.com/mozilla/fxa-auth-server/blob/master/docs/api.md#response-format".to_owned(),
+            }.into()));
+        // Then we'll try to get a new access token.
+        client
+            .expect_oauth_token_with_refresh_token(
+                mockiato::Argument::any,
+                |token| token.partial_eq("refreshtok"),
+                mockiato::Argument::any,
+            )
+            .times(1)
+            .returns_once(Ok(OAuthTokenResponse {
+                keys_jwe: None,
+                refresh_token: None,
+                expires_in: 6000000,
+                scope: "profile".to_owned(),
+                access_token: "good_profile_token".to_owned(),
+            }));
+        // Then hooray it works!
+        client
+            .expect_profile(
+                mockiato::Argument::any,
+                |token| token.partial_eq("good_profile_token"),
+                mockiato::Argument::any,
+            )
+            .times(1)
+            .returns_once(Ok(Some(ResponseAndETag {
+                response: ProfileResponse {
+                    uid: "12345ab".to_string(),
+                    email: "foo@bar.com".to_string(),
+                    locale: "fr-FR".to_string(),
+                    display_name: None,
+                    avatar: "https://foo.avatar".to_string(),
+                    avatar_default: true,
+                    amr_values: vec![],
+                    two_factor_authentication: false,
+                },
+                etag: None,
+            })));
+        fxa.set_client(Arc::new(client));
 
         let p = fxa.get_profile(false).unwrap();
         assert_eq!(p.email, "foo@bar.com");


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/1236

This PR follows Ryan's plan in https://github.com/mozilla/application-services/issues/1236#issuecomment-498907566.

Added dependency: Mockiato (dev dependency), under MIT license. It allows us to make better tests when mocking network calls.