### PR TITLE
Bug 1563169 - migrate PRs logic to use RelEng taskgraph instead

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,23 +1,21 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+---
 version: 1
+reporting: checks-v1
 policy:
   pullRequests: public
 tasks:
   $let:
+    taskgraph:
+      branch: taskgraph
+      revision: f949fb56d96b9509b071ba55853f2d60e8dbbf57
+    trustDomain: app-services
     decision_task_id: {$eval: as_slugid("decision_task")}
     expires_in: {$fromNow: '1 year'}
     # We define the following variable at the very top, because they are used in the
     # default definition
-    head_branch:
-      $if: 'tasks_for == "github-pull-request"'
-      then: ${event.pull_request.head.ref}
-      else:
-        $if: 'tasks_for == "github-push"'
-        then: ${event.ref}
-        else: ${event.release.target_commitish}
 
     head_rev:
       $if: 'tasks_for == "github-pull-request"'
@@ -52,6 +50,86 @@ tasks:
         else: 'app-services-1'
       # TODO: revisit once bug 1533314 is done to possibly infer better priorities
       tasks_priority: highest
+      # Github events have this stuff in different places...
+      ownerEmail:
+          $if: 'tasks_for in ["cron", "action"]'
+          then: '${tasks_for}@noreply.mozilla.org'
+          else:
+              $if: 'tasks_for == "github-push"'
+              then: '${event.pusher.email}'
+              else:
+                  $if: 'tasks_for == "github-pull-request"'
+                  then: '${event.pull_request.user.login}@users.noreply.github.com'
+                  else:
+                      $if: 'tasks_for == "github-release"'
+                      then: '${event.sender.login}@users.noreply.github.com'
+
+      baseRepoUrl:
+          $if: 'tasks_for in ["github-push", "github-release"]'
+          then: '${event.repository.html_url}'
+          else:
+              $if: 'tasks_for == "github-pull-request"'
+              then: '${event.pull_request.base.repo.html_url}'
+              else:
+                  $if: 'tasks_for in ["cron", "action"]'
+                  then: '${repository.url}'
+      repoUrl:
+          $if: 'tasks_for in ["github-push", "github-release"]'
+          then: '${event.repository.html_url}'
+          else:
+              $if: 'tasks_for == "github-pull-request"'
+              then: '${event.pull_request.head.repo.html_url}'
+              else:
+                  $if: 'tasks_for in ["cron", "action"]'
+                  then: '${repository.url}'
+      project:
+          $if: 'tasks_for in ["github-push", "github-release"]'
+          then: '${event.repository.name}'
+          else:
+              $if: 'tasks_for == "github-pull-request"'
+              then: '${event.pull_request.head.repo.name}'
+              else:
+                  $if: 'tasks_for in ["cron", "action"]'
+                  then: '${repository.project}'
+      head_branch:
+          $if: 'tasks_for == "github-pull-request"'
+          then: ${event.pull_request.head.ref}
+          else:
+              $if: 'tasks_for == "github-push"'
+              then: ${event.ref}
+              else:
+                  $if: 'tasks_for == "github-release"'
+                  then: '${event.release.target_commitish}'
+                  else:
+                      $if: 'tasks_for in ["cron", "action"]'
+                      then: '${push.branch}'
+      head_sha:
+          $if: 'tasks_for == "github-push"'
+          then: '${event.after}'
+          else:
+              $if: 'tasks_for == "github-pull-request"'
+              then: '${event.pull_request.head.sha}'
+              else:
+                  $if: 'tasks_for == "github-release"'
+                  then: '${event.release.tag_name}'
+                  else:
+                      $if: 'tasks_for in ["cron", "action"]'
+                      then: '${push.revision}'
+      ownTaskId:
+          $if: '"github" in tasks_for'
+          then: {$eval: as_slugid("decision_task")}
+          else:
+              $if: 'tasks_for == "cron"'
+              then: '${ownTaskId}'
+      pullRequestAction:
+          $if: 'tasks_for == "github-pull-request"'
+          then: ${event.action}
+          else: 'UNDEFINED'
+
+      releaseAction:
+          $if: 'tasks_for == "github-release"'
+          then: ${event.action}
+          else: 'UNDEFINED'
     in:
       $let:
         default_task_definition:
@@ -123,20 +201,132 @@ tasks:
         $match:
           "tasks_for == 'github-pull-request' && event['action'] in ['opened', 'reopened', 'edited', 'synchronize']":
             $let:
-              pull_request_title: ${event.pull_request.title}
-              pull_request_number: ${event.pull_request.number}
-              pull_request_url: ${event.pull_request.html_url}
+              level:
+                $if: 'tasks_for in ["github-push", "github-release"] && repoUrl == "https://github.com/mozilla/application-services"'
+                then: '3'
+                else: '1'
             in:
