### PR TITLE
Add wipe_all to the public webext-storage API

### DIFF
--- a/components/webext-storage/src/api.rs
+++ b/components/webext-storage/src/api.rs
@@ -253,6 +253,19 @@ pub fn clear(tx: &Transaction<'_>, ext_id: &str) -> Result<StorageChanges> {
     Ok(result)
 }
 
+/// While this API isn't available to extensions, Firefox wants a way to wipe
+/// all data for all addons but not sync the deletions. We also don't report
+/// the changes caused by the deletion.
+/// That means that after doing this, the next sync is likely to drag some data
+/// back in - which is fine.
+/// This is much like what the sync support for other components calls a "wipe",
+/// so we name it similarly.
+pub fn wipe_all(tx: &Transaction<'_>) -> Result<()> {
+    // We assume the meta table is only used by sync.
+    tx.execute_batch("DELETE FROM storage_sync_data; DELETE FROM meta;")?;
+    Ok(())
+}
+
 // TODO - get_bytes_in_use()
 
 #[cfg(test)]
@@ -486,6 +499,32 @@ mod tests {
             ErrorKind::QuotaError(QuotaReason::ItemBytes) => {}
             _ => panic!("unexpected error type"),
         };
+        Ok(())
+    }
+
+    fn query_count(conn: &Connection, table: &str) -> u32 {
+        conn.query_row_and_then(
+            &format!("SELECT COUNT(*) FROM {};", table),
+            rusqlite::NO_PARAMS,
+            |row| row.get::<_, u32>(0),
+        )
+        .expect("should work")
+    }
+
+    #[test]
+    fn test_wipe() -> Result<()> {
+        use crate::db::put_meta;
+
+        let mut db = new_mem_db();
+        let tx = db.transaction()?;
+        set(&tx, "ext-a", json!({ "x": "y" }))?;
+        set(&tx, "ext-b", json!({ "y": "x" }))?;
+        put_meta(&tx, "meta", &"meta-meta".to_string())?;
+        assert_eq!(query_count(&tx, "storage_sync_data"), 2);
+        assert_eq!(query_count(&tx, "meta"), 1);
+        wipe_all(&tx)?;
+        assert_eq!(query_count(&tx, "storage_sync_data"), 0);
+        assert_eq!(query_count(&tx, "meta"), 0);
         Ok(())
     }
 }

--- a/components/webext-storage/src/lib.rs
+++ b/components/webext-storage/src/lib.rs
@@ -22,5 +22,7 @@ pub fn delme_demo_usage() -> error::Result<()> {
     store.get("ext-id", json!({}))?;
     store.remove("ext-id", json!({}))?;
     store.clear("ext-id")?;
+    // and it might even...
+    store.wipe_all()?;
     Ok(())
 }

--- a/components/webext-storage/src/store.rs
+++ b/components/webext-storage/src/store.rs
@@ -93,6 +93,15 @@ impl Store {
         Ok(result)
     }
 
+    /// Wipe all local data without syncing or returning any information about
+    /// the deletion.
+    pub fn wipe_all(&self) -> Result<()> {
+        let tx = self.db.unchecked_transaction()?;
+        api::wipe_all(&tx)?;
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Closes the store and its database connection. See the docs for
     /// `StorageDb::close` for more details on when this can fail.
     pub fn close(self) -> result::Result<(), (Store, Error)> {


### PR DESCRIPTION
Firefox names this [clearAll](https://searchfox.org/mozilla-central/rev/2bfe3415fb3a2fba9b1c694bc0b376365e086927/toolkit/components/extensions/ExtensionStorageSync.jsm#1276), but I think `wipe_all` is a better name on our side of the fence. If approved I'll put a patch up for mozilla-central tomorrow so this can actually be called!