### PR TITLE
Workaround protobuf bug

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,7 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.58.1...master)
+
+## General
+
+- Android: An Android 5 and 6 bug related to protobufs is now fixed. ([#3054](https://github.com/mozilla/application-services/pull/3054))

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 
     // There's a bug in versions > 3.9.2 that prevents us from upgrading:
     // https://github.com/protocolbuffers/protobuf/issues/7422
-    implementation 'com.google.protobuf:protobuf-javalite:3.9.2'
+    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
     api project(":full-megazord")
     implementation project(":native-support")
 

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -92,7 +92,7 @@ dependencies {
 
     // There's a bug in versions > 3.9.2 that prevents us from upgrading:
     // https://github.com/protocolbuffers/protobuf/issues/7422
-    implementation 'com.google.protobuf:protobuf-javalite:3.9.2'
+    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
     api project(":full-megazord")
     implementation project(":native-support")
 

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -89,7 +89,7 @@ dependencies {
 
     // There's a bug in versions > 3.9.2 that prevents us from upgrading:
     // https://github.com/protocolbuffers/protobuf/issues/7422
-    implementation 'com.google.protobuf:protobuf-javalite:3.9.2'
+    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
     api project(":full-megazord")
     implementation project(":native-support")
 

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 
     // There's a bug in versions > 3.9.2 that prevents us from upgrading:
     // https://github.com/protocolbuffers/protobuf/issues/7422
-    implementation 'com.google.protobuf:protobuf-javalite:3.9.2'
+    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
     api project(":full-megazord")
     implementation project(":native-support")
 

--- a/components/support/android/build.gradle
+++ b/components/support/android/build.gradle
@@ -32,7 +32,7 @@ dependencies {
     implementation "net.java.dev.jna:jna:$jna_version@aar"
     // There's a bug in versions > 3.9.2 that prevents us from upgrading:
     // https://github.com/protocolbuffers/protobuf/issues/7422
-    api 'com.google.protobuf:protobuf-javalite:3.9.2'
+    api 'com.google.protobuf:protobuf-javalite:3.11.4'
 }
 
 apply from: "$rootDir/publish.gradle"

--- a/components/support/android/src/main/java/mozilla/appservices/support/native/RustBuffer.kt
+++ b/components/support/android/src/main/java/mozilla/appservices/support/native/RustBuffer.kt
@@ -8,6 +8,7 @@ import com.google.protobuf.CodedInputStream
 import com.google.protobuf.CodedOutputStream
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
+import java.nio.ByteBuffer
 
 /**
  * This is a mapping for the `ffi_support::ByteBuffer` struct.
@@ -45,15 +46,27 @@ open class RustBuffer : Structure() {
     @JvmField var len: Long = 0
     @JvmField var data: Pointer? = null
 
+    @Suppress("TooGenericExceptionThrown")
     fun asCodedInputStream(): CodedInputStream? {
         return this.data?.let {
-            CodedInputStream.newInstance(it.getByteBuffer(0, this.len))
+            // We use a ByteArray instead of a ByteBuffer to avoid triggering the following code path:
+            // https://github.com/protocolbuffers/protobuf/blob/e667bf6eaaa2fb1ba2987c6538df81f88500d030/java/core/src/main/java/com/google/protobuf/CodedInputStream.java#L185-L187
+            // Bug: https://github.com/protocolbuffers/protobuf/issues/7422
+            if (this.len < Int.MIN_VALUE || this.len > Int.MAX_VALUE) {
+                throw RuntimeException("len does not fit in a int")
+            }
+            CodedInputStream.newInstance(it.getByteArray(0, this.len.toInt()))
         }
     }
 
     fun asCodedOutputStream(): CodedOutputStream? {
         return this.data?.let {
-            CodedOutputStream.newInstance(it.getByteBuffer(0, this.len))
+            // We use newSafeInstance through reflection to avoid triggering the following code path:
+            // https://github.com/protocolbuffers/protobuf/blob/e667bf6eaaa2fb1ba2987c6538df81f88500d030/java/core/src/main/java/com/google/protobuf/CodedOutputStream.java#L134-L136
+            // Bug: https://github.com/protocolbuffers/protobuf/issues/7422
+            val method = CodedOutputStream::class.java.getDeclaredMethod("newSafeInstance", ByteBuffer::class.java)
+            method.isAccessible = true
+            return method.invoke(null, it.getByteBuffer(0, this.len)) as CodedOutputStream
         }
     }
 

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 
     // There's a bug in versions > 3.9.2 that prevents us from upgrading:
     // https://github.com/protocolbuffers/protobuf/issues/7422
-    implementation 'com.google.protobuf:protobuf-javalite:3.9.2'
+    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
     api project(":full-megazord")
     implementation project(":native-support")
 

--- a/components/tabs/android/build.gradle
+++ b/components/tabs/android/build.gradle
@@ -76,7 +76,7 @@ dependencies {
 
     // There's a bug in versions > 3.9.2 that prevents us from upgrading:
     // https://github.com/protocolbuffers/protobuf/issues/7422
-    implementation 'com.google.protobuf:protobuf-javalite:3.9.2'
+    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
     api project(":full-megazord")
     implementation project(":native-support")
 

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -78,7 +78,7 @@ dependencies {
 
     // There's a bug in versions > 3.9.2 that prevents us from upgrading:
     // https://github.com/protocolbuffers/protobuf/issues/7422
-    implementation 'com.google.protobuf:protobuf-javalite:3.9.2'
+    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
     api project(":full-megazord")
     implementation project(":native-support")
 


### PR DESCRIPTION
The should fix the Android 5 issue reported in https://github.com/mozilla-mobile/fenix/issues/10277 (fixes #3053 also).
However because the fix to the above involves upgrading to 3.11.4, this would resurrect the bug we had earlier in https://github.com/mozilla/application-services/issues/3032, so I also fixed this one in a different way.

I'm going to make review comments to explain what I did here.