### PR TITLE
[ci full]  Revert "Update NSS to 3.48"

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.48.0...master)
 
+## General
+
+- Revert NSS to version 3.46.
+
 ## Logins
 
 ### What's changed

--- a/components/support/rc_crypto/src/hkdf.rs
+++ b/components/support/rc_crypto/src/hkdf.rs
@@ -50,6 +50,10 @@ mod tests {
     use crate::digest;
     use hex;
 
+    // NSS limits the size of derived key material to 576 bytes due to fixed-size `key_block` buffer here:
+    // https://dxr.mozilla.org/mozilla-central/rev/3c0f78074b727fbae112b6eda111d4c4d30cc3ec/security/nss/lib/softoken/pkcs11c.c#7758
+    const NSS_MAX_DERIVED_KEY_MATERIAL: usize = 576;
+
     #[test]
     fn hkdf_produces_correct_result() {
         let secret = hex::decode("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();
@@ -94,7 +98,7 @@ mod tests {
     #[test]
     fn hkdf_rejects_gigantic_output_buffers() {
         let salt = hmac::SigningKey::new(&digest::SHA256, b"salt");
-        let mut out = vec![0u8; 8160 + 1]; // RFC maximum (hashlen * 255) + 1
+        let mut out = vec![0u8; NSS_MAX_DERIVED_KEY_MATERIAL + 1];
         assert!(extract_and_expand(&salt, b"secret", b"info", &mut out).is_err());
     }
 

--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -5,10 +5,10 @@ set -euvx
 # SQLCIPHER_VERSION="4.1.0"
 # SQLCIPHER_SHA256="65144ca3ba4c0f9cd4bae8c20bb42f2b84424bf29d1ebcf04c44a728903b1faa"
 
-NSS="nss-3.48"
-NSS_ARCHIVE="nss-3.48-with-nspr-4.24.tar.gz"
-NSS_URL="http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_48_RTM/src/${NSS_ARCHIVE}"
-NSS_SHA256="a97f96d81c77954fd7aba7ab7310b2e9ab066347bc604c3c5174877113c47f4c"
+NSS="nss-3.46"
+NSS_ARCHIVE="nss-3.46-with-nspr-4.22.tar.gz"
+NSS_URL="http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_46_RTM/src/${NSS_ARCHIVE}"
+NSS_SHA256="3d4197196e870ab2dccc6ee497e0ec83f45ea070fee929dd931491c024d69f31"
 
 # End of configuration.
 
@@ -80,15 +80,13 @@ echo $'\
 diff -r 65efa74ef84a coreconf/config.gypi
 --- a/coreconf/config.gypi      Thu May 16 09:43:04 2019 +0000
 +++ b/coreconf/config.gypi      Thu May 23 19:46:44 2019 -0400
-@@ -138,6 +138,23 @@
+@@ -138,6 +138,21 @@
        \'<(nspr_include_dir)\',
        \'<(nss_dist_dir)/private/<(module)\',
      ],
 +    \'defines\': [
 +      \'HMAC_Update=NSS_HMAC_Update\',
 +      \'HMAC_Init=NSS_HMAC_Init\',
-+      \'CMAC_Update=NSS_CMAC_Update\',
-+      \'CMAC_Init=NSS_CMAC_Init\',
 +      \'MD5_Update=NSS_MD5_Update\',
 +      \'SHA1_Update=NSS_SHA1_Update\',
 +      \'SHA256_Update=NSS_SHA256_Update\',


### PR DESCRIPTION
Maybe fixes https://github.com/mozilla/application-services/issues/2449
This reverts commit 86f3f67a5d8a4fbd2b89d3ba9998e46c7df34e65.
