### PR TITLE
Fix unique constraint errors when merging dupes

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -14,6 +14,13 @@
   the Sync ping. This should be posted to the legacy telemetry submission
   endpoint.
 
+## Places
+
+### What's fixed
+
+- Deduping synced bookmarks with newer server timestamps no longer throws
+  unique constraint violations.
+
 ## Logins
 
 ### Breaking Changes

--- a/components/places/sql/create_sync_triggers.sql
+++ b/components/places/sql/create_sync_triggers.sql
@@ -137,7 +137,7 @@ BEGIN
            OLD.mergedAt,
            2, -- SyncStatus::Normal
            OLD.shouldUpload)
-    ON CONFLICT(guid) DO UPDATE SET
+    ON CONFLICT(id) DO UPDATE SET
         title = excluded.title,
         dateAdded = excluded.dateAdded,
         lastModified = excluded.lastModified,


### PR DESCRIPTION
We should constrain on `moz_bookmarks.id`, not `moz_bookmarks.guid`,
since we might take the remote state _and_ change the GUID, and
SQLite doesn't guarantee that our `updateLocalItems` trigger will
run after `updateGuidsAndSyncFlags`.

This fixes the error @mhammond saw on Slack.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
