### PR TITLE
Use ffi-support from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ffi-support"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "087be066eb6e85d7150f0c5400018a32802f99d688b2d3868c526f7bbfe17960"
+dependencies = [
+ "lazy_static",
+ "log",
+]
+
+[[package]]
 name = "find-places-db"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -770,7 +780,7 @@ dependencies = [
  "dialoguer",
  "error-support",
  "failure",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "lazy_static",
  "log",
@@ -793,7 +803,7 @@ dependencies = [
 name = "fxaclient_ffi"
 version = "0.1.0"
 dependencies = [
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxa-client",
  "lazy_static",
  "log",
@@ -1100,7 +1110,7 @@ dependencies = [
  "env_logger",
  "error-support",
  "failure",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxa-client",
  "interrupt",
  "lazy_static",
@@ -1126,7 +1136,7 @@ name = "logins_ffi"
 version = "0.1.0"
 dependencies = [
  "base16",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "logins",
@@ -1606,7 +1616,7 @@ dependencies = [
  "env_logger",
  "error-support",
  "failure",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "find-places-db",
  "fxa-client",
  "idna",
@@ -1639,7 +1649,7 @@ dependencies = [
 name = "places-ffi"
 version = "0.1.0"
 dependencies = [
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt",
  "lazy_static",
  "log",
@@ -1793,7 +1803,7 @@ dependencies = [
  "error-support",
  "failure",
  "failure_derive",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "lazy_static",
  "log",
@@ -1817,7 +1827,7 @@ name = "push-ffi"
 version = "0.1.0"
 dependencies = [
  "base64 0.12.0",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "prost",
@@ -1956,7 +1966,7 @@ name = "rc_log_ffi"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
 ]
@@ -2287,7 +2297,7 @@ checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 name = "sql-support"
 version = "0.1.0"
 dependencies = [
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt",
  "lazy_static",
  "log",
@@ -2384,7 +2394,7 @@ dependencies = [
  "env_logger",
  "error-support",
  "failure",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt",
  "lazy_static",
  "log",
@@ -2403,7 +2413,7 @@ name = "sync15-traits"
 version = "0.1.0"
 dependencies = [
  "failure",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "serde",
  "serde_json",
@@ -2417,7 +2427,7 @@ version = "0.1.0"
 dependencies = [
  "error-support",
  "failure",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt",
  "lazy_static",
  "log",
@@ -2439,7 +2449,7 @@ dependencies = [
 name = "sync_manager_ffi"
 version = "0.1.0"
 dependencies = [
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "logins_ffi",
  "places-ffi",
@@ -2470,7 +2480,7 @@ dependencies = [
  "clipboard",
  "error-support",
  "failure",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt",
  "log",
  "prost",
@@ -2490,7 +2500,7 @@ name = "tabs_ffi"
 version = "0.1.0"
 dependencies = [
  "base16",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "prost",
@@ -2748,7 +2758,7 @@ version = "0.1.0"
 dependencies = [
  "failure",
  "failure_derive",
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "once_cell",
  "prost",
@@ -2763,7 +2773,7 @@ dependencies = [
 name = "viaduct-reqwest"
 version = "0.1.0"
 dependencies = [
- "ffi-support",
+ "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
  "log",
  "reqwest",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -455,6 +455,7 @@ The following text applies to code linked from these dependencies:
 [failure_derive](https://github.com/rust-lang-nursery/failure),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
+[ffi-support](https://github.com/mozilla/application-services),
 [fixedbitset](https://github.com/bluss/fixedbitset),
 [fnv](https://github.com/servo/rust-fnv),
 [foreign-types-shared](https://github.com/sfackler/foreign-types),

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -19,7 +19,7 @@ serde_derive = "1.0.104"
 serde_json = "1.0.50"
 sync15 = { path = "../sync15" }
 url = "2.1.1"
-ffi-support = { path = "../support/ffi" }
+ffi-support = "0.4"
 viaduct = { path = "../viaduct" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece", "hawk"] }
 error-support = { path = "../support/error" }

--- a/components/fxa-client/ffi/Cargo.toml
+++ b/components/fxa-client/ffi/Cargo.toml
@@ -10,7 +10,7 @@ name = "fxaclient_ffi"
 crate-type = ["lib"]
 
 [dependencies]
-ffi-support = { path = "../../support/ffi" }
+ffi-support = "0.4"
 log = "0.4.8"
 serde_json = "1.0.50"
 lazy_static = "1.4.0"

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.4.0"
 url = "2.1.1"
 failure = "0.1.6"
 sql-support = { path = "../support/sql" }
-ffi-support = { path = "../support/ffi" }
+ffi-support = "0.4"
 interrupt = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }

--- a/components/logins/ffi/Cargo.toml
+++ b/components/logins/ffi/Cargo.toml
@@ -20,6 +20,8 @@ viaduct = { path = "../../viaduct" }
 # For SqlInterruptHandle
 sql-support = { path = "../../support/sql" }
 
+ffi-support = "0.4"
+
 [dependencies.rusqlite]
 version = "0.21.0"
 features = ["sqlcipher"]
@@ -29,6 +31,3 @@ path = ".."
 
 [dependencies.sync15]
 path = "../../sync15"
-
-[dependencies.ffi-support]
-path = "../../support/ffi"

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -21,7 +21,7 @@ percent-encoding = "2.1.0"
 failure = "0.1.6"
 caseless = "0.2.1"
 sql-support = { path = "../support/sql" }
-ffi-support = { path = "../support/ffi" }
+ffi-support = "0.4"
 bitflags = "1.2.1"
 idna = "0.2.0"
 memchr = "2.2.1"

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -16,7 +16,7 @@ default = []
 serde_json = "1.0.50"
 log = "0.4"
 url = "2.1.1"
-ffi-support = { path = "../../support/ffi" }
+ffi-support = "0.4"
 lazy_static = "1.4.0"
 prost = "0.6.1"
 viaduct = { path = "../../viaduct" }

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4.8"
 rusqlite = { version = "0.21.0", features = ["bundled"] }
 url = "2.1.1"
 viaduct = { path = "../viaduct" }
-ffi-support = { path = "../support/ffi" }
+ffi-support = "0.4"
 sql-support = { path = "../support/sql" }
 error-support = { path = "../support/error" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }

--- a/components/push/ffi/Cargo.toml
+++ b/components/push/ffi/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib"]
 serde_json = "1.0.50"
 log = "0.4"
 url = "2.1.1"
-ffi-support = { path = "../../support/ffi" }
+ffi-support = "0.4"
 lazy_static = "1.4.0"
 base64 = "0.12.0"
 push = { path = ".." }

--- a/components/rc_log/Cargo.toml
+++ b/components/rc_log/Cargo.toml
@@ -16,6 +16,6 @@ force_android = []
 
 [dependencies]
 log = "0.4.8"
-ffi-support = { path = "../support/ffi" }
+ffi-support = "0.4"
 lazy_static = "1.4.0"
 cfg-if = "0.1.9"

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -13,7 +13,7 @@ log_query_plans = []
 log = "0.4"
 lazy_static = "1.4.0"
 interrupt = { path = "../interrupt" }
-ffi-support = { path = "../ffi" }
+ffi-support = "0.4"
 
 [dependencies.rusqlite]
 version = "0.21.0"

--- a/components/support/sync15-traits/Cargo.toml
+++ b/components/support/sync15-traits/Cargo.toml
@@ -13,6 +13,6 @@ sync-guid = { path = "../guid" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
-ffi-support = {path = "../ffi"}
+ffi-support = "0.4"
 url = "2.1"
 failure = "0.1.6"

--- a/components/support/viaduct-reqwest/Cargo.toml
+++ b/components/support/viaduct-reqwest/Cargo.toml
@@ -14,6 +14,6 @@ default = []
 [dependencies]
 viaduct = { path = "../../viaduct" }
 reqwest = { version = "0.10.1", features = ["blocking", "native-tls-vendored"] }
-ffi-support = { path = "../ffi" }
+ffi-support = "0.4.0"
 lazy_static = "1.4.0"
 log = "0.4"

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 
 [dependencies]
 base64 = "0.12.0"
-ffi-support = { path = "../support/ffi" }
+ffi-support = "0.4"
 serde = "1.0.104"
 serde_derive = "1.0.104"
 serde_json = "1.0.50"

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -10,7 +10,7 @@ sync15 = { path = "../sync15" }
 places = { path = "../places" }
 logins = { path = "../logins" }
 tabs = { path = "../tabs" }
-ffi-support = { path = "../support/ffi" }
+ffi-support = "0.4"
 failure = "0.1.6"
 error-support = { path = "../support/error" }
 prost = "0.6.1"

--- a/components/sync_manager/ffi/Cargo.toml
+++ b/components/sync_manager/ffi/Cargo.toml
@@ -9,7 +9,7 @@ license = "MPL-2.0"
 [dependencies]
 sync_manager = { path = ".." }
 sync15 = { path = "../../sync15" }
-ffi-support = { path = "../../support/ffi" }
+ffi-support = "0.4"
 places-ffi = { path = "../../places/ffi" }
 logins_ffi = { path = "../../logins/ffi" }
 tabs_ffi = { path = "../../tabs/ffi" }

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.8"
 url = "2.1.1"
 prost = "0.6.1"
 prost-derive = "0.6.1"
-ffi-support = { path = "../support/ffi" }
+ffi-support = "0.4"
 error-support = { path = "../support/error" }
 interrupt = { path = "../support/interrupt" }
 sync-guid = { path = "../support/guid", features = ["random"] }

--- a/components/tabs/ffi/Cargo.toml
+++ b/components/tabs/ffi/Cargo.toml
@@ -17,12 +17,10 @@ base16 = "0.2.1"
 lazy_static = "1.4.0"
 prost = "0.6.1"
 viaduct = { path = "../../viaduct" }
+ffi-support = "0.4"
 
 [dependencies.tabs]
 path = ".."
 
 [dependencies.sync15]
 path = "../../sync15"
-
-[dependencies.ffi-support]
-path = "../../support/ffi"

--- a/components/viaduct/Cargo.toml
+++ b/components/viaduct/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0.50"
 once_cell = "1.3.1"
 prost = "0.6.1"
 prost-derive = "0.6.1"
-ffi-support = { path = "../support/ffi" }
+ffi-support = "0.4"
 
 [build-dependencies]
 prost-build = "0.6.1"

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -434,6 +434,7 @@ The following text applies to code linked from these dependencies:
 [failure_derive](https://github.com/rust-lang-nursery/failure),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
+[ffi-support](https://github.com/mozilla/application-services),
 [fixedbitset](https://github.com/bluss/fixedbitset),
 [getrandom](https://github.com/rust-random/getrandom),
 [glob](https://github.com/rust-lang/glob),

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -97,6 +97,10 @@ the details of which are reproduced below.
     <url>https://github.com/sfackler/fallible-streaming-iterator/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: ffi-support</name>
+    <url>https://raw.githubusercontent.com/mozilla/application-services/master/components/support/ffi/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: fixedbitset</name>
     <url>https://github.com/bluss/fixedbitset/blob/master/LICENSE-APACHE</url>
   </license>

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -447,6 +447,7 @@ The following text applies to code linked from these dependencies:
 [failure_derive](https://github.com/rust-lang-nursery/failure),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
+[ffi-support](https://github.com/mozilla/application-services),
 [fixedbitset](https://github.com/bluss/fixedbitset),
 [fnv](https://github.com/servo/rust-fnv),
 [futures-channel](https://github.com/rust-lang/futures-rs),

--- a/megazords/lockbox/DEPENDENCIES.md
+++ b/megazords/lockbox/DEPENDENCIES.md
@@ -431,6 +431,7 @@ The following text applies to code linked from these dependencies:
 [failure_derive](https://github.com/rust-lang-nursery/failure),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
+[ffi-support](https://github.com/mozilla/application-services),
 [fixedbitset](https://github.com/bluss/fixedbitset),
 [getrandom](https://github.com/rust-random/getrandom),
 [glob](https://github.com/rust-lang/glob),

--- a/megazords/lockbox/android/dependency-licenses.xml
+++ b/megazords/lockbox/android/dependency-licenses.xml
@@ -93,6 +93,10 @@ the details of which are reproduced below.
     <url>https://github.com/sfackler/fallible-streaming-iterator/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: ffi-support</name>
+    <url>https://raw.githubusercontent.com/mozilla/application-services/master/components/support/ffi/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: fixedbitset</name>
     <url>https://github.com/bluss/fixedbitset/blob/master/LICENSE-APACHE</url>
   </license>

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -459,6 +459,12 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "https://github.com/cryptocorrosion/cryptocorrosion/blob/master/stream-ciphers/chacha/LICENSE-APACHE"
         },
     },
+    "ffi-support": {
+        "license_url": {
+            "check": None,
+            "fixup": "https://raw.githubusercontent.com/mozilla/application-services/master/components/support/ffi/LICENSE-APACHE"
+        },
+    },
     "humantime": {
         "repository": {
             "check": None,


### PR DESCRIPTION
This is required for vendoring any component using ffi-support, as glean depends on the version from crates.io.

(It *briefly* worked without this, but then glean landed an update at the same time broke us)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
