### PR TITLE
Kotlin warnings as errors

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -6,6 +6,11 @@
 
 ## FxA Client
 
+### What's Fixed
+
+- The state persistence callback is now correctly triggered after a call
+  to `FirefoxAccount.getProfile`.
+
 ### Breaking changes
 
 - The `FirefoxAccount.destroyDevice` method has been removed in favor of the

--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,11 @@ def libsRootDir = useDownloadedLibs ? rootProject.buildDir : rootProject.rootDir
 subprojects {
     apply plugin: 'digital.wup.android-maven-publish'
 
+    // Enable Kotlin warnings as errors for all modules.
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions.allWarningsAsErrors = true
+    }
+
     // This allows to invoke Gradle like `./gradlew publishToRootProjectBuildDir` (equivalent to
     // `./gradlew publish`) and also `./gradlew publishToProjectBuildDir`.
     publishing {

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/AccountEvent.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/AccountEvent.kt
@@ -19,16 +19,17 @@ sealed class AccountEvent {
 
     companion object {
         private fun fromMessage(msg: MsgTypes.AccountEvent): AccountEvent {
-            when (msg.type) {
+            return when (msg.type) {
                 MsgTypes.AccountEvent.AccountEventType.TAB_RECEIVED -> {
                     val data = msg.tabReceivedData
-                    return TabReceived(
-                            from = if (data.hasFrom()) Device.fromMessage(data.from) else null,
-                            entries = data.entriesList.map {
-                                TabHistoryEntry(title = it.title, url = it.url)
-                            }.toTypedArray()
+                    TabReceived(
+                        from = if (data.hasFrom()) Device.fromMessage(data.from) else null,
+                        entries = data.entriesList.map {
+                            TabHistoryEntry(title = it.title, url = it.url)
+                        }.toTypedArray()
                     )
                 }
+                null -> throw NullPointerException("AccountEvent type cannot be null.")
             }.exhaustive
         }
         internal fun fromCollectionMessage(msg: MsgTypes.AccountEvents): Array<AccountEvent> {

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -145,13 +145,13 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
         val profileBuffer = rustCallWithLock { e ->
             LibFxAFFI.INSTANCE.fxa_profile(this.handle.get(), ignoreCache, e)
         }
+        this.tryPersistState()
         try {
             val p = MsgTypes.Profile.parseFrom(profileBuffer.asCodedInputStream()!!)
             return Profile.fromMessage(p)
         } finally {
             LibFxAFFI.INSTANCE.fxa_bytebuffer_free(profileBuffer)
         }
-        this.tryPersistState()
     }
 
     /**


### PR DESCRIPTION
Fixes #1282.
I've introduced the Kotlin equivalent to `-Werror` so we can catch warnings before they make it to the master branch.
This also fixes a bug where we did not trigger the persist callback on a successful profile check.