### PR TITLE
Emit rerun-if-changed from build.rs files

### DIFF
--- a/components/fxa-client/build.rs
+++ b/components/fxa-client/build.rs
@@ -3,5 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 fn main() {
+    println!("cargo:rerun-if-changed=src/fxa_msg_types.proto");
     prost_build::compile_protos(&["src/fxa_msg_types.proto"], &["src/"]).unwrap();
 }

--- a/components/places/build.rs
+++ b/components/places/build.rs
@@ -3,5 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 fn main() {
+    println!("cargo:rerun-if-changed=src/places_msg_types.proto");
     prost_build::compile_protos(&["src/places_msg_types.proto"], &["src/"]).unwrap();
 }

--- a/components/viaduct/build.rs
+++ b/components/viaduct/build.rs
@@ -3,5 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 fn main() {
+    println!("cargo:rerun-if-changed=src/fetch_msg_types.proto");
     prost_build::compile_protos(&["src/fetch_msg_types.proto"], &["src/"]).unwrap();
 }

--- a/docs/howtos/passing-protobuf-data-over-ffi.md
+++ b/docs/howtos/passing-protobuf-data-over-ffi.md
@@ -47,6 +47,7 @@ follow the examples of the other steps it takes.
      * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
     fn main() {
+        println!("cargo:rerun-if-changed=src/mylib_msg_types.proto");
         prost_build::compile_protos(&["src/mylib_msg_types.proto"], &["src/"]).unwrap();
     }
     ```


### PR DESCRIPTION
#1103 fixes many of the issues where we rebuild rust for no reason, but it still would happen. Digging a little, apparently we need to be emitting `cargo:rerun-if-changed` directives. If we fail to do so, it defaults to the current directory, which means changing code in the android bindings causes everything to rebuild. Gross!

Testing this manually has confirmed it has the desired effect.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
