### PR TITLE
Don't throw away the state persisted to disk when client info changes

### DIFF
--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -126,10 +126,10 @@ fn do_sync_multiple(
         Some(client_info) => {
             // if our storage_init has changed it probably means the user has
             // changed, courtesy of the 'kid' in the structure. Thus, we can't
-            // reuse the client or any other cached state.
+            // reuse the client or the memory cached state. We do keep the disk
+            // state as currently that's only the declined list.
             if client_info.client_init != *storage_init {
                 log::info!("Discarding all state as the account might have changed");
-                *persisted_global_state = None;
                 *mem_cached_state = MemoryCachedState::default();
                 ClientInfo::new(storage_init)?
             } else {
@@ -139,8 +139,7 @@ fn do_sync_multiple(
         }
         None => {
             // We almost certainly have no other state here, but to be safe, we
-            // throw away any we do have.
-            *persisted_global_state = None;
+            // throw away any memory state we do have.
             *mem_cached_state = MemoryCachedState::default();
             ClientInfo::new(storage_init)?
         }


### PR DESCRIPTION
My recent cached state patch introduced and edge-case that's not ideal. If the access token for a user has expired or they've recently changed their password, and sync finds empty storage, we will undecline any engines (ie, we will reset their "choose what to sync").

While this should be very rare, it's possible. This patch fixes it but leaves another edge-case in place - if the account changes and we see empty storage, we will carry the declined list from this device to the new account, which may be different than choices already made on other devices - but this is almost impossible to fix sanely - we could reset to default in that case, but can't magically do the right thing. Resetting to default is what desktop would do, so we should probably do that too - but we'd need to change to API so we get the fxa uid passed in.

For now I think we should take this, and hopefully convince a-c to take it too.