### PR TITLE
Use double square brackets in bash scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,7 +239,7 @@ jobs:
       - checkout
       - run:
           name: Lint Bash scripts with shellcheck
-          command: ./automation/lint_bash_scripts.sh
+          command: sh automation/lint_bash_scripts.sh
   Check Rust dependencies:
     docker:
       - image: circleci/rust:latest

--- a/automation/check_artifact_size.sh
+++ b/automation/check_artifact_size.sh
@@ -6,7 +6,7 @@
 
 set -eu
 
-if [ "$#" -ne 2 ]
+if [[ "$#" -ne 2 ]]
 then
     echo "Usage:"
     echo "./automation/check_artifact_size.sh <buildDir> <artifactId>"
@@ -22,10 +22,10 @@ ARTIFACT_ID="$2"
 # we perform megazord builds, but at least it's an upper bound for now...
 LIMIT=36700160
 
-if [ -d "${BUILD_DIR}" ]; then
+if [[ -d "${BUILD_DIR}" ]]; then
     while IFS= read -r -d '' AAR_FILE; do
         SIZE=$(du -b "${AAR_FILE}" | cut -f 1)
-        if [ "${SIZE}" -gt "${LIMIT}" ]; then
+        if [[ "${SIZE}" -gt "${LIMIT}" ]]; then
             echo "ERROR: Build artifact is unacceptably large." >&2
             du -h "${AAR_FILE}" >&2
             exit 1

--- a/automation/check_megazord.sh
+++ b/automation/check_megazord.sh
@@ -2,7 +2,7 @@
 
 set -euvx
 
-if [ "$#" -ne 1 ]
+if [[ "$#" -ne 1 ]]
 then
     echo "Usage:"
     echo "./automation/check_megazord.sh <megazord_name>"
@@ -13,7 +13,7 @@ MEGAZORD_NAME=$1
 
 # The `full-megazord` is `libmegazord.so`. Eventually we should figure out a way
 # to avoid hardcoding this check, but for now it's not too bad.
-if [ "$MEGAZORD_NAME" = "full" ]; then
+if [[ "$MEGAZORD_NAME" = "full" ]]; then
     MEGAZORD_NAME="megazord"
 fi
 

--- a/automation/license-check.sh
+++ b/automation/license-check.sh
@@ -8,7 +8,7 @@ UNACCEPTABLE=
 for LINE in $(cargo license -t | tail -n +2); do
   NAME=$(echo "${LINE}" | cut -f 1)
   LICENSE=$(echo "${LINE}" | cut -f 5)
-  if [ "x${LICENSE}" = "x" ]; then
+  if [[ "x${LICENSE}" = "x" ]]; then
     LICENSE="UNKNOWN"
   fi
   if grep "^${LICENSE}\$" >/dev/null < "$(dirname "${0}")"/licenses.txt; then true; else
@@ -18,6 +18,6 @@ for LINE in $(cargo license -t | tail -n +2); do
     fi
   fi
 done
-if [ "x${UNACCEPTABLE}" = "x1" ]; then
+if [[ "x${UNACCEPTABLE}" = "x1" ]]; then
   exit 1
 fi

--- a/automation/lint_bash_scripts.sh
+++ b/automation/lint_bash_scripts.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
-if [ ! -f "$PWD/automation/lint_bash_scripts.sh" ]
+if [[ ! -f "$PWD/automation/lint_bash_scripts.sh" ]]
 then
     echo "lint_bash_scripts.sh must be executed from the root directory."
     exit 1

--- a/automation/upload_android_symbols.sh
+++ b/automation/upload_android_symbols.sh
@@ -2,14 +2,14 @@
 
 set -euvx
 
-if [ "${#}" -ne 1 ]
+if [[ "${#}" -ne 1 ]]
 then
     echo "Usage:"
     echo "./automation/upload_android_symbols.sh <project path>"
     exit 1
 fi
 
-if [ ! -f "$PWD/libs/android_defaults.sh" ]
+if [[ ! -f "$PWD/libs/android_defaults.sh" ]]
 then
     echo "upload_android_symbols.sh must be executed from the root directory."
     exit 1
@@ -23,7 +23,7 @@ source "libs/android_defaults.sh"
 OUTPUT_FOLDER="crashreporter-symbols"
 DUMP_SYMS_DIR="automation/symbols-generation/bin"
 
-if [ ! -f "${DUMP_SYMS_DIR}/dump_syms" ]; then
+if [[ ! -f "${DUMP_SYMS_DIR}/dump_syms" ]]; then
   tooltool.py --manifest=automation/symbols-generation/dump_syms.manifest --url=http://taskcluster/tooltool.mozilla-releng.net/ fetch
   chmod +x dump_syms
   mkdir -p "${DUMP_SYMS_DIR}"

--- a/build-scripts/xc-universal-binary.sh
+++ b/build-scripts/xc-universal-binary.sh
@@ -2,7 +2,7 @@
 set -euvx
 
 # This should be invoked from inside xcode, not manually
-if [ "${#}" -ne 4 ]
+if [[ "${#}" -ne 4 ]]
 then
     echo "Usage (note: only call inside xcode!):"
     echo "path/to/build-scripts/xc-universal-binary.sh <STATIC_LIB_NAME> <FFI_TARGET> <APPSVC_ROOT_PATH> <buildvariant>"
@@ -28,7 +28,7 @@ LIBSDIR=${APPSVC_ROOT}/libs
 TARGETDIR=${APPSVC_ROOT}/target
 
 # If the libs don't exist, or it's modification time is older than the last commit in ${LIBSDIR}/ios, wipe it out.
