### PR TITLE
Cut release 0.45.1

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 0.45.0
+libraryVersion: 0.45.1
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.45.1 (_2019-12-10_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.45.0...v0.45.1)
+
+This release exists only to rectify a publishing error that occurred with v0.45.0.
+
 # v0.45.0 (_2019-12-10_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.44.0...v0.45.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.45.0...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.45.1...master)


### PR DESCRIPTION
There was a transient problem while publishing v0.45.0: https://firefox-ci-tc.services.mozilla.com/tasks/ckR4pnkfR4acfnPXKnhsRA