### PR TITLE
Only mirror newly-created bugzilla bugs to github

### DIFF
--- a/tools/sync_bugzilla_to_github.py
+++ b/tools/sync_bugzilla_to_github.py
@@ -43,7 +43,7 @@ SYNCED_ISSUE_CLOSE_COMMENT = 'Upstream bug has been closed with the following re
 JIRA_ISSUE_MARKER = '\N{BOX DRAWINGS LIGHT TRIPLE DASH VERTICAL}'
 
 # For now, only look at recent bugs in order to preserve sanity.
-LAST_CHANGE_TIME = '20190801'
+MIN_CREATION_TIME = '20190801'
 
 
 def log(msg, *args, **kwds):
@@ -138,7 +138,8 @@ class BugSet(object):
                     bugid = str(bugnum)
                     self.bugs[bugid]['comment0'] = bug['comments'][0]['text']
 
-    def _make_query_string(self, product=None, component=None, id=None, resolved=None, last_change_time=None):
+    def _make_query_string(self, product=None, component=None, id=None, resolved=None,
+                           creation_time=None, last_change_time=None):
         def listify(x): return x if isinstance(x, (list, tuple, set)) else (x,)
 
         def encode(x): return urllib.parse.quote(x, safe='')
@@ -149,6 +150,8 @@ class BugSet(object):
             qs.extend('component=' + encode(c) for c in listify(component))
         if id is not None:
             qs.extend('id=' + encode(i) for i in listify(id))
+        if creation_time is not None:
+            qs.append('creation_time=' + creation_time)
         if last_change_time is not None:
             qs.append('last_change_time=' + last_change_time)
         if resolved is not None:
@@ -304,9 +307,9 @@ def sync_bugzilla_to_github():
     log('Finding relevant bugs in bugzilla...')
     bugs = BugSet(os.environ.get('BZ_API_KEY'))
     bugs.update_from_bugzilla(product='Firefox', component='Firefox Accounts',
-                              resolved=False, last_change_time=LAST_CHANGE_TIME)
+                              resolved=False, creation_time=MIN_CREATION_TIME)
     bugs.update_from_bugzilla(product='Firefox', component='Sync',
-                              resolved=False, last_change_time=LAST_CHANGE_TIME)
+                              resolved=False, creation_time=MIN_CREATION_TIME)
     log('Found {} bugzilla bugs', len(bugs))
     log('Syncing to github')
     issues = MirrorIssueSet(


### PR DESCRIPTION
The bug mirror script current pulls in any bugs that were recently modified. I had hoped this would result in a slow trickle of old bugs making their way into Jira for triage, as they happened to be touched organically in github.

In practice, I think it's mostly been annoying to have 4-year-old bugs show up in Jira when someone tweaks a priority flag or adds a CC or whatever.

Let's only pull in bugs that were *created* after a certain time. If we decide we want more bugs pulled into Jira, we can decrease this timestamp over time.
