### PR TITLE
Fixup missing syncids in meta/global.

### DIFF
--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -202,6 +202,24 @@ fn new_global(pgs: &PersistedGlobalState) -> error::Result<MetaGlobalRecord> {
     })
 }
 
+fn fixup_meta_global(global: &mut MetaGlobalRecord) -> bool {
+    let mut changed_any = false;
+    for &(name, version) in DEFAULT_ENGINES.iter() {
+        if !global.engines.contains_key(name) {
+            log::debug!("SyncID for engine {:?} was missing!", name);
+            global.engines.insert(
+                name.to_string(),
+                MetaGlobalEngine {
+                    version,
+                    sync_id: Guid::random(),
+                },
+            );
+            changed_any = true;
+        }
+    }
+    changed_any
+}
+
 pub struct SetupStateMachine<'a> {
     client: &'a dyn SetupStorageClient,
     root_key: &'a KeyBundle,
@@ -393,15 +411,30 @@ impl<'a> SetupStateMachine<'a> {
                             // Persist the new declined.
                             self.pgs
                                 .set_declined(result.declined.iter().cloned().collect());
-
                             // If the declined engines differ from remote, fix that.
-                            if result.declined != initial_global_declined {
-                                global.declined = result.declined.iter().cloned().collect();
+                            let fixed_declined = if result.declined != initial_global_declined {
                                 log::info!(
                                     "Uploading new declined {:?} to meta/global with timestamp {:?}",
                                     global.declined,
                                     global_timestamp,
                                 );
+                                global.declined = result.declined.iter().cloned().collect();
+                                true
+                            } else {
+                                false
+                            };
+                            // If there are missing syncIds, we need to fix those as well
+                            let fixed_ids = if fixup_meta_global(&mut global) {
+                                log::info!(
+                                    "Uploading corrected meta/global with timestamp {:?}",
+                                    global_timestamp,
+                                );
+                                true
+                            } else {
+                                false
+                            };
+
+                            if fixed_declined || fixed_ids {
                                 global_timestamp =
                                     self.client.put_meta_global(global_timestamp, &global)?;
                                 log::debug!("new global_timestamp: {:?}", global_timestamp);
@@ -756,6 +789,22 @@ mod tests {
             default: KeyBundle::new_random().unwrap(),
             collections: HashMap::new(),
         };
+        let mut mg = MetaGlobalRecord {
+            sync_id: "syncIDAAAAAA".into(),
+            storage_version: 5usize,
+            engines: vec![(
+                "bookmarks",
+                MetaGlobalEngine {
+                    version: 1usize,
+                    sync_id: "syncIDBBBBBB".into(),
+                },
+            )]
+            .into_iter()
+            .map(|(key, value)| (key.to_owned(), value))
+            .collect(),
+            declined: vec![],
+        };
+        fixup_meta_global(&mut mg);
         let client = InMemoryClient {
             info_configuration: mocked_success(InfoConfiguration::default()),
             info_collections: mocked_success(InfoCollections::new(
@@ -764,24 +813,7 @@ mod tests {
                     .map(|(key, value)| (key.to_owned(), value.into()))
                     .collect(),
             )),
-            meta_global: mocked_success_ts(
-                MetaGlobalRecord {
-                    sync_id: "syncIDAAAAAA".into(),
-                    storage_version: 5usize,
-                    engines: vec![(
-                        "bookmarks",
-                        MetaGlobalEngine {
-                            version: 1usize,
-                            sync_id: "syncIDBBBBBB".into(),
-                        },
-                    )]
-                    .into_iter()
-                    .map(|(key, value)| (key.to_owned(), value))
-                    .collect(),
-                    declined: vec![],
-                },
-                999_000,
-            ),
+            meta_global: mocked_success_ts(mg, 999_000),
             crypto_keys: mocked_success_ts(
                 keys.to_encrypted_bso_with_timestamp(&root_key, 888_000.into())
                     .expect("should always work in this test"),


### PR DESCRIPTION
Bandaid over #1831, but we probably want it in either case for robustness?

That said, I can't test it or reproduce the issue since FxA is having problems today :(. Supposedly the issues are fixed and things are coming back online.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