-              $mergeDeep:
-                - {$eval: 'default_task_definition'}
-                - scopes:
-                   - assume:repo:${event.repository.html_url[8:]}:pull-request
-                - payload:
-                    env:
-                      GITHUB_PR_TITLE: ${pull_request_title}
-                - metadata:
-                    name: 'Application Services - Decision task (Pull Request #${pull_request_number})'
-                    description: 'Building and testing Application Services - triggered by [#${pull_request_number}](${pull_request_url})'
+              taskId: '${ownTaskId}'
+              taskGroupId:
+                  $if: 'tasks_for == "action"'
+                  then:
+                      '${action.taskGroupId}'
+                  else:
+                      '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
+              schedulerId: '${trustDomain}-level-${level}'
+              created: {$fromNow: ''}
+              deadline: {$fromNow: '1 day'}
+              expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first, despite rounding errors
+              metadata:
+                $merge:
+                  - owner: "${ownerEmail}"
+                    source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
+                  - $if: 'tasks_for in ["github-push", "github-pull-request", "github-release"]'
+                    then:
+                      name: "Decision Task"
+                      description: 'The task that creates all of the other tasks in the task graph'
+              provisionerId: "app-services-${level}"
+              workerType: "decision"
+              tags:
+                kind: decision-task
+              routes:
+                - checks
+              scopes:
+                # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
+                $if: 'tasks_for == "github-push"'
+                then:
+                  $let:
+                    short_head_branch:
+                      $if: 'head_branch[:11] == "refs/heads/"'
+                      then: {$eval: 'head_branch[11:]'}
+                      else: ${head_branch}
+                  in:
+                    - 'assume:repo:${repoUrl[8:]}:branch:${short_head_branch}'
+                else:
+                  $if: 'tasks_for == "github-pull-request"'
+                  then:
+                    - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
+                  else:
+                    $if: 'tasks_for == "github-release"'
+                    then:
+                      - 'assume:repo:${repoUrl[8:]}:release'
+
+              requires: all-completed
+              priority: lowest
+              retries: 5
+
+              payload:
+                env:
+                  # run-task uses these to check out the source; the inputs
+                  # to `mach taskgraph decision` are all on the command line.
+                  $merge:
+                    - APPSERVICES_BASE_REPOSITORY: '${baseRepoUrl}'
+                      APPSERVICES_HEAD_REPOSITORY: '${repoUrl}'
+                      APPSERVICES_HEAD_REF: '${head_branch}'
+                      APPSERVICES_HEAD_REV: '${head_sha}'
+                      APPSERVICES_REPOSITORY_TYPE: git
+                      TASKGRAPH_BASE_REPOSITORY: https://hg.mozilla.org/ci/taskgraph
+                      TASKGRAPH_HEAD_REPOSITORY: https://hg.mozilla.org/ci/${taskgraph.branch}
+                      TASKGRAPH_HEAD_REV: ${taskgraph.revision}
+                      TASKGRAPH_REPOSITORY_TYPE: hg
+                      REPOSITORIES: {$json: {appservices: "Application Services", taskgraph: "Taskgraph"}}
+                      HG_STORE_PATH: /builds/worker/checkouts/hg-store
+                      ANDROID_SDK_ROOT: /builds/worker/android-sdk
+                      MOZ_FETCHES_DIR: /builds/worker/checkouts/src
+                    - $if: 'tasks_for in ["github-pull-request"]'
+                      then:
+                        APPSERVICES_PULL_REQUEST_TITLE: '${event.pull_request.title}'
+                        APPSERVICES_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
+                features:
+                  taskclusterProxy: true
+                  chainOfTrust: true
+                # Note: This task is built server side without the context or tooling that
+                # exist in tree so we must hard code the hash
+                image:
+                  mozillareleases/taskgraph:decision-mobile-6020473b1a928d8df50e234a7ca2e81ade2220a4fb5fbe16b02477dd64a49728@sha256:98d226736b7d03907114bf37938002b90e8a37cbe3a297690e349f1ddddb1d7c
+
+                maxRunTime: 1800
+
+                command:
+                  - /usr/local/bin/run-task
+                  - '--appservices-checkout=/builds/worker/checkouts/src'
+                  - '--taskgraph-checkout=/builds/worker/checkouts/taskgraph'
+                  - '--task-cwd=/builds/worker/checkouts/src'
+                  - '--'
+                  - bash
+                  - -cx
+                  - >
+                    PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
+                    PIP_IGNORE_INSTALLED=0 pip install --user arrow taskcluster pyyaml &&
+                    ln -s /builds/worker/artifacts artifacts &&
+                    ~/.local/bin/taskgraph decision
+                    --pushlog-id='0'
+                    --pushdate='0'
+                    --project='${project}'
+                    --message=""
+                    --owner='${ownerEmail}'
+                    --level='${level}'
+                    --base-repository="$APPSERVICES_BASE_REPOSITORY"
+                    --head-repository="$APPSERVICES_HEAD_REPOSITORY"
+                    --head-ref="$APPSERVICES_HEAD_REF"
+                    --head-rev="$APPSERVICES_HEAD_REV"
+                    --repository-type="$APPSERVICES_REPOSITORY_TYPE"
+                    --tasks-for='${tasks_for}'
+                artifacts:
+                  'public':
+                    type: 'directory'
+                    path: '/builds/worker/artifacts'
+                    expires: {$fromNow: '1 year'}
+              extra:
+                $merge:
+                    - treeherder:
+                          $merge:
+                              - machine:
+                                    platform: gecko-decision
+                              - $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                                then:
+                                    symbol: D
+                    - tasks_for: '${tasks_for}'
           "tasks_for == 'github-push' && head_branch == 'refs/heads/master'":
             $mergeDeep:
               - {$eval: 'default_task_definition'}

--- a/automation/upload_android_symbols.sh
+++ b/automation/upload_android_symbols.sh
@@ -48,5 +48,5 @@ for i in "${!TARGET_ARCHS[@]}"; do
 done
 
 # 2. Upload them.
-pip3 install -r automation/symbols-generation/requirements.txt
+pip3 install --user -r automation/symbols-generation/requirements.txt
 python3 automation/symbols-generation/upload_symbols.py "${OUTPUT_FOLDER}"

