### PR TITLE
Add scripts to easily run a-c and fenix smoketests.

### DIFF
--- a/automation/shared.py
+++ b/automation/shared.py
@@ -1,7 +1,9 @@
 # Common code used by the automation python scripts.
 
+import os
 import subprocess
 from pathlib import Path
+
 
 def step_msg(msg):
     print(f"> \033[34m{msg}\033[0m")
@@ -10,20 +12,53 @@ def fatal_err(msg):
     print(f"\033[31mError: {msg}\033[0m")
     exit(1)
 
-# Run command and let subprocess throw an exception when
-# a command returns a non-zero status.
 def run_cmd_checked(*args, **kwargs):
+    """Run a command, throwing an exception if it exits with non-zero status."""
     kwargs["check"] = True
     return subprocess.run(*args, **kwargs)
 
-# Ensure there is no un-commited or staged files in the working tree.
 def ensure_working_tree_clean():
+    """Error out if there are un-committed or staged files in the working tree."""
     if run_cmd_checked(["git", "status", "--porcelain"], capture_output=True).stdout:
         fatal_err("The working tree has un-commited or staged files.")
 
-# Find the absolute path to the Application Services repository root.
 def find_app_services_root():
+    """Find the absolute path of the Application services repository root."""
     cur_dir = Path(__file__).parent
     while not Path(cur_dir, "LICENSE").exists():
         cur_dir = cur_dir.parent
     return cur_dir.absolute()
+
+def set_gradle_substitution_path(project_dir, name, value):
+    """Set a substitution path property in a gradle `local.properties` file.
+
+    Given the path to a gradle project directory, this helper will set the named
+    property to the given path value in that directory's `local.properties` file.
+    If the named property already exists with the correct value then it will
+    silently succeed; if the named property already exists with a different value
+    then it will noisily fail.
+    """
+    project_dir = Path(project_dir).resolve()
+    properties_file = project_dir / "local.properties"
+    name_eq = name + "="
+    abs_value = Path(value).resolve()
+    # Check if the named property already exists.
+    if properties_file.exists():
+        with properties_file.open() as f:
+            for ln in f:
+                # Not exactly a thorough parser, but should be good enough...
+                if ln.startswith(name_eq):
+                    cur_value = ln[len(name_eq):].strip()
+                    if Path(project_dir, cur_value).resolve() != abs_value:
+                        raise ValueError(f"Conflicting property {name}={cur_value} (not {abs_value})")
+                    return
+    # The file does not contain the required property, append it.
+    # Note that the project probably expects a path relative to the project root.
+    ancestor = Path(os.path.commonpath([project_dir, abs_value]))
+    relpath = Path(".")
+    for _ in project_dir.parts[len(ancestor.parts):]:
+        relpath /= ".."
+    for nm in abs_value.parts[len(ancestor.parts):]:
+        relpath /= nm
+    with properties_file.open("a") as f:
+        f.write(f"{name}={abs_value}\n")

