### PR TITLE
Merging cleanups

### DIFF
--- a/components/webext-storage/src/sync/incoming.rs
+++ b/components/webext-storage/src/sync/incoming.rs
@@ -236,14 +236,16 @@ pub fn plan_incoming(s: IncomingState) -> IncomingAction {
                     // just a 2-way merge...
                     merge(incoming_data, local_data, None)
                 }
-                (DataState::Exists(_), DataState::Deleted) => {
+                (DataState::Deleted, DataState::Exists(_)) => {
                     // We've data locally, but there's an incoming deletion.
                     // Remote wins.
                     IncomingAction::DeleteLocally
                 }
-                (DataState::Deleted, DataState::Exists(local_data)) => {
+                (DataState::Exists(incoming_data), DataState::Deleted) => {
                     // No data locally, but some is incoming - take it.
-                    IncomingAction::TakeRemote { data: local_data }
+                    IncomingAction::TakeRemote {
+                        data: incoming_data,
+                    }
                 }
                 (DataState::Deleted, DataState::Deleted) => {
                     // Nothing anywhere - odd, but OK.

--- a/components/webext-storage/src/sync/incoming.rs
+++ b/components/webext-storage/src/sync/incoming.rs
@@ -313,10 +313,8 @@ pub fn apply_actions(
             // We want to update the local record with 'data' and after this update the item no longer is considered dirty.
             IncomingAction::TakeRemote { data } => {
                 tx.execute_named_cached(
-                    "INSERT INTO storage_sync_data(ext_id, data, sync_change_counter)
-                        VALUES (:ext_id, :data, 0)
-                        ON CONFLICT (ext_id) DO UPDATE
-                        SET data = :data, sync_change_counter = 0",
+                    "INSERT OR REPLACE INTO storage_sync_data(ext_id, data, sync_change_counter)
+                        VALUES (:ext_id, :data, 0)",
                     &[
                         (":ext_id", &item.ext_id),
                         (":data", &serde_json::Value::Object(data)),

--- a/components/webext-storage/src/sync/incoming.rs
+++ b/components/webext-storage/src/sync/incoming.rs
@@ -294,11 +294,14 @@ pub fn apply_actions(
             // We want to update the local record with 'data' and after this update the item no longer is considered dirty.
             IncomingAction::TakeRemote { data } => {
                 tx.execute_named_cached(
-                    "UPDATE storage_sync_data SET data = :data, sync_change_counter = 0 WHERE ext_id = :ext_id",
+                    "INSERT INTO storage_sync_data(ext_id, data, sync_change_counter)
+                        VALUES (:ext_id, :data, 0)
+                        ON CONFLICT (ext_id) DO UPDATE
+                        SET data = :data, sync_change_counter = 0",
                     &[
                         (":ext_id", &item.ext_id),
                         (":data", &serde_json::Value::Object(data)),
-                    ]
+                    ],
                 )?;
             }
 

--- a/components/webext-storage/src/sync/incoming.rs
+++ b/components/webext-storage/src/sync/incoming.rs
@@ -230,9 +230,12 @@ pub fn plan_incoming(s: IncomingState) -> IncomingAction {
                     }
                 }
                 (DataState::Deleted, DataState::Exists(local_data), DataState::Deleted) => {
+                    // Perhaps another client created and then deleted
+                    // the whole object for this extension since the
+                    // last time we synced.
                     // Treat this as a delete of every key that we
-                    // knew was present. Unfortunately, we have no
-                    // information about what keys were present.
+                    // knew was present. Unfortunately, we don't know
+                    // any keys that were present, so we delete no keys.
                     IncomingAction::Merge { data: local_data }
                 }
                 (DataState::Deleted, DataState::Deleted, _) => {

--- a/components/webext-storage/src/sync/mod.rs
+++ b/components/webext-storage/src/sync/mod.rs
@@ -34,11 +34,6 @@ pub struct Record {
 }
 
 // Perform a 2-way or 3-way merge, where the incoming value wins on confict.
-// XXX - this needs more thought, and probably needs significant changes.
-// Main problem is that it doesn't handle deletions - but to do that, we need
-// something other than a simple Option<JsonMap> - we need to differentiate
-// "doesn't exist" from "removed".
-// TODO!
 fn merge(mut other: JsonMap, mut ours: JsonMap, parent: Option<JsonMap>) -> IncomingAction {
     if other == ours {
         return IncomingAction::Same;
@@ -94,6 +89,13 @@ fn merge(mut other: JsonMap, mut ours: JsonMap, parent: Option<JsonMap>) -> Inco
     } else {
         IncomingAction::Merge { data: ours }
     }
+}
+
+fn remove_matching_keys(mut ours: JsonMap, blacklist: &JsonMap) -> JsonMap {
+    for key in blacklist.keys() {
+        ours.remove(key);
+    }
+    ours
 }
 
 // Helpers for tests
@@ -202,5 +204,15 @@ mod tests {
         Ok(())
     }
 
-    // XXX - add `fn test_2way_merging() -> Result<()> {`!!
+    #[test]
+    fn test_remove_matching_keys() -> Result<()> {
+        assert_eq!(
+            remove_matching_keys(
+                map!({"key1": "value1", "key2": "value2"}),
+                &map!({"key1": "ignored", "key3": "ignored"})
+            ),
+            map!({"key2": "value2"})
+        );
+        Ok(())
+    }
 }

--- a/components/webext-storage/src/sync/mod.rs
+++ b/components/webext-storage/src/sync/mod.rs
@@ -79,6 +79,10 @@ fn merge(mut other: JsonMap, mut ours: JsonMap, parent: Option<JsonMap>) -> Inco
             // are the ones where a corresponding key does not exist
             // in parent, so it is a new key, and we need to add it.
             for (key, incoming_value) in other.into_iter() {
+                log::trace!(
+                    "merge: key {} doesn't occur in parent - copying from incoming",
+                    key
+                );
                 ours.insert(key, incoming_value);
             }
         }

--- a/components/webext-storage/src/sync/mod.rs
+++ b/components/webext-storage/src/sync/mod.rs
@@ -158,6 +158,39 @@ mod tests {
                 data: map!({"other_only": "other", "ours_only": "ours", "common": "new_value"})
             }
         );
+        // Field was removed remotely.
+        assert_eq!(
+            merge(
+                map!({"other_only": "other"}),
+                map!({"common": "old_value"}),
+                Some(map!({"common": "old_value"})),
+            ),
+            IncomingAction::TakeRemote {
+                data: map!({"other_only": "other"}),
+            }
+        );
+        // Field was removed remotely but we added another one.
+        assert_eq!(
+            merge(
+                map!({"other_only": "other"}),
+                map!({"common": "old_value", "new_key": "new_value"}),
+                Some(map!({"common": "old_value"})),
+            ),
+            IncomingAction::Merge {
+                data: map!({"other_only": "other", "new_key": "new_value"}),
+            }
+        );
+        // Field was removed both remotely and locally.
+        assert_eq!(
+            merge(
+                map!({}),
+                map!({"new_key": "new_value"}),
+                Some(map!({"common": "old_value"})),
+            ),
+            IncomingAction::Merge {
+                data: map!({"new_key": "new_value"}),
+            }
+        );
         Ok(())
     }
 

--- a/components/webext-storage/src/sync/sync_tests.rs
+++ b/components/webext-storage/src/sync/sync_tests.rs
@@ -64,6 +64,15 @@ fn check_finished_with(conn: &Connection, ext_id: &str, val: serde_json::Value) 
     Ok(())
 }
 
+fn get_mirror_guid(conn: &Connection, extid: &str) -> Result<String> {
+    let guid = conn.query_row_and_then(
+        "SELECT m.guid FROM storage_sync_mirror m WHERE m.ext_id = ?;",
+        vec![extid],
+        |row| row.get::<_, String>(0),
+    )?;
+    Ok(guid)
+}
+
 #[derive(Debug, PartialEq)]
 enum DbData {
     NoRow,
@@ -124,6 +133,23 @@ fn test_simple_outgoing_sync() -> Result<()> {
 }
 
 #[test]
+fn test_simple_incoming_sync() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let data = json!({"key1": "key1-value", "key2": "key2-value"});
+    let payload = Payload::from_record(Record {
+        guid: Guid::from("guid"),
+        ext_id: "ext-id".to_string(),
+        data: Some(data.to_string()),
+    })?;
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    let key1_from_api = get(&tx, "ext-id", json!("key1"))?;
+    assert_eq!(key1_from_api, json!({"key1": "key1-value"}));
+    check_finished_with(&tx, "ext-id", data)?;
+    Ok(())
+}
+
+#[test]
 fn test_simple_tombstone() -> Result<()> {
     // Tombstones are only kept when the mirror has that record - so first
     // test that, then arrange for the mirror to have the record.
@@ -154,12 +180,128 @@ fn test_simple_tombstone() -> Result<()> {
 }
 
 #[test]
-fn test_merged() -> Result<()> {
+fn test_reconciled() -> Result<()> {
     let mut db = new_syncable_mem_db();
     let tx = db.transaction()?;
     let data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", data)?;
-    // Incoming payload without 'key1' and conflicting for 'key2'
+    // Incoming payload with the same data
+    let payload = Payload::from_record(Record {
+        guid: Guid::from("guid"),
+        ext_id: "ext-id".to_string(),
+        data: Some(json!({"key1": "key1-value"}).to_string()),
+    })?;
+    // Should be no outgoing records as we reconciled.
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    check_finished_with(&tx, "ext-id", json!({"key1": "key1-value"}))?;
+    Ok(())
+}
+
+/// Tests that we handle things correctly if we get a payload that is
+/// identical to what is in the mirrored table.
+#[test]
+fn test_reconcile_with_null_payload() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let data = json!({"key1": "key1-value"});
+    set(&tx, "ext-id", data.clone())?;
+    // We try to push this change on the next sync.
+    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(
+        get_mirror_data(&tx, "ext-id"),
+        DbData::Data(data.to_string())
+    );
+    let guid = get_mirror_guid(&tx, "ext-id")?;
+    // Incoming payload with the same data.
+    // This could happen if, for example, another client changed the
+    // key and then put it back the way it was.
+    let payload = Payload::from_record(Record {
+        guid: Guid::from(guid),
+        ext_id: "ext-id".to_string(),
+        data: Some(data.to_string()),
+    })?;
+    // Should be no outgoing records as we reconciled.
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    check_finished_with(&tx, "ext-id", data)?;
+    Ok(())
+}
+
+#[test]
+fn test_accept_incoming_when_local_is_deleted() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    // We only record an extension as deleted locally if it has been
+    // uploaded before being deleted.
+    let data = json!({"key1": "key1-value"});
+    set(&tx, "ext-id", data)?;
+    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    let guid = get_mirror_guid(&tx, "ext-id")?;
+    clear(&tx, "ext-id")?;
+    // Incoming payload without 'key1'. Because we previously uploaded
+    // key1, this means another client deleted it.
+    let payload = Payload::from_record(Record {
+        guid: Guid::from(guid),
+        ext_id: "ext-id".to_string(),
+        data: Some(json!({"key2": "key2-value"}).to_string()),
+    })?;
+    // We completely accept the incoming record.
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    check_finished_with(&tx, "ext-id", json!({"key2": "key2-value"}))?;
+    Ok(())
+}
+
+#[test]
+fn test_accept_incoming_when_local_is_deleted_no_mirror() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let data = json!({"key1": "key1-value"});
+    set(&tx, "ext-id", data)?;
+    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    clear(&tx, "ext-id")?;
+    let payload = Payload::from_record(Record {
+        // Use a random guid so that we don't find the mirrored data.
+        // This test is somewhat bad because deduping might obviate
+        // the need for it.
+        guid: Guid::from("guid"),
+        ext_id: "ext-id".to_string(),
+        data: Some(json!({"key2": "key2-value"}).to_string()),
+    })?;
+    // We completely accept the incoming record.
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    check_finished_with(&tx, "ext-id", json!({"key2": "key2-value"}))?;
+    Ok(())
+}
+
+#[test]
+fn test_accept_deleted_key_mirrored() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let data = json!({"key1": "key1-value", "key2": "key2-value"});
+    set(&tx, "ext-id", data)?;
+    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    let guid = get_mirror_guid(&tx, "ext-id")?;
+    // Incoming payload without 'key1'. Because we previously uploaded
+    // key1, this means another client deleted it.
+    let payload = Payload::from_record(Record {
+        guid: Guid::from(guid),
+        ext_id: "ext-id".to_string(),
+        data: Some(json!({"key2": "key2-value"}).to_string()),
+    })?;
+    // We completely accept the incoming record.
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    check_finished_with(&tx, "ext-id", json!({"key2": "key2-value"}))?;
+    Ok(())
+}
+
+#[test]
+fn test_merged_no_mirror() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let data = json!({"key1": "key1-value"});
+    set(&tx, "ext-id", data)?;
+    // Incoming payload without 'key1' and some data for 'key2'.
+    // Because we never uploaded 'key1', we merge our local values
+    // with the remote.
     let payload = Payload::from_record(Record {
         guid: Guid::from("guid"),
         ext_id: "ext-id".to_string(),
@@ -175,20 +317,132 @@ fn test_merged() -> Result<()> {
 }
 
 #[test]
-fn test_reconciled() -> Result<()> {
+fn test_merged_incoming() -> Result<()> {
     let mut db = new_syncable_mem_db();
     let tx = db.transaction()?;
-    let data = json!({"key1": "key1-value"});
+    let old_data = json!({"key1": "key1-value", "key2": "key2-value", "doomed_key": "deletable"});
+    set(&tx, "ext-id", old_data)?;
+    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    let guid = get_mirror_guid(&tx, "ext-id")?;
+    // We update 'key1' locally.
+    let local_data = json!({"key1": "key1-new", "key2": "key2-value", "doomed_key": "deletable"});
+    set(&tx, "ext-id", local_data)?;
+    // Incoming payload where another client set 'key2' and removed
+    // the 'doomed_key'.
+    // Because we never uploaded our data, we'll merge our
+    // key1 in, but otherwise keep the server's changes.
+    let payload = Payload::from_record(Record {
+        guid: Guid::from(guid),
+        ext_id: "ext-id".to_string(),
+        data: Some(json!({"key1": "key1-value", "key2": "key2-incoming"}).to_string()),
+    })?;
+    // We should send our 'key1'
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    check_finished_with(
+        &tx,
+        "ext-id",
+        json!({"key1": "key1-new", "key2": "key2-incoming"}),
+    )?;
+    Ok(())
+}
+
+#[test]
+fn test_merged_with_null_payload() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let old_data = json!({"key1": "key1-value"});
+    set(&tx, "ext-id", old_data.clone())?;
+    // Push this change remotely.
+    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(
+        get_mirror_data(&tx, "ext-id"),
+        DbData::Data(old_data.to_string())
+    );
+    let guid = get_mirror_guid(&tx, "ext-id")?;
+    let local_data = json!({"key1": "key1-new", "key2": "key2-value"});
+    set(&tx, "ext-id", local_data.clone())?;
+    // Incoming payload with the same old data.
+    let payload = Payload::from_record(Record {
+        guid: Guid::from(guid),
+        ext_id: "ext-id".to_string(),
+        data: Some(old_data.to_string()),
+    })?;
+    // Three-way-merge will not detect any change in key1, so we
+    // should keep our entire new value.
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    check_finished_with(&tx, "ext-id", local_data)?;
+    Ok(())
+}
+
+#[test]
+fn test_deleted_mirrored_object_accept() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data)?;
-    // Incoming payload without 'key1' and conflicting for 'key2'
+    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    let guid = get_mirror_guid(&tx, "ext-id")?;
+    // Incoming payload with data deleted.
+    // We synchronize this deletion by deleting the keys we think
+    // were on the server.
+    let payload = Payload::from_record(Record {
+        guid: Guid::from(guid),
+        ext_id: "ext-id".to_string(),
+        data: None,
+    })?;
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
+    assert_eq!(get_mirror_data(&tx, "ext-id"), DbData::NullRow);
+    Ok(())
+}
+
+#[test]
+fn test_deleted_mirrored_object_merged() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    set(&tx, "ext-id", json!({"key1": "key1-value"}))?;
+    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    let guid = get_mirror_guid(&tx, "ext-id")?;
+    set(
+        &tx,
+        "ext-id",
+        json!({"key1": "key1-new", "key2": "key2-value"}),
+    )?;
+    // Incoming payload with data deleted.
+    // We synchronize this deletion by deleting the keys we think
+    // were on the server.
+    let payload = Payload::from_record(Record {
+        guid: Guid::from(guid),
+        ext_id: "ext-id".to_string(),
+        data: None,
+    })?;
+    // This overrides the change to 'key1', but we still upload 'key2'.
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    check_finished_with(&tx, "ext-id", json!({"key2": "key2-value"}))?;
+    Ok(())
+}
+
+#[test]
+fn test_deleted_not_mirrored_object_merged() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let data = json!({"key1": "key1-value", "key2": "key2-value"});
+    set(&tx, "ext-id", data)?;
+    // Incoming payload with data deleted.
     let payload = Payload::from_record(Record {
         guid: Guid::from("guid"),
         ext_id: "ext-id".to_string(),
-        data: Some(json!({"key1": "key1-value"}).to_string()),
+        data: None,
     })?;