--- a/taskcluster/app_services_taskgraph/__init__.py
+++ b/taskcluster/app_services_taskgraph/__init__.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from importlib import import_module
+import os
+
+from six import text_type
+from voluptuous import Required, Any
+
+
+def register(graph_config):
+    """
+    Import all modules that are siblings of this one, triggering decorators in
+    the process.
+    """
+    _import_modules(["worker_types", "target_tasks"])
+
+
+def _import_modules(modules):
+    for module in modules:
+        import_module(".{}".format(module), package=__name__)
+
+
+def get_decision_parameters(graph_config, parameters):
+    if parameters["tasks_for"] == "github-pull-request":
+        pr_title = os.environ.get("APPSERVICES_PULL_REQUEST_TITLE", "")
+        if "[ci full]" in pr_title:
+            parameters["target_tasks_method"] = "pr-full"
+        elif "[ci skip]" in pr_title:
+            parameters["target_tasks_method"] = "pr-skip"
+        else:
+            parameters["target_tasks_method"] = "pr-normal"

--- a/taskcluster/app_services_taskgraph/build_config.py
+++ b/taskcluster/app_services_taskgraph/build_config.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import os
+import yaml
+
+from taskgraph.util.memoize import memoize
+
+
+def get_components():
+    build_config = _read_build_config()
+    return [{
+        'version': build_config['libraryVersion'],
+        'name': name,
+        'path': project['path'],
+        'artifactId': project['artifactId'],
+        'publications': [{
+            'name': publication['name'],
+            'type': publication['type'],
+        } for publication in project['publications']]
+    } for (name, project) in build_config['projects'].items()]
+
+
+@memoize
+def _read_build_config():
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    project_dir = os.path.realpath(os.path.join(current_dir, '..', '..'))
+
+    with open(os.path.join(project_dir, '.buildconfig-android.yml'), 'rb') as f:
+        return yaml.safe_load(f)

--- a/taskcluster/app_services_taskgraph/loader/__init__.py
+++ b/taskcluster/app_services_taskgraph/loader/__init__.py
@@ -1,0 +1,56 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# XXX: This module defines common functions for loaders. A loader is in
+# charge of taking every task in the kind, applying job-defaults and
+# finding what are the right upstream dependencies
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import copy
+
+
+# Define a collection of group_by functions
+GROUP_BY_MAP = {}
+
+
+def group_by(name):
+    def wrapper(func):
+        GROUP_BY_MAP[name] = func
+        return func
+    return wrapper
+
+
+def group_tasks(config, tasks):
+    group_by_fn = GROUP_BY_MAP[config['group-by']]
+
+    groups = group_by_fn(config, tasks)
+
+    for combinations in groups.itervalues():
+        dependencies = [copy.deepcopy(t) for t in combinations]
+        yield dependencies
+
+
+@group_by('component')
+def component_grouping(config, tasks):
+    groups = {}
+    for task in tasks:
+        if task.kind not in config.get("kind-dependencies", []):
+            continue
+
+        buildconfig = task.attributes["buildconfig"]
+        component = buildconfig["name"]
+        if component == "all":
+            continue
+
+        groups.setdefault(component, []).append(task)
+
+    tasks_for_all_components = [
+        task for task in tasks
+        if task.attributes.get("buildconfig", {}).get("name", "") == "all"
+    ]
+    for _, tasks in groups.iteritems():
+        tasks.extend(copy.deepcopy(tasks_for_all_components))
+
+    return groups

--- a/taskcluster/app_services_taskgraph/loader/build_config.py
+++ b/taskcluster/app_services_taskgraph/loader/build_config.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# XXX: This loader generates a new build task for every component defined in
+# `.buildconfig-android.yml`
+
+from __future__ import print_function, unicode_literals
+
+import os
+
+from copy import deepcopy
+from taskgraph.loader.transform import loader as base_loader
+
+from ..build_config import get_components
+
+
+def loader(kind, path, config, params, loaded_tasks):
+    config['jobs'] = jobs = {
+        component['name']: {
+            'attributes': {
+                'buildconfig': component
+            }
+        }
+        for component in get_components()
+    }
+
+    return base_loader(kind, path, config, params, loaded_tasks)

--- a/taskcluster/app_services_taskgraph/loader/multi_dep.py
+++ b/taskcluster/app_services_taskgraph/loader/multi_dep.py
@@ -1,0 +1,88 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import copy
+
+from voluptuous import Required
+
+from taskgraph.task import Task
+from taskgraph.util.attributes import sorted_unique_list
+from taskgraph.util.schema import Schema
+
+from . import group_tasks
+
+
+schema = Schema({
+    Required('primary-dependency', 'primary dependency task'): Task,
+    Required(
+        'dependent-tasks',
+        'dictionary of dependent tasks, keyed by kind',
+    ): {basestring: Task},
+})
+
+
+def loader(kind, path, config, params, loaded_tasks):
+    """
+    Load tasks based on the jobs dependant kinds, designed for use as
+    multiple-dependent needs.
+    Required ``group-by-fn`` is used to define how we coalesce the
+    multiple deps together to pass to transforms, e.g. all kinds specified get
+    collapsed by platform with `platform`
+    Optional ``primary-dependency`` (ordered list or string) is used to determine
+    which upstream kind to inherit attrs from. See ``get_primary_dep``.
+    Optional ``job-template`` kind configuration value, if specified, will be used to
+    pass configuration down to the specified transforms used.
+    """
+    job_template = config.get('job-template')
+
+    for dep_tasks in group_tasks(config, loaded_tasks):
+        kinds = [dep.kind for dep in dep_tasks]
+        assert_unique_members(
+            kinds, error_msg="multi_dep.py should have filtered down to one task per kind"
+        )
+
+        dep_tasks_per_kind = {dep.kind: dep for dep in dep_tasks}
+
+        job = {'dependent-tasks': dep_tasks_per_kind,
+               'primary-dependency': get_primary_dep(config, dep_tasks_per_kind)}
+        if job_template:
+            job.update(copy.deepcopy(job_template))
+
+        yield job
+
+
+def assert_unique_members(kinds, error_msg=None):
+    if len(kinds) != len(set(kinds)):
+        raise Exception(error_msg)
+
+
+def get_primary_dep(config, dep_tasks):
+    """Find the dependent task to inherit attributes from.
+    If ``primary-dependency`` is defined in ``kind.yml`` and is a string,
+    then find the first dep with that task kind and return it. If it is
+    defined and is a list, the first kind in that list with a matching dep
+    is the primary dependency. If it's undefined, return the first dep.
+    """
+    primary_dependencies = config.get('primary-dependency')
+    if isinstance(primary_dependencies, basestring):
+        primary_dependencies = [primary_dependencies]
+    if not primary_dependencies:
+        assert len(dep_tasks) == 1, "Must define a primary-dependency!"
+        return dep_tasks.values()[0]
+    primary_dep = None
+    for primary_kind in primary_dependencies:
+        for dep_kind in dep_tasks:
+            if dep_kind == primary_kind:
+                assert primary_dep is None, \
+                    "Too many primary dependent tasks in dep_tasks: {}!".format(
+                        [t.label for t in dep_tasks]
+                    )
+                primary_dep = dep_tasks[dep_kind]
+    if primary_dep is None:
+        raise Exception("Can't find dependency of {}: {}".format(
+            config['primary-dependency'], config
+        ))
+    return primary_dep

