### PR TITLE
Remove unnecessary safe call on getString

### DIFF
--- a/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
+++ b/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
@@ -376,7 +376,7 @@ data class FailureReason(
 ) {
     companion object {
         fun fromJSON(jsonObject: JSONObject): FailureReason? {
-            return jsonObject.getString("name")?.let {
+            return jsonObject.getString("name").let {
                 when (it) {
                     "shutdownerror" -> FailureReason(
                         name = FailureName.Shutdown


### PR DESCRIPTION
I noticed this small issue when bumping `compileSdkVersion`.