### PR TITLE
[ci full] Remove skip_serializing_if = "String::is_empty"

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,11 +9,11 @@
 ### Breaking Changes
 
 - `username`, `usernameField`, and `passwordField` are no longer
-  serialized as `null` in the case where they are empty strings.
+  serialized as `null` in the case where they are empty strings. ([#2252](https://github.com/mozilla/application-services/pull/2252/))
 
 - Android: `ServerPassword` fields `username`, `usernameField`, and
   `passwordField` are now required fields -- `null` is not acceptable,
-  but empty strings are OK.
+  but empty strings are OK. ([#2252](https://github.com/mozilla/application-services/pull/2252/))
 
 - iOS: `LoginRecord` fields `username`, `usernameField` and
-  `passwordField` are no longer nullable.
+  `passwordField` are no longer nullable. ([#2252](https://github.com/mozilla/application-services/pull/2252/))

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,10 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.45.1...master)
+
+## Logins
+
+### Breaking Changes
+
+- `username`, `usernameField`, and `passwordField` are no longer
+  serialized as `null` in the case where they are empty strings.

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -10,3 +10,10 @@
 
 - `username`, `usernameField`, and `passwordField` are no longer
   serialized as `null` in the case where they are empty strings.
+
+- Android: `ServerPassword` fields `username`, `usernameField`, and
+  `passwordField` are now required fields -- `null` is not acceptable,
+  but empty strings are OK.
+
+- iOS: `LoginRecord` fields `username`, `usernameField` and
+  `passwordField` are no longer nullable.

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/ServerPassword.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/ServerPassword.kt
@@ -27,7 +27,7 @@ data class ServerPassword(
      */
     val hostname: String,
 
-    val username: String? = null,
+    val username: String,
 
     /**
      * The password field of this record. It is an error to attempt to insert or update
@@ -67,8 +67,8 @@ data class ServerPassword(
      */
     val timePasswordChanged: Long = 0L,
 
-    val usernameField: String? = null,
-    val passwordField: String? = null
+    val usernameField: String,
+    val passwordField: String
 ) {
 
     fun toJSON(): JSONObject {
@@ -80,21 +80,15 @@ data class ServerPassword(
         o.put("timeCreated", timeCreated)
         o.put("timeLastUsed", timeLastUsed)
         o.put("timePasswordChanged", timePasswordChanged)
-        if (username != null) {
-            o.put("username", username)
-        }
+        o.put("username", username)
         if (httpRealm != null) {
             o.put("httpRealm", httpRealm)
         }
         if (formSubmitURL != null) {
             o.put("formSubmitURL", formSubmitURL)
         }
-        if (usernameField != null) {
-            o.put("usernameField", usernameField)
-        }
-        if (passwordField != null) {
-            o.put("passwordField", passwordField)
-        }
+        o.put("usernameField", usernameField)
+        o.put("passwordField", passwordField)
         return o
     }
 
@@ -114,13 +108,13 @@ data class ServerPassword(
 
                     hostname = jsonObject.getString("hostname"),
                     password = jsonObject.getString("password"),
-                    username = stringOrNull("username"),
+                    username = jsonObject.getString("username"),
 
                     httpRealm = stringOrNull("httpRealm"),
                     formSubmitURL = stringOrNull("formSubmitURL"),
 
-                    usernameField = stringOrNull("usernameField"),
-                    passwordField = stringOrNull("passwordField"),
+                    usernameField = jsonObject.getString("usernameField"),
+                    passwordField = jsonObject.getString("passwordField"),
 
                     timesUsed = jsonObject.getInt("timesUsed"),
 

--- a/components/logins/android/src/test/java/mozilla/appservices/logins/LoginsStorageTest.kt
+++ b/components/logins/android/src/test/java/mozilla/appservices/logins/LoginsStorageTest.kt
@@ -35,9 +35,12 @@ abstract class LoginsStorageTest {
 
         store.add(ServerPassword(
                 id = "bbbbbbbbbbbb",
+                username = "Foobar2000",
                 hostname = "https://www.example.org",
                 formSubmitURL = "https://www.example.org/login",
-                password = "MyVeryCoolPassword"
+                password = "MyVeryCoolPassword",
+                usernameField = "users_name",
+                passwordField = "users_password"
         ))
 
         store.lock()
@@ -179,7 +182,9 @@ abstract class LoginsStorageTest {
                     hostname = "https://www.foo.org",
                     httpRealm = "Some Realm",
                     password = "MyPassword",
-                    username = "MyUsername"
+                    username = "MyUsername",
+                    usernameField = "",
+                    passwordField = ""
             ))
         }
 
@@ -194,7 +199,9 @@ abstract class LoginsStorageTest {
                 hostname = "https://www.foo.org",
                 httpRealm = "Some Realm",
                 password = "MyPassword",
-                username = null
+                username = "Foobar2000",
+                usernameField = "",
+                passwordField = ""
         )
 
         val generatedID = test.add(toInsert)
@@ -219,7 +226,10 @@ abstract class LoginsStorageTest {
                 hostname = "http://www.bar.com",
                 formSubmitURL = "http://login.bar.com",
                 password = "DummyPassword",
-                username = "DummyUsername"))
+                username = "DummyUsername",
+                usernameField = "users_name",
+                passwordField = "users_password"
+        ))
 
         assertEquals("123412341234", specificID)
 
@@ -236,21 +246,30 @@ abstract class LoginsStorageTest {
                 hostname = "https://www.foo.org",
                 httpRealm = "Some Realm",
                 password = "MyPassword",
-                username = "MyUsername"))
+                username = "MyUsername",
+                usernameField = "",
+                passwordField = ""
+        ))
 
         val dupeLogin = ServerPassword(
                 id = "",
                 hostname = "https://www.foo.org",
                 httpRealm = "Some Realm",
                 password = "MyPassword",
-                username = "MyUsername")
+                username = "MyUsername",
+                usernameField = "",
+                passwordField = ""
+        )
 
         val nullValueLogin = ServerPassword(
                 id = "",
                 hostname = "https://www.test.org",
                 httpRealm = "Some Other Realm",
                 password = "MyPassword",
-                username = "\u0000MyUsername2")
+                username = "\u0000MyUsername2",
+                usernameField = "",
+                passwordField = ""
+        )
 
         expectException(InvalidRecordException::class.java) {
             test.ensureValid(dupeLogin)
@@ -274,7 +293,9 @@ abstract class LoginsStorageTest {
                     hostname = "https://www.foo.org",
                     httpRealm = "Some Realm",
                     password = "MyPassword",
-                    username = "MyUsername"
+                    username = "MyUsername",
+                    usernameField = "",
+                    passwordField = ""
             ))
         }
 
