### PR TITLE
Cut release 0.38.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 0.37.1
+libraryVersion: 0.38.0
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# v0.38.0 (_2019-08-19_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.37.1...v0.38.0)
+
+## General
+
+- Our OpenSSL dependency has been removed for all platforms other than
+  desktop-linux (used when running local rust unit tests and the android
+  -forUnitTests artifact). All other platforms use NSS.
+  ([#1570](https://github.com/mozilla/application-services/pull/1570))
+
+## Places
+
+### What's Fixed
+
+* Tags containing embedded whitespace are no longer marked as invalid and
+  removed. ([#1616](https://github.com/mozilla/application-services/issues/1616))
 
 # v0.37.1 (_2019-08-09_)
 

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,11 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.37.1...master)
-
-## Places
-
-### What's Fixed
-
-* Tags containing embedded whitespace are no longer marked as invalid and
-  removed. ([#1616](https://github.com/mozilla/application-services/issues/1616))
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.38.0...master)


### PR DESCRIPTION
Mostly to get a release out with the OpenSSL changes (for iOS, surprisingly enough).

There are no breaking changes, but the OpenSSL stuff is big enough that I've made it a major version bump.

CC @vladikoff 
