### PR TITLE
WIP: implement authorization fxn hitting introspect endpoint

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -242,6 +242,18 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
         }
     }
 
+    fun checkAuthorizationStatus(): IntrospectInfo {
+        val buffer = rustCallWithLock { e ->
+            LibFxAFFI.INSTANCE.fxa_check_authorization_status(this.handle.get(), e)
+        }
+        try {
+            val msg = MsgTypes.IntrospectInfo.parseFrom(buffer.asCodedInputStream()!!)
+            return IntrospectInfo.fromMessage(msg)
+        } finally {
+            LibFxAFFI.INSTANCE.fxa_bytebuffer_free(buffer)
+        }
+    }
+
     /**
      * Tries to return a session token
      *

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/IntrospectInfo.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/IntrospectInfo.kt
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.fxaclient
+
+data class IntrospectInfo(
+    val active: Boolean,
+    val tokenType: String,
+    val scope: String?,
+    val exp: Long,
+    val iss: String
+) {
+    companion object {
+        internal fun fromMessage(msg: MsgTypes.IntrospectInfo): IntrospectInfo {
+            return IntrospectInfo(
+                active = msg.active,
+                tokenType = msg.tokenType,
+                scope = if (msg.hasScope()) msg.scope else null,
+                exp = msg.exp,
+                iss = msg.iss
+            )
+        }
+    }
+}

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -52,6 +52,7 @@ internal interface LibFxAFFI : Library {
     fun fxa_get_access_token(fxa: FxaHandle, scope: String, e: RustError.ByReference): RustBuffer.ByValue
     fun fxa_get_session_token(fxa: FxaHandle, e: RustError.ByReference): Pointer?
     fun fxa_get_current_device_id(fxa: FxaHandle, e: RustError.ByReference): Pointer?
+    fun fxa_check_authorization_status(fxa: FxaHandle, e: RustError.ByReference): RustBuffer.ByValue
     fun fxa_clear_access_token_cache(fxa: FxaHandle, e: RustError.ByReference)
 
     fun fxa_set_push_subscription(

--- a/components/fxa-client/examples/oauth_flow.rs
+++ b/components/fxa-client/examples/oauth_flow.rs
@@ -6,7 +6,7 @@ use url::Url;
 const CONTENT_SERVER: &str = "http://127.0.0.1:3030";
 const CLIENT_ID: &str = "7f368c6886429f19";
 const REDIRECT_URI: &str = "https://mozilla.github.io/notes/fxa/android-redirect.html";
-const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
+const SCOPES: &[&str] = &["profile"];
 
 fn main() {
     let mut fxa = FirefoxAccount::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
@@ -19,6 +19,8 @@ fn main() {
     let code = &query_params["code"];
     let state = &query_params["state"];
     fxa.complete_oauth_flow(&code, &state).unwrap();
+    let auth_status = fxa.check_authorization_status();
+    println!("auth_status: {:?}", auth_status);
     let oauth_info = fxa.get_access_token(SCOPES[0]);
     println!("access_token: {:?}", oauth_info);
 }

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -286,6 +286,17 @@ pub extern "C" fn fxa_get_session_token(handle: u64, error: &mut ExternError) ->
     ACCOUNTS.call_with_result_mut(error, handle, |fxa| fxa.get_session_token())
 }
 
+/// Check if OAuth refresh token is authorized
+/// Should be called before retrieving the access token
+#[no_mangle]
+pub extern "C" fn fxa_check_authorization_status(
+    handle: u64,
+    error: &mut ExternError,
+) -> ByteBuffer {
+    log::debug!("fxa_check_authorization_status");
+    ACCOUNTS.call_with_result_mut(error, handle, |fxa| fxa.check_authorization_status())
+}
+
 /// This method should be called when a request made with
 /// an OAuth token failed with an authentication error.
 /// It clears the internal cache of OAuth access tokens,

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -56,11 +56,14 @@ FxARustBuffer fxa_get_access_token(FirefoxAccountHandle handle,
                                    const char *_Nonnull scope,
                                    FxAError *_Nonnull out);
 
-void fxa_clear_access_token_cache(FirefoxAccountHandle handle,
-                                  FxAError *_Nonnull out);
-
 void fxa_disconnect(FirefoxAccountHandle handle,
                     FxAError *_Nonnull out);
+                    
+FxARustBuffer fxa_check_authorization_status(FirefoxAccountHandle handle,
+                                             FxAError *_Nonnull out);
+
+FxARustBuffer fxa_clear_access_token_cache(FirefoxAccountHandle handle,
+                                            FxAError *_Nonnull out);
 
 FirefoxAccountHandle fxa_from_json(const char *_Nonnull json,
                                    FxAError *_Nonnull out);

--- a/components/fxa-client/src/config.rs
+++ b/components/fxa-client/src/config.rs
@@ -47,6 +47,7 @@ pub struct RemoteConfig {
     issuer: String,
     jwks_uri: String,
     token_endpoint: String,
+    introspection_endpoint: String,
     userinfo_endpoint: String,
 }
 
@@ -84,6 +85,7 @@ impl Config {
         issuer: String,
         jwks_uri: String,
         token_endpoint: String,
+        introspection_endpoint: String,
         userinfo_endpoint: String,
         client_id: String,
         redirect_uri: String,
@@ -97,6 +99,7 @@ impl Config {
             issuer,
             jwks_uri,
             token_endpoint,
+            introspection_endpoint,
             userinfo_endpoint,
         };
 
@@ -137,6 +140,7 @@ impl Config {
             // and the openid response has been switched to the new endpoint.
             // token_endpoint: openid_resp.token_endpoint,
             token_endpoint: format!("{}/v1/oauth/token", resp.auth_server_base_url),
+            introspection_endpoint: format!("{}/v1/introspect", resp.oauth_server_base_url),
             userinfo_endpoint: openid_resp.userinfo_endpoint,
         };
         let rc = Arc::new(remote_config);
@@ -197,6 +201,10 @@ impl Config {
         Url::parse(&self.remote_config()?.token_endpoint).map_err(Into::into)
     }
 
+    pub fn introspection_endpoint(&self) -> Result<Url> {
+        Url::parse(&self.remote_config()?.introspection_endpoint).map_err(Into::into)
+    }
+
     pub fn userinfo_endpoint(&self) -> Result<Url> {
         Url::parse(&self.remote_config()?.userinfo_endpoint).map_err(Into::into)
     }
@@ -219,6 +227,7 @@ mod tests {
             issuer: "https://dev.lcip.org/".to_string(),
             jwks_uri: "https://oauth-stable.dev.lcip.org/v1/jwks".to_string(),
             token_endpoint: "https://stable.dev.lcip.org/auth/v1/oauth/token".to_string(),
+            introspection_endpoint: "https://stable.dev.lcip.org/auth/v1/introspect".to_string(),
             userinfo_endpoint: "https://stable.dev.lcip.org/profile/v1/profile".to_string(),
         };
 
@@ -252,6 +261,11 @@ mod tests {
         assert_eq!(
             config.token_endpoint().unwrap().to_string(),
             "https://stable.dev.lcip.org/auth/v1/oauth/token"
+        );
+
+        assert_eq!(
+            config.introspection_endpoint().unwrap().to_string(),
+            "https://stable.dev.lcip.org/auth/v1/introspect"
         );
     }
 }

--- a/components/fxa-client/src/ffi.rs
+++ b/components/fxa-client/src/ffi.rs
@@ -15,7 +15,8 @@
 use crate::{
     commands,
     device::{Capability as DeviceCapability, Device, PushSubscription, Type as DeviceType},
-    msg_types, send_tab, AccessTokenInfo, AccountEvent, Error, ErrorKind, Profile, ScopedKey,
+    msg_types, send_tab, AccessTokenInfo, AccountEvent, Error, ErrorKind, IntrospectInfo, Profile,
+    ScopedKey,
 };
 use ffi_support::{
     implement_into_ffi_by_delegation, implement_into_ffi_by_protobuf, ErrorCode, ExternError,
@@ -69,6 +70,18 @@ impl From<AccessTokenInfo> for msg_types::AccessTokenInfo {
             token: a.token,
             key: a.key.map(Into::into),
             expires_at: a.expires_at,
+        }
+    }
+}
+
+impl From<IntrospectInfo> for msg_types::IntrospectInfo {
+    fn from(a: IntrospectInfo) -> Self {
+        msg_types::IntrospectInfo {
+            active: a.active,
+            token_type: a.token_type,
+            scope: a.scope,
+            exp: a.exp,
+            iss: a.iss,
         }
     }
 }
@@ -227,6 +240,8 @@ implement_into_ffi_by_protobuf!(msg_types::Profile);
 implement_into_ffi_by_delegation!(Profile, msg_types::Profile);
 implement_into_ffi_by_protobuf!(msg_types::AccessTokenInfo);
 implement_into_ffi_by_delegation!(AccessTokenInfo, msg_types::AccessTokenInfo);
+implement_into_ffi_by_protobuf!(msg_types::IntrospectInfo);
+implement_into_ffi_by_delegation!(IntrospectInfo, msg_types::IntrospectInfo);
 implement_into_ffi_by_protobuf!(msg_types::Device);
 implement_into_ffi_by_delegation!(Device, msg_types::Device);
 implement_into_ffi_by_delegation!(AccountEvent, msg_types::AccountEvent);

--- a/components/fxa-client/src/fxa_msg_types.proto
+++ b/components/fxa-client/src/fxa_msg_types.proto
@@ -22,6 +22,14 @@ message AccessTokenInfo {
     required uint64 expires_at = 4;
 }
 
+message IntrospectInfo {
+    required bool active = 1;
+    required string token_type = 2;
+    optional string scope = 3;
+    optional uint64 exp = 4;
+    optional string iss = 5;
+}
+
 message ScopedKey {
     required string kty = 1;
     required string scope = 2;

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -11,7 +11,9 @@ use crate::{
     oauth::{OAuthFlow, RefreshToken},
     scoped_keys::ScopedKey,
 };
-pub use crate::{config::Config, error::*, oauth::AccessTokenInfo, profile::Profile};
+pub use crate::{
+    config::Config, error::*, oauth::AccessTokenInfo, oauth::IntrospectInfo, profile::Profile,
+};
 use serde_derive::*;
 use std::{
     collections::{HashMap, HashSet},

--- a/components/fxa-client/src/state_persistence.rs
+++ b/components/fxa-client/src/state_persistence.rs
@@ -77,6 +77,7 @@ impl From<StateV1> for Result<StateV2> {
                 state.config.issuer,
                 state.config.jwks_uri,
                 state.config.token_endpoint,
+                state.config.introspection_endpoint,
                 state.config.userinfo_endpoint,
                 state.client_id,
                 state.redirect_uri,
@@ -114,6 +115,7 @@ struct V1Config {
     issuer: String,
     jwks_uri: String,
     token_endpoint: String,
+    introspection_endpoint: String,
     userinfo_endpoint: String,
 }
 
@@ -132,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_v1_migration() {
-        let state_v1_json = "{\"schema_version\":\"V1\",\"client_id\":\"98adfa37698f255b\",\"redirect_uri\":\"https://lockbox.firefox.com/fxa/ios-redirect.html\",\"config\":{\"content_url\":\"https://accounts.firefox.com\",\"auth_url\":\"https://api.accounts.firefox.com/\",\"oauth_url\":\"https://oauth.accounts.firefox.com/\",\"profile_url\":\"https://profile.accounts.firefox.com/\",\"token_server_endpoint_url\":\"https://token.services.mozilla.com/1.0/sync/1.5\",\"authorization_endpoint\":\"https://accounts.firefox.com/authorization\",\"issuer\":\"https://accounts.firefox.com\",\"jwks_uri\":\"https://oauth.accounts.firefox.com/v1/jwks\",\"token_endpoint\":\"https://oauth.accounts.firefox.com/v1/token\",\"userinfo_endpoint\":\"https://profile.accounts.firefox.com/v1/profile\"},\"oauth_cache\":{\"https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/apps/lockbox profile\":{\"access_token\":\"bef37ec0340783356bcac67a86c4efa23a56f2ddd0c7a6251d19988bab7bdc99\",\"keys\":\"{\\\"https://identity.mozilla.com/apps/oldsync\\\":{\\\"kty\\\":\\\"oct\\\",\\\"scope\\\":\\\"https://identity.mozilla.com/apps/oldsync\\\",\\\"k\\\":\\\"kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg\\\",\\\"kid\\\":\\\"1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ\\\"},\\\"https://identity.mozilla.com/apps/lockbox\\\":{\\\"kty\\\":\\\"oct\\\",\\\"scope\\\":\\\"https://identity.mozilla.com/apps/lockbox\\\",\\\"k\\\":\\\"Qk4K4xF2PgQ6XvBXW8X7B7AWwWgW2bHQov9NHNd4v-k\\\",\\\"kid\\\":\\\"1231014287-KDVj0DFaO3wGpPJD8oPwVg\\\"}}\",\"refresh_token\":\"bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188\",\"expires_at\":1543474657,\"scopes\":[\"https://identity.mozilla.com/apps/oldsync\",\"https://identity.mozilla.com/apps/lockbox\",\"profile\"]}}}";
+        let state_v1_json = "{\"schema_version\":\"V1\",\"client_id\":\"98adfa37698f255b\",\"redirect_uri\":\"https://lockbox.firefox.com/fxa/ios-redirect.html\",\"config\":{\"content_url\":\"https://accounts.firefox.com\",\"auth_url\":\"https://api.accounts.firefox.com/\",\"oauth_url\":\"https://oauth.accounts.firefox.com/\",\"profile_url\":\"https://profile.accounts.firefox.com/\",\"token_server_endpoint_url\":\"https://token.services.mozilla.com/1.0/sync/1.5\",\"authorization_endpoint\":\"https://accounts.firefox.com/authorization\",\"issuer\":\"https://accounts.firefox.com\",\"jwks_uri\":\"https://oauth.accounts.firefox.com/v1/jwks\",\"token_endpoint\":\"https://oauth.accounts.firefox.com/v1/token\",\"introspection_endpoint\":\"https://oauth.accounts.firefox.com/v1/introspect\",\"userinfo_endpoint\":\"https://profile.accounts.firefox.com/v1/profile\"},\"oauth_cache\":{\"https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/apps/lockbox profile\":{\"access_token\":\"bef37ec0340783356bcac67a86c4efa23a56f2ddd0c7a6251d19988bab7bdc99\",\"keys\":\"{\\\"https://identity.mozilla.com/apps/oldsync\\\":{\\\"kty\\\":\\\"oct\\\",\\\"scope\\\":\\\"https://identity.mozilla.com/apps/oldsync\\\",\\\"k\\\":\\\"kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg\\\",\\\"kid\\\":\\\"1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ\\\"},\\\"https://identity.mozilla.com/apps/lockbox\\\":{\\\"kty\\\":\\\"oct\\\",\\\"scope\\\":\\\"https://identity.mozilla.com/apps/lockbox\\\",\\\"k\\\":\\\"Qk4K4xF2PgQ6XvBXW8X7B7AWwWgW2bHQov9NHNd4v-k\\\",\\\"kid\\\":\\\"1231014287-KDVj0DFaO3wGpPJD8oPwVg\\\"}}\",\"refresh_token\":\"bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188\",\"expires_at\":1543474657,\"scopes\":[\"https://identity.mozilla.com/apps/oldsync\",\"https://identity.mozilla.com/apps/lockbox\",\"profile\"]}}}";
         let state = state_from_json(state_v1_json).unwrap();
         assert!(state.refresh_token.is_some());
         let refresh_token = state.refresh_token.unwrap();

--- a/components/support/cli/src/fxa_creds.rs
+++ b/components/support/cli/src/fxa_creds.rs
@@ -79,6 +79,13 @@ pub fn get_cli_fxa(config: Config, cred_file: &str) -> Result<CliFxa> {
     // TODO: we should probably set a persist callback on acct?
     let mut acct = load_or_create_fxa_creds(cred_file, config)?;
     // `scope` could be a param, but I can't see it changing.
+    match acct.check_authorization_status() {
+        Ok(_) => {}
+        Err(e) => {
+            panic!("No creds - run some other tool to set them up. {}", e);
+        }
+    };
+    acct.check_authorization_status()?;
     let token_info: AccessTokenInfo = match acct.get_access_token(SYNC_SCOPE) {
         Ok(t) => t,
         Err(e) => {

--- a/docs/product-portal/accounts/welcome.md
+++ b/docs/product-portal/accounts/welcome.md
@@ -48,6 +48,7 @@ Firefox Accounts provides a [OAuth 2.0 API](https://github.com/mozilla/fxa-oaut
 Given the URL of the Firefox Accounts server, reliers should fetch the [OpenID Connect Discovery Document](http://openid.net/specs/openid-connect-discovery-1_0.html) from [/.well-known/openid-configuration](https://accounts.firefox.com/.well-known/openid-configuration).  This will return a JSON document with all the endpoint URLs necessary to complete the login flow.  In particular it will contain:
 
 *   "authorization_endpoint": the URL to which the client should be directed to begin the authentication flow
+*   "introspection_endpoint": the URL at which an OAuth access token is checked for authorization status
 *   "token_endpoint": the URL at which an OAuth access code can be exchanged for an access token
 *   "userinfo_endpoint": the URL at which additional user profile data can be obtained
 
@@ -83,6 +84,12 @@ The relying service should make the following security checks:
 *   Verify the **state** in the redirect request matches the **state** value previously associated with the client session.
 
 A failure in either of these verifications indicates a security error and the relying service should re-start the login flow. If the relying service receives one of these requests when the client session is already associated with a FxA user, it should be ignored.
+
+#### Checking authorization status for OAuth token
+
+To check whether an user is authorized, instead of calling the authorization endpoint and waiting
+for an error to be thrown, the return value of `oauth::check_authorization_status` will return
+metadata about user's refresh token. If there is no refresh token held or the token is not authorized, error is thrown.
 
 #### Obtaining an OAuth access token
 

--- a/testing/sync-test/src/auth.rs
+++ b/testing/sync-test/src/auth.rs
@@ -220,6 +220,8 @@ impl TestClient {
                     .expect("Failed to parse TOKENSERVER_URL environment variable!"))
             })
             .unwrap_or_else(|| self.test_acct.cfg.token_server_endpoint_url())?;
+
+        self.fxa.check_authorization_status()?;
         let token = self.fxa.get_access_token(SYNC_SCOPE)?;
 
         let key = token.key.as_ref().unwrap();


### PR DESCRIPTION
Draft Rust setup for #1263

@rfk I am running into a problem of testing the introspect endpoint after setting it up in Rust. 

With the current setup in Rust, I tried to test the endpoint in the `components/fxa-client/examples/oauth_flow.js`, but I encounter a 404 / 999 error when I call the newly added `check_authorization_status` function.

What should I fix?