### PR TITLE
Rename Empty Hostname Error

### DIFF
--- a/components/logins/android/src/main/java/mozilla/appservices/logins/LoginsStorageException.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/LoginsStorageException.kt
@@ -58,8 +58,8 @@ class InterruptedException(msg: String) : LoginsStorageException(msg)
  * A reason a login may be invalid
  */
 enum class InvalidLoginReason {
-    /** Hostnames may not be empty */
-    EMPTY_HOSTNAME,
+    /** Origins may not be empty */
+    EMPTY_ORIGIN,
     /** Passwords may not be empty */
     EMPTY_PASSWORD,
     /** The login already exists */

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/MemoryLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/MemoryLoginsStorage.kt
@@ -256,7 +256,7 @@ class MemoryLoginsStorage(private var list: List<ServerPassword>) : AutoCloseabl
     @Suppress("ThrowsCount")
     private fun checkValid(login: ServerPassword) {
         if (login.hostname == "") {
-            throw InvalidRecordException("Invalid login: Hostname is empty", InvalidLoginReason.EMPTY_HOSTNAME)
+            throw InvalidRecordException("Invalid login: Origin is empty", InvalidLoginReason.EMPTY_ORIGIN)
         }
         if (login.password == "") {
             throw InvalidRecordException("Invalid login: Password is empty", InvalidLoginReason.EMPTY_PASSWORD)

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/rust/RustError.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/rust/RustError.kt
@@ -52,7 +52,7 @@ open class RustError : Structure() {
             5 -> return RequestFailedException(message)
             6 -> return InterruptedException(message)
 
-            64 -> return InvalidRecordException(message, InvalidLoginReason.EMPTY_HOSTNAME)
+            64 -> return InvalidRecordException(message, InvalidLoginReason.EMPTY_ORIGIN)
             65 -> return InvalidRecordException(message, InvalidLoginReason.EMPTY_PASSWORD)
             66 -> return InvalidRecordException(message, InvalidLoginReason.DUPLICATE_LOGIN)
             67 -> return InvalidRecordException(message, InvalidLoginReason.BOTH_TARGETS)

--- a/components/logins/ios/Logins/Errors/LoginStoreError.swift
+++ b/components/logins/ios/Logins/Errors/LoginStoreError.swift
@@ -90,8 +90,8 @@ public enum LoginsStoreError: LocalizedError {
         case Sync15Passwords_DuplicateGuid:
             return .duplicateGuid(message: String(freeingRustString: message!))
 
-        case Sync15Passwords_InvalidLogin_EmptyHostname:
-            return .invalidLogin(message: String(freeingRustString: message!), reason: .emptyHostname)
+        case Sync15Passwords_InvalidLogin_EmptyOrigin:
+            return .invalidLogin(message: String(freeingRustString: message!), reason: .emptyOrigin)
 
         case Sync15Passwords_InvalidLogin_EmptyPassword:
             return .invalidLogin(message: String(freeingRustString: message!), reason: .emptyPassword)
@@ -156,7 +156,7 @@ public enum LoginsStoreError: LocalizedError {
 
 /// Indicates a record is invalid
 public enum InvalidLoginReason {
-    case emptyHostname
+    case emptyOrigin
     case emptyPassword
     case duplicateLogin
     case bothTargets

--- a/components/logins/ios/Logins/RustPasswordAPI.h
+++ b/components/logins/ios/Logins/RustPasswordAPI.h
@@ -16,7 +16,7 @@ typedef enum Sync15PasswordsErrorCode {
     Sync15Passwords_NetworkError     = 5,
     Sync15Passwords_InterruptedError = 6,
 
-    Sync15Passwords_InvalidLogin_EmptyHostname = 64 + 0,
+    Sync15Passwords_InvalidLogin_EmptyOrigin = 64 + 0,
     Sync15Passwords_InvalidLogin_EmptyPassword = 64 + 1,
     Sync15Passwords_InvalidLogin_DuplicateLogin = 64 + 2,
     Sync15Passwords_InvalidLogin_BothTargets = 64 + 3,

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -65,8 +65,9 @@ error_support::define_error! {
 
 #[derive(Debug, Fail)]
 pub enum InvalidLogin {
-    #[fail(display = "Hostname is empty")]
-    EmptyHostname,
+    // EmptyOrigin error occurs when the login's hostname field is empty.
+    #[fail(display = "Origin is empty")]
+    EmptyOrigin,
     #[fail(display = "Password is empty")]
     EmptyPassword,
     #[fail(display = "Login already exists")]

--- a/components/logins/src/ffi.rs
+++ b/components/logins/src/ffi.rs
@@ -40,7 +40,7 @@ pub mod error_codes {
     // InvalidLogin items that can actually be triggered, the others
     // (if they happen accidentally) will come through as unexpected.
 
-    pub const INVALID_LOGIN_EMPTY_HOSTNAME: i32 = 64;
+    pub const INVALID_LOGIN_EMPTY_ORIGIN: i32 = 64;
     pub const INVALID_LOGIN_EMPTY_PASSWORD: i32 = 64 + 1;
     pub const INVALID_LOGIN_DUPLICATE_LOGIN: i32 = 64 + 2;
     pub const INVALID_LOGIN_BOTH_TARGETS: i32 = 64 + 3;
@@ -70,7 +70,7 @@ fn get_code(err: &Error) -> ErrorCode {
         ErrorKind::InvalidLogin(desc) => {
             log::error!("Invalid login: {}", desc);
             ErrorCode::new(match desc {
-                InvalidLogin::EmptyHostname => error_codes::INVALID_LOGIN_EMPTY_HOSTNAME,
+                InvalidLogin::EmptyOrigin => error_codes::INVALID_LOGIN_EMPTY_ORIGIN,
                 InvalidLogin::EmptyPassword => error_codes::INVALID_LOGIN_EMPTY_PASSWORD,
                 InvalidLogin::DuplicateLogin => error_codes::INVALID_LOGIN_DUPLICATE_LOGIN,
                 InvalidLogin::BothTargets => error_codes::INVALID_LOGIN_BOTH_TARGETS,

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -86,7 +86,7 @@ impl Login {
 
     pub fn check_valid(&self) -> Result<()> {
         if self.hostname.is_empty() {
-            throw!(InvalidLogin::EmptyHostname);
+            throw!(InvalidLogin::EmptyOrigin);
         }
 
         if self.password.is_empty() {


### PR DESCRIPTION
Replacing `EMPTY_HOSTNAME` with `EMPTY_ORIGIN` to address potential breaking issue mentioned [here](https://github.com/mozilla/application-services/pull/2101/files#r348128464). I have not included a changelog entry as this PR doesn't introduce new functionality and is an addendum to #2101.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
