### PR TITLE
Only deserialize the `active` field in oauth/introspect response

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/IntrospectInfo.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/IntrospectInfo.kt
@@ -5,20 +5,12 @@
 package mozilla.appservices.fxaclient
 
 data class IntrospectInfo(
-    val active: Boolean,
-    val tokenType: String,
-    val scope: String?,
-    val exp: Long,
-    val iss: String
+    val active: Boolean
 ) {
     companion object {
         internal fun fromMessage(msg: MsgTypes.IntrospectInfo): IntrospectInfo {
             return IntrospectInfo(
-                active = msg.active,
-                tokenType = msg.tokenType,
-                scope = if (msg.hasScope()) msg.scope else null,
-                exp = msg.exp,
-                iss = msg.iss
+                active = msg.active
             )
         }
     }

--- a/components/fxa-client/ios/FxAClient/FxAccountOAuth.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountOAuth.swift
@@ -56,31 +56,15 @@ public struct AccessTokenInfo {
 
 public struct IntrospectInfo {
     public let active: Bool
-    public let tokenType: String
-    public let scope: String?
-    public let exp: Date
-    public let iss: String?
 
     internal init(msg: MsgTypes_IntrospectInfo) {
         active = msg.active
-        tokenType = msg.tokenType
-        scope = msg.hasScope ? msg.scope : nil
-        exp = Date(timeIntervalSince1970: Double(msg.exp))
-        iss = msg.hasIss ? msg.iss : nil
     }
 
     // For testing.
     internal init(
-        active: Bool,
-        tokenType: String,
-        scope: String? = nil,
-        exp: Date = Date(),
-        iss: String? = nil
+        active: Bool
     ) {
         self.active = active
-        self.tokenType = tokenType
-        self.scope = scope
-        self.exp = exp
-        self.iss = iss
     }
 }

--- a/components/fxa-client/src/ffi.rs
+++ b/components/fxa-client/src/ffi.rs
@@ -76,13 +76,7 @@ impl From<AccessTokenInfo> for msg_types::AccessTokenInfo {
 
 impl From<IntrospectInfo> for msg_types::IntrospectInfo {
     fn from(a: IntrospectInfo) -> Self {
-        msg_types::IntrospectInfo {
-            active: a.active,
-            token_type: a.token_type,
-            scope: a.scope,
-            exp: a.exp,
-            iss: a.iss,
-        }
+        msg_types::IntrospectInfo { active: a.active }
     }
 }
 

--- a/components/fxa-client/src/fxa_msg_types.proto
+++ b/components/fxa-client/src/fxa_msg_types.proto
@@ -24,10 +24,6 @@ message AccessTokenInfo {
 
 message IntrospectInfo {
     required bool active = 1;
-    required string token_type = 2;
-    optional string scope = 3;
-    optional uint64 exp = 4;
-    optional string iss = 5;
 }
 
 message ScopedKey {

--- a/components/fxa-client/src/http_client.rs
+++ b/components/fxa-client/src/http_client.rs
@@ -678,10 +678,8 @@ pub struct OAuthAuthResponse {
 #[derive(Deserialize)]
 pub struct IntrospectResponse {
     pub active: bool,
-    pub token_type: String,
-    pub scope: Option<String>,
-    pub exp: Option<u64>,
-    pub iss: Option<String>,
+    // Technically the response has a lot of other fields,
+    // but in practice we only use `active`.
 }
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -97,10 +97,6 @@ impl FirefoxAccount {
         };
         Ok(IntrospectInfo {
             active: resp.active,
-            token_type: resp.token_type,
-            scope: resp.scope,
-            exp: resp.exp,
-            iss: resp.iss,
         })
     }
 
@@ -396,10 +392,6 @@ impl std::fmt::Debug for AccessTokenInfo {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct IntrospectInfo {
     pub active: bool,
-    pub token_type: String,
-    pub scope: Option<String>,
-    pub exp: Option<u64>,
-    pub iss: Option<String>,
 }
 
 #[cfg(test)]
@@ -635,20 +627,10 @@ mod tests {
                 token.partial_eq("refresh_token")
             })
             .times(1)
-            .returns_once(Ok(IntrospectResponse {
-                active: true,
-                token_type: "refresh".to_string(),
-                scope: None,
-                exp: None,
-                iss: None,
-            }));
+            .returns_once(Ok(IntrospectResponse { active: true }));
         fxa.set_client(Arc::new(client));
 
         let auth_status = fxa.check_authorization_status().unwrap();
         assert_eq!(auth_status.active, true);
-        assert_eq!(auth_status.token_type, "refresh".to_string());
-        assert_eq!(auth_status.scope, None);
-        assert_eq!(auth_status.exp, None);
-        assert_eq!(auth_status.iss, None);
     }
 }

--- a/megazords/ios/MozillaAppServicesTests/FxAccountManagerTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountManagerTests.swift
@@ -210,7 +210,7 @@ class FxAccountManagerTests: XCTestCase {
 
             override func checkAuthorizationStatus() throws -> IntrospectInfo {
                 _ = try super.checkAuthorizationStatus()
-                return IntrospectInfo(active: false, tokenType: "refresh_token")
+                return IntrospectInfo(active: false)
             }
         }
         let mgr = mockFxAManager()

--- a/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
@@ -49,7 +49,7 @@ class MockFxAccount: FxAccount {
 
     override func checkAuthorizationStatus() throws -> IntrospectInfo {
         invocations.append(.checkAuthorizationStatus)
-        return IntrospectInfo(active: true, tokenType: "refresh_token")
+        return IntrospectInfo(active: true)
     }
 
     override func clearAccessTokenCache() throws {


### PR DESCRIPTION
Fixes #2792.

I went with the low-effort fix since we don't even use the other fields.