### PR TITLE
Raise exception when license URL is None

### DIFF
--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -814,14 +814,12 @@ class WorkspaceMetadata(object):
                     else:
                         # No potential URLs were actually live.
                         licenseUrl = None
-            if licenseUrl is None:
-                err = "Could not infer license URL for '{}'.\n".format(pkgInfo["name"])
-                err += "Please locate the correct license URL and add it to `PACKAGE_METADATA_FIXUPS`.\n"
-                err += "You may need to poke around in the source repository at {}".format(repo)
-                err += " for a {} license file named {}.".format(chosenLicense, licenseFile)
-                #raise RuntimeError(err)
-                print(err)
-                return None
+        if licenseUrl is None:
+            err = "Could not infer license URL for '{}'.\n".format(pkgInfo["name"])
+            err += "Please locate the correct license URL and add it to `PACKAGE_METADATA_FIXUPS`.\n"
+            err += "You may need to poke around in the source repository at {}".format(repo)
+            err += " for a {} license file named {}.".format(chosenLicense, licenseFile)
+            raise RuntimeError(err)
         # As a special case, convert raw github URLs back into human-friendly page URLs.
         if licenseUrl.startswith("https://raw.githubusercontent.com/"):
             licenseUrl = re.sub(r"raw.githubusercontent.com/([^/]+)/([^/]+)/",
@@ -905,7 +903,7 @@ def group_dependencies_for_printing(deps):
             "license": license,
             "license_text_hash": licenseTextHash,
             "license_text": licenseText,
-            "license_url": deps[0].get("license_url", "No license URL for {}".format(title)),
+            "license_url": deps[0].get("license_url"),
         })
 
     # List groups in the order in which we prefer their license, then in alphabetical order


### PR DESCRIPTION
See https://mozilla.slack.com/archives/CKL0LGV9B/p1585758435166400 where poor @thomcc couldn't figure out why the script was failing for him.
The error that we used to print was being redirected to `megazords/full/android/dependency-licenses.xml` 😅