### PR TITLE
Run getManageAccountURL and getTokenServerEndpointURL on bg thread

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -28,3 +28,5 @@
   - iOS: `FxAConfig.release(contentURL, clientID)` is now `FxAConfig(server: .release, contentURL, clientID)`.
   - Android: `Config.release(contentURL, clientID)` is now `Config(Server.RELEASE, contentURL, clientID)`.
   - These constructors also take a new `tokenServerUrlOverride` optional 4th parameter that overrides the token server URL.
+
+- iOS: `FxAccountManager`'s `getManageAccountURL` and `getTokenServerEndpointURL` methods now run on background thread and return their results in a callback function. ([#2813](https://github.com/mozilla/application-services/pull/2813))

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -219,24 +219,33 @@ open class FxAccountManager {
     }
 
     /// Get the account management URL.
-    public func getManageAccountURL(entrypoint: String) -> Result<URL, Error> {
-        do {
-            return .success(try requireAccount().getManageAccountURL(entrypoint: entrypoint))
-        } catch {
-            return .failure(error)
+    public func getManageAccountURL(
+        entrypoint: String,
+        completionHandler: @escaping (Result<URL, Error>) -> Void
+    ) {
+        DispatchQueue.global().async {
+            do {
+                let url = try self.requireAccount().getManageAccountURL(entrypoint: entrypoint)
+                DispatchQueue.main.async { completionHandler(.success(url)) }
+            } catch {
+                DispatchQueue.main.async { completionHandler(.failure(error)) }
+            }
         }
     }
 
     /// Get the token server URL with `1.0/sync/1.5` appended at the end.
-    public func getTokenServerEndpointURL() -> Result<URL, Error> {
-        do {
-            return .success(
-                try requireAccount()
+    public func getTokenServerEndpointURL(
+        completionHandler: @escaping (Result<URL, Error>) -> Void
+    ) {
+        DispatchQueue.global().async {
+            do {
+                let url = try self.requireAccount()
                     .getTokenServerEndpointURL()
                     .appendingPathComponent("1.0/sync/1.5")
-            )
-        } catch {
-            return .failure(error)
+                DispatchQueue.main.async { completionHandler(.success(url)) }
+            } catch {
+                DispatchQueue.main.async { completionHandler(.failure(error)) }
+            }
         }
     }
 

--- a/megazords/ios/MozillaAppServicesTests/FxAccountManagerTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountManagerTests.swift
@@ -345,10 +345,14 @@ class FxAccountManagerTests: XCTestCase {
         }
         wait(for: [initDone], timeout: 10)
 
-        let url = try! mgr.getTokenServerEndpointURL().get()
-        XCTAssertEqual(
-            url.absoluteString,
-            "https://token.services.mozilla.com/1.0/sync/1.5"
-        )
+        let tokenServerURLCorrect = XCTestExpectation(description: "Server URL is correct")
+        mgr.getTokenServerEndpointURL { url in
+            XCTAssertEqual(
+                try! url.get().absoluteString,
+                "https://token.services.mozilla.com/1.0/sync/1.5"
+            )
+            tokenServerURLCorrect.fulfill()
+        }
+        wait(for: [tokenServerURLCorrect], timeout: 10)
     }
 }


### PR DESCRIPTION
Turns out the first one calls `profile()` and the second one might fetch `.well-known/fxa-client-configuration` lazily.

2/2 and fixes https://github.com/mozilla/application-services/issues/2811.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
