### PR TITLE
Avoid keeping keys in memory and discard state when they change

### DIFF
--- a/components/places/src/history_sync/store.rs
+++ b/components/places/src/history_sync/store.rs
@@ -89,7 +89,6 @@ impl<'a> HistoryStore<'a> {
     }
 
     fn do_reset(&self, assoc: &StoreSyncAssociation) -> Result<()> {
-        log::info!("Resetting history store");
         let tx = self.db.begin_transaction()?;
         reset_storage(self.db)?;
         self.put_meta(LAST_SYNC_META_KEY, &0)?;

--- a/components/sync15/src/client.rs
+++ b/components/sync15/src/client.rs
@@ -222,7 +222,12 @@ impl Sync15StorageClient {
     where
         for<'a> T: serde::de::Deserialize<'a>,
     {
-        log::trace!("request: {} {}", req.method, req.url.path());
+        log::trace!(
+            "request: {} {} ({:?})",
+            req.method,
+            req.url.path(),
+            req.url.query()
+        );
         let resp = req.send()?;
         log::trace!("response: {}", resp.status);
 

--- a/components/sync15/src/coll_state.rs
+++ b/components/sync15/src/coll_state.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::collection_keys::CollectionKeys;
 use crate::error;
 use crate::key_bundle::KeyBundle;
 use crate::request::InfoConfiguration;
@@ -58,6 +59,7 @@ pub enum LocalCollState {
 
 pub struct LocalCollStateMachine<'state> {
     global_state: &'state GlobalState,
+    root_key: &'state KeyBundle,
 }
 
 impl<'state> LocalCollStateMachine<'state> {
@@ -81,8 +83,12 @@ impl<'state> LocalCollStateMachine<'state> {
                             if ids.global == meta_global.sync_id
                                 && ids.coll == engine_meta.sync_id =>
                         {
+                            let coll_keys = CollectionKeys::from_encrypted_bso(
+                                self.global_state.keys.clone(),
+                                self.root_key,
+                            )?;
                             Ok(LocalCollState::Ready {
-                                key: self.global_state.keys.default.clone(),
+                                key: coll_keys.key_for_collection(name).clone(),
                             })
                         }
                         _ => Ok(LocalCollState::SyncIdChanged {
@@ -102,6 +108,7 @@ impl<'state> LocalCollStateMachine<'state> {
 
             LocalCollState::SyncIdChanged { ids } => {
                 let assoc = StoreSyncAssociation::Connected(ids);
+                log::info!("Resetting {} store", store.collection_name());
                 store.reset(&assoc)?;
                 Ok(LocalCollState::Unknown { assoc })
             }
@@ -158,8 +165,12 @@ impl<'state> LocalCollStateMachine<'state> {
     pub fn get_state(
         store: &dyn Store,
         global_state: &'state GlobalState,
+        root_key: &'state KeyBundle,
     ) -> error::Result<Option<CollState>> {
-        let mut gingerbread_man = Self { global_state };
+        let mut gingerbread_man = Self {
+            global_state,
+            root_key,
+        };
         gingerbread_man.run_and_run_as_farst_as_you_can(store)
     }
 }
@@ -176,6 +187,10 @@ mod tests {
     use std::collections::HashMap;
 
     fn get_global_state() -> GlobalState {
+        let keys = CollectionKeys::new_random()
+            .unwrap()
+            .to_encrypted_bso(&KeyBundle::new_random().unwrap())
+            .unwrap();
         GlobalState {
             config: InfoConfiguration::default(),
             collections: InfoCollections::new(HashMap::new()),
@@ -195,7 +210,7 @@ mod tests {
                 declined: vec![],
             },
             global_timestamp: ServerTimestamp::default(),
-            keys: CollectionKeys::new_random().expect("should work"),
+            keys,
         }
     }
 
@@ -260,18 +275,20 @@ mod tests {
 
     #[test]
     fn test_unknown() {
+        let root_key = KeyBundle::new_random().expect("should work");
         let gs = get_global_state();
         let store = TestStore::new("unknown", StoreSyncAssociation::Disconnected);
-        let cs = LocalCollStateMachine::get_state(&store, &gs).expect("should work");
+        let cs = LocalCollStateMachine::get_state(&store, &gs, &root_key).expect("should work");
         assert!(cs.is_none(), "unknown collection name can't sync");
         assert_eq!(store.get_num_resets(), 0);
     }
 
     #[test]
     fn test_known_no_state() {
+        let root_key = KeyBundle::new_random().expect("should work");
         let gs = get_global_state();
         let store = TestStore::new("bookmarks", StoreSyncAssociation::Disconnected);
-        let cs = LocalCollStateMachine::get_state(&store, &gs).expect("should work");
+        let cs = LocalCollStateMachine::get_state(&store, &gs, &root_key).expect("should work");
         assert!(cs.is_some(), "collection can sync");
         assert_eq!(
             store.assoc.replace(StoreSyncAssociation::Disconnected),
@@ -285,6 +302,7 @@ mod tests {
 
     #[test]
     fn test_known_wrong_state() {
+        let root_key = KeyBundle::new_random().expect("should work");
         let gs = get_global_state();
         let store = TestStore::new(
             "bookmarks",
@@ -293,7 +311,7 @@ mod tests {
                 coll: "syncIDYYYYYY".to_string(),
             }),
         );
-        let cs = LocalCollStateMachine::get_state(&store, &gs).expect("should work");
+        let cs = LocalCollStateMachine::get_state(&store, &gs, &root_key).expect("should work");
         assert!(cs.is_some(), "collection can sync");
         assert_eq!(
             store.assoc.replace(StoreSyncAssociation::Disconnected),
@@ -307,6 +325,7 @@ mod tests {
 
     #[test]
     fn test_known_good_state() {
+        let root_key = KeyBundle::new_random().expect("should work");
         let gs = get_global_state();
         let store = TestStore::new(
             "bookmarks",
@@ -315,13 +334,14 @@ mod tests {
                 coll: "syncIDBBBBBB".to_string(),
             }),
         );
-        let cs = LocalCollStateMachine::get_state(&store, &gs).expect("should work");
+        let cs = LocalCollStateMachine::get_state(&store, &gs, &root_key).expect("should work");
         assert!(cs.is_some(), "collection can sync");
         assert_eq!(store.get_num_resets(), 0);
     }
 
     #[test]
     fn test_declined() {
+        let root_key = KeyBundle::new_random().expect("should work");
         let mut gs = get_global_state();
         gs.global.declined.push("bookmarks".to_string());
         let store = TestStore::new(
@@ -331,7 +351,7 @@ mod tests {
                 coll: "syncIDBBBBBB".to_string(),
             }),
         );
-        let cs = LocalCollStateMachine::get_state(&store, &gs).expect("should work");
+        let cs = LocalCollStateMachine::get_state(&store, &gs, &root_key).expect("should work");
         assert!(cs.is_none(), "declined collection can sync");
         assert_eq!(store.get_num_resets(), 0);
     }

--- a/components/sync15/src/coll_state.rs
+++ b/components/sync15/src/coll_state.rs
@@ -186,10 +186,10 @@ mod tests {
     use std::cell::{Cell, RefCell};
     use std::collections::HashMap;
 
-    fn get_global_state() -> GlobalState {
+    fn get_global_state(root_key: &KeyBundle) -> GlobalState {
         let keys = CollectionKeys::new_random()
             .unwrap()
-            .to_encrypted_bso(&KeyBundle::new_random().unwrap())
+            .to_encrypted_bso(&root_key)
             .unwrap();
         GlobalState {
             config: InfoConfiguration::default(),
@@ -276,7 +276,7 @@ mod tests {
     #[test]
     fn test_unknown() {
         let root_key = KeyBundle::new_random().expect("should work");
-        let gs = get_global_state();
+        let gs = get_global_state(&root_key);
         let store = TestStore::new("unknown", StoreSyncAssociation::Disconnected);
         let cs = LocalCollStateMachine::get_state(&store, &gs, &root_key).expect("should work");
         assert!(cs.is_none(), "unknown collection name can't sync");
@@ -286,7 +286,7 @@ mod tests {
     #[test]
     fn test_known_no_state() {
         let root_key = KeyBundle::new_random().expect("should work");
-        let gs = get_global_state();
+        let gs = get_global_state(&root_key);
         let store = TestStore::new("bookmarks", StoreSyncAssociation::Disconnected);
         let cs = LocalCollStateMachine::get_state(&store, &gs, &root_key).expect("should work");
         assert!(cs.is_some(), "collection can sync");
@@ -303,7 +303,7 @@ mod tests {
     #[test]
     fn test_known_wrong_state() {
         let root_key = KeyBundle::new_random().expect("should work");
-        let gs = get_global_state();
+        let gs = get_global_state(&root_key);
         let store = TestStore::new(
             "bookmarks",
             StoreSyncAssociation::Connected(CollSyncIds {
@@ -326,7 +326,7 @@ mod tests {
     #[test]
     fn test_known_good_state() {
         let root_key = KeyBundle::new_random().expect("should work");
-        let gs = get_global_state();
+        let gs = get_global_state(&root_key);
         let store = TestStore::new(
             "bookmarks",
             StoreSyncAssociation::Connected(CollSyncIds {
@@ -342,7 +342,7 @@ mod tests {
     #[test]
     fn test_declined() {
         let root_key = KeyBundle::new_random().expect("should work");
-        let mut gs = get_global_state();
+        let mut gs = get_global_state(&root_key);
         gs.global.declined.push("bookmarks".to_string());
         let store = TestStore::new(
             "bookmarks",

--- a/components/sync15/src/key_bundle.rs
+++ b/components/sync15/src/key_bundle.rs
@@ -83,7 +83,7 @@ impl KeyBundle {
 
     /// Returns the 32 byte digest by value since it's small enough to be passed
     /// around cheaply, and easily convertable into a slice or vec if you want.
-    fn hmac(&self, ciphertext: &[u8]) -> Result<[u8; 32]> {
+    pub fn hmac(&self, ciphertext: &[u8]) -> Result<[u8; 32]> {
         let mut out = [0u8; 32];
         let key = PKey::hmac(self.hmac_key())?;
         let mut signer = Signer::new(MessageDigest::sha256(), &key)?;

--- a/components/sync15/src/key_bundle.rs
+++ b/components/sync15/src/key_bundle.rs
@@ -83,7 +83,7 @@ impl KeyBundle {
 
     /// Returns the 32 byte digest by value since it's small enough to be passed
     /// around cheaply, and easily convertable into a slice or vec if you want.
-    pub fn hmac(&self, ciphertext: &[u8]) -> Result<[u8; 32]> {
+    fn hmac(&self, ciphertext: &[u8]) -> Result<[u8; 32]> {
         let mut out = [0u8; 32];
         let key = PKey::hmac(self.hmac_key())?;
         let mut signer = Signer::new(MessageDigest::sha256(), &key)?;

--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -72,9 +72,11 @@ impl Default for PersistedGlobalState {
     }
 }
 
-/// Holds global Sync state, including server upload limits, and the
+/// Holds global Sync state, including server upload limits, the
 /// last-fetched collection modified times, `meta/global` record, and
-/// the default encryption key.
+/// encrypted copies of the crypto/keys resourse (which we hold as encrypted
+/// both to avoid keeping them in memory longer than necessary, and guard against
+/// the wrong (ie, a different user's) root key being passed in.
 #[derive(Debug, Clone)]
 pub struct GlobalState {
     pub config: InfoConfiguration,

--- a/components/sync15/src/sync.rs
+++ b/components/sync15/src/sync.rs
@@ -6,6 +6,7 @@ use crate::changeset::{CollectionUpdate, IncomingChangeset, OutgoingChangeset};
 use crate::client::Sync15StorageClient;
 use crate::coll_state::{LocalCollStateMachine, StoreSyncAssociation};
 use crate::error::Error;
+use crate::key_bundle::KeyBundle;
 use crate::request::CollectionRequest;
 use crate::state::GlobalState;
 use crate::telemetry;
@@ -52,6 +53,7 @@ pub trait Store {
 pub fn synchronize(
     client: &Sync15StorageClient,
     global_state: &GlobalState,
+    root_sync_key: &KeyBundle,
     store: &dyn Store,
     fully_atomic: bool,
     telem_engine: &mut telemetry::Engine,
@@ -61,7 +63,8 @@ pub fn synchronize(
     log::info!("Syncing collection {}", collection);
 
     // our global state machine is ready - get the collection machine going.
-    let mut coll_state = match LocalCollStateMachine::get_state(store, global_state)? {
+    let mut coll_state = match LocalCollStateMachine::get_state(store, global_state, root_sync_key)?
+    {
         Some(coll_state) => coll_state,
         None => {
             // XXX - this is either "error" or "declined".


### PR DESCRIPTION
Does something like this make sense? It will change where hmac errors might exist, but I don't think in a meaningful way. I've nfi about my amateur attempt to store a hash of the key either, but you get the idea and I'm sure you'll set me straight ;)