### PR TITLE
Expose methods for resetting history and bookmark sync metadata

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -8,6 +8,12 @@
 
 - The Dogear library for merging synced bookmarks has been updated to the latest version.
   ([#2469](https://github.com/mozilla/application-services/pull/2469))
+- Places now exposes `resetHistorySyncMetadata` and `resetBookmarkSyncMetadata`
+  methods, which cleans up all Sync state, including tracking flags and change
+  counters. These methods should be called by consumers when the user signs out,
+  to avoid tracking changes and causing unexpected behavior the next time they
+  sign in.
+  ([#2447](https://github.com/mozilla/application-services/pull/2447))
 
 ### Breaking Changes
 

--- a/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
@@ -289,7 +289,7 @@ interface WritableBookmarksConnection : ReadableBookmarksConnection {
      * from Sync. There are other times when Places resets sync metadata,
      * but those are handled internally in the Rust code.
      */
-    fun resetBookmarks()
+    fun resetBookmarkSyncMetadata()
 
     /**
      * Create a bookmark folder, returning its guid.

--- a/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
@@ -280,6 +280,18 @@ interface WritableBookmarksConnection : ReadableBookmarksConnection {
     fun deleteAllBookmarks()
 
     /**
+     * Resets all sync metadata for bookmarks, including change flags,
+     * sync statuses, and last sync time. The next sync after reset
+     * will behave the same way as a first sync when connecting a new
+     * device.
+     *
+     * This method only needs to be called when the user disconnects
+     * from Sync. There are other times when Places resets sync metadata,
+     * but those are handled internally in the Rust code.
+     */
+    fun resetBookmarks()
+
+    /**
      * Create a bookmark folder, returning its guid.
      *
      * @param parentGUID The GUID of the (soon to be) parent of this bookmark.

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -184,6 +184,11 @@ internal interface LibPlacesFFI : Library {
         error: RustError.ByReference
     ): Long
 
+    fun places_reset(
+        handle: PlacesConnectionHandle,
+        error: RustError.ByReference
+    )
+
     // Returns a JSON string containing a sync ping.
     fun sync15_history_sync(
         handle: PlacesApiHandle,

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -209,11 +209,6 @@ internal interface LibPlacesFFI : Library {
         out_err: RustError.ByReference
     ): Pointer?
 
-    fun places_api_reset_bookmarks(
-        handle: PlacesApiHandle,
-        out_err: RustError.ByReference
-    )
-
     fun bookmarks_get_all_with_url(
         handle: PlacesConnectionHandle,
         url: String,
@@ -275,6 +270,11 @@ internal interface LibPlacesFFI : Library {
     ): Byte
 
     fun bookmarks_delete_everything(
+        handle: PlacesConnectionHandle,
+        error: RustError.ByReference
+    )
+
+    fun bookmarks_reset(
         handle: PlacesConnectionHandle,
         error: RustError.ByReference
     )

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -562,6 +562,12 @@ class PlacesWriterConnection internal constructor(connHandle: Long, api: PlacesA
         }
     }
 
+    override fun resetHistory() {
+        rustCall { error ->
+            LibPlacesFFI.INSTANCE.places_reset(this.handle.get(), error)
+        }
+    }
+
     override fun deleteAllBookmarks() {
         return writeQueryCounters.measure {
             rustCall { error ->
@@ -915,6 +921,18 @@ interface WritableHistoryConnection : ReadableHistoryConnection {
      * should not return.
      */
     fun deleteEverything()
+
+    /**
+     * Resets all sync metadata for history, including change flags,
+     * sync statuses, and last sync time. The next sync after reset
+     * will behave the same way as a first sync when connecting a new
+     * device.
+     *
+     * This method only needs to be called when the user disconnects
+     * from Sync. There are other times when Places resets sync metadata,
+     * but those are handled internally in the Rust code.
+     */
+    fun resetHistory()
 
     /**
      * Deletes all information about the given URL. If the place has previously

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -562,7 +562,7 @@ class PlacesWriterConnection internal constructor(connHandle: Long, api: PlacesA
         }
     }
 
-    override fun resetHistory() {
+    override fun resetHistorySyncMetadata() {
         rustCall { error ->
             LibPlacesFFI.INSTANCE.places_reset(this.handle.get(), error)
         }
@@ -578,7 +578,7 @@ class PlacesWriterConnection internal constructor(connHandle: Long, api: PlacesA
         }
     }
 
-    override fun resetBookmarks() {
+    override fun resetBookmarkSyncMetadata() {
         rustCall { error ->
             LibPlacesFFI.INSTANCE.bookmarks_reset(this.handle.get(), error)
         }
@@ -938,7 +938,7 @@ interface WritableHistoryConnection : ReadableHistoryConnection {
      * from Sync. There are other times when Places resets sync metadata,
      * but those are handled internally in the Rust code.
      */
-    fun resetHistory()
+    fun resetHistorySyncMetadata()
 
     /**
      * Deletes all information about the given URL. If the place has previously

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -578,6 +578,12 @@ class PlacesWriterConnection internal constructor(connHandle: Long, api: PlacesA
         }
     }
 
+    override fun resetBookmarks() {
+        rustCall { error ->
+            LibPlacesFFI.INSTANCE.bookmarks_reset(this.handle.get(), error)
+        }
+    }
+
     override fun deleteBookmarkNode(guid: String): Boolean {
         return writeQueryCounters.measure {
             rustCall { error ->

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -484,6 +484,15 @@ pub extern "C" fn places_accept_result(
 }
 
 #[no_mangle]
+pub extern "C" fn places_reset(handle: u64, error: &mut ExternError) {
+    log::debug!("places_reset");
+    CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
+        storage::history::history_sync::reset(conn)?;
+        Ok(())
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn sync15_history_sync(
     handle: u64,
     key_id: FfiStr<'_>,

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -153,15 +153,6 @@ pub extern "C" fn places_api_return_write_conn(
     })
 }
 
-#[no_mangle]
-pub extern "C" fn places_api_reset_bookmarks(api_handle: u64, error: &mut ExternError) {
-    log::debug!("places_api_reset_bookmarks");
-    APIS.call_with_result(error, api_handle, |api| -> places::Result<_> {
-        api.reset_bookmarks()?;
-        Ok(())
-    })
-}
-
 /// Get the interrupt handle for a connection. Must be destroyed with
 /// `places_interrupt_handle_destroy`.
 #[no_mangle]
@@ -488,6 +479,15 @@ pub extern "C" fn places_reset(handle: u64, error: &mut ExternError) {
     log::debug!("places_reset");
     CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
         storage::history::history_sync::reset(conn)?;
+        Ok(())
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn bookmarks_reset(handle: u64, error: &mut ExternError) {
+    log::debug!("bookmarks_reset");
+    CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
+        storage::bookmarks::bookmark_sync::reset(conn)?;
         Ok(())
     })
 }

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -539,6 +539,33 @@ public class PlacesWriteConnection: PlacesReadConnection {
     }
 
     /**
+     * Resets all sync metadata for history, including change flags,
+     * sync statuses, and last sync time. The next sync after reset
+     * will behave the same way as a first sync when connecting a new
+     * device.
+     *
+     * This method only needs to be called when the user disconnects
+     * from Sync. There are other times when Places resets sync metadata,
+     * but those are handled internally in the Rust code.
+     *
+     * - Throws:
+     *     - `PlacesError.databaseInterrupted`: If a call is made to `interrupt()` on this
+     *                                          object from another thread.
+     *     - `PlacesError.unexpected`: When an error that has not specifically been exposed
+     *                                 to Swift is encountered (for example IO errors from
+     *                                 the database code, etc).
+     *     - `PlacesError.panic`: If the rust code panics while completing this
+     *                            operation. (If this occurs, please let us know).
+     */
+    open func resetHistory() throws {
+        return try queue.sync {
+            try PlacesError.unwrap { err in
+                places_reset(handle, err)
+            }
+        }
+    }
+
+    /**
      * Delete the bookmark with the provided GUID.
      *
      * If the requested bookmark is a folder, all children of

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -188,7 +188,7 @@ public class PlacesAPI {
      *     - `PlacesError.panic`: If the rust code panics while completing this
      *                            operation. (If this occurs, please let us know).
      */
-    open func resetBookmarks() throws {
+    open func resetBookmarkSyncMetadata() throws {
         return try queue.sync {
             try PlacesError.unwrap { err in
                 bookmarks_reset(handle, err)
@@ -559,7 +559,7 @@ public class PlacesWriteConnection: PlacesReadConnection {
      *     - `PlacesError.panic`: If the rust code panics while completing this
      *                            operation. (If this occurs, please let us know).
      */
-    open func resetHistory() throws {
+    open func resetHistorySyncMetadata() throws {
         return try queue.sync {
             try PlacesError.unwrap { err in
                 places_reset(handle, err)

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -175,7 +175,9 @@ public class PlacesAPI {
     }
 
     /**
-     * Reset sync metadata for the bookmarks collection.
+     * Resets all sync metadata for bookmarks, including change flags, sync statuses, and
+     * last sync time. The next sync after reset will behave the same way as a first sync
+     * when connecting a new device.
      *
      * - Throws:
      *     - `PlacesError.databaseInterrupted`: If a call is made to `interrupt()` on this
@@ -186,10 +188,10 @@ public class PlacesAPI {
      *     - `PlacesError.panic`: If the rust code panics while completing this
      *                            operation. (If this occurs, please let us know).
      */
-    open func resetBookmarksMetadata() throws {
+    open func resetBookmarks() throws {
         return try queue.sync {
             try PlacesError.unwrap { err in
-                places_api_reset_bookmarks(handle, err)
+                bookmarks_reset(handle, err)
             }
         }
     }

--- a/components/places/ios/Places/RustPlacesAPI.h
+++ b/components/places/ios/Places/RustPlacesAPI.h
@@ -142,9 +142,6 @@ char *_Nonnull sync15_bookmarks_sync(PlacesAPIHandle handle,
                                      char const *_Nonnull tokenserver_url,
                                      PlacesRustError *_Nonnull out_err);
 
-void places_api_reset_bookmarks(PlacesAPIHandle handle,
-                                PlacesRustError *_Nonnull out_err);
-
 RawPlacesInterruptHandle *_Nullable
 places_new_sync_conn_interrupt_handle(PlacesAPIHandle handle,
                                       PlacesRustError *_Nonnull out_err);
@@ -190,6 +187,9 @@ void bookmarks_update(PlacesConnectionHandle handle,
 uint8_t bookmarks_delete(PlacesConnectionHandle handle,
                          char const *_Nonnull guid_to_delete,
                          PlacesRustError *_Nonnull out_err);
+
+void bookmarks_reset(PlacesAPIHandle handle,
+                     PlacesRustError *_Nonnull out_err);
 
 // MARK: memory/lifecycle management
 

--- a/components/places/ios/Places/RustPlacesAPI.h
+++ b/components/places/ios/Places/RustPlacesAPI.h
@@ -125,6 +125,9 @@ PlacesRustBuffer places_get_visit_infos(PlacesConnectionHandle handle,
                                         int32_t exclude_types,
                                         PlacesRustError *_Nonnull out_err);
 
+void places_reset(PlacesAPIHandle handle,
+                  PlacesRustError *_Nonnull out_err);
+
 char *_Nonnull sync15_history_sync(PlacesAPIHandle handle,
                                    char const *_Nonnull key_id,
                                    char const *_Nonnull access_token,

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -8,10 +8,12 @@
 // db.rs.
 
 use crate::api::places_api::ConnectionType;
-use crate::bookmark_sync::{self, create_synced_bookmark_roots};
+use crate::bookmark_sync::store::LAST_SYNC_META_KEY;
 use crate::db::PlacesDb;
 use crate::error::*;
-use crate::storage::bookmarks::create_bookmark_roots;
+use crate::storage::bookmarks::{
+    bookmark_sync::create_synced_bookmark_roots, create_bookmark_roots,
+};
 use crate::types::SyncStatus;
 use rusqlite::NO_PARAMS;
 use sql_support::ConnExt;
@@ -193,10 +195,7 @@ fn upgrade(db: &PlacesDb, from: i64) -> Result<()> {
         &[
             // Changing `moz_bookmarks_synced_structure` to store multiple
             // parents, so we need to re-download all synced bookmarks.
-            &format!(
-                "DELETE FROM moz_meta WHERE key = '{}'",
-                bookmark_sync::store::LAST_SYNC_META_KEY
-            ),
+            &format!("DELETE FROM moz_meta WHERE key = '{}'", LAST_SYNC_META_KEY),
             "DROP TABLE moz_bookmarks_synced",
             "DROP TABLE moz_bookmarks_synced_structure",
             CREATE_SHARED_SCHEMA_SQL,

--- a/components/places/src/import/fennec/bookmarks.rs
+++ b/components/places/src/import/fennec/bookmarks.rs
@@ -10,7 +10,7 @@ use crate::bookmark_sync::{
 use crate::db::db::PlacesDb;
 use crate::error::*;
 use crate::import::common::{attached_database, ExecuteOnDrop};
-use crate::storage::bookmarks::PublicNode;
+use crate::storage::bookmarks::{bookmark_sync::create_synced_bookmark_roots, PublicNode};
 use crate::types::{BookmarkType, SyncStatus};
 use rusqlite::NO_PARAMS;
 use serde_derive::*;
@@ -86,7 +86,7 @@ fn do_import(places_api: &PlacesApi, fennec_db_file_url: Url) -> Result<Bookmark
     scope.err_if_interrupted()?;
 
     log::debug!("Populating mirror with the bookmarks roots");
-    crate::bookmark_sync::create_synced_bookmark_roots(&conn)?;
+    create_synced_bookmark_roots(&conn)?;
     scope.err_if_interrupted()?;
 
     log::debug!("Creating staging table");


### PR DESCRIPTION
This PR exposes `resetHistory` and `resetBookmarks` methods as part of the public APIs. These should be called when the user signs out, to clean up any remaining local Sync state like change counters and tombstones. Without that, Places will continue to track changes for history and bookmarks locally while the user is signed out, leading to surprises if they sign back in with the same account.

Closes #2250.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
