### PR TITLE
Update verify_connection to return updated subscriptions

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,11 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.53.2...master)
+## Push
+
+### Breaking changes
+
+- Android: The `PushManager.verifyConnection` now returns a `List<SubscriptionChanged>` that contain the channel ID and scope of the subscriptions that have expired.
+  See [`onpushsubscriptionchange`][0] events on how this change can be propagated to notify web content.
+
+[0]: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/onpushsubscriptionchange

--- a/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
@@ -63,7 +63,7 @@ internal interface LibPushFFI : Library {
     fun push_verify_connection(
         mgr: PushManagerHandle,
         out_err: RustError.ByReference
-    ): Byte
+    ): RustBuffer.ByValue
 
     fun push_decrypt(
         mgr: PushManagerHandle,

--- a/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
+++ b/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
@@ -217,13 +217,12 @@ class PushTest {
     @Test
     fun testVerifyConnection() {
         val manager = getPushManager()
-        // Client will call verifyConnection() on initial setup, before UAID set.
-        manager.verifyConnection()
         // Register a subscription
         manager.subscribe(testChannelid, "foo")
         // and call verifyConnection again to emulate a set value.
         val result = manager.verifyConnection()
-        assertEquals("Check changed endpoint", false, result)
+        assertEquals("Endpoints updated", true, result.isNotEmpty())
+        assertEquals("Endpoints updated", "foo", result.first().scope)
     }
 
     @Test

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -139,10 +139,12 @@ pub extern "C" fn push_update(handle: u64, new_token: FfiStr<'_>, error: &mut Ex
 // verify connection using channel list
 // Returns a bool indicating if channel_ids should resubscribe.
 #[no_mangle]
-pub extern "C" fn push_verify_connection(handle: u64, error: &mut ExternError) -> u8 {
+pub extern "C" fn push_verify_connection(handle: u64, error: &mut ExternError) -> ByteBuffer {
     log::debug!("push_verify");
+    use push::msg_types::SubscriptionsChanged;
     MANAGER.call_with_result_mut(error, handle, |mgr| -> Result<_> {
         mgr.verify_connection()
+            .map(|subs| SubscriptionsChanged { subs })
     })
 }
 

--- a/components/push/src/ffi.rs
+++ b/components/push/src/ffi.rs
@@ -11,3 +11,5 @@ implement_into_ffi_by_protobuf!(msg_types::DispatchInfo);
 implement_into_ffi_by_protobuf!(msg_types::KeyInfo);
 implement_into_ffi_by_protobuf!(msg_types::SubscriptionInfo);
 implement_into_ffi_by_protobuf!(msg_types::SubscriptionResponse);
+implement_into_ffi_by_protobuf!(msg_types::SubscriptionChanged);
+implement_into_ffi_by_protobuf!(msg_types::SubscriptionsChanged);

--- a/components/push/src/push_msg_types.proto
+++ b/components/push/src/push_msg_types.proto
@@ -26,3 +26,12 @@ message SubscriptionResponse {
     required string channelID = 1;
     required SubscriptionInfo subscriptionInfo = 2;
 }
+
+message SubscriptionChanged {
+    required string channelID = 1;
+    required string scope = 2;
+}
+
+message SubscriptionsChanged {
+    repeated SubscriptionChanged subs = 1;
+}


### PR DESCRIPTION
Returns a list of `DispatchInfo` to the clients.

Based on changes from https://github.com/mozilla/application-services/pull/1115  and https://github.com/mozilla/application-services/pull/2080.

No tests added just yet, this is a WIP to see if this change is going in the right direction.

Closes #2049

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