@@ -316,7 +337,10 @@ abstract class LoginsStorageTest {
                 hostname = "http://www.bar.com",
                 formSubmitURL = "http://login.bar.com",
                 password = "DummyPassword",
-                username = "DummyUsername"))
+                username = "DummyUsername",
+                usernameField = "users_name",
+                passwordField = "users_password"
+        ))
 
         assertEquals("123412341234", specificID)
 
@@ -348,14 +372,18 @@ abstract class LoginsStorageTest {
                         httpRealm = "Test Realm",
                         formSubmitURL = "https://www.foo.org/login",
                         password = "MyPassword",
-                        username = "MyUsername"
+                        username = "MyUsername",
+                        usernameField = "users_name",
+                        passwordField = "users_password"
                 ),
                 // Neither formSubmitURL nor httpRealm
                 ServerPassword(
                         id = "",
                         hostname = "https://www.foo.org",
                         password = "MyPassword",
-                        username = "MyUsername"
+                        username = "MyUsername",
+                        usernameField = "",
+                        passwordField = ""
                 ),
                 // Empty password
                 ServerPassword(
@@ -363,7 +391,9 @@ abstract class LoginsStorageTest {
                         hostname = "https://www.foo.org",
                         httpRealm = "Some Realm",
                         password = "",
-                        username = "MyUsername"
+                        username = "MyUsername",
+                        usernameField = "",
+                        passwordField = ""
                 ),
                 // Empty hostname
                 ServerPassword(
@@ -371,7 +401,9 @@ abstract class LoginsStorageTest {
                         hostname = "",
                         httpRealm = "Some Realm",
                         password = "MyPassword",
-                        username = "MyUsername"
+                        username = "MyUsername",
+                        usernameField = "",
+                        passwordField = ""
                 )
         )
     }