--- a/taskcluster/app_services_taskgraph/target_tasks.py
+++ b/taskcluster/app_services_taskgraph/target_tasks.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.target_tasks import _target_task, filter_for_tasks_for
+
+
+@_target_task('pr-skip')
+def target_tasks_pr_skip(full_task_graph, parameters, graph_config):
+    return []
+
+
+@_target_task('pr-full')
+def target_tasks_default(full_task_graph, parameters, graph_config):
+    """Target the tasks which have indicated they should be run on this project
+    via the `run_on_projects` attributes."""
+    def filter(task):
+        return filter_for_tasks_for(task, parameters) \
+            and task.attributes.get("run-on-pr-type", "all") in ("full-ci", "all")
+
+    return [l for l, task in full_task_graph.tasks.iteritems() if filter(task)]
+
+
+@_target_task('pr-normal')
+def target_tasks_default(full_task_graph, parameters, graph_config):
+    """Target the tasks which have indicated they should be run on this project
+    via the `run_on_projects` attributes."""
+    def filter(task):
+        return filter_for_tasks_for(task, parameters) \
+                and task.attributes.get("run-on-pr-type", "all") in ("normal-ci", "all")
+
+    return [l for l, task in full_task_graph.tasks.iteritems() if filter(task)]

--- a/taskcluster/app_services_taskgraph/transforms/android_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/android_build.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+
+from ..build_config import get_components
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def add_megazord_checks(config, tasks):
+    components = get_components()
+    megazord_names = [component["name"] for component in components if component["name"].endswith("-megazord")]
+    megazord_commands = ["./automation/check_megazord.sh {}".format(name[0:-9].replace("-", "_")) for name in megazord_names]
+    for task in tasks:
+        if task.pop("add-megazord-checks", False):
+            task["worker"]["script"] += "\n" + "\n".join(megazord_commands)
+        yield task
+

--- a/taskcluster/app_services_taskgraph/transforms/module_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/module_build.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def build_task(config, tasks):
+    for task in tasks:
+        module_info = task["attributes"]["buildconfig"]
+        name = module_info["name"]
+        version = module_info["version"]
+
+        task["worker"]["script"] = task["worker"]["script"].format(module_name=name)
+        task["description"] = task["description"].format(module_name=name)
+        task["worker"]["artifacts"] = artifacts = []
+
+        for publication in module_info["publications"]:
+            primary_extensions = (".pom", ".aar", "-sources.jar") if publication["type"] == "aar" else (".pom", ".jar")
+            extensions = [package_ext + digest_ext for package_ext in primary_extensions for digest_ext in ("", ".sha1", ".md5")]
+            for extension in extensions:
+                artifact_filename = "{}-{}{}".format(publication["name"], version, extension)
+                artifacts.append({
+                    "name": "public/build/{}".format(artifact_filename),
+                    "path": "/builds/worker/checkouts/src/build/maven/org/mozilla/appservices/{}/{}/{}".format(name, version, artifact_filename),
+                    "type": "file",
+                })
+
+        yield task

--- a/taskcluster/app_services_taskgraph/transforms/multi_dep.py
+++ b/taskcluster/app_services_taskgraph/transforms/multi_dep.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def build_name_and_attributes(config, tasks):
+    for task in tasks:
+        task["dependencies"] = {
+            dep.kind: dep.label
+            for dep in _get_all_deps(task)
+        }
+        primary_dep = task["primary-dependency"]
+        copy_of_attributes = primary_dep.attributes.copy()
+        task.setdefault("attributes", copy_of_attributes)
+        # run_on_tasks_for is set as an attribute later in the pipeline
+        task.setdefault("run-on-tasks-for", copy_of_attributes['run_on_tasks_for'])
+        task["name"] = _get_dependent_job_name_without_its_kind(primary_dep)
+
+        yield task
+
+
+def _get_dependent_job_name_without_its_kind(dependent_job):
+    return dependent_job.label[len(dependent_job.kind) + 1:]
+
+
+def _get_all_deps(task):
+    if task.get("dependent-tasks"):
+        return task["dependent-tasks"].values()
+
+    return [task["primary-dependency"]]

