### PR TITLE
Only attempt to sync engines if they have been configured.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,3 +9,12 @@
 ### What's new
 
 - Added invalid character checks from Desktop to `LoginsStorage.ensureValid` and introduced `INVALID_LOGIN_ILLEGAL_FIELD_VALUE` error. ([#2262](https://github.com/mozilla/application-services/pull/2262))
+
+## Sync Manager
+
+### Breaking Changes
+
+- When asked to sync all engines, SyncManager will now sync all engines for which a handle has been set.
+  Previously it would sync all known engines, panicking if a handle had not been set for some engine.
+  While *technically* a breaking chang, we expect that the new behaviour is almost certainly what
+  consuming applications actually want in practice.

--- a/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncParams.kt
+++ b/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncParams.kt
@@ -80,7 +80,7 @@ data class SyncParams(
      * Requesting that we sync an unknown engine type will result in a
      * [UnsupportedEngine] error.
      *
-     * Passing `null` here is used to indicate that all known engines
+     * Passing `null` here is used to indicate that all known and configured engines
      * should be synced.
      */
     val engines: List<String>?,


### PR DESCRIPTION
Previously, if the app asked us to sync all engines then we would attempt to sync all the engines that we know about, causing a panic if one of those engines had not been configured.

Now, we only ever attempt to sync an engine if it has been configured by the app.

Fixes #2312.

I wasn't sure what tests to update for this change, since the `sync_manager` crate itself doesn't seem to have any. I'm kind of hoping CI will fail and point me at some that need changing :-)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
