### PR TITLE
Fix indent in sync15's build.gradle

### DIFF
--- a/components/sync15/android/build.gradle
+++ b/components/sync15/android/build.gradle
@@ -3,32 +3,32 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-   compileSdkVersion rootProject.ext.build.compileSdkVersion
+    compileSdkVersion rootProject.ext.build.compileSdkVersion
 
-   defaultConfig {
-       minSdkVersion rootProject.ext.build['minSdkVersion']
-       targetSdkVersion rootProject.ext.build['targetSdkVersion']
+    defaultConfig {
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
 
-       testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-   }
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
 
-   buildTypes {
-       release {
-           minifyEnabled false
-           proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-           consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
-       }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
+        }
 
-       withoutLib {
-           initWith release
-       }
-   }
+        withoutLib {
+            initWith release
+        }
+    }
 
 }
 
 dependencies {
-   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-   implementation project(':as-support-library')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation project(':as-support-library')
 }
 
 apply from: "$rootDir/publish.gradle"
@@ -36,6 +36,6 @@ apply from: "$rootDir/publish.gradle"
 // please also update the corresponding .buildconfig-android.yml
 // `publishedArtifacts` property.
 ext.configurePublish(
-       /* jnaForTestConfiguration= */ null,
-       /* variantWithoutLib= */ null,
+        /* jnaForTestConfiguration= */ null,
+        /* variantWithoutLib= */ null,
 )


### PR DESCRIPTION
Doesn't feel right to do this in the megazord patch since it will bother anyone who opens this file, even before that lands.