### PR TITLE
Add Debouncing to Get Devices Call

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,3 +9,11 @@
 ### Breaking changes
 
 - The `include_cookies` setting is not supported anymore (was `false` by default). ([#3096](https://github.com/mozilla/application-services/pull/3096))
+
+## FxA Client
+
+- Added option boolean argument `ignoreCache` to ignore caching for `getDevices`. ([#3066](https://github.com/mozilla/application-services/pull/3066))
+
+### ⚠️ Breaking changes ⚠️
+- iOS: Renamed `fetchDevices(forceRefresh)` to `getDevices(ignoreCache)` to establish parity with Android. ([#3066](https://github.com/mozilla/application-services/pull/3066))
+- iOS: Renamed argument of `fetchProfile` from `forceRefresh` to `ignoreCache`. ([#3066](https://github.com/mozilla/application-services/pull/3066))

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -148,7 +148,8 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      */
     fun getProfile(ignoreCache: Boolean): Profile {
         val profileBuffer = rustCallWithLock { e ->
-            LibFxAFFI.INSTANCE.fxa_profile(this.handle.get(), ignoreCache, e)
+            val ignoreCacheArg: Byte = if (ignoreCache) { 1 } else { 0 }
+            LibFxAFFI.INSTANCE.fxa_profile(this.handle.get(), ignoreCacheArg, e)
         }
         this.tryPersistState()
         try {
@@ -465,9 +466,10 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      *
      * This performs network requests, and should not be used on the main thread.
      */
-    fun getDevices(): Array<Device> {
+    fun getDevices(ignoreCache: Boolean = false): Array<Device> {
         val devicesBuffer = rustCall { e ->
-            LibFxAFFI.INSTANCE.fxa_get_devices(this.handle.get(), e)
+            val ignoreCacheArg: Byte = if (ignoreCache) { 1 } else { 0 }
+            LibFxAFFI.INSTANCE.fxa_get_devices(this.handle.get(), ignoreCacheArg, e)
         }
         try {
             val devices = MsgTypes.Devices.parseFrom(devicesBuffer.asCodedInputStream()!!)

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -42,7 +42,7 @@ internal interface LibFxAFFI : Library {
         e: RustError.ByReference
     ): Pointer?
 
-    fun fxa_profile(fxa: FxaHandle, ignoreCache: Boolean, e: RustError.ByReference): RustBuffer.ByValue
+    fun fxa_profile(fxa: FxaHandle, ignoreCache: Byte, e: RustError.ByReference): RustBuffer.ByValue
 
     fun fxa_get_token_server_endpoint_url(fxa: FxaHandle, e: RustError.ByReference): Pointer?
     fun fxa_get_pairing_authority_url(fxa: FxaHandle, e: RustError.ByReference): Pointer?
@@ -66,7 +66,7 @@ internal interface LibFxAFFI : Library {
         e: RustError.ByReference
     )
     fun fxa_set_device_name(fxa: FxaHandle, displayName: String, e: RustError.ByReference)
-    fun fxa_get_devices(fxa: FxaHandle, e: RustError.ByReference): RustBuffer.ByValue
+    fun fxa_get_devices(fxa: FxaHandle, ignoreCache: Byte, e: RustError.ByReference): RustBuffer.ByValue
     fun fxa_disconnect(fxa: FxaHandle, e: RustError.ByReference)
     fun fxa_poll_device_commands(fxa: FxaHandle, e: RustError.ByReference): RustBuffer.ByValue
     fun fxa_handle_push_message(fxa: FxaHandle, jsonPayload: String, e: RustError.ByReference): RustBuffer.ByValue

--- a/components/fxa-client/examples/devices_api.rs
+++ b/components/fxa-client/examples/devices_api.rs
@@ -128,7 +128,7 @@ fn main() -> Result<(), failure::Error> {
                 println!("Display name set to: {}", new_name);
             }
             1 => {
-                let devices = acct.lock().unwrap().get_devices().unwrap();
+                let devices = acct.lock().unwrap().get_devices(false).unwrap();
                 let devices_names: Vec<String> =
                     devices.iter().map(|i| i.display_name.clone()).collect();
                 let mut targets_menu = Select::new();

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -91,11 +91,11 @@ pub extern "C" fn fxa_to_json(handle: u64, error: &mut ExternError) -> *mut c_ch
 #[no_mangle]
 pub extern "C" fn fxa_profile(
     handle: u64,
-    ignore_cache: bool,
+    ignore_cache: u8,
     error: &mut ExternError,
 ) -> ByteBuffer {
     log::debug!("fxa_profile");
-    ACCOUNTS.call_with_result_mut(error, handle, |fxa| fxa.get_profile(ignore_cache))
+    ACCOUNTS.call_with_result_mut(error, handle, |fxa| fxa.get_profile(ignore_cache != 0))
 }
 
 /// Get the pairing URL to navigate to on the Auth side (typically a computer).
@@ -414,15 +414,22 @@ pub extern "C" fn fxa_set_device_name(
 
 /// Fetch the devices (including the current one) in the current account.
 ///
+/// Devices might get cached in-memory and the caller might get served a cached version.
+/// To bypass this, the `ignore_cache` parameter can be set to `true`.
+///
 /// # Safety
 ///
 /// A destructor [fxa_bytebuffer_free] is provided for releasing the memory for this
 /// pointer type.
 #[no_mangle]
-pub extern "C" fn fxa_get_devices(handle: u64, error: &mut ExternError) -> ByteBuffer {
+pub extern "C" fn fxa_get_devices(
+    handle: u64,
+    ignore_cache: u8,
+    error: &mut ExternError,
+) -> ByteBuffer {
     log::debug!("fxa_get_devices");
     ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
-        fxa.get_devices().map(|d| {
+        fxa.get_devices(ignore_cache != 0).map(|d| {
             let devices = d.into_iter().map(|device| device.into()).collect();
             fxa_client::msg_types::Devices { devices }
         })

--- a/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
@@ -15,7 +15,7 @@ open class FirefoxAccount: RustFxAccount {
     open func getProfile(completionHandler: @escaping (Profile?, Error?) -> Void) {
         DispatchQueue.global().async {
             do {
-                let profile = try super.getProfile(forceRefresh: false)
+                let profile = try super.getProfile(ignoreCache: false)
                 DispatchQueue.main.async { completionHandler(profile, nil) }
             } catch {
                 DispatchQueue.main.async { completionHandler(nil, error) }

--- a/components/fxa-client/ios/FxAClient/FxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccount.swift
@@ -22,10 +22,10 @@ class FxAccount: RustFxAccount {
         persistCallback = nil
     }
 
-    override func getProfile(forceRefresh: Bool) throws -> Profile {
+    override func getProfile(ignoreCache: Bool) throws -> Profile {
         defer { tryPersistState() }
         return try notifyAuthErrors {
-            try super.getProfile(forceRefresh: forceRefresh)
+            try super.getProfile(ignoreCache: ignoreCache)
         }
     }
 
@@ -67,9 +67,9 @@ class FxAccount: RustFxAccount {
         }
     }
 
-    override func fetchDevices() throws -> [Device] {
+    override func getDevices(ignoreCache: Bool = false) throws -> [Device] {
         return try notifyAuthErrors {
-            try super.fetchDevices()
+            try super.getDevices(ignoreCache: ignoreCache)
         }
     }
 

--- a/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
@@ -34,7 +34,7 @@ public class DeviceConstellation {
         DispatchQueue.global().async {
             FxALog.info("Refreshing device list...")
             do {
-                let devices = try self.account.fetchDevices()
+                let devices = try self.account.getDevices(ignoreCache: true)
                 let localDevice = devices.first { $0.isCurrentDevice }
                 if localDevice?.subscriptionExpired ?? false {
                     FxALog.debug("Current device needs push endpoint registration.")

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -270,12 +270,12 @@ open class FxAccountManager {
     /// Refresh the user profile in the background. A threshold is applied
     /// to profile fetch calls on the Rust side to avoid hammering the servers
     /// with requests. If you absolutely know your profile is out-of-date and
-    /// need a fresh one, use the `forceRefresh` param to bypass the
+    /// need a fresh one, use the `ignoreCache` param to bypass the
     /// threshold.
     ///
     /// If it succeeds, a `.accountProfileUpdate` notification will get fired.
-    public func refreshProfile(forceRefresh: Bool = false) {
-        processEvent(event: .fetchProfile(forceRefresh: forceRefresh)) {
+    public func refreshProfile(ignoreCache: Bool = false) {
+        processEvent(event: .fetchProfile(ignoreCache: ignoreCache)) {
             // Do nothing
         }
     }
@@ -439,7 +439,7 @@ open class FxAccountManager {
 
                 postAuthenticated(authType: authData.authType)
 
-                return Event.fetchProfile(forceRefresh: false)
+                return Event.fetchProfile(ignoreCache: false)
             }
             case .accountRestored: do {
                 FxALog.info("Registering persistence callback")
@@ -450,7 +450,7 @@ open class FxAccountManager {
 
                 postAuthenticated(authType: .existingAccount)
 
-                return Event.fetchProfile(forceRefresh: false)
+                return Event.fetchProfile(ignoreCache: false)
             }
             case .authenticatedViaMigration: do {
                 // Note that we are not registering an account persistence callback here like
@@ -463,7 +463,7 @@ open class FxAccountManager {
 
                 postAuthenticated(authType: .migrated)
 
-                return Event.fetchProfile(forceRefresh: false)
+                return Event.fetchProfile(ignoreCache: false)
             }
             case .recoveredFromAuthenticationProblem: do {
                 FxALog.info("Registering persistence callback")
@@ -478,7 +478,7 @@ open class FxAccountManager {
 
                 postAuthenticated(authType: .recovered)
 
-                return Event.fetchProfile(forceRefresh: false)
+                return Event.fetchProfile(ignoreCache: false)
             }
             case let .changedPassword(newSessionToken): do {
                 do {
@@ -493,18 +493,18 @@ open class FxAccountManager {
 
                     postAuthenticated(authType: .existingAccount)
 
-                    return Event.fetchProfile(forceRefresh: false)
+                    return Event.fetchProfile(ignoreCache: false)
                 } catch {
                     FxALog.error("Error handling the session token change: \(error)")
                 }
             }
-            case let .fetchProfile(forceRefresh): do {
+            case let .fetchProfile(ignoreCache): do {
                 // Profile fetching and account authentication issues:
                 // https://github.com/mozilla/application-services/issues/483
                 FxALog.info("Fetching profile...")
 
                 do {
-                    profile = try requireAccount().getProfile(forceRefresh: forceRefresh)
+                    profile = try requireAccount().getProfile(ignoreCache: ignoreCache)
                 } catch {
                     return Event.failedToFetchProfile
                 }
@@ -527,7 +527,7 @@ open class FxAccountManager {
             case let .fetchProfile(refresh): do {
                 FxALog.info("Refreshing profile...")
                 do {
-                    profile = try requireAccount().getProfile(forceRefresh: refresh)
+                    profile = try requireAccount().getProfile(ignoreCache: refresh)
                 } catch {
                     return Event.failedToFetchProfile
                 }

--- a/components/fxa-client/ios/FxAClient/FxAccountState.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountState.swift
@@ -34,7 +34,7 @@ internal enum Event {
     case authenticatedViaMigration
     case authenticationError /* (error: AuthException) */
     case recoveredFromAuthenticationProblem
-    case fetchProfile(forceRefresh: Bool)
+    case fetchProfile(ignoreCache: Bool)
     case fetchedProfile
     case failedToFetchProfile
     case logout

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -91,10 +91,11 @@ FirefoxAccountHandle fxa_new(const char *_Nonnull content_base,
                              FxAError *_Nonnull out);
 
 FxARustBuffer fxa_profile(FirefoxAccountHandle handle,
-                          bool ignore_cache,
+                          uint8_t ignore_cache,
                           FxAError *_Nonnull out);
 
 FxARustBuffer fxa_get_devices(FirefoxAccountHandle handle,
+                              uint8_t ignore_cache,
                               FxAError *_Nonnull out);
 
 FxARustBuffer fxa_poll_device_commands(FirefoxAccountHandle handle,

--- a/components/fxa-client/ios/FxAClient/RustFxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/RustFxAccount.swift
@@ -52,9 +52,10 @@ open class RustFxAccount {
     /// Throws `FirefoxAccountError.Unauthorized` if we couldn't find any suitable access token
     /// to make that call. The caller should then start the OAuth Flow again with
     /// the "profile" scope.
-    open func getProfile(forceRefresh: Bool) throws -> Profile {
+    open func getProfile(ignoreCache: Bool) throws -> Profile {
+        let ignoreCacheArg = UInt8(ignoreCache ? 1 : 0)
         let ptr = try rustCall { err in
-            fxa_profile(self.raw, forceRefresh, err)
+            fxa_profile(self.raw, ignoreCacheArg, err)
         }
         defer { fxa_bytebuffer_free(ptr) }
         let msg = try! MsgTypes_Profile(serializedData: Data(rustBuffer: ptr))
@@ -181,9 +182,10 @@ open class RustFxAccount {
         }
     }
 
-    open func fetchDevices() throws -> [Device] {
+    open func getDevices(ignoreCache: Bool = false) throws -> [Device] {
+        let ignoreCacheArg = UInt8(ignoreCache ? 1 : 0)
         let ptr = try rustCall { err in
-            fxa_get_devices(self.raw, err)
+            fxa_get_devices(self.raw, ignoreCacheArg, err)
         }
         defer { fxa_bytebuffer_free(ptr) }
         let msg = try! MsgTypes_Devices(serializedData: Data(rustBuffer: ptr))

--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -12,22 +12,42 @@ use crate::{
         CommandData, DeviceUpdateRequest, DeviceUpdateRequestBuilder, PendingCommand,
         UpdateDeviceResponse,
     },
-    FirefoxAccount, IncomingDeviceCommand,
+    util, CachedResponse, FirefoxAccount, IncomingDeviceCommand,
 };
 use serde_derive::*;
 use std::collections::{HashMap, HashSet};
 
+// An devices response is considered fresh for `DEVICES_FRESHNESS_THRESHOLD` ms.
+const DEVICES_FRESHNESS_THRESHOLD: u64 = 60_000; // 1 minute
+
 impl FirefoxAccount {
     /// Fetches the list of devices from the current account including
     /// the current one.
-    pub fn get_devices(&self) -> Result<Vec<Device>> {
+    ///
+    /// * `ignore_cache` - If set to true, bypass the in-memory cache
+    /// and fetch devices from the server.
+    pub fn get_devices(&mut self, ignore_cache: bool) -> Result<Vec<Device>> {
+        if let Some(d) = &self.devices_cache {
+            if !ignore_cache && util::now() < d.cached_at + DEVICES_FRESHNESS_THRESHOLD {
+                return Ok(d.response.clone());
+            }
+        }
+
         let refresh_token = self.get_refresh_token()?;
-        self.client.devices(&self.state.config, &refresh_token)
+        let response = self.client.devices(&self.state.config, &refresh_token)?;
+
+        self.devices_cache = Some(CachedResponse {
+            response: response.clone(),
+            cached_at: util::now(),
+            etag: "".into(),
+        });
+
+        Ok(response)
     }
 
-    pub fn get_current_device(&self) -> Result<Option<Device>> {
+    pub fn get_current_device(&mut self) -> Result<Option<Device>> {
         Ok(self
-            .get_devices()?
+            .get_devices(false)?
             .into_iter()
             .find(|d| d.is_current_device))
     }
@@ -186,7 +206,7 @@ impl FirefoxAccount {
         &mut self,
         messages: Vec<PendingCommand>,
     ) -> Result<Vec<IncomingDeviceCommand>> {
-        let devices = self.get_devices()?;
+        let devices = self.get_devices(false)?;
         let parsed_commands = messages
             .into_iter()
             .filter_map(|msg| match self.parse_command(msg.data, &devices) {
@@ -665,5 +685,81 @@ mod tests {
         fxa.set_client(Arc::new(client));
 
         fxa.ensure_capabilities(&[Capability::SendTab]).unwrap();
+    }
+
+    #[test]
+    fn test_get_devices() {
+        let mut fxa = setup();
+        let mut client = FxAClientMock::new();
+        client
+            .expect_devices(mockiato::Argument::any, mockiato::Argument::any)
+            .times(1)
+            .returns_once(Ok(vec![Device {
+                common: DeviceResponseCommon {
+                    id: "device1".into(),
+                    display_name: "".to_string(),
+                    device_type: DeviceType::Desktop,
+                    push_subscription: None,
+                    available_commands: HashMap::new(),
+                    push_endpoint_expired: true,
+                },
+                is_current_device: true,
+                location: DeviceLocation {
+                    city: None,
+                    country: None,
+                    state: None,
+                    state_code: None,
+                },
+                last_access_time: None,
+            }]));
+
+        fxa.set_client(Arc::new(client));
+        assert!(fxa.devices_cache.is_none());
+
+        assert!(fxa.get_devices(false).is_ok());
+        assert!(fxa.devices_cache.is_some());
+
+        let cache = fxa.devices_cache.clone().unwrap();
+        assert!(!cache.response.is_empty());
+        assert!(cache.cached_at > 0);
+
+        let cached_devices = cache.response;
+        assert_eq!(cached_devices[0].id, "device1".to_string());
+
+        // Check that a second call to get_devices doesn't hit the server
+        assert!(fxa.get_devices(false).is_ok());
+        assert!(fxa.devices_cache.clone().is_some());
+
+        let cache2 = fxa.devices_cache.unwrap();
+        let cached_devices2 = cache2.response;
+
+        assert_eq!(cache.cached_at, cache2.cached_at);
+        assert_eq!(cached_devices.len(), cached_devices2.len());
+        assert_eq!(cached_devices[0].id, cached_devices2[0].id);
+    }
+
+    #[test]
+    fn test_get_devices_network_errors() {
+        let mut fxa = setup();
+        let mut client = FxAClientMock::new();
+        client
+            .expect_devices(mockiato::Argument::any, mockiato::Argument::any)
+            .times(1)
+            .returns_once(Err(ErrorKind::RemoteError {
+                code: 500,
+                errno: 101,
+                error: "Did not work!".to_owned(),
+                message: "Did not work!".to_owned(),
+                info: "Did not work!".to_owned(),
+            }
+            .into()));
+
+        fxa.set_client(Arc::new(client));
+        assert!(fxa.devices_cache.is_none());
+
+        let res = fxa.get_devices(false);
+
+        assert!(res.is_err());
+        assert!(fxa.devices_cache.is_none());
     }
 }

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -62,6 +62,7 @@ pub struct FirefoxAccount {
     state: State,
     flow_store: HashMap<String, OAuthFlow>,
     attached_clients_cache: Option<CachedResponse<Vec<http_client::GetAttachedClientResponse>>>,
+    devices_cache: Option<CachedResponse<Vec<http_client::GetDeviceResponse>>>,
 }
 
 impl FirefoxAccount {
@@ -71,6 +72,7 @@ impl FirefoxAccount {
             state,
             flow_store: HashMap::new(),
             attached_clients_cache: None,
+            devices_cache: None,
         }
     }
 
@@ -134,12 +136,18 @@ impl FirefoxAccount {
         state_persistence::state_to_json(&self.state)
     }
 
+    /// Clear the attached clients and devices cache
+    pub fn clear_devices_and_attached_clients_cache(&mut self) {
+        self.attached_clients_cache = None;
+        self.devices_cache = None;
+    }
+
     /// Clear the whole persisted/cached state of the account, but keep just
     /// enough information to eventually reconnect to the same user account later.
     pub fn start_over(&mut self) {
         self.state = self.state.start_over();
         self.flow_store.clear();
-        self.attached_clients_cache = None;
+        self.clear_devices_and_attached_clients_cache();
     }
 
     /// Get the Sync Token Server endpoint URL.
@@ -220,10 +228,15 @@ impl FirefoxAccount {
     ///
     /// **💾 This method alters the persisted account state.**
     pub fn disconnect(&mut self) {
+        let current_device_result;
+        {
+            current_device_result = self.get_current_device();
+        }
+
         if let Some(ref refresh_token) = self.state.refresh_token {
             // Delete the current device (which deletes the refresh token), or
             // the refresh token directly if we don't have a device.
-            let destroy_result = match self.get_current_device() {
+            let destroy_result = match current_device_result {
                 // If we get an error trying to fetch our device record we'll at least
                 // still try to delete the refresh token itself.
                 Ok(Some(device)) => {

--- a/components/fxa-client/src/oauth/attached_clients.rs
+++ b/components/fxa-client/src/oauth/attached_clients.rs
@@ -9,6 +9,7 @@ use crate::{error::*, util, CachedResponse, FirefoxAccount};
 const ATTACHED_CLIENTS_FRESHNESS_THRESHOLD: u64 = 60_000; // 1 minute
 
 impl FirefoxAccount {
+    /// Fetches the list of attached clients connected to the current account.
     pub fn get_attached_clients(&mut self, session_token: &str) -> Result<Vec<AttachedClient>> {
         if let Some(a) = &self.attached_clients_cache {
             if util::now() < a.cached_at + ATTACHED_CLIENTS_FRESHNESS_THRESHOLD {

--- a/components/fxa-client/src/push.rs
+++ b/components/fxa-client/src/push.rs
@@ -35,7 +35,7 @@ impl FirefoxAccount {
                 Ok(vec![AccountEvent::ProfileUpdated])
             }
             PushPayload::DeviceConnected(DeviceConnectedPushPayload { device_name }) => {
-                self.attached_clients_cache = None;
+                self.clear_devices_and_attached_clients_cache();
                 Ok(vec![AccountEvent::DeviceConnected { device_name }])
             }
             PushPayload::DeviceDisconnected(DeviceDisconnectedPushPayload { device_id }) => {

--- a/components/fxa-client/src/send_tab.rs
+++ b/components/fxa-client/src/send_tab.rs
@@ -38,8 +38,8 @@ impl FirefoxAccount {
     }
 
     /// Send a single tab to another device designated by its device ID.
-    pub fn send_tab(&self, target_device_id: &str, title: &str, url: &str) -> Result<()> {
-        let devices = self.get_devices()?;
+    pub fn send_tab(&mut self, target_device_id: &str, title: &str, url: &str) -> Result<()> {
+        let devices = self.get_devices(false)?;
         let target = devices
             .iter()
             .find(|d| d.id == target_device_id)
@@ -82,8 +82,8 @@ impl FirefoxAccount {
         }
     }
 
-    fn diagnose_remote_keys(&self, local_send_tab_key: PrivateSendTabKeys) -> Result<()> {
-        let own_device = self
+    fn diagnose_remote_keys(&mut self, local_send_tab_key: PrivateSendTabKeys) -> Result<()> {
+        let own_device = &mut self
             .get_current_device()?
             .ok_or_else(|| ErrorKind::SendTabDiagnosisError("No remote device."))?;
 

--- a/megazords/ios/MozillaAppServicesTests/FxAccountManagerTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountManagerTests.swift
@@ -14,7 +14,7 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .accountRestored))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticated(authData: FxaAuthData(code: "foo", state: "bar", actionQueryParam: "bobo"))))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticationError))
-        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchProfile(forceRefresh: false)))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchProfile(ignoreCache: false)))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchedProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .logout))
@@ -34,7 +34,7 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .accountRestored))
         XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .authenticated(authData: FxaAuthData(code: "foo", state: "bar", actionQueryParam: "bobo"))))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticationError))
-        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchProfile(forceRefresh: false)))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchProfile(ignoreCache: false)))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchedProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .logout))
@@ -54,7 +54,7 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .accountRestored))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticated(authData: FxaAuthData(code: "foo", state: "bar", actionQueryParam: "bobo"))))
         XCTAssertEqual(.authenticationProblem, FxAccountManager.nextState(state: state, event: .authenticationError))
-        XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .fetchProfile(forceRefresh: false)))
+        XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .fetchProfile(ignoreCache: false)))
         XCTAssertEqual(.authenticatedWithProfile, FxAccountManager.nextState(state: state, event: .fetchedProfile))
         XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertEqual(.notAuthenticated, FxAccountManager.nextState(state: state, event: .logout))
@@ -74,7 +74,7 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .accountRestored))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticated(authData: FxaAuthData(code: "foo", state: "bar", actionQueryParam: "bobo"))))
         XCTAssertEqual(.authenticationProblem, FxAccountManager.nextState(state: state, event: .authenticationError))
-        XCTAssertEqual(.authenticatedWithProfile, FxAccountManager.nextState(state: state, event: .fetchProfile(forceRefresh: false)))
+        XCTAssertEqual(.authenticatedWithProfile, FxAccountManager.nextState(state: state, event: .fetchProfile(ignoreCache: false)))
         XCTAssertEqual(.authenticatedWithProfile, FxAccountManager.nextState(state: state, event: .fetchedProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertEqual(.notAuthenticated, FxAccountManager.nextState(state: state, event: .logout))
@@ -94,7 +94,7 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .accountRestored))
         XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .authenticated(authData: FxaAuthData(code: "foo", state: "bar", actionQueryParam: "bobo"))))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticationError))
-        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchProfile(forceRefresh: false)))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchProfile(ignoreCache: false)))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchedProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertEqual(.notAuthenticated, FxAccountManager.nextState(state: state, event: .logout))
@@ -114,7 +114,7 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .accountRestored))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticated(authData: FxaAuthData(code: "foo", state: "bar", actionQueryParam: "bobo"))))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticationError))
-        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchProfile(forceRefresh: false)))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchProfile(ignoreCache: false)))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchedProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertEqual(.notAuthenticated, FxAccountManager.nextState(state: state, event: .logout))
@@ -296,8 +296,8 @@ class FxAccountManagerTests: XCTestCase {
     func testProfileRecoverableAuthError() {
         class MockAccount: MockFxAccount {
             var profileCallCount = 0
-            override func getProfile(forceRefresh: Bool) throws -> Profile {
-                let profile = try super.getProfile(forceRefresh: forceRefresh)
+            override func getProfile(ignoreCache: Bool) throws -> Profile {
+                let profile = try super.getProfile(ignoreCache: ignoreCache)
                 profileCallCount += 1
                 if profileCallCount == 1 {
                     notifyAuthError()

--- a/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
@@ -15,7 +15,7 @@ class MockFxAccount: FxAccount {
         case clearAccessTokenCache
         case getAccessToken
         case initializeDevice
-        case fetchDevices
+        case getDevices
     }
 
     init() {
@@ -38,8 +38,8 @@ class MockFxAccount: FxAccount {
         invocations.append(.initializeDevice)
     }
 
-    override func fetchDevices() throws -> [Device] {
-        invocations.append(.fetchDevices)
+    override func getDevices(ignoreCache _: Bool) throws -> [Device] {
+        invocations.append(.getDevices)
         return []
     }
 
@@ -65,7 +65,7 @@ class MockFxAccount: FxAccount {
         return AccessTokenInfo(scope: "profile", token: "toktok")
     }
 
-    override func getProfile(forceRefresh _: Bool) throws -> Profile {
+    override func getProfile(ignoreCache _: Bool) throws -> Profile {
         invocations.append(.getProfile)
         return Profile(uid: "uid", email: "foo@bar.bobo")
     }


### PR DESCRIPTION
Fixes #2625
- adds debouncing to `get_devices()`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
