### PR TITLE
Match up tabs and clients

### DIFF
--- a/components/sync15/src/clients/mod.rs
+++ b/components/sync15/src/clients/mod.rs
@@ -11,7 +11,6 @@ mod record;
 mod ser;
 
 pub use engine::Engine;
-pub use record::ClientRecord;
 
 /// A command processor applies incoming commands like wipes and resets for all
 /// stores, and returns commands to send to other clients. It also manages
@@ -59,6 +58,15 @@ pub enum CommandStatus {
 pub struct RemoteClient {
     pub device_name: String,
     pub device_type: Option<DeviceType>,
+}
+
+impl From<&record::ClientRecord> for RemoteClient {
+    fn from(record: &record::ClientRecord) -> RemoteClient {
+        RemoteClient {
+            device_name: record.name.clone(),
+            device_type: record.typ.as_ref().and_then(DeviceType::try_from_str),
+        }
+    }
 }
 
 /// Information about this device to include in its client record. This should

--- a/components/sync15/src/clients/mod.rs
+++ b/components/sync15/src/clients/mod.rs
@@ -11,6 +11,7 @@ mod record;
 mod ser;
 
 pub use engine::Engine;
+pub use record::ClientRecord;
 
 /// A command processor applies incoming commands like wipes and resets for all
 /// stores, and returns commands to send to other clients. It also manages
@@ -53,6 +54,13 @@ pub enum CommandStatus {
     Unsupported,
 }
 
+/// Information about a remote client in the clients collection.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RemoteClient {
+    pub device_name: String,
+    pub device_type: Option<DeviceType>,
+}
+
 /// Information about this device to include in its client record. This should
 /// be persisted across syncs, as part of the sync manager state.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -79,6 +87,17 @@ pub enum DeviceType {
 }
 
 impl DeviceType {
+    pub fn try_from_str(d: impl AsRef<str>) -> Option<DeviceType> {
+        match d.as_ref() {
+            "desktop" => Some(DeviceType::Desktop),
+            "mobile" => Some(DeviceType::Mobile),
+            "tablet" => Some(DeviceType::Tablet),
+            "vr" => Some(DeviceType::VR),
+            "tv" => Some(DeviceType::TV),
+            _ => None,
+        }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             DeviceType::Desktop => "desktop",

--- a/components/sync15/src/lib.rs
+++ b/components/sync15/src/lib.rs
@@ -27,8 +27,11 @@ mod util;
 // Re-export some of the types callers are likely to want for convenience.
 pub use crate::bso_record::{BsoRecord, CleartextBso, EncryptedBso, EncryptedPayload, Payload};
 pub use crate::changeset::{IncomingChangeset, OutgoingChangeset, RecordChangeset};
-pub use crate::client::{SetupStorageClient, Sync15StorageClient, Sync15StorageClientInit};
+pub use crate::client::{
+    SetupStorageClient, Sync15ClientResponse, Sync15StorageClient, Sync15StorageClientInit,
+};
 pub use crate::coll_state::{CollState, CollSyncIds, StoreSyncAssociation};
+pub use crate::collection_keys::CollectionKeys;
 pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::key_bundle::KeyBundle;
 pub use crate::migrate_state::extract_v1_state;

--- a/components/tabs/src/lib.rs
+++ b/components/tabs/src/lib.rs
@@ -19,3 +19,7 @@ pub use crate::storage::{ClientRemoteTabs, RemoteTab};
 pub use crate::sync::engine::TabsEngine;
 pub use crate::sync::store::TabsStore;
 pub use error::{Error, ErrorKind, Result};
+
+// Re-export `DeviceType`, so that it's easier for consumers to make
+// `ClientRemoteTabs` structs without importing `sync15`.
+pub use sync15::clients::DeviceType;

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::cell::RefCell;
+use sync15::clients::DeviceType;
 
 #[derive(Clone, Debug)]
 pub struct RemoteTab {
@@ -14,7 +15,9 @@ pub struct RemoteTab {
 
 #[derive(Clone, Debug)]
 pub struct ClientRemoteTabs {
-    pub client_id: String, // Corresponds to the FxA device id of the client.
+    pub client_id: String, // Corresponds to the `clients` collection ID of the client.
+    pub client_name: String,
+    pub device_type: DeviceType,
     pub remote_tabs: Vec<RemoteTab>,
 }
 

--- a/components/tabs/src/sync/record.rs
+++ b/components/tabs/src/sync/record.rs
@@ -18,7 +18,7 @@ pub struct TabsRecordTab {
 #[serde(rename_all = "camelCase")]
 pub struct TabsRecord {
     pub id: String, // `String` instead of `SyncGuid` because some IDs are FxA device ID.
-    // pub client_name: String,
+    pub client_name: String,
     pub tabs: Vec<TabsRecordTab>,
 }
 

--- a/components/tabs/src/sync/store.rs
+++ b/components/tabs/src/sync/store.rs
@@ -34,7 +34,7 @@ impl RemoteTab {
 }
 
 impl ClientRemoteTabs {
-    fn from_record_with_device(
+    fn from_record_with_remote_client(
         client_id: String,
         remote_client: &RemoteClient,
         record: TabsRecord,
@@ -90,8 +90,7 @@ impl<'a> Store for TabsStore<'a> {
     }
 
     fn prepare_for_sync(&self, engine: &clients::Engine<'_>) -> Result<(), failure::Error> {
-        self.remote_clients
-            .replace(engine.recent_client_list.clone());
+        self.remote_clients.replace(engine.recent_clients.clone());
         Ok(())
     }
 
@@ -119,7 +118,7 @@ impl<'a> Store for TabsStore<'a> {
             };
             let id = record.id.clone();
             let tab = if let Some(remote_client) = self.remote_clients.borrow().get(&id) {
-                ClientRemoteTabs::from_record_with_device(id, remote_client, record)
+                ClientRemoteTabs::from_record_with_remote_client(id, remote_client, record)
             } else {
                 ClientRemoteTabs::from_record(id, record)
             };

--- a/components/tabs/src/sync/store.rs
+++ b/components/tabs/src/sync/store.rs
@@ -5,9 +5,10 @@
 use crate::storage::TabsStorage;
 use crate::storage::{ClientRemoteTabs, RemoteTab};
 use crate::sync::record::{TabsRecord, TabsRecordTab};
-use std::cell::Cell;
-use std::result;
+use std::cell::{Cell, RefCell};
+use std::{collections::HashMap, result};
 use sync15::{
+    clients::{self, DeviceType, RemoteClient},
     telemetry, CollectionRequest, IncomingChangeset, OutgoingChangeset, Payload, ServerTimestamp,
     Store, StoreSyncAssociation,
 };
@@ -33,15 +34,31 @@ impl RemoteTab {
 }
 
 impl ClientRemoteTabs {
+    fn from_record_with_device(
+        client_id: String,
+        remote_client: &RemoteClient,
+        record: TabsRecord,
+    ) -> Self {
+        Self {
+            client_id,
+            client_name: remote_client.device_name.clone(),
+            device_type: remote_client.device_type.unwrap_or(DeviceType::Mobile),
+            remote_tabs: record.tabs.iter().map(RemoteTab::from_record_tab).collect(),
+        }
+    }
+
     fn from_record(client_id: String, record: TabsRecord) -> Self {
         Self {
             client_id,
+            client_name: record.client_name,
+            device_type: DeviceType::Mobile,
             remote_tabs: record.tabs.iter().map(RemoteTab::from_record_tab).collect(),
         }
     }
     fn to_record(&self) -> TabsRecord {
         TabsRecord {
             id: self.client_id.clone(),
+            client_name: self.client_name.clone(),
             tabs: self
                 .remote_tabs
                 .iter()
@@ -53,6 +70,7 @@ impl ClientRemoteTabs {
 
 pub struct TabsStore<'a> {
     storage: &'a TabsStorage,
+    remote_clients: RefCell<HashMap<String, RemoteClient>>,
     last_sync: Cell<Option<ServerTimestamp>>, // We use a cell because `sync_finished` doesn't take a mutable reference to &self.
 }
 
@@ -60,6 +78,7 @@ impl<'a> TabsStore<'a> {
     pub fn new(storage: &'a TabsStorage) -> Self {
         Self {
             storage,
+            remote_clients: RefCell::default(),
             last_sync: Cell::default(),
         }
     }
@@ -68,6 +87,12 @@ impl<'a> TabsStore<'a> {
 impl<'a> Store for TabsStore<'a> {
     fn collection_name(&self) -> &'static str {
         "tabs"
+    }
+
+    fn prepare_for_sync(&self, engine: &clients::Engine<'_>) -> Result<(), failure::Error> {
+        self.remote_clients
+            .replace(engine.recent_client_list.clone());
+        Ok(())
     }
 
     fn apply_incoming(
@@ -92,16 +117,37 @@ impl<'a> Store for TabsStore<'a> {
                     continue;
                 }
             };
-            // TODO: this is wrong anything that doesn't use the sync manager crate,
-            // we need to get fxa_client_id from the clients collection instead.
             let id = record.id.clone();
-            remote_tabs.push(ClientRemoteTabs::from_record(id, record));
+            let tab = if let Some(remote_client) = self.remote_clients.borrow().get(&id) {
+                ClientRemoteTabs::from_record_with_device(id, remote_client, record)
+            } else {
+                ClientRemoteTabs::from_record(id, record)
+            };
+            remote_tabs.push(tab);
         }
         self.storage.replace_remote_tabs(remote_tabs);
         let mut outgoing = OutgoingChangeset::new("tabs".into(), inbound.timestamp);
         if let Some(local_tabs) = self.storage.get_local_tabs() {
+            let (client_name, device_type) = self
+                .remote_clients
+                .borrow()
+                .get(local_id)
+                .map(|client| {
+                    (
+                        client.device_name.clone(),
+                        client.device_type.unwrap_or(DeviceType::Mobile),
+                    )
+                })
+                .unwrap_or_else(|| {
+                    // TODO: Since we know our own client ID thanks to
+                    // `self.remote_clients`, we don't need consumers to
+                    // pass it themselves.
+                    (String::new(), DeviceType::Mobile)
+                });
             let local_record = ClientRemoteTabs {
                 client_id: local_id.to_owned(),
+                client_name,
+                device_type,
                 remote_tabs: local_tabs.to_vec(),
             };
             let payload = Payload::from_record(local_record.to_record())?;

--- a/testing/sync-test/src/tabs.rs
+++ b/testing/sync-test/src/tabs.rs
@@ -3,7 +3,7 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 
 use crate::auth::TestClient;
 use crate::testing::TestGroup;
-use tabs::{ClientRemoteTabs, RemoteTab, TabsEngine};
+use tabs::{ClientRemoteTabs, DeviceType, RemoteTab, TabsEngine};
 
 // helpers...
 
@@ -59,6 +59,8 @@ fn test_tabs(c0: &mut TestClient, c1: &mut TestClient) {
         &c1.tabs_engine,
         &ClientRemoteTabs {
             client_id: c0.fxa.get_current_device_id().unwrap(),
+            client_name: String::new(),
+            device_type: DeviceType::Mobile,
             remote_tabs: vec![t0],
         },
     );
@@ -86,6 +88,8 @@ fn test_tabs(c0: &mut TestClient, c1: &mut TestClient) {
         &c0.tabs_engine,
         &ClientRemoteTabs {
             client_id: c1.fxa.get_current_device_id().unwrap(),
+            client_name: String::new(),
+            device_type: DeviceType::Mobile,
             remote_tabs: vec![t1, t2],
         },
     );


### PR DESCRIPTION
A quick-'n-dirty fix for #2006. I didn't change the clients engine any further, and I'm not sure if I'm happy with the `prepare_for_sync` method, but it does the trick.

Closes #2006.