### PR TITLE
Replace getByHostName() with getByBaseDomain()

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,12 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.46.0...master)
+## Logins
+
+### Breaking Changes
+
+- `LoginsStorage.getByHostname` has been removed ([#2152](https://github.com/mozilla/application-services/issues/2152)
+
+### What's new
+
+- `LoginsStorage.getByBaseDomain` has been added ([#2152](https://github.com/mozilla/application-services/issues/2152)

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -209,12 +209,10 @@ class DatabaseLoginsStorage(private val dbPath: String) : AutoCloseable, LoginsS
     }
 
     @Throws(LoginsStorageException::class)
-    override fun getByHostname(hostname: String): List<ServerPassword> {
+    override fun getByBaseDomain(baseDomain: String): List<ServerPassword> {
         return readQueryCounters.measure {
             val json = rustCallWithLock { raw, error ->
-                LoginsStoreMetrics.readQueryTime.measure {
-                    PasswordSyncAdapter.INSTANCE.sync15_passwords_get_by_hostname(raw, hostname, error)
-                }
+                PasswordSyncAdapter.INSTANCE.sync15_passwords_get_by_base_domain(raw, baseDomain, error)
             }.getAndConsumeRustString()
             ServerPassword.fromJSONArray(json)
         }

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/LoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/LoginsStorage.kt
@@ -147,12 +147,12 @@ interface LoginsStorage : AutoCloseable {
     fun list(): List<ServerPassword>
 
     /**
-     * Fetch the list of passwords for some hostname from the underlying storage layer.
+     * Fetch the list of passwords for some base domain from the underlying storage layer.
      *
      * @throws [LoginsStorageException] On unexpected errors (IO failure, rust panics, etc)
      */
     @Throws(LoginsStorageException::class)
-    fun getByHostname(hostname: String): List<ServerPassword>
+    fun getByBaseDomain(hostname: String): List<ServerPassword>
 
     /**
      * Inserts the provided login into the database, returning its id.

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/LoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/LoginsStorage.kt
@@ -152,7 +152,7 @@ interface LoginsStorage : AutoCloseable {
      * @throws [LoginsStorageException] On unexpected errors (IO failure, rust panics, etc)
      */
     @Throws(LoginsStorageException::class)
-    fun getByBaseDomain(hostname: String): List<ServerPassword>
+    fun getByBaseDomain(baseDomain: String): List<ServerPassword>
 
     /**
      * Inserts the provided login into the database, returning its id.

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/MemoryLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/MemoryLoginsStorage.kt
@@ -235,10 +235,8 @@ class MemoryLoginsStorage(private var list: List<ServerPassword>) : AutoCloseabl
 
     @Synchronized
     @Throws(LoginsStorageException::class)
-    override fun getByHostname(hostname: String): List<ServerPassword> {
-        checkUnlocked()
-        list = list.filter { it.hostname == hostname }
-        return ArrayList(list)
+    override fun getByBaseDomain(baseDomain: String): List<ServerPassword> {
+        throw UnsupportedOperationException("Only DatabaseLoginsStorage supports getByBaseDomain")
     }
 
     private fun checkNotClosed() {

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/rust/PasswordSyncAdapter.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/rust/PasswordSyncAdapter.kt
@@ -44,7 +44,7 @@ internal interface PasswordSyncAdapter : Library {
     fun sync15_passwords_get_all(handle: LoginsDbHandle, error: RustError.ByReference): Pointer?
 
     // return json array
-    fun sync15_passwords_get_by_hostname(handle: LoginsDbHandle, hostname: String, error: RustError.ByReference): Pointer?
+    fun sync15_passwords_get_by_base_domain(handle: LoginsDbHandle, basedomain: String, error: RustError.ByReference): Pointer?
 
     // Returns a JSON string containing a sync ping.
     fun sync15_passwords_sync(

--- a/components/logins/examples/sync_pass_sql.rs
+++ b/components/logins/examples/sync_pass_sql.rs
@@ -298,7 +298,7 @@ fn main() -> Result<()> {
     }
 
     loop {
-        match prompt_char("[A]dd, [D]elete, [U]pdate, [S]ync, [V]iew, [H]ostname search, [R]eset, [W]ipe, [T]ouch, E[x]ecute SQL Query, or [Q]uit").unwrap_or('?') {
+        match prompt_char("[A]dd, [D]elete, [U]pdate, [S]ync, [V]iew, [B]ase-domain search, [R]eset, [W]ipe, [T]ouch, E[x]ecute SQL Query, or [Q]uit").unwrap_or('?') {
             'A' | 'a' => {
                 log::info!("Adding new record");
                 let record = read_login();
@@ -376,16 +376,16 @@ fn main() -> Result<()> {
                     log::warn!("Failed to dump passwords? This is probably bad! {}", e);
                 }
             }
-            'H' | 'h' => {
-                log::info!("Hostname search");
-                if let Some(hostname) = prompt_string("Hostname (one line only, press enter when done):\n") {
-                    match engine.get_by_hostname(&hostname) {
+            'B' | 'b' => {
+                log::info!("Base Domain search");
+                if let Some(basedomain) = prompt_string("Base domain (one line only, press enter when done):\n") {
+                    match engine.get_by_base_domain(&basedomain) {
                         Err(e) => {
-                            log::warn!("Hostname lookup failed! {}", e);
+                            log::warn!("Base domain lookup failed! {}", e);
                             log::warn!("BT: {:?}", e.backtrace());
                         },
                         Ok(result) => {
-                            log::info!("Hostname result: {}", serde_json::to_string_pretty(&result).unwrap());
+                            log::info!("Base domain result: {}", serde_json::to_string_pretty(&result).unwrap());
                         }
                     }
                 }

--- a/components/logins/ffi/src/lib.rs
+++ b/components/logins/ffi/src/lib.rs
@@ -203,14 +203,17 @@ pub extern "C" fn sync15_passwords_get_all(handle: u64, error: &mut ExternError)
 }
 
 #[no_mangle]
-pub extern "C" fn sync15_passwords_get_by_hostname(
+pub extern "C" fn sync15_passwords_get_by_base_domain(
     handle: u64,
-    hostname: FfiStr<'_>,
+    base_domain: FfiStr<'_>,
     error: &mut ExternError,
 ) -> *mut c_char {
-    log::debug!("sync15_passwords_get_by_hostname");
+    log::debug!("sync15_passwords_get_by_base_domain");
     ENGINES.call_with_result(error, handle, |state| -> Result<String> {
-        let passwords = state.lock().unwrap().get_by_hostname(hostname.as_str())?;
+        let passwords = state
+            .lock()
+            .unwrap()
+            .get_by_base_domain(base_domain.as_str())?;
         let result = serde_json::to_string(&passwords)?;
         Ok(result)
     })

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -282,12 +282,12 @@ open class LoginsStorage {
         }
     }
 
-    /// Get the list of records for some hostname.
-    open func getByHostname(hostname: String) throws -> [LoginRecord] {
+    /// Get the list of records for some base domain.
+    open func getByBaseDomain(baseDomain: String) throws -> [LoginRecord] {
         return try queue.sync {
             let engine = try self.getUnlocked()
             let rustStr = try LoginsStoreError.unwrap { err in
-                sync15_passwords_get_by_hostname(engine, hostname, err)
+                sync15_passwords_get_by_base_domain(engine, baseDomain, err)
             }
             let jsonStr = String(freeingRustString: rustStr)
             return try LoginRecord.fromJSONArray(jsonStr)

--- a/components/logins/ios/Logins/RustPasswordAPI.h
+++ b/components/logins/ios/Logins/RustPasswordAPI.h
@@ -52,8 +52,8 @@ char *_Nullable sync15_passwords_get_by_id(Sync15PasswordEngineHandle handle,
                                           char const *_Nonnull id,
                                           Sync15PasswordsError *_Nonnull error_out);
 
-char *_Nullable sync15_passwords_get_by_hostname(Sync15PasswordEngineHandle handle,
-                                          char const *_Nonnull hostname,
+char *_Nullable sync15_passwords_get_by_base_domain(Sync15PasswordEngineHandle handle,
+                                          char const *_Nonnull baseDomain,
                                           Sync15PasswordsError *_Nonnull error_out);
 
 char *_Nullable sync15_passwords_get_all(Sync15PasswordEngineHandle handle,

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -1269,7 +1269,7 @@ mod tests {
         assert!(&unique_login_check.is_ok())
     }
 
-    fn check_matches(db: &LoginDb, query: &str, expected: &Vec<&str>) {
+    fn check_matches(db: &LoginDb, query: &str, expected: &[&str]) {
         let mut results = db
             .get_by_base_domain(query)
             .unwrap()
@@ -1277,7 +1277,7 @@ mod tests {
             .map(|l| l.hostname)
             .collect::<Vec<String>>();
         results.sort();
-        let mut sorted = expected.clone();
+        let mut sorted = expected.to_owned();
         sorted.sort();
         assert_eq!(sorted, results);
     }
@@ -1302,7 +1302,7 @@ mod tests {
             check_matches(&db, query, &good);
         }
         for query in zero_queries {
-            check_matches(&db, query, &vec![]);
+            check_matches(&db, query, &[]);
         }
     }
 

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -26,6 +26,7 @@ use sync15::{
     OutgoingChangeset, Payload, ServerTimestamp, Store, StoreSyncAssociation,
 };
 use sync_guid::Guid;
+use url::{Host, Url};
 
 pub struct LoginDb {
     pub db: Connection,
@@ -301,9 +302,54 @@ impl LoginDb {
         rows.collect::<Result<_>>()
     }
 
-    pub fn get_by_hostname(&self, hostname: &str) -> Result<Vec<Login>> {
-        let mut stmt = self.db.prepare_cached(&GET_ALL_BY_HOSTNAME_SQL)?;
-        let rows = stmt.query_and_then(&[hostname], Login::from_row)?;
+    pub fn get_by_base_domain(&self, base_domain: &str) -> Result<Vec<Login>> {
+        // We first parse the input string as a host so it is normalized.
+        let base_host = match Host::parse(base_domain) {
+            Ok(d) => d,
+            Err(e) => {
+                // don't log the input string as it's PII.
+                log::warn!("get_by_base_domain was passed an invalid domain: {}", e);
+                return Ok(vec![]);
+            }
+        };
+        // We just do a linear scan. Another option is to have an indexed
+        // reverse-host column or similar, but current thinking is that it's
+        // extra complexity for (probably) zero actual benefit given the record
+        // counts are expected to be so low.
+        // A regex would probably make this simpler, but we don't want to drag
+        // in a regex lib just for this.
+        let mut stmt = self.db.prepare_cached(&GET_ALL_SQL)?;
+        let rows = stmt
+            .query_and_then(NO_PARAMS, Login::from_row)?
+            .filter(|r| {
+                let login = r
+                    .as_ref()
+                    .ok()
+                    .and_then(|login| Url::parse(&login.hostname).ok());
+                let this_host = login.as_ref().and_then(|url| url.host());
+                match (&base_host, this_host) {
+                    (Host::Domain(base), Some(Host::Domain(look))) => {
+                        // a fairly long-winded way of saying
+                        // `login.hostname == base_domain ||
+                        //  login.hostname.ends_with('.' + base_domain);`
+                        let mut rev_input = base.chars().rev();
+                        let mut rev_host = look.chars().rev();
+                        loop {
+                            match (rev_input.next(), rev_host.next()) {
+                                (Some(ref a), Some(ref b)) if a == b => continue,
+                                (None, None) => return true, // exactly equal
+                                (None, Some(ref h)) => return *h == '.',
+                                _ => return false,
+                            }
+                        }
+                    }
+                    // ip addresses must match exactly.
+                    (Host::Ipv4(base), Some(Host::Ipv4(look))) => *base == look,
+                    (Host::Ipv6(base), Some(Host::Ipv6(look))) => *base == look,
+                    // all "mismatches" in domain types are false.
+                    _ => false,
+                }
+            });
         rows.collect::<Result<_>>()
     }
 
@@ -1102,19 +1148,6 @@ lazy_static! {
          LIMIT 1",
         common_cols = schema::COMMON_COLS,
     );
-    static ref GET_ALL_BY_HOSTNAME_SQL: String = format!(
-        "SELECT {common_cols}
-         FROM loginsL
-         WHERE is_deleted = 0
-           AND hostname = :hostname
-         UNION ALL
-
-         SELECT {common_cols}
-         FROM loginsM
-         WHERE is_overridden = 0
-           AND hostname = :hostname",
-        common_cols = schema::COMMON_COLS,
-    );
     static ref CLONE_ENTIRE_MIRROR_SQL: String = format!(
         "INSERT OR IGNORE INTO loginsL ({common_cols}, local_modified, is_deleted, sync_status)
          SELECT {common_cols}, NULL AS local_modified, 0 AS is_deleted, 0 AS sync_status
@@ -1234,5 +1267,109 @@ mod tests {
 
         db.delete(login.guid_str()).unwrap();
         assert!(&unique_login_check.is_ok())
+    }
+
+    fn check_matches(db: &LoginDb, query: &str, expected: &Vec<&str>) {
+        let mut results = db
+            .get_by_base_domain(query)
+            .unwrap()
+            .into_iter()
+            .map(|l| l.hostname)
+            .collect::<Vec<String>>();
+        results.sort();
+        let mut sorted = expected.clone();
+        sorted.sort();
+        assert_eq!(sorted, results);
+    }
+
+    fn check_good_bad(
+        good: Vec<&str>,
+        bad: Vec<&str>,
+        good_queries: Vec<&str>,
+        zero_queries: Vec<&str>,
+    ) {
+        let db = LoginDb::open_in_memory(Some("testing")).unwrap();
+        for h in good.iter().chain(bad.iter()) {
+            db.add(Login {
+                hostname: (*h).into(),
+                http_realm: Some((*h).into()),
+                password: "test".into(),
+                ..Login::default()
+            })
+            .unwrap();
+        }
+        for query in good_queries {
+            check_matches(&db, query, &good);
+        }
+        for query in zero_queries {
+            check_matches(&db, query, &vec![]);
+        }
+    }
+
+    #[test]
+    fn test_get_by_base_domain_invalid() {
+        check_good_bad(
+            vec!["https://example.com"],
+            vec![],
+            vec![],
+            vec!["invalid query"],
+        );
+    }
+
+    #[test]
+    fn test_get_by_base_domain() {
+        check_good_bad(
+            vec![
+                "https://example.com",
+                "https://www.example.com",
+                "http://www.example.com",
+                "http://www.example.com:8080",
+                "http://sub.example.com:8080",
+                "https://sub.example.com:8080",
+                "https://sub.sub.example.com",
+            ],
+            vec![
+                "https://badexample.com",
+                "https://example.co",
+                "https://example.com.au",
+            ],
+            vec!["example.com"],
+            vec!["foo.com"],
+        );
+        // punycode! This is likely to need adjusting once we normalize
+        // on insert.
+        check_good_bad(
+            vec![
+                "http://😍.com",
+                "http://xn--r28h.com", // punycoded version of the above.
+            ],
+            vec!["http://💖.com"],
+            vec!["😍.com", "xn--r28h.com"],
+            vec![],
+        );
+    }
+
+    #[test]
+    fn test_get_by_base_domain_ipv4() {
+        check_good_bad(
+            vec!["http://127.0.0.1", "https://127.0.0.1:8000"],
+            vec!["https://127.0.0.0", "https://example.com"],
+            vec!["127.0.0.1"],
+            vec!["127.0.0.2"],
+        );
+    }
+
+    #[test]
+    fn test_get_by_base_domain_ipv6() {
+        check_good_bad(
+            vec![
+                "http://[::1]",
+                "https://[::1]:8000",
+                "https://[0:0:0:0:0:0:0:1]", // this is [::1]
+            ],
+            vec!["https://[0:0:0:0:0:0:1:1]", "https://example.com"],
+            vec!["[::1]", "[0:0:0:0:0:0:0:1]"],
+            vec!["[0:0:0:0:0:0:1:2]"],
+        );
     }
 }

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -1327,6 +1327,11 @@ mod tests {
                 "http://sub.example.com:8080",
                 "https://sub.example.com:8080",
                 "https://sub.sub.example.com",
+                "ftp://sub.example.com",
+                // Handling file:// is questionable - it would also be fine to
+                // not handle it! It's left here more to document the fact that
+                // we do!
+                "file://example.com",
             ],
             vec![
                 "https://badexample.com",

--- a/components/logins/src/engine.rs
+++ b/components/logins/src/engine.rs
@@ -44,8 +44,8 @@ impl PasswordEngine {
         self.db.get_by_id(id)
     }
 
-    pub fn get_by_hostname(&self, hostname: &str) -> Result<Vec<Login>> {
-        self.db.get_by_hostname(hostname)
+    pub fn get_by_base_domain(&self, base_domain: &str) -> Result<Vec<Login>> {
+        self.db.get_by_base_domain(base_domain)
     }
 
     pub fn touch(&self, id: &str) -> Result<()> {
@@ -244,13 +244,13 @@ mod test {
         assert_eq!(list[0], b_from_db);
 
         let list = engine
-            .get_by_hostname("https://www.example2.com")
+            .get_by_base_domain("example2.com")
             .expect("Expect a list for this hostname");
         assert_eq!(list.len(), 1);
         assert_eq!(list[0], b_from_db);
 
         let list = engine
-            .get_by_hostname("https://www.example.com")
+            .get_by_base_domain("www.example.com")
             .expect("Expect an empty list");
         assert_eq!(list.len(), 0);
 


### PR DESCRIPTION
Just checking out approaches. I don't think we can get sqlite's LIKE to
do the right thing, but it appears we could wire up an arbitrary regexp
user function and have that work, or even just our own custom
user function specifically for this case. If we didn't use a regexp,
this is the best way I can see to implement what we need, but that's
almost certainly naive.

So just getting this up for comment before my weekend starts so I can
make more productive progress Monday.

(FWIW, I can't find any consumers of get_by_hostname() so was planning
on killing that. LMK if that still sounds ok.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
