### PR TITLE
Add ability to get an OAuth code using a session token via the `authorizeAuthCode` method.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,3 +9,9 @@
 ### What's new
 
 - Exposed `stroage::bookmarks::erase_everything`, which deletes all bookmarks without affecting      history, through FFI.
+
+## FxA Client
+
+### What's new
+
+Android: Add ability to get an OAuth code using a session token via the `authorizeOAuthCode` method.

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -265,6 +265,27 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
     }
 
     /**
+     * Provisions an OAuth code using the session token from state
+     *
+     * @param clientId OAuth client id.
+     * @param scopes Array of scopes for the OAuth code.
+     * @param state OAuth flow state.
+     * @param accessType Type of access, "offline" or "online".
+     * This performs network requests, and should not be used on the main thread.
+     */
+    fun authorizeOAuthCode(
+        clientId: String,
+        scopes: Array<String>,
+        state: String,
+        accessType: String = "online"
+    ): String {
+        val scope = scopes.joinToString(" ")
+        return rustCallWithLock { e ->
+            LibFxAFFI.INSTANCE.fxa_authorize_auth_code(this.handle.get(), clientId, scope, state, accessType, e)
+        }.getAndConsumeRustString()
+    }
+
+    /**
      * This method should be called when a request made with
      * an OAuth token failed with an authentication error.
      * It clears the internal cache of OAuth access tokens,

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -52,6 +52,7 @@ internal interface LibFxAFFI : Library {
     fun fxa_get_access_token(fxa: FxaHandle, scope: String, e: RustError.ByReference): RustBuffer.ByValue
     fun fxa_get_session_token(fxa: FxaHandle, e: RustError.ByReference): Pointer?
     fun fxa_get_current_device_id(fxa: FxaHandle, e: RustError.ByReference): Pointer?
+    fun fxa_authorize_auth_code(fxa: FxaHandle, clientId: String, scope: String, state: String, accessType: String, e: RustError.ByReference): Pointer?
     fun fxa_clear_access_token_cache(fxa: FxaHandle, e: RustError.ByReference)
 
     fun fxa_set_push_subscription(

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -365,6 +365,33 @@ pub extern "C" fn fxa_get_devices(handle: u64, error: &mut ExternError) -> ByteB
     })
 }
 
+/// Try to get an OAuth code using a session token.
+///
+/// The system will use the stored `session_token` to provision a new code and return it.
+///
+/// # Safety
+///
+/// A destructor [fxa_bytebuffer_free] is provided for releasing the memory for this
+/// pointer type.
+#[no_mangle]
+pub extern "C" fn fxa_authorize_auth_code(
+    handle: u64,
+    client_id: FfiStr<'_>,
+    scope: FfiStr<'_>,
+    state: FfiStr<'_>,
+    access_type: FfiStr<'_>,
+    error: &mut ExternError,
+) -> *mut c_char {
+    log::debug!("fxa_authorize_auth_code");
+    ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
+        let client_id = client_id.as_str();
+        let scope = scope.as_str();
+        let state = state.as_str();
+        let access_type = access_type.as_str();
+        fxa.authorize_code_using_session_token(client_id, scope, state, access_type)
+    })
+}
+
 /// Poll and parse available remote commands targeted to our own device.
 ///
 /// # Safety

--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -138,6 +138,33 @@ impl FirefoxAccount {
         self.oauth_flow(url, &scopes)
     }
 
+    /// Fetch an OAuth code for a particular client using a session token from the account state.
+    /// This method doesn't support OAuth public clients at this time.
+    ///
+    /// * `client_id` - OAuth client id.
+    /// * `scopes` - Space-separated list of requested scopes.
+    /// * `state` - OAuth state.
+    /// * `access_type` - Type of OAuth access, can be "offline" and "online.
+    pub fn authorize_code_using_session_token(
+        &mut self,
+        client_id: &str,
+        scope: &str,
+        state: &str,
+        access_type: &str,
+    ) -> Result<String> {
+        let session_token = self.get_session_token()?;
+        let resp = self.client.authorization_code_using_session_token(
+            &self.state.config,
+            &client_id,
+            &session_token,
+            &scope,
+            &state,
+            &access_type,
+        )?;
+
+        Ok(resp.code)
+    }
+
     fn oauth_flow(&mut self, mut url: Url, scopes: &[&str]) -> Result<String> {
         self.clear_access_token_cache();
         let state = util::random_base64_url_string(16)?;


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/2001

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
