### PR TITLE
Re-enable redundant-clone lint. Fixes #2425

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,7 +256,7 @@ jobs:
       - test-setup
       - run: rustup component add clippy
       - run: cargo clippy --version
-      - run: cargo clippy --all --all-targets --all-features -- -D warnings -A clippy::redundant_clone
+      - run: cargo clippy --all --all-targets --all-features -- -D warnings
       # --no-default-features does not work on a workspace, so we do it for every crate.
       - run: |
           for package in $(cargo metadata --format-version 1 | jq -r '.workspace_members[] | sub(" .*$"; "")'); do
@@ -266,7 +266,7 @@ jobs:
             # it, but whatever.
             manifest=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == $pkg) | .manifest_path' --arg pkg $package)
             echo "## no-default-features clippy for $package (manifest @ $manifest)"
-            cargo clippy --manifest-path $manifest --all-targets --no-default-features -- -D warnings -A clippy::redundant_clone
+            cargo clippy --manifest-path $manifest --all-targets --no-default-features -- -D warnings
           done
   Lint Bash scripts:
     docker:

--- a/components/fxa-client/examples/devices_api.rs
+++ b/components/fxa-client/examples/devices_api.rs
@@ -70,7 +70,7 @@ fn create_fxa_creds(cfg: Config) -> Result<FirefoxAccount, failure::Error> {
 
 fn main() -> Result<(), failure::Error> {
     let cfg = Config::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
-    let mut acct = load_or_create_fxa_creds(cfg.clone())?;
+    let mut acct = load_or_create_fxa_creds(cfg)?;
 
     // Make sure the device and the send-tab command are registered.
     acct.initialize_device(

--- a/components/fxa-client/src/migrator.rs
+++ b/components/fxa-client/src/migrator.rs
@@ -68,7 +68,7 @@ impl FirefoxAccount {
             k: k_sync,
             kid,
         };
-        self.state.session_token = Some(migration_session_token.clone());
+        self.state.session_token = Some(migration_session_token);
         self.state
             .scoped_keys
             .insert(scopes::OLD_SYNC.to_string(), k_sync_scoped_key);

--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -209,7 +209,7 @@ impl FirefoxAccount {
         }
 
         self.flow_store.insert(
-            state.clone(), // Since state is supposed to be unique, we use it to key our flows.
+            state, // Since state is supposed to be unique, we use it to key our flows.
             OAuthFlow {
                 scoped_keys_flow: Some(scoped_keys_flow),
                 code_verifier,

--- a/components/logins/examples/sync_pass_sql.rs
+++ b/components/logins/examples/sync_pass_sql.rs
@@ -144,7 +144,7 @@ fn show_sql(e: &PasswordEngine, sql: &str) -> Result<()> {
                     Value::Null => Cell::new("null").style_spec("Fd"),
                     Value::Integer(i) => Cell::new(&i.to_string()).style_spec("Fb"),
                     Value::Real(r) => Cell::new(&r.to_string()).style_spec("Fb"),
-                    Value::Text(s) => Cell::new(&s.to_string()).style_spec("Fr"),
+                    Value::Text(s) => Cell::new(&s).style_spec("Fr"),
                     Value::Blob(b) => Cell::new(&format!("{}b blob", b.len())),
                 })
             })

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -1685,7 +1685,7 @@ mod tests {
         // Setting up test cases
         let valid_login_guid1: Guid = Guid::random();
         let valid_login1 = Login {
-            guid: valid_login_guid1.clone(),
+            guid: valid_login_guid1,
             form_submit_url: Some("https://www.example.com".into()),
             hostname: "https://www.example.com".into(),
             http_realm: None,
@@ -1695,7 +1695,7 @@ mod tests {
         };
         let valid_login_guid2: Guid = Guid::random();
         let valid_login2 = Login {
-            guid: valid_login_guid2.clone(),
+            guid: valid_login_guid2,
             form_submit_url: Some("https://www.example2.com".into()),
             hostname: "https://www.example2.com".into(),
             http_realm: None,
@@ -1705,7 +1705,7 @@ mod tests {
         };
         let valid_login_guid3: Guid = Guid::random();
         let valid_login3 = Login {
-            guid: valid_login_guid3.clone(),
+            guid: valid_login_guid3,
             form_submit_url: Some("https://www.example3.com".into()),
             hostname: "https://www.example3.com".into(),
             http_realm: None,
@@ -1715,7 +1715,7 @@ mod tests {
         };
         let duplicate_login_guid: Guid = Guid::random();
         let duplicate_login = Login {
-            guid: duplicate_login_guid.clone(),
+            guid: duplicate_login_guid,
             form_submit_url: Some("https://www.example.com".into()),
             hostname: "https://www.example.com".into(),
             http_realm: None,
@@ -1724,11 +1724,7 @@ mod tests {
             ..Login::default()
         };
 
-        let duplicate_logins = vec![
-            valid_login1.clone(),
-            duplicate_login.clone(),
-            valid_login2.clone(),
-        ];
+        let duplicate_logins = vec![valid_login1.clone(), duplicate_login, valid_login2.clone()];
 
         let duplicate_logins_metrics = MigrationMetrics {
             fixup_phase: MigrationPhaseMetrics {
@@ -1750,11 +1746,7 @@ mod tests {
             ..MigrationMetrics::default()
         };
 
-        let valid_logins = vec![
-            valid_login1.clone(),
-            valid_login2.clone(),
-            valid_login3.clone(),
-        ];
+        let valid_logins = vec![valid_login1, valid_login2, valid_login3];
 
         let valid_logins_metrics = MigrationMetrics {
             fixup_phase: MigrationPhaseMetrics {

--- a/components/logins/src/engine.rs
+++ b/components/logins/src/engine.rs
@@ -239,7 +239,7 @@ mod test {
         let mut list = engine.list().expect("Grabbing list to work");
         assert_eq!(list.len(), 2);
 
-        let mut expect = vec![a_from_db.clone(), b_from_db.clone()];
+        let mut expect = vec![a_from_db, b_from_db.clone()];
 
         list.sort_by(|a, b| b.guid.cmp(&a.guid));
         expect.sort_by(|a, b| b.guid.cmp(&a.guid));
@@ -270,7 +270,7 @@ mod test {
         let b2 = Login {
             password: "newpass".into(),
             guid: Guid::from(b_id.as_str()),
-            ..b.clone()
+            ..b
         };
 
         engine.update(b2.clone()).expect("update b should work");

--- a/components/logins/src/update_plan.rs
+++ b/components/logins/src/update_plan.rs
@@ -61,7 +61,7 @@ impl UpdatePlan {
 
     pub fn plan_delete(&mut self, id: Guid) {
         self.delete_local.push(id.clone());
-        self.delete_mirror.push(id.clone());
+        self.delete_mirror.push(id);
     }
 
     pub fn plan_mirror_update(&mut self, login: Login, time: ServerTimestamp) {

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -707,7 +707,7 @@ mod tests {
         let conn = new_mem_connection();
 
         let url = Url::parse("http://exämple.com/123").unwrap();
-        let visit = VisitObservation::new(url.clone())
+        let visit = VisitObservation::new(url)
             .with_title("Example page 123".to_string())
             .with_visit_type(VisitTransition::Typed)
             .with_at(Timestamp::now());

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -105,7 +105,7 @@ impl PlacesApi {
     ) -> Result<Arc<Self>> {
         let id = ID_COUNTER.fetch_add(1, Ordering::SeqCst);
         match target.get(&db_name).and_then(Weak::upgrade) {
-            Some(existing) => Ok(existing.clone()),
+            Some(existing) => Ok(existing),
             None => {
                 // We always create a new read-write connection for an initial open so
                 // we can create the schema and/or do version upgrades.

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -161,7 +161,7 @@ fn plan_incoming_record(conn: &PlacesDb, record: HistoryRecord, max_visits: usiz
     if guid_changed || !to_apply.is_empty() {
         let new_title = Some(record.title);
         IncomingPlan::Apply {
-            url: url.clone(),
+            url,
             new_title,
             visits: to_apply,
         }
@@ -797,7 +797,7 @@ mod tests {
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let url = Url::parse("https://example.com")?;
         let now = SystemTime::now();
-        let obs = VisitObservation::new(url.clone())
+        let obs = VisitObservation::new(url)
             .with_visit_type(VisitTransition::Link)
             .with_at(Some(now.into()));
         apply_observation(&db, obs)?;

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -1253,7 +1253,7 @@ pub fn fetch_tree(
                     guid: Some(row.guid.clone()),
                     date_added: Some(row.date_added),
                     last_modified: Some(row.last_modified),
-                    title: row.title.clone(),
+                    title: row.title,
                     children: Vec::new(),
                 }
                 .into(),
@@ -1261,8 +1261,8 @@ pub fn fetch_tree(
                     guid: Some(row.guid.clone()),
                     date_added: Some(row.date_added),
                     last_modified: Some(row.last_modified),
-                    title: row.title.clone(),
-                    url: Url::parse(row.url.clone().unwrap().as_str())?,
+                    title: row.title,
+                    url: Url::parse(row.url.unwrap().as_str())?,
                 }
                 .into(),
                 BookmarkType::Separator => SeparatorNode {
@@ -1579,7 +1579,7 @@ mod tests {
             date_added: None,
             last_modified: None,
             guid: None,
-            url: url.clone(),
+            url,
             title: None,
         });
         let guid2 = insert_bookmark(&conn, &bm2)?;
@@ -1668,7 +1668,7 @@ mod tests {
             date_added: None,
             last_modified: None,
             guid: None,
-            url: url.clone(),
+            url,
             title: Some("the title".into()),
         });
         let guid = insert_bookmark(&conn, &bm)?;
@@ -2305,7 +2305,7 @@ mod tests {
         assert_json_tree_with_depth(
             &conn,
             &BookmarkRootGuid::Unfiled.into(),
-            expected.clone(),
+            expected,
             &FetchDepth::Specific(1),
         );
 

--- a/components/places/src/storage/bookmarks/public_node.rs
+++ b/components/places/src/storage/bookmarks/public_node.rs
@@ -334,7 +334,7 @@ mod test {
                 node_type: BookmarkType::Bookmark,
                 guid: "bookmark4___".into(),
                 title: Some("yes 2".into()),
-                url: Some(url.clone()),
+                url: Some(url),
                 parent_guid: Some(BookmarkRootGuid::Unfiled.into()),
                 position: 3,
                 child_guids: None,

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -1507,13 +1507,12 @@ mod tests {
         let _ = env_logger::try_init();
         let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).unwrap();
 
-        let to_add = [
-            Url::parse("https://www.example.com/1").unwrap(),
-            Url::parse("https://www.example.com/12").unwrap(),
-            Url::parse("https://www.example.com/123").unwrap(),
-        ];
+        let u0 = Url::parse("https://www.example.com/1").unwrap();
+        let u1 = Url::parse("https://www.example.com/12").unwrap();
+        let u2 = Url::parse("https://www.example.com/123").unwrap();
 
-        for item in &to_add {
+        let to_add = [&u0, &u1, &u2];
+        for &item in &to_add {
             apply_observation(
                 &conn,
                 VisitObservation::new(item.clone()).with_visit_type(VisitTransition::Link),
@@ -1525,16 +1524,16 @@ mod tests {
 
         let get_visited_request = [
             // 0 blank
-            (2, to_add[1].clone()),
-            (1, to_add[0].clone()),
+            (2, u1.clone()),
+            (1, u0),
             // 3 blank
-            (4, to_add[2].clone()),
+            (4, u2),
             // 5 blank
             // Note: url for 6 is not visited.
             (6, Url::parse("https://www.example.com/1234").unwrap()),
             // 7 blank
             // Note: dupe is allowed
-            (8, to_add[1].clone()),
+            (8, u1),
             // 9 is blank
         ];
 

--- a/components/places/tests/ios_bookmarks.rs
+++ b/components/places/tests/ios_bookmarks.rs
@@ -184,10 +184,10 @@ impl IosTree {
         res.local.insert(dogear::UNFILED_GUID, unfiled.clone());
         res.local.insert(dogear::MOBILE_GUID, mobile.clone());
         // buffer does not have `root`, but does have these.
-        res.buffer.insert(dogear::MENU_GUID, menu.clone());
-        res.buffer.insert(dogear::TOOLBAR_GUID, toolbar.clone());
-        res.buffer.insert(dogear::UNFILED_GUID, unfiled.clone());
-        res.buffer.insert(dogear::MOBILE_GUID, mobile.clone());
+        res.buffer.insert(dogear::MENU_GUID, menu);
+        res.buffer.insert(dogear::TOOLBAR_GUID, toolbar);
+        res.buffer.insert(dogear::UNFILED_GUID, unfiled);
+        res.buffer.insert(dogear::MOBILE_GUID, mobile);
 
         res
     }

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -57,7 +57,7 @@ pub extern "C" fn push_connection_new(
             database_path: db_path,
             ..Default::default()
         };
-        PushManager::new(config.clone())
+        PushManager::new(config)
     })
 }
 

--- a/components/push/src/communications.rs
+++ b/components/push/src/communications.rs
@@ -114,7 +114,7 @@ pub fn connect(
     };
     let connection = ConnectHttp {
         uaid,
-        options: options.clone(),
+        options,
         auth,
     };
 
@@ -592,12 +592,8 @@ mod test {
             .with_header("content-type", "application/json")
             .with_body(body_cl_success)
             .create();
-            let conn = connect(
-                config.clone(),
-                Some(DUMMY_UAID.to_owned()),
-                Some(SECRET.to_owned()),
-            )
-            .unwrap();
+            let conn =
+                connect(config, Some(DUMMY_UAID.to_owned()), Some(SECRET.to_owned())).unwrap();
             let response = conn.channel_list().unwrap();
             ap_mock.assert();
             assert!(response == [DUMMY_CHID.to_owned()]);

--- a/components/push/src/subscriber.rs
+++ b/components/push/src/subscriber.rs
@@ -29,7 +29,7 @@ impl PushManager {
         let uaid = store.get_meta("uaid")?;
         let pm = PushManager {
             config: config.clone(),
-            conn: connect(config, uaid.clone(), store.get_meta("auth")?)?,
+            conn: connect(config, uaid, store.get_meta("auth")?)?,
             store,
         };
         Ok(pm)

--- a/components/remerge/src/schema/json.rs
+++ b/components/remerge/src/schema/json.rs
@@ -457,10 +457,7 @@ impl<'a> SchemaParser<'a> {
 
         ensure!(
             req_version.matches(&cur_version),
-            SchemaError::LocalRequiredVersionNotCompatible(
-                req_version.clone(),
-                cur_version.clone()
-            )
+            SchemaError::LocalRequiredVersionNotCompatible(req_version, cur_version)
         );
         Ok((cur_version, req_version))
     }

--- a/components/remerge/src/util.rs
+++ b/components/remerge/src/util.rs
@@ -30,8 +30,9 @@ pub fn is_base64url_byte(b: u8) -> bool {
 /// and is more well-behaved from a type-checking perspective.
 macro_rules! throw {
     ($e:expr $(,)?) => {{
-        log::error!("Error: {}", $e);
-        return Err(std::convert::Into::into($e));
+        let e = $e;
+        log::error!("Error: {}", e);
+        return Err(std::convert::Into::into(e));
     }};
 }
 

--- a/components/sync15/src/bso_record.rs
+++ b/components/sync15/src/bso_record.rs
@@ -541,7 +541,7 @@ mod tests {
     #[test]
     fn test_record_auto_fields() {
         let payload = json!({ "id": "aaaaaaaaaaaa", "age": 105, "meta": "data", "sortindex": 100, "ttl": 99 });
-        let bso = Payload::from_json(payload.clone())
+        let bso = Payload::from_json(payload)
             .unwrap()
             .into_bso("dummy".into());
 
@@ -554,7 +554,7 @@ mod tests {
         assert_eq!(bso.ttl, Some(99));
 
         let keybundle = KeyBundle::new_random().unwrap();
-        let encrypted = bso.clone().encrypt(&keybundle).unwrap();
+        let encrypted = bso.encrypt(&keybundle).unwrap();
 
         let decrypted = encrypted.decrypt(&keybundle).unwrap();
         // We add auto fields during decryption.
@@ -567,12 +567,12 @@ mod tests {
     #[test]
     fn test_record_bad_hmac() {
         let payload = json!({ "id": "aaaaaaaaaaaa", "age": 105, "meta": "data", "sortindex": 100, "ttl": 99 });
-        let bso = Payload::from_json(payload.clone())
+        let bso = Payload::from_json(payload)
             .unwrap()
             .into_bso("dummy".into());
 
         let keybundle = KeyBundle::new_random().unwrap();
-        let encrypted = bso.clone().encrypt(&keybundle).unwrap();
+        let encrypted = bso.encrypt(&keybundle).unwrap();
         let keybundle2 = KeyBundle::new_random().unwrap();
 
         let e = encrypted

--- a/components/sync15/src/migrate_state.rs
+++ b/components/sync15/src/migrate_state.rs
@@ -150,7 +150,7 @@ mod tests {
             make_csids("qZKAMjhyV6Ti", "8M-HfX6dm-pD")
         );
         assert_eq!(
-            extract_v1_ids_only(Some(s.clone()), "bookmarks"),
+            extract_v1_ids_only(Some(s), "bookmarks"),
             make_csids("qZKAMjhyV6Ti", "AVXtnKkH5OTi")
         );
     }
@@ -164,7 +164,7 @@ mod tests {
         })
         .unwrap();
         assert_eq!(
-            extract_v1_state(Some(s.clone()), "addresses"),
+            extract_v1_state(Some(s), "addresses"),
             (
                 make_csids("qZKAMjhyV6Ti", "8M-HfX6dm-pD"),
                 Some(expected_state)
@@ -184,7 +184,7 @@ mod tests {
         assert_eq!(extract_v1_ids_only(Some(s.clone()), "addresses"), None);
         // bookmarks wasn't reset.
         assert_eq!(
-            extract_v1_ids_only(Some(s.clone()), "bookmarks"),
+            extract_v1_ids_only(Some(s), "bookmarks"),
             make_csids("qZKAMjhyV6Ti", "AVXtnKkH5OTi")
         );
     }
@@ -198,6 +198,6 @@ mod tests {
             make_csids("qZKAMjhyV6Ti", "8M-HfX6dm-pD")
         );
         // bookmarks was reset.
-        assert_eq!(extract_v1_ids_only(Some(s.clone()), "bookmarks"), None);
+        assert_eq!(extract_v1_ids_only(Some(s), "bookmarks"), None);
     }
 }

--- a/components/sync15/src/request.rs
+++ b/components/sync15/src/request.rs
@@ -694,7 +694,7 @@ mod test {
             .sort_by(RequestOrder::Oldest)
             .older_than(ServerTimestamp(9_876_540))
             .newer_than(ServerTimestamp(1_234_560))
-            .build_url(base.clone())
+            .build_url(base)
             .unwrap();
         assert_eq!(complex.as_str(),
             "https://example.com/sync/storage/specific?full=1&limit=10&older=9876.54&newer=1234.56&sort=oldest");
@@ -828,7 +828,7 @@ mod test {
 
             {
                 let batch = self.cur_batch.as_mut().unwrap();
-                batch.posts.push(post.clone());
+                batch.posts.push(post);
                 batch.records += num_records;
                 batch.bytes += record_payload_bytes;
 

--- a/components/tabs/src/sync/store.rs
+++ b/components/tabs/src/sync/store.rs
@@ -157,7 +157,7 @@ impl<'a> Store for TabsStore<'a> {
                 })
                 .unwrap_or_else(|| (String::new(), DeviceType::Mobile));
             let local_record = ClientRemoteTabs {
-                client_id: local_id.to_owned(),
+                client_id: local_id,
                 client_name,
                 device_type,
                 remote_tabs: local_tabs.to_vec(),


### PR DESCRIPTION
There were only one or two false positives, which I think are fixed on nightly clippy, and easy to work around by tweaking the code. We just had a surprising number of unnecessary clones...

The CI issue is totally unrelated and will be fixed by an incoming patch I'm going to do before wandering off and getting breakfast or something... (still a little jetlagged / mentally not fully back to west coast time).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
