### PR TITLE
[DO NOT MERGE] Simulate a type mismatch in sync-manager FFI layer.

### DIFF
--- a/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncManager.kt
+++ b/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncManager.kt
@@ -29,7 +29,10 @@ object SyncManager {
      */
     fun setLogins(loginsDbHandle: Long) {
         rustCall { err ->
-            LibSyncManagerFFI.INSTANCE.sync_manager_set_logins(loginsDbHandle, err)
+            // XXX TODO: Whoops! A typo during a refactor of this interface code
+            // has lead to us calling the wrong underlying FFI function.
+            // Will we catch this in CI?
+            LibSyncManagerFFI.INSTANCE.sync_manager_set_places(loginsDbHandle, err)
         }
     }
 


### PR DESCRIPTION
This PR is designed to simulate an integration-level bug in a consuming
app that uses the sync-manager, the sort of passing-the-wrong-argument
accident that might happen due to copy-paste or a refactor.

Do we have CI that's capable of catching this issue before it
makes its way into a release?