### PR TITLE
Ensure declined engines don't have engine records in meta/global

### DIFF
--- a/components/sync_manager/src/manager.rs
+++ b/components/sync_manager/src/manager.rs
@@ -180,7 +180,6 @@ impl SyncManager {
     }
 
     pub fn sync(&mut self, params: SyncParams) -> Result<SyncResult> {
-        log::debug!("Got sync input: {:?}", params);
         let mut have_engines = vec![];
         let places = self.places.upgrade();
         let logins = self.logins.upgrade();


### PR DESCRIPTION
AFAICT desktop doesn't delete these when an engine is declined, but it does expect other clients to do so.

Something can't be right there, but this is a fix that ensures meta/global doesn't have any engine records for declined engines, which seems to be what https://searchfox.org/mozilla-central/source/services/sync/modules/stages/enginesync.js#268 expects.

It also fixes a bad log statement, and avoids logging a struct that contains sensitive data.

CC @grigoryk 