### PR TITLE
Update NSS to 3.52 [ci full]

### DIFF
--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -85,7 +85,6 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
                 "certhi",
                 "cryptohi",
                 "freebl_static",
-                "hw-acc-crypto",
                 "nspr4",
                 "nss_static",
                 "nssb",
@@ -100,18 +99,29 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
             // Hardware specific libs.
             let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
             let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-            // https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#159-168
+            // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#278-296
+            if target_arch == "arm" || target_arch == "aarch64" {
+                static_libs.push("armv8_c_lib");
+            }
             if target_arch == "x86_64" || target_arch == "x86" {
                 static_libs.push("gcm-aes-x86_c_lib");
-            } else if target_arch == "aarch64" {
+            }
+            if target_arch == "arm" {
+                static_libs.push("gcm-aes-arm32-neon_c_lib")
+            }
+            if target_arch == "aarch64" {
                 static_libs.push("gcm-aes-aarch64_c_lib");
             }
-            // https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#224-233
+            if target_arch == "x86_64" {
+                static_libs.push("hw-acc-crypto-avx");
+                static_libs.push("hw-acc-crypto-avx2");
+            }
+            // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#315-324
             if ((target_os == "android" || target_os == "linux") && target_arch == "x86_64")
                 || target_os == "windows"
             {
                 static_libs.push("intel-gcm-wrap_c_lib");
-                // https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#43-47
+                // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#43-47
                 if (target_os == "android" || target_os == "linux") && target_arch == "x86_64" {
                     static_libs.push("intel-gcm-s_lib");
                 }

--- a/components/support/rc_crypto/nss/nss_sys/src/bindings/pkcs11n.rs
+++ b/components/support/rc_crypto/nss/nss_sys/src/bindings/pkcs11n.rs
@@ -6,10 +6,12 @@ pub use crate::*;
 
 pub const CKM_NSS_HKDF_SHA256: u32 = 3_461_563_220; // (CKM_NSS + 4)
 
+pub type CK_GCM_PARAMS = CK_GCM_PARAMS_V3;
 #[repr(C)]
-pub struct CK_GCM_PARAMS {
+pub struct CK_GCM_PARAMS_V3 {
     pub pIv: CK_BYTE_PTR,
     pub ulIvLen: CK_ULONG,
+    pub ulIvBits: CK_ULONG,
     pub pAAD: CK_BYTE_PTR,
     pub ulAADLen: CK_ULONG,
     pub ulTagBits: CK_ULONG,

--- a/components/support/rc_crypto/nss/src/aes.rs
+++ b/components/support/rc_crypto/nss/src/aes.rs
@@ -31,6 +31,12 @@ pub fn aes_gcm_crypt(
     let mut gcm_params = nss_sys::CK_GCM_PARAMS {
         pIv: nonce.as_ptr() as nss_sys::CK_BYTE_PTR,
         ulIvLen: nss_sys::CK_ULONG::try_from(nonce.len())?,
+        ulIvBits: nss_sys::CK_ULONG::try_from(
+            nonce
+                .len()
+                .checked_mul(8)
+                .ok_or_else(|| ErrorKind::InternalError)?,
+        )?,
         pAAD: aad.as_ptr() as nss_sys::CK_BYTE_PTR,
         ulAADLen: nss_sys::CK_ULONG::try_from(aad.len())?,
         ulTagBits: nss_sys::CK_ULONG::try_from(AES_GCM_TAG_LENGTH * 8)?,

--- a/components/support/rc_crypto/src/hkdf.rs
+++ b/components/support/rc_crypto/src/hkdf.rs
@@ -49,10 +49,6 @@ mod tests {
     use super::*;
     use crate::digest;
 
-    // NSS limits the size of derived key material to 576 bytes due to fixed-size `key_block` buffer here:
-    // https://dxr.mozilla.org/mozilla-central/rev/3c0f78074b727fbae112b6eda111d4c4d30cc3ec/security/nss/lib/softoken/pkcs11c.c#7758
-    const NSS_MAX_DERIVED_KEY_MATERIAL: usize = 576;
-
     #[test]
     fn hkdf_produces_correct_result() {
         let secret = hex::decode("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b").unwrap();
@@ -97,7 +93,7 @@ mod tests {
     #[test]
     fn hkdf_rejects_gigantic_output_buffers() {
         let salt = hmac::SigningKey::new(&digest::SHA256, b"salt");
-        let mut out = vec![0u8; NSS_MAX_DERIVED_KEY_MATERIAL + 1];
+        let mut out = vec![0u8; 8160 + 1]; // RFC maximum (hashlen * 255) + 1
         assert!(extract_and_expand(&salt, b"secret", b"info", &mut out).is_err());
     }
 

--- a/libs/build-all-ios.sh
+++ b/libs/build-all-ios.sh
@@ -61,9 +61,11 @@ universal_lib "nss" "libnsspki.a" "${TARGET_ARCHS[@]}"
 universal_lib "nss" "libpkcs12.a" "${TARGET_ARCHS[@]}"
 universal_lib "nss" "libplds4.a" "${TARGET_ARCHS[@]}"
 universal_lib "nss" "libssl.a" "${TARGET_ARCHS[@]}"
-universal_lib "nss" "libhw-acc-crypto.a" "${TARGET_ARCHS[@]}"
+universal_lib "nss" "libhw-acc-crypto-avx.a" "x86_64"
+universal_lib "nss" "libhw-acc-crypto-avx2.a" "x86_64"
 universal_lib "nss" "libgcm-aes-x86_c_lib.a" "x86_64"
 universal_lib "nss" "libgcm-aes-aarch64_c_lib.a" "arm64"
+universal_lib "nss" "libarmv8_c_lib.a" "arm64"
 
 echo "# Building sqlcipher"
 for i in "${!TARGET_ARCHS[@]}"; do

--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -5,10 +5,10 @@ set -euvx
 SQLCIPHER_VERSION="4.3.0"
 SQLCIPHER_SHA256="fccb37e440ada898902b294d02cde7af9e8706b185d77ed9f6f4d5b18b4c305f"
 
-NSS="nss-3.46"
-NSS_ARCHIVE="nss-3.46-with-nspr-4.22.tar.gz"
-NSS_URL="http://ftp.mozilla.org/pub/security/nss/releases/NSS_3_46_RTM/src/${NSS_ARCHIVE}"
-NSS_SHA256="3d4197196e870ab2dccc6ee497e0ec83f45ea070fee929dd931491c024d69f31"
+NSS="nss-3.52"
+NSS_ARCHIVE="nss-3.52-with-nspr-4.25.tar.gz"
+NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_52_RTM/src/${NSS_ARCHIVE}"
+NSS_SHA256="6c0dccbe4e357539fcbe81407bf26f3c89559ebf3054e75d8d4cec5a618498b1"
 
 # End of configuration.
 
@@ -75,13 +75,15 @@ echo $'\
 diff -r 65efa74ef84a coreconf/config.gypi
 --- a/coreconf/config.gypi      Thu May 16 09:43:04 2019 +0000
 +++ b/coreconf/config.gypi      Thu May 23 19:46:44 2019 -0400
-@@ -138,6 +138,21 @@
+@@ -138,6 +138,23 @@
        \'<(nspr_include_dir)\',
        \'<(nss_dist_dir)/private/<(module)\',
      ],
 +    \'defines\': [
 +      \'HMAC_Update=NSS_HMAC_Update\',
 +      \'HMAC_Init=NSS_HMAC_Init\',
++      \'CMAC_Update=NSS_CMAC_Update\',
++      \'CMAC_Init=NSS_CMAC_Init\',
 +      \'MD5_Update=NSS_MD5_Update\',
 +      \'SHA1_Update=NSS_SHA1_Update\',
 +      \'SHA256_Update=NSS_SHA256_Update\',

--- a/libs/build-nss-android.sh
+++ b/libs/build-nss-android.sh
@@ -110,19 +110,27 @@ cp -p -L "${BUILD_DIR}/lib/libpkcs7.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libsmime.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libsoftokn_static.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libssl.a" "${DIST_DIR}/lib"
-cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto.a" "${DIST_DIR}/lib"
 # HW specific.
-# https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#159-163
+# https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#278-296
 if [[ "${TOOLCHAIN}" == "i686-linux-android" ]] || [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
-elif [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]; then
+fi
+if [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]] || [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]; then
+  cp -p -L "${BUILD_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"
+fi
+if [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-aarch64_c_lib.a" "${DIST_DIR}/lib"
 fi
-# https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#224-228
-# https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#43-47
+if [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]; then
+  cp -p -L "${BUILD_DIR}/lib/libgcm-aes-arm32-neon_c_lib.a" "${DIST_DIR}/lib"
+fi
+# https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#315-324
+# https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#43-47
 if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libintel-gcm-wrap_c_lib.a" "${DIST_DIR}/lib"
   cp -p -L "${BUILD_DIR}/lib/libintel-gcm-s_lib.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx2.a" "${DIST_DIR}/lib"
 fi
 cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libplc4.a" "${DIST_DIR}/lib"
 cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libplds4.a" "${DIST_DIR}/lib"

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -100,7 +100,8 @@ cp -p -L "${NSS_DIST_OBJ_DIR}/lib/${PREFIX}pkcs7.${EXT}" "${DIST_DIR}/lib"
 cp -p -L "${NSS_DIST_OBJ_DIR}/lib/${PREFIX}smime.${EXT}" "${DIST_DIR}/lib"
 cp -p -L "${NSS_DIST_OBJ_DIR}/lib/${PREFIX}softokn_static.${EXT}" "${DIST_DIR}/lib"
 cp -p -L "${NSS_DIST_OBJ_DIR}/lib/${PREFIX}ssl.${EXT}" "${DIST_DIR}/lib"
-cp -p -L "${NSS_DIST_OBJ_DIR}/lib/${PREFIX}hw-acc-crypto.${EXT}" "${DIST_DIR}/lib"
+cp -p -L "${NSS_DIST_OBJ_DIR}/lib/${PREFIX}hw-acc-crypto-avx.${EXT}" "${DIST_DIR}/lib"
+cp -p -L "${NSS_DIST_OBJ_DIR}/lib/${PREFIX}hw-acc-crypto-avx2.${EXT}" "${DIST_DIR}/lib"
 
 # HW specific.
 # https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#159-163

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -47,21 +47,26 @@ if [[ -d "${DIST_DIR}" ]]; then
   exit 0
 fi
 
-# TODO compile on macOS/windows machines once `chainOfTrust` is supported on macOS (1499051).
+# TODO We do not know how to cross compile these, so we cheat by downloading them and the how is pretty disgusting.
+# https://github.com/mozilla/application-services/issues/962
 if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
-  # Generated from nss-try@0c5d37301637ed024de8c2cbdbecf144aae12163.
-  curl -sfSL --retry 5 --retry-delay 10 -O "https://fxa-dev-bucket.s3-us-west-2.amazonaws.com/a-s/nss_nspr_static_libs_darwin.tar.bz2"
-  SHA256="b25d6d057d39213aeb5426dfbb0223a1d33f1706a1fcde1b3547fd7895c922f7"
-  echo "${SHA256}  nss_nspr_static_libs_darwin.tar.bz2" | shasum -a 256 -c - || exit 2
-  tar xvjf nss_nspr_static_libs_darwin.tar.bz2 && rm -rf nss_nspr_static_libs_darwin.tar.bz2
+  # Generated from nss-try@11e799981c28df3b4c36be1b5aabcca6f91ce798.
+  curl -sfSL --retry 5 --retry-delay 10 -O "https://fxa-dev-bucket.s3-us-west-2.amazonaws.com/nss/nss_nspr_static_3.52_darwin.bz2"
+  SHA256="c6ae59b3cd0dd8bd1e28c3dd7b26f720d220599e2ce7802cba81b884989e9a89"
+  echo "${SHA256}  nss_nspr_static_3.52_darwin.bz2" | shasum -a 256 -c - || exit 2
+  tar xvjf nss_nspr_static_3.52_darwin.bz2 && rm -rf nss_nspr_static_3.52_darwin.bz2
   NSS_DIST_DIR=$(abspath "dist")
 elif [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
-  # Generated from nss-try@0c5d37301637ed024de8c2cbdbecf144aae12163.
-  curl -sfSL --retry 5 --retry-delay 10 -O "https://fxa-dev-bucket.s3-us-west-2.amazonaws.com/a-s/nss_nspr_static_libs_win32.7z"
-  SHA256="cdafb89f727f7a5d6cf1c6c01b58af150f780a4438863d3a1f98b6aa50809ded"
-  echo "${SHA256}  nss_nspr_static_libs_win32.7z" | shasum -a 256 -c - || exit 2
-  7z x nss_nspr_static_libs_win32.7z -aoa && rm -rf nss_nspr_static_libs_win32.7z
+  # Generated from nss-try@11e799981c28df3b4c36be1b5aabcca6f91ce798.
+  curl -sfSL --retry 5 --retry-delay 10 -O "https://fxa-dev-bucket.s3-us-west-2.amazonaws.com/nss/nss_nspr_static_3.52_mingw.7z"
+  SHA256="07fe3d0b0bc1b2cf51552fe0a7c8e6103b0a6b1baef5d4412dbfdcd0e1b834de"
+  echo "${SHA256}  nss_nspr_static_3.52_mingw.7z" | shasum -a 256 -c - || exit 2
+  7z x nss_nspr_static_3.52_mingw.7z -aoa && rm -rf nss_nspr_static_3.52_mingw.7z
   NSS_DIST_DIR=$(abspath "dist")
+  # NSPR outputs .a files when cross-compiling.
+  mv "${NSS_DIST_DIR}/Release/lib/libplc4.a" "${NSS_DIST_DIR}/Release/lib/libplc4.lib"
+  mv "${NSS_DIST_DIR}/Release/lib/libplds4.a" "${NSS_DIST_DIR}/Release/lib/libplds4.lib"
+  mv "${NSS_DIST_DIR}/Release/lib/libnspr4.a" "${NSS_DIST_DIR}/Release/lib/libnspr4.lib"
 elif [[ "$(uname -s)" == "Darwin" ]] || [[ "$(uname -s)" == "Linux" ]]; then
   "${NSS_SRC_DIR}"/nss/build.sh \
     -v \

--- a/libs/build-nss-ios.sh
+++ b/libs/build-nss-ios.sh
@@ -100,12 +100,14 @@ cp -p -L "${BUILD_DIR}/lib/libpkcs7.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libsmime.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libsoftokn_static.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libssl.a" "${DIST_DIR}/lib"
-cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto.a" "${DIST_DIR}/lib"
 # HW specific.
 if [[ "${ARCH}" == "x86_64" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx2.a" "${DIST_DIR}/lib"
 elif [[ "${ARCH}" == "arm64" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-aarch64_c_lib.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"
 fi
 cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libplc4.a" "${DIST_DIR}/lib"
 cp -p -L "${NSPR_BUILD_DIR}/dist/lib/libplds4.a" "${DIST_DIR}/lib"

--- a/libs/build-sqlcipher-android.sh
+++ b/libs/build-sqlcipher-android.sh
@@ -89,7 +89,6 @@ LIBS="\
   -lcerthi \
   -lcryptohi \
   -lfreebl_static \
-  -lhw-acc-crypto \
   -lnspr4 \
   -lnss_static \
   -lnssb \
@@ -104,11 +103,18 @@ LIBS="\
 
 if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]] || [[ "${TOOLCHAIN}" == "i686-linux-android" ]]; then
   LIBS="${LIBS} -lgcm-aes-x86_c_lib"
-elif [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]; then
+fi
+if [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]] || [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]; then
+  LIBS="${LIBS} -larmv8_c_lib"
+fi
+if [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]; then
   LIBS="${LIBS} -lgcm-aes-aarch64_c_lib"
 fi
+if [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]; then
+  LIBS="${LIBS} -lgcm-aes-arm32-neon_c_lib"
+fi
 if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]]; then
-  LIBS="${LIBS} -lintel-gcm-wrap_c_lib -lintel-gcm-s_lib"
+  LIBS="${LIBS} -lintel-gcm-wrap_c_lib -lintel-gcm-s_lib -lhw-acc-crypto-avx -lhw-acc-crypto-avx2"
 fi
 
 BUILD_DIR=$(mktemp -d)

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -87,7 +87,8 @@ LIBS="\
   -lcerthi \
   -lcryptohi \
   -lfreebl_static \
-  -lhw-acc-crypto \
+  -lhw-acc-crypto-avx \
+  -lhw-acc-crypto-avx2 \
   -lnspr4 \
   -lnss_static \
   -lnssb \

--- a/libs/build-sqlcipher-ios.sh
+++ b/libs/build-sqlcipher-ios.sh
@@ -99,7 +99,6 @@ LIBS="\
   -lcerthi \
   -lcryptohi \
   -lfreebl_static \
-  -lhw-acc-crypto \
   -lnspr4 \
   -lnss_static \
   -lnssb \
@@ -113,9 +112,9 @@ LIBS="\
 "
 
 if [[ "${ARCH}" == "x86_64" ]]; then
-  LIBS="${LIBS} -lgcm-aes-x86_c_lib"
+  LIBS="${LIBS} -lgcm-aes-x86_c_lib -lhw-acc-crypto-avx -lhw-acc-crypto-avx2"
 else
-  LIBS="${LIBS} -lgcm-aes-aarch64_c_lib"
+  LIBS="${LIBS} -lgcm-aes-aarch64_c_lib -larmv8_c_lib"
 fi
 
 BUILD_DIR=$(mktemp -d)


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/2451.

Between NSS 3.46 and 3.49.1, AES ciphers got hardware acceleration on ARM platforms through:

- `gcm-aes-arm32-neon_c_lib` which uses neon instructions on ARM targets to accelerate AES-GCM. (bug 1562548)
- `armv8_c_lib` was added to accelerate AES-CBC on both ARM and ARM64. (bug 1152625)

This PR includes these new static libs to our build.