### PR TITLE
Fix 2472

### DIFF
--- a/components/places/src/import/common.rs
+++ b/components/places/src/import/common.rs
@@ -10,8 +10,12 @@ use url::Url;
 
 // sanitize_timestamp can't use `Timestamp::now();` directly because it needs
 // to sanitize both created and modified, plus ensure modified isn't before
-// created - which isn't possible with the non-monotonic timestamp. So we just
-// have a single `now` used by all bookmarks.
+// created - which isn't possible with the non-monotonic timestamp.
+// So we have a static `NOW`, which will be initialized the first time it is
+// referenced, and that value subsequently used for every imported bookmark (and
+// note that it's only used in cases where the existing timestamps are invalid.)
+// This is fine for our use-case, where we do exactly one import as soon as the
+// process starts.
 lazy_static::lazy_static! {
     pub static ref NOW: Timestamp = Timestamp::now();
 }

--- a/components/places/src/import/common.rs
+++ b/components/places/src/import/common.rs
@@ -4,10 +4,20 @@
 
 use crate::api::places_api::SyncConn;
 use crate::error::*;
+use crate::types::Timestamp;
 use rusqlite::named_params;
 use url::Url;
 
+// sanitize_timestamp can't use `Timestamp::now();` directly because it needs
+// to sanitize both created and modified, plus ensure modified isn't before
+// created - which isn't possible with the non-monotonic timestamp. So we just
+// have a single `now` used by all bookmarks.
+lazy_static::lazy_static! {
+    pub static ref NOW: Timestamp = Timestamp::now();
+}
+
 pub mod sql_fns {
+    use crate::import::common::NOW;
     use crate::storage::URL_LENGTH_MAX;
     use crate::types::Timestamp;
     use rusqlite::{functions::Context, types::ValueRef, Result};
@@ -16,8 +26,8 @@ pub mod sql_fns {
 
     #[inline(never)]
     pub fn sanitize_timestamp(ctx: &Context<'_>) -> Result<Timestamp> {
-        let now = Timestamp::now();
-        let is_sane = |ts: Timestamp| -> bool { Timestamp::EARLIEST < ts && ts < now };
+        let now = *NOW;
+        let is_sane = |ts: Timestamp| -> bool { Timestamp::EARLIEST <= ts && ts <= now };
         if let Ok(ts) = ctx.get::<i64>(0) {
             let ts = Timestamp(u64::try_from(ts).unwrap_or(0));
             if is_sane(ts) {

--- a/components/places/tests/fennec_bookmarks.rs
+++ b/components/places/tests/fennec_bookmarks.rs
@@ -428,11 +428,11 @@ fn test_timestamp_sanitization() -> Result<()> {
 
     // NOTE: The results of testing not-sane is somewhat arbitrary - there are
     // a number of results which would be fine - so long as the 'created can't
-    // be after modified' invalirant holds true (which is checked in
+    // be after modified' invaliant holds true (which is checked in
     // get_actual_timestamps())
 
     // created in the past and sane, modified not sane (too early) -> created as specified, modified = now
-    // (easily argued that modified -> now is better, but that's tricky in the sql)
+    // (easily argued that modified -> created is better, but that's tricky in the sql)
     assert_eq!(
         get_actual_timestamps(earlier, Timestamp(0))?,
         (earlier, now)

--- a/components/sync15/src/util.rs
+++ b/components/sync15/src/util.rs
@@ -15,20 +15,6 @@ use std::{fmt, num};
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Default)]
 pub struct ServerTimestamp(pub i64);
 
-impl From<ServerTimestamp> for i64 {
-    #[inline]
-    fn from(ts: ServerTimestamp) -> Self {
-        ts.0
-    }
-}
-
-impl From<ServerTimestamp> for f64 {
-    #[inline]
-    fn from(ts: ServerTimestamp) -> Self {
-        ts.0 as f64 / 1000.0
-    }
-}
-
 impl From<i64> for ServerTimestamp {
     #[inline]
     fn from(ts: i64) -> Self {


### PR DESCRIPTION
Very much a WIP - lots of tests. tl;dr is that tags will be lost if local is newer, but, for reasons I don't yet understand, keywords will apparently not.

I've made a hacky attempt to fix tags by artificially using a very early timestamp of the Fennec record has tags - but see all the XXX comments in the test - we still end up with various items being outgoing where I don't think they should be.

I'm putting this up so it can inform a discussion between Lina and myself (and anyone else who cares) tomorrow.