### PR TITLE
Restrict deleting from `moz_places` if there are keywords

### DIFF
--- a/components/places/sql/create_shared_schema.sql
+++ b/components/places/sql/create_shared_schema.sql
@@ -232,6 +232,6 @@ CREATE TABLE IF NOT EXISTS moz_bookmarks_synced_tag_relation(
 -- doesn't write it.
 CREATE TABLE IF NOT EXISTS moz_keywords(
     place_id INTEGER PRIMARY KEY REFERENCES moz_places(id)
-                     ON DELETE CASCADE,
+                     ON DELETE RESTRICT,
     keyword TEXT NOT NULL UNIQUE
 );

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -237,7 +237,7 @@ fn upgrade(db: &PlacesDb, from: i64) -> Result<()> {
             // Add a new table to hold synced and migrated search keywords.
             "CREATE TABLE IF NOT EXISTS moz_keywords(
                  place_id INTEGER PRIMARY KEY REFERENCES moz_places(id)
-                                  ON DELETE CASCADE,
+                                  ON DELETE RESTRICT,
                  keyword TEXT NOT NULL UNIQUE
              )",
             // Add an index on synced keywords, so that we can search for


### PR DESCRIPTION
If a Place has keywords, we should delete them from `moz_keywords`
first, before deleting the Place from `moz_places`. This is to catch
coding errors where we accidentally ignore the `foreign_count` and
delete the Place, losing its keywords in the process.

Since we never shipped the schema in #2501 in a release, this doesn't
need a migration.

(I didn't take my own advice from #2520 for keywords, too 😭):

> While we're here, let's also change the constraints on `moz_tags_relation` and `moz_bookmarks_synced` to `ON DELETE RESTRICT`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
