### PR TITLE
Persist OAuth access tokens in the account state.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,11 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.39.2...master)
+
+## FxA Client
+
+### What's new
+
+- The OAuth access token cache is now persisted as part of the account state data,
+  which should reduce the number of times callers need to fetch a fresh access token
+  from the server.

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -221,6 +221,7 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      * Tries to fetch an access token for the given scope.
      *
      * This performs network requests, and should not be used on the main thread.
+     * It may modify the persisted account state.
      *
      * @param scope Single OAuth scope (no spaces) for which the client wants access
      * @return [AccessTokenInfo] that stores the token, along with its scopes and keys when complete
@@ -232,6 +233,7 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
         val buffer = rustCallWithLock { e ->
             LibFxAFFI.INSTANCE.fxa_get_access_token(this.handle.get(), scope, e)
         }
+        this.tryPersistState()
         try {
             val msg = MsgTypes.AccessTokenInfo.parseFrom(buffer.asCodedInputStream()!!)
             return AccessTokenInfo.fromMessage(msg)

--- a/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
@@ -243,6 +243,7 @@ open class FirefoxAccount {
                 let infoBuffer = try FirefoxAccountError.unwrap { err in
                     fxa_get_access_token(self.raw, scope, err)
                 }
+                self.tryPersistState()
                 let msg = try! MsgTypes_AccessTokenInfo(serializedData: Data(rustBuffer: infoBuffer))
                 fxa_bytebuffer_free(infoBuffer)
                 let tokenInfo = AccessTokenInfo(msg: msg)

--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -31,11 +31,13 @@ impl FirefoxAccount {
     /// using `begin_oauth_flow`.
     ///
     /// * `scopes` - Space-separated list of requested scopes.
+    ///
+    /// **💾 This method may alter the persisted account state.**
     pub fn get_access_token(&mut self, scope: &str) -> Result<AccessTokenInfo> {
         if scope.contains(' ') {
             return Err(ErrorKind::MultipleScopesRequested.into());
         }
-        if let Some(oauth_info) = self.access_token_cache.get(scope) {
+        if let Some(oauth_info) = self.state.access_token_cache.get(scope) {
             if oauth_info.expires_at > util::now_secs() + OAUTH_MIN_TIME_LEFT {
                 return Ok(oauth_info.clone());
             }
@@ -71,7 +73,8 @@ impl FirefoxAccount {
             key: self.state.scoped_keys.get(scope).cloned(),
             expires_at,
         };
-        self.access_token_cache
+        self.state
+            .access_token_cache
             .insert(scope.to_string(), token_info.clone());
         Ok(token_info)
     }
@@ -268,7 +271,7 @@ impl FirefoxAccount {
     }
 
     pub fn clear_access_token_cache(&mut self) {
-        self.access_token_cache.clear();
+        self.state.access_token_cache.clear();
     }
 }
 
@@ -317,7 +320,8 @@ mod tests {
 
     impl FirefoxAccount {
         pub fn add_cached_token(&mut self, scope: &str, token_info: AccessTokenInfo) {
-            self.access_token_cache
+            self.state
+                .access_token_cache
                 .insert(scope.to_string(), token_info);
         }
     }

--- a/components/fxa-client/src/state_persistence.rs
+++ b/components/fxa-client/src/state_persistence.rs
@@ -89,6 +89,7 @@ impl From<StateV1> for Result<StateV2> {
             session_token: None,
             current_device_id: None,
             last_seen_profile: None,
+            access_token_cache: HashMap::new(),
         })
     }
 }
@@ -165,5 +166,28 @@ mod tests {
             lockbox_key.scope,
             "https://identity.mozilla.com/apps/lockbox"
         );
+    }
+
+    #[test]
+    fn test_v2_ignores_unknown_fields_introduced_by_future_changes_to_the_schema() {
+        let state_v2_json = "{\"schema_version\":\"V2\",\"config\":{\"client_id\":\"98adfa37698f255b\",\"redirect_uri\":\"https://lockbox.firefox.com/fxa/ios-redirect.html\",\"content_url\":\"https://accounts.firefox.com\",\"auth_url\":\"https://api.accounts.firefox.com/\",\"oauth_url\":\"https://oauth.accounts.firefox.com/\",\"profile_url\":\"https://profile.accounts.firefox.com/\",\"token_server_endpoint_url\":\"https://token.services.mozilla.com/1.0/sync/1.5\",\"authorization_endpoint\":\"https://accounts.firefox.com/authorization\",\"issuer\":\"https://accounts.firefox.com\",\"jwks_uri\":\"https://oauth.accounts.firefox.com/v1/jwks\",\"token_endpoint\":\"https://oauth.accounts.firefox.com/v1/token\",\"userinfo_endpoint\":\"https://profile.accounts.firefox.com/v1/profile\"},\"refresh_token\":{\"token\":\"bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188\",\"scopes\":[\"https://identity.mozilla.com/apps/oldysnc\"]},\"scoped_keys\":{\"https://identity.mozilla.com/apps/oldsync\":{\"kty\":\"oct\",\"scope\":\"https://identity.mozilla.com/apps/oldsync\",\"k\":\"kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg\",\"kid\":\"1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ\"}},\"login_state\":{\"Unknown\":null},\"a_new_field\":42}";
+        let state = state_from_json(state_v2_json).unwrap();
+        let refresh_token = state.refresh_token.unwrap();
+        assert_eq!(
+            refresh_token.token,
+            "bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188"
+        );
+    }
+
+    #[test]
+    fn test_v2_creates_an_empty_access_token_cache_if_its_missing() {
+        let state_v2_json = "{\"schema_version\":\"V2\",\"config\":{\"client_id\":\"98adfa37698f255b\",\"redirect_uri\":\"https://lockbox.firefox.com/fxa/ios-redirect.html\",\"content_url\":\"https://accounts.firefox.com\",\"auth_url\":\"https://api.accounts.firefox.com/\",\"oauth_url\":\"https://oauth.accounts.firefox.com/\",\"profile_url\":\"https://profile.accounts.firefox.com/\",\"token_server_endpoint_url\":\"https://token.services.mozilla.com/1.0/sync/1.5\",\"authorization_endpoint\":\"https://accounts.firefox.com/authorization\",\"issuer\":\"https://accounts.firefox.com\",\"jwks_uri\":\"https://oauth.accounts.firefox.com/v1/jwks\",\"token_endpoint\":\"https://oauth.accounts.firefox.com/v1/token\",\"userinfo_endpoint\":\"https://profile.accounts.firefox.com/v1/profile\"},\"refresh_token\":{\"token\":\"bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188\",\"scopes\":[\"https://identity.mozilla.com/apps/oldysnc\"]},\"scoped_keys\":{\"https://identity.mozilla.com/apps/oldsync\":{\"kty\":\"oct\",\"scope\":\"https://identity.mozilla.com/apps/oldsync\",\"k\":\"kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg\",\"kid\":\"1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ\"}},\"login_state\":{\"Unknown\":null}}";
+        let state = state_from_json(state_v2_json).unwrap();
+        let refresh_token = state.refresh_token.unwrap();
+        assert_eq!(
+            refresh_token.token,
+            "bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188"
+        );
+        assert_eq!(state.access_token_cache.len(), 0);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/1272.

I don't necessarily think we should merge this urgently, I just wanted to explore what it would look like as an option.

I added some basic tests for forward- and backward- compatibility. I wonder if it's worth adding more around e.g. restoring from JSON and then trying to use a token that has expired) but that mostly felt like testing that serde was doing the right thing.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - ~~`./gradlew ktlint detekt` runs without emitting any warnings~~
  - ~~`swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes~~
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- ~~[ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)~~