### PR TITLE
Cherry-pick fixes for v0.31.3

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,10 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.31.2...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.31.2...release-v0.31)
+
+## Places
+
+### What's Fixed
+
+- Ensures bookmark sync doesn't fail if a bookmark or query is missing or has an invalid URL ([#1325](https://github.com/mozilla/application-services/issues/1325))

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,3 +9,9 @@
 ### What's Fixed
 
 - Ensures bookmark sync doesn't fail if a bookmark or query is missing or has an invalid URL ([#1325](https://github.com/mozilla/application-services/issues/1325))
+
+## FxA Client
+
+### Fixes
+
+- Fixes SendTab initializeDevice in Android to use the proper device type ([#1314](https://github.com/mozilla/application-services/pull/1314))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
  "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2200,7 +2200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2597,7 +2597,7 @@ name = "unicode-normalization"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3021,7 +3021,7 @@ dependencies = [
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallbitvec 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1764fe2b30ee783bfe3b9b37b2649d8d590b3148bb12e0079715d4d5c673562e"
-"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/Device.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/Device.kt
@@ -42,7 +42,12 @@ data class Device(
         }
 
         fun toNumber(): Int {
-            return MsgTypes.Device.Type.DESKTOP.number
+            // the number resolves to values in fxa_msg_types.proto#L41
+            return when (this) {
+                DESKTOP -> MsgTypes.Device.Type.DESKTOP.number
+                MOBILE -> MsgTypes.Device.Type.MOBILE.number
+                else -> MsgTypes.Device.Type.UNKNOWN.number
+            }
         }
     }
     data class PushSubscription(

--- a/docs/howtos/cut-a-new-release.md
+++ b/docs/howtos/cut-a-new-release.md
@@ -1,6 +1,6 @@
 # Application Services Release Process
 
-These are the steps needed to cut a new release.
+These are the steps needed to cut a new release from latest master.
 
 1. Update the changelog.
     1. Copy the contents from `CHANGES_UNRELEASED.md` into the top of `CHANGELOG.md`, except for the part that links to this document.
@@ -51,3 +51,28 @@ These are the steps needed to cut a new release.
         - You can do this before the release has been cut by adding `substitutions.application-services.dir=/path/to/application-services` in your `local.properties` file in android-components. Remember that you have done this, however, as it overrides changes in `Dependencies.kt`.
 
     5. Get it PRed and landed.
+
+
+These are the steps needed to cut a new point-release from an existing release that is behind latest master.
+
+1. If necessary, make a new branch named `release-v0.XX` which will be used for all point-releases on the `v0.XX.Y`
+   series. Example:
+    ```
+    git checkout -b release-v0.31 v0.31.2
+    git push -u origin release-v0.31
+    ```
+2. Make a new branch with any fixes to be included in the release, *remembering not to make any breaking API
+   changes.*. This may involve cherry-picking fixes from master, or developing a new fix directly against the
+   branch. Example:
+    ```
+    git checkout -b fixes-for-v0.31.3 release-v0.31
+    git cherry-pick 37d35304a4d1d285c8f6f3ce3df3c412fcd2d6c6
+    git push -u origin fixes-for-v0.31.3
+    ```
+3. Follow the above steps for cuting a new release from master, except that:
+    * When opening a PR to land the commits, target the `release-v0.XX` branch rather than master.
+    * When cutting the new release via github's UI, target the `release-v0.XX` branch rather than master.
+4. Merge the new release back to master.
+    * This will typically require a PR and involve resolving merge conflicts in the changelog.
+    * This ensures we do not accidentally orphan any fixes that were made directly against the release branch,
+      and also helps ensure that every release has an easily-discoverable changelog entry in master.


### PR DESCRIPTION
For consideration in service of #1344, I have:

* Created a `release-v0.31` branch forked from the latest `v0.31.2` tag.
* Created this branch to cherry-pick some fixes onto it from master.
* Added some preliminary docs about what I'm doing.

This is partly to test CI, and partly for feedback on the approach here. If we like it, then some time tomorrow I'll go ahead and turn this into a proper release.

Fixes #1344.