### PR TITLE
Refactor FxA persisted-state logic so that it's all in one place.

### DIFF
--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -7,12 +7,17 @@
 
 use crate::{
     commands::send_tab::SendTabPayload,
-    device::{Capability as DeviceCapability, Device},
-    oauth::{OAuthFlow, RefreshToken, OAUTH_WEBCHANNEL_REDIRECT},
+    device::Device,
+    oauth::{OAuthFlow, OAUTH_WEBCHANNEL_REDIRECT},
     scoped_keys::ScopedKey,
+    state_persistence::State,
 };
 pub use crate::{
-    config::Config, error::*, oauth::AccessTokenInfo, oauth::IntrospectInfo, profile::Profile,
+    config::Config,
+    error::*,
+    oauth::IntrospectInfo,
+    oauth::{AccessTokenInfo, RefreshToken},
+    profile::Profile,
 };
 use serde_derive::*;
 use std::{
@@ -54,66 +59,12 @@ unsafe impl<'a> Sync for http_client::FxAClientMock<'a> {}
 // to be modified.
 pub struct FirefoxAccount {
     client: Arc<FxAClient>,
-    state: StateV2,
+    state: State,
     flow_store: HashMap<String, OAuthFlow>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
-pub struct MigrationData {
-    k_xcs: String,
-    k_sync: String,
-    copy_session_token: bool,
-    session_token: String,
-}
-
-// If this structure is modified, please:
-// 1. Check if a migration needs to be done, as
-// these fields are persisted as a JSON string
-// (see `state_persistence.rs`).
-// 2. Check if the `StateVX.start_over` function
-// also needs to to be modified.
-#[derive(Clone, Serialize, Deserialize)]
-pub(crate) struct StateV2 {
-    config: Config,
-    current_device_id: Option<String>,
-    refresh_token: Option<RefreshToken>,
-    scoped_keys: HashMap<String, ScopedKey>,
-    last_handled_command: Option<u64>,
-    // Remove serde(default) once we are V3.
-    #[serde(default)]
-    commands_data: HashMap<String, String>,
-    #[serde(default)] // Same
-    device_capabilities: HashSet<DeviceCapability>,
-    #[serde(default)] // Same
-    access_token_cache: HashMap<String, AccessTokenInfo>,
-    session_token: Option<String>, // Hex-formatted string.
-    last_seen_profile: Option<CachedResponse<Profile>>,
-    in_flight_migration: Option<MigrationData>,
-}
-
-impl StateV2 {
-    /// Clear the whole persisted state of the account, but keep just enough
-    /// information to eventually reconnect to the same user account later.
-    fn start_over(&self) -> StateV2 {
-        StateV2 {
-            config: self.config.clone(),
-            current_device_id: None,
-            // Leave the profile cache untouched so we can reconnect later.
-            last_seen_profile: self.last_seen_profile.clone(),
-            refresh_token: None,
-            scoped_keys: HashMap::new(),
-            last_handled_command: None,
-            commands_data: HashMap::new(),
-            access_token_cache: HashMap::new(),
-            device_capabilities: HashSet::new(),
-            session_token: None,
-            in_flight_migration: None,
-        }
-    }
-}
-
 impl FirefoxAccount {
-    fn from_state(state: StateV2) -> Self {
+    fn from_state(state: State) -> Self {
         Self {
             client: Arc::new(http_client::Client::new()),
             state,
@@ -125,7 +76,7 @@ impl FirefoxAccount {
     ///
     /// **💾 This method alters the persisted account state.**
     pub fn with_config(config: Config) -> Self {
-        Self::from_state(StateV2 {
+        Self::from_state(State {
             config,
             refresh_token: None,
             scoped_keys: HashMap::new(),

--- a/components/fxa-client/src/migrator.rs
+++ b/components/fxa-client/src/migrator.rs
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{error::*, scoped_keys::ScopedKey, scopes, FirefoxAccount, MigrationData};
+use crate::{error::*, scoped_keys::ScopedKey, scopes, FirefoxAccount};
 use ffi_support::IntoFfi;
 use serde_derive::*;
 use std::time::Instant;
+
+// Values to pass back to calling code over the FFI.
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Default)]
 pub struct FxAMigrationResult {
@@ -33,6 +35,16 @@ unsafe impl IntoFfi for MigrationState {
             MigrationState::ReuseSessionToken => 2,
         }
     }
+}
+
+// Migration-related data that we may need to serialize in the persisted account state.
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct MigrationData {
+    k_xcs: String,
+    k_sync: String,
+    copy_session_token: bool,
+    session_token: String,
 }
 
 impl FirefoxAccount {

--- a/components/fxa-client/src/state_persistence.rs
+++ b/components/fxa-client/src/state_persistence.rs
@@ -2,13 +2,48 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{config::Config, error::*, RefreshToken, ScopedKey, StateV2};
+//! This module implements the ability to serialize a `FirefoxAccount` struct to and from
+//! a JSON string. The idea is that calling code will use this to persist the account state
+//! to storage.
+//!
+//! Many of the details here are a straightforward use of `serde`, with all persisted data being
+//! a field on a `State` struct. This is, however, some additional complexity around handling data
+//! migrations - we need to be able to evolve the internal details of the `State` struct while
+//! gracefully handing users who are upgrading from an older version of a consuming app, which has
+//! stored account state from an older version of this component.
+//!
+//! Data migration is handled by explicitly naming different versions of the state struct to
+//! correspond to different incompatible changes to the data representation, e.g. `StateV1` and
+//! `StateV2`. We then wrap this in a `PersistedState` enum whose serialization gets explicitly
+//! tagged with the corresponding state version number.
+//!
+//! For backwards-compatible changes to the data (such as adding a new field that has a sensible
+//! default) we keep the current `State` struct, but modify it in such a way that `serde` knows
+//! how to do the right thing.
+//!
+//! For backwards-incompatible changes to the data (such as removing or significantly refactoring
+//! fields) we define a new `StateV{X+1}` struct, and use the `From` trait to define how to update
+//! from older struct versions.
+
 use serde_derive::*;
 use std::{
     collections::{HashMap, HashSet},
     iter::FromIterator,
 };
-type State = StateV2;
+
+use crate::{
+    config::Config,
+    device::Capability as DeviceCapability,
+    migrator::MigrationData,
+    oauth::{AccessTokenInfo, RefreshToken},
+    profile::Profile,
+    scoped_keys::ScopedKey,
+    CachedResponse, Result,
+};
+
+// These are public API for working with the persisted state.
+
+pub(crate) type State = StateV2;
 
 pub(crate) fn state_from_json(data: &str) -> Result<State> {
     let stored_state: PersistedState = serde_json::from_str(data)?;
@@ -20,6 +55,16 @@ pub(crate) fn state_to_json(state: &State) -> Result<String> {
     serde_json::to_string(&state).map_err(Into::into)
 }
 
+fn upgrade_state(in_state: PersistedState) -> Result<State> {
+    match in_state {
+        PersistedState::V1(state) => state.into(),
+        PersistedState::V2(state) => Ok(state),
+    }
+}
+
+// `PersistedState` is a tagged container for one of the state versions.
+// Serde picks the right `StructVX` to deserialized based on the schema_version tag.
+
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "schema_version")]
 #[allow(clippy::large_enum_variant)]
@@ -29,14 +74,64 @@ enum PersistedState {
     V2(StateV2),
 }
 
-fn upgrade_state(in_state: PersistedState) -> Result<State> {
-    match in_state {
-        PersistedState::V1(state) => state.into(),
-        PersistedState::V2(state) => Ok(state),
+// `StateV2` is the current state schema. It and its fields all need to be public
+// so that they can be used directly elsewhere in the crate.
+//
+// If you want to modify what gets stored in the state, consider the following:
+//
+//   * Is the change backwards-compatible with previously-serialized data?
+//     If so then you'll need to tell serde how to fill in a suitable default.
+//     If not then you'll need to make a new `StateV3` and implement an explicit migration.
+//
+//   * Does the new field need to be modified when the user disconnects from the account?
+//     If so then you'll need to update `StateV2.start_over` function.
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct StateV2 {
+    pub(crate) config: Config,
+    pub(crate) current_device_id: Option<String>,
+    pub(crate) refresh_token: Option<RefreshToken>,
+    pub(crate) scoped_keys: HashMap<String, ScopedKey>,
+    pub(crate) last_handled_command: Option<u64>,
+    // Everything below here was added after `StateV2` was initially defined,
+    // and hence needs to have a suitable default value.
+    // We can remove serde(default) when we define a `StateV3`.
+    #[serde(default)]
+    pub(crate) commands_data: HashMap<String, String>,
+    #[serde(default)]
+    pub(crate) device_capabilities: HashSet<DeviceCapability>,
+    #[serde(default)]
+    pub(crate) access_token_cache: HashMap<String, AccessTokenInfo>,
+    pub(crate) session_token: Option<String>, // Hex-formatted string.
+    pub(crate) last_seen_profile: Option<CachedResponse<Profile>>,
+    pub(crate) in_flight_migration: Option<MigrationData>,
+}
+
+impl StateV2 {
+    /// Clear the whole persisted state of the account, but keep just enough
+    /// information to eventually reconnect to the same user account later.
+    pub(crate) fn start_over(&self) -> StateV2 {
+        StateV2 {
+            config: self.config.clone(),
+            current_device_id: None,
+            // Leave the profile cache untouched so we can reconnect later.
+            last_seen_profile: self.last_seen_profile.clone(),
+            refresh_token: None,
+            scoped_keys: HashMap::new(),
+            last_handled_command: None,
+            commands_data: HashMap::new(),
+            access_token_cache: HashMap::new(),
+            device_capabilities: HashSet::new(),
+            session_token: None,
+            in_flight_migration: None,
+        }
     }
 }
 
-// Migrations
+// Migration from `StateV1`. There was a lot of changing of structs and renaming of fields,
+// but the key change is that we went from supporting multiple active refresh_tokens to
+// only supporting a single one.
+
 impl From<StateV1> for Result<StateV2> {
     fn from(state: StateV1) -> Self {
         let mut all_refresh_tokens: Vec<V1AuthInfo> = vec![];
@@ -96,7 +191,15 @@ impl From<StateV1> for Result<StateV2> {
     }
 }
 
-// Older data structures used for migration purposes.
+// `StateV1` was a previous state schema.
+//
+// The below is sufficient to read existing state data serialized in this form, but should not
+// be used to create new data using that schema, so it is deliberately private and deliberately
+// does not derive(Serialize).
+//
+// If you find yourself modifying this code, you're almost certainly creating a potential data-migration
+// problem and should reconsider.
+
 #[derive(Deserialize)]
 struct StateV1 {
     client_id: String,
@@ -133,7 +236,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_v1_migration() {
+    fn test_migration_from_v1() {
+        // This is a snapshot of what some persisted StateV1 data would look like in practice.
+        // It's very important that you don't modify this string, which would defeat the point of the test!
         let state_v1_json = "{\"schema_version\":\"V1\",\"client_id\":\"98adfa37698f255b\",\"redirect_uri\":\"https://lockbox.firefox.com/fxa/ios-redirect.html\",\"config\":{\"content_url\":\"https://accounts.firefox.com\",\"auth_url\":\"https://api.accounts.firefox.com/\",\"oauth_url\":\"https://oauth.accounts.firefox.com/\",\"profile_url\":\"https://profile.accounts.firefox.com/\",\"token_server_endpoint_url\":\"https://token.services.mozilla.com/1.0/sync/1.5\",\"authorization_endpoint\":\"https://accounts.firefox.com/authorization\",\"issuer\":\"https://accounts.firefox.com\",\"jwks_uri\":\"https://oauth.accounts.firefox.com/v1/jwks\",\"token_endpoint\":\"https://oauth.accounts.firefox.com/v1/token\",\"userinfo_endpoint\":\"https://profile.accounts.firefox.com/v1/profile\"},\"oauth_cache\":{\"https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/apps/lockbox profile\":{\"access_token\":\"bef37ec0340783356bcac67a86c4efa23a56f2ddd0c7a6251d19988bab7bdc99\",\"keys\":\"{\\\"https://identity.mozilla.com/apps/oldsync\\\":{\\\"kty\\\":\\\"oct\\\",\\\"scope\\\":\\\"https://identity.mozilla.com/apps/oldsync\\\",\\\"k\\\":\\\"kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg\\\",\\\"kid\\\":\\\"1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ\\\"},\\\"https://identity.mozilla.com/apps/lockbox\\\":{\\\"kty\\\":\\\"oct\\\",\\\"scope\\\":\\\"https://identity.mozilla.com/apps/lockbox\\\",\\\"k\\\":\\\"Qk4K4xF2PgQ6XvBXW8X7B7AWwWgW2bHQov9NHNd4v-k\\\",\\\"kid\\\":\\\"1231014287-KDVj0DFaO3wGpPJD8oPwVg\\\"}}\",\"refresh_token\":\"bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188\",\"expires_at\":1543474657,\"scopes\":[\"https://identity.mozilla.com/apps/oldsync\",\"https://identity.mozilla.com/apps/lockbox\",\"profile\"]}}}";
         let state = state_from_json(state_v1_json).unwrap();
         assert!(state.refresh_token.is_some());
@@ -172,6 +277,8 @@ mod tests {
 
     #[test]
     fn test_v2_ignores_unknown_fields_introduced_by_future_changes_to_the_schema() {
+        // This is a snapshot of what some persisted StateV2 data would look before any backwards-compatible changes
+        // were made. It's very important that you don't modify this string, which would defeat the point of the test!
         let state_v2_json = "{\"schema_version\":\"V2\",\"config\":{\"client_id\":\"98adfa37698f255b\",\"redirect_uri\":\"https://lockbox.firefox.com/fxa/ios-redirect.html\",\"content_url\":\"https://accounts.firefox.com\",\"remote_config\":{\"auth_url\":\"https://api.accounts.firefox.com/\",\"oauth_url\":\"https://oauth.accounts.firefox.com/\",\"profile_url\":\"https://profile.accounts.firefox.com/\",\"token_server_endpoint_url\":\"https://token.services.mozilla.com/1.0/sync/1.5\",\"authorization_endpoint\":\"https://accounts.firefox.com/authorization\",\"issuer\":\"https://accounts.firefox.com\",\"jwks_uri\":\"https://oauth.accounts.firefox.com/v1/jwks\",\"token_endpoint\":\"https://oauth.accounts.firefox.com/v1/token\",\"userinfo_endpoint\":\"https://profile.accounts.firefox.com/v1/profile\"}},\"refresh_token\":{\"token\":\"bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188\",\"scopes\":[\"https://identity.mozilla.com/apps/oldysnc\"]},\"scoped_keys\":{\"https://identity.mozilla.com/apps/oldsync\":{\"kty\":\"oct\",\"scope\":\"https://identity.mozilla.com/apps/oldsync\",\"k\":\"kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg\",\"kid\":\"1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ\"}},\"login_state\":{\"Unknown\":null},\"a_new_field\":42}";
         let state = state_from_json(state_v2_json).unwrap();
         let refresh_token = state.refresh_token.unwrap();


### PR DESCRIPTION
Every time I want to do something to the FxA persisted state, I first go looking for it in `state_persistence.rs`, then remember that that file only contains the *old* persisted-state code, and the definition for the current State struct lives in the main `lib.rs` file.

I wanted to see what it would look like to put all of the state-related code in one place, and this PR is the result. IMHO moving all the state code into `state_pesistence.rs` made it a bit easier to write some narrative docs about how the setup works as a whole, in addition to not having to remember which bits live where.

The downside is that it has a whole bunch of `pub(crate)` declarations that weren't previously necessary when `StateV2` lived in `lib.rs`, which I assume must be the original reason for splitting it up.

I personally think that this change makes the code easier to understand on balance, but that could be my own peculiar preferences coming through. @eoger what do you think?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
