### PR TITLE
Exclude bookmarks without URLs from `fetch_new_remote_contents`

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,9 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.32.2...master)
+
+## Places
+
+### What's Fixed
+
+- Ensures bookmark sync doesn't fail if a bookmark or query is missing or has an invalid URL ([#1325](https://github.com/mozilla/application-services/issues/1325))


### PR DESCRIPTION
When we download bookmarks with missing or invalid URLs, we insert them
into `moz_bookmarks_synced` with a null `urlId`, and flag them with
`SyncedBookmarkValidity::Replace`. However, `fetch_new_remote_contents`
didn't take this into account, and would try to fetch _all_ items,
assuming that bookmarks and queries had URLs, causing the rusqlite
error in #1325. The fix is to treat the URL as optional, and ignore
bookmarks and queries that don't have one.

Closes #1325.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
