### PR TITLE
Force android packaging tasks to re-run on every build.

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -68,6 +68,17 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
         project.afterEvaluate {
             forUnitTestsJarTask.dependsOn(tasks["cargoBuild"])
         }
+
+        // For inscrutable reasons, the various android packaging gradle tasks do
+        // not get re-run when the underlying rust code changes. Something is not
+        // correctly configuring gradle's up-to-date checks, but I've reached the
+        // limit of how much time I'm willing to spend on figuring it out. Deleting
+        // these intermediate files forces re-execution of the task.
+        // Ref https://github.com/mozilla/application-services/issues/2659
+        task forceGradleToRefreshPackagedLibsWhenTheRustCodeChanges(type: Delete) {
+          delete "$buildDir/intermediates/merged_jni_libs"
+        }
+        preBuild.dependsOn(forceGradleToRefreshPackagedLibsWhenTheRustCodeChanges)
     }
 
     task sourcesJar(type: Jar) {


### PR DESCRIPTION
For inscrutable reasons, the various android packaging gradle tasks do
not get re-run when the underlying rust code changes. Something is not
correctly configuring gradle's up-to-date checks, but I've reached the
imit of how much time I'm willing to spend on figuring it out. Deleting
some intermediate files seems to force the tasks to re-run, and I was
not able to measure any increase in overall build time on my machine.

I don't like this, but I dislike it less than I dislike having to double-
check whether the rust code I have on disk the same as the rust code
compiled into my built artifacts.

Fixes #2659 (or at the very least, hacks its way around it).
