### PR TITLE
Reset Send Tab keys on decrypt error

### DIFF
--- a/components/fxa-client/src/commands/send_tab.rs
+++ b/components/fxa-client/src/commands/send_tab.rs
@@ -117,7 +117,7 @@ impl PrivateSendTabKeys {
 }
 
 #[derive(Serialize, Deserialize)]
-struct SendTabKeysPayload {
+pub(crate) struct SendTabKeysPayload {
     /// Hex encoded kid.
     kid: String,
     /// Base 64 encoded IV.
@@ -130,7 +130,7 @@ struct SendTabKeysPayload {
 }
 
 impl SendTabKeysPayload {
-    fn decrypt(self, scoped_key: &ScopedKey) -> Result<PublicSendTabKeys> {
+    pub(crate) fn decrypt(self, scoped_key: &ScopedKey) -> Result<PublicSendTabKeys> {
         let (ksync, kxcs) = extract_oldsync_key_components(scoped_key)?;
         if hex::decode(self.kid)? != kxcs {
             return Err(ErrorKind::MismatchedKeys.into());
@@ -170,6 +170,12 @@ impl PublicSendTabKeys {
     pub fn as_command_data(&self, scoped_key: &ScopedKey) -> Result<String> {
         let encrypted_public_keys = self.encrypt(scoped_key)?;
         Ok(serde_json::to_string(&encrypted_public_keys)?)
+    }
+    pub(crate) fn public_key(&self) -> &str {
+        &self.public_key
+    }
+    pub(crate) fn auth_secret(&self) -> &str {
+        &self.auth_secret
     }
 }
 

--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -111,6 +111,18 @@ impl FirefoxAccount {
         Ok(())
     }
 
+    /// Re-register the device capabilities, this should only be used internally.
+    pub(crate) fn reregister_current_capabilities(&mut self) -> Result<()> {
+        let current_capabilities: Vec<Capability> =
+            self.state.device_capabilities.clone().into_iter().collect();
+        let commands = self.register_capabilities(&current_capabilities)?;
+        let update = DeviceUpdateRequestBuilder::new()
+            .available_commands(&commands)
+            .build();
+        self.update_device(update)?;
+        Ok(())
+    }
+
     pub(crate) fn invoke_command(
         &self,
         command: &str,
@@ -171,7 +183,7 @@ impl FirefoxAccount {
     }
 
     fn parse_commands_messages(
-        &self,
+        &mut self,
         messages: Vec<PendingCommand>,
     ) -> Result<Vec<IncomingDeviceCommand>> {
         let devices = self.get_devices()?;
@@ -189,7 +201,7 @@ impl FirefoxAccount {
     }
 
     fn parse_command(
-        &self,
+        &mut self,
         command_data: CommandData,
         devices: &[Device],
     ) -> Result<IncomingDeviceCommand> {

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -59,6 +59,9 @@ pub enum ErrorKind {
     #[fail(display = "Unknown command: {}", _0)]
     UnknownCommand(String),
 
+    #[fail(display = "Send Tab diagnosis error: {}", _0)]
+    SendTabDiagnosisError(&'static str),
+
     #[fail(display = "Empty names")]
     EmptyOAuthScopeNames,
 


### PR DESCRIPTION
Fixes #3095.

For some reason I was not receiving tabs on Firefox for iOS beta v25. The following patch fixes my problem: when we get a tab decryption error delete the send-tab keys, regenerate them and re-upload the device record.