### PR TITLE
Persist keywords in `moz_keywords` instead of using the Sync tables

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,11 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.54.0...master)
+
+## Places
+
+### What's fixed
+
+- Improve handling of bookmark search keywords. Keywords are now imported
+  correctly from Fennec, and signing out of Sync in Firefox for iOS no longer
+  loses keywords ([#2501](https://github.com/mozilla/application-services/pull/2501)).

--- a/components/places/sql/create_shared_schema.sql
+++ b/components/places/sql/create_shared_schema.sql
@@ -198,6 +198,8 @@ CREATE TABLE IF NOT EXISTS moz_bookmarks_synced(
 );
 
 CREATE INDEX IF NOT EXISTS moz_bookmarks_synced_urls ON moz_bookmarks_synced(placeId);
+CREATE INDEX IF NOT EXISTS moz_bookmarks_synced_keywords ON moz_bookmarks_synced(keyword)
+                                                            WHERE keyword NOT NULL;
 
 -- This table holds parent-child relationships and positions for synced items,
 -- from each folder's `children`. Unlike `moz_bookmarks`, this is stored
@@ -220,3 +222,16 @@ CREATE TABLE IF NOT EXISTS moz_bookmarks_synced_tag_relation(
                            ON DELETE CASCADE,
     PRIMARY KEY(itemId, tagId)
 ) WITHOUT ROWID;
+
+-- This table holds search keywords for URLs. Desktop would like to replace
+-- these with custom search engines eventually (bug 648398); however, we
+-- must still round-trip keywords imported via Sync or migrated from Fennec.
+-- Since none of the `moz_bookmarks_synced_*` tables are durable, we store
+-- keywords for URLs in a separate table. Unlike Desktop, we don't support
+-- custom POST data, since we don't sync it (bug 1345417), and Fennec
+-- doesn't write it.
+CREATE TABLE IF NOT EXISTS moz_keywords(
+    place_id INTEGER PRIMARY KEY REFERENCES moz_places(id)
+                     ON DELETE CASCADE,
+    keyword TEXT NOT NULL UNIQUE
+);

--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -306,3 +306,35 @@ BEGIN
         foreign_count = foreign_count - 1
     WHERE id = OLD.place_id;
 END;
+
+-- These triggers adjust the foreign count for URLs with keywords, so that
+-- they won't be expired or automatically removed.
+
+CREATE TEMP TRIGGER moz_keywords_afterinsert_trigger
+AFTER INSERT ON moz_keywords
+BEGIN
+    UPDATE moz_places SET
+        foreign_count = foreign_count + 1
+    WHERE id = NEW.place_id;
+END;
+
+CREATE TEMP TRIGGER moz_keywords_afterupdate_trigger
+AFTER UPDATE OF place_id ON moz_keywords
+WHEN OLD.place_id <> NEW.place_id
+BEGIN
+    UPDATE moz_places SET
+        foreign_count = foreign_count + 1
+    WHERE id = NEW.place_id;
+
+    UPDATE moz_places SET
+        foreign_count = foreign_count - 1
+    WHERE id = OLD.place_id;
+END;
+
+CREATE TEMP TRIGGER moz_keywords_afterdelete_trigger
+AFTER DELETE ON moz_keywords
+BEGIN
+    UPDATE moz_places SET
+        foreign_count = foreign_count - 1
+    WHERE id = OLD.place_id;
+END;

--- a/components/places/sql/create_sync_temp_tables.sql
+++ b/components/places/sql/create_sync_temp_tables.sql
@@ -25,7 +25,8 @@ CREATE TEMP TABLE itemsToApply(
     oldTitle TEXT,
     newTitle TEXT,
     oldPlaceId INTEGER,
-    newPlaceId INTEGER
+    newPlaceId INTEGER,
+    newKeyword TEXT
 );
 
 CREATE INDEX existingItems ON itemsToApply(localId) WHERE localId NOT NULL;
@@ -33,6 +34,8 @@ CREATE INDEX existingItems ON itemsToApply(localId) WHERE localId NOT NULL;
 CREATE INDEX oldPlaceIds ON itemsToApply(newKind, oldPlaceId);
 
 CREATE INDEX newPlaceIds ON itemsToApply(newKind, newPlaceId);
+
+CREATE INDEX newKeywords ON itemsToApply(newKeyword) WHERE newKeyword NOT NULL;
 
 CREATE TEMP TABLE applyNewLocalStructureOps(
     mergedGuid TEXT PRIMARY KEY,

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -912,9 +912,9 @@ impl<'de> Deserialize<'de> for BookmarkTreeNode {
 /// Get the URL of the bookmark matching a keyword
 pub fn bookmarks_get_url_for_keyword(db: &PlacesDb, keyword: &str) -> Result<Option<Url>> {
     let bookmark_url = db.try_query_row(
-        "SELECT url FROM moz_places p
-        JOIN moz_bookmarks_synced b ON b.placeId = p.id
-        WHERE b.keyword = :keyword",
+        "SELECT h.url FROM moz_keywords k
+         JOIN moz_places h ON h.id = k.place_id
+         WHERE k.keyword = :keyword",
         &[(":keyword", &keyword)],
         |row| row.get::<_, String>("url"),
         true,
@@ -1565,10 +1565,10 @@ mod tests {
 
         // create a bookmark with keyword 'donut' pointing at it.
         conn.execute_named_cached(
-            "INSERT INTO moz_bookmarks_synced
-                (keyword, placeId, guid)
+            "INSERT INTO moz_keywords
+                (keyword, place_id)
             VALUES
-                ('donut', :place_id, 'fake_guid___')",
+                ('donut', :place_id)",
             &[(":place_id", &place_id)],
         )
         .expect("should work");
@@ -1581,10 +1581,10 @@ mod tests {
 
         // now change the keyword to 'ice cream'
         conn.execute_named_cached(
-            "REPLACE INTO moz_bookmarks_synced
-                (keyword, placeId, guid)
+            "REPLACE INTO moz_keywords
+                (keyword, place_id)
             VALUES
-                ('ice cream', :place_id, 'fake_guid___')",
+                ('ice cream', :place_id)",
             &[(":place_id", &place_id)],
         )
         .expect("should work");


### PR DESCRIPTION
Before this patch, we stored keywords for incoming bookmarks in the
`moz_bookmarks_synced` table, and read them back out from that table
when we uploaded outgoing records. This was done for a few reasons:

* In the beginning, Rust Places didn't support search keywords at all.
  There are plans to unify keywords and custom search engines, since
  they solve the same problem, but it's not currently a priority.
  https://bugzilla.mozilla.org/show_bug.cgi?id=648398 has more
  context.
* However, keyword searches were a very popular feature in Firefox for
  iOS, so we added an API to read them out of `moz_bookmarks_synced`
  in #1345.
* This was still fine, since the only way to get keywords into Fenix
  and iOS was via Sync. (Though there were some gotchas; for instance,
  disconnecting Sync would lose all keywords).
* But the Fennec to Fenix migration meant that there are now two ways
  to get keywords into Fenix, since Fennec supported setting them on
  bookmarks.

To make things more interesting, keywords are handled differently
across our products. Desktop exposes keywords as bookmark properties,
but, internally, associates them with (URL, POST data) tuples.
(This is also why they're closer to custom search engines than
bookmarks). But Sync, Fennec, and the old (before a-s) Firefox for iOS
associated them with individual bookmarks.

This patch takes a middle ground. Keywords are associated with URLs,
like Desktop, and we store those associations in a separate
`moz_keywords` table. This means keywords imported from Fennec should
be migrated, and signing out of Sync in Firefox for iOS no longer
loses keywords. Like Fennec and iOS, we don't support POST data,
since we don't sync it, and there's no UI for setting it.

The keyword syncing code is the same as Desktop's: we remove all
synced keywords from all local URLs, and all local keywords from old
and new synced URLs, then apply incoming items with new keywords and
URLs. We also flag items with the same keyword and different URLs,
as well as items with different keywords and the same URL, for
reupload, to enforce the "1 keyword per URL" association.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `cargo test --all` produces no test failures
  - `cargo clippy --all --all-targets --all-features` runs without emitting any warnings
  - `cargo fmt` does not produce any changes to the code
  - `./gradlew ktlint detekt` runs without emitting any warnings
  - `swiftformat --swiftversion 4 megazords components/*/ios && swiftlint` runs without emitting any warnings or producing changes
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
