### PR TITLE
Optimize iOS CI runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ commands:
       - run:
           name: Install sccache
           command: |
-            SCCACHE_VERSION=0.2.11
+            SCCACHE_VERSION=0.2.13
             if [ "$(uname)" == "Darwin" ]; then
               SCCACHE="sccache-${SCCACHE_VERSION}-x86_64-apple-darwin"
             else
@@ -24,14 +24,10 @@ commands:
             echo 'export "RUST_LOG"="sccache=info"' >> $BASH_ENV
             # Incremental compilation isn't supported by sccache.
             echo 'export "CARGO_INCREMENTAL"="0"' >> $BASH_ENV
-            sccache --version
-  install-xcpretty:
-    steps:
-      - run:
-          name: Install xcpretty
-          command: |
-            gem install --user-install xcpretty
-            echo 'export PATH="$HOME/.gem/ruby/2.3.0/bin:$PATH"' >> $BASH_ENV
+      # Run in a different shell to source $BASH_ENV modified above.
+      - run: |
+          sccache --version
+          sccache --zero-stats
   install-mdbook:
     steps:
       - run:
@@ -63,15 +59,12 @@ commands:
         default: "stable"
     steps:
       - run:
-          name: Setup Rust toolchain
+          name: Set up Rust toolchain
           command: |
+            rustup update
             rustup install <<parameters.rust-version>>
             rustup default <<parameters.rust-version>>
-            rustup update
             rustc --version
-  install-clang: # Used by bindgen for nss_sys.
-    steps:
-      - run: sudo apt-get install clang
   build-libs:
     parameters:
       platform:
@@ -113,6 +106,19 @@ commands:
             popd
       - build-libs:
           platform: ios
+  carthage-bootstrap:
+    steps:
+      - restore_cache:
+          name: Restore Carthage/ cache
+          key: carthage-dir-cache-{{ arch }}-{{ checksum "Cartfile.resolved" }}
+      - run:
+          name: Bootstrap Carthage dependencies
+          command: carthage bootstrap --platform iOS --cache-builds
+      - save_cache:
+          name: Save Carthage/ cache
+          key: carthage-dir-cache-{{ arch }}-{{ checksum "Cartfile.resolved" }}
+          paths:
+            - Carthage
   test-setup:
     parameters:
       rust-version:
@@ -124,7 +130,8 @@ commands:
       - setup-rust-toolchain:
           rust-version: <<parameters.rust-version>>
       - setup-sccache
-      - install-clang
+      # nss_sys's bindgen needs clang.
+      - run: sudo apt-get install clang
       # clipboard crate depends on some x11 libs.
       - run: sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev
       - run: |
@@ -145,11 +152,9 @@ commands:
           rust-version: <<parameters.rust-version>>
       # Test with 1. only default features on, 2. all features on, 3. no features on.
       # This is not perfect (really we want the cartesian product), but is good enough in practice.
-      - run: sccache --zero-stats
       - run:
           name: Test (default features, no features, and all features)
           command: bash automation/all_rust_tests.sh --verbose
-      - run: sccache --show-stats
   dependency-checks:
     steps:
       - run:
@@ -211,9 +216,10 @@ commands:
           key: sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}
           paths:
             - "~/.cache/sccache"
-      - store-sccache-logs
-  store-sccache-logs:
+      - sccache-stats-and-logs
+  sccache-stats-and-logs:
     steps:
+      - run: sccache --show-stats
       - store_artifacts:
           path: /tmp/sccache.log
           destination: logs/sccache.log
@@ -242,9 +248,11 @@ jobs:
       - image: circleci/rust:latest
     steps:
       - test-setup
+      - restore-sccache-cache
       - run: rustup component add clippy
       - run: cargo clippy --version
       - run: bash automation/all_clippy_checks.sh
+      - save-sccache-cache
   Lint Bash scripts:
     docker:
       - image: koalaman/shellcheck-alpine:stable
@@ -296,29 +304,29 @@ jobs:
     macos:
       xcode: "11.4.0"
     steps:
-      - install-rust
-      - setup-rust-toolchain
-      - checkout
-      - setup-sccache
-      - build-ios-libs
       # We do not use the ssccache cache helper commands as
       # the macOS cache is in a different folder.
       - restore_cache:
           name: Restore sccache cache
           key: sccache-cache-macos-{{ arch }}
+      - checkout
+      - install-rust
+      - setup-rust-toolchain
       - run:
-          name: Setup build environment
+          name: Toggle brew auto-updates
           command: |
-            rustup target add aarch64-apple-ios x86_64-apple-ios
             if [ -z "${CIRCLE_TAG}" ]; then
               # On non-release builds do not update brew (takes ages).
               echo 'export HOMEBREW_NO_AUTO_UPDATE=1' >> $BASH_ENV
             fi
-            brew outdated carthage || brew upgrade carthage
-            carthage bootstrap --platform iOS
+      - setup-sccache
+      - build-ios-libs
+      - run:
+          name: Set up the build environment
+          command: |
+            rustup target add aarch64-apple-ios x86_64-apple-ios
             brew install swift-protobuf
-            # See https://circleci.com/docs/2.0/testing-ios/#pre-starting-the-simulator
-            xcrun instruments -w "iPhone 8 (13.0) [" || true
+      - carthage-bootstrap
       - run:
           name: Verify the build environment
           command: ./libs/verify-ios-environment.sh
@@ -348,7 +356,7 @@ jobs:
           key: sccache-cache-macos-{{ arch }}-{{ epoch }}
           paths:
             - "~/Library/Caches/Mozilla.sccache"
-      - store-sccache-logs
+      - sccache-stats-and-logs
       - run:
           name: "Create Carthage bin-only project specification"
           command: |

--- a/automation/run_ios_tests.sh
+++ b/automation/run_ios_tests.sh
@@ -6,6 +6,8 @@ set -euvx
 # updated rust recently.
 rustup update stable
 
+carthage bootstrap --platform iOS --cache-builds
+
 set -o pipefail && \
 xcodebuild \
   -workspace ./megazords/ios/MozillaAppServices.xcodeproj/project.xcworkspace \


### PR DESCRIPTION
I've noticed we always have to wait a long time before the CircleCI "iOS build and test" job finishes, so I profiled and optimized it a little bit. (explanations in a self-review to come).

This brings the iOS CI time from 15-20 minutes to about 10 minutes.