### PR TITLE
Remove failure dependency from ffi-support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,8 +662,6 @@ version = "0.3.6"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "ffi-support"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -763,7 +763,7 @@ dependencies = [
  "dialoguer 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "force-viaduct-reqwest 0.1.0",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -787,7 +787,7 @@ dependencies = [
 name = "fxaclient_ffi"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "fxa-client 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1097,7 +1097,7 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "force-viaduct-reqwest 0.1.0",
  "fxa-client 0.1.0",
  "interrupt 0.1.0",
@@ -1121,7 +1121,7 @@ name = "logins_ffi"
 version = "0.1.0"
 dependencies = [
  "base16 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins 0.1.0",
@@ -1592,7 +1592,7 @@ dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "find-places-db 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "force-viaduct-reqwest 0.1.0",
  "fxa-client 0.1.0",
@@ -1627,7 +1627,7 @@ name = "places-ffi"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "interrupt 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1781,7 +1781,7 @@ dependencies = [
  "error-support 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "force-viaduct-reqwest 0.1.0",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1805,7 +1805,7 @@ name = "push-ffi"
 version = "0.1.0"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2042,7 +2042,7 @@ name = "rc_log_ffi"
 version = "0.1.0"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2391,7 +2391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "sql-support"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "interrupt 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2498,7 +2498,7 @@ dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "interrupt 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2518,7 +2518,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "interrupt 0.1.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2540,7 +2540,7 @@ dependencies = [
 name = "sync_manager_ffi"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logins_ffi 0.1.0",
  "places-ffi 0.1.0",
@@ -2571,7 +2571,7 @@ dependencies = [
  "clipboard 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-support 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "force-viaduct-reqwest 0.1.0",
  "interrupt 0.1.0",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2591,7 +2591,7 @@ name = "tabs_ffi"
 version = "0.1.0"
 dependencies = [
  "base16 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2953,7 +2953,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ffi-support 0.3.6",
+ "ffi-support 0.4.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -21,8 +21,6 @@ log_backtraces = ["log_panics", "backtrace"]
 [dependencies]
 log = "0.4"
 lazy_static = "1.4.0"
-failure = { version = "0.1.6", default-features = false }
-failure_derive = "0.1.5"
 
 [dependencies.backtrace]
 optional = true

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffi-support"
 edition = "2018"
-version = "0.3.6"
+version = "0.4.0"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 description = "A crate to help expose Rust functions over the FFI."
 repository = "https://github.com/mozilla/application-services"

--- a/components/support/ffi/src/handle_map.rs
+++ b/components/support/ffi/src/handle_map.rs
@@ -64,7 +64,8 @@
 
 use crate::error::{ErrorCode, ExternError};
 use crate::into_ffi::IntoFfi;
-use failure_derive::Fail;
+use std::error::Error as StdError;
+use std::fmt;
 use std::ops;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Mutex, RwLock};
@@ -170,31 +171,43 @@ pub const MAX_CAPACITY: usize = (1 << 15) - 1;
 const MIN_CAPACITY: usize = 4;
 
 /// An error representing the ways a `Handle` may be invalid.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Fail)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum HandleError {
     /// Identical to invalid handle, but has a slightly more helpful
     /// message for the most common case 0.
-    #[fail(display = "Tried to use a null handle (this object has probably been closed)")]
     NullHandle,
 
     /// Returned from [`Handle::from_u64`] if [`Handle::is_valid`] fails.
-    #[fail(display = "u64 could not encode a valid Handle")]
     InvalidHandle,
 
     /// Returned from get/get_mut/delete if the handle is stale (this indicates
     /// something equivalent to a use-after-free / double-free, etc).
-    #[fail(display = "Handle has stale version number")]
     StaleVersion,
 
     /// Returned if the handle index references an index past the end of the
     /// HandleMap.
-    #[fail(display = "Handle references a index past the end of this HandleMap")]
     IndexPastEnd,
 
     /// The handle has a map_id for a different map than the one it was
     /// attempted to be used with.
-    #[fail(display = "Handle is from a different map")]
     WrongMap,
+}
+
+impl StdError for HandleError {}
+
+impl fmt::Display for HandleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use HandleError::*;
+        match self {
+            NullHandle => {
+                f.write_str("Tried to use a null handle (this object has probably been closed)")
+            }
+            InvalidHandle => f.write_str("u64 could not encode a valid Handle"),
+            StaleVersion => f.write_str("Handle has stale version number"),
+            IndexPastEnd => f.write_str("Handle references a index past the end of this HandleMap"),
+            WrongMap => f.write_str("Handle is from a different map"),
+        }
+    }
 }
 
 impl From<HandleError> for ExternError {

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -309,7 +309,6 @@ fn init_panic_handling_once() {
     INIT_BACKTRACES.call_once(move || {
         #[cfg(all(feature = "log_backtraces", not(target_os = "android")))]
         {
-            // Turn on backtraces for failure, if it's still listening.
             std::env::set_var("RUST_BACKTRACE", "1");
         }
         // Turn on a panic hook which logs both backtraces and the panic
@@ -325,10 +324,6 @@ fn init_panic_handling_once() {
                 ("<unknown>", 0)
             };
             log::error!("### Rust `panic!` hit at file '{}', line {}", file, line);
-            // We could use failure for failure::Backtrace (and we enable RUST_BACKTRACE
-            // to opt-in to backtraces on failure errors if possible), however:
-            // - `failure` only checks the RUST_BACKTRACE variable once, and we could have errors
-            //   before this. So we just use the backtrace crate directly.
             #[cfg(all(feature = "log_backtraces", not(target_os = "android")))]
             {
                 log::error!("  Complete stack trace:\n{:?}", backtrace::Backtrace::new());


### PR DESCRIPTION
It's betteer to just implement std::error::Error directly.
That reduces compile times and the burden for users of ffi-support,
which might not depend on failure at all.

As @thomcc mentioned in #2448 he had the idea of getting rid of it anyway.
That was an easy task to fulfill.

Signed-off-by: Jan-Erik Rediger <jrediger@mozilla.com>

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
