### PR TITLE
Apply CI FULL rule only on [ci full] tagged PRs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -35,6 +35,7 @@ pull_request_rules:
   # Copy pasta of above, with different checks.
   - name: automatic merge for master (CI FULL)
     conditions:
+      - title~=\[ci full\]
       - "#approved-reviews-by>=1"
       - base=master
       - label=checkin-needed


### PR DESCRIPTION
It's not technically needed, but it should make rules clearer to follow.