### PR TITLE
Remove `local_id` from `TabsEngine` constructor.

### DIFF
--- a/components/sync15/src/clients/engine.rs
+++ b/components/sync15/src/clients/engine.rs
@@ -313,6 +313,12 @@ impl<'a> Engine<'a> {
 
         Ok(inbound)
     }
+
+    pub fn local_client_id(&self) -> String {
+        // Bit dirty but it's the easiest way to reach to our own
+        // device ID without refactoring the whole sync manager crate.
+        self.command_processor.settings().fxa_device_id.clone()
+    }
 }
 
 #[cfg(test)]

--- a/components/tabs/android/src/main/java/mozilla/appservices/remotetabs/RemoteTabsProvider.kt
+++ b/components/tabs/android/src/main/java/mozilla/appservices/remotetabs/RemoteTabsProvider.kt
@@ -12,12 +12,12 @@ import mozilla.appservices.remotetabs.rust.RustError
 import mozilla.appservices.sync15.SyncTelemetryPing
 import java.util.concurrent.atomic.AtomicLong
 
-class RemoteTabsProvider(localDeviceId: String) : AutoCloseable {
+class RemoteTabsProvider : AutoCloseable {
     private var handle: AtomicLong = AtomicLong(0)
 
     init {
         handle.set(rustCall { error ->
-            LibRemoteTabsFFI.INSTANCE.remote_tabs_new(localDeviceId, error)
+            LibRemoteTabsFFI.INSTANCE.remote_tabs_new(error)
         })
     }
 
@@ -56,7 +56,7 @@ class RemoteTabsProvider(localDeviceId: String) : AutoCloseable {
     /**
      * Convenience Sync function.
      */
-    fun sync(syncInfo: SyncAuthInfo): SyncTelemetryPing {
+    fun sync(syncInfo: SyncAuthInfo, localDeviceId: String): SyncTelemetryPing {
         val json = rustCallWithLock { error ->
             LibRemoteTabsFFI.INSTANCE.remote_tabs_sync(
                     this.handle.get(),
@@ -64,6 +64,7 @@ class RemoteTabsProvider(localDeviceId: String) : AutoCloseable {
                     syncInfo.fxaAccessToken,
                     syncInfo.syncKey,
                     syncInfo.tokenserverURL,
+                    localDeviceId,
                     error
             )?.getAndConsumeRustString()
         }

--- a/components/tabs/android/src/main/java/mozilla/appservices/remotetabs/rust/LibRemoteTabsFFI.kt
+++ b/components/tabs/android/src/main/java/mozilla/appservices/remotetabs/rust/LibRemoteTabsFFI.kt
@@ -19,7 +19,6 @@ internal interface LibRemoteTabsFFI : Library {
     }
 
     fun remote_tabs_new(
-        local_id: String,
         error: RustError.ByReference
     ): TabsApiHandle
 
@@ -44,6 +43,7 @@ internal interface LibRemoteTabsFFI : Library {
         access_token: String,
         sync_key: String,
         token_server_url: String,
+        local_device_id: String,
         error: RustError.ByReference
     ): Pointer?
 

--- a/components/tabs/examples/tabs_sync.rs
+++ b/components/tabs/examples/tabs_sync.rs
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
     let mut cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file)?;
     let device_id = cli_fxa.account.get_current_device_id()?;
 
-    let mut engine = TabsEngine::new(&device_id);
+    let mut engine = TabsEngine::new();
 
     loop {
         match prompt_char("[U]pdate local state, [L]ist remote tabs, [S]ync or [Q]uit")
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
             }
             'S' | 's' => {
                 log::info!("Syncing!");
-                match engine.sync(&cli_fxa.client_init, &cli_fxa.root_sync_key) {
+                match engine.sync(&cli_fxa.client_init, &cli_fxa.root_sync_key, &device_id) {
                     Err(e) => {
                         log::warn!("Sync failed! {}", e);
                     }

--- a/components/tabs/ffi/src/lib.rs
+++ b/components/tabs/ffi/src/lib.rs
@@ -27,11 +27,10 @@ fn parse_url(url: &str) -> Result<url::Url> {
 }
 
 #[no_mangle]
-pub extern "C" fn remote_tabs_new(local_id: FfiStr<'_>, error: &mut ExternError) -> u64 {
+pub extern "C" fn remote_tabs_new(error: &mut ExternError) -> u64 {
     log::debug!("remote_tabs_new");
     ENGINES.insert_with_result(error, || -> Result<_> {
-        let local_id = local_id.as_str();
-        Ok(Arc::new(Mutex::new(TabsEngine::new(local_id))))
+        Ok(Arc::new(Mutex::new(TabsEngine::new())))
     })
 }
 
@@ -42,6 +41,7 @@ pub extern "C" fn remote_tabs_sync(
     access_token: FfiStr<'_>,
     sync_key: FfiStr<'_>,
     tokenserver_url: FfiStr<'_>,
+    local_device_id: FfiStr<'_>,
     error: &mut ExternError,
 ) -> *mut c_char {
     log::debug!("remote_tabs_sync");
@@ -53,6 +53,7 @@ pub extern "C" fn remote_tabs_sync(
                 tokenserver_url: parse_url(tokenserver_url.as_str())?,
             },
             &sync15::KeyBundle::from_ksync_base64(sync_key.as_str())?,
+            local_device_id.as_str(),
         )?;
         Ok(ping)
     })

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -22,22 +22,22 @@ pub struct ClientRemoteTabs {
 }
 
 pub struct TabsStorage {
-    local_id: String,
     local_tabs: RefCell<Option<Vec<RemoteTab>>>,
     remote_tabs: RefCell<Option<Vec<ClientRemoteTabs>>>,
 }
 
+impl Default for TabsStorage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TabsStorage {
-    pub fn new(local_id: &str) -> Self {
+    pub fn new() -> Self {
         Self {
-            local_id: local_id.to_owned(),
             local_tabs: RefCell::default(),
             remote_tabs: RefCell::default(),
         }
-    }
-
-    pub fn get_local_id(&self) -> &str {
-        &self.local_id
     }
 
     pub fn update_local_state(&mut self, local_state: Vec<RemoteTab>) {

--- a/components/tabs/src/sync/engine.rs
+++ b/components/tabs/src/sync/engine.rs
@@ -6,7 +6,7 @@ use crate::error::*;
 use crate::storage::{ClientRemoteTabs, RemoteTab, TabsStorage};
 use crate::sync::store::TabsStore;
 use interrupt::NeverInterrupts;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use sync15::{sync_multiple, telemetry, KeyBundle, MemoryCachedState, Sync15StorageClientInit};
 
 pub struct TabsEngine {
@@ -14,10 +14,16 @@ pub struct TabsEngine {
     mem_cached_state: Cell<MemoryCachedState>,
 }
 
+impl Default for TabsEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TabsEngine {
-    pub fn new(local_id: &str) -> Self {
+    pub fn new() -> Self {
         Self {
-            storage: TabsStorage::new(local_id),
+            storage: TabsStorage::new(),
             mem_cached_state: Cell::default(),
         }
     }
@@ -35,9 +41,16 @@ impl TabsEngine {
         &self,
         storage_init: &Sync15StorageClientInit,
         root_sync_key: &KeyBundle,
+        local_id: &str,
     ) -> Result<telemetry::SyncTelemetryPing> {
         let mut mem_cached_state = self.mem_cached_state.take();
-        let store = TabsStore::new(&self.storage);
+        let mut store = TabsStore::new(&self.storage);
+        // Since we are syncing without the sync manager, there's no
+        // command processor, therefore no clients engine, and in
+        // consequence `TabsStore::prepare_for_sync` is never called
+        // which means our `local_id` will never be set.
+        // Do it here.
+        store.local_id = RefCell::new(local_id.to_owned());
 
         let mut result = sync_multiple(
             &[&store],

--- a/testing/sync-test/src/logins.rs
+++ b/testing/sync-test/src/logins.rs
@@ -75,7 +75,7 @@ pub fn touch_login(e: &PasswordEngine, id: &str, times: usize) -> LoginResult<Lo
 }
 
 pub fn sync_logins(client: &mut TestClient) -> Result<(), failure::Error> {
-    let (init, key) = client.data_for_sync()?;
+    let (init, key, _device_id) = client.data_for_sync()?;
     client.logins_engine.sync(&init, &key)?;
     Ok(())
 }

--- a/testing/sync-test/src/tabs.rs
+++ b/testing/sync-test/src/tabs.rs
@@ -34,8 +34,8 @@ pub fn assert_remote_tabs_equiv(l: &ClientRemoteTabs, r: &ClientRemoteTabs) {
 }
 
 pub fn sync_tabs(client: &mut TestClient) -> Result<(), failure::Error> {
-    let (init, key) = client.data_for_sync()?;
-    client.tabs_engine.sync(&init, &key)?;
+    let (init, key, device_id) = client.data_for_sync()?;
+    client.tabs_engine.sync(&init, &key, &device_id)?;
     Ok(())
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/2162. This would make it easier to integrate with a-c.