### PR TITLE
Add plaintext headers migration logic for iOS

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -8,6 +8,10 @@
 
 - `LoginsStorage.importLogins` returns logins migration metrics as JSON object. ([#2382](https://github.com/mozilla/application-services/issues/2382))
 
+- iOS only: Added a migration path for apps to convert the encrypted database headers to plaintext([#2100](https://github.com/mozilla/application-services/issues/2100)).  
+New databases must be opened using `LoginsStorage.unlockWithKeyAndSalt` instead of `LoginsStorage.unlock` which is now deprecated.  
+To migrate current users databases, it is required to call `LoginsStorage.migrateToPlaintextHeader` before opening the database. This new method requires a salt. The salt persistence is now the responsibility of the application, which should be stored alongside the encryption key. For an existing database, the salt can be obtained using `LoginsStorage.getDbSaltForKey`.
+
 ### What's new
 
 - Android: Added ability to rekey the database via `rekeyDatabase`. [[#2228](https://github.com/mozilla/application-services/pull/2228)]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,6 +1113,7 @@ dependencies = [
  "sql-support 0.1.0",
  "sync-guid 0.1.0",
  "sync15 0.1.0",
+ "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -38,3 +38,4 @@ chrono = "0.4.8"
 clap = "2.32.0"
 cli-support = { path = "../support/cli" }
 force-viaduct-reqwest = { path = "../support/force-viaduct-reqwest" }
+tempdir = "0.3.7"

--- a/components/logins/ios/Logins/Errors/LoginStoreError.swift
+++ b/components/logins/ios/Logins/Errors/LoginStoreError.swift
@@ -41,6 +41,10 @@ public enum LoginsStoreError: LocalizedError {
     /// abort some operation.
     case interrupted(message: String)
 
+    /// This error is emitted if the salt provided to unlock the
+    /// database was invalid.
+    case invalidSalt(message: String)
+
     /// Our implementation of the localizedError protocol -- (This shows up in Sentry)
     public var errorDescription: String? {
         switch self {
@@ -62,6 +66,8 @@ public enum LoginsStoreError: LocalizedError {
             return "LoginsStoreError.network: \(message)"
         case let .interrupted(message):
             return "LoginsStoreError.interrupted: \(message)"
+        case let .invalidSalt(message):
+            return "LoginsStoreError.invalidSalt: \(message)"
         }
     }
 
@@ -116,6 +122,9 @@ public enum LoginsStoreError: LocalizedError {
 
         case Sync15Passwords_InterruptedError:
             return .interrupted(message: String(freeingRustString: message!))
+
+        case Sync15Passwords_InvalidSaltError:
+            return .invalidSalt(message: String(freeingRustString: message!))
 
         default:
             return .unspecified(message: String(freeingRustString: message!))

--- a/components/logins/ios/Logins/RustPasswordAPI.h
+++ b/components/logins/ios/Logins/RustPasswordAPI.h
@@ -15,6 +15,7 @@ typedef enum Sync15PasswordsErrorCode {
     Sync15Passwords_InvalidKeyError  = 4,
     Sync15Passwords_NetworkError     = 5,
     Sync15Passwords_InterruptedError = 6,
+    Sync15Passwords_InvalidSaltError = 7,
 
     Sync15Passwords_InvalidLogin_EmptyOrigin = 64 + 0,
     Sync15Passwords_InvalidLogin_EmptyPassword = 64 + 1,
@@ -40,6 +41,11 @@ Sync15PasswordEngineHandle sync15_passwords_state_new(char const *_Nonnull db_pa
                                                       char const *_Nonnull encryption_key,
                                                       Sync15PasswordsError *_Nonnull error_out);
 
+Sync15PasswordEngineHandle sync15_passwords_state_new_with_salt(char const *_Nonnull db_path,
+                                                                char const *_Nonnull encryption_key,
+                                                                char const *_Nonnull salt,
+                                                                Sync15PasswordsError *_Nonnull error_out);
+
 Sync15PasswordEngineHandle sync15_passwords_state_new_with_hex_key(char const *_Nonnull db_path,
                                                                    uint8_t const *encryption_key_bytes,
                                                                    uint32_t encryption_key_len,
@@ -47,6 +53,15 @@ Sync15PasswordEngineHandle sync15_passwords_state_new_with_hex_key(char const *_
 
 void sync15_passwords_state_destroy(Sync15PasswordEngineHandle handle,
                                     Sync15PasswordsError *_Nonnull error_out);
+
+char *_Nullable sync15_passwords_get_db_salt(char const *_Nonnull db_path,
+                                             char const *_Nonnull encryption_key,
+                                             Sync15PasswordsError *_Nonnull error_out);
+
+void sync15_passwords_migrate_plaintext_header(char const *_Nonnull db_path,
+                                               char const *_Nonnull encryption_key,
+                                               char const *_Nonnull salt,
+                                               Sync15PasswordsError *_Nonnull error_out);
 
 char *_Nullable sync15_passwords_get_by_id(Sync15PasswordEngineHandle handle,
                                           char const *_Nonnull id,

--- a/components/logins/src/engine.rs
+++ b/components/logins/src/engine.rs
@@ -28,6 +28,14 @@ impl PasswordEngine {
         })
     }
 
+    pub fn new_with_salt(path: impl AsRef<Path>, encryption_key: &str, salt: &str) -> Result<Self> {
+        let db = LoginDb::open_with_salt(path, encryption_key, salt)?;
+        Ok(Self {
+            db,
+            mem_cached_state: Cell::default(),
+        })
+    }
+
     pub fn new_in_memory(encryption_key: Option<&str>) -> Result<Self> {
         let db = LoginDb::open_in_memory(encryption_key)?;
         Ok(Self {

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -36,6 +36,9 @@ pub enum ErrorKind {
     #[fail(display = "The logins tables are not empty")]
     NonEmptyTable,
 
+    #[fail(display = "The provided salt is invalid")]
+    InvalidSalt,
+
     #[fail(display = "Error synchronizing: {}", _0)]
     SyncAdapterError(#[fail(cause)] sync15::Error),
 

--- a/components/logins/src/ffi.rs
+++ b/components/logins/src/ffi.rs
@@ -35,6 +35,9 @@ pub mod error_codes {
     /// An operation has been interrupted.
     pub const INTERRUPTED: i32 = 6;
 
+    /// An invalid salt was provided.
+    pub const INVALID_SALT: i32 = 7;
+
     // Skip a bunch of spaces to make it clear these are part of a group,
     // even as more and more errors get added. We're only exposing the
     // InvalidLogin items that can actually be triggered, the others
@@ -100,6 +103,11 @@ fn get_code(err: &Error) -> ErrorCode {
         ErrorKind::Interrupted(_) => {
             log::warn!("Operation interrupted (Outside SQL)");
             ErrorCode::new(error_codes::INTERRUPTED)
+        }
+
+        ErrorKind::InvalidSalt => {
+            log::error!("Invalid salt provided");
+            ErrorCode::new(error_codes::INVALID_SALT)
         }
 
         err => {

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -18,6 +18,7 @@ mod util;
 mod ffi;
 
 // Mostly exposed for the sync manager.
+pub use crate::db::LoginDb;
 pub use crate::db::LoginStore;
 pub use crate::engine::*;
 pub use crate::error::*;


### PR DESCRIPTION
Fixes #2100.
This roughly follows @rfk's approach described in https://github.com/mozilla/application-services/issues/2100#issuecomment-567369194.