### PR TITLE
Downgrade `url` version to 2.1.

### DIFF
--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1"
 serde_derive = "1"
 sql-support = { path = "../support/sql" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
-url = { version = "2.1.1", features = ["serde"] }
+url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
 version = "0.23.1"


### PR DESCRIPTION
`url@2.1.1` contains backward-incompatible changes that break Firefox
builds. We should fix those failures and get Firefox on the new version,
but, for now, it's easier to downgrade our version in `webext-storage`.

Firefox bug here: https://bugzilla.mozilla.org/show_bug.cgi?id=1633289