### PR TITLE
Rename `delete_place_by_guid` to `delete_visits_for`

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,19 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.54.1...master)
+
+## Places
+
+### ⚠️ Breaking changes ⚠️
+
+- Android: `PlacesConnection.deletePlace` has been renamed to
+  `deleteVisitsFor`, to clarify that it might not actually delete the
+  page if it's bookmarked, or has a keyword or tags
+  ([#2695](https://github.com/mozilla/application-services/pull/2695)).
+
+### What's fixed
+
+- `history::delete_visits_for` (formerly `delete_place_by_guid`) now correctly
+  deletes all visits from a page if it has foreign key references, like
+  bookmarks, keywords, or tags. Previously, this would cause a constraint
+  violation ([#2695](https://github.com/mozilla/application-services/pull/2695)).

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -113,7 +113,7 @@ internal interface LibPlacesFFI : Library {
         out_err: RustError.ByReference
     )
 
-    fun places_delete_place(
+    fun places_delete_visits_for(
         handle: PlacesConnectionHandle,
         url: String,
         out_err: RustError.ByReference

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -514,11 +514,11 @@ class PlacesWriterConnection internal constructor(connHandle: Long, api: PlacesA
         }
     }
 
-    override fun deletePlace(url: String) {
+    override fun deleteVisitsFor(url: String) {
         return writeQueryCounters.measure {
             rustCall { error ->
                 PlacesManagerMetrics.writeQueryTime.measure {
-                    LibPlacesFFI.INSTANCE.places_delete_place(
+                    LibPlacesFFI.INSTANCE.places_delete_visits_for(
                         this.handle.get(), url, error)
                 }
             }
@@ -958,20 +958,22 @@ interface WritableHistoryConnection : ReadableHistoryConnection {
     fun deleteEverything()
 
     /**
-     * Deletes all information about the given URL. If the place has previously
-     * been synced, a tombstone will be written to the sync server, meaning
-     * the place should be deleted on all synced devices.
+     * Deletes all visits from the given URL. If the page has previously
+     * been synced, a tombstone will be written to the Sync server, meaning
+     * visits for the page should be deleted from all synced devices. If
+     * the page is bookmarked, or has a keyword or tags, only its visits
+     * will be removed; otherwise, the page will be removed completely.
      *
-     * The exception to this is if the place is duplicated on the sync server
-     * (duplicate server-side places are a form of corruption), in which case
-     * only the place whose GUID corresponds to the local GUID will be
-     * deleted. This is (hopefully) rare, and sadly there is not much we can
-     * do about it. It indicates a client-side bug that occurred at some
-     * point in the past.
+     * Note that, if the page is duplicated on the Sync server (that is,
+     * the server has a record with the page URL, but its GUID is different
+     * than the one we have locally), only the record whose GUID matches the
+     * local GUID will be deleted. This is (hopefully) rare, and sadly there
+     * is not much we can do about it. It indicates a client-side bug that
+     * occurred at some point in the past.
      *
      * @param url the url to be removed.
      */
-    fun deletePlace(url: String)
+    fun deleteVisitsFor(url: String)
 
     /**
      * Deletes all visits which occurred since the specified time. If the

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -280,19 +280,19 @@ pub extern "C" fn places_get_visited_urls_in_range(
 }
 
 #[no_mangle]
-pub extern "C" fn places_delete_place(handle: u64, url: FfiStr<'_>, error: &mut ExternError) {
-    log::debug!("places_delete_place");
+pub extern "C" fn places_delete_visits_for(handle: u64, url: FfiStr<'_>, error: &mut ExternError) {
+    log::debug!("places_delete_visits_for");
     CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
         let url = parse_url(url.as_str())?;
         let guid = match parse_url(url.as_str()) {
             Ok(url) => storage::history::url_to_guid(conn, &url)?,
             Err(e) => {
-                log::warn!("Invalid URL passed to places_delete_place, {}", e);
+                log::warn!("Invalid URL passed to places_delete_visits_for, {}", e);
                 storage::history::href_to_guid(conn, url.clone().as_str())?
             }
         };
         if let Some(guid) = guid {
-            storage::history::delete_place_by_guid(conn, &guid)?;
+            storage::history::delete_visits_for(conn, &guid)?;
         }
         Ok(())
     })

--- a/components/places/ios/Places/RustPlacesAPI.h
+++ b/components/places/ios/Places/RustPlacesAPI.h
@@ -93,9 +93,9 @@ RawPlacesInterruptHandle *_Nullable places_new_interrupt_handle(PlacesConnection
 void places_interrupt(RawPlacesInterruptHandle *_Nonnull interrupt,
                       PlacesRustError *_Nonnull out_err);
 
-void places_delete_place(PlacesConnectionHandle handle,
-                         const char *_Nonnull place_url,
-                         PlacesRustError *_Nonnull out_err);
+void places_delete_visits_for(PlacesConnectionHandle handle,
+                              const char *_Nonnull place_url,
+                              PlacesRustError *_Nonnull out_err);
 
 void places_delete_visit(PlacesConnectionHandle handle,
                          const char *_Nonnull place_url,

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -301,7 +301,7 @@ mod tests {
     use crate::history_sync::ServerVisitTimestamp;
     use crate::observation::VisitObservation;
     use crate::storage::history::history_sync::fetch_visits;
-    use crate::storage::history::{apply_observation, delete_place_by_guid, url_to_guid};
+    use crate::storage::history::{apply_observation, delete_visits_for, url_to_guid};
     use crate::types::{SyncStatus, Timestamp};
     use interrupt::NeverInterrupts;
     use serde_json::json;
@@ -1029,7 +1029,7 @@ mod tests {
         assert_eq!(get_sync(&db, &url), (SyncStatus::Normal, 1));
 
         // Delete it.
-        delete_place_by_guid(&db, &guid)?;
+        delete_visits_for(&db, &guid)?;
 
         // should be a local tombstone.
         assert_eq!(get_tombstone_count(&db), 1);


### PR DESCRIPTION
This commit changes the behavior of `delete_place_by_guid` to only
delete the Place if it doesn't have any foreign key references, like
bookmarks, tags, or keywords. If it does, we can't delete the Place
outright, as that would cause a constraint violation at best, and
data loss at worst. Instead, we delete all visits for the Place,
but leave its row in `moz_places`, inserting tombstones if the Place
is synced.

This commit also renames `delete_place_by_guid` to clarify that it
might not actually delete the Place. However, the Kotlin method
retains its old name (`PlacesWriterConnection#deletePlace`) for now.

See #2520.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
