### PR TITLE
Avoid panicing when closing places db.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,13 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.31.2...master)
+
+## Places
+
+### What's fixed
+
+- Fix an error that could happen when the place database is closed.
+  ([#1304](https://github.com/mozilla/application-services/pull/1304))
+
+- iOS only: Ensure interruption errors don't come through as network errors.
+  ([#1304](https://github.com/mozilla/application-services/pull/1304))

--- a/components/logins/src/ffi.rs
+++ b/components/logins/src/ffi.rs
@@ -35,8 +35,8 @@ pub mod error_codes {
     /// A request to the sync server failed.
     pub const NETWORK: i32 = 6;
 
-    /// A request to the sync server failed.
-    pub const INTERRUPTED: i32 = 6;
+    /// An operation has been interrupted.
+    pub const INTERRUPTED: i32 = 7;
 }
 
 fn get_code(err: &Error) -> ErrorCode {

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -156,9 +156,10 @@ impl Drop for PlacesDb {
     fn drop(&mut self) {
         // In line with both the recommendations from SQLite and the behavior of places in
         // Database.cpp, we run `PRAGMA optimize` before closing the connection.
-        self.db
-            .execute_batch("PRAGMA optimize(0x02);")
-            .expect("PRAGMA optimize should always succeed!");
+        let res = self.db.execute_batch("PRAGMA optimize(0x02);");
+        if let Err(e) = res {
+            log::warn!("Failed to execute pragma optimize (DB locked?): {}", e);
+        }
     }
 }
 


### PR DESCRIPTION
This also has the iOS-relevant portion of #1239, since we're cutting this release for iOS and they're seeing a lot of errors that they can't distinguish between network and interruption.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
