### PR TITLE
Merge v0.55.3 to release branch

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 0.55.2
+libraryVersion: 0.55.3
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.55.3 (_2020-04-16_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.55.2...v0.55.3)
+
+## Places
+
+- Fix table name for history migration
+
 # v0.55.2 (_2020-04-14_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.55.1...v0.55.2)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.55.2...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.55.3...master)

--- a/components/places/src/import/fennec/history.rs
+++ b/components/places/src/import/fennec/history.rs
@@ -163,7 +163,7 @@ lazy_static::lazy_static! {
 
     // Count Fennec history visits
     static ref COUNT_FENNEC_HISTORY_VISITS: &'static str =
-        "SELECT COUNT(*) FROM fennec.history"
+        "SELECT COUNT(*) FROM fennec.visits"
     ;
 
     // Count Fenix history visits


### PR DESCRIPTION
Looks like the v0.55.3 release didn't get merged to the release-v0.55 branch. It needs to land there so that any future v0.55 dot-releases include the fix.