### PR TITLE
Add explicit evaluation-order dependenies on the full-megazord.

### DIFF
--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
+evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
     android.libraryVariants.all { variant ->

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
+evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
     android.libraryVariants.all { variant ->

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
+evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
     android.libraryVariants.all { variant ->

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -101,6 +101,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
+evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
     android.libraryVariants.all { variant ->

--- a/components/rc_log/android/build.gradle
+++ b/components/rc_log/android/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
+evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
     android.libraryVariants.all { variant ->

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -100,6 +100,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
+evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
     android.libraryVariants.all { variant ->

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
+evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
     android.libraryVariants.all { variant ->


### PR DESCRIPTION
So here's a fun thing I discovered today: the names of all of our gradle projects that depend on
`:full-megazord` happen to sort after the string `"full-megazord"`, leading to the happy side-effect that gradle will evaluate the `:full-megazord` project before any of projects that depend on it.

If you try to copy one of those as a template for a new thing whose name sorts *before* `"full-megazord"`, gradle will complain about your attempt to take a dependency on the `:full-megazord:cargoBuild` task, because that task doesn't exist until gradle has evaluated the `:full-megazord` project.

This commit adds an explicit dependency relationship for all the projects that depend on `:full-megazord`, so that when our future selves go to copy-paste an existing `build.gradle` into a new project named `"aardvark"` or whatever, we don't get a bunch of confusing gradle errors.

It would be nice to factor out this "make the thing depend on `:full-megazord:cargoBuild`" logic into a shared helper, but my gradle skills are not up to figuring that out right now.