### PR TITLE
Derive Serialize for AccountEvent and IncomingDeviceCommand

### DIFF
--- a/components/fxa-client/src/commands/send_tab.rs
+++ b/components/fxa-client/src/commands/send_tab.rs
@@ -38,7 +38,7 @@ impl EncryptedSendTabPayload {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SendTabPayload {
     pub entries: Vec<TabHistoryEntry>,
 }
@@ -69,7 +69,7 @@ impl SendTabPayload {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TabHistoryEntry {
     pub title: String,
     pub url: String,

--- a/components/fxa-client/src/http_client.rs
+++ b/components/fxa-client/src/http_client.rs
@@ -507,7 +507,7 @@ pub struct CommandData {
     pub sender: Option<String>,
 }
 
-#[derive(Clone, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PushSubscription {
     #[serde(rename = "pushCallback")]
     pub endpoint: String,
@@ -540,7 +540,7 @@ pub struct DeviceUpdateRequest<'a> {
     available_commands: Option<Option<&'a HashMap<String, String>>>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum DeviceType {
     #[serde(rename = "desktop")]
     Desktop,
@@ -616,7 +616,7 @@ impl<'a> DeviceUpdateRequestBuilder<'a> {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeviceLocation {
     pub city: Option<String>,
     pub country: Option<String>,
@@ -625,7 +625,7 @@ pub struct DeviceLocation {
     pub state_code: Option<String>,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct GetDeviceResponse {
     #[serde(flatten)]
     pub common: DeviceResponseCommon,
@@ -645,7 +645,7 @@ impl std::ops::Deref for GetDeviceResponse {
 
 pub type UpdateDeviceResponse = DeviceResponseCommon;
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DeviceResponseCommon {
     pub id: String,
     #[serde(rename = "name")]

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -239,20 +239,29 @@ impl FirefoxAccount {
     }
 }
 
+#[derive(Debug, Serialize)]
+#[serde(tag = "eventType", content = "data")]
+#[serde(rename_all = "camelCase")]
 pub enum AccountEvent {
     IncomingDeviceCommand(Box<IncomingDeviceCommand>),
     ProfileUpdated,
     AccountAuthStateChanged,
     AccountDestroyed,
+    // Can be removed when https://github.com/serde-rs/serde/pull/1695 lands.
+    #[serde(rename_all = "camelCase")]
     DeviceConnected {
         device_name: String,
     },
+    #[serde(rename_all = "camelCase")]
     DeviceDisconnected {
         device_id: String,
         is_local_device: bool,
     },
 }
 
+#[derive(Debug, Serialize)]
+#[serde(tag = "commandType", content = "data")]
+#[serde(rename_all = "camelCase")]
 pub enum IncomingDeviceCommand {
     TabReceived {
         sender: Option<Device>,


### PR DESCRIPTION
Can't serialize to JSON these structs on moz-central. I've also derived `Debug` coz it's always useful.