### PR TITLE
Remove `sync15-withoutLib` from android build config, as there's no such thing

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -39,7 +39,7 @@ projects:
   sync15-library:
     path: components/sync15/android
     artifactId: sync15
-    publishedArtifacts: [sync15, sync15-withoutLib]
+    publishedArtifacts: [sync15]
     description: Shared Sync types for Kotlin.
   lockbox-megazord:
     uploadSymbols: true


### PR DESCRIPTION
Fixes #1277 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
