### PR TITLE
Implement IntoFfi for some common pointer variants

### DIFF
--- a/components/support/ffi/src/into_ffi.rs
+++ b/components/support/ffi/src/into_ffi.rs
@@ -260,3 +260,16 @@ macro_rules! impl_into_ffi_for_primitive {
 
 // See IntoFfi docs for why this is not exhaustive
 impl_into_ffi_for_primitive![(), i8, u8, i16, u16, i32, u32, i64, u64, f32, f64];
+
+// just cuts down on boilerplate. Not public.
+macro_rules! impl_into_ffi_for_pointer {
+    ($($T:ty),+) => {$(
+        unsafe impl IntoFfi for $T {
+            type Value = Self;
+            #[inline] fn ffi_default() -> Self { ptr::null_mut() }
+            #[inline] fn into_ffi_value(self) -> Self { self }
+        }
+    )+}
+}
+
+impl_into_ffi_for_pointer![*mut i8, *const i8, *mut u8, *const u8];


### PR DESCRIPTION
This is useful for nested map handling, where the inner handler already
converts into the ffi type and the outer handler tries to do the same.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
