### PR TITLE
Exclude mobile bindings from cargo packaging

### DIFF
--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["Edouard Oger <eoger@fastmail.com>"]
 license = "MPL-2.0"
+exclude = ["/android", "/ios"]
 
 [dependencies]
 base64 = "0.12.0"

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 license = "MPL-2.0"
+exclude = ["/android", "/ios"]
 
 [features]
 log_query_plans = ["sql-support/log_query_plans"]

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["application-services@mozilla.com"]
 license = "MPL-2.0"
+exclude = ["/android", "/ios"]
 
 [features]
 log_query_plans = ["sql-support/log_query_plans"]
@@ -31,7 +32,6 @@ dogear = "0.4.0"
 interrupt = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
-
 
 [dependencies.rusqlite]
 version = "0.22.0"

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["jrconlin <me+crypt@jrconlin.com>", "Phil Jenvey <pjenvey@underboss.org>"]
 license = "MPL-2.0"
+exclude = ["/android", "/ios"]
 
 [features]
 default = []

--- a/components/rc_log/Cargo.toml
+++ b/components/rc_log/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2018"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 license = "MPL-2.0"
+exclude = ["/android", "/ios"]
 
 [lib]
 name = "rc_log_ffi"

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 license = "MPL-2.0"
+exclude = ["/android", "/ios"]
 
 [features]
 default = []

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["application-services <application-services@mozilla.com>"]
 edition = "2018"
 license = "MPL-2.0"
+exclude = ["/android", "/ios"]
 
 [dependencies]
 sync15 = { path = "../sync15" }

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2018"
 version = "0.1.0"
 authors = ["application-services@mozilla.com"]
 license = "MPL-2.0"
+exclude = ["/android", "/ios"]
 
 [features]
 default = []

--- a/components/viaduct/Cargo.toml
+++ b/components/viaduct/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 edition = "2018"
 license = "MPL-2.0"
+exclude = ["/android", "/ios"]
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
I've noticed while vendoring `fxa-client` on mozilla-central that the `android` and `ios` folders also get pulled in.