### PR TITLE
Exclude hidden URLs from syncing and views

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,13 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.38.2...master)
+
+## Places
+
+### What's fixed
+
+- Hidden URLs (redirect sources, or links visited in frames) are no longer
+  synced or returned in `get_visit_infos` or `get_visit_page`. Additionally,
+  a new `is_hidden` flag is added to `HistoryVisitInfo`, though it's currently
+  always `false`, since those visits are excluded.
+  ([#1715](https://github.com/mozilla/application-services/pull/1715))

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -953,7 +953,13 @@ data class VisitInfo(
     /**
      * What the transition type of the visit is.
      */
-    val visitType: VisitType
+    val visitType: VisitType,
+
+    /**
+     * Whether the page is hidden because it redirected to another page, or was
+     * visited in a frame.
+     */
+    val isHidden: Boolean
 ) {
     companion object {
         internal fun fromMessage(msg: MsgTypes.HistoryVisitInfos): List<VisitInfo> {
@@ -961,7 +967,8 @@ data class VisitInfo(
                 VisitInfo(url = it.url,
                     title = it.title,
                     visitTime = it.timestamp,
-                    visitType = intToVisitType[it.visitType]!!)
+                    visitType = intToVisitType[it.visitType]!!,
+                    isHidden = it.isHidden)
             }
         }
     }

--- a/components/places/src/places_msg_types.proto
+++ b/components/places/src/places_msg_types.proto
@@ -12,6 +12,7 @@ message HistoryVisitInfo {
     optional string title = 2;
     required int64 timestamp = 3;
     required int32 visit_type = 4;
+    required bool is_hidden = 5;
 }
 
 message HistoryVisitInfos {

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -187,6 +187,7 @@ impl HistoryVisitInfo {
             title: row.get("title")?,
             timestamp: visit_date.0 as i64,
             visit_type: visit_type as i32,
+            is_hidden: row.get("hidden")?,
         })
     }
 }


### PR DESCRIPTION
Hidden URLs are useful for storing redirect chains, and may be useful
for manual searching or awesomebar matches. However, the history
record format doesn't currently include the referrer or hidden state,
so we exclude them entirely to match Desktop, and to avoid cluttering
other devices with redirect sources.

We also filter them out in visit queries, so that Fenix doesn't have
to make changes for mozilla-mobile/fenix#3526. In a future release,
we can either return them and have Fenix filter them out in some
views, or add a flag to include or exclude them.

See #1492.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
