### PR TITLE
ci: rm non-blocking rust changelog job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,30 +255,6 @@ jobs:
       - setup-rust-toolchain
       - checkout
       - dependency-checks
-  Log Rust Changes:
-    docker:
-      - image: python:3.7-buster
-    steps:
-      - setup_remote_docker:
-          version: 18.02.0-ce
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="18.06.3-ce"
-            curl -sfSL --retry 5 --retry-delay 10 -o /tmp/docker-$VER.tgz https://download.docker.com/linux/static/stable/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run:
-          name: pull find-package-rugaru image
-          command: |
-            docker pull mozilla/dependencyscan:latest
-      - run:
-          name: log a rust dependency changes
-          command: |
-            printf "{\"org\": \"mozilla-services\", \"repo\": \"application-services\", \"ref\": {\"value\": \"master\", \"kind\": \"branch\"}, \"repo_url\": \"https://github.com/mozilla/application-services.git\"}\n{\"org\": \"mozilla-services\", \"repo\": \"application-services\", \"ref\": {\"value\": \"$CIRCLE_SHA1\", \"kind\": \"commit\"}, \"repo_url\": \"https://github.com/mozilla/application-services.git\"}\n"  | \
-                docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock --name fpr-cargo_metadata mozilla/dependencyscan:latest python fpr/run_pipeline.py cargo_metadata | \
-                docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock --name fpr-rust_changelog mozilla/dependencyscan:latest python fpr/run_pipeline.py rust_changelog -m Cargo.toml
   Mirror Bugzilla issues into GitHub:
     docker:
       - image: circleci/python:latest
@@ -439,9 +415,6 @@ workflows:
   check-dependencies:
     jobs:
       - Check Rust dependencies
-  log-rust-changelog:
-    jobs:
-      - Log Rust Changes
   bash-lint:
     jobs:
       - Lint Bash scripts


### PR DESCRIPTION
reverts: #1771

Drop the rust changelog CI job.

We're (foxsec/secops) working on an alternative that doesn't run in CI and provides more historical and cross-repo data, but it will break the current CI job interface.

### Pull Request checklist ###

- [ ] **Quality**: This PR builds and tests run cleanly

This is a CI change and should not break code tests.

- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not

PR does not include code or code test changes.

- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one

PR does not include code or code test changes.

