### PR TITLE
ios bookmark import may create non-punycode places

### DIFF
--- a/components/places/src/import/common.rs
+++ b/components/places/src/import/common.rs
@@ -32,6 +32,8 @@ pub mod sql_fns {
         Ok(now)
     }
 
+    // Possibly better named as "normalize URL" - even in non-error cases, the
+    // result string may not be the same href used passed as input.
     #[inline(never)]
     pub fn validate_url(ctx: &Context<'_>) -> Result<Option<String>> {
         let val = ctx.get_raw(0);
@@ -48,20 +50,6 @@ pub mod sql_fns {
         } else {
             Ok(None)
         }
-    }
-
-    #[inline(never)]
-    pub fn is_valid_url(ctx: &Context<'_>) -> Result<Option<bool>> {
-        Ok(match ctx.get_raw(0) {
-            ValueRef::Text(s) if s.len() <= URL_LENGTH_MAX => {
-                if let Ok(s) = std::str::from_utf8(s) {
-                    Some(Url::parse(s).is_ok())
-                } else {
-                    Some(false)
-                }
-            }
-            _ => Some(false),
-        })
     }
 }
 

--- a/components/places/tests/ios_bookmarks.rs
+++ b/components/places/tests/ios_bookmarks.rs
@@ -418,6 +418,18 @@ fn test_import_with_local() -> Result<()> {
         ..IosNode::default()
     });
 
+    let b2id = nodes.insert_local(IosNode {
+        bmk_uri: Some("http://💖.com/💖".into()),
+        parentid: dogear::MOBILE_GUID,
+        ..IosNode::default()
+    });
+
+    let b3id = nodes.insert_local(IosNode {
+        bmk_uri: Some("http://xn--r28h.com/%F0%9F%98%8D".into()),
+        parentid: dogear::MOBILE_GUID,
+        ..IosNode::default()
+    });
+
     nodes.populate(&ios_db)?;
     let places_api = PlacesApi::new(tmpdir.path().join("places.sqlite"))?;
     places::import::import_ios_bookmarks(&places_api, ios_path)?;
@@ -442,6 +454,14 @@ fn test_import_with_local() -> Result<()> {
         Some(url::Url::parse("https://www.example.com/1%202%203").unwrap())
     );
 
+    let bmk2 =
+        bookmarks::public_node::fetch_bookmark(&places_db, &sync_guid(&b2id), false)?.unwrap();
+    assert_eq!(bmk2.url, Some(url::Url::parse("http://💖.com/💖").unwrap()));
+
+    let bmk3 =
+        bookmarks::public_node::fetch_bookmark(&places_db, &sync_guid(&b3id), false)?.unwrap();
+    assert_eq!(bmk3.url, Some(url::Url::parse("http://😍.com/😍").unwrap()));
+
     let mobile = bookmarks::public_node::fetch_bookmark(
         &places_db,
         &sync_guid(&dogear::MOBILE_GUID),
@@ -451,7 +471,12 @@ fn test_import_with_local() -> Result<()> {
 
     assert_eq!(
         mobile.child_guids,
-        Some(vec![sync_guid(&b0id), sync_guid(&b1id),])
+        Some(vec![
+            sync_guid(&b0id),
+            sync_guid(&b1id),
+            sync_guid(&b2id),
+            sync_guid(&b3id)
+        ])
     );
 
     Ok(())


### PR DESCRIPTION
It looks like the iOS import could create non-punycoded hosts - this might be theoretical if it's impossible for non-punycoded URLs to end up in the iOS db in the first place, but given thom vaguely agreed `is_valid_url()` isn't ideal I thought it worth fixing anyway.