### PR TITLE
Avoid unnecessary nss dep in sync_guid [ci full]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,7 +2462,7 @@ name = "sync-guid"
 version = "0.1.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rc_crypto 0.1.0",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1107,7 +1107,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "more-asserts 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "prettytable-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1127,7 +1127,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins 0.1.0",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sql-support 0.1.0",
  "sync15 0.1.0",
@@ -1604,7 +1604,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1788,7 +1788,7 @@ dependencies = [
  "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rc_crypto 0.1.0",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1807,7 +1807,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "push 0.1.0",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "sync15 0.1.0",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2030,7 +2030,7 @@ dependencies = [
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hawk 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nss 0.1.0",
 ]
 
@@ -2111,7 +2111,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2177,13 +2177,13 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2390,7 +2390,7 @@ dependencies = [
  "interrupt 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2463,7 +2463,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3294,7 +3294,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
+"checksum libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7a8223ba845dde334ce739a90b554ad3ce75f888b968cc93a11176cad2e58f2"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"
@@ -3388,7 +3388,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 "checksum ring 0.16.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6747f8da1f2b1fabbee1aaa4eb8a11abf9adef0bf58a41cee45db5d59cecdfac"
-"checksum rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"
+"checksum rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "64a656821bb6317a84b257737b7934f79c0dbb7eb694710475908280ebad3e64"
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,8 +1042,8 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.17.0"
-source = "git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b#844839d9a54fc32874d31002a6f976b06e59049b"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2035,7 +2035,7 @@ dependencies = [
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hawk 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.17.0 (git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b)",
+ "libsqlite3-sys 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nss 0.1.0",
 ]
 
@@ -2113,7 +2113,7 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "index_vec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.17.0 (git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b)",
+ "libsqlite3-sys 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nss_build_common 0.1.0",
@@ -2190,7 +2190,7 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.17.0 (git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b)",
+ "libsqlite3-sys 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3301,7 +3301,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum libsqlite3-sys 0.17.0 (git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b)" = "<none>"
+"checksum libsqlite3-sys 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "266eb8c361198e8d1f682bc974e5d9e2ae90049fb1943890904d11dad7d4a77d"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,7 @@ dependencies = [
 [[package]]
 name = "libsqlite3-sys"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b#844839d9a54fc32874d31002a6f976b06e59049b"
 dependencies = [
  "cc 1.0.49 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1375,10 +1375,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nss_build_common"
+version = "0.1.0"
+
+[[package]]
 name = "nss_sys"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.52.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nss_build_common 0.1.0",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2030,7 +2035,7 @@ dependencies = [
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hawk 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.17.0 (git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b)",
  "nss 0.1.0",
 ]
 
@@ -2108,8 +2113,10 @@ dependencies = [
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "index_vec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.17.0 (git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nss_build_common 0.1.0",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2183,7 +2190,7 @@ dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-streaming-iterator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libsqlite3-sys 0.17.0 (git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b)",
  "lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3294,7 +3301,7 @@ dependencies = [
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-"checksum libsqlite3-sys 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f7a8223ba845dde334ce739a90b554ad3ce75f888b968cc93a11176cad2e58f2"
+"checksum libsqlite3-sys 0.17.0 (git+https://github.com/jgallagher/rusqlite.git?rev=844839d9a54fc32874d31002a6f976b06e59049b)" = "<none>"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum lock_api 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "79b2de95ecb4691949fea4716ca53cdbcfccb2c612e19644a8bad05edcf9f47b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,3 @@ members = [
 opt-level = "s"
 debug = true
 lto = true
-
-# Without the change in https://github.com/jgallagher/rusqlite/pull/608, it
-# would be very hard (I can't think of hoq) for remerge to both avoid the NSS
-# dep and keep `cargo test` from the root of a-s working. This is just the
-# bindgen crate more or less, so it seems fine to me to use a rev while we wait
-# for a release.
-[patch.crates-io.libsqlite3-sys]
-git = 'https://github.com/jgallagher/rusqlite.git'
-rev = '844839d9a54fc32874d31002a6f976b06e59049b'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "components/support/interrupt",
     "components/support/rc_crypto",
     "components/support/rc_crypto/nss",
+    "components/support/rc_crypto/nss/nss_build_common",
     "components/support/rc_crypto/nss/nss_sys",
     "components/support/sql",
     "components/sync_manager",
@@ -37,3 +38,12 @@ members = [
 opt-level = "s"
 debug = true
 lto = true
+
+# Without the change in https://github.com/jgallagher/rusqlite/pull/608, it
+# would be very hard (I can't think of hoq) for remerge to both avoid the NSS
+# dep and keep `cargo test` from the root of a-s working. This is just the
+# bindgen crate more or less, so it seems fine to me to use a rev while we wait
+# for a release.
+[patch.crates-io.libsqlite3-sys]
+git = 'https://github.com/jgallagher/rusqlite.git'
+rev = '844839d9a54fc32874d31002a6f976b06e59049b'

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -26,7 +26,7 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 
 [dependencies.rusqlite]
-version = "0.20.0"
+version = "0.21.0"
 features = ["sqlcipher", "limits"]
 
 [dev-dependencies]

--- a/components/logins/ffi/Cargo.toml
+++ b/components/logins/ffi/Cargo.toml
@@ -23,7 +23,7 @@ viaduct = { path = "../../viaduct" }
 sql-support = { path = "../../support/sql" }
 
 [dependencies.rusqlite]
-version = "0.20.0"
+version = "0.21.0"
 features = ["sqlcipher"]
 
 [dependencies.logins]

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -36,7 +36,7 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 
 
 [dependencies.rusqlite]
-version = "0.20.0"
+version = "0.21.0"
 features = ["functions", "bundled"]
 
 [dev-dependencies]

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -19,7 +19,7 @@ base64 = "0.11.0"
 failure = "0.1.6"
 failure_derive = "0.1.5"
 log = "0.4.8"
-rusqlite = { version = "0.20.0", features = ["bundled"] }
+rusqlite = { version = "0.21.0", features = ["bundled"] }
 url = "1.7.2"
 viaduct = { path = "../viaduct" }
 ffi-support = { path = "../support/ffi" }

--- a/components/push/ffi/Cargo.toml
+++ b/components/push/ffi/Cargo.toml
@@ -21,7 +21,7 @@ viaduct = { path = "../../viaduct" }
 prost = "0.5.0"
 
 [dependencies.rusqlite]
-version = "0.20.0"
+version = "0.21.0"
 features = ["limits", "functions"]
 
 [dependencies.sync15]

--- a/components/remerge/Cargo.toml
+++ b/components/remerge/Cargo.toml
@@ -24,5 +24,5 @@ matches = "0.1.8"
 num-traits = "0.2.8"
 
 [dependencies.rusqlite]
-version = "0.20.0"
+version = "0.21.0"
 features = ["functions", "bundled", "serde_json"]

--- a/components/remerge/Cargo.toml
+++ b/components/remerge/Cargo.toml
@@ -26,7 +26,7 @@ num-traits = "0.2.8"
 # A *direct* dep on the -sys crate is required for our build.rs
 # to see the DEP_SQLITE3_LINK_TARGET env var that cargo sets
 # on its behalf.
-libsqlite3-sys = "0.17.0"
+libsqlite3-sys = "0.17.1"
 
 [dependencies.rusqlite]
 version = "0.21.0"

--- a/components/remerge/Cargo.toml
+++ b/components/remerge/Cargo.toml
@@ -23,6 +23,14 @@ sync-guid = {path = "../support/guid", features = ["random", "rusqlite_support"]
 matches = "0.1.8"
 num-traits = "0.2.8"
 
+# A *direct* dep on the -sys crate is required for our build.rs
+# to see the DEP_SQLITE3_LINK_TARGET env var that cargo sets
+# on its behalf.
+libsqlite3-sys = "0.17.0"
+
 [dependencies.rusqlite]
 version = "0.21.0"
 features = ["functions", "bundled", "serde_json"]
+
+[build-dependencies]
+nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }

--- a/components/remerge/build.rs
+++ b/components/remerge/build.rs
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Work around the fact that `sqlcipher` might get enabled by a cargo feature
+//! another crate in teh workspace needs, without setting up nss. (This is a
+//! gross hack).
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    // Ugh. This is really really dumb. We don't care about sqlcipher at all. really
+    if nss_build_common::env_str("DEP_SQLITE3_LINK_TARGET") == Some("sqlcipher".into()) {
+        // If NSS_DIR isn't set, we don't really care, ignore the Err case.
+        let _ = nss_build_common::link_nss();
+    }
+}

--- a/components/support/guid/Cargo.toml
+++ b/components/support/guid/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2018"
 [dependencies]
 rusqlite = { version = "0.20.0", optional = true }
 serde = { version = "1.0.101", optional = true }
-rc_crypto = { path = "../rc_crypto", optional = true }
+rand = { version = "0.7", optional = true }
 base64 = { version = "0.11.0", optional = true }
 
 [features]
-random = ["rc_crypto", "base64"]
+random = ["rand", "base64"]
 rusqlite_support = ["rusqlite"]
 serde_support = ["serde"]
 # By default we support serde, but not rusqlite.

--- a/components/support/guid/Cargo.toml
+++ b/components/support/guid/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
-rusqlite = { version = "0.20.0", optional = true }
+rusqlite = { version = "0.21.0", optional = true }
 serde = { version = "1.0.101", optional = true }
 rand = { version = "0.7", optional = true }
 base64 = { version = "0.11.0", optional = true }

--- a/components/support/guid/src/lib.rs
+++ b/components/support/guid/src/lib.rs
@@ -134,10 +134,7 @@ impl Guid {
     /// feature.
     #[cfg(feature = "random")]
     pub fn random() -> Self {
-        let mut bytes = [0u8; 9];
-        // TODO: investigate if we should replace this with something infallible
-        // (from e.g. `rand`)
-        rc_crypto::rand::fill(&mut bytes).unwrap();
+        let bytes: [u8; 9] = rand::random();
 
         // Note: only first 12 bytes are used, but remaining are required to
         // build the FastGuid

--- a/components/support/rc_crypto/Cargo.toml
+++ b/components/support/rc_crypto/Cargo.toml
@@ -14,7 +14,7 @@ failure = "0.1.6"
 failure_derive = "0.1.5"
 error-support = { path = "../error" }
 nss = { path = "nss" }
-libsqlite3-sys = { version = "0.16.0", features = ["bundled"] }
+libsqlite3-sys = { version = "0.17.0", features = ["bundled"] }
 hawk = { version = "3.0.0", default-features = false, optional = true }
 ece = { version = "1.1.0", default-features = false, features = ["serializable-keys"], optional = true }
 

--- a/components/support/rc_crypto/nss/nss_build_common/Cargo.toml
+++ b/components/support/rc_crypto/nss/nss_build_common/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "nss_build_common"
+version = "0.1.0"
+authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+[dependencies]

--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -1,0 +1,142 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This shouldn't exist, but does because if something isn't going to link
+//! against `nss` but has an `nss`-enabled `sqlcipher` turned on (for example,
+//! by a `cargo` feature activated by something else in the workspace).
+//! it might need to issue link commands for NSS.
+//!
+//! It essentially contains the non-bindgen part of nss_sys's build.rs.
+
+use std::{
+    env,
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum LinkingKind {
+    Dynamic { folded_libs: bool },
+    Static,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct NoNssDir;
+
+pub fn link_nss() -> Result<(PathBuf, PathBuf), NoNssDir> {
+    let (lib_dir, include_dir) = get_nss()?;
+    println!(
+        "cargo:rustc-link-search=native={}",
+        lib_dir.to_string_lossy()
+    );
+    println!("cargo:include={}", include_dir.to_string_lossy());
+    let kind = determine_kind();
+    link_nss_libs(kind);
+    Ok((lib_dir, include_dir))
+}
+
+fn get_nss() -> Result<(PathBuf, PathBuf), NoNssDir> {
+    let nss_dir = env("NSS_DIR").ok_or(NoNssDir)?;
+    let nss_dir = Path::new(&nss_dir);
+    let lib_dir = nss_dir.join("lib");
+    let include_dir = nss_dir.join("include");
+    Ok((lib_dir, include_dir))
+}
+
+fn determine_kind() -> LinkingKind {
+    if env_flag("NSS_STATIC") {
+        LinkingKind::Static
+    } else {
+        let folded_libs = env_flag("NSS_USE_FOLDED_LIBS");
+        LinkingKind::Dynamic { folded_libs }
+    }
+}
+
+fn link_nss_libs(kind: LinkingKind) {
+    let libs = get_nss_libs(kind);
+    // Emit -L flags
+    let kind_str = match kind {
+        LinkingKind::Dynamic { .. } => "dylib",
+        LinkingKind::Static => "static",
+    };
+    for lib in libs {
+        println!("cargo:rustc-link-lib={}={}", kind_str, lib);
+    }
+}
+
+fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
+    match kind {
+        LinkingKind::Static => {
+            let mut static_libs = vec![
+                "certdb",
+                "certhi",
+                "cryptohi",
+                "freebl_static",
+                "hw-acc-crypto",
+                "nspr4",
+                "nss_static",
+                "nssb",
+                "nssdev",
+                "nsspki",
+                "nssutil",
+                "pk11wrap_static",
+                "plc4",
+                "plds4",
+                "softokn_static",
+            ];
+            // Hardware specific libs.
+            let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+            let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+            // https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#159-168
+            if target_arch == "x86_64" || target_arch == "x86" {
+                static_libs.push("gcm-aes-x86_c_lib");
+            } else if target_arch == "aarch64" {
+                static_libs.push("gcm-aes-aarch64_c_lib");
+            }
+            // https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#224-233
+            if ((target_os == "android" || target_os == "linux") && target_arch == "x86_64")
+                || target_os == "windows"
+            {
+                static_libs.push("intel-gcm-wrap_c_lib");
+                // https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#43-47
+                if (target_os == "android" || target_os == "linux") && target_arch == "x86_64" {
+                    static_libs.push("intel-gcm-s_lib");
+                }
+            }
+            static_libs
+        }
+        LinkingKind::Dynamic { folded_libs } => {
+            let mut dylibs = vec!["freebl3", "nss3", "nssckbi", "softokn3"];
+            if !folded_libs {
+                dylibs.append(&mut vec!["nspr4", "nssutil3", "plc4", "plds4"]);
+            }
+            dylibs
+        }
+    }
+}
+
+pub fn env(name: &str) -> Option<OsString> {
+    println!("cargo:rerun-if-env-changed={}", name);
+    env::var_os(name)
+}
+
+pub fn env_str(name: &str) -> Option<String> {
+    println!("cargo:rerun-if-env-changed={}", name);
+    env::var(name).ok()
+}
+
+pub fn env_flag(name: &str) -> bool {
+    match env_str(name).as_ref().map(String::as_ref) {
+        Some("1") => true,
+        Some("0") => false,
+        Some(s) => {
+            println!(
+                "cargo:warning=unknown value for environment var {:?}: {:?}. Ignoring",
+                name, s
+            );
+            false
+        }
+        None => false,
+    }
+}

--- a/components/support/rc_crypto/nss/nss_sys/Cargo.toml
+++ b/components/support/rc_crypto/nss/nss_sys/Cargo.toml
@@ -13,3 +13,4 @@ bindgen = "0.52.0"
 serde = "1.0.101"
 serde_derive = "1.0.101"
 toml = "0.5.3"
+nss_build_common = {path = "../nss_build_common"}

--- a/components/support/rc_crypto/nss/nss_sys/build.rs
+++ b/components/support/rc_crypto/nss/nss_sys/build.rs
@@ -4,21 +4,12 @@
 
 use bindgen::Builder;
 use serde_derive::Deserialize;
-use std::{
-    env,
-    ffi::OsString,
-    fs,
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::{env, fs, path::PathBuf, process::Command};
 use toml;
 
-const BINDINGS_CONFIG: &'static str = "bindings.toml";
+use nss_build_common::*;
 
-enum LinkingKind {
-    Dynamic { folded_libs: bool },
-    Static,
-}
+const BINDINGS_CONFIG: &'static str = "bindings.toml";
 
 // This is the format of a single section of the configuration file.
 #[derive(Deserialize)]
@@ -46,30 +37,6 @@ struct Bindings {
     exclude: Option<Vec<String>>,
 }
 
-fn env(name: &str) -> Option<OsString> {
-    println!("cargo:rerun-if-env-changed={}", name);
-    env::var_os(name)
-}
-
-fn env_str(name: &str) -> Option<String> {
-    println!("cargo:rerun-if-env-changed={}", name);
-    env::var(name).ok()
-}
-
-fn env_flag(name: &str) -> bool {
-    match env_str(name).as_ref().map(String::as_ref) {
-        Some("1") => true,
-        Some("0") => false,
-        Some(s) => {
-            println!(
-                "cargo:warning=unknown value for environment var {:?}: {:?}. Ignoring",
-                name, s
-            );
-            false
-        }
-        None => false,
-    }
-}
 const DEFAULT_ANDROID_NDK_API_VERSION: &str = "21";
 
 // Set the CLANG_PATH env variable to point to the right clang for the NDK in question.
@@ -103,100 +70,13 @@ fn main() {
     // Note: this has to be first!
     maybe_setup_ndk_clang_path();
     // 1. NSS linking.
-    let (lib_dir, include_dir) = get_nss();
-    println!(
-        "cargo:rustc-link-search=native={}",
-        lib_dir.to_string_lossy()
-    );
-    println!("cargo:include={}", include_dir.to_string_lossy());
-    let kind = determine_kind();
-    link_nss_libs(&kind);
+    let (_, include_dir) = link_nss().expect("To build nss_sys, NSS_DIR must be set!");
     // 2. Bindings.
     let config_file = PathBuf::from(BINDINGS_CONFIG);
     println!("cargo:rerun-if-changed={}", config_file.to_str().unwrap());
     let config = fs::read_to_string(config_file).expect("unable to read binding configuration");
     let bindings: Bindings = toml::from_str(&config).unwrap();
     build_bindings(&bindings, &include_dir.join("nss"));
-}
-
-fn determine_kind() -> LinkingKind {
-    return if env_flag("NSS_STATIC") {
-        LinkingKind::Static
-    } else {
-        let folded_libs = env_flag("NSS_USE_FOLDED_LIBS");
-        return LinkingKind::Dynamic { folded_libs };
-    };
-}
-
-fn link_nss_libs(kind: &LinkingKind) {
-    let libs = get_nss_libs(kind);
-    // Emit -L flags
-    let kind_str = match kind {
-        LinkingKind::Dynamic { .. } => "dylib",
-        LinkingKind::Static => "static",
-    };
-    for lib in libs {
-        println!("cargo:rustc-link-lib={}={}", kind_str, lib);
-    }
-}
-
-fn get_nss_libs(kind: &LinkingKind) -> Vec<&'static str> {
-    match kind {
-        LinkingKind::Static => {
-            let mut static_libs = vec![
-                "certdb",
-                "certhi",
-                "cryptohi",
-                "freebl_static",
-                "hw-acc-crypto",
-                "nspr4",
-                "nss_static",
-                "nssb",
-                "nssdev",
-                "nsspki",
-                "nssutil",
-                "pk11wrap_static",
-                "plc4",
-                "plds4",
-                "softokn_static",
-            ];
-            // Hardware specific libs.
-            let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-            let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-            // https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#159-168
-            if target_arch == "x86_64" || target_arch == "x86" {
-                static_libs.push("gcm-aes-x86_c_lib");
-            } else if target_arch == "aarch64" {
-                static_libs.push("gcm-aes-aarch64_c_lib");
-            }
-            // https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#224-233
-            if ((target_os == "android" || target_os == "linux") && target_arch == "x86_64")
-                || target_os == "windows"
-            {
-                static_libs.push("intel-gcm-wrap_c_lib");
-                // https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#43-47
-                if (target_os == "android" || target_os == "linux") && target_arch == "x86_64" {
-                    static_libs.push("intel-gcm-s_lib");
-                }
-            }
-            return static_libs;
-        }
-        LinkingKind::Dynamic { folded_libs } => {
-            let mut dylibs = vec!["freebl3", "nss3", "nssckbi", "softokn3"];
-            if !folded_libs {
-                dylibs.append(&mut vec!["nspr4", "nssutil3", "plc4", "plds4"]);
-            }
-            return dylibs;
-        }
-    }
-}
-
-fn get_nss() -> (PathBuf, PathBuf) {
-    let nss_dir = env("NSS_DIR").expect("To build nss_sys, NSS_DIR must be set!");
-    let nss_dir = Path::new(&nss_dir);
-    let lib_dir = nss_dir.join("lib");
-    let include_dir = nss_dir.join("include");
-    (lib_dir, include_dir)
 }
 
 fn build_bindings(bindings: &Bindings, include_dir: &PathBuf) {

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -16,5 +16,5 @@ interrupt = { path = "../interrupt" }
 ffi-support = { path = "../ffi" }
 
 [dependencies.rusqlite]
-version = "0.20.0"
+version = "0.21.0"
 features = ["functions", "limits", "bundled"]


### PR DESCRIPTION
`rand`'s RNG is fine for generating GUIDs, and we want to punt on bringing in the nss stack to m-c for a bit.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
