### PR TITLE
2918 replace json macro with OAauthTokenRequest

### DIFF
--- a/components/fxa-client/src/http_client.rs
+++ b/components/fxa-client/src/http_client.rs
@@ -137,11 +137,11 @@ impl FxAClient for Client {
         code_verifier: &str,
     ) -> Result<OAuthTokenResponse> {
         
-        let req_body = OAauthTokenRequest::WithCode{
+        let req_body = OAauthTokenRequest::Code{
             code: code.to_string(),
             client_id: config.client_id.to_string(),
             code_verifier: code_verifier.to_string(),
-            grant_type: Some(authorization_code_grant_type()),
+            grant_type: Some("authorization_code".to_string()),
             ttl: None
         };
         
@@ -178,9 +178,9 @@ impl FxAClient for Client {
         ttl: Option<u64>,
         scopes: &[&str],
     ) -> Result<OAuthTokenResponse> {
-        let req = OAauthTokenRequest::WithRefreshToken {
+        let req = OAauthTokenRequest::RefreshToken {
             client_id: config.client_id.clone(),
-            grant_type: refresh_token_grant_type(),
+            grant_type: "refresh_token".to_string(),
             refresh_token: refresh_token.to_string(),
             scope: Some(scopes.join(" ")),
             ttl,
@@ -671,34 +671,10 @@ pub struct DeviceResponseCommon {
 // https://github.com/mozilla/fxa/blob/8ae0e6876a50c7f386a9ec5b6df9ebb54ccdf1b5/packages/fxa-auth-server/lib/oauth/routes/token.js#L70-L152
 
 
-// this functions are used to give a default value to the grant type
-// field if we want to deserialize and also avoid constants values
-// hardtyped in the code
-fn refresh_token_grant_type()->String{
-    "refresh_token".to_string()
-}
-
-fn fxa_credentials_grant_type()->String{
-    "fxa-credentials".to_string()
-}
-
-fn authorization_code_grant_type()->String{
-    "authorization_code".to_string()
-}
-
-fn online_access_type()->String{
-    "online".to_string()
-}
-
-fn offline_access_type()->String{
-    "offline".to_string()
-}
-
 #[derive(Serialize)]
 enum OAauthTokenRequest{
-    WithRefreshToken {
+    RefreshToken {
         client_id: String,
-        #[serde(default = "refresh_token_grant_type")]
         grant_type: String,        
         refresh_token: String,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -707,25 +683,10 @@ enum OAauthTokenRequest{
         ttl: Option<u64>,
         
     },
-    WithSessionToken{
-        client_id: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        client_secret: Option<String>,
-        #[serde(default = "fxa_credentials_grant_type")]
-        grant_type: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        scope: Option<String>,
-        #[serde(default = "online_access_type")]
-        access_type: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        ttl: Option<u64>,
-            
-    },
-    WithCode{
+    Code{
         client_id: String,
         code: String,
         code_verifier: String,
-        #[serde(default = "authorization_code_grant_type")]
         grant_type: Option<String>,
         ttl: Option<u64>
     }


### PR DESCRIPTION
Fixes #2918 .

I've modified the previously introduced `OAauthTokenRequest` introducing an `enum` as recommended making the distinction for `RefreshToken` and `Code`. 

- Modified `OAauthTokenRequest` to make it a serializable enum
- Modified the code that make use of `make_oauth_token_request`


 
### Pull Request checklist ###

- This change doesn't need to be added to the changes list since only refactors the code.
- There is no new functionalities added to the code so I don't see the need for new tests

<!-- Before submitting the PR, please address each item -->
- [] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
