### PR TITLE
Let Fenix be able to migrate the session token without creating a new one

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,3 +9,16 @@
 - Android: Added ability to rekey the database via `rekeyDatabase`. [[#2228](https://github.com/mozilla/application-services/pull/2228)]
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.43.1...master)
+## FxA Client
+
+### Breaking Changes
+
+* Android: `migrateFromSessionToken` now reuses the existing 'sessionToken' instead of creating a new session token.
+
+### What's new
+
+* Android: New method `copyFromSessionToken` will create a new 'sessionToken' state, this is what `migrateFromSessionToken` used to do,
+before this release.
+
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.44.0...master)

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -85,7 +85,14 @@ internal interface LibFxAFFI : Library {
     )
     fun fxa_send_tab(fxa: FxaHandle, targetDeviceId: String, title: String, url: String, e: RustError.ByReference)
 
-    fun fxa_migrate_from_session_token(fxa: FxaHandle, sessionToken: String, kSync: String, kXCS: String, e: RustError.ByReference)
+    fun fxa_migrate_from_session_token(
+        fxa: FxaHandle,
+        sessionToken: String,
+        kSync: String,
+        kXCS: String,
+        copySessionToken: Boolean,
+        e: RustError.ByReference
+    )
 
     fun fxa_str_free(string: Pointer)
     fun fxa_bytebuffer_free(buffer: RustBuffer.ByValue)

--- a/components/fxa-client/examples/migration.rs
+++ b/components/fxa-client/examples/migration.rs
@@ -2,8 +2,10 @@ use cli_support::prompt::prompt_string;
 use fxa_client::FirefoxAccount;
 
 static CLIENT_ID: &str = "3c49430b43dfba77";
-static CONTENT_SERVER: &str = "https://latest.dev.lcip.org";
-static REDIRECT_URI: &str = "https://latest.dev.lcip.org/oauth/success/3c49430b43dfba77";
+//static CONTENT_SERVER: &str = "https://latest.dev.lcip.org";
+static CONTENT_SERVER: &str = "http://127.0.0.1:3030";
+//static REDIRECT_URI: &str = "https://latest.dev.lcip.org/oauth/success/3c49430b43dfba77";
+static REDIRECT_URI: &str = "http://127.0.0.1:3030/oauth/success/3c49430b43dfba77";
 
 fn main() {
     let mut fxa = FirefoxAccount::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
@@ -13,7 +15,7 @@ fn main() {
     let k_sync: String = prompt_string("k_sync").unwrap();
     println!("Enter kXCS (hex-string):");
     let k_xcs: String = prompt_string("k_xcs").unwrap();
-    fxa.migrate_from_session_token(&session_token, &k_sync, &k_xcs)
+    fxa.migrate_from_session_token(&session_token, &k_sync, &k_xcs, true)
         .unwrap();
     println!("WOW! You've been migrated.");
     println!("JSON: {}", fxa.to_json().unwrap());

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -237,6 +237,7 @@ pub extern "C" fn fxa_migrate_from_session_token(
     session_token: FfiStr<'_>,
     k_sync: FfiStr<'_>,
     k_xcs: FfiStr<'_>,
+    copy_session_token: bool,
     error: &mut ExternError,
 ) {
     log::debug!("fxa_migrate_from_session_token");
@@ -244,7 +245,7 @@ pub extern "C" fn fxa_migrate_from_session_token(
         let session_token = session_token.as_str();
         let k_sync = k_sync.as_str();
         let k_xcs = k_xcs.as_str();
-        fxa.migrate_from_session_token(session_token, k_sync, k_xcs)
+        fxa.migrate_from_session_token(session_token, k_sync, k_xcs, copy_session_token)
     });
 }
 


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/1677

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
