### PR TITLE
Update ece to 1.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,15 +94,6 @@ checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "base64"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
@@ -542,11 +533,11 @@ checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
 name = "ece"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63d22c3e9165d2a16da68804e1d8fcda3a822b091d255c57f68969fe17b9d35"
+checksum = "2e831571186ec514efc697af518eee5e4aaecc13edeb4a918227f7bcba2c20b1"
 dependencies = [
- "base64 0.10.1",
+ "base64 0.12.0",
  "byteorder",
  "failure",
  "failure_derive",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -437,7 +437,6 @@ The following text applies to code linked from these dependencies:
 [autocfg](https://github.com/cuviper/autocfg),
 [backtrace-sys](https://github.com/alexcrichton/backtrace-rs),
 [backtrace](https://github.com/rust-lang/backtrace-rs),
-[base64](https://github.com/alicemaz/rust-base64),
 [base64](https://github.com/marshallpierce/rust-base64),
 [bitflags](https://github.com/bitflags/bitflags),
 [cc](https://github.com/alexcrichton/cc-rs),

--- a/components/support/rc_crypto/Cargo.toml
+++ b/components/support/rc_crypto/Cargo.toml
@@ -16,7 +16,7 @@ error-support = { path = "../error" }
 nss = { path = "nss" }
 libsqlite3-sys = { version = "0.17.2", features = ["bundled"] }
 hawk = { version = "3.1.0", default-features = false, optional = true }
-ece = { version = "1.1.0", default-features = false, features = ["serializable-keys"], optional = true }
+ece = { version = "1.1.2", default-features = false, features = ["serializable-keys"], optional = true }
 
 [dev-dependencies]
 hex = "0.4.0"

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -419,7 +419,6 @@ The following text applies to code linked from these dependencies:
 [anyhow](https://github.com/dtolnay/anyhow),
 [backtrace-sys](https://github.com/alexcrichton/backtrace-rs),
 [backtrace](https://github.com/rust-lang/backtrace-rs),
-[base64](https://github.com/alicemaz/rust-base64),
 [base64](https://github.com/marshallpierce/rust-base64),
 [bitflags](https://github.com/bitflags/bitflags),
 [cc](https://github.com/alexcrichton/cc-rs),

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -34,10 +34,6 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: base64</name>
-    <url>https://github.com/alicemaz/rust-base64/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: base64</name>
     <url>https://github.com/marshallpierce/rust-base64/blob/master/LICENSE-APACHE</url>
   </license>
   <license>

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -429,7 +429,6 @@ The following text applies to code linked from these dependencies:
 [autocfg](https://github.com/cuviper/autocfg),
 [backtrace-sys](https://github.com/alexcrichton/backtrace-rs),
 [backtrace](https://github.com/rust-lang/backtrace-rs),
-[base64](https://github.com/alicemaz/rust-base64),
 [base64](https://github.com/marshallpierce/rust-base64),
 [bitflags](https://github.com/bitflags/bitflags),
 [cc](https://github.com/alexcrichton/cc-rs),

--- a/megazords/lockbox/DEPENDENCIES.md
+++ b/megazords/lockbox/DEPENDENCIES.md
@@ -417,7 +417,6 @@ The following text applies to code linked from these dependencies:
 [anyhow](https://github.com/dtolnay/anyhow),
 [backtrace-sys](https://github.com/alexcrichton/backtrace-rs),
 [backtrace](https://github.com/rust-lang/backtrace-rs),
-[base64](https://github.com/alicemaz/rust-base64),
 [base64](https://github.com/marshallpierce/rust-base64),
 [bitflags](https://github.com/bitflags/bitflags),
 [cc](https://github.com/alexcrichton/cc-rs),

--- a/megazords/lockbox/android/dependency-licenses.xml
+++ b/megazords/lockbox/android/dependency-licenses.xml
@@ -34,10 +34,6 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: base64</name>
-    <url>https://github.com/alicemaz/rust-base64/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: base64</name>
     <url>https://github.com/marshallpierce/rust-base64/blob/master/LICENSE-APACHE</url>
   </license>
   <license>


### PR DESCRIPTION
1 less copy of base64 in moz-central 🎉 