### PR TITLE
Add OriginWasOpaque

### DIFF
--- a/components/remerge/src/error.rs
+++ b/components/remerge/src/error.rs
@@ -66,6 +66,8 @@ pub enum InvalidRecord {
     WrongFieldType(String, crate::schema::FieldKind),
     #[fail(display = "The field {:?} must parse as a valid url", _0)]
     NotUrl(String),
+    #[fail(display = "The field {:?} must have a non-opaque origin", _0)]
+    OriginWasOpaque(String),
     #[fail(display = "The field {:?} is out of the required bounds", _0)]
     OutOfBounds(String),
     #[fail(display = "The field {:?} is not a valid record_set", _0)]

--- a/components/remerge/src/error.rs
+++ b/components/remerge/src/error.rs
@@ -68,6 +68,8 @@ pub enum InvalidRecord {
     NotUrl(String),
     #[fail(display = "The field {:?} must have a non-opaque origin", _0)]
     OriginWasOpaque(String),
+    #[fail(display = "The field {:?} has more URL parts than just an origin", _0)]
+    UrlWasNotOrigin(String),
     #[fail(display = "The field {:?} is out of the required bounds", _0)]
     OutOfBounds(String),
     #[fail(display = "The field {:?} is not a valid record_set", _0)]

--- a/components/remerge/src/schema/desc.rs
+++ b/components/remerge/src/schema/desc.rs
@@ -128,9 +128,9 @@ impl Field {
                         if *is_origin {
                             let o = url.origin();
                             if !o.is_tuple() {
-                                // XXX Should have a special error for 'not an origin'
-                                throw!(NotUrl(self.name.clone()));
+                                throw!(OriginWasOpaque(self.name.clone()));
                             }
+                            // Truncate value to just origin
                             Ok(o.ascii_serialization().into())
                         } else {
                             Ok(url.to_string().into())

--- a/components/remerge/src/schema/desc.rs
+++ b/components/remerge/src/schema/desc.rs
@@ -130,6 +130,14 @@ impl Field {
                             if !o.is_tuple() {
                                 throw!(OriginWasOpaque(self.name.clone()));
                             }
+                            if url.username() != ""
+                                || url.password().is_some()
+                                || url.path() != "/"
+                                || url.query().is_some()
+                                || url.fragment().is_some()
+                            {
+                                throw!(UrlWasNotOrigin(self.name.clone()));
+                            }
                             // Truncate value to just origin
                             Ok(o.ascii_serialization().into())
                         } else {

--- a/docs/design/remerge/schema-format.md
+++ b/docs/design/remerge/schema-format.md
@@ -188,8 +188,10 @@ URLs may use the following merge strategies:
 
 ### Options
 
-- `is_origin`: Optional bool to indicate that only the origin of this URL is
-  significant, and the rest should be discarded. Defaults to false.
+- `is_origin`: Optional bool to indicate that this field only stores
+  origins, not full URLs. A URL that contains information besides the
+  origin (e.g. username, password, path, query or fragment) will be
+  rejected for this field. Defaults to false.
 
 - `default`: Optional default value.
 


### PR DESCRIPTION
Fixes #2232.

This PR is based on the `remerge-storage` branch (from PR #2226).

My understanding of #2232 is that we should customize the error for the opaque-origin case and leave the silent-truncation-of-URLs behavior alone, but I'm happy to change it so that it throws when a URL is not just an origin (which is what I would have expected).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - Tests have not yet been written in the underlying PR.
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
  - Any changelog entry in the underlying PR will be sufficient for this error as well.
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - No new dependencies were added.
