### PR TITLE
Release v0.50.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 0.49.0
+libraryVersion: 0.50.0
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# v0.50.0 (_2020-02-05_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.49.0...v0.50.0)
+
+## FxA Client
+
+### What's changed
+
+- Android: `migrateFromSessionToken` now correctly persists in-flight migration state even
+  when throwing an error ([#2586](https://github.com/mozilla/application-services/pull/2586)).
+
+### Breaking changes
+
+- `isInMigrationState` now returns an enum rather than a boolean, to indicate whether
+  the migration will re-use or duplicate the underlying sessionToken.
+  ([#2586](https://github.com/mozilla/application-services/pull/2586))
+
+
 # v0.49.0 (_2020-02-03_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.48.3...v0.49.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.49.0...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.50.0...master)

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -346,10 +346,10 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      *
      * @return bool Returns a boolean if we are in a migration state
      */
-    fun isInMigrationState(): Boolean {
+    fun isInMigrationState(): MigrationState {
         rustCall { e ->
             val state = LibFxAFFI.INSTANCE.fxa_is_in_migration_state(this.handle.get(), e)
-            return state.toInt() != 0
+            return MigrationState.fromNumber(state.toInt())
         }
     }
 

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -322,12 +322,23 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      * This performs network requests, and should not be used on the main thread.
      */
     fun migrateFromSessionToken(sessionToken: String, kSync: String, kXCS: String): JSONObject {
-        val json = rustCallWithLock { e ->
-            LibFxAFFI.INSTANCE.fxa_migrate_from_session_token(this.handle.get(), sessionToken, kSync, kXCS, false, e)
-        }.getAndConsumeRustString()
-
-        this.tryPersistState()
-        return JSONObject(json)
+        try {
+            val json = rustCallWithLock { e ->
+                LibFxAFFI.INSTANCE.fxa_migrate_from_session_token(
+                    this.handle.get(),
+                    sessionToken,
+                    kSync,
+                    kXCS,
+                    false,
+                    e
+                )
+            }.getAndConsumeRustString()
+            return JSONObject(json)
+        } finally {
+            // Even a failed migration might alter the persisted account state, if it's able to be retried.
+            // It's safe to call this unconditionally, as the underlying code will not leave partial states.
+            this.tryPersistState()
+        }
     }
 
     /**
@@ -353,12 +364,16 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      * This performs network requests, and should not be used on the main thread.
      */
     fun copyFromSessionToken(sessionToken: String, kSync: String, kXCS: String): JSONObject {
-        val json = rustCallWithLock { e ->
-            LibFxAFFI.INSTANCE.fxa_migrate_from_session_token(this.handle.get(), sessionToken, kSync, kXCS, true, e)
-        }.getAndConsumeRustString()
-
-        this.tryPersistState()
-        return JSONObject(json)
+        try {
+            val json = rustCallWithLock { e ->
+                LibFxAFFI.INSTANCE.fxa_migrate_from_session_token(this.handle.get(), sessionToken, kSync, kXCS, true, e)
+            }.getAndConsumeRustString()
+            return JSONObject(json)
+        } finally {
+            // Even a failed migration might alter the persisted account state, if it's able to be retried.
+            // It's safe to call this unconditionally, as the underlying code will not leave partial states.
+            this.tryPersistState()
+        }
     }
 
     /**
@@ -369,12 +384,16 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      * This performs network requests, and should not be used on the main thread.
      */
     fun retryMigrateFromSessionToken(): JSONObject {
-        val json = rustCallWithLock { e ->
-            LibFxAFFI.INSTANCE.fxa_retry_migrate_from_session_token(this.handle.get(), e)
-        }.getAndConsumeRustString()
-
-        this.tryPersistState()
-        return JSONObject(json)
+        try {
+            val json = rustCallWithLock { e ->
+                LibFxAFFI.INSTANCE.fxa_retry_migrate_from_session_token(this.handle.get(), e)
+            }.getAndConsumeRustString()
+            return JSONObject(json)
+        } finally {
+            // A failure her might alter the persisted account state, if we discover a permanent migration failure.
+            // It's safe to call this unconditionally, as the underlying code will not leave partial states.
+            this.tryPersistState()
+        }
     }
 
     /**

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/MigrationState.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/MigrationState.kt
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.fxaclient
+
+enum class MigrationState {
+    NONE,
+    COPY_SESSION_TOKEN,
+    REUSE_SESSION_TOKEN;
+
+    companion object {
+        @Suppress("TooGenericExceptionThrown")
+        internal fun fromNumber(v: Number): MigrationState {
+            return when (v) {
+                0 -> NONE
+                1 -> COPY_SESSION_TOKEN
+                2 -> REUSE_SESSION_TOKEN
+                else -> throw RuntimeException("[Bug] unknown MigrationState value $v")
+            }
+        }
+    }
+}

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -13,6 +13,7 @@ use ffi_support::{
 };
 use fxa_client::{
     device::{Capability as DeviceCapability, PushSubscription},
+    migrator::MigrationState,
     msg_types, FirefoxAccount,
 };
 use std::os::raw::c_char;
@@ -256,8 +257,8 @@ pub extern "C" fn fxa_migrate_from_session_token(
 #[no_mangle]
 pub extern "C" fn fxa_is_in_migration_state(handle: u64, error: &mut ExternError) -> u8 {
     log::debug!("fxa_is_in_migration_state");
-    ACCOUNTS.call_with_result(error, handle, |fxa| -> fxa_client::Result<u8> {
-        Ok(fxa.is_in_migration_state() as u8)
+    ACCOUNTS.call_with_result(error, handle, |fxa| -> fxa_client::Result<MigrationState> {
+        Ok(fxa.is_in_migration_state())
     })
 }
 

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -26,7 +26,7 @@ mod config;
 pub mod device;
 pub mod error;
 pub mod ffi;
-mod migrator;
+pub mod migrator;
 // Include the `msg_types` module, which is generated from msg_types.proto.
 pub mod msg_types {
     include!(concat!(env!("OUT_DIR"), "/msg_types.rs"));


### PR DESCRIPTION
Fixes #2585, and some other comments from @grigoryk as he worked on integrating this over in https://github.com/mozilla-mobile/android-components/pull/5800.

Note that this PR is to a newly-created `release-0.50.x` branch rather than to master, since we want to get this into a-c ASAP without pulling in unrelated changes. I'm not thrilled about the process for doing so, but that can be a discussion for a more leisurely time.

There are three commits here:

* One to fix the issue with state persistence in #2585.
* One to expose the `copy_session_token` bool back to the calling app.
* One to tag the new release.

Given that many folks are out this week, I'm doing them inline in this PR for review as a single unit.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
