### PR TITLE
Add mergify to repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 version: 2.1
 
+# ⚠️ If you add, rename or delete a job here, please also update .mergify.yml! ⚠️
+
 commands:
   setup-sccache:
     steps:
@@ -509,7 +511,7 @@ workflows:
   carthage-framework:
     jobs:
       - iOS build and test:
-          filters:  # required since `Release` has tag filters AND requires `Build`
+          filters: # required since `Release` has tag filters AND requires `Build`
             tags:
               only: /.*/
       - Carthage release:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,69 @@
+pull_request_rules:
+  - name: remove outdated reviews for non-core authors
+    conditions:
+      - base=master
+      - author!=@mozilla/application-services
+    actions:
+      dismiss_reviews:
+        message: The pull request has been modified, dismissing previous reviews.
+      label:
+        remove:
+          - checkin-needed
+  - name: automatic merge for master
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=master
+      - label=checkin-needed
+      - "status-success=android-build-pr"
+      - "status-success=lint-detekt"
+      - "status-success=lint-ktlint"
+      - "status-success=ci/circleci: Check Protobuf files are up-to-date"
+      - "status-success=ci/circleci: Check Rust dependencies"
+      - "status-success=ci/circleci: Check Rust formatting"
+      - "status-success=ci/circleci: Check Swift formatting"
+      - "status-success=ci/circleci: Lint Bash scripts"
+      - "status-success=ci/circleci: Lint Rust with clippy"
+      - "status-success=ci/circleci: Rust benchmarks"
+      - "status-success=ci/circleci: Rust tests"
+      - "status-success=ci/circleci: Sync integration tests"
+      - "status-success=ci/circleci: iOS build and test"
+    actions:
+      merge:
+        method: merge
+        strict: smart
+        strict_method: rebase
+  # Copy pasta of above, with different checks.
+  - name: automatic merge for master (CI FULL)
+    conditions:
+      - "#approved-reviews-by>=1"
+      - base=master
+      - label=checkin-needed
+      - "status-success=module-build-logins"
+      - "status-success=module-build-httpconfig"
+      - "status-success=module-build-full-megazord"
+      - "status-success=module-build-tabs"
+      - "status-success=module-build-lockbox-megazord"
+      - "status-success=module-build-rustlog"
+      - "status-success=module-build-places"
+      - "status-success=module-build-sync15"
+      - "status-success=module-build-syncmanager"
+      - "status-success=module-build-fxaclient"
+      - "status-success=module-build-push"
+      - "status-success=module-build-native-support"
+      - "status-success=lint-detekt"
+      - "status-success=lint-ktlint"
+      - "status-success=ci/circleci: Check Protobuf files are up-to-date"
+      - "status-success=ci/circleci: Check Rust dependencies"
+      - "status-success=ci/circleci: Check Rust formatting"
+      - "status-success=ci/circleci: Check Swift formatting"
+      - "status-success=ci/circleci: Lint Bash scripts"
+      - "status-success=ci/circleci: Lint Rust with clippy"
+      - "status-success=ci/circleci: Rust benchmarks"
+      - "status-success=ci/circleci: Rust tests"
+      - "status-success=ci/circleci: Sync integration tests"
+      - "status-success=ci/circleci: iOS build and test"
+    actions:
+      merge:
+        method: merge
+        strict: smart
+        strict_method: rebase

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
+# ⚠️ If you add, rename or delete a job here, please also update .mergify.yml! ⚠️
+
 loader: taskgraph.loader.transform:loader
 
 transforms:
@@ -26,7 +28,7 @@ jobs:
       - project:releng:services/tooltool/api/download/internal
     worker-type: b-linux
     worker:
-      docker-image: {in-tree: linux}
+      docker-image: { in-tree: linux }
       max-run-time: 1800
       script: |
         rsync -a /builds/worker/fetches/libs/ /builds/worker/checkouts/src/libs/
@@ -36,7 +38,7 @@ jobs:
         ./gradlew --no-daemon testDebug
     run:
       using: run-task
-      cwd: '{checkout}'
+      cwd: "{checkout}"
     fetches:
       toolchain:
         - android-libs

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
+# ⚠️ If you add, rename or delete a job here, please also update .mergify.yml! ⚠️
+
 loader: taskgraph.loader.transform:loader
 
 transforms:
@@ -11,18 +13,18 @@ transforms:
 job-defaults:
   worker-type: b-linux
   worker:
-    docker-image: {in-tree: linux}
+    docker-image: { in-tree: linux }
     max-run-time: 1800
   run:
     using: run-task
-    cwd: '{checkout}'
+    cwd: "{checkout}"
 
 jobs:
   detekt:
-    description: 'detekt'
+    description: "detekt"
     run:
       command: ./gradlew --no-daemon clean detekt
   ktlint:
-    description: 'ktlint'
+    description: "ktlint"
     run:
       command: ./gradlew --no-daemon clean ktlint

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
+# ⚠️ If you add, rename or delete a job here, please also update .mergify.yml! ⚠️
+
 loader: app_services_taskgraph.loader.build_config:loader
 
 transforms:
@@ -18,12 +20,12 @@ job-defaults:
   attributes:
     run-on-pr-type: full-ci
   run-on-tasks-for: [github-pull-request]
-  description: '{module_name} - Build and test'
+  description: "{module_name} - Build and test"
   scopes:
     - project:releng:services/tooltool/api/download/internal
   worker-type: b-linux
   worker:
-    docker-image: {in-tree: linux}
+    docker-image: { in-tree: linux }
     max-run-time: 1800
     script: |
       rsync -a /builds/worker/fetches/libs/ /builds/worker/checkouts/src/libs/
@@ -34,7 +36,7 @@ job-defaults:
       ./gradlew --no-daemon ":{module_name}:checkMavenArtifacts"
   run:
     using: run-task
-    cwd: '{checkout}'
+    cwd: "{checkout}"
   fetches:
     toolchain:
       - android-libs


### PR DESCRIPTION
We can now have an auto-merging bot in our repository thanks to the removal of the signed commits requirement. Bors is not approved at Mozilla but Mergify seems ok, so how about we give it a try?

Automatic merge will happen if all the following conditions are true:
- There's at least 1 approved review
- For non-team members: approved reviews are not stale
- The "checkin-needed" label is present
- All the CI jobs have passed