### PR TITLE
Add basic docs for testing local changes on Firefox for iOS.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ you work on app-services projects.  We have:
       * [How to set up your local android build environment](./howtos/setup-android-build-environment.md)
       * [How to try out local changes in Fenix](./howtos/locally-published-components-in-fenix.md)
       * [How to try out local changes in the Reference Browser](./howtos/working-with-reference-browser.md)
+      * [How to try out local changes in Firefox for iOS](./howtos/locally-published-components-in-ios.md)
       * [How to access logs for debugging](./logging.md)
     * Process guidelines:
       * [How to cut a new release](./howtos/cut-a-new-release.md)

--- a/docs/howtos/locally-published-components-in-ios.md
+++ b/docs/howtos/locally-published-components-in-ios.md
@@ -1,0 +1,18 @@
+# Using locally-published components in Firefox for iOS
+
+It's often important to test work-in-progress changes to this repo against a real-world
+consumer project. Here are our current best-practices for approaching this on iOS:
+
+1. Make a local build of the application-services framework using `./build-carthage.sh`.
+1. Checkout and `carthage bootstrap` the consuming app (for example using [these instructions with Firefox for
+   iOS](https://github.com/mozilla-mobile/firefox-ios#building-the-code)).
+1. In the consuming app, replace the application-services framework with a symlink to your local build. For example:
+
+   ```
+   rm -rf Carthage/Build/iOS/MozillaAppServices.framework
+   ln -s path/to/application-services/Carthage/Build/iOS/Static/MozillaAppServices.framework Carthage/Build/iOS
+   ```
+1. Open the consuming app project in XCode and build it from there.
+
+After making changes to application-services code, re-run `./build-carthage.sh` and then rebuild
+the consuming app. You may need to clear the XCode cache using Cmd+k if the app doesn't seem to pick up your changes.


### PR DESCRIPTION
This turns @eoger's helpful comment over in https://github.com/mozilla-services/services-engineering/issues/33#issuecomment-589723545 into a longer-lived reference doc.