### PR TITLE
Fix docs typo: "switch" -> "swift".

### DIFF
--- a/automation/all_tests.sh
+++ b/automation/all_tests.sh
@@ -5,7 +5,7 @@
 #
 # There are surprisingly many things to run to fully check all the code,
 # since we are simultaneously a rust project, a kotlin/gradle project,
-# and a switch project!
+# and a swift project!
 
 set -eux
 


### PR DESCRIPTION
Sadly we do not (yet) target running Firefox on the Nintendo Switch. I think I must have had Switch on the brain in the leadup to Christmas for some mysterious reason...

Fixes #2602.