### PR TITLE
Add some quality-of-life improvements for running android smoketests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ credentials.json
 *-engine.json
 .cargo
 *.db
+.*.swp
 
 # Android stuff.
 *.iml
@@ -14,6 +15,7 @@ build
 .DS_Store
 captures
 .externalNativeBuild
+.lastAutoPublishContentsHash
 
 # iOS stuff.
 xcuserdata

--- a/automation/publish_to_maven_local_if_modified.py
+++ b/automation/publish_to_maven_local_if_modified.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# Purpose: Publish android packages to local maven repo, but only if changed since last publish.
+# Dependencies: None
+# Usage: ./automation/publish_to_maven_local_if_modified.py
+
+import os
+import time
+import hashlib
+import argparse
+from shared import run_cmd_checked, find_app_services_root, fatal_err
+import re
+
+LAST_CONTENTS_HASH_FILE = ".lastAutoPublishContentsHash"
+
+parser = argparse.ArgumentParser(description="Publish android packages to local maven repo, but only if changed since last publish")
+parser.parse_args()
+
+root_dir = find_app_services_root()
+if str(root_dir) != os.path.abspath(os.curdir):
+    fatal_err(f"This only works if run from the repo root ({root_dir!r} != {os.path.abspath(os.curdir)!r})")
+
+# Calculate a hash reflecting the current state of the repo.
+
+contents_hash = hashlib.sha256()
+
+contents_hash.update(
+    run_cmd_checked(["git", "rev-parse", "HEAD"], capture_output=True).stdout
+)
+contents_hash.update(b"\x00")
+
+# Git can efficiently tell us about changes to tracked files, including
+# the diff of their contents, if you give it enough "-v"s.
+
+changes = run_cmd_checked(["git", "status", "-v", "-v"], capture_output=True).stdout
+contents_hash.update(changes)
+contents_hash.update(b"\x00")
+
+# But unfortunately it can only tell us the names of untracked
+# files, so we need to slurp their contents in for ourselves.
+
+changes_lines = iter(ln.strip() for ln in changes.split(b"\n"))
+try:
+    ln = next(changes_lines)
+    while not ln.startswith(b"Untracked files:"):
+        ln = next(changes_lines)
+    ln = next(changes_lines) # skip instruction about using `git add`
+    ln = next(changes_lines)
+    while ln:
+        with open(ln, "rb") as f:
+            contents_hash.update(f.read())
+        contents_hash.update(b"\x00")
+        ln = next(changes_lines)
+except StopIteration:
+    pass
+contents_hash.update(b"\x00")
+
+contents_hash = contents_hash.hexdigest()
+
+# If the contents hash has changed since last publish, re-publish.
+
+last_contents_hash = ""
+try:
+    with open(LAST_CONTENTS_HASH_FILE) as f:
+        last_contents_hash = f.read().strip()
+except FileNotFoundError:
+    pass
+
+if contents_hash == last_contents_hash:
+    print("Contents have not changed, no need to publish")
+else:
+    print("Contents have changed, publishing")
+    run_cmd_checked(["./gradlew", "publishToMavenLocal", f"-Plocal={time.time_ns()}"])
+    with open(LAST_CONTENTS_HASH_FILE, "w") as f:
+        f.write(contents_hash)
+        f.write("\n")

--- a/automation/shared.py
+++ b/automation/shared.py
@@ -61,4 +61,4 @@ def set_gradle_substitution_path(project_dir, name, value):
     for nm in abs_value.parts[len(ancestor.parts):]:
         relpath /= nm
     with properties_file.open("a") as f:
-        f.write(f"{name}={abs_value}\n")
+        f.write(f"{name}={relpath}\n")

--- a/automation/smoke-test-android-components.py
+++ b/automation/smoke-test-android-components.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Purpose: Run android-components tests against this application-services working tree.
-# Dependencies: yaml
+# Dependencies: PyYAML
 # Usage: ./automation/smoke-test-android-components.py
 
 import argparse

--- a/automation/smoke-test-fenix.py
+++ b/automation/smoke-test-fenix.py
@@ -79,8 +79,11 @@ if ac_repo_path is not None:
 if action == "do-nothing":
     exit(0)
 elif action == "run-tests" or action is None:
+    # Fenix has unittest targets for a wide variety of different configurations.
+    # It's not useful to us to run them all, so just pick the one that sounds like it's
+    # least likely to be broken for unrelated reasons.
     step_msg("Running fenix tests")
-    run_cmd_checked(["./gradlew", "app:test"], cwd=repo_path)
+    run_cmd_checked(["./gradlew", "app:testGeckoBetaDebugUnitTest"], cwd=repo_path)
     # XXX TODO: I would also like to run the sync integration tests described here:
     #   https://docs.google.com/document/d/1dhxlbGQBA6aJi2Xz-CsJZuGJPRReoL7nfm9cYu4HcZI/
     # However they do not currently pass reliably on my machine.

--- a/build.gradle
+++ b/build.gradle
@@ -280,12 +280,13 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
 
 // Extremely unsophisticated way to publish a local development version while hiding implementation details.
 //
-// For now we just run `publishToMavenLocal` while setting the special property `local`, and have some logic
-// in our gradle scripts to construct an auto-incrementing version number when this property is set.
+// This shells out to a python script that tries to detect whether the working directory has changed since the last
+// time it was run, and it so then it shells out to `./gradlew publishToMavenLocal -Plocal=<timestamp>` to publish
+// a new version of of the code with an auto-incrementing version number.
 //
-// I hope to grow this into something more sophisticated over time (e.g. to avoid re-publishing when nothing
-// has changed, perhaps cleanup old versions, etc) while keeping a stable `./gradlew autoPublishForLocalDevelopment`
+// It would be nice to implement this natively in gradle using gradle's own change-detection facilities, but I don't know
+// enough about gradle to take that on. At least this approach gives a nice stable  `./gradlew autoPublishForLocalDevelopment`
 // interface  for consumers.
 task autoPublishForLocalDevelopment(type: Exec) {
-  commandLine "./gradlew", "publishToMavenLocal", "-Plocal=true"
+  commandLine "./automation/publish_to_maven_local_if_modified.py"
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -9,11 +9,6 @@ def libProjectName = properties.libProjectName
 def libUrl = properties.libUrl
 def libVcsUrl = properties.libVcsUrl
 
-static def getLocalPublicationTimestamp() {
-    def date = new Date()
-    return date.format('yyyyMMddHHmmss')
-}
-
 // `jnaForTestConfiguration` is a hacky way to say yes, I'm using JNA and want
 // to pack the JNA dispatch libraries and my Rust libraries into a single JAR
 // for use in unit tests that run on a development host (and not an Android
@@ -117,7 +112,7 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                     // For mavenLocal publishing workflow, increment the version number every publish.
                     // We only do this to the .pom file and not in $MEGAZORD_VERSION, because otherwise we
                     // would need to rebuild the megazord .so on every publish, even if nothing else had changed.
-                    version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + getLocalPublicationTimestamp() : '')
+                    version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
                     packaging = "aar"
 
                     license {
@@ -164,7 +159,7 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                         artifactId = "${theArtifactId}-forUnitTests"
                         description = theDescription
                         // For mavenLocal publishing workflow, increment the version number every publish.
-                        version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + getLocalPublicationTimestamp() : '')
+                        version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
                         packaging = "jar"
 
                         licenses {


### PR DESCRIPTION
The most important one is that we avoid publishing a new set of aars
if no code has actually changed. I'm not thrilled about the *way* we
accomplish it, but it works for me...
