### PR TITLE
Use 7s request timeout on iOS

### DIFF
--- a/components/viaduct/src/settings.rs
+++ b/components/viaduct/src/settings.rs
@@ -24,7 +24,7 @@ pub(crate) struct Settings {
 }
 
 #[cfg(target_os = "ios")]
-const TIMEOUT_DURATION: Duration = Duration::from_secs(30);
+const TIMEOUT_DURATION: Duration = Duration::from_secs(7);
 
 #[cfg(not(target_os = "ios"))]
 const TIMEOUT_DURATION: Duration = Duration::from_secs(10);


### PR DESCRIPTION
c1f5558d6a208aecd0eacb01ba96ee852dbead9d did the opposite of what its commit title said :)

Part 1/2 of fixing https://github.com/mozilla/application-services/issues/2811.

cc @thomcc 