### PR TITLE
Ensure unicode history urls imported from Fennec are punycoded. Fixes…

### DIFF
--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -107,11 +107,11 @@ impl PageInfo {
 
 // fetch_page_info gives you one of these.
 #[derive(Debug)]
-struct FetchedPageInfo {
-    page: PageInfo,
+pub struct FetchedPageInfo {
+    pub page: PageInfo,
     // XXX - not clear what this is used for yet, and whether it should be local, remote or either?
     // The sql below isn't quite sure either :)
-    last_visit_id: Option<RowId>,
+    pub last_visit_id: Option<RowId>,
 }
 
 impl FetchedPageInfo {
@@ -124,7 +124,7 @@ impl FetchedPageInfo {
 }
 
 // History::FetchPageInfo
-fn fetch_page_info(db: &PlacesDb, url: &Url) -> Result<Option<FetchedPageInfo>> {
+pub fn fetch_page_info(db: &PlacesDb, url: &Url) -> Result<Option<FetchedPageInfo>> {
     let sql = "
       SELECT guid, url, id, title, hidden, typed, frecency,
              visit_count_local, visit_count_remote,

--- a/components/places/tests/fennec_bookmarks.rs
+++ b/components/places/tests/fennec_bookmarks.rs
@@ -147,12 +147,14 @@ fn test_import() -> Result<()> {
         let url = Url::parse(url_str)?;
         let conn = places_api.open_connection(ConnectionType::ReadOnly)?;
         Ok(conn.query_row_and_then(
-            "SELECT COUNT(*) from main.moz_bookmarks b
-            LEFT JOIN main.moz_places h ON h.id = b.fk
-            WHERE h.url_hash = hash(:url) AND h.url = :url",
+            "SELECT EXISTS(
+                SELECT 1 FROM main.moz_bookmarks b
+                LEFT JOIN main.moz_places h ON h.id = b.fk
+                WHERE h.url_hash = hash(:url) AND h.url = :url
+            )",
             &[&url.as_str()],
-            |r| r.get::<_, u32>(0),
-        )? == 1)
+            |r| r.get(0),
+        )?)
     }
 
     let tmpdir = tempdir().unwrap();

--- a/components/places/tests/fennec_bookmarks.rs
+++ b/components/places/tests/fennec_bookmarks.rs
@@ -140,6 +140,21 @@ fn test_import_unsupported_db_version() -> Result<()> {
 
 #[test]
 fn test_import() -> Result<()> {
+    use places::api::places_api::ConnectionType;
+    use url::Url;
+
+    fn bookmark_exists(places_api: &PlacesApi, url_str: &str) -> Result<bool> {
+        let url = Url::parse(url_str)?;
+        let conn = places_api.open_connection(ConnectionType::ReadOnly)?;
+        Ok(conn.query_row_and_then(
+            "SELECT COUNT(*) from main.moz_bookmarks b
+            LEFT JOIN main.moz_places h ON h.id = b.fk
+            WHERE h.url_hash = hash(:url) AND h.url = :url",
+            &[&url.as_str()],
+            |r| r.get::<_, u32>(0),
+        )? == 1)
+    }
+
     let tmpdir = tempdir().unwrap();
     let fennec_path = tmpdir.path().join("browser.db");
     let fennec_db = empty_fennec_db(&fennec_path)?;
@@ -248,6 +263,20 @@ fn test_import() -> Result<()> {
             url: Some("https://foo.bar".to_owned()),
             ..Default::default()
         },
+        FennecBookmark {
+            _id: 12,
+            parent: 7,
+            title: Some("Non-punycode".to_owned()),
+            url: Some("http://\u{1F496}.com/\u{1F496}".to_owned()),
+            ..Default::default()
+        },
+        FennecBookmark {
+            _id: 13,
+            parent: 7,
+            title: Some("Already punycode".to_owned()),
+            url: Some("http://xn--r28h.com/%F0%9F%98%8D".to_owned()),
+            ..Default::default()
+        },
     ];
     insert_bookmarks(&fennec_db, &bookmarks)?;
 
@@ -257,6 +286,10 @@ fn test_import() -> Result<()> {
     assert_eq!(pinned.len(), 1);
     assert_eq!(pinned[0].title, Some("Pinned Bookmark".to_owned()));
 
+    assert!(bookmark_exists(&places_api, &"about:firefox")?);
+    assert!(bookmark_exists(&places_api, &"https://bar.foo")?);
+    assert!(bookmark_exists(&places_api, &"http://💖.com/💖")?);
+    assert!(bookmark_exists(&places_api, &"http://😍.com/😍")?);
     // Uncomment the following to debug with cargo test -- --nocapture.
     // println!(
     //     "Places DB Path: {}",

--- a/components/places/tests/fennec_history.rs
+++ b/components/places/tests/fennec_history.rs
@@ -196,9 +196,8 @@ fn test_import() -> Result<()> {
             url: "I'm a super invalid URL, yo".to_owned(),
             ..Default::default()
         },
-        // Add "http://💖.com/💖" using an escaped string.
         FennecHistory {
-            url: "http://\u{1F496}.com/\u{1F496}".to_owned(),
+            url: "http://💖.com/💖".to_owned(),
             ..Default::default()
         },
         // Add "http://😍.com/😍" already punycoded.


### PR DESCRIPTION
… #2280.

Fixed for history by using a staging table and ensuring `validate_url()`
is called for each URL. Adds a number of tests for both history and
bookmarks, although bookmarks didn't exhibit any problems.

I also removed all usage of `is_valid_url()` from the Fennec import
because it is error prone - checking if a URL is valid is not enough -
they must also be passed through `validate_url()` - and because
`validate_url()` also checks the validity, there's no need for
`is_valid_url()` However, I couldn't remove it entirely because it's
still used by the iOS import. There's a risk that import code will
have the same problem, so we should consider similar changes there -
but I thought I'd get feedback on the Fennec side first.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
