### PR TITLE
Avoid unnecessary calls to the server in FirefoxAccount.ensure_capabilities

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,11 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.52.0...master)
+
+## FxA Client
+
+### What's changed
+
+- The `ensureCapabilities` method will not perform any network requests if the
+  given capabilities are already registered with the server.
+  ([#2681](https://github.com/mozilla/application-services/pull/2681)).

--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -311,6 +311,10 @@ impl FirefoxAccount {
                 log::warn!("Device information restoration failed: {:?}", err);
             }
         }
+        // When our keys change, we might need to re-register device capabilities with the server.
+        // Ensure that this happens on the next call to ensure_capabilities.
+        self.state.device_capabilities.clear();
+
         Ok(())
     }
 


### PR DESCRIPTION
If the set of capabilities has not changed since the last time we registered with the server, then we don't need to upload a copy of what it already has.

We already keep a list of the previously-registered capabilities, so this PR:

* Checks it before uploading new capabilities to the server.
* Tries to clear it in cases where it might have got out of sync with what's on the server.

@eoger r?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