--- a/taskcluster/app_services_taskgraph/transforms/out_of_docker_setup.py
+++ b/taskcluster/app_services_taskgraph/transforms/out_of_docker_setup.py
@@ -1,0 +1,82 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# These transforms perform additional setup that could not have been done in the Dockerfile
+# due to this Taskcluster bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1587611
+
+from __future__ import absolute_import, print_function, unicode_literals
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+CROSS_COMPILE_SETUP = '''
+# Rust requires dsymutil on the PATH: https://github.com/rust-lang/rust/issues/52728.
+export RUST_BACKTRACE='1'
+export RUSTFLAGS='-Dwarnings'
+export CARGO_INCREMENTAL='0'
+export CI='1'
+export CCACHE='sccache'
+export RUSTC_WRAPPER='sccache'
+export SCCACHE_IDLE_TIMEOUT='1200'
+export SCCACHE_CACHE_SIZE='40G'
+export SCCACHE_ERROR_LOG='/builds/worker/sccache.log'
+export RUST_LOG='sccache=info'
+
+# Rust
+set -eux; \
+    RUSTUP_PLATFORM='x86_64-unknown-linux-gnu'; \
+    RUSTUP_VERSION='1.18.3'; \
+    RUSTUP_SHA256='a46fe67199b7bcbbde2dcbc23ae08db6f29883e260e23899a88b9073effc9076'; \
+    curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"; \
+    echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain none; \
+    rm rustup-init
+export PATH=$HOME/.cargo/bin:$PATH
+
+rustup toolchain install stable
+rustup default stable
+rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android
+
+# Cross compile setup
+export PATH=$PATH:/tmp/clang/bin
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_NSS_STATIC=1
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_NSS_DIR=/builds/worker/checkouts/src/libs/desktop/darwin/nss
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_SQLCIPHER_LIB_DIR=/builds/worker/checkouts/src/libs/desktop/darwin/sqlcipher/lib
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CC=/tmp/clang/bin/clang
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_TOOLCHAIN_PREFIX=/tmp/cctools/bin
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_AR=/tmp/cctools/bin/x86_64-darwin11-ar
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RANLIB=/tmp/cctools/bin/x86_64-darwin11-ranlib
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_LD_LIBRARY_PATH=/tmp/clang/lib
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C linker=/tmp/clang/bin/clang -C link-arg=-B -C link-arg=/tmp/cctools/bin -C link-arg=-target -C link-arg=x86_64-darwin11 -C link-arg=-isysroot -C link-arg=/tmp/MacOSX10.11.sdk -C link-arg=-Wl,-syslibroot,/tmp/MacOSX10.11.sdk -C link-arg=-Wl,-dead_strip"
+    # For ring's use of `cc`.
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /tmp/cctools/bin -target x86_64-darwin11 -isysroot /tmp/MacOSX10.11.sdk -Wl,-syslibroot,/tmp/MacOSX10.11.sdk -Wl,-dead_strip"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-C linker=x86_64-w64-mingw32-gcc"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_PC_WINDOWS_GNU_AR=x86_64-w64-mingw32-ar
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_PC_WINDOWS_GNU_CC=x86_64-w64-mingw32-gcc
+
+# Install clang, a port of cctools, and the macOS SDK into /tmp. This
+# is all cribbed from mozilla-central; start at
+# https://searchfox.org/mozilla-central/rev/39cb1e96cf97713c444c5a0404d4f84627aee85d/build/macosx/cross-mozconfig.common.
+
+pushd /tmp
+
+tooltool.py \
+  --url=http://taskcluster/tooltool.mozilla-releng.net/ \
+  --manifest="/builds/worker/checkouts/src/libs/macos-cc-tools.manifest" \
+  fetch
+
+rustup target add x86_64-apple-darwin
+rustup target add x86_64-pc-windows-gnu
+
+popd
+'''
+
+
+@transforms.add
+def _cross_compile(config, tasks):
+    for task in tasks:
+        script = task["worker"]["script"]
+        task["worker"]["script"] = CROSS_COMPILE_SETUP + "\n" + script
+        yield task

--- a/taskcluster/app_services_taskgraph/transforms/script_to_run_task.py
+++ b/taskcluster/app_services_taskgraph/transforms/script_to_run_task.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# These transforms perform additional setup that could not have been done in the Dockerfile
+# due to this Taskcluster bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1587611
+
+from __future__ import absolute_import, print_function, unicode_literals
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+def script_to_bash_command(script):
+    return [
+        "/bin/bash",
+        "--login",
+        "-c",
+        "cat <<'SCRIPT' > ../script.sh && bash -e ../script.sh\n{}\nSCRIPT".format(script)
+    ]
+
+
+@transforms.add
+def build_task(config, tasks):
+    for task in tasks:
+        script = task["worker"].pop("script")
+        bash_command = script_to_bash_command(script)
+        task["run"]["command"] = bash_command
+
+        yield task

