### PR TITLE
Implement a skeleton `sync15::BridgedEngine` for extension storage

### DIFF
--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -52,6 +52,9 @@ pub enum ErrorKind {
 
     #[fail(display = "Database version {} is not supported", _0)]
     UnsupportedDatabaseVersion(i64),
+
+    #[fail(display = "This operation isn't implemented yet")]
+    NotImplemented,
 }
 
 error_support::define_error! {

--- a/components/webext-storage/src/store.rs
+++ b/components/webext-storage/src/store.rs
@@ -5,6 +5,7 @@
 use crate::api::{self, StorageChanges};
 use crate::db::StorageDb;
 use crate::error::*;
+use crate::sync;
 use std::path::Path;
 use std::result;
 
@@ -106,6 +107,11 @@ impl Store {
         api::wipe_all(&tx)?;
         tx.commit()?;
         Ok(())
+    }
+
+    /// Returns a bridged sync engine for Desktop for this store.
+    pub fn bridged_engine(&self) -> sync::BridgedEngine<'_> {
+        sync::BridgedEngine::new(&self.db)
     }
 
     /// Closes the store and its database connection. See the docs for

--- a/components/webext-storage/src/sync/bridge.rs
+++ b/components/webext-storage/src/sync/bridge.rs
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use sync15_traits::{self, ApplyResults, IncomingEnvelope};
+
+use crate::api;
+use crate::db::StorageDb;
+use crate::error::{Error, ErrorKind, Result};
+
+/// A bridged engine implements all the methods needed to make the
+/// `storage.sync` store work with Desktop's Sync implementation.
+/// Conceptually, it's similar to `sync15_traits::Store`, which we
+/// should eventually rename and unify with this trait (#2841).
+pub struct BridgedEngine<'a> {
+    db: &'a StorageDb,
+}
+
+impl<'a> BridgedEngine<'a> {
+    /// Creates a bridged engine for syncing.
+    pub fn new(db: &'a StorageDb) -> Self {
+        BridgedEngine { db }
+    }
+}
+
+impl<'a> sync15_traits::BridgedEngine for BridgedEngine<'a> {
+    type Error = Error;
+
+    fn last_sync(&self) -> Result<i64> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn set_last_sync(&self, _last_sync_millis: i64) -> Result<()> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn sync_id(&self) -> Result<Option<String>> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn reset_sync_id(&self) -> Result<String> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn ensure_current_sync_id(&self, _new_sync_id: &str) -> Result<String> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn store_incoming(&self, _incoming_envelopes: &[IncomingEnvelope]) -> Result<()> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn apply(&self) -> Result<ApplyResults> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn set_uploaded(&self, _server_modified_millis: i64, _ids: &[String]) -> Result<()> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn sync_finished(&self) -> Result<()> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn reset(&self) -> Result<()> {
+        Err(ErrorKind::NotImplemented.into())
+    }
+
+    fn wipe(&self) -> Result<()> {
+        let tx = self.db.unchecked_transaction()?;
+        api::wipe_all(&tx)?;
+        tx.commit()?;
+        Ok(())
+    }
+}

--- a/components/webext-storage/src/sync/mod.rs
+++ b/components/webext-storage/src/sync/mod.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+mod bridge;
 mod incoming;
 mod outgoing;
 
@@ -12,6 +13,7 @@ use serde_derive::*;
 use sync15_traits::ServerTimestamp;
 use sync_guid::Guid as SyncGuid;
 
+pub use bridge::BridgedEngine;
 use incoming::IncomingAction;
 
 type JsonMap = serde_json::Map<String, serde_json::Value>;


### PR DESCRIPTION
Currently, the only supported method is `wipe`, with all other
methods returning `NotImplemented`. We can wire this up to Mark's
syncing implementation in #2892. This also implements enough of the
glue to where it can be vendored and used in Desktop.