### PR TITLE
Disable failure's features, including its backtrace dependency

### DIFF
--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -21,7 +21,7 @@ log_backtraces = ["log_panics", "backtrace"]
 [dependencies]
 log = "0.4"
 lazy_static = "1.4.0"
-failure = "0.1.6"
+failure = { version = "0.1.6", default-features = false }
 failure_derive = "0.1.5"
 
 [dependencies.backtrace]


### PR DESCRIPTION
ffi-support handles backtrace support by calling into the library
directly.
This is already an optional feature.
By not requiring default features of failure consumers of ffi-support
can enable (or disable) these themselves.

Glean is such a user and we identified problems having backtrace pulled in when included in mozilla-central on Windows targets.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