--- a/taskcluster/app_services_taskgraph/transforms/toolchain.py
+++ b/taskcluster/app_services_taskgraph/transforms/toolchain.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def resolve_keys(config, tasks):
+    for task in tasks:
+        resolve_keyed_by(task, "routes", item_name=task["name"], **{
+            "tasks-for": config.params["tasks_for"]
+        })
+        yield task

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+  - app_services_taskgraph.transforms.android_build:transforms
+  - app_services_taskgraph.transforms.out_of_docker_setup:transforms
+  - app_services_taskgraph.transforms.script_to_run_task:transforms
+  - taskgraph.transforms.job:transforms
+  - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+  - toolchain
+
+jobs:
+  pr:
+    attributes:
+      run-on-pr-type: normal-ci
+    add-megazord-checks: true
+    needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
+    run-on-tasks-for: [github-pull-request]
+    description: Build and test (Android - linux-x86-64)
+    scopes:
+      - project:releng:services/tooltool/api/download/internal
+    worker-type: b-linux
+    worker:
+      docker-image: {in-tree: linux}
+      max-run-time: 1800
+      script: |
+        rsync -a /builds/worker/fetches/libs/ /builds/worker/checkouts/src/libs/
+        echo "rust.targets=linux-x86-64,x86_64\n" > local.properties
+        ./gradlew --no-daemon clean
+        ./gradlew --no-daemon assembleDebug
+        ./gradlew --no-daemon testDebug
+    run:
+      using: run-task
+      cwd: '{checkout}'
+    fetches:
+      toolchain:
+        - android-libs
+        - desktop-linux-libs
+        - desktop-macos-libs
+        - desktop-win32-x86-64-libs

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+trust-domain: app-services
+task-priority: highest
+
+taskgraph:
+  register: app_services_taskgraph:register
+  repositories:
+    appservices:
+      name: "Application Services"
+  cached-task-prefix: project.application-services
+  decision-parameters: 'app_services_taskgraph:get_decision_parameters'
+
+workers:
+  aliases:
+    b-linux:
+      provisioner: 'app-services-{level}'
+      implementation: docker-worker
+      os: linux
+      worker-type: 'b-linux'
+    images:
+      provisioner: 'app-services-{level}'
+      implementation: docker-worker
+      os: linux
+      worker-type: 'images'
+
+scriptworker:
+  scope-prefix: project:mozilla:application-services:releng

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.docker_image:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+jobs:
+    linux: {}

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+  - taskgraph.transforms.job:transforms
+  - taskgraph.transforms.task:transforms
+
+job-defaults:
+  worker-type: b-linux
+  worker:
+    docker-image: {in-tree: linux}
+    max-run-time: 1800
+  run:
+    using: run-task
+    cwd: '{checkout}'
+
+jobs:
+  detekt:
+    description: 'detekt'
+    run:
+      command: ./gradlew --no-daemon clean detekt
+  ktlint:
+    description: 'ktlint'
+    run:
+      command: ./gradlew --no-daemon clean ktlint

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: app_services_taskgraph.loader.build_config:loader
+
+transforms:
+  - app_services_taskgraph.transforms.module_build:transforms
+  - app_services_taskgraph.transforms.out_of_docker_setup:transforms
+  - app_services_taskgraph.transforms.script_to_run_task:transforms
+  - taskgraph.transforms.job:transforms
+  - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+  - toolchain
+
+job-defaults:
+  attributes:
+    run-on-pr-type: full-ci
+  run-on-tasks-for: [github-pull-request]
+  description: '{module_name} - Build and test'
+  scopes:
+    - project:releng:services/tooltool/api/download/internal
+  worker-type: b-linux
+  worker:
+    docker-image: {in-tree: linux}
+    max-run-time: 1800
+    script: |
+      rsync -a /builds/worker/fetches/libs/ /builds/worker/checkouts/src/libs/
+      echo "rust.targets=arm,arm64,x86_64,x86,darwin,linux-x86-64,win32-x86-64-gnu\n" > local.properties
+      ./gradlew --no-daemon ":{module_name}:testDebug"
+      ./gradlew --no-daemon ":{module_name}:assembleRelease"
+      ./gradlew --no-daemon ":{module_name}:publish"
+      ./gradlew --no-daemon ":{module_name}:checkMavenArtifacts"
+  run:
+    using: run-task
+    cwd: '{checkout}'
+  fetches:
+    toolchain:
+      - android-libs
+      - desktop-linux-libs
+      - desktop-macos-libs
+      - desktop-win32-x86-64-libs

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -1,0 +1,57 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+  - app_services_taskgraph.transforms.toolchain:transforms
+  - taskgraph.transforms.job:transforms
+  - taskgraph.transforms.cached_tasks:transforms
+  - taskgraph.transforms.task:transforms
+
+job-defaults:
+  routes:
+    by-tasks-for:
+      github-push:
+        - notify.email.a-s-ci-failures@mozilla.com.on-failed
+      default: []
+  run:
+    using: toolchain-script
+    resources:
+      - 'libs'
+  worker-type: b-linux
+  worker:
+    env: {}
+    docker-image: {in-tree: linux}
+    max-run-time: 7200
+
+jobs:
+  android:
+    description: 'Android libs (all architectures): build'
+    run:
+      script: android.sh
+      toolchain-alias: android-libs
+      toolchain-artifact: public/build/android.tar.gz
+  desktop-linux:
+    description: 'Desktop libs (Linux): build'
+    run:
+      script: desktop-linux.sh
+      toolchain-alias: desktop-linux-libs
+      toolchain-artifact: public/build/linux.tar.gz
+  desktop-macos:
+    description: 'Desktop libs (macOS): build'
+    scopes:
+      - project:releng:services/tooltool/api/download/internal
+    worker:
+      docker-image: {in-tree: linux}
+    run:
+      script: desktop-macos.sh
+      toolchain-alias: desktop-macos-libs
+      toolchain-artifact: public/build/macos.tar.gz
+  desktop-win32-x86-64:
+    description: 'Desktop libs (win32-x86-64): build'
+    run:
+      script: desktop-win32-x86-64.sh
+      toolchain-alias: desktop-win32-x86-64-libs
+      toolchain-artifact: public/build/win.tar.gz