-if [ ! -d "${LIBSDIR}/ios" ] || [ "$(stat -f "%m" "${LIBSDIR}/ios")" -lt "$(git log -n 1 --pretty=format:%at -- "${LIBSDIR}")" ]; then
+if [[ ! -d "${LIBSDIR}/ios" ]] || [[ "$(stat -f "%m" "${LIBSDIR}/ios")" -lt "$(git log -n 1 --pretty=format:%at -- "${LIBSDIR}")" ]]; then
     echo "No iOS libs present, or they are stale"
     pushd "${LIBSDIR}"
     rm -rf ios

--- a/libs/android_defaults.sh
+++ b/libs/android_defaults.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-if [ -z "${ANDROID_NDK_TOOLCHAIN_DIR:-}" ]; then
+if [[ -z "${ANDROID_NDK_TOOLCHAIN_DIR:-}" ]]; then
     export ANDROID_NDK_TOOLCHAIN_DIR="/tmp/android-ndk-toolchain"
     echo "The ANDROID_NDK_TOOLCHAIN_DIR env variable is not set. Defaulting to ${ANDROID_NDK_TOOLCHAIN_DIR}"
 fi
 
-if [ -z "${ANDROID_NDK_API_VERSION:-}" ]; then
+if [[ -z "${ANDROID_NDK_API_VERSION:-}" ]]; then
     export ANDROID_NDK_API_VERSION=21
     echo "The ANDROID_NDK_API_VERSION env variable is not set. Defaulting to ${ANDROID_NDK_API_VERSION}"
 fi

--- a/libs/bootstrap-desktop.sh
+++ b/libs/bootstrap-desktop.sh
@@ -5,12 +5,12 @@
 # not have the desired effect if you try to run it directly, because it
 # uses `export` to set environment variables.
 
-if [ ! -f "$(pwd)/libs/build-all.sh" ]; then
+if [[ ! -f "$(pwd)/libs/build-all.sh" ]]; then
   echo "ERROR: bootstrap-desktop.sh should be run from the root directory of the repo"
   exit 1
 fi
 
-if [ "$(uname -s)" == "Darwin" ]; then
+if [[ "$(uname -s)" == "Darwin" ]]; then
   APPSERVICES_PLATFORM_DIR="$(pwd)/libs/desktop/darwin"
 else
   APPSERVICES_PLATFORM_DIR="$(pwd)/libs/desktop/linux-x86-64"
@@ -20,12 +20,12 @@ export SQLCIPHER_INCLUDE_DIR="${APPSERVICES_PLATFORM_DIR}/sqlcipher/include"
 export OPENSSL_DIR="${APPSERVICES_PLATFORM_DIR}/openssl"
 export NSS_STATIC="1"
 export NSS_DIR="${APPSERVICES_PLATFORM_DIR}/nss"
-if [ ! -d "${SQLCIPHER_LIB_DIR}" ] || [ ! -d "${OPENSSL_DIR}" ] || [ ! -d "${NSS_DIR}" ]; then
+if [[ ! -d "${SQLCIPHER_LIB_DIR}" ]] || [[ ! -d "${OPENSSL_DIR}" ]] || [[ ! -d "${NSS_DIR}" ]]; then
   pushd libs
   ./build-all.sh desktop
   popd
 fi;
-if [ "$(uname -s)" == "Darwin" ] && [ ! -f "/usr/include/pthread.h" ]; then
+if [[ "$(uname -s)" == "Darwin" ]] && [[ ! -f "/usr/include/pthread.h" ]]; then
   # rustc does not include the macOS SDK headers in its include list yet
   # (see https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes)
   echo "macOS system headers are not installed in /usr/include, please run:"

