### PR TITLE
Convert microsecond timestamps when importing history visits

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,9 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.41.0...master)
+
+## Android
+
+### What's new
+
+- Fennec history import now supports microsecond timestamps for `date_visited`.

--- a/components/places/tests/fennec_history.rs
+++ b/components/places/tests/fennec_history.rs
@@ -201,6 +201,12 @@ fn test_import() -> Result<()> {
             is_local: false,
         },
         FennecVisit {
+            history: &history[1],
+            visit_type: VisitTransition::Link,
+            date: Timestamp::from(1_565_117_123_123_123), // Microsecond timestamp should be imported.
+            is_local: false,
+        },
+        FennecVisit {
             history: &history[3],
             visit_type: VisitTransition::Link,
             date: Timestamp::from(1_565_117_389_898),


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/1946.