### PR TITLE
[ci skip] Remove useless comment as RFC 153 landed

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -37,8 +37,6 @@ tasks:
       else: false
 
     user:
-      # dependabot-preview[bot]@users.noreply.github.com doesn't validate as email.
-      # It would be easier if TC simply didn't enforce an email format for "owner".
       $if: 'event.sender.login == "dependabot-preview[bot]"'
       then: dependabot
       else: ${event.sender.login}


### PR DESCRIPTION
https://github.com/taskcluster/taskcluster-rfcs/pull/153 landed so we no longer need this comment.

Truth be told, I wanted to merge a dummy PR on master so that I can test the scope issue fallout from merging https://github.com/mozilla/application-services/pull/2820