--- a/libs/build-all-android.sh
+++ b/libs/build-all-android.sh
@@ -12,7 +12,7 @@ TARGET_ARCHS_TOOLCHAINS=("x86_64-linux-android" "i686-linux-android" "aarch64-li
 
 # End of configuration.
 
-if [ "${#}" -ne 3 ]
+if [[ "${#}" -ne 3 ]]
 then
     echo "Usage:"
     echo "./build-all-android.sh <OPENSSL_SRC_PATH> <SQLCIPHER_SRC_PATH> <NSS_SRC_PATH>"
@@ -30,7 +30,7 @@ for i in "${!TARGET_ARCHS[@]}"; do
   ARCH=${TARGET_ARCHS[${i}]}
   DIST=${TARGET_ARCHS_DISTS[${i}]}
   DIST_DIR=$(abspath "android/${DIST}/nss")
-  if [ -d "${DIST_DIR}" ]; then
+  if [[ -d "${DIST_DIR}" ]]; then
     echo "${DIST_DIR} already exists. Skipping building nss."
   else
     ./build-nss-android.sh "${NSS_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" "${TARGET_ARCHS_TOOLCHAINS[${i}]}" "${ANDROID_NDK_API_VERSION}" || exit 1
@@ -42,7 +42,7 @@ for i in "${!TARGET_ARCHS[@]}"; do
   ARCH=${TARGET_ARCHS[${i}]}
   DIST=${TARGET_ARCHS_DISTS[${i}]}
   DIST_DIR=$(abspath "android/${DIST}/openssl")
-  if [ -d "${DIST_DIR}" ]; then
+  if [[ -d "${DIST_DIR}" ]]; then
     echo "${DIST_DIR} already exists. Skipping building openssl."
   else
     ./build-openssl-android.sh "${OPENSSL_SRC_PATH}" "${DIST_DIR}" "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" "${TARGET_ARCHS_TOOLCHAINS[${i}]}" "${ANDROID_NDK_API_VERSION}" || exit 1
@@ -55,7 +55,7 @@ for i in "${!TARGET_ARCHS[@]}"; do
   DIST=${TARGET_ARCHS_DISTS[${i}]}
   NSS_DIR=$(abspath "android/${DIST}/nss")
   DIST_DIR=$(abspath "android/${DIST}/sqlcipher")
-  if [ -d "${DIST_DIR}" ]; then
+  if [[ -d "${DIST_DIR}" ]]; then
     echo "${DIST_DIR} already exists. Skipping building sqlcipher."
   else
     ./build-sqlcipher-android.sh "${SQLCIPHER_SRC_PATH}" "${DIST_DIR}" "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" "${TARGET_ARCHS_TOOLCHAINS[${i}]}" "${ANDROID_NDK_API_VERSION}" "${NSS_DIR}" || exit 1

--- a/libs/build-all-ios.sh
+++ b/libs/build-all-ios.sh
@@ -6,7 +6,7 @@ IOS_MIN_SDK_VERSION="11.0"
 # Our short-names for the architectures.
 TARGET_ARCHS=("x86_64" "arm64")
 
-if [ "${#}" -ne 3 ]
+if [[ "${#}" -ne 3 ]]
 then
     echo "Usage:"
     echo "./build-all-ios.sh <OPENSSL_SRC_PATH> <SQLCIPHER_SRC_PATH> <NSS_SRC_PATH>"
@@ -23,7 +23,7 @@ function universal_lib() {
   shift; shift
   UNIVERSAL_DIR="ios/universal/${DIR_NAME}"
   LIB_PATH="${UNIVERSAL_DIR}/lib/${LIB_NAME}"
-  if [ ! -e "${LIB_PATH}" ]; then
+  if [[ ! -e "${LIB_PATH}" ]]; then
     mkdir -p "${UNIVERSAL_DIR}/lib"
     CMD="lipo"
     for ARCH in "${@}"; do
@@ -38,7 +38,7 @@ echo "# Building NSS"
 for i in "${!TARGET_ARCHS[@]}"; do
   ARCH=${TARGET_ARCHS[${i}]}
   DIST_DIR=$(abspath "ios/${ARCH}/nss")
-  if [ -d "${DIST_DIR}" ]; then
+  if [[ -d "${DIST_DIR}" ]]; then
     echo "${DIST_DIR} already exists. Skipping building nss."
   else
     ./build-nss-ios.sh "${NSS_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${IOS_MIN_SDK_VERSION}" || exit 1
@@ -69,7 +69,7 @@ echo "# Building openssl"
 for i in "${!TARGET_ARCHS[@]}"; do
   ARCH=${TARGET_ARCHS[${i}]}
   DIST_DIR=$(abspath "ios/${ARCH}/openssl")
-  if [ -d "${DIST_DIR}" ]; then
+  if [[ -d "${DIST_DIR}" ]]; then
     echo "${DIST_DIR} already exists. Skipping building openssl."
   else
     ./build-openssl-ios.sh "${OPENSSL_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${IOS_MIN_SDK_VERSION}" || exit 1
@@ -82,7 +82,7 @@ echo "# Building sqlcipher"
 for i in "${!TARGET_ARCHS[@]}"; do
   ARCH=${TARGET_ARCHS[${i}]}
   DIST_DIR=$(abspath "ios/${ARCH}/sqlcipher")
-  if [ -d "${DIST_DIR}" ]; then
+  if [[ -d "${DIST_DIR}" ]]; then
     echo "${DIST_DIR} already exists. Skipping building sqlcipher."
   else
     ./build-sqlcipher-ios.sh "${SQLCIPHER_SRC_PATH}" "${DIST_DIR}" "${ARCH}" "${IOS_MIN_SDK_VERSION}" || exit 1
@@ -91,7 +91,7 @@ done
 universal_lib "sqlcipher" "libsqlcipher.a" "${TARGET_ARCHS[@]}"
 
 HEADER_DIST_DIR="ios/universal/openssl/include/openssl"
-if [ ! -e "${HEADER_DIST_DIR}" ]; then
+if [[ ! -e "${HEADER_DIST_DIR}" ]]; then
   mkdir -p ${HEADER_DIST_DIR}
   cp -L "${OPENSSL_SRC_PATH}"/include/openssl/*.h "${HEADER_DIST_DIR}"
   # The following file is generated during compilation, we pick the one in arm64.
@@ -99,7 +99,7 @@ if [ ! -e "${HEADER_DIST_DIR}" ]; then
 fi
 
 HEADER_DIST_DIR="ios/universal/sqlcipher/include/sqlcipher"
-if [ ! -e "${HEADER_DIST_DIR}" ]; then
+if [[ ! -e "${HEADER_DIST_DIR}" ]]; then
   mkdir -p ${HEADER_DIST_DIR}
   # Choice of arm64 is arbitrary, it shouldn't matter.
   HEADER_SRC_DIR=$(abspath "ios/arm64/sqlcipher/include/sqlcipher")
@@ -107,7 +107,7 @@ if [ ! -e "${HEADER_DIST_DIR}" ]; then
 fi
 
 HEADER_DIST_DIR="ios/universal/nss/include/nss"
-if [ ! -e "${HEADER_DIST_DIR}" ]; then
+if [[ ! -e "${HEADER_DIST_DIR}" ]]; then
   mkdir -p ${HEADER_DIST_DIR}
   # Choice of arm64 is arbitrary, it shouldn't matter.
   HEADER_SRC_DIR=$(abspath "ios/arm64/nss/include/nss")

--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -15,13 +15,13 @@ NSS="nss-3.44"
 
 # End of configuration.
 
-if [ ! -f "$(pwd)/build-all.sh" ]
+if [[ ! -f "$(pwd)/build-all.sh" ]]
 then
     echo "build-all.sh must be executed from within the libs/ directory."
     exit 1
 fi
 
-if [ "${#}" -ne 1 ]
+if [[ "${#}" -ne 1 ]]
 then
     echo "Usage:"
     echo "./build-all.sh [ios|android|desktop]"
@@ -33,25 +33,25 @@ PLATFORM="${1}"
 abspath () { case "${1}" in /*)printf "%s\\n" "${1}";; *)printf "%s\\n" "${PWD}/${1}";; esac; }
 export -f abspath
 
-if ! [ -x "$(command -v gyp)" ]; then
+if ! [[ -x "$(command -v gyp)" ]]; then
   echo 'Error: gyp needs to be installed and executable. See https://github.com/mogemimi/pomdog/wiki/How-to-Install-GYP for install instructions.' >&2
   exit 1
 fi
 
-if ! [ -x "$(command -v ninja)" ]; then
+if ! [[ -x "$(command -v ninja)" ]]; then
   echo 'Error: ninja needs to be installed and executable. See https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages for install instructions.' >&2
   exit 1
 fi
 
 # SQLCipher needs TCL.
-if ! [ -x "$(command -v tclsh)" ]; then
+if ! [[ -x "$(command -v tclsh)" ]]; then
   echo 'Error: tclsh needs to be installed and executable. See https://www.tcl.tk/software/tcltk/.' >&2
   exit 1
 fi
 
 OPENSSL="openssl-${OPENSSL_VERSION}"
 rm -rf "${OPENSSL}"
-if [ ! -e "${OPENSSL}.tar.gz" ]; then
+if [[ ! -e "${OPENSSL}.tar.gz" ]]; then
   echo "Downloading ${OPENSSL}.tar.gz"
   curl -L -O "https://www.openssl.org/source/${OPENSSL}.tar.gz"
 else
@@ -68,7 +68,7 @@ SQLCIPHER_SRC_PATH=$(abspath "sqlcipher")
 # ... and uncomment the following once SQLCipher has an NSS crypto backend.
 # SQLCIPHER="v${SQLCIPHER_VERSION}"
 # rm -rf "${SQLCIPHER}"
-# if [ ! -e "${SQLCIPHER}.tar.gz" ]; then
+# if [[ ! -e "${SQLCIPHER}.tar.gz" ]]; then
 #   echo "Downloading ${SQLCIPHER}.tar.gz"
 #   curl -L -O "https://github.com/sqlcipher/sqlcipher/archive/${SQLCIPHER}.tar.gz"
 # else
@@ -85,7 +85,7 @@ hg clone https://hg.mozilla.org/projects/nss/ -r 0c5d37301637ed024de8c2cbdbecf14
 git clone --single-branch --branch without-versions https://github.com/eoger/nspr.git "${NSS}"/nspr
 # hg clone https://hg.mozilla.org/projects/nspr/ -r cc73b6c7dab2e8053533e1f2c0c23dc721e10b76 "${NSS}"/nspr
 # ... and uncomment the following once NSS 3.45 and NSPR 4.22 are out.
-# if [ ! -e "${NSS_ARCHIVE}" ]; then
+# if [[ ! -e "${NSS_ARCHIVE}" ]]; then
 #   echo "Downloading ${NSS_ARCHIVE}"
 #   curl -L -O "${NSS_URL}"
 # else
@@ -125,18 +125,18 @@ diff -r 65efa74ef84a coreconf/config.gypi
          \'include_dirs\': [
 ' | patch "${NSS_SRC_PATH}/nss/coreconf/config.gypi"
 
-if [ "${PLATFORM}" == "ios" ]
+if [[ "${PLATFORM}" == "ios" ]]
 then
   ./build-all-ios.sh "${OPENSSL_SRC_PATH}" "${SQLCIPHER_SRC_PATH}" "${NSS_SRC_PATH}"
-elif [ "${PLATFORM}" == "android" ]
+elif [[ "${PLATFORM}" == "android" ]]
 then
   ./build-all-android.sh "${OPENSSL_SRC_PATH}" "${SQLCIPHER_SRC_PATH}" "${NSS_SRC_PATH}"
-elif [ "${PLATFORM}" == "desktop" ]
+elif [[ "${PLATFORM}" == "desktop" ]]
 then
   ./build-nss-desktop.sh "${NSS_SRC_PATH}"
   ./build-openssl-desktop.sh "${OPENSSL_SRC_PATH}"
   ./build-sqlcipher-desktop.sh "${SQLCIPHER_SRC_PATH}"
-elif [ "${PLATFORM}" == "darwin" ] || [ "${PLATFORM}" == "win32-x86-64" ]
+elif [[ "${PLATFORM}" == "darwin" ]] || [[ "${PLATFORM}" == "win32-x86-64" ]]
 then
   ./build-nss-desktop.sh "${NSS_SRC_PATH}" "${PLATFORM}"
   ./build-openssl-desktop.sh "${OPENSSL_SRC_PATH}" "${PLATFORM}"

--- a/libs/build-nss-android.sh
+++ b/libs/build-nss-android.sh
@@ -4,7 +4,7 @@
 
 set -euvx
 
-if [ "${#}" -ne 6 ]
+if [[ "${#}" -ne 6 ]]
 then
     echo "Usage:"
     echo "./build-nss-android.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <TOOLCHAIN_PATH> <TOOLCHAIN> <ANDROID_NDK_API_VERSION>"
@@ -18,25 +18,25 @@ TOOLCHAIN_PATH=${4}
 TOOLCHAIN=${5}
 ANDROID_NDK_API_VERSION=${6}
 
-if [ -d "${DIST_DIR}" ]; then
+if [[ -d "${DIST_DIR}" ]]; then
   echo "${DIST_DIR} folder already exists. Skipping build."
   exit 0
 fi
 
 PLATFORM_PATH="${ANDROID_NDK_ROOT}/platforms/android-${ANDROID_NDK_API_VERSION}/arch-${ARCH}"
-if [ "${TOOLCHAIN}" == "x86_64-linux-android" ]
+if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]]
 then
   GYP_ARCH="x64"
   LDFLAGS="-L${PLATFORM_PATH}/usr/lib64"
   NSPR_64="--enable-64bit"
-elif [ "${TOOLCHAIN}" == "i686-linux-android" ]
+elif [[ "${TOOLCHAIN}" == "i686-linux-android" ]]
 then
   GYP_ARCH="ia32"
-elif [ "${TOOLCHAIN}" == "aarch64-linux-android" ]
+elif [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]
 then
   GYP_ARCH="arm64"
   NSPR_64="--enable-64bit"
-elif [ "${TOOLCHAIN}" == "arm-linux-androideabi" ]
+elif [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]
 then
   GYP_ARCH="arm"
 else

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -4,7 +4,7 @@
 
 set -euvx
 
-if [ "${#}" -lt 1 ] || [ "${#}" -gt 2 ]
+if [[ "${#}" -lt 1 ]] || [[ "${#}" -gt 2 ]]
 then
   echo "Usage:"
   echo "./build-nss-desktop.sh <ABSOLUTE_SRC_DIR> [CROSS_COMPILE_TARGET]"
@@ -16,7 +16,7 @@ NSS_SRC_DIR=${1}
 # only intended for automation.
 CROSS_COMPILE_TARGET=${2-}
 
-if [ -n "${CROSS_COMPILE_TARGET}" ] && [ "$(uname -s)" != "Linux" ]; then
+if [[ -n "${CROSS_COMPILE_TARGET}" ]] && [[ "$(uname -s)" != "Linux" ]]; then
   echo "Can only cross compile from 'Linux'; 'uname -s' is $(uname -s)"
   exit 1
 fi
@@ -25,12 +25,12 @@ if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
   DIST_DIR=$(abspath "desktop/win32-x86-64/nss")
 elif [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   DIST_DIR=$(abspath "desktop/darwin/nss")
-elif [ -n "${CROSS_COMPILE_TARGET}" ]; then
+elif [[ -n "${CROSS_COMPILE_TARGET}" ]]; then
   echo "Cannot build NSS for unrecognized target OS ${CROSS_COMPILE_TARGET}"
   exit 1
-elif [ "$(uname -s)" == "Darwin" ]; then
+elif [[ "$(uname -s)" == "Darwin" ]]; then
   DIST_DIR=$(abspath "desktop/darwin/nss")
-elif [ "$(uname -s)" == "Linux" ]; then
+elif [[ "$(uname -s)" == "Linux" ]]; then
   # This is a JNA weirdness: "x86-64" rather than "x86_64".
   DIST_DIR=$(abspath "desktop/linux-x86-64/nss")
 else
@@ -38,7 +38,7 @@ else
    exit 1
 fi
 
-if [ -d "${DIST_DIR}" ]; then
+if [[ -d "${DIST_DIR}" ]]; then
   echo "${DIST_DIR} folder already exists. Skipping build."
   exit 0
 fi
@@ -58,7 +58,7 @@ elif [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
   echo "${SHA256}  nss_nspr_static_libs_win32.7z" | shasum -a 256 -c - || exit 2
   7z x nss_nspr_static_libs_win32.7z -aoa && rm -rf nss_nspr_static_libs_win32.7z
   NSS_DIST_DIR=$(abspath "dist")
-elif [ "$(uname -s)" == "Darwin" ] || [ "$(uname -s)" == "Linux" ]; then
+elif [[ "$(uname -s)" == "Darwin" ]] || [[ "$(uname -s)" == "Linux" ]]; then
   "${NSS_SRC_DIR}"/nss/build.sh \
     --opt \
     --static \
@@ -72,7 +72,7 @@ fi
 if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
   EXT="lib"
   PREFIX=""
-elif [ "$(uname -s)" == "Darwin" ] || [ "$(uname -s)" == "Linux" ]; then
+elif [[ "$(uname -s)" == "Darwin" ]] || [[ "$(uname -s)" == "Linux" ]]; then
   EXT="a"
   PREFIX="lib"
 fi

--- a/libs/build-nss-ios.sh
+++ b/libs/build-nss-ios.sh
@@ -4,7 +4,7 @@
 
 set -euvx
 
-if [ "${#}" -ne 4 ]
+if [[ "${#}" -ne 4 ]]
 then
     echo "Usage:"
     echo "./build-nss-ios.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <IOS_MIN_SDK_VERSION>"
@@ -16,7 +16,7 @@ DIST_DIR=${2}
 ARCH=${3}
 IOS_MIN_SDK_VERSION=${4}
 
-if [ -d "${DIST_DIR}" ]; then
+if [[ -d "${DIST_DIR}" ]]; then
   echo "${DIST_DIR} folder already exists. Skipping build."
   exit 0
 fi

--- a/libs/build-openssl-android.sh
+++ b/libs/build-openssl-android.sh
@@ -4,7 +4,7 @@
 
 set -euvx
 
-if [ "${#}" -ne 5 ]
+if [[ "${#}" -ne 5 ]]
 then
     echo "Usage:"
     echo "./build-openssl-android.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <TOOLCHAIN_PATH> <TOOLCHAIN> <ANDROID_NDK_API_VERSION>"
@@ -17,7 +17,7 @@ TOOLCHAIN_PATH=${3}
 TOOLCHAIN=${4}
 ANDROID_NDK_API_VERSION=${5}
 
-if [ -d "${DIST_DIR}" ]; then
+if [[ -d "${DIST_DIR}" ]]; then
   echo "${DIST_DIR}"" folder already exists. Skipping build."
   exit 0
 fi
@@ -31,16 +31,16 @@ export PATH="${TOOLCHAIN_PATH}/bin:${PATH}"
 OPENSSL_OUTPUT_PATH="/tmp/openssl-${TOOLCHAIN}_${$}"
 mkdir -p "${OPENSSL_OUTPUT_PATH}"
 
-if [ "${TOOLCHAIN}" == "x86_64-linux-android" ]
+if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]]
 then
   CONFIGURE_ARCH="android64-x86_64"
-elif [ "${TOOLCHAIN}" == "i686-linux-android" ]
+elif [[ "${TOOLCHAIN}" == "i686-linux-android" ]]
 then
   CONFIGURE_ARCH="android-x86"
-elif [ "${TOOLCHAIN}" == "aarch64-linux-android" ]
+elif [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]
 then
   CONFIGURE_ARCH="android-arm64"
-elif [ "${TOOLCHAIN}" == "arm-linux-androideabi" ]
+elif [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]
 then
   CONFIGURE_ARCH="android-arm"
 else

--- a/libs/build-openssl-desktop.sh
+++ b/libs/build-openssl-desktop.sh
@@ -4,7 +4,7 @@ set -euvx
 
 # End of configuration.
 
-if [ "${#}" -lt 1 ] || [ "${#}" -gt 2 ]
+if [[ "${#}" -lt 1 ]] || [[ "${#}" -gt 2 ]]
 then
   echo "Usage:"
   echo "./build-openssl-desktop.sh <OPENSSL_SRC_PATH> [CROSS_COMPILE_TARGET]"
@@ -14,7 +14,7 @@ fi
 OPENSSL_SRC_PATH=${1}
 CROSS_COMPILE_TARGET=${2-}
 
-if [ -n "${CROSS_COMPILE_TARGET}" ] && [ "$(uname -s)" != "Linux" ]; then
+if [[ -n "${CROSS_COMPILE_TARGET}" ]] && [[ "$(uname -s)" != "Linux" ]]; then
   echo "Can only cross compile from 'Linux'; 'uname -s' is $(uname -s)"
   exit 1
 fi
@@ -23,12 +23,12 @@ if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
   OPENSSL_DIR=$(abspath "desktop/win32-x86-64/openssl")
 elif [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   OPENSSL_DIR=$(abspath "desktop/darwin/openssl")
-elif [ -n "${CROSS_COMPILE_TARGET}" ]; then
+elif [[ -n "${CROSS_COMPILE_TARGET}" ]]; then
   echo "Cannot build OpenSSL for unrecognized target OS ${CROSS_COMPILE_TARGET}"
   exit 1
-elif [ "$(uname -s)" == "Darwin" ]; then
+elif [[ "$(uname -s)" == "Darwin" ]]; then
   OPENSSL_DIR=$(abspath "desktop/darwin/openssl")
-elif [ "$(uname -s)" == "Linux" ]; then
+elif [[ "$(uname -s)" == "Linux" ]]; then
   # This is a JNA weirdness: "x86-64" rather than "x86_64".
   OPENSSL_DIR=$(abspath "desktop/linux-x86-64/openssl")
 else
@@ -36,7 +36,7 @@ else
    exit 1
 fi
 
-if [ -d "${OPENSSL_DIR}" ]; then
+if [[ -d "${OPENSSL_DIR}" ]]; then
   echo "${OPENSSL_DIR} folder already exists. Skipping build."
   exit 0
 fi
@@ -77,12 +77,12 @@ elif [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
     ./Configure --cross-compile-prefix=x86_64-w64-mingw32- mingw64 \
       shared \
       --prefix="${OPENSSL_OUTPUT_PATH}"
-elif [ "$(uname -s)" == "Darwin" ]; then
+elif [[ "$(uname -s)" == "Darwin" ]]; then
     # Force 64 bits on macOS.
     ./Configure darwin64-x86_64-cc \
       shared \
       --prefix="${OPENSSL_OUTPUT_PATH}"
-elif [ "$(uname -s)" == "Linux" ]; then
+elif [[ "$(uname -s)" == "Linux" ]]; then
     ./config shared \
       --prefix="${OPENSSL_OUTPUT_PATH}"
 fi

--- a/libs/build-openssl-ios.sh
+++ b/libs/build-openssl-ios.sh
@@ -4,7 +4,7 @@
 
 set -euvx
 
-if [ "${#}" -ne 4 ]
+if [[ "${#}" -ne 4 ]]
 then
     echo "Usage:"
     echo "./build-openssl-ios.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <IOS_MIN_SDK_VERSION>"
@@ -16,7 +16,7 @@ DIST_DIR=${2}
 ARCH=${3}
 IOS_MIN_SDK_VERSION=${4}
 
-if [ -d "${DIST_DIR}" ]; then
+if [[ -d "${DIST_DIR}" ]]; then
   echo "${DIST_DIR} folder already exists. Skipping build."
   exit 0
 fi

--- a/libs/build-sqlcipher-android.sh
+++ b/libs/build-sqlcipher-android.sh
@@ -4,7 +4,7 @@
 
 set -euvx
 
-if [ "${#}" -ne 6 ]
+if [[ "${#}" -ne 6 ]]
 then
     echo "Usage:"
     echo "./build-sqlcipher-android.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <TOOLCHAIN_PATH> <TOOLCHAIN> <ANDROID_NDK_API_VERSION> <NSS_DIR>"
@@ -18,7 +18,7 @@ TOOLCHAIN=${4}
 ANDROID_NDK_API_VERSION=${5}
 NSS_DIR=${6}
 
-if [ -d "${DIST_DIR}" ]; then
+if [[ -d "${DIST_DIR}" ]]; then
   echo "${DIST_DIR} folder already exists. Skipping build."
   exit 0
 fi
@@ -31,16 +31,16 @@ export LD="${TOOLCHAIN_BIN}/${TOOLCHAIN}-ld"
 export AR="${TOOLCHAIN_BIN}/${TOOLCHAIN}-ar"
 export CFLAGS="-D__ANDROID_API__=${ANDROID_NDK_API_VERSION}"
 
-if [ "${TOOLCHAIN}" == "x86_64-linux-android" ]
+if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]]
 then
   HOST="x86_64-linux"
-elif [ "${TOOLCHAIN}" == "i686-linux-android" ]
+elif [[ "${TOOLCHAIN}" == "i686-linux-android" ]]
 then
   HOST="i686-linux"
-elif [ "${TOOLCHAIN}" == "aarch64-linux-android" ]
+elif [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]
 then
   HOST="arm-linux"
-elif [ "${TOOLCHAIN}" == "arm-linux-androideabi" ]
+elif [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]
 then
   HOST="arm-linux"
 else

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -2,7 +2,7 @@
 
 set -euvx
 
-if [ "${#}" -lt 1 ] || [ "${#}" -gt 2 ]
+if [[ "${#}" -lt 1 ]] || [[ "${#}" -gt 2 ]]
 then
   echo "Usage:"
   echo "./build-sqlcipher-desktop.sh <ABSOLUTE_SRC_DIR> [CROSS_COMPILE_TARGET]"
@@ -14,7 +14,7 @@ SQLCIPHER_SRC_DIR=${1}
 # only intended for automation.
 CROSS_COMPILE_TARGET=${2-}
 
-if [ -n "${CROSS_COMPILE_TARGET}" ] && [ "$(uname -s)" != "Linux" ]; then
+if [[ -n "${CROSS_COMPILE_TARGET}" ]] && [[ "$(uname -s)" != "Linux" ]]; then
   echo "Can only cross compile from 'Linux'; 'uname -s' is $(uname -s)"
   exit 1
 fi
@@ -25,13 +25,13 @@ if [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
 elif [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   DIST_DIR=$(abspath "desktop/darwin/sqlcipher")
   NSS_DIR=$(abspath "desktop/darwin/nss")
-elif [ -n "${CROSS_COMPILE_TARGET}" ]; then
+elif [[ -n "${CROSS_COMPILE_TARGET}" ]]; then
   echo "Cannot build SQLCipher for unrecognized target OS ${CROSS_COMPILE_TARGET}"
   exit 1
-elif [ "$(uname -s)" == "Darwin" ]; then
+elif [[ "$(uname -s)" == "Darwin" ]]; then
   DIST_DIR=$(abspath "desktop/darwin/sqlcipher")
   NSS_DIR=$(abspath "desktop/darwin/nss")
-elif [ "$(uname -s)" == "Linux" ]; then
+elif [[ "$(uname -s)" == "Linux" ]]; then
   # This is a JNA weirdness: "x86-64" rather than "x86_64".
   DIST_DIR=$(abspath "desktop/linux-x86-64/sqlcipher")
   NSS_DIR=$(abspath "desktop/linux-x86-64/nss")
@@ -40,7 +40,7 @@ else
    exit 1
 fi
 
-if [ -d "${DIST_DIR}" ]; then
+if [[ -d "${DIST_DIR}" ]]; then
   echo "${DIST_DIR} folder already exists. Skipping build."
   exit 0
 fi
@@ -181,7 +181,7 @@ popd
     CFLAGS="${SQLCIPHER_CFLAGS}" \
     LDFLAGS="-L${NSS_DIR}/lib" \
     LIBS="${LIBS}"
-elif [ "$(uname -s)" == "Darwin" ]; then
+elif [[ "$(uname -s)" == "Darwin" ]]; then
   "${SQLCIPHER_SRC_DIR}/configure" \
     --with-pic \
     --disable-shared \
@@ -191,7 +191,7 @@ elif [ "$(uname -s)" == "Darwin" ]; then
     CFLAGS="${SQLCIPHER_CFLAGS}" \
     LDFLAGS="-L${NSS_DIR}/lib" \
     LIBS="${LIBS}"
-elif [ "$(uname -s)" == "Linux" ]; then
+elif [[ "$(uname -s)" == "Linux" ]]; then
   "${SQLCIPHER_SRC_DIR}/configure" \
     --with-pic \
     --disable-shared \

--- a/libs/build-sqlcipher-ios.sh
+++ b/libs/build-sqlcipher-ios.sh
@@ -4,7 +4,7 @@
 
 set -euvx
 
-if [ "${#}" -ne 4 ]
+if [[ "${#}" -ne 4 ]]
 then
     echo "Usage:"
     echo "./build-sqlcipher-ios.sh <ABSOLUTE_SRC_DIR> <DIST_DIR> <ARCH> <IOS_MIN_SDK_VERSION>"
@@ -16,7 +16,7 @@ DIST_DIR=${2}
 ARCH=${3}
 IOS_MIN_SDK_VERSION=${4}
 
-if [ -d "${DIST_DIR}" ]; then
+if [[ -d "${DIST_DIR}" ]]; then
   echo "${DIST_DIR} folder already exists. Skipping build."
   exit 0
 fi

--- a/libs/setup_toolchains_local.sh
+++ b/libs/setup_toolchains_local.sh
@@ -11,13 +11,13 @@ CLANG_BINS=("x86_64-linux-android-clang" "i686-linux-android-clang" "aarch64-lin
 
 ANDROID_NDK_ROOT="${1:-${ANDROID_NDK_ROOT}}"
 
-if [ -z "${ANDROID_NDK_ROOT}" ]; then
+if [[ -z "${ANDROID_NDK_ROOT}" ]]; then
     echo "Usage:"
     echo "./setup_toolchains_local.sh <ANDROID_NDK_ROOT>"
     exit 1
 fi
 
-if [ ! -f "$PWD/android_defaults.sh" ]
+if [[ ! -f "$PWD/android_defaults.sh" ]]
 then
     echo "setup_toolchains_local.sh must be executed from within the libs/ directory."
     exit 1
@@ -33,7 +33,7 @@ echo ""
 
 # Toolchains installation
 for ARCH in "${TARGET_ARCHS[@]}"; do
-  if [ ! -d "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" ]; then
+  if [[ ! -d "${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" ]]; then
     echo "Installing ${ARCH} toolchain..."
     python3 "${ANDROID_NDK_ROOT}/build/tools/make_standalone_toolchain.py" --arch="${ARCH}" --api="${ANDROID_NDK_API_VERSION}" --install-dir="${ANDROID_NDK_TOOLCHAIN_DIR}/${ARCH}-${ANDROID_NDK_API_VERSION}" --deprecated-headers --force
   else

--- a/libs/verify-android-environment.sh
+++ b/libs/verify-android-environment.sh
@@ -7,35 +7,35 @@
 NDK_VERSION=15
 RUST_TARGETS=("aarch64-linux-android" "armv7-linux-androideabi" "i686-linux-android" "x86_64-linux-android")
 
-if [ ! -f "$(pwd)/libs/build-all.sh" ]; then
+if [[ ! -f "$(pwd)/libs/build-all.sh" ]]; then
   echo "ERROR: verify-android-environment.sh should be run from the root directory of the repo"
   exit 1
 fi
 
-if [ -z "${ANDROID_HOME}" ]; then
+if [[ -z "${ANDROID_HOME}" ]]; then
   echo "Could not find Android SDK:"
   echo 'Please install the Android SDK and then set ANDROID_HOME.'
   exit 1
 fi
 
-if [ -z "${ANDROID_NDK_ROOT}" ]; then
+if [[ -z "${ANDROID_NDK_ROOT}" ]]; then
   echo "Could not find Android NDK:"
   echo 'Please install the Android NDK r15c and then set ANDROID_NDK_ROOT.'
   exit 1
 fi
 
-if [ -z "${ANDROID_NDK_HOME}" ]; then
+if [[ -z "${ANDROID_NDK_HOME}" ]]; then
   echo "Environment variable \$ANDROID_NDK_HOME is not set:"
   echo "Please export ANDROID_NDK_HOME=\$ANDROID_NDK_ROOT for compatibility with the android gradle plugin."
   exit 1
-elif [ "${ANDROID_NDK_HOME}" != "${ANDROID_NDK_ROOT}" ]; then
+elif [[ "${ANDROID_NDK_HOME}" != "${ANDROID_NDK_ROOT}" ]]; then
   echo "Environment variable \$ANDROID_NDK_HOME is different from \$ANDROID_NDK_ROOT."
   echo "Please adjust your environment variables to ensure they are the same."
   exit 1
 fi
 
 INSTALLED_NDK_VERSION=$(sed -En -e 's/^Pkg.Revision[ \t]*=[ \t]*([0-9a-f]+).*/\1/p' "${ANDROID_NDK_ROOT}/source.properties")
-if [ "${INSTALLED_NDK_VERSION}" != ${NDK_VERSION} ]; then
+if [[ "${INSTALLED_NDK_VERSION}" != "${NDK_VERSION}" ]]; then
   echo "Wrong Android NDK version:"
   echo "Expected version ${NDK_VERSION}, got ${INSTALLED_NDK_VERSION}"
   exit 1
@@ -43,7 +43,7 @@ fi
 
 rustup target add "${RUST_TARGETS[@]}"
 
-if [ -z "${ANDROID_NDK_TOOLCHAIN_DIR}" ]; then
+if [[ -z "${ANDROID_NDK_TOOLCHAIN_DIR}" ]]; then
   echo "Could not find Android NDK toolchain directory:"
   echo "1. Create a directory where to set up the toolchains (e.g. ~/.ndk-standalone-toolchains)."
   echo "2. Set ANDROID_NDK_TOOLCHAIN_DIR to this newly created directory."
@@ -53,14 +53,14 @@ fi
 
 # Determine the Java command to use to start the JVM.
 # Same implementation as gradlew
-if [ -n "$JAVA_HOME" ] ; then
-    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+if [[ -n "$JAVA_HOME" ]] ; then
+    if [[ -x "$JAVA_HOME/jre/sh/java" ]] ; then
         # IBM's JDK on AIX uses strange locations for the executables
         JAVACMD="$JAVA_HOME/jre/sh/java"
     else
         JAVACMD="$JAVA_HOME/bin/java"
     fi
-    if [ ! -x "$JAVACMD" ] ; then
+    if [[ ! -x "$JAVACMD" ]] ; then
         die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
 
 Please set the JAVA_HOME variable in your environment to match the

--- a/testing/err-if-symbol.sh
+++ b/testing/err-if-symbol.sh
@@ -2,7 +2,7 @@
 
 set -euvx
 
-if [ "$#" -ne 3 ]
+if [[ "$#" -ne 3 ]]
 then
     echo "Usage: <path/to/relevant/nm> <path/to/relevant/library> <symbol_name>"
     echo "Example Usage:"


### PR DESCRIPTION
Our contributor @tinoism reported that `source libs/boostrap-desktop.sh` was not working for them and giving them an instance of https://unix.stackexchange.com/questions/502061/logical-operator-and-zsh-version-5-7-x-installed-using-homebrew.
Let's fix that by using ksh-style double square brackets.