### PR TITLE
Calculate new release version number from the base branch, not the current checkout [ci smoketest fenix]

### DIFF
--- a/docs/howtos/cut-a-new-release.md
+++ b/docs/howtos/cut-a-new-release.md
@@ -51,6 +51,10 @@
     git push -u origin fixes-for-v0.31.3
     ```
 3. Follow the above steps for cuting a new release from master, except that:
+    * When running the `./automation/prepare-release.py` script, use the `--base-branch` argument to point it at your release branch, and specify `patch` as the release type. Example:
+       ```
+       ./automation/prepare-release.py --base-branch=release-v0.31 patch
+       ```
     * When opening a PR to land the commits, target the `release-v0.XX` branch rather than master.
     * When cutting the new release via github's UI, target the `release-v0.XX` branch rather than master.
 4. Merge the new release back to master.


### PR DESCRIPTION
I recently cut a point-release from a previous version, using the handy `--base-branch` feature to cut from a release branch instead of master. It *mostly* worked, except that it calculated the wrong version number, based on what I had checked out rather than what was in the specified base branch.  This fixes it and also adds some brief docs to guide others who may be doing this task.
