### PR TITLE
Run clippy/rustfmt under 1.39 istead of latest, given that we don't use latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,8 @@ jobs:
       - image: circleci/rust:1.38
     steps:
       - checkout
-      - setup-rust-toolchain
+      - setup-rust-toolchain:
+          rust-version: 1.38.0
       - run: rustup component add rustfmt
       - run: rustfmt --version
       - run: cargo fmt -- --check
@@ -253,7 +254,8 @@ jobs:
     docker:
       - image: circleci/rust:1.38
     steps:
-      - test-setup
+      - test-setup:
+          rust-version: 1.38.0
       - run: rustup component add clippy
       - run: cargo clippy --version
       - run: cargo clippy --all --all-targets --all-features -- -D warnings

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ jobs:
       - run: swiftformat megazords components/*/ios --lint --swiftversion 4 --verbose
   Check Rust formatting:
     docker:
-      - image: circleci/rust:latest
+      - image: circleci/rust:1.39
     steps:
       - checkout
       - setup-rust-toolchain
@@ -251,7 +251,7 @@ jobs:
       - run: cargo fmt -- --check
   Lint Rust with clippy:
     docker:
-      - image: circleci/rust:latest
+      - image: circleci/rust:1.39
     steps:
       - test-setup
       - run: rustup component add clippy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ jobs:
       - run: swiftformat megazords components/*/ios --lint --swiftversion 4 --verbose
   Check Rust formatting:
     docker:
-      - image: circleci/rust:1.39
+      - image: circleci/rust:1.38
     steps:
       - checkout
       - setup-rust-toolchain
@@ -251,7 +251,7 @@ jobs:
       - run: cargo fmt -- --check
   Lint Rust with clippy:
     docker:
-      - image: circleci/rust:1.39
+      - image: circleci/rust:1.38
     steps:
       - test-setup
       - run: rustup component add clippy

--- a/components/sync15/src/token.rs
+++ b/components/sync15/src/token.rs
@@ -371,9 +371,7 @@ impl<TF: TokenFetcher> TokenProviderImpl<TF> {
                 // this is unrecoverable.
                 Err(ErrorKind::StorageResetError.into())
             }
-            TokenState::Backoff(ref remaining, _) => {
-                Err(ErrorKind::BackoffError(*remaining).into())
-            }
+            TokenState::Backoff(ref remaining, _) => Err(ErrorKind::BackoffError(*remaining).into()),
         }
     }
 


### PR DESCRIPTION
We should really fix this soon, but there's no reason to have failing CI jobs until we do.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
