### PR TITLE
Ensure we handle pending origin and frecency updates after inserting history and updating bookmarks

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -11,3 +11,12 @@
 - The `ensureCapabilities` method will not perform any network requests if the
   given capabilities are already registered with the server.
   ([#2681](https://github.com/mozilla/application-services/pull/2681)).
+
+## Places
+
+### What's fixed
+
+- `storage::history::apply_observation` and `storage::bookmarks::update_bookmark`
+  now flush pending origin and frecency updates. This fixes a bug where origins
+  might be flushed at surprising times, like right after clearing history
+  ([#2693](https://github.com/mozilla/application-services/issues/2693)).

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -724,7 +724,7 @@ mod tests {
                 url: Url::parse("http://example.com/").unwrap(),
                 title: "example.com/".into(),
                 icon_url: None,
-                frecency: -1,
+                frecency: 1999,
                 reasons: vec![MatchReason::Origin],
             }]
         );

--- a/components/places/src/db/tx/mod.rs
+++ b/components/places/src/db/tx/mod.rs
@@ -33,6 +33,16 @@ enum PlacesTransactionRepr<'conn> {
 }
 
 impl<'conn> PlacesTransaction<'conn> {
+    /// Returns `true` if the current transaction should be committed at the
+    /// earliest opportunity.
+    #[inline]
+    pub fn should_commit(&self) -> bool {
+        match &self.0 {
+            PlacesTransactionRepr::ChunkedWrite(tx) => tx.should_commit(),
+            _ => true,
+        }
+    }
+
     /// - For transactions on sync connnections: Checks to see if we have held a
     ///   transaction for longer than the requested time, and if so, commits the
     ///   current transaction and opens another.

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -494,6 +494,7 @@ pub fn update_bookmark(db: &PlacesDb, guid: &SyncGuid, item: &UpdatableItem) -> 
     let existing = get_raw_bookmark(db, guid)?
         .ok_or_else(|| InvalidPlaceInfo::NoSuchGuid(guid.to_string()))?;
     let result = update_bookmark_in_tx(db, guid, item, existing);
+    super::delete_pending_temp_tables(db)?;
     // Note: `tx` automatically rolls back on drop if we don't commit
     tx.commit()?;
     result

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -119,6 +119,7 @@ pub fn apply_observation_direct(
             Some(visit_ob.get_redirect_frecency_boost()),
         )?;
     }
+    delete_pending_temp_tables(db)?;
     Ok(visit_row_id)
 }
 
@@ -537,9 +538,6 @@ fn cleanup_pages(db: &PlacesDb, pages: &[PageToClean]) -> Result<()> {
         Ok(())
     })?;
 
-    // desktop now updates moz_updateoriginsdelete_temp, icons, annos, etc
-    // some of which might end up making sense for us too.
-    // XXX - moz_updateoriginsdelete_temp is part of https://github.com/mozilla/application-services/pull/429
     Ok(())
 }
 
@@ -2287,6 +2285,58 @@ mod tests {
             conn.query_one::<i64>("SELECT COUNT(*) FROM moz_historyvisits")
                 .unwrap(),
         );
+    }
+
+    // See https://github.com/mozilla-mobile/fenix/issues/8531#issuecomment-590498878.
+    #[test]
+    fn test_delete_everything_deletes_origins() {
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).unwrap();
+
+        let u = Url::parse("https://www.reddit.com/r/climbing").expect("Should parse URL");
+        let ts = Timestamp::now().0 - 5_000_000;
+        let obs = VisitObservation::new(u)
+            .with_visit_type(VisitTransition::Link)
+            .with_at(Timestamp(ts));
+        apply_observation(&conn, obs).expect("Should apply observation");
+
+        delete_everything(&conn).expect("Should delete everything");
+
+        // We should clear all origins after deleting everythig.
+        let origin_count = conn
+            .query_one::<i64>("SELECT COUNT(*) FROM moz_origins")
+            .expect("Should fetch origin count");
+        assert_eq!(0, origin_count);
+    }
+
+    #[test]
+    fn test_apply_observation_updates_origins() {
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).unwrap();
+
+        let obs_for_a = VisitObservation::new(
+            Url::parse("https://example1.com/a").expect("Should parse URL A"),
+        )
+        .with_visit_type(VisitTransition::Link)
+        .with_at(Timestamp(Timestamp::now().0 - 5_000_000));
+        apply_observation(&conn, obs_for_a).expect("Should apply observation for A");
+
+        let obs_for_b = VisitObservation::new(
+            Url::parse("https://example2.com/b").expect("Should parse URL B"),
+        )
+        .with_visit_type(VisitTransition::Link)
+        .with_at(Timestamp(Timestamp::now().0 - 2_500_000));
+        apply_observation(&conn, obs_for_b).expect("Should apply observation for B");
+
+        let mut origins = conn
+            .prepare("SELECT host FROM moz_origins")
+            .expect("Should prepare origins statement")
+            .query_and_then(NO_PARAMS, |row| -> rusqlite::Result<_> {
+                Ok(row.get::<_, String>(0)?)
+            })
+            .expect("Should fetch all origins")
+            .map(|r| r.expect("Should get origin from row"))
+            .collect::<Vec<_>>();
+        origins.sort();
+        assert_eq!(origins, &["example1.com", "example2.com",]);
     }
 
     #[test]

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -625,12 +625,6 @@ pub mod history_sync {
         Ok(Some((page_info, visits)))
     }
 
-    /// Called when incoming changes are finished, but before we commit the
-    /// transaction prior to fetching outgoing ones.
-    pub fn finish_incoming(db: &PlacesDb) -> Result<()> {
-        delete_pending_temp_tables(db)
-    }
-
     /// Apply history visit from sync. This assumes they have all been
     /// validated, deduped, etc - it's just the storage we do here.
     pub fn apply_synced_visits(


### PR DESCRIPTION
See the commit messages for the details. The first commit is just in case; the second one is the actual fix. I wish there was a better way to ensure we called `delete_pending_temp_tables` after changing `moz_places`; the entire origin temp tables thing is kind of a hack around SQLite's lack of `FOR EACH STATEMENT` triggers, which would simplify this _so much_.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
