### PR TITLE
Tweak cron schedule for circleci jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -440,7 +440,7 @@ workflows:
       - Check Rust dependencies
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "0 7 * * *"
           filters:
             branches:
               only:
@@ -450,7 +450,7 @@ workflows:
       - Mirror Bugzilla issues into GitHub
     triggers:
       - schedule:
-          cron: "0 * * * *"
+          cron: "0,30 * * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
I think it would be fine if the "check rust dependencies" job ran only once per day, since we don't tend to respond to it with hour-level granularity.

I also think it would be nice to get bugzilla updates mirrored more quickly, so bumping that to run every half hour.