### PR TITLE
Run tests against rust beta periodically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,16 @@ jobs:
       - restore-sccache-cache
       - rust-tests
       - save-sccache-cache
+  # These run periodically (driven by cron).
+  Rust tests - beta:
+    docker:
+      - image: circleci/rust:latest
+    resource_class: xlarge
+    steps:
+      - restore-sccache-cache
+      - rust-tests:
+          rust-version: "beta"
+      - save-sccache-cache
   Sync integration tests:
     docker:
       - image: circleci/rust:latest-browsers
@@ -454,6 +464,16 @@ workflows:
   check-dependencies-periodically:
     jobs:
       - Check Rust dependencies
+    triggers:
+      - schedule:
+          cron: "0 7 * * *"
+          filters:
+            branches:
+              only:
+                - master
+  run-beta-tests-periodically:
+    jobs:
+      - Rust tests - beta
     triggers:
       - schedule:
           cron: "0 7 * * *"


### PR DESCRIPTION
Had some time waiting for a build so just banged this out. I don't know what happened to the bug for this, but I believe there is one?

I'm not exactly sure the frequency is what we want. It also occurs to me that maybe we should test on nightly too, since I suspect the cost of doing periodic tests like this is probably comparatively low.

r? @rfk for general "does this frequency seem right"
r? @eoger for making sure I'm not doing something dumb that will make our CI slow.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
