### PR TITLE
Include license info in binary distributions.

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Licenses for Third-Party Dependencies
 
-Software packages built from this source code may incorporate code from a number of third-party dependencies.
+Binary distributions of this software incorporate code from a number of third-party dependencies.
 These dependencies are available under a variety of free and open source licenses,
 the details of which are reproduced below.
 

--- a/build-carthage.sh
+++ b/build-carthage.sh
@@ -20,4 +20,4 @@ xcpretty
 
 # Exclude SwiftProtobuf.
 rm -rf Carthage/Build/iOS/SwiftProtobuf.framework*
-zip -r "${FRAMEWORK_NAME}" Carthage/Build/iOS
+zip -r "${FRAMEWORK_NAME}" Carthage/Build/iOS megazords/ios/DEPENDENCIES.md

--- a/docs/howtos/consuming-rust-components-on-ios.md
+++ b/docs/howtos/consuming-rust-components-on-ios.md
@@ -36,6 +36,12 @@ The project has additional 3rd-party dependencies that a client must link agains
 - *SwiftProtoBuf.framework* should be automatically downloaded by carthage while pulling in the application-services dependency.
 - [Add that framework to Xcode.](#adding-a-carthage-provided-framework-to-xcode)
 
+## Third-party licenses
+
+This project incorporates code from a number of third-party dependencies,
+under a variety of open-source licenses. You should review the license info
+in the file `DEPENDENCIES.md` and decide on an appropriate way to include
+license and attribution notices into your product.
 
 
 

--- a/docs/product-portal/applications/consuming-megazord-libraries.md
+++ b/docs/product-portal/applications/consuming-megazord-libraries.md
@@ -131,4 +131,16 @@ dependencies {
 ```
 
 This will make the appropriate `.so` files available to your tests at runtime, without affecting the code
-that is bunlded into the built version of your app.
+that is bundled into the built version of your app.
+
+
+## Third-party licenses
+
+This project incorporates code from a number of third-party dependencies,
+under a variety of open-source licenses, and the set of dependencies will vary
+depending on which megazord is in use.
+
+Each megazord publication in Maven is accompanied by a file named like
+`example-megazord-X.Y.Z.LICENSES.md`. You should review the license info
+in this file and decide on an appropriate way to include license and attribution
+notices into your product.

--- a/megazords/fenix/DEPENDENCIES.md
+++ b/megazords/fenix/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Licenses for Third-Party Dependencies
 
-Software packages built from this source code may incorporate code from a number of third-party dependencies.
+Binary distributions of this software incorporate code from a number of third-party dependencies.
 These dependencies are available under a variety of free and open source licenses,
 the details of which are reproduced below.
 

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Licenses for Third-Party Dependencies
 
-Software packages built from this source code may incorporate code from a number of third-party dependencies.
+Binary distributions of this software incorporate code from a number of third-party dependencies.
 These dependencies are available under a variety of free and open source licenses,
 the details of which are reproduced below.
 

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Licenses for Third-Party Dependencies
 
-Software packages built from this source code may incorporate code from a number of third-party dependencies.
+Binary distributions of this software incorporate code from a number of third-party dependencies.
 These dependencies are available under a variety of free and open source licenses,
 the details of which are reproduced below.
 

--- a/megazords/lockbox/DEPENDENCIES.md
+++ b/megazords/lockbox/DEPENDENCIES.md
@@ -1,6 +1,6 @@
 # Licenses for Third-Party Dependencies
 
-Software packages built from this source code may incorporate code from a number of third-party dependencies.
+Binary distributions of this software incorporate code from a number of third-party dependencies.
 These dependencies are available under a variety of free and open source licenses,
 the details of which are reproduced below.
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -95,6 +95,12 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                 // Can't publish Javadoc yet: fxaclient isn't well behaved.
                 // artifact javadocJar
 
+                if (isMegazord) {
+                    artifact file("${projectDir}/../DEPENDENCIES.md"), {
+                        extension "LICENSES.md"
+                    }
+                }
+
                 // If this goes haywire with
                 // 'Cannot configure the 'publishing' extension after it has been accessed.',
                 // see https://github.com/researchgate/gradle-release/issues/125 and
@@ -130,7 +136,9 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
             if (isMegazord) {
                 forUnitTestsJar(MavenPublication) {
                     artifact tasks['forUnitTestsJar']
-
+                    artifact file("${projectDir}/../DEPENDENCIES.md"), {
+                        extension "LICENSES.md"
+                    }
                     pom {
                         groupId = theGroupId
                         artifactId = "${theArtifactId}-forUnitTests"

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -734,7 +734,7 @@ def print_dependency_summary(deps, file=sys.stdout):
 
     pf("# Licenses for Third-Party Dependencies")
     pf("")
-    pf("Software packages built from this source code may incorporate code from a number of third-party dependencies.")
+    pf("Binary distributions of this software incorporate code from a number of third-party dependencies.")
     pf("These dependencies are available under a variety of free and open source licenses,")
     pf("the details of which are reproduced below.")
     pf("")


### PR DESCRIPTION
And also add some base-bones docs on how consumers can obtain it. Fixes #1141.
