### PR TITLE
Bug 1563169 - add Taskcluster support for master pushes

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -55,6 +55,7 @@ tasks:
           else:
               $if: 'tasks_for == "github-push"'
               then: '${event.pusher.email}'
+              # Assume Pull Request
               else:
                   $if: 'tasks_for == "github-pull-request"'
                   then: '${event.pull_request.user.login}@users.noreply.github.com'
@@ -197,142 +198,156 @@ tasks:
               taskclusterProxy: true
       in:
         $match:
-          "tasks_for == 'github-pull-request' && event['action'] in ['opened', 'reopened', 'edited', 'synchronize']":
+          "(tasks_for == 'github-pull-request' && event['action'] in ['opened', 'reopened', 'synchronize']) || (tasks_for == 'github-push' && head_branch[:10] != 'refs/tags/')":
             $let:
               level:
                 $if: 'tasks_for in ["github-push", "github-release"] && repoUrl == "https://github.com/mozilla/application-services"'
                 then: '3'
                 else: '1'
+              short_head_branch:
+                $if: 'head_branch[:11] == "refs/heads/"'
+                then: {$eval: 'head_branch[11:]'}
             in:
-              taskId: '${ownTaskId}'
-              taskGroupId:
-                  $if: 'tasks_for == "action"'
-                  then:
-                      '${action.taskGroupId}'
-                  else:
-                      '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
-              schedulerId: '${trustDomain}-level-${level}'
-              created: {$fromNow: ''}
-              deadline: {$fromNow: '1 day'}
-              expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first, despite rounding errors
-              metadata:
-                $merge:
-                  - owner: "${ownerEmail}"
-                    source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
-                  - $if: 'tasks_for in ["github-push", "github-pull-request", "github-release"]'
+              $mergeDeep:
+                - taskGroupId:
+                    $if: 'tasks_for == "action"'
                     then:
-                      name: "Decision Task"
-                      description: 'The task that creates all of the other tasks in the task graph'
-              provisionerId: "app-services-${level}"
-              workerType: "decision"
-              tags:
-                kind: decision-task
-              routes:
-                - checks
-              scopes:
-                # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
-                $if: 'tasks_for == "github-push"'
-                then:
-                  $let:
-                    short_head_branch:
-                      $if: 'head_branch[:11] == "refs/heads/"'
-                      then: {$eval: 'head_branch[11:]'}
-                      else: ${head_branch}
-                  in:
-                    - 'assume:repo:${repoUrl[8:]}:branch:${short_head_branch}'
-                else:
-                  $if: 'tasks_for == "github-pull-request"'
-                  then:
-                    - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
-                  else:
-                    $if: 'tasks_for == "github-release"'
+                        '${action.taskGroupId}'
+                    else:
+                        '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
+                  taskId: '${ownTaskId}'
+                  schedulerId: '${trustDomain}-level-${level}'
+                  created: {$fromNow: ''}
+                  deadline: {$fromNow: '1 day'}
+                  expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first, despite rounding errors
+                  metadata:
+                    $merge:
+                      - owner: "${ownerEmail}"
+                        source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
+                      - $if: 'tasks_for in ["github-push", "github-pull-request", "github-release"]'
+                        then:
+                          name: "Decision Task"
+                          description: 'The task that creates all of the other tasks in the task graph'
+                  provisionerId: "app-services-${level}"
+                  workerType: "decision"
+                  tags:
+                    $if: 'tasks_for in ["github-push", "github-pull-request"]'
                     then:
-                      - 'assume:repo:${repoUrl[8:]}:release'
-
-              requires: all-completed
-              priority: lowest
-              retries: 5
-
-              payload:
-                env:
-                  # run-task uses these to check out the source; the inputs
-                  # to `mach taskgraph decision` are all on the command line.
-                  $merge:
-                    - APPSERVICES_BASE_REPOSITORY: '${baseRepoUrl}'
-                      APPSERVICES_HEAD_REPOSITORY: '${repoUrl}'
-                      APPSERVICES_HEAD_REF: '${head_branch}'
-                      APPSERVICES_HEAD_REV: '${head_sha}'
-                      APPSERVICES_REPOSITORY_TYPE: git
-                      TASKGRAPH_BASE_REPOSITORY: https://hg.mozilla.org/ci/taskgraph
-                      TASKGRAPH_HEAD_REPOSITORY: https://hg.mozilla.org/ci/${taskgraph.branch}
-                      TASKGRAPH_HEAD_REV: ${taskgraph.revision}
-                      TASKGRAPH_REPOSITORY_TYPE: hg
-                      REPOSITORIES: {$json: {appservices: "Application Services", taskgraph: "Taskgraph"}}
-                      HG_STORE_PATH: /builds/worker/checkouts/hg-store
-                      ANDROID_SDK_ROOT: /builds/worker/android-sdk
-                      MOZ_FETCHES_DIR: /builds/worker/checkouts/src
-                    - $if: 'tasks_for in ["github-pull-request"]'
+                      kind: decision-task
+                  routes:
+                    $flattenDeep:
+                      - checks
+                      - $if: 'level == "3"'
+                        then:
+                          - tc-treeherder.v2.${project}.${head_sha}
+                          # TODO Bug 1601928: Make this scope fork-friendly once ${project} is better defined. This will enable
+                          # staging release promotion on forks.
+                          - $if: 'tasks_for == "github-push"'
+                            then:
+                              - index.project.${project}.v2.branch.${short_head_branch}.latest.taskgraph.decision
+                              - index.project.${project}.v2.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
+                          - $if: 'tasks_for == "cron"'
+                            then:
+                              # cron context provides ${head_branch} as a short one
+                              - index.project.${project}.v2.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
+                              - index.project.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
+                              - index.project.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
+                  scopes:
+                    $if: 'tasks_for == "github-push"'
+                    then:
+                      # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
+                      - 'assume:repo:${repoUrl[8:]}:branch:${short_head_branch}'
+                    else:
+                      $if: 'tasks_for == "github-pull-request"'
                       then:
-                        APPSERVICES_PULL_REQUEST_TITLE: '${event.pull_request.title}'
-                        APPSERVICES_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
-                features:
-                  taskclusterProxy: true
-                  chainOfTrust: true
-                # Note: This task is built server side without the context or tooling that
-                # exist in tree so we must hard code the hash
-                image:
-                  mozillareleases/taskgraph:decision-mobile-6020473b1a928d8df50e234a7ca2e81ade2220a4fb5fbe16b02477dd64a49728@sha256:98d226736b7d03907114bf37938002b90e8a37cbe3a297690e349f1ddddb1d7c
+                        - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
+                      else:
+                        $if: 'tasks_for == "github-release"'
+                        then:
+                          - 'assume:repo:${repoUrl[8:]}:release'
+                        else:
+                          $if: 'tasks_for == "action"'
+                          then:
+                            # when all actions are hooks, we can calculate this directly rather than using a variable
+                            - '${action.repo_scope}'
+                          else:
+                            - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
+                  requires: all-completed
+                  priority: lowest
+                  retries: 5
 
-                maxRunTime: 1800
+                  payload:
+                    env:
+                      # run-task uses these to check out the source; the inputs
+                      # to `mach taskgraph decision` are all on the command line.
+                      $merge:
+                        - APPSERVICES_BASE_REPOSITORY: '${baseRepoUrl}'
+                          APPSERVICES_HEAD_REPOSITORY: '${repoUrl}'
+                          APPSERVICES_HEAD_REF: '${head_branch}'
+                          APPSERVICES_HEAD_REV: '${head_sha}'
+                          APPSERVICES_REPOSITORY_TYPE: git
+                          TASKGRAPH_BASE_REPOSITORY: https://hg.mozilla.org/ci/taskgraph
+                          TASKGRAPH_HEAD_REPOSITORY: https://hg.mozilla.org/ci/${taskgraph.branch}
+                          TASKGRAPH_HEAD_REV: ${taskgraph.revision}
+                          TASKGRAPH_REPOSITORY_TYPE: hg
+                          REPOSITORIES: {$json: {appservices: "Application Services", taskgraph: "Taskgraph"}}
+                          HG_STORE_PATH: /builds/worker/checkouts/hg-store
+                          ANDROID_SDK_ROOT: /builds/worker/android-sdk
+                          MOZ_FETCHES_DIR: /builds/worker/checkouts/src
+                        - $if: 'tasks_for in ["github-pull-request"]'
+                          then:
+                            APPSERVICES_PULL_REQUEST_TITLE: '${event.pull_request.title}'
+                            APPSERVICES_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
+                    features:
+                      taskclusterProxy: true
+                      chainOfTrust: true
+                    # Note: This task is built server side without the context or tooling that
+                    # exist in tree so we must hard code the hash
+                    image:
+                      mozillareleases/taskgraph:decision-mobile-6020473b1a928d8df50e234a7ca2e81ade2220a4fb5fbe16b02477dd64a49728@sha256:98d226736b7d03907114bf37938002b90e8a37cbe3a297690e349f1ddddb1d7c
 