-    // Should be no outgoing records as we reconciled.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
-    check_finished_with(&tx, "ext-id", json!({"key1": "key1-value"}))?;
+    // We normally delete the keys we think were on the server, but
+    // here we have no information about what was on the server, so we
+    // don't delete anything. We merge in all undeleted keys.
+    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    check_finished_with(
+        &tx,
+        "ext-id",
+        json!({"key1": "key1-value", "key2": "key2-value"}),
+    )?;
     Ok(())
 }
 
@@ -198,12 +452,15 @@ fn test_conflicting_incoming() -> Result<()> {
     let tx = db.transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data)?;
-    // Incoming payload without 'key1' and conflicting for 'key2'
+    // Incoming payload without 'key1' and conflicting for 'key2'.
+    // Because we never uploaded either of our keys, we'll merge our
+    // key1 in, but the server key2 wins.
     let payload = Payload::from_record(Record {
         guid: Guid::from("guid"),
         ext_id: "ext-id".to_string(),
         data: Some(json!({"key2": "key2-incoming"}).to_string()),
     })?;
+    // We should send our 'key1'
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
     check_finished_with(
         &tx,
@@ -212,6 +469,3 @@ fn test_conflicting_incoming() -> Result<()> {
     )?;
     Ok(())
 }
-
-// There are lots more we could add here, particularly around the resolution of
-// deletion of keys and deletions of the entire value.

