### PR TITLE
Avoid panicing when importing a completely empty Fennec db

### DIFF
--- a/components/places/src/import/fennec/bookmarks.rs
+++ b/components/places/src/import/fennec/bookmarks.rs
@@ -139,12 +139,9 @@ fn do_import(places_api: &PlacesApi, fennec_db_file_url: Url) -> Result<Bookmark
 
     log::debug!("Counting Fenix bookmarks");
     let num_succeeded = select_count(&conn, &COUNT_FENIX_BOOKMARKS);
-    // This is possible because we auto-create missing roots...
-    let num_failed = if num_succeeded <= num_total {
-        num_total - num_succeeded
-    } else {
-        0
-    };
+    // saturating_sub because num_succeeded could be > num_total due to
+    // us auto-creating missing roots...
+    let num_failed = num_total.saturating_sub(num_succeeded);
 
     auto_detach.execute_now()?;
 

--- a/components/places/src/import/fennec/bookmarks.rs
+++ b/components/places/src/import/fennec/bookmarks.rs
@@ -139,7 +139,12 @@ fn do_import(places_api: &PlacesApi, fennec_db_file_url: Url) -> Result<Bookmark
 
     log::debug!("Counting Fenix bookmarks");
     let num_succeeded = select_count(&conn, &COUNT_FENIX_BOOKMARKS);
-    let num_failed = num_total - num_succeeded;
+    // This is possible because we auto-create missing roots...
+    let num_failed = if num_succeeded <= num_total {
+        num_total - num_succeeded
+    } else {
+        0
+    };
 
     auto_detach.execute_now()?;
 


### PR DESCRIPTION
Because we underflow due to how we count. I think the slight discrepancy in the counts that still remains is OK though (see the test for details)