### PR TITLE
Bug 1563169 - remove treeherder route since in taskgraph.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -239,7 +239,6 @@ tasks:
                       - checks
                       - $if: 'level == "3"'
                         then:
-                          - tc-treeherder.v2.${project}.${head_sha}
                           # TODO Bug 1601928: Make this scope fork-friendly once ${project} is better defined. This will enable
                           # staging release promotion on forks.
                           - $if: 'tasks_for == "github-push"'


### PR DESCRIPTION
Follow-up bustage fix for https://github.com/mozilla/application-services/pull/3034

We don't need this route for now as we don't have support for app-services in TH. Will add a todo for once releases are ready. 