### PR TITLE
Remove the unused `is_in_memory` from places.

### DIFF
--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -20,17 +20,15 @@ pub struct PlacesDb {
     conn_type: ConnectionType,
     interrupt_counter: Arc<AtomicUsize>,
     api_id: usize,
-    in_memory: bool,
     pub(super) coop_tx_lock: Arc<Mutex<()>>,
 }
 
 impl PlacesDb {
-    pub fn with_connection(
+    fn with_connection(
         db: Connection,
         conn_type: ConnectionType,
         api_id: usize,
         coop_tx_lock: Arc<Mutex<()>>,
-        in_memory: bool,
     ) -> Result<Self> {
         let initial_pragmas = "
             -- The value we use was taken from Desktop Firefox, and seems necessary to
@@ -78,7 +76,6 @@ impl PlacesDb {
             api_id,
             interrupt_counter: Arc::new(AtomicUsize::new(0)),
             coop_tx_lock,
-            in_memory,
         };
         match res.conn_type() {
             // For read-only connections, we can avoid opening a transaction,
@@ -107,7 +104,6 @@ impl PlacesDb {
             conn_type,
             api_id,
             coop_tx_lock,
-            false,
         )?)
     }
 
@@ -120,7 +116,6 @@ impl PlacesDb {
             conn_ty,
             0,
             Arc::new(Mutex::new(())),
-            true,
         )?)
     }
 
@@ -144,11 +139,6 @@ impl PlacesDb {
     #[inline]
     pub fn api_id(&self) -> usize {
         self.api_id
-    }
-
-    #[inline]
-    pub fn is_in_memory(&self) -> bool {
-        self.in_memory
     }
 }
 


### PR DESCRIPTION
I noticed this unused code when working on webext-storage - places seems complicated enough withut unused code, so figured I should :killitwithfire.