### PR TITLE
[DO NOT MERGE] Simulate a missing symbol in the fxa-client build.

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -148,7 +148,7 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      */
     fun getProfile(ignoreCache: Boolean): Profile {
         val profileBuffer = rustCallWithLock { e ->
-            LibFxAFFI.INSTANCE.fxa_profile(this.handle.get(), ignoreCache, e)
+            LibFxAFFI.INSTANCE.fxa_profil(this.handle.get(), ignoreCache, e)
         }
         this.tryPersistState()
         try {

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -42,7 +42,9 @@ internal interface LibFxAFFI : Library {
         e: RustError.ByReference
     ): Pointer?
 
-    fun fxa_profile(fxa: FxaHandle, ignoreCache: Boolean, e: RustError.ByReference): RustBuffer.ByValue
+    // XXX TODO: Whoops! Something has gone wrong in the build and the Kotlin side is trying
+    // to reference a symbol that doesn't exist on the Rust side. Will we catch this in CI?
+    fun fxa_profil(fxa: FxaHandle, ignoreCache: Boolean, e: RustError.ByReference): RustBuffer.ByValue
 
     fun fxa_get_token_server_endpoint_url(fxa: FxaHandle, e: RustError.ByReference): Pointer?
     fun fxa_get_pairing_authority_url(fxa: FxaHandle, e: RustError.ByReference): Pointer?

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -89,7 +89,7 @@ FirefoxAccountHandle fxa_new(const char *_Nonnull content_base,
                              const char *_Nullable token_server_url_override,
                              FxAError *_Nonnull out);
 
-FxARustBuffer fxa_profile(FirefoxAccountHandle handle,
+FxARustBuffer fxa_profil(FirefoxAccountHandle handle,
                           bool ignore_cache,
                           FxAError *_Nonnull out);
 

--- a/components/fxa-client/ios/FxAClient/RustFxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/RustFxAccount.swift
@@ -54,7 +54,7 @@ open class RustFxAccount {
     /// the "profile" scope.
     open func getProfile() throws -> Profile {
         let ptr = try rustCall { err in
-            fxa_profile(self.raw, false, err)
+            fxa_profil(self.raw, false, err)
         }
         defer { fxa_bytebuffer_free(ptr) }
         let msg = try! MsgTypes_Profile(serializedData: Data(rustBuffer: ptr))


### PR DESCRIPTION
This PR is designed to simulate an integration-level build issue
in the fxa-client component, the sort of thing that might happen
during a refactor of some build tooling.

Do we have CI that's capable of catching this issue before it
makes its way into a release?