--- a/components/logins/ios/Logins/LoginRecord.swift
+++ b/components/logins/ios/Logins/LoginRecord.swift
@@ -22,7 +22,7 @@ open class LoginRecord {
     public var password: String
 
     /// This record's username, if any.
-    public var username: String?
+    public var username: String
 
     /// The challenge string for HTTP Basic authentication.
     ///
@@ -67,10 +67,10 @@ open class LoginRecord {
     public var timePasswordChanged: Int64 = 0
 
     /// HTML field name of the username, if known.
-    public var usernameField: String?
+    public var usernameField: String
 
     /// HTML field name of the password, if known.
-    public var passwordField: String?
+    public var passwordField: String
 
     open func toJSONDict() -> [String: Any] {
         var dict: [String: Any] = [
@@ -82,11 +82,11 @@ open class LoginRecord {
             "timeCreated": self.timeCreated,
             "timeLastUsed": self.timeLastUsed,
             "timePasswordChanged": self.timePasswordChanged,
-        ]
 
-        if let username = self.username {
-            dict["username"] = username
-        }
+            "username": self.username,
+            "passwordField": self.passwordField,
+            "usernameField": self.usernameField,
+        ]
 
         if let httpRealm = self.httpRealm {
             dict["httpRealm"] = httpRealm
@@ -96,13 +96,6 @@ open class LoginRecord {
             dict["formSubmitURL"] = formSubmitURL
         }
 
-        if let passwordField = self.passwordField {
-            dict["passwordField"] = passwordField
-        }
-
-        if let usernameField = self.usernameField {
-            dict["usernameField"] = usernameField
-        }
         return dict
     }
 
@@ -121,7 +114,7 @@ open class LoginRecord {
             password: dict["password"] as? String ?? "",
             hostname: dict["hostname"] as? String ?? "",
 
-            username: dict["username"] as? String,
+            username: dict["username"] as? String ?? "",
 
             formSubmitURL: dict["formSubmitURL"] as? String,
             httpRealm: dict["httpRealm"] as? String,
@@ -131,23 +124,23 @@ open class LoginRecord {
             timeCreated: (dict["timeCreated"] as? Int64) ?? 0,
             timePasswordChanged: (dict["timePasswordChanged"] as? Int64) ?? 0,
 
-            usernameField: dict["usernameField"] as? String,
-            passwordField: dict["passwordField"] as? String
+            usernameField: dict["usernameField"] as? String ?? "",
+            passwordField: dict["passwordField"] as? String ?? ""
         )
     }
 
     init(id: String,
          password: String,
          hostname: String,
-         username: String?,
+         username: String,
          formSubmitURL: String?,
          httpRealm: String?,
          timesUsed: Int?,
          timeLastUsed: Int64?,
          timeCreated: Int64?,
          timePasswordChanged: Int64?,
-         usernameField: String?,
-         passwordField: String?) {
+         usernameField: String,
+         passwordField: String) {
         self.id = id
         self.password = password
         self.hostname = hostname

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -283,17 +283,14 @@ pub struct Login {
     pub http_realm: Option<String>,
 
     #[serde(default)]
-    #[serde(skip_serializing_if = "String::is_empty")]
     pub username: String,
 
     pub password: String,
 
     #[serde(default)]
-    #[serde(skip_serializing_if = "String::is_empty")]
     pub username_field: String,
 
     #[serde(default)]
-    #[serde(skip_serializing_if = "String::is_empty")]
     pub password_field: String,
 
     #[serde(default)]

--- a/megazords/ios/MozillaAppServicesTests/LoginsTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/LoginsTests.swift
@@ -57,8 +57,8 @@ class LoginsTests: XCTestCase {
             timeLastUsed: nil,
             timeCreated: nil,
             timePasswordChanged: nil,
-            usernameField: nil,
-            passwordField: nil
+            usernameField: "users_name",
+            passwordField: "users_password"
         ))
 
         let record0 = try! storage.get(id: id0)!
@@ -76,8 +76,8 @@ class LoginsTests: XCTestCase {
             timeLastUsed: nil,
             timeCreated: nil,
             timePasswordChanged: nil,
-            usernameField: nil,
-            passwordField: nil
+            usernameField: "",
+            passwordField: ""
         ))
 
         let record1 = try! storage.get(id: id1)!
@@ -101,8 +101,8 @@ class LoginsTests: XCTestCase {
             timeLastUsed: nil,
             timeCreated: nil,
             timePasswordChanged: nil,
-            usernameField: nil,
-            passwordField: nil
+            usernameField: "users_name",
+            passwordField: "users_password"
         ))
 
         let dupeLogin = LoginRecord(
@@ -116,8 +116,8 @@ class LoginsTests: XCTestCase {
             timeLastUsed: nil,
             timeCreated: nil,
             timePasswordChanged: nil,
-            usernameField: nil,
-            passwordField: nil
+            usernameField: "users_name",
+            passwordField: "users_password"
         )
 
         let nullValueLogin = LoginRecord(
@@ -131,8 +131,8 @@ class LoginsTests: XCTestCase {
             timeLastUsed: nil,
             timeCreated: nil,
             timePasswordChanged: nil,
-            usernameField: nil,
-            passwordField: nil
+            usernameField: "users_name",
+            passwordField: "users_password"
         )
 
         XCTAssertThrowsError(try storage.ensureValid(login: dupeLogin))


### PR DESCRIPTION
Fixes #1985.

The docs say in ch01.1-logins.md that in Firefox Desktop,
usernameField and passwordField are always "empty". This seems to
imply that we should serialize empty strings in those fields too.

This PR also carries through this change at the Swift and Kotlin levels.

### Pull Request checklist ###
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - I wasn't able to run `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` without access to a Mac.
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - I do not believe new tests are needed for this PR, as it just adjusts some field attributes.
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - No new dependencies were introduced.
