### PR TITLE
Avoid including Category-3 data in logins migration metrics.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,10 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.48.0...master)
+
+## Logins
+
+### What's changed
+
+* The error strings returned by `LoginsStorage.importLogins` as part of the migration metrics bundle,
+  no longer include potentially-sensitive information such as guids.

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -82,3 +82,30 @@ pub enum InvalidLogin {
     #[fail(display = "Login has illegal field: {}", _0)]
     IllegalFieldValue { field_info: String },
 }
+
+impl Error {
+    // Get a short textual label identifying the type of error that occurred,
+    // but without including any potentially-sensitive information.
+    pub fn label(&self) -> &'static str {
+        match self.kind() {
+            ErrorKind::BadSyncStatus(_) => "BadSyncStatus",
+            ErrorKind::DuplicateGuid(_) => "DuplicateGuid",
+            ErrorKind::NoSuchRecord(_) => "NoSuchRecord",
+            ErrorKind::NonEmptyTable => "NonEmptyTable",
+            ErrorKind::InvalidSalt => "InvalidSalt",
+            ErrorKind::SyncAdapterError(_) => "SyncAdapterError",
+            ErrorKind::JsonError(_) => "JsonError",
+            ErrorKind::UrlParseError(_) => "UrlParseError",
+            ErrorKind::SqlError(_) => "SqlError",
+            ErrorKind::Interrupted(_) => "Interrupted",
+            ErrorKind::InvalidLogin(desc) => match desc {
+                InvalidLogin::EmptyOrigin => "InvalidLogin::EmptyOrigin",
+                InvalidLogin::EmptyPassword => "InvalidLogin::EmptyPassword",
+                InvalidLogin::DuplicateLogin => "InvalidLogin::DuplicateLogin",
+                InvalidLogin::BothTargets => "InvalidLogin::BothTargets",
+                InvalidLogin::NoTarget => "InvalidLogin::NoTarget",
+                InvalidLogin::IllegalFieldValue { .. } => "InvalidLogin::IllegalFieldValue",
+            },
+        }
+    }
+}


### PR DESCRIPTION
As noted in https://github.com/mozilla/application-services/issues/2407#issuecomment-570415979, I don't think we should include any non-Category-2 data in the metrics returned from logins import, which in practice means that we shouldn't return any detailed error strings which might contain guids, URLs, etc.

This PR replaces the detailed errors strings with simple string labels, which will hopefully be somewhat friendly for querying but which don't leak any sensitive information.

It's still up to consuming a-c code to figure out how to include these in the migration metrics ping, but this approach means there's no risk of accidentally including sensitive data.

Fixes #2407.