--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -1,0 +1,168 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# We use this specific version because our decision task also runs on this one.
+# We also use that same version in decisionlib.py
+FROM ubuntu:bionic-20180821
+
+MAINTAINER Edouard Oger "eoger@mozilla.com"
+
+RUN echo "trigger rebuild"
+
+# Add worker user
+
+RUN mkdir /builds && \
+    useradd -d /builds/worker -s /bin/bash -m worker && \
+    chown worker:worker /builds/worker && \
+    mkdir /builds/worker/artifacts && \
+    chown worker:worker /builds/worker/artifacts
+
+WORKDIR /builds/worker/
+
+# Configuration
+
+ENV ANDROID_BUILD_TOOLS "28.0.3"
+ENV ANDROID_SDK_VERSION "3859397"
+ENV ANDROID_PLATFORM_VERSION "28"
+
+# Set up the language variables to avoid problems (we run locale-gen later).
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+# Do not use fancy output on taskcluster
+ENV TERM dumb
+
+ENV GRADLE_OPTS -Xmx4096m -Dorg.gradle.daemon=false
+
+# Used to detect in scripts whether we are running on taskcluster
+ENV CI_TASKCLUSTER true
+
+ENV \
+    # Some APT packages like 'tzdata' wait for user input on install by default.
+    # https://stackoverflow.com/questions/44331836/apt-get-install-tzdata-noninteractive
+    DEBIAN_FRONTEND=noninteractive
+
+# System.
+
+RUN apt-get update -qq \
+    && apt-get install -qy --no-install-recommends \
+        # To compile Android stuff.
+        openjdk-8-jdk \
+        git \
+        curl \
+        # Required by symbolstore.py.
+        file \
+        # Will set up the timezone to UTC (?).
+        tzdata \
+        # To install UTF-8 locales.
+        locales \
+        # For `cc` crates; see https://github.com/jwilm/alacritty/issues/1440.
+        # <TODO: Is this still true?>.
+        g++ \
+        # <TODO: Explain why we have this dependency>.
+        clang \
+        python3 \
+        python3-pip \
+        # taskcluster > mohawk > setuptools.
+        python3-setuptools \
+        # Required to extract the Android SDK/NDK.
+        unzip \
+        # Required by tooltool to extract tar.xz archives.
+        xz-utils \
+        # Required to build libs/.
+        make \
+        # Required to build sqlcipher.
+        tclsh \
+        # Required in libs/ by some scripts patching the source they download.
+        patch \
+        # For windows cross-compilation.
+        mingw-w64 \
+        ## NSS build dependencies
+        gyp \
+        ninja-build \
+        zlib1g-dev \
+        # <TODO: Delete p7zip once NSS windows is actually compiled instead of downloaded>.
+        p7zip-full \
+        ## End of NSS build dependencies
+        rsync \
+    && apt-get clean
+
+RUN pip3 install --upgrade pip
+RUN pip3 install \
+    'taskcluster>=4,<5' \
+    pyyaml
+
+# Compile the UTF-8 english locale files (required by Python).
+RUN locale-gen en_US.UTF-8
+
+# Android SDK
+
+RUN mkdir -p /builds/worker/android-sdk
+WORKDIR /builds/worker
+
+ENV ANDROID_HOME /builds/worker/android-sdk
+ENV ANDROID_SDK_HOME /builds/worker/android-sdk
+ENV PATH ${PATH}:${ANDROID_SDK_HOME}/tools:${ANDROID_SDK_HOME}/tools/bin:${ANDROID_SDK_HOME}/platform-tools:/opt/tools:${ANDROID_SDK_HOME}/build-tools/${ANDROID_BUILD_TOOLS}
+
+RUN curl -sfSL --retry 5 --retry-delay 10 https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_VERSION}.zip > sdk.zip \
+    && unzip -q sdk.zip -d ${ANDROID_SDK_HOME} \
+    && rm sdk.zip \
+    && mkdir -p /builds/worker/android-sdk/.android/ \
+    && touch /builds/worker/android-sdk/.android/repositories.cfg \
+    && yes | sdkmanager --licenses \
+    && sdkmanager --verbose "platform-tools" \
+        "platforms;android-${ANDROID_PLATFORM_VERSION}" \
+        "build-tools;${ANDROID_BUILD_TOOLS}" \
+        "extras;android;m2repository" \
+        "extras;google;m2repository"
+
+RUN chown -R worker:worker /builds/worker/android-sdk
+
+# Android NDK
+
+# r15c agrees with mozilla-central and, critically, supports the --deprecated-headers flag needed to
+# build OpenSSL
+ENV ANDROID_NDK_VERSION "r20"
+
+# $ANDROID_NDK_ROOT is the preferred name, but the android gradle plugin uses $ANDROID_NDK_HOME.
+ENV ANDROID_NDK_ROOT /builds/worker/android-ndk
+ENV ANDROID_NDK_HOME /builds/worker/android-ndk
+
+RUN curl -sfSL --retry 5 --retry-delay 10 https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip > ndk.zip \
+    && unzip -q ndk.zip -d /builds/worker \
+    && rm ndk.zip \
+    && mv /builds/worker/android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_ROOT}
+
+ENV ANDROID_NDK_TOOLCHAIN_DIR /builds/worker/.android-ndk-r15c-toolchain
+ENV ANDROID_NDK_API_VERSION 21
+
+# sccache
+RUN \
+    curl -sfSL --retry 5 --retry-delay 10 \
+        https://github.com/mozilla/sccache/releases/download/0.2.11/sccache-0.2.11-x86_64-unknown-linux-musl.tar.gz \
+        | tar -xz --strip-components=1 -C /usr/local/bin/ \
+            sccache-0.2.11-x86_64-unknown-linux-musl/sccache
+
+# tooltool
+RUN \
+    curl -sfSL --retry 10 --retry-delay 10 \
+         -o /usr/local/bin/tooltool.py \
+         https://raw.githubusercontent.com/mozilla/build-tooltool/36511dae0ead6848017e2d569b1f6f1b36984d40/tooltool.py && \
+         chmod +x /usr/local/bin/tooltool.py
+
+
+# %include-run-task
+
+ENV SHELL=/bin/bash \
+    HOME=/builds/worker \
+    PATH=/builds/worker/.local/bin:$PATH
+
+
+VOLUME /builds/worker/checkouts
+VOLUME /builds/worker/.cache
+
+
+# run-task expects to run as root
+USER root

