### PR TITLE
Use numeric versions instead of semver for schema versions

### DIFF
--- a/components/remerge/sql/schema.sql
+++ b/components/remerge/sql/schema.sql
@@ -7,11 +7,11 @@ CREATE TABLE remerge_schemas (
     is_legacy        TINYINT NOT NULL,
 
     -- The version of this schema
-    version          TEXT NOT NULL UNIQUE,
+    version          INTEGER NOT NULL UNIQUE,
 
     -- If the schema is marked as having a required version, this is that
     -- version
-    required_version TEXT,
+    required_version INTEGER,
 
     -- The schema's text as JSON.
     schema_text      TEXT NOT NULL
@@ -22,7 +22,7 @@ CREATE TABLE rec_local (
     id             INTEGER PRIMARY KEY,
     guid           TEXT NOT NULL UNIQUE,
 
-    remerge_schema_version TEXT,
+    remerge_schema_version INTEGER NOT NULL,
     -- XXX Should this be nullable for the case where is_deleted == true?
     record_data    TEXT NOT NULL,
     -- A local timestamp

--- a/components/remerge/src/engine.rs
+++ b/components/remerge/src/engine.rs
@@ -72,7 +72,7 @@ mod test {
 
     lazy_static::lazy_static! {
         pub static ref SCHEMA: String = json!({
-            "version": "1.0.0",
+            "version": 1,
             "name": "logins-example",
             "legacy": true,
             "fields": [

--- a/components/remerge/src/schema/desc.rs
+++ b/components/remerge/src/schema/desc.rs
@@ -25,8 +25,8 @@ index_vec::define_index_type! {
 #[derive(Clone, Debug, PartialEq)]
 pub struct RecordSchema {
     pub name: String,
-    pub version: semver::Version,
-    pub required_version: semver::VersionReq,
+    pub version: u32,
+    pub required_version: u32,
 
     pub remerge_features_used: Vec<String>,
 

--- a/components/remerge/src/schema/error.rs
+++ b/components/remerge/src/schema/error.rs
@@ -110,22 +110,6 @@ impl std::fmt::Display for BadRecordSetDefaultKind {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SemverProp {
-    Version,
-    RequiredVersion,
-}
-
-impl std::fmt::Display for SemverProp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use SemverProp::*;
-        match self {
-            Version => f.write_str("version"),
-            RequiredVersion => f.write_str("required_version"),
-        }
-    }
-}
-
 #[derive(Debug, Fail)]
 pub enum SchemaError {
     #[fail(display = "Schema format error: {}", _0)]
@@ -135,32 +119,10 @@ pub enum SchemaError {
     WrongFormatVersion(usize),
 
     #[fail(
-        display = "Failed to parse semantic version string {:?} from property '{}': {}",
-        got, prop, err
-    )]
-    VersionParseFailed {
-        prop: SemverProp,
-        got: String,
-        #[fail(cause)]
-        err: semver::SemVerError,
-    },
-
-    #[fail(
-        display = "Failed to parse semantic version requirement {:?} from property '{}': {}",
-        got, prop, err
-    )]
-    VersionReqParseFailed {
-        prop: SemverProp,
-        got: String,
-        #[fail(cause)]
-        err: semver::ReqParseError,
-    },
-
-    #[fail(
         display = "Schema required_version '{}' and version '{}' are not compatible.",
         _0, _1
     )]
-    LocalRequiredVersionNotCompatible(semver::VersionReq, semver::Version),
+    LocalRequiredVersionNotCompatible(u32, u32),
 
     #[fail(
         display = "Remerge feature {} is required but not supported locally",

--- a/components/remerge/src/storage/bootstrap.rs
+++ b/components/remerge/src/storage/bootstrap.rs
@@ -72,18 +72,18 @@ pub(super) fn bootstrap(
         INSERT INTO remerge_schemas (is_legacy, version, required_version, schema_text)
         VALUES (:legacy, :version, :req_version, :text)
     ";
-    let ver_str = native.parsed.version.to_string();
+    let version = native.parsed.version;
     db.execute_named(
         sql,
         rusqlite::named_params! {
             ":legacy": native.parsed.legacy,
-            ":version": ver_str,
-            ":req_version": native.parsed.required_version.to_string(),
+            ":version": version,
+            ":req_version": native.parsed.required_version,
             ":text": native.source,
         },
     )?;
-    meta::put(db, meta::LOCAL_SCHEMA_VERSION, &ver_str)?;
-    meta::put(db, meta::NATIVE_SCHEMA_VERSION, &ver_str)?;
+    meta::put(db, meta::LOCAL_SCHEMA_VERSION, &version)?;
+    meta::put(db, meta::NATIVE_SCHEMA_VERSION, &version)?;
     meta::put(db, meta::COLLECTION_NAME, &native.parsed.name)?;
     meta::put(db, meta::CHANGE_COUNTER, &1)?;
     Ok((

--- a/components/remerge/src/storage/db.rs
+++ b/components/remerge/src/storage/db.rs
@@ -124,7 +124,7 @@ impl RemergeDb {
             )",
             named_params! {
                 ":guid": id,
-                ":schema_ver": self.info.local.version.to_string(),
+                ":schema_ver": self.info.local.version,
                 ":record": record,
                 ":now": now,
                 ":status": SyncStatus::New as u8,
@@ -213,7 +213,7 @@ impl RemergeDb {
             named_params! {
                 ":now_ms": now_ms,
                 ":guid": id,
-                ":schema_ver": self.info.local.version.to_string(),
+                ":schema_ver": self.info.local.version,
                 ":vclock": vclock,
                 ":changed": SyncStatus::Changed as u8,
             })?;
@@ -331,7 +331,7 @@ impl RemergeDb {
                 ":guid": guid,
                 ":changed": SyncStatus::Changed as u8,
                 ":record": record,
-                ":schema_ver": self.info.local.version.to_string(),
+                ":schema_ver": self.info.local.version,
                 ":now_millis": now_ms,
                 ":own_id": self.client_id,
                 ":vclock": vclock,

--- a/components/remerge/tests/test_schemas.json
+++ b/components/remerge/tests/test_schemas.json
@@ -8,28 +8,11 @@
         }
     },
     {
-        "error": "VersionParseFailed",
-        "schema": {
-            "name": "test",
-            "version": "garbage",
-            "fields": []
-        }
-    },
-    {
-        "error": "VersionReqParseFailed",
-        "schema": {
-            "name": "test",
-            "version": "1.0.0",
-            "required_version": "garbage",
-            "fields": []
-        }
-    },
-    {
         "error": "LocalRequiredVersionNotCompatible",
         "schema": {
             "name": "test",
-            "version": "1.0.0",
-            "required_version": "2.0.0",
+            "version": 1,
+            "required_version": 2,
             "fields": []
         }
     },
@@ -37,7 +20,7 @@
         "error": "MissingRemergeFeature",
         "schema": {
             "name": "test",
-            "version": "1.0.0",
+            "version": 1,
             "fields": [],
             "remerge_features_used": ["example"]
         }
@@ -45,7 +28,7 @@
     {
         "error": "DuplicateField",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -62,7 +45,7 @@
     {
         "error": "IllegalMergeForType",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -76,7 +59,7 @@
     {
         "error": "IllegalMergeForType",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -90,7 +73,7 @@
     {
         "error": "UnknownCompositeRoot",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -104,7 +87,7 @@
     {
         "error": "TypeForbidsMergeStrat",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -118,7 +101,7 @@
     {
         "error": "TypeNotComposite",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -136,7 +119,7 @@
     {
         "error": "DeprecatedRequiredConflict",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -151,7 +134,7 @@
     {
         "error": "NoBoundsCheckInfo",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -166,7 +149,7 @@
     {
         "error": "BadNumBounds",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -182,7 +165,7 @@
     {
         "error": "BadNumDefault",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -200,7 +183,7 @@
         "error": "NumberClampOnCompositeRoot",
         "skip": true,
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -221,7 +204,7 @@
     {
         "error": "CompositeRecursion",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -240,7 +223,7 @@
     {
         "error": "BadDefaultUrl",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -254,7 +237,7 @@
     {
         "error": "BadDefaultOrigin",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -269,7 +252,7 @@
     {
         "error": "MergeTakeSumNoMax",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -286,7 +269,7 @@
     {
         "error": "DefaultTimestampTooOld",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -300,7 +283,7 @@
     {
         "error": "DedupeOnWithDuplicateField",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -319,7 +302,7 @@
     {
         "error": "UnknownDedupeOnField",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -335,7 +318,7 @@
     {
         "error": "PartialCompositeDedupeOn",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -355,7 +338,7 @@
     },
     {
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -378,7 +361,7 @@
     {
         "error": "MultipleOwnGuid",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -396,7 +379,7 @@
     {
         "error": "MultipleUpdateAt",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "fields": [
                 {
@@ -415,7 +398,7 @@
     {
         "error": "LegacyMissingId",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "legacy": true,
             "fields": [
@@ -429,7 +412,7 @@
     {
         "error": "DeprecatedFieldDedupeOn",
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "test",
             "legacy": true,
             "fields": [
@@ -447,7 +430,7 @@
 
     {
         "schema": {
-            "version": "1.0.0",
+            "version": 1,
             "name": "logins-example",
             "legacy": true,
             "fields": [


### PR DESCRIPTION
Fixes #2319.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - [x] `cargo test --all` produces no test failures
  - [ ] `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
    - A bunch of warnings show up, possibly because of a new version of Rust, or because this is an old branch
  - [ ] `cargo fmt` does not produce any changes to the code
    - `cargo fmt` wants to change other components (places and sync15)
  - [ ] `./gradlew ktlint detekt` runs without emitting any warnings
    - Presumed true since I didn't touch any Kotlin code
  - [ ] `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
    - Can't verify because I don't have any Apple hardware
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - Underlying code is untested as yet
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - I assume this will be covered by the same changelog entry introducing Remerge
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - No new dependencies are introduced.
