### PR TITLE
Allow nss_sys to link against NSS/NSPR dynamically

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,6 +232,7 @@ subprojects {
 // the Cargo build.  We assume that the `libs/` directory has been populated
 // before invoking Gradle (or Cargo).
 ext.cargoExec = { spec, toolchain ->
+    spec.environment("NSS_USE_FOLDED_LIBS", "1")
     spec.environment("OPENSSL_STATIC", "1")
     spec.environment("NSS_DIR",               new File(libsRootDir, "libs/${toolchain.folder}/nss").absolutePath)
     spec.environment("OPENSSL_DIR",           new File(libsRootDir, "libs/${toolchain.folder}/openssl").absolutePath)

--- a/libs/build-sqlcipher-android.sh
+++ b/libs/build-sqlcipher-android.sh
@@ -80,21 +80,10 @@ SQLCIPHER_CFLAGS=" \
 "
 
 LIBS="\
-  -lcertdb \
-  -lcerthi \
-  -lcryptohi \
-  -lfreebl_static \
-  -lhw-acc-crypto \
-  -lnspr4 \
-  -lnss_static \
-  -lnssb \
-  -lnssdev \
-  -lnsspki \
-  -lnssutil \
-  -lpk11wrap_static \
-  -lplc4 \
-  -lplds4 \
-  -lsoftokn_static \
+  -lfreebl3 \
+  -lnss3 \
+  -lnssckbi \
+  -lsoftokn3 \
 "
 
 if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]] || [[ "${TOOLCHAIN}" == "i686-linux-android" ]]; then


### PR DESCRIPTION
We might want to do this later if we either want to publish rc_crypto on crates.io or if we want to use Fenix's GeckoView NSS libs instead of bringing our own.