### PR TITLE
Uses scriptworker-k8s provisioner for beetmoving/signing

### DIFF
--- a/automation/taskcluster/decisionlib.py
+++ b/automation/taskcluster/decisionlib.py
@@ -278,7 +278,7 @@ class Task:
 class BeetmoverTask(Task):
     def __init__(self, name):
         super().__init__(name)
-        self.provisioner_id = "scriptworker-prov-v1"
+        self.provisioner_id = "scriptworker-k8s"
         self.app_name = None
         self.app_version = None
         self.upstream_artifacts = []
@@ -306,7 +306,7 @@ class BeetmoverTask(Task):
 class SignTask(Task):
     def __init__(self, name):
         super().__init__(name)
-        self.provisioner_id = "scriptworker-prov-v1"
+        self.provisioner_id = "scriptworker-k8s"
         self.upstream_artifacts = []
 
     with_upstream_artifact = chaining(append_to_attr, "upstream_artifacts")


### PR DESCRIPTION
The `scriptworker-prov-v1` provisioner has been deactivated as of 2 weekends ago.
Signing/beetmoving/"scriptworker" workers have been moved to `scriptworker-k8s`. This patch should resolve this missing migration

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
