### PR TITLE
Fix typo in dependendency summary script

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -49,7 +49,7 @@ the details of which are reproduced below.
 -------------
 ## Mozilla Public License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [NSPR](https://hg.mozilla.org/projects/nspr),
 [NSS](https://hg.mozilla.org/projects/nss),
 [ece](https://github.com/mozilla/rust-ece),
@@ -434,7 +434,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 -------------
 ## Apache License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [autocfg](https://github.com/cuviper/autocfg),
 [backtrace-sys](https://github.com/alexcrichton/backtrace-rs),
 [backtrace](https://github.com/rust-lang/backtrace-rs),
@@ -775,7 +775,7 @@ limitations under the License.
 -------------
 ## MIT License: aho-corasick, byteorder, memchr, termcolor
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
 [memchr](https://github.com/BurntSushi/rust-memchr),
@@ -808,7 +808,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: ansi_term
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
@@ -838,7 +838,7 @@ SOFTWARE.
 -------------
 ## MIT License: atty
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [atty](https://github.com/softprops/atty)
 
 ```
@@ -867,7 +867,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: bincode
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bincode](https://github.com/servo/bincode)
 
 ```
@@ -897,7 +897,7 @@ SOFTWARE.
 -------------
 ## MIT License: bytes
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bytes](https://github.com/carllerche/bytes)
 
 ```
@@ -931,7 +931,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: caseless
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [caseless](https://github.com/SimonSapin/rust-caseless)
 
 ```
@@ -962,7 +962,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: clap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [clap](https://github.com/clap-rs/clap)
 
 ```
@@ -992,7 +992,7 @@ SOFTWARE.
 -------------
 ## MIT License: h2
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [h2](https://github.com/hyperium/h2)
 
 ```
@@ -1026,7 +1026,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: http-body
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [http-body](https://github.com/hyperium/http-body)
 
 ```
@@ -1060,7 +1060,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: hyper
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [hyper](https://github.com/hyperium/hyper)
 
 ```
@@ -1089,7 +1089,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: kernel32-sys, winapi-build, ws2_32-sys
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [kernel32-sys](https://github.com/retep998/winapi-rs),
 [winapi-build](https://github.com/retep998/winapi-rs),
 [ws2_32-sys](https://github.com/retep998/winapi-rs)
@@ -1119,7 +1119,7 @@ SOFTWARE.
 -------------
 ## MIT License: libsqlite3-sys, rusqlite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libsqlite3-sys](https://github.com/jgallagher/rusqlite),
 [rusqlite](https://github.com/jgallagher/rusqlite)
 
@@ -1148,7 +1148,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: matches
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [matches](https://github.com/SimonSapin/rust-std-candidates)
 
 ```
@@ -1182,7 +1182,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: memoffset
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [memoffset](https://github.com/Gilnaa/memoffset)
 
 ```
@@ -1209,7 +1209,7 @@ SOFTWARE.
 -------------
 ## MIT License: mime_guess
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [mime_guess](https://github.com/abonander/mime_guess)
 
 ```
@@ -1240,7 +1240,7 @@ SOFTWARE.
 -------------
 ## MIT License: miniz_oxide
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [miniz_oxide](https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide)
 
 ```
@@ -1270,7 +1270,7 @@ SOFTWARE.
 -------------
 ## MIT License: mio
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [mio](https://github.com/carllerche/mio)
 
 ```
@@ -1298,7 +1298,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: nom
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [nom](https://github.com/Geal/nom)
 
 ```
@@ -1327,7 +1327,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: openssl-sys
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [openssl-sys](https://github.com/sfackler/rust-openssl)
 
 ```
@@ -1361,7 +1361,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: schannel
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [schannel](https://github.com/steffengy/schannel-rs)
 
 ```
@@ -1377,7 +1377,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 -------------
 ## MIT License: slab, string
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [slab](https://github.com/carllerche/slab),
 [string](https://github.com/carllerche/string)
 
@@ -1412,7 +1412,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: strsim
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [strsim](https://github.com/dguo/strsim-rs)
 
 ```
@@ -1444,7 +1444,7 @@ SOFTWARE.
 -------------
 ## MIT License: synstructure
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [synstructure](https://github.com/mystor/synstructure)
 
 ```
@@ -1460,7 +1460,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 -------------
 ## MIT License: textwrap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [textwrap](https://github.com/mgeisler/textwrap)
 
 ```
@@ -1490,7 +1490,7 @@ SOFTWARE.
 -------------
 ## MIT License: tokio, tokio-buf, tokio-current-thread, tokio-executor, tokio-io, tokio-reactor, tokio-sync, tokio-tcp, tokio-threadpool, tokio-timer
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [tokio-buf](https://github.com/tokio-rs/tokio),
 [tokio-current-thread](https://github.com/tokio-rs/tokio),
 [tokio-executor](https://github.com/tokio-rs/tokio),
@@ -1533,7 +1533,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: try-lock
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [try-lock](https://github.com/seanmonstar/try-lock)
 
 ```
@@ -1563,7 +1563,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: try_from
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [try_from](https://github.com/derekjw/try_from)
 
 ```
@@ -1593,7 +1593,7 @@ SOFTWARE.
 -------------
 ## MIT License: want
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [want](https://github.com/seanmonstar/want)
 
 ```
@@ -1622,7 +1622,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: which
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [which](https://github.com/harryfei/which-rs.git)
 
 ```
@@ -1650,7 +1650,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: winapi
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [winapi](https://github.com/retep998/winapi-rs)
 
 ```
@@ -1680,7 +1680,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: winreg
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [winreg](https://github.com/gentoo90/winreg-rs)
 
 ```
@@ -1708,7 +1708,7 @@ THE SOFTWARE.
 -------------
 ## CC0-1.0 License: base16
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [base16](https://github.com/thomcc/rust-base16)
 
 ```
@@ -1838,7 +1838,7 @@ express Statement of Purpose.
 -------------
 ## ISC License: libloading
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libloading](https://github.com/nagisa/rust_libloading/)
 
 ```
@@ -1859,7 +1859,7 @@ THIS SOFTWARE.
 -------------
 ## ISC License: ring
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ring](https://github.com/briansmith/ring)
 
 ```
@@ -1882,7 +1882,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 -------------
 ## BSD-3-Clause License: bindgen
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bindgen](https://github.com/rust-lang/rust-bindgen)
 
 ```
@@ -1920,7 +1920,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## BSD-3-Clause License: protobuf
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [protobuf](https://github.com/protocolbuffers/protobuf)
 
 ```
@@ -1961,7 +1961,7 @@ support library is itself covered by the above license.
 -------------
 ## BSD-3-Clause License: sqlcipher
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlcipher](https://github.com/sqlcipher/sqlcipher)
 
 ```
@@ -1994,7 +1994,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## Zlib License: adler32
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [adler32](https://github.com/remram44/adler32-rs)
 
 ```
@@ -2046,7 +2046,7 @@ Copyright notice for the original C code from the zlib project:
 -------------
 ## OpenSSL License
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [openssl](https://www.openssl.org/source/)
 
 ```
@@ -2180,7 +2180,7 @@ The following text applies to code linked from these dependendencies:
 -------------
 ## Optional Notice: SQLite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlite](https://www.sqlite.org/)
 
 ```

--- a/megazords/fenix/DEPENDENCIES.md
+++ b/megazords/fenix/DEPENDENCIES.md
@@ -30,7 +30,7 @@ the details of which are reproduced below.
 -------------
 ## Mozilla Public License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [NSPR](https://hg.mozilla.org/projects/nspr),
 [NSS](https://hg.mozilla.org/projects/nss),
 [ece](https://github.com/mozilla/rust-ece),
@@ -415,7 +415,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 -------------
 ## Apache License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [autocfg](https://github.com/cuviper/autocfg),
 [backtrace-sys](https://github.com/alexcrichton/backtrace-rs),
 [backtrace](https://github.com/rust-lang/backtrace-rs),
@@ -718,7 +718,7 @@ limitations under the License.
 -------------
 ## MIT License: aho-corasick, byteorder, memchr, termcolor
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
 [memchr](https://github.com/BurntSushi/rust-memchr),
@@ -751,7 +751,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: ansi_term
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
@@ -781,7 +781,7 @@ SOFTWARE.
 -------------
 ## MIT License: atty
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [atty](https://github.com/softprops/atty)
 
 ```
@@ -810,7 +810,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: bincode
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bincode](https://github.com/servo/bincode)
 
 ```
@@ -840,7 +840,7 @@ SOFTWARE.
 -------------
 ## MIT License: bytes
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bytes](https://github.com/carllerche/bytes)
 
 ```
@@ -874,7 +874,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: caseless
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [caseless](https://github.com/SimonSapin/rust-caseless)
 
 ```
@@ -905,7 +905,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: clap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [clap](https://github.com/clap-rs/clap)
 
 ```
@@ -935,7 +935,7 @@ SOFTWARE.
 -------------
 ## MIT License: libsqlite3-sys, rusqlite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libsqlite3-sys](https://github.com/jgallagher/rusqlite),
 [rusqlite](https://github.com/jgallagher/rusqlite)
 
@@ -964,7 +964,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: matches
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [matches](https://github.com/SimonSapin/rust-std-candidates)
 
 ```
@@ -998,7 +998,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: nom
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [nom](https://github.com/Geal/nom)
 
 ```
@@ -1027,7 +1027,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: strsim
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [strsim](https://github.com/dguo/strsim-rs)
 
 ```
@@ -1059,7 +1059,7 @@ SOFTWARE.
 -------------
 ## MIT License: synstructure
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [synstructure](https://github.com/mystor/synstructure)
 
 ```
@@ -1075,7 +1075,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 -------------
 ## MIT License: textwrap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [textwrap](https://github.com/mgeisler/textwrap)
 
 ```
@@ -1105,7 +1105,7 @@ SOFTWARE.
 -------------
 ## MIT License: which
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [which](https://github.com/harryfei/which-rs.git)
 
 ```
@@ -1133,7 +1133,7 @@ THE SOFTWARE.
 -------------
 ## CC0-1.0 License: base16
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [base16](https://github.com/thomcc/rust-base16)
 
 ```
@@ -1263,7 +1263,7 @@ express Statement of Purpose.
 -------------
 ## ISC License: libloading
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libloading](https://github.com/nagisa/rust_libloading/)
 
 ```
@@ -1284,7 +1284,7 @@ THIS SOFTWARE.
 -------------
 ## ISC License: ring
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ring](https://github.com/briansmith/ring)
 
 ```
@@ -1307,7 +1307,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 -------------
 ## BSD-3-Clause License: bindgen
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bindgen](https://github.com/rust-lang/rust-bindgen)
 
 ```
@@ -1345,7 +1345,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## BSD-3-Clause License: protobuf
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [protobuf](https://github.com/protocolbuffers/protobuf)
 
 ```
@@ -1386,7 +1386,7 @@ support library is itself covered by the above license.
 -------------
 ## BSD-3-Clause License: sqlcipher
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlcipher](https://github.com/sqlcipher/sqlcipher)
 
 ```
@@ -1419,7 +1419,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## Optional Notice: SQLite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlite](https://www.sqlite.org/)
 
 ```

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -30,7 +30,7 @@ the details of which are reproduced below.
 -------------
 ## Mozilla Public License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [NSPR](https://hg.mozilla.org/projects/nspr),
 [NSS](https://hg.mozilla.org/projects/nss),
 [ece](https://github.com/mozilla/rust-ece),
@@ -415,7 +415,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 -------------
 ## Apache License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [autocfg](https://github.com/cuviper/autocfg),
 [backtrace-sys](https://github.com/alexcrichton/backtrace-rs),
 [backtrace](https://github.com/rust-lang/backtrace-rs),
@@ -718,7 +718,7 @@ limitations under the License.
 -------------
 ## MIT License: aho-corasick, byteorder, memchr, termcolor
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
 [memchr](https://github.com/BurntSushi/rust-memchr),
@@ -751,7 +751,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: ansi_term
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
@@ -781,7 +781,7 @@ SOFTWARE.
 -------------
 ## MIT License: atty
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [atty](https://github.com/softprops/atty)
 
 ```
@@ -810,7 +810,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: bincode
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bincode](https://github.com/servo/bincode)
 
 ```
@@ -840,7 +840,7 @@ SOFTWARE.
 -------------
 ## MIT License: bytes
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bytes](https://github.com/carllerche/bytes)
 
 ```
@@ -874,7 +874,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: caseless
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [caseless](https://github.com/SimonSapin/rust-caseless)
 
 ```
@@ -905,7 +905,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: clap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [clap](https://github.com/clap-rs/clap)
 
 ```
@@ -935,7 +935,7 @@ SOFTWARE.
 -------------
 ## MIT License: libsqlite3-sys, rusqlite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libsqlite3-sys](https://github.com/jgallagher/rusqlite),
 [rusqlite](https://github.com/jgallagher/rusqlite)
 
@@ -964,7 +964,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: matches
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [matches](https://github.com/SimonSapin/rust-std-candidates)
 
 ```
@@ -998,7 +998,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: nom
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [nom](https://github.com/Geal/nom)
 
 ```
@@ -1027,7 +1027,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: strsim
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [strsim](https://github.com/dguo/strsim-rs)
 
 ```
@@ -1059,7 +1059,7 @@ SOFTWARE.
 -------------
 ## MIT License: synstructure
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [synstructure](https://github.com/mystor/synstructure)
 
 ```
@@ -1075,7 +1075,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 -------------
 ## MIT License: textwrap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [textwrap](https://github.com/mgeisler/textwrap)
 
 ```
@@ -1105,7 +1105,7 @@ SOFTWARE.
 -------------
 ## MIT License: which
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [which](https://github.com/harryfei/which-rs.git)
 
 ```
@@ -1133,7 +1133,7 @@ THE SOFTWARE.
 -------------
 ## CC0-1.0 License: base16
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [base16](https://github.com/thomcc/rust-base16)
 
 ```
@@ -1263,7 +1263,7 @@ express Statement of Purpose.
 -------------
 ## ISC License: libloading
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libloading](https://github.com/nagisa/rust_libloading/)
 
 ```
@@ -1284,7 +1284,7 @@ THIS SOFTWARE.
 -------------
 ## ISC License: ring
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ring](https://github.com/briansmith/ring)
 
 ```
@@ -1307,7 +1307,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 -------------
 ## BSD-3-Clause License: bindgen
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bindgen](https://github.com/rust-lang/rust-bindgen)
 
 ```
@@ -1345,7 +1345,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## BSD-3-Clause License: protobuf
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [protobuf](https://github.com/protocolbuffers/protobuf)
 
 ```
@@ -1386,7 +1386,7 @@ support library is itself covered by the above license.
 -------------
 ## BSD-3-Clause License: sqlcipher
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlcipher](https://github.com/sqlcipher/sqlcipher)
 
 ```
@@ -1419,7 +1419,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## Optional Notice: SQLite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlite](https://www.sqlite.org/)
 
 ```

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -41,7 +41,7 @@ the details of which are reproduced below.
 -------------
 ## Mozilla Public License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [NSPR](https://hg.mozilla.org/projects/nspr),
 [NSS](https://hg.mozilla.org/projects/nss),
 [ece](https://github.com/mozilla/rust-ece),
@@ -426,7 +426,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 -------------
 ## Apache License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [autocfg](https://github.com/cuviper/autocfg),
 [backtrace-sys](https://github.com/alexcrichton/backtrace-rs),
 [backtrace](https://github.com/rust-lang/backtrace-rs),
@@ -758,7 +758,7 @@ limitations under the License.
 -------------
 ## MIT License: aho-corasick, byteorder, memchr, termcolor
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
 [memchr](https://github.com/BurntSushi/rust-memchr),
@@ -791,7 +791,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: ansi_term
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
@@ -821,7 +821,7 @@ SOFTWARE.
 -------------
 ## MIT License: atty
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [atty](https://github.com/softprops/atty)
 
 ```
@@ -850,7 +850,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: bytes
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bytes](https://github.com/carllerche/bytes)
 
 ```
@@ -884,7 +884,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: caseless
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [caseless](https://github.com/SimonSapin/rust-caseless)
 
 ```
@@ -915,7 +915,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: clap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [clap](https://github.com/clap-rs/clap)
 
 ```
@@ -945,7 +945,7 @@ SOFTWARE.
 -------------
 ## MIT License: h2
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [h2](https://github.com/hyperium/h2)
 
 ```
@@ -979,7 +979,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: http-body
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [http-body](https://github.com/hyperium/http-body)
 
 ```
@@ -1013,7 +1013,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: hyper
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [hyper](https://github.com/hyperium/hyper)
 
 ```
@@ -1042,7 +1042,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: libsqlite3-sys, rusqlite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libsqlite3-sys](https://github.com/jgallagher/rusqlite),
 [rusqlite](https://github.com/jgallagher/rusqlite)
 
@@ -1071,7 +1071,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: matches
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [matches](https://github.com/SimonSapin/rust-std-candidates)
 
 ```
@@ -1105,7 +1105,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: memoffset
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [memoffset](https://github.com/Gilnaa/memoffset)
 
 ```
@@ -1132,7 +1132,7 @@ SOFTWARE.
 -------------
 ## MIT License: mime_guess
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [mime_guess](https://github.com/abonander/mime_guess)
 
 ```
@@ -1163,7 +1163,7 @@ SOFTWARE.
 -------------
 ## MIT License: miniz_oxide
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [miniz_oxide](https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide)
 
 ```
@@ -1193,7 +1193,7 @@ SOFTWARE.
 -------------
 ## MIT License: mio
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [mio](https://github.com/carllerche/mio)
 
 ```
@@ -1221,7 +1221,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: nom
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [nom](https://github.com/Geal/nom)
 
 ```
@@ -1250,7 +1250,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: slab, string
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [slab](https://github.com/carllerche/slab),
 [string](https://github.com/carllerche/string)
 
@@ -1285,7 +1285,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: strsim
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [strsim](https://github.com/dguo/strsim-rs)
 
 ```
@@ -1317,7 +1317,7 @@ SOFTWARE.
 -------------
 ## MIT License: synstructure
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [synstructure](https://github.com/mystor/synstructure)
 
 ```
@@ -1333,7 +1333,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 -------------
 ## MIT License: textwrap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [textwrap](https://github.com/mgeisler/textwrap)
 
 ```
@@ -1363,7 +1363,7 @@ SOFTWARE.
 -------------
 ## MIT License: tokio, tokio-buf, tokio-current-thread, tokio-executor, tokio-io, tokio-reactor, tokio-sync, tokio-tcp, tokio-threadpool, tokio-timer
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [tokio-buf](https://github.com/tokio-rs/tokio),
 [tokio-current-thread](https://github.com/tokio-rs/tokio),
 [tokio-executor](https://github.com/tokio-rs/tokio),
@@ -1406,7 +1406,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: try-lock
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [try-lock](https://github.com/seanmonstar/try-lock)
 
 ```
@@ -1436,7 +1436,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: try_from
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [try_from](https://github.com/derekjw/try_from)
 
 ```
@@ -1466,7 +1466,7 @@ SOFTWARE.
 -------------
 ## MIT License: want
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [want](https://github.com/seanmonstar/want)
 
 ```
@@ -1495,7 +1495,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: which
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [which](https://github.com/harryfei/which-rs.git)
 
 ```
@@ -1523,7 +1523,7 @@ THE SOFTWARE.
 -------------
 ## CC0-1.0 License: base16
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [base16](https://github.com/thomcc/rust-base16)
 
 ```
@@ -1653,7 +1653,7 @@ express Statement of Purpose.
 -------------
 ## ISC License: libloading
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libloading](https://github.com/nagisa/rust_libloading/)
 
 ```
@@ -1674,7 +1674,7 @@ THIS SOFTWARE.
 -------------
 ## ISC License: ring
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ring](https://github.com/briansmith/ring)
 
 ```
@@ -1697,7 +1697,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 -------------
 ## BSD-3-Clause License: bindgen
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bindgen](https://github.com/rust-lang/rust-bindgen)
 
 ```
@@ -1735,7 +1735,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## BSD-3-Clause License: sqlcipher
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlcipher](https://github.com/sqlcipher/sqlcipher)
 
 ```
@@ -1768,7 +1768,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## Zlib License: adler32
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [adler32](https://github.com/remram44/adler32-rs)
 
 ```
@@ -1820,7 +1820,7 @@ Copyright notice for the original C code from the zlib project:
 -------------
 ## Optional Notice: SQLite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlite](https://www.sqlite.org/)
 
 ```

--- a/megazords/lockbox/DEPENDENCIES.md
+++ b/megazords/lockbox/DEPENDENCIES.md
@@ -28,7 +28,7 @@ the details of which are reproduced below.
 -------------
 ## Mozilla Public License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [NSPR](https://hg.mozilla.org/projects/nspr),
 [NSS](https://hg.mozilla.org/projects/nss),
 [ece](https://github.com/mozilla/rust-ece),
@@ -413,7 +413,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 -------------
 ## Apache License 2.0
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [autocfg](https://github.com/cuviper/autocfg),
 [backtrace-sys](https://github.com/alexcrichton/backtrace-rs),
 [backtrace](https://github.com/rust-lang/backtrace-rs),
@@ -713,7 +713,7 @@ limitations under the License.
 -------------
 ## MIT License: aho-corasick, byteorder, memchr, termcolor
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
 [memchr](https://github.com/BurntSushi/rust-memchr),
@@ -746,7 +746,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: ansi_term
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ansi_term](https://github.com/ogham/rust-ansi-term)
 
 ```
@@ -776,7 +776,7 @@ SOFTWARE.
 -------------
 ## MIT License: atty
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [atty](https://github.com/softprops/atty)
 
 ```
@@ -805,7 +805,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: bytes
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bytes](https://github.com/carllerche/bytes)
 
 ```
@@ -839,7 +839,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: clap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [clap](https://github.com/clap-rs/clap)
 
 ```
@@ -869,7 +869,7 @@ SOFTWARE.
 -------------
 ## MIT License: libsqlite3-sys, rusqlite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libsqlite3-sys](https://github.com/jgallagher/rusqlite),
 [rusqlite](https://github.com/jgallagher/rusqlite)
 
@@ -898,7 +898,7 @@ THE SOFTWARE.
 -------------
 ## MIT License: matches
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [matches](https://github.com/SimonSapin/rust-std-candidates)
 
 ```
@@ -932,7 +932,7 @@ DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: nom
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [nom](https://github.com/Geal/nom)
 
 ```
@@ -961,7 +961,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------
 ## MIT License: strsim
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [strsim](https://github.com/dguo/strsim-rs)
 
 ```
@@ -993,7 +993,7 @@ SOFTWARE.
 -------------
 ## MIT License: synstructure
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [synstructure](https://github.com/mystor/synstructure)
 
 ```
@@ -1009,7 +1009,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 -------------
 ## MIT License: textwrap
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [textwrap](https://github.com/mgeisler/textwrap)
 
 ```
@@ -1039,7 +1039,7 @@ SOFTWARE.
 -------------
 ## MIT License: which
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [which](https://github.com/harryfei/which-rs.git)
 
 ```
@@ -1067,7 +1067,7 @@ THE SOFTWARE.
 -------------
 ## CC0-1.0 License: base16
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [base16](https://github.com/thomcc/rust-base16)
 
 ```
@@ -1197,7 +1197,7 @@ express Statement of Purpose.
 -------------
 ## ISC License: libloading
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [libloading](https://github.com/nagisa/rust_libloading/)
 
 ```
@@ -1218,7 +1218,7 @@ THIS SOFTWARE.
 -------------
 ## ISC License: ring
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [ring](https://github.com/briansmith/ring)
 
 ```
@@ -1241,7 +1241,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 -------------
 ## BSD-3-Clause License: bindgen
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [bindgen](https://github.com/rust-lang/rust-bindgen)
 
 ```
@@ -1279,7 +1279,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## BSD-3-Clause License: protobuf
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [protobuf](https://github.com/protocolbuffers/protobuf)
 
 ```
@@ -1320,7 +1320,7 @@ support library is itself covered by the above license.
 -------------
 ## BSD-3-Clause License: sqlcipher
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlcipher](https://github.com/sqlcipher/sqlcipher)
 
 ```
@@ -1353,7 +1353,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 -------------
 ## Optional Notice: SQLite
 
-The following text applies to code linked from these dependendencies:
+The following text applies to code linked from these dependencies:
 [sqlite](https://www.sqlite.org/)
 
 ```

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3 
+#!/usr/bin/env python3
 #
 # This script can be used to generate a summary of our third-party dependencies,
 # including license details. Use it like this:
@@ -937,7 +937,7 @@ def print_dependency_summary_markdown(deps, file=sys.stdout):
                 for info in section["dependencies"]]
         # Dedupe in case of multiple versons of dependencies.
         pkgs = sorted(set(pkgs))
-        pf("The following text applies to code linked from these dependendencies:\n{}", ",\n".join(pkgs))
+        pf("The following text applies to code linked from these dependencies:\n{}", ",\n".join(pkgs))
         pf("")
         pf("```")
         assert "```" not in section["license_text"]


### PR DESCRIPTION
This is https://github.com/mozilla/application-services/pull/2358 squashed into a single, signed commit.