### PR TITLE
Destroy the refresh token after fetching the device list

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -6,6 +6,10 @@
 
 ## FxA Client
 
+### What's fixed
+
+- The `FirefoxAccount.disconnect` method should now properly dispose of the associated device record.
+
 ### Breaking changes
 
 - The `FirefoxAccount.beginOAuthFlow` method does not require the `wantsKeys` argument anymore

--- a/components/fxa-client/src/profile.rs
+++ b/components/fxa-client/src/profile.rs
@@ -107,10 +107,6 @@ mod tests {
         }
     }
 
-    // FIXME: https://github.com/myelin-ai/mockiato/issues/106.
-    unsafe impl<'a> Send for FxAClientMock<'a> {}
-    unsafe impl<'a> Sync for FxAClientMock<'a> {}
-
     #[test]
     fn test_fetch_profile() {
         let mut fxa =


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/1556.