### PR TITLE
 Disable rust incremental compilation on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
             # Do not forget to re-export these variables in xc-universal-binary.sh!
             echo 'export "RUSTC_WRAPPER"="sccache"' >> $BASH_ENV
             echo 'export "SCCACHE_IDLE_TIMEOUT"="1200"' >> $BASH_ENV
-            echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
+            echo 'export "SCCACHE_CACHE_SIZE"="2G"' >> $BASH_ENV
             echo 'export "SCCACHE_ERROR_LOG"="/tmp/sccache.log"' >> $BASH_ENV
             echo 'export "RUST_LOG"="sccache=info"' >> $BASH_ENV
             # Incremental compilation isn't supported by sccache.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,9 +140,11 @@ commands:
           rust-version: <<parameters.rust-version>>
       # Test with 1. only default features on, 2. all features on, 3. no features on.
       # This is not perfect (really we want the cartesian product), but is good enough in practice.
+      - run: sccache --zero-stats
       - run:
           name: Test (default features, no features, and all features)
           command: bash automation/all_rust_tests.sh --verbose
+      - run: sccache --show-stats
   dependency-checks:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ commands:
             echo 'export "SCCACHE_CACHE_SIZE"="1G"' >> $BASH_ENV
             echo 'export "SCCACHE_ERROR_LOG"="/tmp/sccache.log"' >> $BASH_ENV
             echo 'export "RUST_LOG"="sccache=info"' >> $BASH_ENV
+            # Incremental compilation isn't supported by sccache.
+            echo 'export "CARGO_INCREMENTAL"="0"' >> $BASH_ENV
             sccache --version
   install-xcpretty:
     steps:

--- a/automation/taskcluster/decision_task.py
+++ b/automation/taskcluster/decision_task.py
@@ -187,10 +187,12 @@ def gradle_module_task(libs_tasks, module_info, deploy_environment):
             yes | sdkmanager --licenses
             ./gradlew --no-daemon clean
         """)
+        .with_script("sccache --zero-stats")
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "testDebug")))
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "assembleRelease")))
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "publish")))
         .with_script("./gradlew --no-daemon {}".format(gradle_module_task_name(module, "checkMavenArtifacts")))
+        .with_script("sccache --show-stats")
     )
     for publication in module_info['publications']:
         for artifact in publication.to_artifacts(('', '.sha1', '.md5')):


### PR DESCRIPTION
This decreases the CircleCI run times by 28% on average.