--- a/taskcluster/scripts/toolchain/android.sh
+++ b/taskcluster/scripts/toolchain/android.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd src
+. ./taskcluster/scripts/toolchain/rustup-setup.sh
+./libs/verify-android-environment.sh
+pushd libs
+./build-all.sh android
+popd
+mkdir -p "$UPLOAD_DIR"
+tar -czf "$UPLOAD_DIR"/android.tar.gz libs/android

--- a/taskcluster/scripts/toolchain/cross-compile-setup.sh
+++ b/taskcluster/scripts/toolchain/cross-compile-setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+export PATH=$PATH:/tmp/clang/bin
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_NSS_STATIC=1
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_NSS_DIR=/builds/worker/checkouts/src/libs/desktop/darwin/nss
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_SQLCIPHER_LIB_DIR=/builds/worker/checkouts/src/libs/desktop/darwin/sqlcipher/lib
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CC=/tmp/clang/bin/clang
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_TOOLCHAIN_PREFIX=/tmp/cctools/bin
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_AR=/tmp/cctools/bin/x86_64-darwin11-ar
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RANLIB=/tmp/cctools/bin/x86_64-darwin11-ranlib
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_LD_LIBRARY_PATH=/tmp/clang/lib
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C linker=/tmp/clang/bin/clang -C link-arg=-B -C link-arg=/tmp/cctools/bin -C link-arg=-target -C link-arg=x86_64-darwin11 -C link-arg=-isysroot -C link-arg=/tmp/MacOSX10.11.sdk -C link-arg=-Wl,-syslibroot,/tmp/MacOSX10.11.sdk -C link-arg=-Wl,-dead_strip"
+    # For ring's use of `cc`.
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /tmp/cctools/bin -target x86_64-darwin11 -isysroot /tmp/MacOSX10.11.sdk -Wl,-syslibroot,/tmp/MacOSX10.11.sdk -Wl,-dead_strip"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS="-C linker=x86_64-w64-mingw32-gcc"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_PC_WINDOWS_GNU_AR=x86_64-w64-mingw32-ar
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_PC_WINDOWS_GNU_CC=x86_64-w64-mingw32-gcc
+
+# Install clang, a port of cctools, and the macOS SDK into /tmp. This
+# is all cribbed from mozilla-central; start at
+# https://searchfox.org/mozilla-central/rev/39cb1e96cf97713c444c5a0404d4f84627aee85d/build/macosx/cross-mozconfig.common.
+
+pushd /tmp || exit
+
+tooltool.py \
+  --url=http://taskcluster/tooltool.mozilla-releng.net/ \
+  --manifest="/builds/worker/checkouts/src/libs/macos-cc-tools.manifest" \
+  fetch
+
+rustup target add x86_64-apple-darwin
+rustup target add x86_64-pc-windows-gnu
+
+popd || exit

--- a/taskcluster/scripts/toolchain/desktop-linux.sh
+++ b/taskcluster/scripts/toolchain/desktop-linux.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd src
+. ./taskcluster/scripts/toolchain/rustup-setup.sh
+./libs/verify-android-environment.sh
+pushd libs
+./build-all.sh desktop
+popd
+mkdir -p "$UPLOAD_DIR"
+tar -czf "$UPLOAD_DIR"/linux.tar.gz libs/desktop

--- a/taskcluster/scripts/toolchain/desktop-macos.sh
+++ b/taskcluster/scripts/toolchain/desktop-macos.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+cd src
+. ./taskcluster/scripts/toolchain/rustup-setup.sh
+. ./taskcluster/scripts/toolchain/cross-compile-setup.sh
+pushd libs
+./build-all.sh darwin
+popd
+mkdir -p "$UPLOAD_DIR"
+tar -czf "$UPLOAD_DIR"/macos.tar.gz libs/desktop

--- a/taskcluster/scripts/toolchain/desktop-win32-x86-64.sh
+++ b/taskcluster/scripts/toolchain/desktop-win32-x86-64.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+cd src
+. ./taskcluster/scripts/toolchain/rustup-setup.sh
+pushd libs
+./build-all.sh win32-x86-64
+popd
+mkdir -p "$UPLOAD_DIR"
+tar -czf "$UPLOAD_DIR"/win.tar.gz libs/desktop

--- a/taskcluster/scripts/toolchain/rustup-setup.sh
+++ b/taskcluster/scripts/toolchain/rustup-setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+export RUST_BACKTRACE='1'
+export RUSTFLAGS='-Dwarnings'
+export CARGO_INCREMENTAL='0'
+export CI='1'
+export CCACHE='sccache'
+export RUSTC_WRAPPER='sccache'
+export SCCACHE_IDLE_TIMEOUT='1200'
+export SCCACHE_CACHE_SIZE='40G'
+export SCCACHE_ERROR_LOG='/builds/worker/sccache.log'
+export RUST_LOG='sccache=info'
+
+# Rust
+set -eux; \
+    RUSTUP_PLATFORM='x86_64-unknown-linux-gnu'; \
+    RUSTUP_VERSION='1.18.3'; \
+    RUSTUP_SHA256='a46fe67199b7bcbbde2dcbc23ae08db6f29883e260e23899a88b9073effc9076'; \
+    curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"; \
+    echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --default-toolchain none; \
+    rm rustup-init
+export PATH=$HOME/.cargo/bin:$PATH
+
+
+rustup toolchain install stable
+rustup default stable
+rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android


### PR DESCRIPTION
This is an attempt to split the awesome work that @mitchhentges did in https://github.com/mozilla/application-services/pull/1945/ and land it in gradual phases:
* first landing PRs and iterating
* then landing the master pushes and iterating
* take care of github releases
* cleanup of old existing logic of `decisionlib`

This PRs tracks the first phase, taking care of PRs. 