### PR TITLE
Include dependency license info in megazord .pom files.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,10 +161,13 @@ commands:
             rustup install nightly
             cargo metadata --locked > /dev/null
             python3 ./tools/dependency_summary.py --check ./DEPENDENCIES.md
-            python3 ./tools/dependency_summary.py --all-android-targets --package megazord --check megazords/full/DEPENDENCIES.md
             python3 ./tools/dependency_summary.py --all-ios-targets --package megazord_ios --check megazords/ios/DEPENDENCIES.md
+            python3 ./tools/dependency_summary.py --all-android-targets --package megazord --check megazords/full/DEPENDENCIES.md
+            python3 ./tools/dependency_summary.py --all-android-targets --package megazord --format pom --check megazords/full/android/dependency-licenses.xml
             python3 ./tools/dependency_summary.py --all-android-targets --package fenix --check megazords/fenix/DEPENDENCIES.md
+            python3 ./tools/dependency_summary.py --all-android-targets --package fenix --format pom --check megazords/fenix/android/dependency-licenses.xml
             python3 ./tools/dependency_summary.py --all-android-targets --package lockbox --check megazords/lockbox/DEPENDENCIES.md
+            python3 ./tools/dependency_summary.py --all-android-targets --package lockbox --format pom --check megazords/lockbox/android/dependency-licenses.xml
 
   sync-bugzilla-to-github:
     steps:

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,11 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.42.2...master)
+
+## General
+
+### What's New
+
+- On Android, our Megazord libraries now include license information for dependencies
+  as part of their `.pom` file, making it easily available to tools such as the
+   [oss-licenses-plugin](https://github.com/google/play-services-plugins/tree/master/oss-licenses-plugin)

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -45,7 +45,7 @@ the details of which are reproduced below.
 * [BSD-3-Clause License: sqlcipher](#bsd-3-clause-license-sqlcipher)
 * [Zlib License: adler32](#zlib-license-adler32)
 * [OpenSSL License](#openssl-license)
-* [Optional Notice: SQlite](#optional-notice-sqlite)
+* [Optional Notice: SQLite](#optional-notice-sqlite)
 -------------
 ## Mozilla Public License 2.0
 
@@ -478,7 +478,7 @@ The following text applies to code linked from these dependendencies:
 [hex](https://github.com/KokaKiwi/rust-hex),
 [http](https://github.com/hyperium/http),
 [httparse](https://github.com/seanmonstar/httparse),
-[humantime](None),
+[humantime](https://github.com/tailhook/humantime),
 [hyper-tls](https://github.com/hyperium/hyper-tls),
 [idna](https://github.com/servo/rust-url/),
 [indexmap](https://github.com/bluss/indexmap),
@@ -809,7 +809,7 @@ THE SOFTWARE.
 ## MIT License: ansi_term
 
 The following text applies to code linked from these dependendencies:
-[ansi_term](None)
+[ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
 The MIT License (MIT)
@@ -2178,7 +2178,7 @@ The following text applies to code linked from these dependendencies:
 
 ```
 -------------
-## Optional Notice: SQlite
+## Optional Notice: SQLite
 
 The following text applies to code linked from these dependendencies:
 [sqlite](https://www.sqlite.org/)

--- a/megazords/fenix/DEPENDENCIES.md
+++ b/megazords/fenix/DEPENDENCIES.md
@@ -26,7 +26,7 @@ the details of which are reproduced below.
 * [BSD-3-Clause License: bindgen](#bsd-3-clause-license-bindgen)
 * [BSD-3-Clause License: protobuf](#bsd-3-clause-license-protobuf)
 * [BSD-3-Clause License: sqlcipher](#bsd-3-clause-license-sqlcipher)
-* [Optional Notice: SQlite](#optional-notice-sqlite)
+* [Optional Notice: SQLite](#optional-notice-sqlite)
 -------------
 ## Mozilla Public License 2.0
 
@@ -438,7 +438,7 @@ The following text applies to code linked from these dependendencies:
 [glob](https://github.com/rust-lang/glob),
 [heck](https://github.com/withoutboats/heck),
 [hex](https://github.com/KokaKiwi/rust-hex),
-[humantime](None),
+[humantime](https://github.com/tailhook/humantime),
 [idna](https://github.com/servo/rust-url/),
 [iovec](https://github.com/carllerche/iovec),
 [itertools](https://github.com/bluss/rust-itertools),
@@ -750,7 +750,7 @@ THE SOFTWARE.
 ## MIT License: ansi_term
 
 The following text applies to code linked from these dependendencies:
-[ansi_term](None)
+[ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
 The MIT License (MIT)
@@ -1415,7 +1415,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 -------------
-## Optional Notice: SQlite
+## Optional Notice: SQLite
 
 The following text applies to code linked from these dependendencies:
 [sqlite](https://www.sqlite.org/)

--- a/megazords/fenix/android/dependency-licenses.xml
+++ b/megazords/fenix/android/dependency-licenses.xml
@@ -1,0 +1,539 @@
+<licenses>
+<!--
+Binary distributions of this software incorporate code from a number of third-party dependencies.
+These dependencies are available under a variety of free and open source licenses,
+the details of which are reproduced below.
+-->
+  <license>
+    <name>Mozilla Public License 2.0: NSPR</name>
+    <url>https://hg.mozilla.org/projects/nspr/raw-file/tip/LICENSE</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: NSS</name>
+    <url>https://hg.mozilla.org/projects/nss/raw-file/tip/COPYING</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: ece</name>
+    <url>https://github.com/mozilla/rust-ece/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: hawk</name>
+    <url>https://github.com/taskcluster/rust-hawk/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: autocfg</name>
+    <url>https://github.com/cuviper/autocfg/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: backtrace</name>
+    <url>https://github.com/rust-lang/backtrace-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: backtrace-sys</name>
+    <url>https://github.com/rust-lang/backtrace-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: base64</name>
+    <url>https://github.com/alicemaz/rust-base64/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: base64</name>
+    <url>https://github.com/alicemaz/rust-base64/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: bitflags</name>
+    <url>https://github.com/bitflags/bitflags/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: c2-chacha</name>
+    <url>https://github.com/cryptocorrosion/cryptocorrosion/blob/master/stream-ciphers/chacha/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: cc</name>
+    <url>https://github.com/alexcrichton/cc-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: cexpr</name>
+    <url>https://github.com/jethrogb/rust-cexpr/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: cfg-if</name>
+    <url>https://github.com/alexcrichton/cfg-if/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: clang-sys</name>
+    <url>https://github.com/KyleMayes/clang-sys/blob/master/LICENSE.txt</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: dogear</name>
+    <url>https://github.com/mozilla/dogear/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: either</name>
+    <url>https://github.com/bluss/either/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: env_logger</name>
+    <url>https://github.com/sebasmagri/env_logger/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: failure</name>
+    <url>https://github.com/rust-lang-nursery/failure/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: failure_derive</name>
+    <url>https://github.com/withoutboats/failure_derive/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: fallible-iterator</name>
+    <url>https://github.com/sfackler/rust-fallible-iterator/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: fallible-streaming-iterator</name>
+    <url>https://github.com/sfackler/fallible-streaming-iterator/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: fixedbitset</name>
+    <url>https://github.com/bluss/fixedbitset/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: getrandom</name>
+    <url>https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: glob</name>
+    <url>https://github.com/rust-lang/glob/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: heck</name>
+    <url>https://github.com/withoutboats/heck/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: hex</name>
+    <url>https://github.com/KokaKiwi/rust-hex/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: humantime</name>
+    <url>https://github.com/tailhook/humantime/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: idna</name>
+    <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: idna</name>
+    <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: iovec</name>
+    <url>https://github.com/carllerche/iovec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: itertools</name>
+    <url>https://github.com/bluss/rust-itertools/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: itoa</name>
+    <url>https://github.com/dtolnay/itoa/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: jna</name>
+    <url>https://github.com/java-native-access/jna/blob/master/AL2.0</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: lazy_static</name>
+    <url>https://github.com/rust-lang-nursery/lazy-static.rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: libc</name>
+    <url>https://github.com/rust-lang/libc/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: linked-hash-map</name>
+    <url>https://github.com/contain-rs/linked-hash-map/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: lock_api</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: log</name>
+    <url>https://github.com/rust-lang/log/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: lru-cache</name>
+    <url>https://github.com/contain-rs/lru-cache/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: multimap</name>
+    <url>https://github.com/havarnov/multimap/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: once_cell</name>
+    <url>https://github.com/matklad/once_cell/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: once_cell</name>
+    <url>https://github.com/matklad/once_cell/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: parking_lot</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: parking_lot_core</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: peeking_take_while</name>
+    <url>https://github.com/fitzgen/peeking_take_while/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: percent-encoding</name>
+    <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: petgraph</name>
+    <url>https://github.com/bluss/petgraph/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: pkg-config</name>
+    <url>https://github.com/rust-lang/pkg-config-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: ppv-lite86</name>
+    <url>https://github.com/cryptocorrosion/cryptocorrosion/blob/master/utils-simd/ppv-lite86/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: proc-macro2</name>
+    <url>https://github.com/alexcrichton/proc-macro2/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: proc-macro2</name>
+    <url>https://github.com/alexcrichton/proc-macro2/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost-build</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost-derive</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost-types</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: quick-error</name>
+    <url>https://github.com/tailhook/quick-error/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: quote</name>
+    <url>https://github.com/dtolnay/quote/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: quote</name>
+    <url>https://github.com/dtolnay/quote/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_chacha</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_chacha</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_core</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_core</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_core</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_hc</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_isaac</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_jitter</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_os</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_pcg</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_xorshift</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: regex</name>
+    <url>https://github.com/rust-lang/regex/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: regex-syntax</name>
+    <url>https://github.com/rust-lang/regex/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: remove_dir_all</name>
+    <url>https://github.com/XAMPPRocky/remove_dir_all/blob/master/LICENCE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rustc-demangle</name>
+    <url>https://github.com/alexcrichton/rustc-demangle/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rustc-hash</name>
+    <url>https://github.com/rust-lang-nursery/rustc-hash/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rustc_version</name>
+    <url>https://github.com/Kimundi/rustc-version-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: ryu</name>
+    <url>https://github.com/dtolnay/ryu/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: safemem</name>
+    <url>https://github.com/abonander/safemem/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: scopeguard</name>
+    <url>https://github.com/bluss/scopeguard/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: semver</name>
+    <url>https://github.com/steveklabnik/semver/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: semver-parser</name>
+    <url>https://github.com/steveklabnik/semver-parser/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: serde</name>
+    <url>https://github.com/serde-rs/serde/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: serde_derive</name>
+    <url>https://github.com/serde-rs/serde/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: serde_json</name>
+    <url>https://github.com/serde-rs/json/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: shlex</name>
+    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: smallbitvec</name>
+    <url>https://github.com/servo/smallbitvec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: smallvec</name>
+    <url>https://github.com/servo/rust-smallvec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: syn</name>
+    <url>https://github.com/dtolnay/syn/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: syn</name>
+    <url>https://github.com/dtolnay/syn/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: tempfile</name>
+    <url>https://github.com/Stebalien/tempfile/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: thread_local</name>
+    <url>https://github.com/Amanieu/thread_local-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: time</name>
+    <url>https://github.com/time-rs/time/blob/master/LICENSE-Apache</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: toml</name>
+    <url>https://github.com/alexcrichton/toml-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-bidi</name>
+    <url>https://github.com/servo/unicode-bidi/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-normalization</name>
+    <url>https://github.com/unicode-rs/unicode-normalization/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-segmentation</name>
+    <url>https://github.com/unicode-rs/unicode-segmentation/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-width</name>
+    <url>https://github.com/unicode-rs/unicode-width/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-xid</name>
+    <url>https://github.com/unicode-rs/unicode-xid/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-xid</name>
+    <url>https://github.com/unicode-rs/unicode-xid/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: url</name>
+    <url>https://github.com/servo/rust-url/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: url_serde</name>
+    <url>https://github.com/servo/rust-url/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: vec_map</name>
+    <url>https://github.com/contain-rs/vec-map/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: version_check</name>
+    <url>https://github.com/SergioBenitez/version_check/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: winapi</name>
+    <url>https://github.com/retep998/winapi-rs/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: winapi-x86_64-pc-windows-gnu</name>
+    <url>https://github.com/retep998/winapi-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>MIT License: aho-corasick</name>
+    <url>https://github.com/BurntSushi/aho-corasick/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: byteorder</name>
+    <url>https://github.com/BurntSushi/byteorder/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: memchr</name>
+    <url>https://github.com/BurntSushi/rust-memchr/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: termcolor</name>
+    <url>https://github.com/BurntSushi/termcolor/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: ansi_term</name>
+    <url>https://github.com/ogham/rust-ansi-term/blob/master/LICENCE</url>
+  </license>
+  <license>
+    <name>MIT License: atty</name>
+    <url>https://github.com/softprops/atty/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: bincode</name>
+    <url>https://github.com/servo/bincode/blob/master/LICENSE.md</url>
+  </license>
+  <license>
+    <name>MIT License: bytes</name>
+    <url>https://github.com/carllerche/bytes/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: caseless</name>
+    <url>https://github.com/SimonSapin/rust-caseless/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: clap</name>
+    <url>https://github.com/clap-rs/clap/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: libsqlite3-sys</name>
+    <url>https://github.com/jgallagher/rusqlite/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: rusqlite</name>
+    <url>https://github.com/jgallagher/rusqlite/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: matches</name>
+    <url>https://github.com/SimonSapin/rust-std-candidates/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: nom</name>
+    <url>https://github.com/Geal/nom/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: strsim</name>
+    <url>https://github.com/dguo/strsim-rs/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: synstructure</name>
+    <url>https://github.com/mystor/synstructure/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: textwrap</name>
+    <url>https://github.com/mgeisler/textwrap/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: which</name>
+    <url>https://github.com/harryfei/which-rs/blob/master/LICENSE.txt</url>
+  </license>
+  <license>
+    <name>MIT License: which</name>
+    <url>https://github.com/harryfei/which-rs/blob/master/LICENSE.txt</url>
+  </license>
+  <license>
+    <name>CC0-1.0 License: base16</name>
+    <url>https://github.com/thomcc/rust-base16/blob/master/LICENSE-CC0</url>
+  </license>
+  <license>
+    <name>ISC License: libloading</name>
+    <url>https://github.com/nagisa/rust_libloading/blob//master/LICENSE</url>
+  </license>
+  <license>
+    <name>ISC License: ring</name>
+    <url>https://github.com/briansmith/ring/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>BSD-3-Clause License: bindgen</name>
+    <url>https://github.com/rust-lang/rust-bindgen/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>BSD-3-Clause License: protobuf</name>
+    <url>https://github.com/protocolbuffers/protobuf/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>BSD-3-Clause License: sqlcipher</name>
+    <url>https://github.com/sqlcipher/sqlcipher/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Optional Notice: SQLite</name>
+    <url>https://sqlite.org/copyright.html</url>
+  </license>
+</licenses>

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -26,7 +26,7 @@ the details of which are reproduced below.
 * [BSD-3-Clause License: bindgen](#bsd-3-clause-license-bindgen)
 * [BSD-3-Clause License: protobuf](#bsd-3-clause-license-protobuf)
 * [BSD-3-Clause License: sqlcipher](#bsd-3-clause-license-sqlcipher)
-* [Optional Notice: SQlite](#optional-notice-sqlite)
+* [Optional Notice: SQLite](#optional-notice-sqlite)
 -------------
 ## Mozilla Public License 2.0
 
@@ -438,7 +438,7 @@ The following text applies to code linked from these dependendencies:
 [glob](https://github.com/rust-lang/glob),
 [heck](https://github.com/withoutboats/heck),
 [hex](https://github.com/KokaKiwi/rust-hex),
-[humantime](None),
+[humantime](https://github.com/tailhook/humantime),
 [idna](https://github.com/servo/rust-url/),
 [iovec](https://github.com/carllerche/iovec),
 [itertools](https://github.com/bluss/rust-itertools),
@@ -750,7 +750,7 @@ THE SOFTWARE.
 ## MIT License: ansi_term
 
 The following text applies to code linked from these dependendencies:
-[ansi_term](None)
+[ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
 The MIT License (MIT)
@@ -1415,7 +1415,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 -------------
-## Optional Notice: SQlite
+## Optional Notice: SQLite
 
 The following text applies to code linked from these dependendencies:
 [sqlite](https://www.sqlite.org/)

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -1,0 +1,539 @@
+<licenses>
+<!--
+Binary distributions of this software incorporate code from a number of third-party dependencies.
+These dependencies are available under a variety of free and open source licenses,
+the details of which are reproduced below.
+-->
+  <license>
+    <name>Mozilla Public License 2.0: NSPR</name>
+    <url>https://hg.mozilla.org/projects/nspr/raw-file/tip/LICENSE</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: NSS</name>
+    <url>https://hg.mozilla.org/projects/nss/raw-file/tip/COPYING</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: ece</name>
+    <url>https://github.com/mozilla/rust-ece/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: hawk</name>
+    <url>https://github.com/taskcluster/rust-hawk/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: autocfg</name>
+    <url>https://github.com/cuviper/autocfg/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: backtrace</name>
+    <url>https://github.com/rust-lang/backtrace-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: backtrace-sys</name>
+    <url>https://github.com/rust-lang/backtrace-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: base64</name>
+    <url>https://github.com/alicemaz/rust-base64/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: base64</name>
+    <url>https://github.com/alicemaz/rust-base64/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: bitflags</name>
+    <url>https://github.com/bitflags/bitflags/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: c2-chacha</name>
+    <url>https://github.com/cryptocorrosion/cryptocorrosion/blob/master/stream-ciphers/chacha/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: cc</name>
+    <url>https://github.com/alexcrichton/cc-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: cexpr</name>
+    <url>https://github.com/jethrogb/rust-cexpr/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: cfg-if</name>
+    <url>https://github.com/alexcrichton/cfg-if/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: clang-sys</name>
+    <url>https://github.com/KyleMayes/clang-sys/blob/master/LICENSE.txt</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: dogear</name>
+    <url>https://github.com/mozilla/dogear/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: either</name>
+    <url>https://github.com/bluss/either/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: env_logger</name>
+    <url>https://github.com/sebasmagri/env_logger/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: failure</name>
+    <url>https://github.com/rust-lang-nursery/failure/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: failure_derive</name>
+    <url>https://github.com/withoutboats/failure_derive/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: fallible-iterator</name>
+    <url>https://github.com/sfackler/rust-fallible-iterator/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: fallible-streaming-iterator</name>
+    <url>https://github.com/sfackler/fallible-streaming-iterator/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: fixedbitset</name>
+    <url>https://github.com/bluss/fixedbitset/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: getrandom</name>
+    <url>https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: glob</name>
+    <url>https://github.com/rust-lang/glob/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: heck</name>
+    <url>https://github.com/withoutboats/heck/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: hex</name>
+    <url>https://github.com/KokaKiwi/rust-hex/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: humantime</name>
+    <url>https://github.com/tailhook/humantime/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: idna</name>
+    <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: idna</name>
+    <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: iovec</name>
+    <url>https://github.com/carllerche/iovec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: itertools</name>
+    <url>https://github.com/bluss/rust-itertools/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: itoa</name>
+    <url>https://github.com/dtolnay/itoa/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: jna</name>
+    <url>https://github.com/java-native-access/jna/blob/master/AL2.0</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: lazy_static</name>
+    <url>https://github.com/rust-lang-nursery/lazy-static.rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: libc</name>
+    <url>https://github.com/rust-lang/libc/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: linked-hash-map</name>
+    <url>https://github.com/contain-rs/linked-hash-map/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: lock_api</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: log</name>
+    <url>https://github.com/rust-lang/log/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: lru-cache</name>
+    <url>https://github.com/contain-rs/lru-cache/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: multimap</name>
+    <url>https://github.com/havarnov/multimap/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: once_cell</name>
+    <url>https://github.com/matklad/once_cell/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: once_cell</name>
+    <url>https://github.com/matklad/once_cell/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: parking_lot</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: parking_lot_core</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: peeking_take_while</name>
+    <url>https://github.com/fitzgen/peeking_take_while/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: percent-encoding</name>
+    <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: petgraph</name>
+    <url>https://github.com/bluss/petgraph/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: pkg-config</name>
+    <url>https://github.com/rust-lang/pkg-config-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: ppv-lite86</name>
+    <url>https://github.com/cryptocorrosion/cryptocorrosion/blob/master/utils-simd/ppv-lite86/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: proc-macro2</name>
+    <url>https://github.com/alexcrichton/proc-macro2/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: proc-macro2</name>
+    <url>https://github.com/alexcrichton/proc-macro2/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost-build</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost-derive</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost-types</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: quick-error</name>
+    <url>https://github.com/tailhook/quick-error/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: quote</name>
+    <url>https://github.com/dtolnay/quote/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: quote</name>
+    <url>https://github.com/dtolnay/quote/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_chacha</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_chacha</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_core</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_core</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_core</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_hc</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_isaac</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_jitter</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_os</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_pcg</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_xorshift</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: regex</name>
+    <url>https://github.com/rust-lang/regex/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: regex-syntax</name>
+    <url>https://github.com/rust-lang/regex/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: remove_dir_all</name>
+    <url>https://github.com/XAMPPRocky/remove_dir_all/blob/master/LICENCE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rustc-demangle</name>
+    <url>https://github.com/alexcrichton/rustc-demangle/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rustc-hash</name>
+    <url>https://github.com/rust-lang-nursery/rustc-hash/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rustc_version</name>
+    <url>https://github.com/Kimundi/rustc-version-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: ryu</name>
+    <url>https://github.com/dtolnay/ryu/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: safemem</name>
+    <url>https://github.com/abonander/safemem/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: scopeguard</name>
+    <url>https://github.com/bluss/scopeguard/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: semver</name>
+    <url>https://github.com/steveklabnik/semver/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: semver-parser</name>
+    <url>https://github.com/steveklabnik/semver-parser/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: serde</name>
+    <url>https://github.com/serde-rs/serde/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: serde_derive</name>
+    <url>https://github.com/serde-rs/serde/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: serde_json</name>
+    <url>https://github.com/serde-rs/json/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: shlex</name>
+    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: smallbitvec</name>
+    <url>https://github.com/servo/smallbitvec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: smallvec</name>
+    <url>https://github.com/servo/rust-smallvec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: syn</name>
+    <url>https://github.com/dtolnay/syn/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: syn</name>
+    <url>https://github.com/dtolnay/syn/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: tempfile</name>
+    <url>https://github.com/Stebalien/tempfile/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: thread_local</name>
+    <url>https://github.com/Amanieu/thread_local-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: time</name>
+    <url>https://github.com/time-rs/time/blob/master/LICENSE-Apache</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: toml</name>
+    <url>https://github.com/alexcrichton/toml-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-bidi</name>
+    <url>https://github.com/servo/unicode-bidi/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-normalization</name>
+    <url>https://github.com/unicode-rs/unicode-normalization/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-segmentation</name>
+    <url>https://github.com/unicode-rs/unicode-segmentation/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-width</name>
+    <url>https://github.com/unicode-rs/unicode-width/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-xid</name>
+    <url>https://github.com/unicode-rs/unicode-xid/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-xid</name>
+    <url>https://github.com/unicode-rs/unicode-xid/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: url</name>
+    <url>https://github.com/servo/rust-url/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: url_serde</name>
+    <url>https://github.com/servo/rust-url/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: vec_map</name>
+    <url>https://github.com/contain-rs/vec-map/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: version_check</name>
+    <url>https://github.com/SergioBenitez/version_check/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: winapi</name>
+    <url>https://github.com/retep998/winapi-rs/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: winapi-x86_64-pc-windows-gnu</name>
+    <url>https://github.com/retep998/winapi-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>MIT License: aho-corasick</name>
+    <url>https://github.com/BurntSushi/aho-corasick/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: byteorder</name>
+    <url>https://github.com/BurntSushi/byteorder/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: memchr</name>
+    <url>https://github.com/BurntSushi/rust-memchr/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: termcolor</name>
+    <url>https://github.com/BurntSushi/termcolor/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: ansi_term</name>
+    <url>https://github.com/ogham/rust-ansi-term/blob/master/LICENCE</url>
+  </license>
+  <license>
+    <name>MIT License: atty</name>
+    <url>https://github.com/softprops/atty/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: bincode</name>
+    <url>https://github.com/servo/bincode/blob/master/LICENSE.md</url>
+  </license>
+  <license>
+    <name>MIT License: bytes</name>
+    <url>https://github.com/carllerche/bytes/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: caseless</name>
+    <url>https://github.com/SimonSapin/rust-caseless/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: clap</name>
+    <url>https://github.com/clap-rs/clap/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: libsqlite3-sys</name>
+    <url>https://github.com/jgallagher/rusqlite/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: rusqlite</name>
+    <url>https://github.com/jgallagher/rusqlite/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: matches</name>
+    <url>https://github.com/SimonSapin/rust-std-candidates/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: nom</name>
+    <url>https://github.com/Geal/nom/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: strsim</name>
+    <url>https://github.com/dguo/strsim-rs/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: synstructure</name>
+    <url>https://github.com/mystor/synstructure/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: textwrap</name>
+    <url>https://github.com/mgeisler/textwrap/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: which</name>
+    <url>https://github.com/harryfei/which-rs/blob/master/LICENSE.txt</url>
+  </license>
+  <license>
+    <name>MIT License: which</name>
+    <url>https://github.com/harryfei/which-rs/blob/master/LICENSE.txt</url>
+  </license>
+  <license>
+    <name>CC0-1.0 License: base16</name>
+    <url>https://github.com/thomcc/rust-base16/blob/master/LICENSE-CC0</url>
+  </license>
+  <license>
+    <name>ISC License: libloading</name>
+    <url>https://github.com/nagisa/rust_libloading/blob//master/LICENSE</url>
+  </license>
+  <license>
+    <name>ISC License: ring</name>
+    <url>https://github.com/briansmith/ring/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>BSD-3-Clause License: bindgen</name>
+    <url>https://github.com/rust-lang/rust-bindgen/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>BSD-3-Clause License: protobuf</name>
+    <url>https://github.com/protocolbuffers/protobuf/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>BSD-3-Clause License: sqlcipher</name>
+    <url>https://github.com/sqlcipher/sqlcipher/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Optional Notice: SQLite</name>
+    <url>https://sqlite.org/copyright.html</url>
+  </license>
+</licenses>

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -37,7 +37,7 @@ the details of which are reproduced below.
 * [BSD-3-Clause License: bindgen](#bsd-3-clause-license-bindgen)
 * [BSD-3-Clause License: sqlcipher](#bsd-3-clause-license-sqlcipher)
 * [Zlib License: adler32](#zlib-license-adler32)
-* [Optional Notice: SQlite](#optional-notice-sqlite)
+* [Optional Notice: SQLite](#optional-notice-sqlite)
 -------------
 ## Mozilla Public License 2.0
 
@@ -468,7 +468,7 @@ The following text applies to code linked from these dependendencies:
 [hex](https://github.com/KokaKiwi/rust-hex),
 [http](https://github.com/hyperium/http),
 [httparse](https://github.com/seanmonstar/httparse),
-[humantime](None),
+[humantime](https://github.com/tailhook/humantime),
 [hyper-tls](https://github.com/hyperium/hyper-tls),
 [idna](https://github.com/servo/rust-url/),
 [indexmap](https://github.com/bluss/indexmap),
@@ -792,7 +792,7 @@ THE SOFTWARE.
 ## MIT License: ansi_term
 
 The following text applies to code linked from these dependendencies:
-[ansi_term](None)
+[ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
 The MIT License (MIT)
@@ -1818,7 +1818,7 @@ Copyright notice for the original C code from the zlib project:
 
 ```
 -------------
-## Optional Notice: SQlite
+## Optional Notice: SQLite
 
 The following text applies to code linked from these dependendencies:
 [sqlite](https://www.sqlite.org/)

--- a/megazords/lockbox/DEPENDENCIES.md
+++ b/megazords/lockbox/DEPENDENCIES.md
@@ -24,7 +24,7 @@ the details of which are reproduced below.
 * [BSD-3-Clause License: bindgen](#bsd-3-clause-license-bindgen)
 * [BSD-3-Clause License: protobuf](#bsd-3-clause-license-protobuf)
 * [BSD-3-Clause License: sqlcipher](#bsd-3-clause-license-sqlcipher)
-* [Optional Notice: SQlite](#optional-notice-sqlite)
+* [Optional Notice: SQLite](#optional-notice-sqlite)
 -------------
 ## Mozilla Public License 2.0
 
@@ -435,7 +435,7 @@ The following text applies to code linked from these dependendencies:
 [glob](https://github.com/rust-lang/glob),
 [heck](https://github.com/withoutboats/heck),
 [hex](https://github.com/KokaKiwi/rust-hex),
-[humantime](None),
+[humantime](https://github.com/tailhook/humantime),
 [idna](https://github.com/servo/rust-url/),
 [iovec](https://github.com/carllerche/iovec),
 [itertools](https://github.com/bluss/rust-itertools),
@@ -745,7 +745,7 @@ THE SOFTWARE.
 ## MIT License: ansi_term
 
 The following text applies to code linked from these dependendencies:
-[ansi_term](None)
+[ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
 The MIT License (MIT)
@@ -1349,7 +1349,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ```
 -------------
-## Optional Notice: SQlite
+## Optional Notice: SQLite
 
 The following text applies to code linked from these dependendencies:
 [sqlite](https://www.sqlite.org/)

--- a/megazords/lockbox/android/dependency-licenses.xml
+++ b/megazords/lockbox/android/dependency-licenses.xml
@@ -1,0 +1,515 @@
+<licenses>
+<!--
+Binary distributions of this software incorporate code from a number of third-party dependencies.
+These dependencies are available under a variety of free and open source licenses,
+the details of which are reproduced below.
+-->
+  <license>
+    <name>Mozilla Public License 2.0: NSPR</name>
+    <url>https://hg.mozilla.org/projects/nspr/raw-file/tip/LICENSE</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: NSS</name>
+    <url>https://hg.mozilla.org/projects/nss/raw-file/tip/COPYING</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: ece</name>
+    <url>https://github.com/mozilla/rust-ece/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: hawk</name>
+    <url>https://github.com/taskcluster/rust-hawk/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: autocfg</name>
+    <url>https://github.com/cuviper/autocfg/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: backtrace</name>
+    <url>https://github.com/rust-lang/backtrace-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: backtrace-sys</name>
+    <url>https://github.com/rust-lang/backtrace-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: base64</name>
+    <url>https://github.com/alicemaz/rust-base64/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: base64</name>
+    <url>https://github.com/alicemaz/rust-base64/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: bitflags</name>
+    <url>https://github.com/bitflags/bitflags/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: c2-chacha</name>
+    <url>https://github.com/cryptocorrosion/cryptocorrosion/blob/master/stream-ciphers/chacha/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: cc</name>
+    <url>https://github.com/alexcrichton/cc-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: cexpr</name>
+    <url>https://github.com/jethrogb/rust-cexpr/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: cfg-if</name>
+    <url>https://github.com/alexcrichton/cfg-if/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: clang-sys</name>
+    <url>https://github.com/KyleMayes/clang-sys/blob/master/LICENSE.txt</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: either</name>
+    <url>https://github.com/bluss/either/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: env_logger</name>
+    <url>https://github.com/sebasmagri/env_logger/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: failure</name>
+    <url>https://github.com/rust-lang-nursery/failure/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: failure_derive</name>
+    <url>https://github.com/withoutboats/failure_derive/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: fallible-iterator</name>
+    <url>https://github.com/sfackler/rust-fallible-iterator/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: fallible-streaming-iterator</name>
+    <url>https://github.com/sfackler/fallible-streaming-iterator/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: fixedbitset</name>
+    <url>https://github.com/bluss/fixedbitset/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: getrandom</name>
+    <url>https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: glob</name>
+    <url>https://github.com/rust-lang/glob/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: heck</name>
+    <url>https://github.com/withoutboats/heck/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: hex</name>
+    <url>https://github.com/KokaKiwi/rust-hex/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: humantime</name>
+    <url>https://github.com/tailhook/humantime/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: idna</name>
+    <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: iovec</name>
+    <url>https://github.com/carllerche/iovec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: itertools</name>
+    <url>https://github.com/bluss/rust-itertools/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: itoa</name>
+    <url>https://github.com/dtolnay/itoa/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: jna</name>
+    <url>https://github.com/java-native-access/jna/blob/master/AL2.0</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: lazy_static</name>
+    <url>https://github.com/rust-lang-nursery/lazy-static.rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: libc</name>
+    <url>https://github.com/rust-lang/libc/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: linked-hash-map</name>
+    <url>https://github.com/contain-rs/linked-hash-map/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: lock_api</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: log</name>
+    <url>https://github.com/rust-lang/log/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: lru-cache</name>
+    <url>https://github.com/contain-rs/lru-cache/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: multimap</name>
+    <url>https://github.com/havarnov/multimap/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: once_cell</name>
+    <url>https://github.com/matklad/once_cell/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: once_cell</name>
+    <url>https://github.com/matklad/once_cell/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: parking_lot</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: parking_lot_core</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: peeking_take_while</name>
+    <url>https://github.com/fitzgen/peeking_take_while/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: percent-encoding</name>
+    <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: petgraph</name>
+    <url>https://github.com/bluss/petgraph/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: pkg-config</name>
+    <url>https://github.com/rust-lang/pkg-config-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: ppv-lite86</name>
+    <url>https://github.com/cryptocorrosion/cryptocorrosion/blob/master/utils-simd/ppv-lite86/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: proc-macro2</name>
+    <url>https://github.com/alexcrichton/proc-macro2/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: proc-macro2</name>
+    <url>https://github.com/alexcrichton/proc-macro2/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost-build</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost-derive</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: prost-types</name>
+    <url>https://github.com/danburkert/prost/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: quick-error</name>
+    <url>https://github.com/tailhook/quick-error/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: quote</name>
+    <url>https://github.com/dtolnay/quote/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: quote</name>
+    <url>https://github.com/dtolnay/quote/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_chacha</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_chacha</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_core</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_core</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_core</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_hc</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_isaac</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_jitter</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_os</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_pcg</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand_xorshift</name>
+    <url>https://github.com/rust-random/rand/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: regex</name>
+    <url>https://github.com/rust-lang/regex/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: regex-syntax</name>
+    <url>https://github.com/rust-lang/regex/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: remove_dir_all</name>
+    <url>https://github.com/XAMPPRocky/remove_dir_all/blob/master/LICENCE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rustc-demangle</name>
+    <url>https://github.com/alexcrichton/rustc-demangle/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rustc-hash</name>
+    <url>https://github.com/rust-lang-nursery/rustc-hash/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rustc_version</name>
+    <url>https://github.com/Kimundi/rustc-version-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: ryu</name>
+    <url>https://github.com/dtolnay/ryu/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: safemem</name>
+    <url>https://github.com/abonander/safemem/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: scopeguard</name>
+    <url>https://github.com/bluss/scopeguard/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: semver</name>
+    <url>https://github.com/steveklabnik/semver/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: semver-parser</name>
+    <url>https://github.com/steveklabnik/semver-parser/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: serde</name>
+    <url>https://github.com/serde-rs/serde/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: serde_derive</name>
+    <url>https://github.com/serde-rs/serde/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: serde_json</name>
+    <url>https://github.com/serde-rs/json/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: shlex</name>
+    <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: smallvec</name>
+    <url>https://github.com/servo/rust-smallvec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: syn</name>
+    <url>https://github.com/dtolnay/syn/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: syn</name>
+    <url>https://github.com/dtolnay/syn/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: tempfile</name>
+    <url>https://github.com/Stebalien/tempfile/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: thread_local</name>
+    <url>https://github.com/Amanieu/thread_local-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: time</name>
+    <url>https://github.com/time-rs/time/blob/master/LICENSE-Apache</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: toml</name>
+    <url>https://github.com/alexcrichton/toml-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-bidi</name>
+    <url>https://github.com/servo/unicode-bidi/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-normalization</name>
+    <url>https://github.com/unicode-rs/unicode-normalization/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-segmentation</name>
+    <url>https://github.com/unicode-rs/unicode-segmentation/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-width</name>
+    <url>https://github.com/unicode-rs/unicode-width/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-xid</name>
+    <url>https://github.com/unicode-rs/unicode-xid/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: unicode-xid</name>
+    <url>https://github.com/unicode-rs/unicode-xid/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: url</name>
+    <url>https://github.com/servo/rust-url/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: vec_map</name>
+    <url>https://github.com/contain-rs/vec-map/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: version_check</name>
+    <url>https://github.com/SergioBenitez/version_check/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: winapi</name>
+    <url>https://github.com/retep998/winapi-rs/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: winapi-x86_64-pc-windows-gnu</name>
+    <url>https://github.com/retep998/winapi-rs/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>MIT License: aho-corasick</name>
+    <url>https://github.com/BurntSushi/aho-corasick/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: byteorder</name>
+    <url>https://github.com/BurntSushi/byteorder/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: memchr</name>
+    <url>https://github.com/BurntSushi/rust-memchr/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: termcolor</name>
+    <url>https://github.com/BurntSushi/termcolor/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: ansi_term</name>
+    <url>https://github.com/ogham/rust-ansi-term/blob/master/LICENCE</url>
+  </license>
+  <license>
+    <name>MIT License: atty</name>
+    <url>https://github.com/softprops/atty/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: bytes</name>
+    <url>https://github.com/carllerche/bytes/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: clap</name>
+    <url>https://github.com/clap-rs/clap/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: libsqlite3-sys</name>
+    <url>https://github.com/jgallagher/rusqlite/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: rusqlite</name>
+    <url>https://github.com/jgallagher/rusqlite/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: matches</name>
+    <url>https://github.com/SimonSapin/rust-std-candidates/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: nom</name>
+    <url>https://github.com/Geal/nom/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: strsim</name>
+    <url>https://github.com/dguo/strsim-rs/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: synstructure</name>
+    <url>https://github.com/mystor/synstructure/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: textwrap</name>
+    <url>https://github.com/mgeisler/textwrap/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: which</name>
+    <url>https://github.com/harryfei/which-rs/blob/master/LICENSE.txt</url>
+  </license>
+  <license>
+    <name>MIT License: which</name>
+    <url>https://github.com/harryfei/which-rs/blob/master/LICENSE.txt</url>
+  </license>
+  <license>
+    <name>CC0-1.0 License: base16</name>
+    <url>https://github.com/thomcc/rust-base16/blob/master/LICENSE-CC0</url>
+  </license>
+  <license>
+    <name>ISC License: libloading</name>
+    <url>https://github.com/nagisa/rust_libloading/blob//master/LICENSE</url>
+  </license>
+  <license>
+    <name>ISC License: ring</name>
+    <url>https://github.com/briansmith/ring/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>BSD-3-Clause License: bindgen</name>
+    <url>https://github.com/rust-lang/rust-bindgen/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>BSD-3-Clause License: protobuf</name>
+    <url>https://github.com/protocolbuffers/protobuf/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>BSD-3-Clause License: sqlcipher</name>
+    <url>https://github.com/sqlcipher/sqlcipher/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>Optional Notice: SQLite</name>
+    <url>https://sqlite.org/copyright.html</url>
+  </license>
+</licenses>

--- a/publish.gradle
+++ b/publish.gradle
@@ -112,10 +112,22 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                     version = rootProject.ext.library.version
                     packaging = "aar"
 
-                    licenses {
-                        license {
-                            name = libLicense
-                            url = libLicenseUrl
+
+                    license {
+                        name = libLicense
+                        url = libLicenseUrl
+                    }
+
+                    // Megazords include compiled code from third-party rust dependencies.
+                    // We add the license info of those dependencies to the .pom to make it
+                    // easy for consumers to incorporate into their license info page.
+                    if (isMegazord) {
+                        def depLicenses = new XmlSlurper().parse(new File("${projectDir}/dependency-licenses.xml"))
+                        depLicenses.license.each { node ->
+                            license {
+                                name = node.name.text()
+                                url = node.url.text()
+                            }
                         }
                     }
 

--- a/tools/regenerate_dependency_summaries.sh
+++ b/tools/regenerate_dependency_summaries.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
 
 python3 ./tools/dependency_summary.py > ./DEPENDENCIES.md
-python3 ./tools/dependency_summary.py --all-android-targets --package megazord > megazords/full/DEPENDENCIES.md
+
 python3 ./tools/dependency_summary.py --all-ios-targets --package megazord_ios > megazords/ios/DEPENDENCIES.md
+
+python3 ./tools/dependency_summary.py --all-android-targets --package megazord > megazords/full/DEPENDENCIES.md
+python3 ./tools/dependency_summary.py --all-android-targets --package megazord --format pom > megazords/full/android/dependency-licenses.xml
+
 python3 ./tools/dependency_summary.py --all-android-targets --package fenix > megazords/fenix/DEPENDENCIES.md
+python3 ./tools/dependency_summary.py --all-android-targets --package fenix --format pom > megazords/fenix/android/dependency-licenses.xml
+
 python3 ./tools/dependency_summary.py --all-android-targets --package lockbox > megazords/lockbox/DEPENDENCIES.md
+python3 ./tools/dependency_summary.py --all-android-targets --package lockbox --format pom > megazords/lockbox/android/dependency-licenses.xml


### PR DESCRIPTION
Some of our consumers use this handy plugin [1] to automagically
include dependency license info in their app. By including our
own dependency license info in our .pom file we can make it
easy for those consumers to include correct license info for
all the transitive dependencies they pick up through us.

This was more involved than I would have liked, because the .pom file
format expects a link to the license rather than the license text itself,
so I had to do another round of fixups on dependencies that bundle the
license text but don't provide an obvious link to it. *sigh*.

Fixes https://github.com/mozilla/application-services/issues/1736.

[1] https://github.com/google/play-services-plugins/tree/master/oss-licenses-plugin

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- ~~[ ] **Quality**: This PR builds and tests run cleanly~~
  - No code changes, only tooling changes.
- ~~[ ] **Tests**: This PR includes thorough tests or an explanation of why it does not~~
  - No change changes, just lots of manual evaluation of the generated files.
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
- ~~[ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)~~
  - No new dependencies.