--- a/automation/smoke-test-android-components.py
+++ b/automation/smoke-test-android-components.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+# Purpose: Run android-components tests against this application-services working tree.
+# Dependencies: yaml
+# Usage: ./automation/smoke-test-android-components.py
+
+import argparse
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+import yaml
+from shared import step_msg, fatal_err, run_cmd_checked, find_app_services_root, set_gradle_substitution_path
+
+parser = argparse.ArgumentParser(description="Run android-components tests against this application-services working tree.")
+
+group = parser.add_mutually_exclusive_group()
+group.add_argument("--use-local-repo",
+                    metavar="LOCAL_REPO_PATH",
+                    help="Use a local copy of a-c instead of cloning it.")
+group.add_argument("--remote-repo-url",
+                    metavar="REMOTE_REPO_URL",
+                    help="Clone a different a-c repository.")
+parser.add_argument("--branch",
+                    help="Branch of a-c to use.")
+parser.add_argument("--action",
+                    # XXX TODO: it would be very nice to have a "launch sample app" helper here as well.
+                    choices=["run-tests", "do-nothing"],
+                    help="Run the following action once a-c is set up.")
+
+DEFAULT_REMOTE_REPO_URL="https://github.com/mozilla-mobile/android-components.git"
+
+args = parser.parse_args()
+local_repo_path = args.use_local_repo
+remote_repo_url = args.remote_repo_url
+branch = args.branch
+action = args.action
+
+repo_path = local_repo_path
+if repo_path is None:
+    repo_path = tempfile.mkdtemp(suffix="-a-c")
+    if remote_repo_url is None:
+        remote_repo_url = DEFAULT_REMOTE_REPO_URL
+    step_msg(f"Cloning {remote_repo_url}")
+    run_cmd_checked(["git", "clone", remote_repo_url, repo_path])
+    if branch is not None:
+        run_cmd_checked(["git", "checkout", branch], cwd=repo_path)
+elif branch is not None:
+    fatal_err("Cannot specify fenix branch when using a local repo; check it out locally and try again.")
+
+step_msg(f"Configuring {repo_path} to autopublish appservices")
+set_gradle_substitution_path(repo_path, "autoPublish.application-services.dir", find_app_services_root())
+
+if action == "do-nothing":
+    exit(0)
+elif action == "run-tests" or action is None:
+    # There are a lot of non-app-services-related components and we don't want to run all their tests.
+    # Read the build config to find which projects actually depend on appservices.
+    # It's a bit gross but it makes the tests run faster!
+    # First, find out what names a-c uses to refer to apservices projects in dependency declarations.
+    dep_names = set()
+    dep_pattern = re.compile("\s*const val ([A-Za-z0-9_]+) = .*Versions.mozilla_appservices")
+    with Path(repo_path, "buildSrc", "src", "main", "java", "Dependencies.kt").open() as f:
+        for ln in f:
+            m = dep_pattern.match(ln)
+            if m is not None:
+                dep_names.add(m.group(1))
+    step_msg(f"Found the following appservices dependency names: {dep_names}")
+    # Now find all projects that depend on one of those names.
+    projects = set()
+    with Path(repo_path, ".buildconfig.yml").open() as f:
+        buildconfig = yaml.safe_load(f.read())
+    for (project, details) in buildconfig["projects"].items():
+        with Path(repo_path, details["path"], "build.gradle").open() as f:
+            for ln in f:
+                for dep_name in dep_names:
+                    if dep_name in ln:
+                        projects.add(project)
+                        break
+    step_msg(f"Running android-components tests for {len(projects)} projects: {projects}")
+    run_cmd_checked(["./gradlew"] + [f"{project}:test" for project in projects], cwd=repo_path)
+else:
+    print("Sorry I did not understand what you wanted. Good luck!")

--- a/automation/smoke-test-fenix.py
+++ b/automation/smoke-test-fenix.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# Purpose: Run Fenix tests against this application-services working tree.
+# Usage: ./automation/smoke-test-fenix.py
+
+import argparse
+import subprocess
+import tempfile
+from pathlib import Path
+from shared import step_msg, fatal_err, run_cmd_checked, find_app_services_root, set_gradle_substitution_path
+
+parser = argparse.ArgumentParser(description="Run Fenix tests against this application-services working tree.")
+
+group = parser.add_mutually_exclusive_group()
+group.add_argument("--use-local-repo",
+                    metavar="LOCAL_REPO_PATH",
+                    help="Use a local copy of fenix instead of cloning it.")
+group.add_argument("--remote-repo-url",
+                    metavar="REMOTE_REPO_URL",
+                    help="Clone a different fenix repository.")
+group = parser.add_mutually_exclusive_group()
+group.add_argument("--use-local-ac-repo",
+                   metavar="LOCAL_AC_REPO_PATH",
+                   help="Use a local copy of a-c instead of latest release")
+group.add_argument("--remote-ac-repo-url",
+                   metavar="REMOTE_AC_REPO_URL",
+                   help="Use a clone of a-c repo instead of latest release.")
+parser.add_argument("--branch",
+                    help="Branch of fenix to use.")
+parser.add_argument("--ac-branch",
+                    default="master",
+                    help="Branch of android-components to use.")
+parser.add_argument("--action",
+                    # XXX TODO: it would be very nice to have a "launch the app" helper here as well.
+                    choices=["run-tests", "do-nothing"],
+                    help="Run the following action once fenix is set up.")
+
+DEFAULT_REMOTE_REPO_URL="https://github.com/mozilla-mobile/fenix.git"
+
+args = parser.parse_args()
+local_repo_path = args.use_local_repo
+remote_repo_url = args.remote_repo_url
+local_ac_repo_path = args.use_local_ac_repo
+remote_ac_repo_url = args.remote_ac_repo_url
+fenix_branch = args.branch
+ac_branch = args.branch
+action = args.action
+
+repo_path = local_repo_path
+if repo_path is None:
+    repo_path = tempfile.mkdtemp(suffix="-fenix")
+    if remote_repo_url is None:
+        remote_repo_url = DEFAULT_REMOTE_REPO_URL
+    step_msg(f"Cloning {remote_repo_url}")
+    run_cmd_checked(["git", "clone", remote_repo_url, repo_path])
+    if fenix_branch is not None:
+        run_cmd_checked(["git", "checkout", fenix_branch], cwd=repo_path)
+elif fenix_branch is not None:
+    fatal_err("Cannot specify fenix branch when using a local repo; check it out locally and try again.")
+
+ac_repo_path = local_ac_repo_path
+if ac_repo_path is None:
+    if remote_ac_repo_url is not None:
+        ac_repo_path = tempfile.mkdtemp(suffix="-fenix")
+        step_msg(f"Cloning {remote_ac_repo_url}")
+        run_cmd_checked(["git", "clone", remote_ac_repo_url, ac_repo_path])
+        if ac_branch is not None:
+            run_cmd_checked(["git", "checkout", ac_branch], cwd=ac_repo_path)
+elif ac_branch is not None:
+    fatal_err(
+        "Cannot specify a-c branch when using a local repo; check it out locally and try again.")
+
+step_msg(f"Configuring {repo_path} to autopublish appservices")
+set_gradle_substitution_path(repo_path, "autoPublish.application-services.dir", find_app_services_root())
+if ac_repo_path is not None:
+    step_msg(f"Configuring {repo_path} to autopublish android-components from {ac_repo_path}")
+    set_gradle_substitution_path(repo_path, "autoPublish.android-components.dir", ac_repo_path)
+
+if action == "do-nothing":
+    exit(0)
+elif action == "run-tests" or action is None:
+    step_msg("Running fenix tests")
+    run_cmd_checked(["./gradlew", "app:test"], cwd=repo_path)
+    # XXX TODO: I would also like to run the sync integration tests described here:
+    #   https://docs.google.com/document/d/1dhxlbGQBA6aJi2Xz-CsJZuGJPRReoL7nfm9cYu4HcZI/
+    # However they do not currently pass reliably on my machine.
+else:
+    print("Sorry I did not understand what you wanted. Good luck!")

