### PR TITLE
Run regenerate_dependency_summaries unders verbose (and strict) flags

### DIFF
--- a/tools/regenerate_dependency_summaries.sh
+++ b/tools/regenerate_dependency_summaries.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -euvx
+
 python3 ./tools/dependency_summary.py > ./DEPENDENCIES.md
 
 python3 ./tools/dependency_summary.py --all-ios-targets --package megazord_ios > megazords/ios/DEPENDENCIES.md


### PR DESCRIPTION
This script takes a while and produces no output until its done. Easy fix is to use the same flags we use for other scripts, which at least makes it clear something is happening.