### PR TITLE
Add "smoketest" instructions to the release docs.

### DIFF
--- a/docs/howtos/cut-a-new-release.md
+++ b/docs/howtos/cut-a-new-release.md
@@ -2,25 +2,34 @@
 
 ## Make a new release from latest master.
 
-1. Run the `./automation/prepare-release.py` script to create a release commit and open a pull-request. If this script does not work for you, please refer to the "Create a release commit manually" section in this document.
-2. Cut the actual release.
+1. Smoketest whether the release will integrate cleanly with key downstream consumers:
+    - Run the `./automation/smoke-test-firefox-ios.py` script to test integration with Firefox for iOS.
+    - Run the `./automation/smoke-test-android-components.py` script to test integration with Android Components.
+    - Run the `./automation/smoke-test-fenix.py` script to test integration with Fenix
+    - Build and run the [sync sample app](https://github.com/mozilla-mobile/android-components/tree/master/samples/sync) in android-components
+      against your local checkout using the [local publishing flow](./locally-published-components-in-fenix.md).
+
+    If these tests fail, it indicates a breaking change. Check that such a change is called out
+    in the changelog, and file downstream bugs to track the work of integrating it.
+2. Run the `./automation/prepare-release.py` script to create a release commit and open a pull-request. If this script does not work for you, please refer to the "Create a release commit manually" section in this document.
+3. Cut the actual release.
     1. Click "Releases", and then "Draft a New Release" in the github UI.
     2. Enter `v<myversion>` as the tag. It's important this is the same as the tags that are in the changelog.
     3. Under the description, paste the contents of the release notes from CHANGELOG.md.
     4. Note that the release is not avaliable until the taskcluster build completes for that tag.
         - Finding this out takes a little navigation in the github UI. It's available at `https://github.com/mozilla/application-services/commits/v<VERSION NUMBER>` in the build status info (the emoji) next to the last commit.
         - If the taskcluster tag and/or release tasks fail, ping someone in slack and we'll figure out what to do.
-3. If you need to manually produce the iOS build for some reason (for example, if CircleCI cannot), someone with a mac needs to do the following steps:
+4. If you need to manually produce the iOS build for some reason (for example, if CircleCI cannot), someone with a mac needs to do the following steps:
     1. If necessary, set up for performing iOS builds using `./libs/verify-ios-environment.sh`.
     2. Run `./build-carthage.sh` in the root of the repository.
     3. Upload the resulting `MozillaAppServices.framework.zip` as an attachment on the github release.
-4. In order for consumers to have access, we need to update in [android-components](https://github.com/mozilla-mobile/android-components).
+5. In order for consumers to have access, we need to update in [android-components](https://github.com/mozilla-mobile/android-components).
     1. If the changes expose new functionality, or otherwise require changes to code or documentation in https://github.com/mozilla-mobile/android-components, perform those. This part is often done at the same time as the changes in application-services, to avoid being blocked on steps 3-4 of this document.
     2. Change the versions of our dependencies in [buildSrc/src/main/java/Dependencies.kt](https://github.com/mozilla-mobile/android-components/blob/master/buildSrc/src/main/java/Dependencies.kt).
     3. Note the relevant changes in their [docs/changelog.md](https://github.com/mozilla-mobile/android-components/blob/master/docs/changelog.md), and update the application-services version there as well in their list of dependency versions.
     4. **_Important: Manually test the changes versus the samples in android-components._**
         - We do not have automated test coverage for much of the network functionality at this point, so this is crucial.
-        - You can do this before the release has been cut by adding `substitutions.application-services.dir=/path/to/application-services` in your `local.properties` file in android-components. Remember that you have done this, however, as it overrides changes in `Dependencies.kt`.
+        - You can do this using the smoketest instructions in step (1) above.
 
     5. Get it PRed and landed.
 


### PR DESCRIPTION
Since we've worked on smoothing out the process of smoketesting
downsteam consumers against local changes in a-s, we should be
able to use this to replace the current rather vague instructions
in the release process docs.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
