### PR TITLE
Don't use a bool argument over the FFI in fxa_migrate_from_session_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v0.50.1 (_2020-02-06_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.50.0...v0.50.1)
+
+## FxA Client
+
+### What's changed
+
+- Fixed a potentially-unsafe use of a boolean in the FFI interface for `migrateFromSessionToken`.
+  ([#2592](https://github.com/mozilla/application-services/pull/2592)).
+
+
 # v0.50.0 (_2020-02-05_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.49.0...v0.50.0)

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -329,7 +329,7 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
                     sessionToken,
                     kSync,
                     kXCS,
-                    false,
+                    0,
                     e
                 )
             }.getAndConsumeRustString()
@@ -366,7 +366,7 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
     fun copyFromSessionToken(sessionToken: String, kSync: String, kXCS: String): JSONObject {
         try {
             val json = rustCallWithLock { e ->
-                LibFxAFFI.INSTANCE.fxa_migrate_from_session_token(this.handle.get(), sessionToken, kSync, kXCS, true, e)
+                LibFxAFFI.INSTANCE.fxa_migrate_from_session_token(this.handle.get(), sessionToken, kSync, kXCS, 1, e)
             }.getAndConsumeRustString()
             return JSONObject(json)
         } finally {

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -90,7 +90,7 @@ internal interface LibFxAFFI : Library {
         sessionToken: String,
         kSync: String,
         kXCS: String,
-        copySessionToken: Boolean,
+        copySessionToken: Byte,
         e: RustError.ByReference
     ): Pointer?
 

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -238,7 +238,7 @@ pub extern "C" fn fxa_migrate_from_session_token(
     session_token: FfiStr<'_>,
     k_sync: FfiStr<'_>,
     k_xcs: FfiStr<'_>,
-    copy_session_token: bool,
+    copy_session_token: u8,
     error: &mut ExternError,
 ) -> *mut c_char {
     log::debug!("fxa_migrate_from_session_token");
@@ -247,7 +247,7 @@ pub extern "C" fn fxa_migrate_from_session_token(
         let k_sync = k_sync.as_str();
         let k_xcs = k_xcs.as_str();
         let migration_metrics =
-            fxa.migrate_from_session_token(session_token, k_sync, k_xcs, copy_session_token)?;
+            fxa.migrate_from_session_token(session_token, k_sync, k_xcs, copy_session_token != 0)?;
         let result = serde_json::to_string(&migration_metrics)?;
         Ok(result)
     })

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -80,6 +80,13 @@ FxARustBuffer fxa_profile(FirefoxAccountHandle handle,
                           bool ignore_cache,
                           FxAError *_Nonnull out);
 
+void fxa_migrate_from_session_token(FirefoxAccountHandle handle,
+                                    const char *_Nonnull sessionToken,
+                                    const char *_Nonnull kSync,
+                                    const char *_Nonnull kXCS,
+                                    uint8_t copySessionToken,
+                                    FxAError *_Nonnull out);
+
 char *_Nullable fxa_get_token_server_endpoint_url(FirefoxAccountHandle handle,
                                                   FxAError *_Nonnull out);
 


### PR DESCRIPTION
This is https://github.com/mozilla/application-services/pull/2591 cherry-picked against latest migration release.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
