### PR TITLE
Cache the tokenserver token and info/configuration unless there was an auth error.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -4,6 +4,12 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.51.1...master)
 
+## Sync
+
+### What's changed
+
+- Better caching of the tokenserver token and info/configuration response ([#2616](https://github.com/mozilla/application-services/issues/2616))
+
 ## Places
 
 ### What's changed


### PR DESCRIPTION
Fixes #2616.

Due to a silly error we previously only cached them when a sync failed!
Fixing that is trivial but there were some TODO comments about not
dropping the cached values due to simple network or store errors
(eg, if, say, bookmarks got itself into a bad state, that shouldn't mean
these values are never cached for that user) - so now they are persisted
between syncs unless there was an auth error.

This fix also changes places-utils so it can perform multiple syncs,
meaning it's easier to see this caching behavior when running that
utility.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
