### PR TITLE
Use LocalizedError and not Error in swift, and override errorDescription

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,10 +2,18 @@
 
 # Unreleased Changes
 
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.32.0...master)
+
 ## FxA Client
 
 ### Fixes
 
 - Fixes SendTab initializeDevice in Android to use the proper device type ([#1314](https://github.com/mozilla/application-services/pull/1314))
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.32.0...master)
+## iOS Bindings
+
+### What's Fixed
+
+- Errors emitted from the rust code should now all properly output their description. ([#1323](https://github.com/mozilla/application-services/pull/1323))
+
+

--- a/components/fxa-client/ios/FxAClient/Errors/FxAError.swift
+++ b/components/fxa-client/ios/FxAClient/Errors/FxAError.swift
@@ -7,11 +7,25 @@ import Foundation
 // FIXME: these should be lower case.
 // swiftlint:disable identifier_name
 
-public enum FirefoxAccountError: Error {
+public enum FirefoxAccountError: LocalizedError {
     case Unauthorized(message: String)
     case Network(message: String)
     case Unspecified(message: String)
     case Panic(message: String)
+
+    /// Our implementation of the localizedError protocol -- (This shows up in Sentry)
+    public var errorDescription: String? {
+        switch self {
+        case let .Unauthorized(message):
+            return "FirefoxAccountError.Unauthorized: \(message)"
+        case let .Network(message):
+            return "FirefoxAccountError.Network: \(message)"
+        case let .Unspecified(message):
+            return "FirefoxAccountError.Unspecified: \(message)"
+        case let .Panic(message):
+            return "FirefoxAccountError.Panic: \(message)"
+        }
+    }
 
     // The name is attempting to indicate that we free fxaError.message if it
     // existed, and that it's a very bad idea to touch it after you call this

--- a/components/logins/ios/Logins/Errors/LoginStoreError.swift
+++ b/components/logins/ios/Logins/Errors/LoginStoreError.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 /// Indicates an error occurred while calling into the logins storage layer
-public enum LoginsStoreError: Error {
+public enum LoginsStoreError: LocalizedError {
     /// This is a catch-all error code used for errors not yet exposed to consumers,
     /// typically since it doesn't seem like there's a sane way for them to be handled.
     case unspecified(message: String)
@@ -44,6 +44,30 @@ public enum LoginsStoreError: Error {
     /// This error is emitted if a call to `interrupt()` is made to
     /// abort some operation.
     case interrupted(message: String)
+
+    /// Our implementation of the localizedError protocol -- (This shows up in Sentry)
+    public var errorDescription: String? {
+        switch self {
+        case let .unspecified(message):
+            return "LoginsStoreError.unspecified: \(message)"
+        case let .panic(message):
+            return "LoginsStoreError.panic: \(message)"
+        case let .authInvalid(message):
+            return "LoginsStoreError.authInvalid: \(message)"
+        case let .noSuchRecord(message):
+            return "LoginsStoreError.noSuchRecord: \(message)"
+        case let .duplicateGuid(message):
+            return "LoginsStoreError.duplicateGuid: \(message)"
+        case let .invalidLogin(message):
+            return "LoginsStoreError.invalidLogin: \(message)"
+        case let .invalidKey(message):
+            return "LoginsStoreError.invalidKey: \(message)"
+        case let .network(message):
+            return "LoginsStoreError.network: \(message)"
+        case let .interrupted(message):
+            return "LoginsStoreError.interrupted: \(message)"
+        }
+    }
 
     // The name is attempting to indicate that we free rustError.message if it
     // existed, and that it's a very bad idea to touch it after you call this

--- a/components/places/ios/Places/Errors/PlacesError.swift
+++ b/components/places/ios/Places/Errors/PlacesError.swift
@@ -6,7 +6,7 @@ import Foundation
 import os.log
 
 /// Indicates an error occurred while calling into the places storage layer
-public enum PlacesError: Error {
+public enum PlacesError: LocalizedError {
     /// This indicates an attempt to use a connection after the PlacesAPI
     /// it came from is destroyed. This indicates a usage error of this library.
     case connUseAfterAPIClosed
@@ -55,6 +55,38 @@ public enum PlacesError: Error {
     /// Thrown when attempting to update or delete a root, or
     /// insert a new item as a child of root________.
     case cannotUpdateRoot(message: String)
+
+    /// Our implementation of the localizedError protocol -- (This shows up in Sentry)
+    public var errorDescription: String? {
+        switch self {
+        case .connUseAfterAPIClosed:
+            return "PlacesError.connUseAfterAPIClosed"
+        case let .unexpected(message):
+            return "PlacesError.unexpected: \(message)"
+        case let .panic(message):
+            return "PlacesError.panic: \(message)"
+        case let .invalidPlace(message):
+            return "PlacesError.invalidPlace: \(message)"
+        case let .urlParseError(message):
+            return "PlacesError.urlParseError: \(message)"
+        case let .databaseBusy(message):
+            return "PlacesError.databaseBusy: \(message)"
+        case let .databaseInterrupted(message):
+            return "PlacesError.databaseInterrupted: \(message)"
+        case let .databaseCorrupt(message):
+            return "PlacesError.databaseCorrupt: \(message)"
+        case let .invalidParent(message):
+            return "PlacesError.invalidParent: \(message)"
+        case let .noSuchItem(message):
+            return "PlacesError.noSuchItem: \(message)"
+        case let .urlTooLong(message):
+            return "PlacesError.urlTooLong: \(message)"
+        case let .illegalChange(message):
+            return "PlacesError.illegalChange: \(message)"
+        case let .cannotUpdateRoot(message):
+            return "PlacesError.cannotUpdateRoot: \(message)"
+        }
+    }
 
     // The name is attempting to indicate that we free rustError.message if it
     // existed, and that it's a very bad idea to touch it after you call this


### PR DESCRIPTION
This make the firefox-ios sentry errors a little easier to deal with.

Fixes #853.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