--- a/automation/smoke-test-firefox-ios.py
+++ b/automation/smoke-test-firefox-ios.py
@@ -18,7 +18,6 @@ group.add_argument("--remote-repo-url",
                     metavar="REMOTE_REPO_PATH",
                     help="Clone a different firefox-ios repository.")
 parser.add_argument("--branch",
-                    default="master",
                     help="Branch of firefox-ios to use.")
 parser.add_argument("--action",
                     choices=["open-project", "run-tests", "do-nothing"],
@@ -40,7 +39,10 @@ if local_repo_path is None:
         remote_repo_url = DEFAULT_REMOTE_REPO_URL
     step_msg(f"Cloning {remote_repo_url}")
     run_cmd_checked(["git", "clone", remote_repo_url, repo_path])
-    run_cmd_checked(["git", "checkout", firefox_ios_branch], cwd=repo_path)
+    if firefox_ios_branch is not None:
+        run_cmd_checked(["git", "checkout", firefox_ios_branch], cwd=repo_path)
+elif firefox_ios_branch is not None:
+    fatal_err("Cannot specify branch when using a local repo; check it out locally and try again.")
 
 if not Path(repo_path, "Carthage").exists():
     step_msg("Carthage folder not present. Running the firefox-ios bootstrap script")

--- a/docs/howtos/smoke-testing-app-services.md
+++ b/docs/howtos/smoke-testing-app-services.md
@@ -7,4 +7,15 @@ It can be done manually using substitution scripts, but we also have scripts tha
 
 The `automation/smoke-test-firefox-ios.py` script will clone (or use a local version) of Firefox iOS and
 run tests against the current application-services worktree.  
-Add the `-h` argument to discover all the script exciting options!
+Add the `-h` argument to discover all of the script's exciting options!
+
+## Android Components
+
+The `automation/smoke-test-android-components.py` script will clone (or use a local version) of
+android-components and run a subset of its tests against the current application-services worktree.
+It tries to only run tests that might be relevant to application-services functionality.
+
+## Fenix
+
+The `automation/smoke-test-fenix.py` script will clone (or use a local version) of Fenix and
+run tests against the current application-services worktree.


### PR DESCRIPTION
Like the scripts that @eoger added recently for iOS, but for android.

The fenix script depends on https://github.com/mozilla-mobile/fenix/pull/8681 which hasn't merged to master yet.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
