### PR TITLE
Improve handling of duplicate tags and URLs 

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,12 @@
   See [`onpushsubscriptionchange`][0] events on how this change can be propagated to notify web content.
 
 [0]: https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/onpushsubscriptionchange
+
+## Places
+
+### What's fixed
+
+- Improve handling of tags for bookmarks with the same URL. These bookmarks no
+  longer cause syncs to fail ([#2750](https://github.com/mozilla/application-services/pull/2750)),
+  and bookmarks with duplicate or mismatched tags are reuploaded
+  ([#2774](https://github.com/mozilla/application-services/pull/2774)).

--- a/components/places/sql/create_shared_schema.sql
+++ b/components/places/sql/create_shared_schema.sql
@@ -197,6 +197,8 @@ CREATE TABLE IF NOT EXISTS moz_bookmarks_synced(
     siteURL TEXT
 );
 
+CREATE INDEX IF NOT EXISTS moz_bookmarks_synced_urls ON moz_bookmarks_synced(placeId);
+
 -- This table holds parent-child relationships and positions for synced items,
 -- from each folder's `children`. Unlike `moz_bookmarks`, this is stored
 -- separately because we might see an incoming folder before its children. This

--- a/components/places/src/bookmark_sync/tests/synced_item.rs
+++ b/components/places/src/bookmark_sync/tests/synced_item.rs
@@ -24,7 +24,7 @@ use url::Url;
 /// target of the comparison. We use this instead of Option<> so that we
 /// can correctly check Option<> fields (ie, so that None isn't ambiguous
 /// between "no value specified" and "value is exactly None"
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum SyncedBookmarkValue<T> {
     Unspecified,
     Specified(T),
@@ -48,7 +48,7 @@ where
     }
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct SyncedBookmarkItem {
     pub id: SyncedBookmarkValue<RowId>,
     pub guid: SyncedBookmarkValue<SyncGuid>,

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -18,7 +18,7 @@ use crate::types::SyncStatus;
 use rusqlite::NO_PARAMS;
 use sql_support::ConnExt;
 
-const VERSION: i64 = 9;
+const VERSION: i64 = 10;
 
 // Shared schema and temp tables for the read-write and Sync connections.
 const CREATE_SHARED_SCHEMA_SQL: &str = include_str!("../../sql/create_shared_schema.sql");
@@ -215,6 +215,17 @@ fn upgrade(db: &PlacesDb, from: i64) -> Result<()> {
                  WHERE syncStatus = {}",
                 SyncStatus::New as u8
             ),
+        ],
+        || Ok(()),
+    )?;
+    migration(
+        db,
+        9,
+        10,
+        &[
+            // Add an index for synced bookmark URLs.
+            "CREATE INDEX IF NOT EXISTS moz_bookmarks_synced_urls
+             ON moz_bookmarks_synced(placeId)",
         ],
         || Ok(()),
     )?;


### PR DESCRIPTION
#2750:

> So, what happens if we have bookmarks with the same URL and _different_ tags? Or, what happens if we have duplicates in the `tags` list—like, a bookmark with `tags: ["one", "one", "two", "three"]`? Those are fodder for a later patch...

This is that patch! 😆 @eoger and @lougeniaC64, please let me know if the comments and SQL make sense, and if I can make it easier to understand in any way. Let's increase the bus factor (I _think_ that's the right direction, to spread more knowledge around and reduce the risk? 😂) on bookmark sync.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
