### PR TITLE
Fix misplaced `unsafe` in fxa FFI

### DIFF
--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -450,12 +450,14 @@ pub extern "C" fn fxa_handle_push_message(
     })
 }
 
-/// Initalizes our own device, most of the time this will be called right after logging-in
-/// for the first time.
-/// This method is marked un-safe as it reconstitutes an array of capabilities
-/// from a pointer.
+/// Initalizes our own device, most of the time this will be called right after
+/// logging-in for the first time.
+///
+/// # Safety
+/// This function is unsafe because it will dereference `capabilities_data` and
+/// read `capabilities_len` bytes from it.
 #[no_mangle]
-pub extern "C" fn fxa_initialize_device(
+pub unsafe extern "C" fn fxa_initialize_device(
     handle: u64,
     name: FfiStr<'_>,
     device_type: i32,
@@ -465,9 +467,8 @@ pub extern "C" fn fxa_initialize_device(
 ) {
     log::debug!("fxa_initialize_device");
     ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
-        let capabilities = unsafe {
-            DeviceCapability::from_protobuf_array_ptr(capabilities_data, capabilities_len)
-        };
+        let capabilities =
+            DeviceCapability::from_protobuf_array_ptr(capabilities_data, capabilities_len);
         // This should not fail as device_type i32 representation is derived from our .proto schema.
         let device_type =
             msg_types::device::Type::from_i32(device_type).expect("Unknown device type code");
@@ -476,8 +477,12 @@ pub extern "C" fn fxa_initialize_device(
 }
 
 /// Ensure that the device capabilities are registered with the server.
+///
+/// # Safety
+/// This function is unsafe because it will dereference `capabilities_data` and
+/// read `capabilities_len` bytes from it.
 #[no_mangle]
-pub extern "C" fn fxa_ensure_capabilities(
+pub unsafe extern "C" fn fxa_ensure_capabilities(
     handle: u64,
     capabilities_data: *const u8,
     capabilities_len: i32,
@@ -485,9 +490,8 @@ pub extern "C" fn fxa_ensure_capabilities(
 ) {
     log::debug!("fxa_ensure_capabilities");
     ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
-        let capabilities = unsafe {
-            DeviceCapability::from_protobuf_array_ptr(capabilities_data, capabilities_len)
-        };
+        let capabilities =
+            DeviceCapability::from_protobuf_array_ptr(capabilities_data, capabilities_len);
         fxa.ensure_capabilities(&capabilities)
     })
 }


### PR DESCRIPTION
Functions that deref raw pointers are unsafe, always. Nothing misuses this, but it's still good to be consistent.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
