### PR TITLE
Bump benchmarks resource_class to large in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,6 +317,7 @@ jobs:
   Rust benchmarks:
     docker:
       - image: circleci/rust:latest
+    resource_class: large
     steps:
       - restore-sccache-cache
       - bench-all


### PR DESCRIPTION
Lets see if this fixes the failures. Given that it was running fine on the default before, I suspect we might not need to jump to xlarge with it.