### PR TITLE
Allow token server URL override

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -19,3 +19,12 @@
   deletes all visits from a page if it has foreign key references, like
   bookmarks, keywords, or tags. Previously, this would cause a constraint
   violation ([#2695](https://github.com/mozilla/application-services/pull/2695)).
+
+## FxA Client
+
+### Breaking changes
+
+- In order to account better for self-hosted FxA/Sync backends, the FxAConfig objects have been reworked. ([#2801](https://github.com/mozilla/application-services/pull/2801))
+  - iOS: `FxAConfig.release(contentURL, clientID)` is now `FxAConfig(server: .release, contentURL, clientID)`.
+  - Android: `Config.release(contentURL, clientID)` is now `Config(Server.RELEASE, contentURL, clientID)`.
+  - These constructors also take a new `tokenServerUrlOverride` optional 4th parameter that overrides the token server URL.

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/Config.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/Config.kt
@@ -8,8 +8,12 @@ package mozilla.appservices.fxaclient
  * Config represents the server endpoint configurations needed for the
  * authentication flow.
  */
-class Config constructor(val contentUrl: String, val clientId: String, val redirectUri: String) {
-
+class Config constructor(
+    val contentUrl: String,
+    val clientId: String,
+    val redirectUri: String,
+    val tokenServerUrlOverride: String? = null
+) {
     enum class Server(val contentUrl: String) {
         RELEASE("https://accounts.firefox.com"),
         STABLE("https://stable.dev.lcip.org"),
@@ -17,50 +21,10 @@ class Config constructor(val contentUrl: String, val clientId: String, val redir
         CHINA("https://accounts.firefox.com.cn")
     }
 
-    constructor(server: Server, clientId: String, redirectUri: String) :
-        this(server.contentUrl, clientId, redirectUri)
-
-    companion object {
-        /**
-         * Set up endpoints used in the production Firefox Accounts instance.
-         *
-         * @param clientId Client Id of the FxA relier
-         * @param redirectUri Redirect Uri of the FxA relier
-         */
-        fun release(clientId: String, redirectUri: String): Config {
-            return Config(Server.RELEASE.contentUrl, clientId, redirectUri)
-        }
-
-        /**
-         * Set up endpoints used in the stable Firefox Accounts instance.
-         *
-         * @param clientId Client Id of the FxA relier
-         * @param redirectUri Redirect Uri of the FxA relier
-         */
-        fun stable(clientId: String, redirectUri: String): Config {
-            return Config(Server.STABLE.contentUrl, clientId, redirectUri)
-        }
-
-        /**
-         * Set up endpoints used in the dev
-         * Firefox Accounts instance.
-         *
-         * @param clientId Client Id of the FxA relier
-         * @param redirectUri Redirect Uri of the FxA relier
-         */
-        fun dev(clientId: String, redirectUri: String): Config {
-            return Config(Server.DEV.contentUrl, clientId, redirectUri)
-        }
-
-        /**
-         * Set up endpoints used in the production Firefox Accounts China
-         * instance.
-         *
-         * @param clientId Client Id of the FxA relier
-         * @param redirectUri Redirect Uri of the FxA relier
-         */
-        fun china(clientId: String, redirectUri: String): Config {
-            return Config(Server.CHINA.contentUrl, clientId, redirectUri)
-        }
-    }
+    constructor(
+        server: Server,
+        clientId: String,
+        redirectUri: String,
+        tokenServerUrlOverride: String? = null
+    ) : this(server.contentUrl, clientId, redirectUri, tokenServerUrlOverride)
 }

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -28,7 +28,13 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      */
     constructor(config: Config, persistCallback: PersistCallback? = null) :
     this(rustCall { e ->
-        LibFxAFFI.INSTANCE.fxa_new(config.contentUrl, config.clientId, config.redirectUri, e)
+        LibFxAFFI.INSTANCE.fxa_new(
+            config.contentUrl,
+            config.clientId,
+            config.redirectUri,
+            config.tokenServerUrlOverride,
+            e
+        )
     }, persistCallback) {
         // Persist the newly created instance state.
         this.tryPersistState()

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -22,6 +22,7 @@ internal interface LibFxAFFI : Library {
         contentUrl: String,
         clientId: String,
         redirectUri: String,
+        tokenServerUrlOverride: String?,
         e: RustError.ByReference
     ): FxaHandle
 

--- a/components/fxa-client/examples/migration.rs
+++ b/components/fxa-client/examples/migration.rs
@@ -1,5 +1,5 @@
 use cli_support::prompt::prompt_string;
-use fxa_client::FirefoxAccount;
+use fxa_client::{Config, FirefoxAccount};
 use std::{thread, time};
 
 static CLIENT_ID: &str = "3c49430b43dfba77";
@@ -7,7 +7,8 @@ static CONTENT_SERVER: &str = "https://accounts.firefox.com";
 static REDIRECT_URI: &str = "https://accounts.firefox.com/oauth/success/3c49430b43dfba77";
 
 fn main() {
-    let mut fxa = FirefoxAccount::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
+    let config = Config::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
+    let mut fxa = FirefoxAccount::with_config(config);
     println!("Enter Session token (hex-string):");
     let session_token: String = prompt_string("session token").unwrap();
     println!("Enter kSync (hex-string):");

--- a/components/fxa-client/examples/oauth_flow.rs
+++ b/components/fxa-client/examples/oauth_flow.rs
@@ -1,5 +1,5 @@
 use cli_support::prompt::prompt_string;
-use fxa_client::FirefoxAccount;
+use fxa_client::{Config, FirefoxAccount};
 use std::collections::HashMap;
 use url::Url;
 
@@ -9,7 +9,8 @@ const REDIRECT_URI: &str = "https://mozilla.github.io/notes/fxa/android-redirect
 const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
 
 fn main() {
-    let mut fxa = FirefoxAccount::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
+    let config = Config::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
+    let mut fxa = FirefoxAccount::with_config(config);
     let url = fxa.begin_oauth_flow(&SCOPES).unwrap();
     println!("Open the following URL:");
     println!("{}", url);

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -34,6 +34,7 @@ pub extern "C" fn fxa_new(
     content_url: FfiStr<'_>,
     client_id: FfiStr<'_>,
     redirect_uri: FfiStr<'_>,
+    token_server_url_override: FfiStr<'_>,
     err: &mut ExternError,
 ) -> u64 {
     log::debug!("fxa_new");
@@ -41,7 +42,13 @@ pub extern "C" fn fxa_new(
         let content_url = content_url.as_str();
         let client_id = client_id.as_str();
         let redirect_uri = redirect_uri.as_str();
-        FirefoxAccount::new(content_url, client_id, redirect_uri)
+        let token_server_url_override = token_server_url_override.as_opt_str();
+        FirefoxAccount::new(
+            content_url,
+            client_id,
+            redirect_uri,
+            token_server_url_override,
+        )
     })
 }
 

--- a/components/fxa-client/ios/FxAClient/FxAccountConfig.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountConfig.swift
@@ -5,46 +5,39 @@
 import Foundation
 
 open class FxAConfig {
-    // FIXME: these should be lower case.
-    // swiftlint:disable identifier_name
     public enum Server: String {
-        case Release = "https://accounts.firefox.com"
-        case Stable = "https://stable.dev.lcip.org"
-        case Dev = "https://accounts.stage.mozaws.net"
-        case China = "https://accounts.firefox.com.cn"
+        case release = "https://accounts.firefox.com"
+        case stable = "https://stable.dev.lcip.org"
+        case dev = "https://accounts.stage.mozaws.net"
+        case china = "https://accounts.firefox.com.cn"
     }
-
-    // swiftlint:enable identifier_name
 
     let contentUrl: String
     let clientId: String
     let redirectUri: String
+    let tokenServerUrlOverride: String?
 
-    public init(contentUrl: String, clientId: String, redirectUri: String) {
+    public init(
+        contentUrl: String,
+        clientId: String,
+        redirectUri: String,
+        tokenServerUrlOverride: String? = nil
+    ) {
         self.contentUrl = contentUrl
         self.clientId = clientId
         self.redirectUri = redirectUri
+        self.tokenServerUrlOverride = tokenServerUrlOverride
     }
 
-    public init(withServer server: Server, clientId: String, redirectUri: String) {
+    public init(
+        server: Server,
+        clientId: String,
+        redirectUri: String,
+        tokenServerUrlOverride: String? = nil
+    ) {
         contentUrl = server.rawValue
         self.clientId = clientId
         self.redirectUri = redirectUri
-    }
-
-    public static func release(clientId: String, redirectUri: String) -> FxAConfig {
-        return FxAConfig(withServer: FxAConfig.Server.Release, clientId: clientId, redirectUri: redirectUri)
-    }
-
-    public static func stable(clientId: String, redirectUri: String) -> FxAConfig {
-        return FxAConfig(withServer: FxAConfig.Server.Stable, clientId: clientId, redirectUri: redirectUri)
-    }
-
-    public static func dev(clientId: String, redirectUri: String) -> FxAConfig {
-        return FxAConfig(withServer: FxAConfig.Server.Dev, clientId: clientId, redirectUri: redirectUri)
-    }
-
-    public static func china(clientId: String, redirectUri: String) -> FxAConfig {
-        return FxAConfig(withServer: FxAConfig.Server.China, clientId: clientId, redirectUri: redirectUri)
+        self.tokenServerUrlOverride = tokenServerUrlOverride
     }
 }

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -86,6 +86,7 @@ char *_Nullable fxa_to_json(FirefoxAccountHandle handle,
 FirefoxAccountHandle fxa_new(const char *_Nonnull content_base,
                              const char *_Nonnull client_id,
                              const char *_Nonnull redirect_uri,
+                             const char *_Nullable token_server_url_override,
                              FxAError *_Nonnull out);
 
 FxARustBuffer fxa_profile(FirefoxAccountHandle handle,

--- a/components/fxa-client/ios/FxAClient/RustFxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/RustFxAccount.swift
@@ -17,7 +17,7 @@ open class RustFxAccount {
     /// OAuth Flow.
     public required convenience init(config: FxAConfig) throws {
         let pointer = try rustCall { err in
-            fxa_new(config.contentUrl, config.clientId, config.redirectUri, err)
+            fxa_new(config.contentUrl, config.clientId, config.redirectUri, config.tokenServerUrlOverride, err)
         }
         self.init(raw: pointer)
     }

--- a/components/fxa-client/src/config.rs
+++ b/components/fxa-client/src/config.rs
@@ -30,6 +30,7 @@ pub struct Config {
     content_url: String,
     // RemoteConfig is lazily fetched from the server.
     remote_config: RefCell<Option<Arc<RemoteConfig>>>,
+    token_server_url_override: Option<String>,
     pub client_id: String,
     pub redirect_uri: String,
 }
@@ -75,7 +76,20 @@ impl Config {
             client_id: client_id.to_string(),
             redirect_uri: redirect_uri.to_string(),
             remote_config: RefCell::new(None),
+            token_server_url_override: None,
         }
+    }
+
+    /// Override the token server URL that would otherwise be provided by the
+    /// FxA .well-known/fxa-client-configuration endpoint.
+    /// This is used by self-hosters that still use the product FxA servers
+    /// for authentication purposes but use their own Sync storage backend.
+    pub fn override_token_server_url<'a>(
+        &'a mut self,
+        token_server_url_override: &str,
+    ) -> &'a mut Self {
+        self.token_server_url_override = Some(token_server_url_override.to_owned());
+        self
     }
 
     // FIXME
@@ -94,6 +108,7 @@ impl Config {
         introspection_endpoint: Option<String>,
         client_id: String,
         redirect_uri: String,
+        token_server_url_override: Option<String>,
     ) -> Self {
         let remote_config = RemoteConfig {
             auth_url,
@@ -113,6 +128,7 @@ impl Config {
             remote_config: RefCell::new(Some(Arc::new(remote_config))),
             client_id,
             redirect_uri,
+            token_server_url_override,
         }
     }
 
@@ -191,7 +207,12 @@ impl Config {
     }
 
     pub fn token_server_endpoint_url(&self) -> Result<Url> {
-        Url::parse(&self.remote_config()?.token_server_endpoint_url).map_err(Into::into)
+        if let Some(token_server_url_override) = &self.token_server_url_override {
+            return Ok(Url::parse(&token_server_url_override)?);
+        }
+        Ok(Url::parse(
+            &self.remote_config()?.token_server_endpoint_url,
+        )?)
     }
 
     pub fn authorization_endpoint(&self) -> Result<Url> {
@@ -262,6 +283,7 @@ mod tests {
             remote_config: RefCell::new(Some(Arc::new(remote_config))),
             client_id: "263ceaa5546dce83".to_string(),
             redirect_uri: "https://127.0.0.1:8080".to_string(),
+            token_server_url_override: None,
         };
         assert_eq!(
             config.auth_url_path("v1/account/keys").unwrap().to_string(),
@@ -292,6 +314,41 @@ mod tests {
         assert_eq!(
             config.introspection_endpoint().unwrap().to_string(),
             "https://oauth-stable.dev.lcip.org/v1/introspect"
+        );
+    }
+
+    #[test]
+    fn test_tokenserver_url_override() {
+        let remote_config = RemoteConfig {
+            auth_url: "https://stable.dev.lcip.org/auth/".to_string(),
+            oauth_url: "https://oauth-stable.dev.lcip.org/".to_string(),
+            profile_url: "https://stable.dev.lcip.org/profile/".to_string(),
+            token_server_endpoint_url: "https://stable.dev.lcip.org/syncserver/token/1.0/sync/1.5"
+                .to_string(),
+            authorization_endpoint: "https://oauth-stable.dev.lcip.org/v1/authorization"
+                .to_string(),
+            issuer: "https://dev.lcip.org/".to_string(),
+            jwks_uri: "https://oauth-stable.dev.lcip.org/v1/jwks".to_string(),
+            token_endpoint: "https://stable.dev.lcip.org/auth/v1/oauth/token".to_string(),
+            introspection_endpoint: Some(
+                "https://oauth-stable.dev.lcip.org/v1/introspect".to_string(),
+            ),
+            userinfo_endpoint: "https://stable.dev.lcip.org/profile/v1/profile".to_string(),
+        };
+
+        let mut config = Config {
+            content_url: "https://stable.dev.lcip.org/".to_string(),
+            remote_config: RefCell::new(Some(Arc::new(remote_config))),
+            client_id: "263ceaa5546dce83".to_string(),
+            redirect_uri: "https://127.0.0.1:8080".to_string(),
+            token_server_url_override: None,
+        };
+
+        config.override_token_server_url("https://foo.bar");
+
+        assert_eq!(
+            config.token_server_endpoint_url().unwrap().to_string(),
+            "https://foo.bar/"
         );
     }
 }

--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -319,14 +319,15 @@ mod tests {
     use crate::http_client::*;
     use crate::oauth::RefreshToken;
     use crate::scoped_keys::ScopedKey;
+    use crate::Config;
     use std::collections::HashSet;
     use std::sync::Arc;
 
     fn setup() -> FirefoxAccount {
         // I'd love to be able to configure a single mocked client here,
         // but can't work out how to do that within the typesystem.
-        let mut fxa =
-            FirefoxAccount::new("https://stable.dev.lcip.org", "12345678", "https://foo.bar");
+        let config = Config::stable_dev("12345678", "https://foo.bar");
+        let mut fxa = FirefoxAccount::with_config(config);
         fxa.state.refresh_token = Some(RefreshToken {
             token: "refreshtok".to_string(),
             scopes: HashSet::default(),

--- a/components/fxa-client/src/migrator.rs
+++ b/components/fxa-client/src/migrator.rs
@@ -202,14 +202,15 @@ impl FirefoxAccount {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http_client::*;
+    use crate::{http_client::*, Config};
     use std::collections::HashMap;
     use std::sync::Arc;
 
     fn setup() -> FirefoxAccount {
         // I'd love to be able to configure a single mocked client here,
         // but can't work out how to do that within the typesystem.
-        FirefoxAccount::new("https://stable.dev.lcip.org", "12345678", "https://foo.bar")
+        let config = Config::stable_dev("12345678", "https://foo.bar");
+        FirefoxAccount::with_config(config)
     }
 
     macro_rules! assert_match {

--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -397,7 +397,7 @@ pub struct IntrospectInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http_client::*;
+    use crate::{http_client::*, Config};
     use std::borrow::Cow;
     use std::collections::HashMap;
     use std::sync::Arc;
@@ -412,11 +412,12 @@ mod tests {
 
     #[test]
     fn test_oauth_flow_url() {
-        let mut fxa = FirefoxAccount::new(
+        let config = Config::new(
             "https://accounts.firefox.com",
             "12345678",
             "https://foo.bar",
         );
+        let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa.begin_oauth_flow(&["profile"]).unwrap();
         let flow_url = Url::parse(&url).unwrap();
 
@@ -475,8 +476,8 @@ mod tests {
 
     #[test]
     fn test_force_auth_url() {
-        let mut fxa =
-            FirefoxAccount::new("https://stable.dev.lcip.org", "12345678", "https://foo.bar");
+        let config = Config::stable_dev("12345678", "https://foo.bar");
+        let mut fxa = FirefoxAccount::with_config(config);
         let email = "test@example.com";
         fxa.add_cached_profile("123", email);
         let url = fxa.begin_oauth_flow(&["profile"]).unwrap();
@@ -492,11 +493,12 @@ mod tests {
     #[test]
     fn test_webchannel_context_url() {
         const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
-        let mut fxa = FirefoxAccount::new(
+        let config = Config::new(
             "https://accounts.firefox.com",
             "12345678",
             "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel",
         );
+        let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa.begin_oauth_flow(&SCOPES).unwrap();
         let url = Url::parse(&url).unwrap();
         let query_params: HashMap<_, _> = url.query_pairs().into_owned().collect();
@@ -510,11 +512,12 @@ mod tests {
         const SCOPES: &[&str] = &["https://identity.mozilla.com/apps/oldsync"];
         const PAIRING_URL: &str = "https://accounts.firefox.com/pair#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
 
-        let mut fxa = FirefoxAccount::new(
+        let config = Config::new(
             "https://accounts.firefox.com",
             "12345678",
             "urn:ietf:wg:oauth:2.0:oob:oauth-redirect-webchannel",
         );
+        let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa.begin_pairing_flow(&PAIRING_URL, &SCOPES).unwrap();
         let url = Url::parse(&url).unwrap();
         let query_params: HashMap<_, _> = url.query_pairs().into_owned().collect();
@@ -529,11 +532,12 @@ mod tests {
         const PAIRING_URL: &str = "https://accounts.firefox.com/pair#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
         const EXPECTED_URL: &str = "https://accounts.firefox.com/pair/supp?client_id=12345678&redirect_uri=https%3A%2F%2Ffoo.bar&scope=https%3A%2F%2Fidentity.mozilla.com%2Fapps%2Foldsync&state=SmbAA_9EA5v1R2bgIPeWWw&code_challenge_method=S256&code_challenge=ZgHLPPJ8XYbXpo7VIb7wFw0yXlTa6MUOVfGiADt0JSM&access_type=offline&keys_jwk=eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIiwieCI6Ing5LUltQjJveDM0LTV6c1VmbW5sNEp0Ti14elV2eFZlZXJHTFRXRV9BT0kiLCJ5IjoiNXBKbTB3WGQ4YXdHcm0zREl4T1pWMl9qdl9tZEx1TWlMb1RkZ1RucWJDZyJ9#channel_id=658db7fe98b249a5897b884f98fb31b7&channel_key=1hIDzTj5oY2HDeSg_jA2DhcOcAn5Uqq0cAYlZRNUIo4";
 
-        let mut fxa = FirefoxAccount::new(
+        let config = Config::new(
             "https://accounts.firefox.com",
             "12345678",
             "https://foo.bar",
         );
+        let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa.begin_pairing_flow(&PAIRING_URL, &SCOPES).unwrap();
         let flow_url = Url::parse(&url).unwrap();
         let expected_parsed_url = Url::parse(EXPECTED_URL).unwrap();
@@ -589,11 +593,8 @@ mod tests {
     #[test]
     fn test_pairing_flow_origin_mismatch() {
         static PAIRING_URL: &str = "https://bad.origin.com/pair#channel_id=foo&channel_key=bar";
-        let mut fxa = FirefoxAccount::new(
-            "https://accounts.firefox.com",
-            "12345678",
-            "https://foo.bar",
-        );
+        let config = Config::stable_dev("12345678", "https://foo.bar");
+        let mut fxa = FirefoxAccount::with_config(config);
         let url =
             fxa.begin_pairing_flow(&PAIRING_URL, &["https://identity.mozilla.com/apps/oldsync"]);
 
@@ -612,8 +613,8 @@ mod tests {
 
     #[test]
     fn test_check_authorization_status() {
-        let mut fxa =
-            FirefoxAccount::new("https://stable.dev.lcip.org", "12345678", "https://foo.bar");
+        let config = Config::stable_dev("12345678", "https://foo.bar");
+        let mut fxa = FirefoxAccount::with_config(config);
 
         let refresh_token_scopes = std::collections::HashSet::new();
         fxa.state.refresh_token = Some(RefreshToken {

--- a/components/fxa-client/src/profile.rs
+++ b/components/fxa-client/src/profile.rs
@@ -85,6 +85,7 @@ mod tests {
     use crate::{
         http_client::*,
         oauth::{AccessTokenInfo, RefreshToken},
+        Config,
     };
     use std::sync::Arc;
 
@@ -109,8 +110,8 @@ mod tests {
 
     #[test]
     fn test_fetch_profile() {
-        let mut fxa =
-            FirefoxAccount::new("https://stable.dev.lcip.org", "12345678", "https://foo.bar");
+        let config = Config::stable_dev("12345678", "https://foo.bar");
+        let mut fxa = FirefoxAccount::with_config(config);
 
         fxa.add_cached_token(
             "profile",
@@ -151,8 +152,8 @@ mod tests {
 
     #[test]
     fn test_expired_access_token_refetch() {
-        let mut fxa =
-            FirefoxAccount::new("https://stable.dev.lcip.org", "12345678", "https://foo.bar");
+        let config = Config::stable_dev("12345678", "https://foo.bar");
+        let mut fxa = FirefoxAccount::with_config(config);
 
         fxa.add_cached_token(
             "profile",

--- a/components/fxa-client/src/state_persistence.rs
+++ b/components/fxa-client/src/state_persistence.rs
@@ -176,6 +176,7 @@ impl From<StateV1> for Result<StateV2> {
                 None,
                 state.client_id,
                 state.redirect_uri,
+                None,
             ),
             refresh_token,
             scoped_keys: all_scoped_keys,

--- a/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
@@ -120,7 +120,7 @@ class MockDeviceConstellation: DeviceConstellation {
 
 func mockFxAManager() -> MockFxAccountManager {
     return MockFxAccountManager(
-        config: .release(clientId: "clientid", redirectUri: "redirect"),
+        config: FxAConfig(server: .release, clientId: "clientid", redirectUri: "redirect"),
         deviceConfig: DeviceConfig(name: "foo", type: .mobile, capabilities: [])
     )
 }


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/2794.

I went with the "low-level" route since Grisha doesn't want to see the override URL in the manager itself, which I'm fine with.