### PR TITLE
Do not error-out on unknown push commands

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,9 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.37.0...master)
+
+## FxA Client
+
+### What's fixed
+
+- `FirefoxAccount.handlePushMessage` will not return an error on unknown push payloads.


### PR DESCRIPTION
Partial fix to https://github.com/mozilla-mobile/fenix/issues/4635.