### PR TITLE
Import clang headers only on Linux [ci full]

### DIFF
--- a/components/support/rc_crypto/nss/nss_sys/build.rs
+++ b/components/support/rc_crypto/nss/nss_sys/build.rs
@@ -245,9 +245,10 @@ fn fix_include_dirs(mut builder: Builder) -> Builder {
                         .to_str()
                         .unwrap()
                 ))
-                .clang_arg(format!("-D__ANDROID_API__={}", android_api_version))
+                .clang_arg(format!("-D__ANDROID_API__={}", android_api_version));
+            if cfg!(target_os = "linux") {
                 // stddef.h isn't defined otherwise.
-                .clang_arg(format!(
+                builder = builder.clang_arg(format!(
                     "-I{}",
                     toolchain_dir
                         .join(format!(
@@ -256,7 +257,8 @@ fn fix_include_dirs(mut builder: Builder) -> Builder {
                         ))
                         .to_str()
                         .unwrap()
-                ))
+                ));
+            }
         }
         _ => {}
     }


### PR DESCRIPTION
While working on https://github.com/mozilla/application-services/pull/1916 I noticed I introduced the issue again by bringing the "stddef.h block" back. So this is the minimal fix for that.

Fixes https://github.com/mozilla/application-services/issues/1908.