### PR TITLE
Clean up invariant handling in sync-guid and add Guid::random()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2452,6 +2452,8 @@ dependencies = [
 name = "sync-guid"
 version = "0.1.0"
 dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rc_crypto 0.1.0",
  "rusqlite 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -32,7 +32,8 @@ bytes = "0.4.11"
 dogear = "0.2.6"
 interrupt = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
-sync-guid = { path = "../support/guid", features = ["rusqlite_support"]}
+sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
+
 
 [dependencies.rusqlite]
 version = "0.19.0"

--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -667,9 +667,7 @@ struct Driver {
 
 impl dogear::Driver for Driver {
     fn generate_new_guid(&self, _invalid_guid: &dogear::Guid) -> dogear::Result<dogear::Guid> {
-        Ok(SyncGuid::from(sync15::random_guid().unwrap())
-            .as_str()
-            .into())
+        Ok(SyncGuid::random().as_str().into())
     }
 
     fn record_telemetry_event(&self, event: TelemetryEvent) {

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -344,7 +344,7 @@ mod sql_fns {
 
     #[inline(never)]
     pub fn generate_guid(_ctx: &Context<'_>) -> Result<SyncGuid> {
-        Ok(SyncGuid::from(sync15::random_guid().unwrap()))
+        Ok(SyncGuid::random())
     }
 }
 

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn test_places_no_tombstone() {
         let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("no memory db");
-        let guid = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid = SyncGuid::random();
 
         conn.execute_named_cached(
             "INSERT INTO moz_places (guid, url, url_hash) VALUES (:guid, :url, hash(:url))",
@@ -297,7 +297,7 @@ mod tests {
     #[test]
     fn test_places_tombstone_removal() {
         let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("no memory db");
-        let guid = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid = SyncGuid::random();
 
         conn.execute_named_cached(
             "INSERT INTO moz_places_tombstones VALUES (:guid)",
@@ -398,11 +398,11 @@ mod tests {
     fn test_bookmark_foreign_count_triggers() {
         // create the place.
         let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("no memory db");
-        let guid1 = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid1 = SyncGuid::random();
         let url1 = Url::parse("http://example.com")
             .expect("valid url")
             .into_string();
-        let guid2 = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid2 = SyncGuid::random();
         let url2 = Url::parse("http://example2.com")
             .expect("valid url")
             .into_string();

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -453,7 +453,7 @@ mod tests {
 
         // try and add an incoming record with the same URL but different guid.
         let record = HistoryRecord {
-            id: SyncGuid::from(sync15::random_guid().unwrap()),
+            id: SyncGuid::random(),
             title: "title".into(),
             hist_uri: "https://example.com".into(),
             sortindex: 0,
@@ -477,10 +477,10 @@ mod tests {
         // This is testing the case when there are no local visits to that URL.
         let _ = env_logger::try_init();
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
-        let guid1 = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid1 = SyncGuid::random();
         let ts1: Timestamp = (SystemTime::now() - Duration::new(5, 0)).into();
 
-        let guid2 = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid2 = SyncGuid::random();
         let ts2: Timestamp = SystemTime::now().into();
         let url = Url::parse("https://example.com")?;
 
@@ -537,10 +537,10 @@ mod tests {
         let _ = env_logger::try_init();
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
 
-        let guid1 = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid1 = SyncGuid::random();
         let ts1: Timestamp = (SystemTime::now() - Duration::new(5, 0)).into();
 
-        let guid2 = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid2 = SyncGuid::random();
         let ts2: Timestamp = SystemTime::now().into();
         let url = Url::parse("https://example.com")?;
 
@@ -599,10 +599,10 @@ mod tests {
         let _ = env_logger::try_init();
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
 
-        let guid1 = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid1 = SyncGuid::random();
         let ts1: Timestamp = (SystemTime::now() - Duration::new(5, 0)).into();
 
-        let guid2 = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid2 = SyncGuid::random();
         let ts2: Timestamp = SystemTime::now().into();
         let url = Url::parse("https://example.com")?;
 

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -291,10 +291,7 @@ fn insert_bookmark_in_tx(db: &PlacesDb, bm: &InsertableItem) -> Result<SyncGuid>
               (:fk, :type, :parent, :position, :title, :dateAdded, :lastModified,
                :guid, :syncStatus, :syncChangeCounter)";
 
-    let guid = bm
-        .guid()
-        .clone()
-        .unwrap_or_else(|| SyncGuid::from(sync15::random_guid().unwrap()));
+    let guid = bm.guid().clone().unwrap_or_else(SyncGuid::random);
     let date_added = bm.date_added().unwrap_or_else(Timestamp::now);
     // last_modified can't be before date_added
     let last_modified = max(
@@ -910,7 +907,7 @@ mod test_serialize {
 
     #[test]
     fn test_tree_serialize() -> Result<()> {
-        let guid = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid = SyncGuid::random();
         let tree = BookmarkTreeNode::Folder(FolderNode {
             guid: Some(guid.clone()),
             date_added: None,
@@ -1036,10 +1033,7 @@ fn add_subtree_infos(parent: &SyncGuid, tree: &FolderNode, insert_infos: &mut Ve
                 .into(),
             ),
             BookmarkTreeNode::Folder(f) => {
-                let my_guid = f
-                    .guid
-                    .clone()
-                    .unwrap_or_else(|| SyncGuid::from(sync15::random_guid().unwrap()));
+                let my_guid = f.guid.clone().unwrap_or_else(SyncGuid::random);
                 // must add the folder before we recurse into children.
                 insert_infos.push(
                     InsertableFolder {
@@ -1493,10 +1487,10 @@ mod tests {
         let _ = env_logger::try_init();
         let conn = new_mem_connection();
 
-        let guid1 = SyncGuid::from(sync15::random_guid().unwrap());
-        let guid2 = SyncGuid::from(sync15::random_guid().unwrap());
-        let guid2_1 = SyncGuid::from(sync15::random_guid().unwrap());
-        let guid3 = SyncGuid::from(sync15::random_guid().unwrap());
+        let guid1 = SyncGuid::random();
+        let guid2 = SyncGuid::random();
+        let guid2_1 = SyncGuid::random();
+        let guid3 = SyncGuid::random();
 
         let jtree = json!({
             "guid": &BookmarkRootGuid::Unfiled.as_guid(),

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -2070,7 +2070,7 @@ mod tests {
 
         apply_synced_visits(
             &conn,
-            &SyncGuid::from(sync15::random_guid().unwrap()),
+            &SyncGuid::random(),
             &url::Url::parse("http://www.example.com/123").unwrap(),
             &None,
             &[
@@ -2102,7 +2102,7 @@ mod tests {
         // Check that we don't insert a place if all visits are too old.
         apply_synced_visits(
             &conn,
-            &SyncGuid::from(sync15::random_guid().unwrap()),
+            &SyncGuid::random(),
             &url::Url::parse("http://www.example.com/1234").unwrap(),
             &None,
             &[HistoryRecordVisit {

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -147,7 +147,7 @@ fn fetch_page_info(db: &PlacesDb, url: &Url) -> Result<Option<FetchedPageInfo>> 
 fn new_page_info(db: &PlacesDb, url: &Url, new_guid: Option<SyncGuid>) -> Result<PageInfo> {
     let guid = match new_guid {
         Some(guid) => guid,
-        None => SyncGuid::from(sync15::random_guid().unwrap()),
+        None => SyncGuid::random(),
     };
     let url_str = url.as_str();
     if url_str.len() > URL_LENGTH_MAX {

--- a/components/support/guid/Cargo.toml
+++ b/components/support/guid/Cargo.toml
@@ -8,8 +8,11 @@ edition = "2018"
 [dependencies]
 rusqlite = { version = "0.19.0", optional = true }
 serde = { version = "1.0.79", optional = true }
+rc_crypto = { path = "../rc_crypto", optional = true }
+base64 = { version = "0.10.1", optional = true }
 
 [features]
+random = ["rc_crypto", "base64"]
 rusqlite_support = ["rusqlite"]
 serde_support = ["serde"]
 # By default we support serde, but not rusqlite.

--- a/components/support/guid/src/lib.rs
+++ b/components/support/guid/src/lib.rs
@@ -4,6 +4,8 @@
 
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
+// (It's tempting to avoid the utf8 checks, but they're easy to get wrong, so)
+#![deny(unsafe_code)]
 #[cfg(feature = "serde_support")]
 mod serde_support;
 
@@ -39,16 +41,19 @@ enum Repr {
     Fast(FastGuid),
 
     // invariants:
-    // - _0.len() <= MAX_GUID_LEN
-    // - _0.bytes().all(|&b| Guid::is_valid_byte(b))
+    // - _0.len() > MAX_FAST_GUID_LEN
     Slow(String),
 }
 
+/// Invariants:
+///
+/// - `len <= MAX_FAST_GUID_LEN`.
+/// - `data[0..len]` encodes valid utf8.
+/// - `data[len..].iter().all(|&b| b == b'\0')`
+///
+/// Note: None of these are required for memory safety, just correctness.
 #[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 struct FastGuid {
-    // invariants:
-    // - len <= MAX_FAST_GUID_LEN.
-    // - data[0..len].iter().all(|&b| Guid::is_valid_byte(b))
     len: u8,
     data: [u8; MAX_FAST_GUID_LEN],
 }
@@ -61,7 +66,7 @@ const MAX_FAST_GUID_LEN: usize = 14;
 impl FastGuid {
     #[inline]
     fn from_slice(bytes: &[u8]) -> Self {
-        // Cecked by the caller, so debug_assert is fine.
+        // Checked by the caller, so debug_assert is fine.
         debug_assert!(
             can_use_fast(bytes),
             "Bug: Caller failed to check can_use_fast: {:?}",
@@ -77,14 +82,8 @@ impl FastGuid {
 
     #[inline]
     fn as_str(&self) -> &str {
-        // Sanity check we weren't mutated and that nobody's creating us in other ways.
-        debug_assert!(
-            can_use_fast(self.bytes()),
-            "Bug: FastGuid bytes became invalid: {:?}",
-            self.bytes()
-        );
-        // This should never fail, but it's not worth using unsafe for.
-        str::from_utf8(self.bytes()).unwrap()
+        // Note: we only use debug_assert! to enusre valid utf8-ness, so this need
+        str::from_utf8(self.bytes()).expect("Invalid fast guid bytes!")
     }
 
     #[inline]
@@ -103,37 +102,37 @@ impl FastGuid {
 // - false to use Repr::Slow
 #[inline]
 fn can_use_fast<T: ?Sized + AsRef<[u8]>>(bytes: &T) -> bool {
-    bytes.as_ref().len() <= MAX_FAST_GUID_LEN
+    let bytes = bytes.as_ref();
+    // This is fine as a debug_assert since we'll still panic if it's ever used
+    // in such a way where it would matter.
+    debug_assert!(str::from_utf8(bytes).is_ok());
+    bytes.len() <= MAX_FAST_GUID_LEN
 }
 
 impl Guid {
-    /// Try to convert `b` into a `Guid`.
+    /// Convert `b` into a `Guid`.
     #[inline]
     fn from_string(s: String) -> Self {
         Guid::from_vec(s.into_bytes())
     }
 
-    /// Try to convert `b` into a `Guid`.
+    /// Convert `b` into a `Guid`.
     #[inline]
     fn from_slice(b: &[u8]) -> Self {
         if can_use_fast(b) {
             Guid(Repr::Fast(FastGuid::from_slice(b)))
         } else {
-            debug_assert!(b.iter().all(|v| v.is_ascii()));
-            // This unwrap can't fire unless there's a bug in `can_use_fast`,
-            // but it's not worth using unsafe here.
-            Guid(Repr::Slow(String::from_utf8(b.into()).unwrap()))
+            Guid::new_slow(b.into())
         }
     }
 
-    /// Try to convert `v` to a `Guid`, consuming it.
+    /// Convert `v` to a `Guid`, consuming it.
     #[inline]
     fn from_vec(v: Vec<u8>) -> Self {
         if can_use_fast(&v) {
             Guid(Repr::Fast(FastGuid::from_slice(&v)))
         } else {
-            debug_assert!(v.iter().all(|b| b.is_ascii()));
-            Guid(Repr::Slow(String::from_utf8(v).unwrap()))
+            Guid::new_slow(v)
         }
     }
 
@@ -169,17 +168,22 @@ impl Guid {
         self.len() == 12 && self.bytes().all(Guid::is_valid_places_byte)
     }
 
-    /// Returns true if the byte `b` is a character that is allowed to
-    /// appear in a GUID.
-    #[inline]
-    pub fn is_valid_byte(b: u8) -> bool {
-        b' ' <= b && b <= b'~'
-    }
-
     /// Returns true if the byte `b` is a valid base64url byte.
     #[inline]
     pub fn is_valid_places_byte(b: u8) -> bool {
         BASE64URL_BYTES[b as usize] == 1
+    }
+
+    #[cold]
+    fn new_slow(v: Vec<u8>) -> Self {
+        assert!(
+            !can_use_fast(&v),
+            "Could use fast for guid (len = {})",
+            v.len()
+        );
+        Guid(Repr::Slow(
+            String::from_utf8(v).expect("Invalid slow guid bytes!"),
+        ))
     }
 }
 


### PR DESCRIPTION
As I said, I had a couple things that I wanted to fix that were hard to articulate in a PR comment. Mostly that the comments mostly documented the way the invariant behaved when the guid cared a lot about what it stored.

I probably should have left adding Guid::random for another patch though, but while I was there it felt like I should add it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
