### PR TITLE
Evaluate is_staging boolean provided by environment

### DIFF
--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -26,7 +26,7 @@ def main(task_for):
     elif task_for == "github-push":
         android_multiarch()
     elif task_for == "github-release":
-        is_staging = os.environ['IS_STAGING']
+        is_staging = os.environ['IS_STAGING'] == 'true'
         android_multiarch_release(is_staging)
     else:
         raise ValueError("Unrecognized $TASK_FOR value: %r", task_for)


### PR DESCRIPTION
Right, since there wasn't a convention to `argparse` decision task parameters, I passed `IS_STAGING` via an environment variable. Of course, since we aren't leveraging a parsing library, we just get the raw value - in this case, we get `"true"` and `"false"` instead of `True` and `False`.
This manually adds parsing.

I'd :heart: to send values to the script via regular arguments in the future, but I'd wait until `taskgraph` is rolled out to see if it recommends a different mechanism

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
- [ ] Brief staging run to verify changes
