### PR TITLE
Document our decision to encourage, but not enforce, signed commits.

### DIFF
--- a/docs/build-and-publish-pipeline.md
+++ b/docs/build-and-publish-pipeline.md
@@ -37,14 +37,20 @@ For Android consumers these are the steps by which Application Services code bec
 and the integrity-protection mechanisms that apply at each step:
 
 1. Code is developed in branches and lands on `master` via pull request.
-    * GitHub branch protection prevents code being pushed to `master` without review,
-      and requires signed tags (but doesn't check *who* they're signed by).
+    * GitHub branch protection prevents code being pushed to `master` without review.
     * CircleCI and TaskCluster run automated tests against the code, but do not have
       the ability to push modified code back to GitHub thanks to the above branch protection.
       * TaskCluster jobs do not run against PRs opened by the general public,
         only for PRs from repo collaborators.
+    * Contra the [github org security guidelines](https://wiki.mozilla.org/GitHub/Repository_Security),
+      signing of individual commits is encouraged but is **not required**. Our experience in practice
+      has been that this adds friction for contributors without sufficient tangible benefit.
 2. Developers manually create a release from latest `master`.
     * The ability to create new releases is managed entirely via github's permission model.
+    * TODO: the [github org security guidelines](https://wiki.mozilla.org/GitHub/Repository_Security)
+      recommend signing tags, and auditing all included commits as part of the release process.
+      We should conider some tooling to support this. I don't think there's any way to force 
+      githib to only accept signed releases in the same way it can enforce signed commits.
 3. TaskCluster checks out the release tag, builds it for all target platforms, and runs automated tests.
     * These tasks run in a pre-built docker image, helping assure integrity of the build environment.
     * TODO: could this step check for signed tags as an additional integrity measure?

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,7 +53,7 @@ When submitting a PR:
 - Base your branch off the current `master` (see below for an example workflow).
 - Add both your code and new tests if relevant.
 - Please do not include merge commits in pull requests; include only commits with the new relevant code.
-- Your patch must be [GPG signed](https://help.github.com/articles/managing-commit-signature-verification) to ensure the commits come from a trusted source.
+- We encourage you to [GPG sign your commits](https://help.github.com/articles/managing-commit-signature-verification).
 
 ## Code Review ##
 


### PR DESCRIPTION
In the Kitchen Sync meeting earlier today, we discussed how the current restriction of only landing signed commits on master has proved to be an ongoing pain point without any tangible benefits. The GitHub org security checklist says that requiring signed commits is "strongly encouraged" and that if we don't do it, we should document the reasons why.

So, I'm documenting the reasons why and I will disable the config in github once this documentation change lands on master. If you strongly disagree with this course of action, now's your change to speak up.

(FWIW, I will continue to sign my commits, because I think we can get to a world where the workflow is less annoying and the benefits more tangible, and I'd encourage others to do the same.)