### PR TITLE
Add BridgedEngine to sync15-traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,13 +966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interrupt"
-version = "0.1.0"
-dependencies = [
- "failure",
-]
-
-[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,7 +1077,6 @@ dependencies = [
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxa-client",
- "interrupt",
  "lazy_static",
  "log 0.4.8",
  "more-asserts",
@@ -1092,6 +1084,7 @@ dependencies = [
  "prost",
  "prost-derive",
  "rusqlite",
+ "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1571,7 +1564,6 @@ dependencies = [
  "find-places-db",
  "fxa-client",
  "idna",
- "interrupt",
  "lazy_static",
  "log 0.4.8",
  "memchr",
@@ -1582,6 +1574,7 @@ dependencies = [
  "prost-derive",
  "rand 0.7.3",
  "rusqlite",
+ "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1600,11 +1593,11 @@ name = "places-ffi"
 version = "0.1.0"
 dependencies = [
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "interrupt",
  "lazy_static",
  "log 0.4.8",
  "places",
  "prost",
+ "saci-interrupt",
  "serde_json",
  "sql-support",
  "sync-guid",
@@ -2203,6 +2196,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
+name = "saci-interrupt"
+version = "0.1.0"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,10 +2337,10 @@ name = "sql-support"
 version = "0.1.0"
 dependencies = [
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "interrupt",
  "lazy_static",
  "log 0.4.8",
  "rusqlite",
+ "saci-interrupt",
 ]
 
 [[package]]
@@ -2437,10 +2434,10 @@ dependencies = [
  "error-support",
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "interrupt",
  "lazy_static",
  "log 0.4.8",
  "rc_crypto",
+ "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2456,8 +2453,8 @@ version = "0.1.0"
 dependencies = [
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "interrupt",
  "log 0.4.8",
+ "saci-interrupt",
  "serde",
  "serde_json",
  "sync-guid",
@@ -2471,13 +2468,13 @@ dependencies = [
  "error-support",
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "interrupt",
  "lazy_static",
  "log 0.4.8",
  "logins",
  "places",
  "prost",
  "prost-derive",
+ "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2573,10 +2570,10 @@ dependencies = [
  "error-support",
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "interrupt",
  "log 0.4.8",
  "prost",
  "prost-derive",
+ "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3014,12 +3011,12 @@ dependencies = [
  "env_logger",
  "error-support",
  "failure",
- "interrupt",
  "lazy_static",
  "libsqlite3-sys",
  "log 0.4.8",
  "nss_build_common",
  "rusqlite",
+ "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "interrupt-support"
+version = "0.1.0"
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1081,7 @@ dependencies = [
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxa-client",
+ "interrupt-support",
  "lazy_static",
  "log 0.4.8",
  "more-asserts",
@@ -1084,7 +1089,6 @@ dependencies = [
  "prost",
  "prost-derive",
  "rusqlite",
- "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1564,6 +1568,7 @@ dependencies = [
  "find-places-db",
  "fxa-client",
  "idna",
+ "interrupt-support",
  "lazy_static",
  "log 0.4.8",
  "memchr",
@@ -1574,7 +1579,6 @@ dependencies = [
  "prost-derive",
  "rand 0.7.3",
  "rusqlite",
- "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1593,11 +1597,11 @@ name = "places-ffi"
 version = "0.1.0"
 dependencies = [
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interrupt-support",
  "lazy_static",
  "log 0.4.8",
  "places",
  "prost",
- "saci-interrupt",
  "serde_json",
  "sql-support",
  "sync-guid",
@@ -2196,10 +2200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
-name = "saci-interrupt"
-version = "0.1.0"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,10 +2337,10 @@ name = "sql-support"
 version = "0.1.0"
 dependencies = [
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interrupt-support",
  "lazy_static",
  "log 0.4.8",
  "rusqlite",
- "saci-interrupt",
 ]
 
 [[package]]
@@ -2434,10 +2434,10 @@ dependencies = [
  "error-support",
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interrupt-support",
  "lazy_static",
  "log 0.4.8",
  "rc_crypto",
- "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2453,8 +2453,8 @@ version = "0.1.0"
 dependencies = [
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interrupt-support",
  "log 0.4.8",
- "saci-interrupt",
  "serde",
  "serde_json",
  "sync-guid",
@@ -2468,13 +2468,13 @@ dependencies = [
  "error-support",
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interrupt-support",
  "lazy_static",
  "log 0.4.8",
  "logins",
  "places",
  "prost",
  "prost-derive",
- "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2570,10 +2570,10 @@ dependencies = [
  "error-support",
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interrupt-support",
  "log 0.4.8",
  "prost",
  "prost-derive",
- "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3011,12 +3011,12 @@ dependencies = [
  "env_logger",
  "error-support",
  "failure",
+ "interrupt-support",
  "lazy_static",
  "libsqlite3-sys",
  "log 0.4.8",
  "nss_build_common",
  "rusqlite",
- "saci-interrupt",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
+checksum = "410a7488c0a728c7ceb4ad59b9567eb4053d02e8cc7f5c0e0eeeb39518369213"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2456,6 +2456,7 @@ version = "0.1.0"
 dependencies = [
  "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "interrupt",
  "log 0.4.8",
  "serde",
  "serde_json",

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -21,7 +21,7 @@ url = "2.1.1"
 failure = "0.1.6"
 sql-support = { path = "../support/sql" }
 ffi-support = "0.4"
-saci-interrupt = { path = "../support/interrupt" }
+interrupt-support = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 prost = "0.6.1"

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -21,7 +21,7 @@ url = "2.1.1"
 failure = "0.1.6"
 sql-support = { path = "../support/sql" }
 ffi-support = "0.4"
-interrupt = { path = "../support/interrupt" }
+saci-interrupt = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 prost = "0.6.1"

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -52,7 +52,7 @@ pub enum ErrorKind {
     UrlParseError(#[fail(cause)] url::ParseError),
 
     #[fail(display = "{}", _0)]
-    Interrupted(#[fail(cause)] interrupt::Interrupted),
+    Interrupted(#[fail(cause)] saci_interrupt::Interrupted),
 
     #[fail(display = "Protobuf decode error: {}", _0)]
     ProtobufDecodeError(#[fail(cause)] prost::DecodeError),
@@ -65,7 +65,7 @@ error_support::define_error! {
         (UrlParseError, url::ParseError),
         (SqlError, rusqlite::Error),
         (InvalidLogin, InvalidLogin),
-        (Interrupted, interrupt::Interrupted),
+        (Interrupted, saci_interrupt::Interrupted),
         (ProtobufDecodeError, prost::DecodeError),
     }
 }

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -52,7 +52,7 @@ pub enum ErrorKind {
     UrlParseError(#[fail(cause)] url::ParseError),
 
     #[fail(display = "{}", _0)]
-    Interrupted(#[fail(cause)] saci_interrupt::Interrupted),
+    Interrupted(#[fail(cause)] interrupt_support::Interrupted),
 
     #[fail(display = "Protobuf decode error: {}", _0)]
     ProtobufDecodeError(#[fail(cause)] prost::DecodeError),
@@ -65,7 +65,7 @@ error_support::define_error! {
         (UrlParseError, url::ParseError),
         (SqlError, rusqlite::Error),
         (InvalidLogin, InvalidLogin),
-        (Interrupted, saci_interrupt::Interrupted),
+        (Interrupted, interrupt_support::Interrupted),
         (ProtobufDecodeError, prost::DecodeError),
     }
 }

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -29,7 +29,7 @@ memchr = "2.2.1"
 prost = "0.6.1"
 prost-derive = "0.6.1"
 dogear = "0.4.0"
-saci-interrupt = { path = "../support/interrupt" }
+interrupt-support = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -29,7 +29,7 @@ memchr = "2.2.1"
 prost = "0.6.1"
 prost-derive = "0.6.1"
 dogear = "0.4.0"
-interrupt = { path = "../support/interrupt" }
+saci-interrupt = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -20,7 +20,7 @@ ffi-support = "0.4"
 lazy_static = "1.4.0"
 prost = "0.6.1"
 viaduct = { path = "../../viaduct" }
-saci-interrupt = { path = "../../support/interrupt" }
+interrupt-support = { path = "../../support/interrupt" }
 sql-support = { path = "../../support/sql" }
 sync-guid = { path = "../../support/guid" }
 

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -20,7 +20,7 @@ ffi-support = "0.4"
 lazy_static = "1.4.0"
 prost = "0.6.1"
 viaduct = { path = "../../viaduct" }
-interrupt = { path = "../../support/interrupt" }
+saci-interrupt = { path = "../../support/interrupt" }
 sql-support = { path = "../../support/sql" }
 sync-guid = { path = "../../support/guid" }
 

--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -53,7 +53,7 @@ struct MergeInterruptee<'a, I>(&'a I);
 
 impl<'a, I> AbortSignal for MergeInterruptee<'a, I>
 where
-    I: saci_interrupt::Interruptee,
+    I: interrupt_support::Interruptee,
 {
     #[inline]
     fn aborted(&self) -> bool {

--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -53,7 +53,7 @@ struct MergeInterruptee<'a, I>(&'a I);
 
 impl<'a, I> AbortSignal for MergeInterruptee<'a, I>
 where
-    I: interrupt::Interruptee,
+    I: saci_interrupt::Interruptee,
 {
     #[inline]
     fn aborted(&self) -> bool {

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -5,7 +5,7 @@
 use crate::storage::bookmarks::BookmarkRootGuid;
 use crate::types::BookmarkType;
 use failure::Fail;
-use interrupt::Interrupted;
+use saci_interrupt::Interrupted;
 use serde_json::Value as JsonValue;
 
 // Note: If you add new error types that should be returned to consumers on the other side of the

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -5,7 +5,7 @@
 use crate::storage::bookmarks::BookmarkRootGuid;
 use crate::types::BookmarkType;
 use failure::Fail;
-use saci_interrupt::Interrupted;
+use interrupt_support::Interrupted;
 use serde_json::Value as JsonValue;
 
 // Note: If you add new error types that should be returned to consumers on the other side of the

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -15,8 +15,7 @@ use crate::storage::{
     },
 };
 use crate::types::{Timestamp, VisitTransition};
-use saci_interrupt::Interruptee;
-use serde_json;
+use interrupt_support::Interruptee;
 use std::collections::HashSet;
 use std::time::{SystemTime, UNIX_EPOCH};
 use sync15::telemetry;
@@ -303,7 +302,7 @@ mod tests {
     use crate::storage::history::history_sync::fetch_visits;
     use crate::storage::history::{apply_observation, delete_visits_for, url_to_guid};
     use crate::types::{SyncStatus, Timestamp};
-    use saci_interrupt::NeverInterrupts;
+    use interrupt_support::NeverInterrupts;
     use serde_json::json;
     use sql_support::ConnExt;
     use std::time::Duration;

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -15,7 +15,8 @@ use crate::storage::{
     },
 };
 use crate::types::{Timestamp, VisitTransition};
-use interrupt::Interruptee;
+use saci_interrupt::Interruptee;
+use serde_json;
 use std::collections::HashSet;
 use std::time::{SystemTime, UNIX_EPOCH};
 use sync15::telemetry;
@@ -302,7 +303,7 @@ mod tests {
     use crate::storage::history::history_sync::fetch_visits;
     use crate::storage::history::{apply_observation, delete_visits_for, url_to_guid};
     use crate::types::{SyncStatus, Timestamp};
-    use interrupt::NeverInterrupts;
+    use saci_interrupt::NeverInterrupts;
     use serde_json::json;
     use sql_support::ConnExt;
     use std::time::Duration;

--- a/components/support/interrupt/Cargo.toml
+++ b/components/support/interrupt/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "saci-interrupt"
+name = "interrupt-support"
 version = "0.1.0"
 authors = ["application-services@mozilla.com"]
 license = "MPL-2.0"

--- a/components/support/interrupt/Cargo.toml
+++ b/components/support/interrupt/Cargo.toml
@@ -1,9 +1,6 @@
 [package]
-name = "interrupt"
+name = "saci-interrupt"
 version = "0.1.0"
 authors = ["application-services@mozilla.com"]
 license = "MPL-2.0"
 edition = "2018"
-
-[dependencies]
-failure = "0.1.6"

--- a/components/support/interrupt/src/lib.rs
+++ b/components/support/interrupt/src/lib.rs
@@ -5,10 +5,6 @@
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
-// Helps manage "interruptable" things across our various crates.
-
-use failure::Fail;
-
 // Note that in the future it might make sense to also add a trait for
 // an Interruptable, but we don't need this abstraction now and it's unclear
 // if we ever will.
@@ -19,7 +15,7 @@ use failure::Fail;
 pub trait Interruptee {
     fn was_interrupted(&self) -> bool;
 
-    fn err_if_interrupted(&self) -> std::result::Result<(), Interrupted> {
+    fn err_if_interrupted(&self) -> Result<(), Interrupted> {
         if self.was_interrupted() {
             return Err(Interrupted);
         }
@@ -38,6 +34,13 @@ impl Interruptee for NeverInterrupts {
 }
 
 /// The error returned by err_if_interrupted.
-#[derive(Debug, Fail, Clone, PartialEq)]
-#[fail(display = "The operation was interrupted.")]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Interrupted;
+
+impl std::fmt::Display for Interrupted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("The operation was interrupted")
+    }
+}
+
+impl std::error::Error for Interrupted {}

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -12,7 +12,7 @@ log_query_plans = []
 [dependencies]
 log = "0.4"
 lazy_static = "1.4.0"
-saci-interrupt = { path = "../interrupt" }
+interrupt-support = { path = "../interrupt" }
 ffi-support = "0.4"
 
 [dependencies.rusqlite]

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -12,7 +12,7 @@ log_query_plans = []
 [dependencies]
 log = "0.4"
 lazy_static = "1.4.0"
-interrupt = { path = "../interrupt" }
+saci-interrupt = { path = "../interrupt" }
 ffi-support = "0.4"
 
 [dependencies.rusqlite]

--- a/components/support/sql/src/interrupt.rs
+++ b/components/support/sql/src/interrupt.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use ffi_support::implement_into_ffi_by_pointer;
-use interrupt::Interruptee;
 use rusqlite::InterruptHandle;
+use saci_interrupt::Interruptee;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
@@ -62,7 +62,7 @@ impl SqlInterruptScope {
     }
     /// Add this as an inherent method to reduce the amount of things users have to bring in.
     #[inline]
-    pub fn err_if_interrupted(&self) -> Result<(), interrupt::Interrupted> {
+    pub fn err_if_interrupted(&self) -> Result<(), saci_interrupt::Interrupted> {
         <Self as Interruptee>::err_if_interrupted(self)
     }
 }

--- a/components/support/sql/src/interrupt.rs
+++ b/components/support/sql/src/interrupt.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use ffi_support::implement_into_ffi_by_pointer;
+use interrupt_support::Interruptee;
 use rusqlite::InterruptHandle;
-use saci_interrupt::Interruptee;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
@@ -62,7 +62,7 @@ impl SqlInterruptScope {
     }
     /// Add this as an inherent method to reduce the amount of things users have to bring in.
     #[inline]
-    pub fn err_if_interrupted(&self) -> Result<(), saci_interrupt::Interrupted> {
+    pub fn err_if_interrupted(&self) -> Result<(), interrupt_support::Interrupted> {
         <Self as Interruptee>::err_if_interrupted(self)
     }
 }

--- a/components/support/sync15-traits/Cargo.toml
+++ b/components/support/sync15-traits/Cargo.toml
@@ -17,4 +17,4 @@ ffi-support = "0.4"
 url = "2.1"
 failure = "0.1.6"
 
-saci-interrupt = { path = "../interrupt" }
+interrupt-support = { path = "../interrupt" }

--- a/components/support/sync15-traits/Cargo.toml
+++ b/components/support/sync15-traits/Cargo.toml
@@ -16,3 +16,5 @@ log = "0.4"
 ffi-support = "0.4"
 url = "2.1"
 failure = "0.1.6"
+
+interrupt = { path = "../interrupt" }

--- a/components/support/sync15-traits/Cargo.toml
+++ b/components/support/sync15-traits/Cargo.toml
@@ -17,4 +17,4 @@ ffi-support = "0.4"
 url = "2.1"
 failure = "0.1.6"
 
-interrupt = { path = "../interrupt" }
+saci-interrupt = { path = "../interrupt" }

--- a/components/support/sync15-traits/src/bridged_engine.rs
+++ b/components/support/sync15-traits/src/bridged_engine.rs
@@ -1,0 +1,172 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! These types should eventually move to the `sync15-traits` crate in
+//! Application Services. They're defined in a separate crate in m-c now so
+//! that Golden Gate doesn't rely on their internals.
+
+use std::{sync::Mutex, sync::MutexGuard, sync::PoisonError};
+
+use interrupt::Interruptee;
+
+/// A bridged Sync engine implements all the methods needed to support
+/// Desktop Sync.
+pub trait BridgedEngine {
+    /// The type returned for errors.
+    type Error;
+
+    /// Initializes the engine. This is called once, when the engine is first
+    /// created, and guaranteed to be called before any of the other methods.
+    /// The default implementation does nothing.
+    fn initialize(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    /// Returns the last sync time, in milliseconds, for this engine's
+    /// collection. This is called before each sync, to determine the lower
+    /// bound for new records to fetch from the server.
+    fn last_sync(&self) -> Result<i64, Self::Error>;
+
+    /// Sets the last sync time, in milliseconds. This is called throughout
+    /// the sync, to fast-forward the stored last sync time to match the
+    /// timestamp on the uploaded records.
+    fn set_last_sync(&self, last_sync_millis: i64) -> Result<(), Self::Error>;
+
+    /// Returns the sync ID for this engine's collection. This is only used in
+    /// tests.
+    fn sync_id(&self) -> Result<Option<String>, Self::Error>;
+
+    /// Resets the sync ID for this engine's collection, returning the new ID.
+    /// As a side effect, implementations should reset all local Sync state,
+    /// as in `reset`.
+    fn reset_sync_id(&self) -> Result<String, Self::Error>;
+
+    /// Ensures that the locally stored sync ID for this engine's collection
+    /// matches the `new_sync_id` from the server. If the two don't match,
+    /// implementations should reset all local Sync state, as in `reset`.
+    /// This method returns the assigned sync ID, which can be either the
+    /// `new_sync_id`, or a different one if the engine wants to force other
+    /// devices to reset their Sync state for this collection the next time they
+    /// sync.
+    fn ensure_current_sync_id(&self, new_sync_id: &str) -> Result<String, Self::Error>;
+
+    /// Stages a batch of incoming Sync records. This is called multiple
+    /// times per sync, once for each batch. Implementations can use the
+    /// signal to check if the operation was aborted, and cancel any
+    /// pending work.
+    fn store_incoming(
+        &self,
+        incoming_cleartexts: &[String],
+        signal: &dyn Interruptee,
+    ) -> Result<(), Self::Error>;
+
+    /// Applies all staged records, reconciling changes on both sides and
+    /// resolving conflicts. Returns a list of records to upload.
+    fn apply(&self, signal: &dyn Interruptee) -> Result<Vec<String>, Self::Error>;
+
+    /// Indicates that the given record IDs were uploaded successfully to the
+    /// server. This is called multiple times per sync, once for each batch
+    /// upload.
+    fn set_uploaded(
+        &self,
+        server_modified_millis: i64,
+        ids: &[String],
+        signal: &dyn Interruptee,
+    ) -> Result<(), Self::Error>;
+
+    /// Indicates that all records have been uploaded. At this point, any record
+    /// IDs marked for upload that haven't been passed to `set_uploaded`, can be
+    /// assumed to have failed: for example, because the server rejected a record
+    /// with an invalid TTL or sort index.
+    fn sync_finished(&self, signal: &dyn Interruptee) -> Result<(), Self::Error>;
+
+    /// Resets all local Sync state, including any change flags, mirrors, and
+    /// the last sync time, such that the next sync is treated as a first sync
+    /// with all new local data. Does not erase any local user data.
+    fn reset(&self) -> Result<(), Self::Error>;
+
+    /// Erases all local user data for this collection, and any Sync metadata.
+    /// This method is destructive, and unused for most collections.
+    fn wipe(&self) -> Result<(), Self::Error>;
+
+    /// Tears down the engine. The opposite of `initialize`, `finalize` is
+    /// called when an engine is disabled, or otherwise no longer needed. The
+    /// default implementation does nothing.
+    fn finalize(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// A blanket implementation of `BridgedEngine` for any `Mutex<BridgedEngine>`.
+/// This is provided for convenience, since we expect most bridges to hold
+/// their engines in an `Arc<Mutex<impl BridgedEngine>>`.
+impl<E> BridgedEngine for Mutex<E>
+where
+    E: BridgedEngine,
+    E::Error: for<'a> From<PoisonError<MutexGuard<'a, E>>>,
+{
+    type Error = E::Error;
+
+    fn initialize(&self) -> Result<(), Self::Error> {
+        self.lock()?.initialize()
+    }
+
+    fn last_sync(&self) -> Result<i64, Self::Error> {
+        self.lock()?.last_sync()
+    }
+
+    fn set_last_sync(&self, millis: i64) -> Result<(), Self::Error> {
+        self.lock()?.set_last_sync(millis)
+    }
+
+    fn store_incoming(
+        &self,
+        incoming_cleartexts: &[String],
+        signal: &dyn Interruptee,
+    ) -> Result<(), Self::Error> {
+        self.lock()?.store_incoming(incoming_cleartexts, signal)
+    }
+
+    fn apply(&self, signal: &dyn Interruptee) -> Result<Vec<String>, Self::Error> {
+        self.lock()?.apply(signal)
+    }
+
+    fn set_uploaded(
+        &self,
+        server_modified_millis: i64,
+        ids: &[String],
+        signal: &dyn Interruptee,
+    ) -> Result<(), Self::Error> {
+        self.lock()?
+            .set_uploaded(server_modified_millis, ids, signal)
+    }
+
+    fn sync_finished(&self, signal: &dyn Interruptee) -> Result<(), Self::Error> {
+        self.lock()?.sync_finished(signal)
+    }
+
+    fn reset(&self) -> Result<(), Self::Error> {
+        self.lock()?.reset()
+    }
+
+    fn wipe(&self) -> Result<(), Self::Error> {
+        self.lock()?.wipe()
+    }
+
+    fn finalize(&self) -> Result<(), Self::Error> {
+        self.lock()?.finalize()
+    }
+
+    fn sync_id(&self) -> Result<Option<String>, Self::Error> {
+        self.lock()?.sync_id()
+    }
+
+    fn reset_sync_id(&self) -> Result<String, Self::Error> {
+        self.lock()?.reset_sync_id()
+    }
+
+    fn ensure_current_sync_id(&self, new_sync_id: &str) -> Result<String, Self::Error> {
+        self.lock()?.ensure_current_sync_id(new_sync_id)
+    }
+}

--- a/components/support/sync15-traits/src/bridged_engine.rs
+++ b/components/support/sync15-traits/src/bridged_engine.rs
@@ -8,7 +8,7 @@
 
 use std::{sync::Mutex, sync::MutexGuard, sync::PoisonError};
 
-use interrupt::Interruptee;
+use saci_interrupt::Interruptee;
 
 /// A bridged Sync engine implements all the methods needed to support
 /// Desktop Sync.

--- a/components/support/sync15-traits/src/lib.rs
+++ b/components/support/sync15-traits/src/lib.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #![warn(rust_2018_idioms)]
+mod bridged_engine;
 mod changeset;
 pub mod client;
 mod payload;
@@ -11,6 +12,7 @@ mod server_timestamp;
 mod store;
 pub mod telemetry;
 
+pub use bridged_engine::BridgedEngine;
 pub use changeset::{IncomingChangeset, OutgoingChangeset, RecordChangeset};
 pub use payload::Payload;
 pub use request::{CollectionRequest, RequestOrder};

--- a/components/support/sync15-traits/src/lib.rs
+++ b/components/support/sync15-traits/src/lib.rs
@@ -12,7 +12,7 @@ mod server_timestamp;
 mod store;
 pub mod telemetry;
 
-pub use bridged_engine::BridgedEngine;
+pub use bridged_engine::{ApplyResults, BridgedEngine};
 pub use changeset::{IncomingChangeset, OutgoingChangeset, RecordChangeset};
 pub use payload::Payload;
 pub use request::{CollectionRequest, RequestOrder};

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -22,7 +22,7 @@ base16 = "0.2.1"
 failure = "0.1.6"
 rc_crypto = { path = "../support/rc_crypto", features = ["hawk"] }
 viaduct = { path = "../viaduct" }
-interrupt = { path = "../support/interrupt" }
+saci-interrupt = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 sync15-traits = {path = "../support/sync15-traits"}

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -22,7 +22,7 @@ base16 = "0.2.1"
 failure = "0.1.6"
 rc_crypto = { path = "../support/rc_crypto", features = ["hawk"] }
 viaduct = { path = "../viaduct" }
-saci-interrupt = { path = "../support/interrupt" }
+interrupt-support = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 sync15-traits = {path = "../support/sync15-traits"}

--- a/components/sync15/src/clients/engine.rs
+++ b/components/sync15/src/clients/engine.rs
@@ -14,7 +14,7 @@ use crate::{
     request::{CollectionRequest, InfoConfiguration},
     state::GlobalState,
 };
-use saci_interrupt::Interruptee;
+use interrupt_support::Interruptee;
 use sync15_traits::client::ClientData;
 
 use super::{
@@ -347,8 +347,7 @@ impl<'a> Engine<'a> {
 mod tests {
     use crate::clients::{CommandStatus, DeviceType, Settings};
     use crate::util::ServerTimestamp;
-    use failure;
-    use saci_interrupt::NeverInterrupts;
+    use interrupt_support::NeverInterrupts;
     use serde_json::{json, Value};
     use std::result;
 

--- a/components/sync15/src/clients/engine.rs
+++ b/components/sync15/src/clients/engine.rs
@@ -14,7 +14,7 @@ use crate::{
     request::{CollectionRequest, InfoConfiguration},
     state::GlobalState,
 };
-use interrupt::Interruptee;
+use saci_interrupt::Interruptee;
 use sync15_traits::client::ClientData;
 
 use super::{
@@ -345,13 +345,12 @@ impl<'a> Engine<'a> {
 
 #[cfg(test)]
 mod tests {
-    use std::result;
-
-    use interrupt::NeverInterrupts;
-    use serde_json::{json, Value};
-
     use crate::clients::{CommandStatus, DeviceType, Settings};
     use crate::util::ServerTimestamp;
+    use failure;
+    use saci_interrupt::NeverInterrupts;
+    use serde_json::{json, Value};
+    use std::result;
 
     use super::*;
 

--- a/components/sync15/src/error.rs
+++ b/components/sync15/src/error.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use failure::Fail;
-use interrupt::Interrupted;
 use rc_crypto::hawk;
+use saci_interrupt::Interrupted;
 use std::string;
 use std::time::SystemTime;
 use sync15_traits::request::UnacceptableBaseUrl;

--- a/components/sync15/src/error.rs
+++ b/components/sync15/src/error.rs
@@ -3,8 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use failure::Fail;
+use interrupt_support::Interrupted;
 use rc_crypto::hawk;
-use saci_interrupt::Interrupted;
 use std::string;
 use std::time::SystemTime;
 use sync15_traits::request::UnacceptableBaseUrl;

--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -12,7 +12,7 @@ use crate::key_bundle::KeyBundle;
 use crate::record_types::{MetaGlobalEngine, MetaGlobalRecord};
 use crate::request::{InfoCollections, InfoConfiguration};
 use crate::util::ServerTimestamp;
-use interrupt::Interruptee;
+use saci_interrupt::Interruptee;
 use serde_derive::*;
 use sync_guid::Guid;
 
@@ -666,7 +666,7 @@ mod tests {
 
     use crate::bso_record::{BsoRecord, EncryptedBso, EncryptedPayload, Payload};
     use crate::record_types::CryptoKeysRecord;
-    use interrupt::NeverInterrupts;
+    use saci_interrupt::NeverInterrupts;
 
     struct InMemoryClient {
         info_configuration: error::Result<Sync15ClientResponse<InfoConfiguration>>,

--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -12,7 +12,7 @@ use crate::key_bundle::KeyBundle;
 use crate::record_types::{MetaGlobalEngine, MetaGlobalRecord};
 use crate::request::{InfoCollections, InfoConfiguration};
 use crate::util::ServerTimestamp;
-use saci_interrupt::Interruptee;
+use interrupt_support::Interruptee;
 use serde_derive::*;
 use sync_guid::Guid;
 
@@ -666,7 +666,7 @@ mod tests {
 
     use crate::bso_record::{BsoRecord, EncryptedBso, EncryptedPayload, Payload};
     use crate::record_types::CryptoKeysRecord;
-    use saci_interrupt::NeverInterrupts;
+    use interrupt_support::NeverInterrupts;
 
     struct InMemoryClient {
         info_configuration: error::Result<Sync15ClientResponse<InfoConfiguration>>,

--- a/components/sync15/src/sync.rs
+++ b/components/sync15/src/sync.rs
@@ -10,7 +10,7 @@ use crate::error::Error;
 use crate::key_bundle::KeyBundle;
 use crate::state::GlobalState;
 use crate::telemetry;
-use interrupt::Interruptee;
+use saci_interrupt::Interruptee;
 
 pub use sync15_traits::{IncomingChangeset, Store};
 

--- a/components/sync15/src/sync.rs
+++ b/components/sync15/src/sync.rs
@@ -10,7 +10,7 @@ use crate::error::Error;
 use crate::key_bundle::KeyBundle;
 use crate::state::GlobalState;
 use crate::telemetry;
-use saci_interrupt::Interruptee;
+use interrupt_support::Interruptee;
 
 pub use sync15_traits::{IncomingChangeset, Store};
 

--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -15,7 +15,7 @@ use crate::status::{ServiceStatus, SyncResult};
 use crate::sync::{self, Store};
 use crate::telemetry;
 use failure::Fail;
-use interrupt::Interruptee;
+use saci_interrupt::Interruptee;
 use std::collections::HashMap;
 use std::mem;
 use std::result;

--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -15,7 +15,7 @@ use crate::status::{ServiceStatus, SyncResult};
 use crate::sync::{self, Store};
 use crate::telemetry;
 use failure::Fail;
-use saci_interrupt::Interruptee;
+use interrupt_support::Interruptee;
 use std::collections::HashMap;
 use std::mem;
 use std::result;

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -23,4 +23,4 @@ url = "2.1.1"
 serde = "1.0.104"
 serde_derive = "1.0.104"
 serde_json = "1.0.50"
-saci-interrupt = { path = "../support/interrupt" }
+interrupt-support = { path = "../support/interrupt" }

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -23,4 +23,4 @@ url = "2.1.1"
 serde = "1.0.104"
 serde_derive = "1.0.104"
 serde_json = "1.0.50"
-interrupt = { path = "../support/interrupt" }
+saci-interrupt = { path = "../support/interrupt" }

--- a/components/sync_manager/src/error.rs
+++ b/components/sync_manager/src/error.rs
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 use failure::Fail;
-use logins;
-use places;
-use saci_interrupt::Interrupted;
-use sync15;
+use interrupt_support::Interrupted;
 
 #[derive(Debug, Fail)]
 pub enum ErrorKind {

--- a/components/sync_manager/src/error.rs
+++ b/components/sync_manager/src/error.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 use failure::Fail;
-use interrupt::Interrupted;
+use logins;
+use places;
+use saci_interrupt::Interrupted;
+use sync15;
 
 #[derive(Debug, Fail)]
 pub enum ErrorKind {

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -21,7 +21,7 @@ prost = "0.6.1"
 prost-derive = "0.6.1"
 ffi-support = "0.4"
 error-support = { path = "../support/error" }
-interrupt = { path = "../support/interrupt" }
+saci-interrupt = { path = "../support/interrupt" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 
 [dev-dependencies]

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -21,7 +21,7 @@ prost = "0.6.1"
 prost-derive = "0.6.1"
 ffi-support = "0.4"
 error-support = { path = "../support/error" }
-saci-interrupt = { path = "../support/interrupt" }
+interrupt-support = { path = "../support/interrupt" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 
 [dev-dependencies]

--- a/components/tabs/src/sync/engine.rs
+++ b/components/tabs/src/sync/engine.rs
@@ -5,7 +5,7 @@
 use crate::error::*;
 use crate::storage::{ClientRemoteTabs, RemoteTab, TabsStorage};
 use crate::sync::store::TabsStore;
-use interrupt::NeverInterrupts;
+use saci_interrupt::NeverInterrupts;
 use std::cell::{Cell, RefCell};
 use sync15::{sync_multiple, telemetry, KeyBundle, MemoryCachedState, Sync15StorageClientInit};
 

--- a/components/tabs/src/sync/engine.rs
+++ b/components/tabs/src/sync/engine.rs
@@ -5,7 +5,7 @@
 use crate::error::*;
 use crate::storage::{ClientRemoteTabs, RemoteTab, TabsStorage};
 use crate::sync::store::TabsStore;
-use saci_interrupt::NeverInterrupts;
+use interrupt_support::NeverInterrupts;
 use std::cell::{Cell, RefCell};
 use sync15::{sync_multiple, telemetry, KeyBundle, MemoryCachedState, Sync15StorageClientInit};
 

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 [dependencies]
 error-support = { path = "../support/error" }
 failure = "0.1.6"
-saci-interrupt = { path = "../support/interrupt" }
+interrupt-support = { path = "../support/interrupt" }
 lazy_static = "1.4.0"
 log = "0.4"
 serde = "1"

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 [dependencies]
 error-support = { path = "../support/error" }
 failure = "0.1.6"
-interrupt = { path = "../support/interrupt" }
+saci-interrupt = { path = "../support/interrupt" }
 lazy_static = "1.4.0"
 log = "0.4"
 serde = "1"

--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use failure::Fail;
-use interrupt::Interrupted;
+use saci_interrupt::Interrupted;
 
 #[derive(Debug)]
 pub enum QuotaReason {

--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use failure::Fail;
-use saci_interrupt::Interrupted;
+use interrupt_support::Interrupted;
 
 #[derive(Debug)]
 pub enum QuotaReason {


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1626128 / https://jira.mozilla.com/browse/SYNC-1033

Last commit might be all we need to do for https://bugzilla.mozilla.org/show_bug.cgi?id=1628892 / https://jira.mozilla.com/browse/SYNC-1088

I also renamed `interrupt` to `saci-interrupt` and made it manually implement errors. Failure is a really slow dependency to compile, and saved us like 5 lines, and also this is a dep very specific to our team and so it kinda should reflect that (I've always kind of hated how broad it's name was). I used `saci-` over `as-` since the latter is an english word.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
