### PR TITLE
Mark unused param in FxAccountMocks.swift to keep CI happy

### DIFF
--- a/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
@@ -60,7 +60,7 @@ class MockFxAccount: FxAccount {
         invocations.append(.clearAccessTokenCache)
     }
 
-    override func getAccessToken(scope _: String, ttl: UInt64? = nil) throws -> AccessTokenInfo {
+    override func getAccessToken(scope _: String, ttl _: UInt64? = nil) throws -> AccessTokenInfo {
         invocations.append(.getAccessToken)
         return AccessTokenInfo(scope: "profile", token: "toktok")
     }


### PR DESCRIPTION
No idea what caused this to start complaining recently, but 🤷 