### PR TITLE
Add `{Incoming, Outgoing}Envelope` types for bridged engines

### DIFF
--- a/components/support/sync15-traits/src/lib.rs
+++ b/components/support/sync15-traits/src/lib.rs
@@ -12,7 +12,7 @@ mod server_timestamp;
 mod store;
 pub mod telemetry;
 
-pub use bridged_engine::{ApplyResults, BridgedEngine};
+pub use bridged_engine::{ApplyResults, BridgedEngine, IncomingEnvelope, OutgoingEnvelope};
 pub use changeset::{IncomingChangeset, OutgoingChangeset, RecordChangeset};
 pub use payload::Payload;
 pub use request::{CollectionRequest, RequestOrder};


### PR DESCRIPTION
We need a way to pass BSO metadata, like the last modified time and
sort index, from Desktop Sync to our bridged Rust engines. We can't
pass Desktop's BSOs directly because they're encrypted, and we rely
on the existing `Weave.Crypto` machinery to decrypt them.

So instead, we introduce envelopes, which combine BSO metadata
fields with the decrypted cleartext. We intentionally use a new term,
instead of calling these "records", to avoid confusion between Desktop
Sync records (which conflate BSOs, encrypted wrappers, and payloads)
and `sync-15` records (which are just the payloads).

Envelopes are an internal concept: they are never sent to the server,
and the only methods available on them are conversions for turning
them into payloads, and building them from payloads.

These structs are shared between Desktop Sync JS code and our Rust
code. See the comments in Desktop's `bridged_engine.js`, in
[this Phabricator diff](https://phabricator.services.mozilla.com/D73581)
for more details.