### PR TITLE
Cut release 0.46.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 0.45.1
+libraryVersion: 0.46.0
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# v0.46.0 (_2019-12-12_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.45.1...v0.46.0)
+
+## Logins
+
+### Breaking Changes
+
+- The Android bindings now collect some basic performance and quality metrics via Glean.
+  Applications that submit telemetry via Glean must request a data review for these metrics
+  before integrating the logins component. See the component README.md for more details.
+  ([#2225](https://github.com/mozilla/application-services/pull/2225))
+- `username`, `usernameField`, and `passwordField` are no longer
+  serialized as `null` in the case where they are empty strings. ([#2252](https://github.com/mozilla/application-services/pull/2252))
+  - Android: `ServerPassword` fields `username`, `usernameField`, and
+    `passwordField` are now required fields -- `null` is not acceptable,
+    but empty strings are OK.
+  - iOS: `LoginRecord` fields `username`, `usernameField` and
+    `passwordField` are no longer nullable.
+
 # v0.45.1 (_2019-12-10_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.45.0...v0.45.1)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,20 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.45.1...master)
-
-## Logins
-
-### Breaking Changes
-
-- The Android bindings now collect some basic performance and quality metrics via Glean.
-  Applications that submit telemetry via Glean must request a data review for these metrics
-  before integrating the logins component. See the component README.md for more details.
-  ([#2225](https://github.com/mozilla/application-services/pull/2225))
-- `username`, `usernameField`, and `passwordField` are no longer
-  serialized as `null` in the case where they are empty strings. ([#2252](https://github.com/mozilla/application-services/pull/2252))
-  - Android: `ServerPassword` fields `username`, `usernameField`, and
-    `passwordField` are now required fields -- `null` is not acceptable,
-    but empty strings are OK.
-  - iOS: `LoginRecord` fields `username`, `usernameField` and
-    `passwordField` are no longer nullable.
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.46.0...master)


### PR DESCRIPTION
This has a couple of breaking changes to logins (including new metrics) so I want to get them released and merged into upstream before paging the context out of my head.