--- a/components/webext-storage/src/sync/sync_tests.rs
+++ b/components/webext-storage/src/sync/sync_tests.rs
@@ -391,7 +391,7 @@ fn test_deleted_mirrored_object_accept() -> Result<()> {
         data: None,
     })?;
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
-    assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
+    assert_eq!(get_local_data(&tx, "ext-id"), DbData::NullRow);
     assert_eq!(get_mirror_data(&tx, "ext-id"), DbData::NullRow);
     Ok(())
 }


### PR DESCRIPTION
### Pull Request checklist ###
- [?] **Quality**: This PR builds and tests run cleanly
  - The tests for this package pass but I'm hoping for CI to confirm.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR does not necessitate any changelog entries beyond those provided in the parent branch
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - This PR does not add or change any dependencies

Fixes #2900.

This implementation of `chrome.storage.sync` does not have per-key tombstones. This means that we can't 100% conform to the same merge behavior that the existing implementation has. However, I discussed this in Slack with @mhammond and @thomcc and they argued that this only matters in edge cases[1] and it was acceptable for the gains in simplicity in the implementation.

[1]: The obvious case here is when another client adds and then removes a key. In this case, we have no way of knowing this happened and cannot "server wins" remove the key locally.

There was an outstanding question of how to handle it when the remote object is completely deleted. One possibility is to accept this as "server wins" and completely delete the local object. Another possibility is to delete keys from the local object corresponding to the keys that were deleted as part of the whole-object delete. The previous kinto.js-based implementation does not offer a mechanism whereby the whole object can be deleted; instead it deletes individual objects and syncs those tombstones, so for conformance with that, I went with removing matching keys. Of course, this whole-object deletion could have happened after other keys were added, but because there were no tombstones, we can't know that and thus can't delete keys matching it. Indeed, we could receive word of this whole-object deletion before we ever heard about what keys were on the server, and again because there are no per-key tombstones, we can't know what to delete. I chose the behavior "only delete keys which you knew were there", which seems easy enough to implement consistently.