-                command:
-                  - /usr/local/bin/run-task
-                  - '--appservices-checkout=/builds/worker/checkouts/src'
-                  - '--taskgraph-checkout=/builds/worker/checkouts/taskgraph'
-                  - '--task-cwd=/builds/worker/checkouts/src'
-                  - '--'
-                  - bash
-                  - -cx
-                  - >
-                    PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
-                    PIP_IGNORE_INSTALLED=0 pip install --user arrow taskcluster pyyaml &&
-                    ln -s /builds/worker/artifacts artifacts &&
-                    ~/.local/bin/taskgraph decision
-                    --pushlog-id='0'
-                    --pushdate='0'
-                    --project='${project}'
-                    --message=""
-                    --owner='${ownerEmail}'
-                    --level='${level}'
-                    --base-repository="$APPSERVICES_BASE_REPOSITORY"
-                    --head-repository="$APPSERVICES_HEAD_REPOSITORY"
-                    --head-ref="$APPSERVICES_HEAD_REF"
-                    --head-rev="$APPSERVICES_HEAD_REV"
-                    --repository-type="$APPSERVICES_REPOSITORY_TYPE"
-                    --tasks-for='${tasks_for}'
-                artifacts:
-                  'public':
-                    type: 'directory'
-                    path: '/builds/worker/artifacts'
-                    expires: {$fromNow: '1 year'}
-              extra:
-                $merge:
-                    - treeherder:
-                          $merge:
-                              - machine:
-                                    platform: gecko-decision
-                              - $if: 'tasks_for in ["github-push", "github-pull-request"]'
-                                then:
-                                    symbol: D
-                    - tasks_for: '${tasks_for}'
-          "tasks_for == 'github-push' && head_branch == 'refs/heads/master'":
-            $mergeDeep:
-              - {$eval: 'default_task_definition'}
-              - scopes:
-                - assume:repo:${event.repository.html_url[8:]}:branch:master
-              - metadata:
-                  name: Application Services - Decision task (master)
-                  description: Schedules the build and test tasks for Application Services.
+                    maxRunTime: 1800
+
+                    command:
+                      - /usr/local/bin/run-task
+                      - '--appservices-checkout=/builds/worker/checkouts/src'
+                      - '--taskgraph-checkout=/builds/worker/checkouts/taskgraph'
+                      - '--task-cwd=/builds/worker/checkouts/src'
+                      - '--'
+                      - bash
+                      - -cx
+                      - >
+                        PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
+                        PIP_IGNORE_INSTALLED=0 pip install --user arrow taskcluster pyyaml &&
+                        ln -s /builds/worker/artifacts artifacts &&
+                        ~/.local/bin/taskgraph decision
+                        --pushlog-id='0'
+                        --pushdate='0'
+                        --project='${project}'
+                        --message=""
+                        --owner='${ownerEmail}'
+                        --level='${level}'
+                        --base-repository="$APPSERVICES_BASE_REPOSITORY"
+                        --head-repository="$APPSERVICES_HEAD_REPOSITORY"
+                        --head-ref="$APPSERVICES_HEAD_REF"
+                        --head-rev="$APPSERVICES_HEAD_REV"
+                        --repository-type="$APPSERVICES_REPOSITORY_TYPE"
+                        --tasks-for='${tasks_for}'
+                    artifacts:
+                      'public':
+                        type: 'directory'
+                        path: '/builds/worker/artifacts'
+                        expires: {$fromNow: '1 year'}
+                  extra:
+                    $merge:
+                        - treeherder:
+                              $merge:
+                                  - machine:
+                                        platform: gecko-decision
+                                  - $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                                    then:
+                                        symbol: D
+                        - tasks_for: '${tasks_for}'
           "tasks_for == 'github-release' && event['action'] == 'published'":
             $let:
               is_staging:

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -19,7 +19,7 @@ kind-dependencies:
 job-defaults:
   attributes:
     run-on-pr-type: full-ci
-  run-on-tasks-for: [github-pull-request]
+  run-on-tasks-for: [github-pull-request, github-push]
   description: "{module_name} - Build and test"
   scopes:
     - project:releng:services/tooltool/api/download/internal


### PR DESCRIPTION
I ran this locally via [taskgraph-diff](https://hg.mozilla.org/ci/taskgraph/file/tip/README.rst#l65) and the diffs look good. Doesn't touch at all PRs and adds the same sets of jobs that we define for master pushes.

So this should change nothing in master pushes and PR, but the way the tasks are being scheduled, via taskgraph. Once this happens, the docker-image should no longer be scheduled in the PRs, as well as the toolchains recreation since level-3 tasks will be cached in level-1 as well.