### PR TITLE
Add firefox-ios smoke testing infrastructure

### DIFF
--- a/automation/shared.py
+++ b/automation/shared.py
@@ -1,6 +1,7 @@
 # Common code used by the automation python scripts.
 
 import subprocess
+from pathlib import Path
 
 def step_msg(msg):
     print(f"> \033[34m{msg}\033[0m")
@@ -19,3 +20,10 @@ def run_cmd_checked(*args, **kwargs):
 def ensure_working_tree_clean():
     if run_cmd_checked(["git", "status", "--porcelain"], capture_output=True).stdout:
         fatal_err("The working tree has un-commited or staged files.")
+
+# Find the absolute path to the Application Services repository root.
+def find_app_services_root():
+    cur_dir = Path(__file__).parent
+    while not Path(cur_dir, "LICENSE").exists():
+        cur_dir = cur_dir.parent
+    return cur_dir.absolute()

--- a/automation/smoke-test-firefox-ios.py
+++ b/automation/smoke-test-firefox-ios.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# Purpose: Run Firefox-iOS tests against this application-services working tree.
+# Usage: ./automation/smoke-test-firefox-ios.py
+
+import argparse
+import subprocess
+import tempfile
+from pathlib import Path
+from shared import step_msg, fatal_err, run_cmd_checked, find_app_services_root
+
+parser = argparse.ArgumentParser(description="Run Firefox-iOS tests against this application-services working tree.")
+group = parser.add_mutually_exclusive_group()
+group.add_argument("--use-local-repo",
+                    metavar="LOCAL_REPO_PATH",
+                    help="Use a local copy of firefox-ios instead of cloning it.")
+group.add_argument("--remote-repo-url",
+                    metavar="REMOTE_REPO_PATH",
+                    help="Clone a different firefox-ios repository.")
+parser.add_argument("--branch",
+                    default="master",
+                    help="Branch of firefox-ios to use.")
+parser.add_argument("--action",
+                    choices=["open-project", "run-tests", "do-nothing"],
+                    help="Run the following action once firefox-ios is set up.")
+
+DEFAULT_REMOTE_REPO_URL="https://github.com/mozilla-mobile/firefox-ios.git"
+
+args = parser.parse_args()
+firefox_ios_branch = args.branch
+local_repo_path = args.use_local_repo
+remote_repo_url = args.remote_repo_url
+action = args.action
+
+repo_path = local_repo_path
+
+if local_repo_path is None:
+    repo_path = tempfile.mkdtemp(suffix="-fxios")
+    if remote_repo_url is None:
+        remote_repo_url = DEFAULT_REMOTE_REPO_URL
+    step_msg(f"Cloning {remote_repo_url}")
+    run_cmd_checked(["git", "clone", remote_repo_url, repo_path])
+    run_cmd_checked(["git", "checkout", firefox_ios_branch], cwd=repo_path)
+
+if not Path(repo_path, "Carthage").exists():
+    step_msg("Carthage folder not present. Running the firefox-ios bootstrap script")
+    run_cmd_checked(["./bootstrap.sh"], cwd=repo_path)
+step_msg("Running carthage substitution script")
+run_cmd_checked(["./appservices_local_dev.sh", "enable", find_app_services_root()], cwd=repo_path)
+
+if action == "do-nothing":
+    exit(0)
+elif action == "open-project":
+    run_cmd_checked(["open", "Client.xcodeproj"], cwd=repo_path)
+elif action == "run-tests" or action is None:
+    # TODO: we specify scheme = Fennec, but it might be wrong? Check with iOS peeps.
+    step_msg("Running firefox-ios tests")
+    subprocess.run("""\
+    set -o pipefail && \
+    xcodebuild \
+    -workspace ./Client.xcodeproj/project.xcworkspace \
+    -scheme Fennec \
+    -sdk iphonesimulator \
+    -destination 'platform=iOS Simulator,name=iPhone 8' \
+    test | \
+    tee raw_xcodetest.log | \
+    xcpretty && exit "${PIPESTATUS[0]}"
+    """, cwd=repo_path, shell=True)
+else:
+    print("Sorry I did not understand what you wanted. Good luck!")

--- a/docs/howtos/smoke-testing-app-services.md
+++ b/docs/howtos/smoke-testing-app-services.md
@@ -1,0 +1,10 @@
+# Smoke testing Application Services against end-user apps
+
+This is a great way of finding integration bugs with application services.
+It can be done manually using substitution scripts, but we also have scripts that will do all of these for you.
+
+## Firefox iOS
+
+The `automation/smoke-test-firefox-ios.py` script will clone (or use a local version) of Firefox iOS and
+run tests against the current application-services worktree.  
+Add the `-h` argument to discover all the script exciting options!


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/2720.

f? @rfk 

The following script is meant both for local development and for CI.
Here are some scenarios I imagined:

- For the a-s developer wanting to see how their changes impact firefox-ios, they can run
`./automation/smoke-test-firefox-ios.py --use-local-repo ~/firefox-ios --action open-project` then they are ready to go and play with the app.

- For CI in a PR named "New Bobo [ci fxios=bobo-branch]": CircleCi would run `./automation/smoke-test-firefox-ios.py --action run-tests --branch bobo-branch`, checking out FxiOS on the bobo-branch and running the tests for us.

I'm sure with more usage we can refine this script better and see what workflows do people prefer.