### PR TITLE
Cargo update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
+checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
 dependencies = [
  "cc",
  "libc",
@@ -249,18 +249,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clicolors-control"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
-dependencies = [
- "atty",
- "lazy_static",
- "libc",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "clipboard"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,18 +292,19 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6728a28023f207181b193262711102bfbaf47cc9d13bc71d0736607ef8efe88c"
+checksum = "dea0f3e2e8d7dba335e913b97f9e1992c86c4399d54f8be1d31c8727d0652064"
 dependencies = [
- "clicolors-control",
  "encode_unicode",
  "lazy_static",
  "libc",
  "regex",
+ "terminal_size",
  "termios",
  "unicode-width",
  "winapi 0.3.8",
+ "winapi-util",
 ]
 
 [[package]]
@@ -457,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c5e5ac752e18207b12e16b10631ae5f7f68f8805f335f9b817ead83d9ffce1"
+checksum = "cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d"
 dependencies = [
  "quote",
  "syn",
@@ -477,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b5eb0fce3c4f955b8d8d864b131fb8863959138da962026c106ba7a2e3bf7a"
+checksum = "f4aa86af7b19b40ef9cbef761ed411a49f0afa06b7b6dcd3dfe2f96a3c546138"
 dependencies = [
  "console",
  "lazy_static",
@@ -601,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
  "failure_derive",
@@ -611,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "failure_derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -859,9 +848,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d737e0f947a1864e93d33fdef4af8445a00d1ed8dc0c8ddb73139ea6abf15"
+checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
 dependencies = [
  "libc",
 ]
@@ -1004,9 +993,9 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a27d435371a2fa5b6d2b028a74bbdb1234f308da363226a2854ca3ff8ba7055"
+checksum = "fa5a448de267e7358beaf4a5d849518fe9a0c13fce7afd44b06e68550e5562a7"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1215,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
+checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
  "cfg-if",
  "fuchsia-zircon",
@@ -1331,9 +1320,9 @@ checksum = "a629868a433328c35d654e1e1fb4648a68a042e3c71de4e507a9bcf4602c5635"
 
 [[package]]
 name = "net2"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+checksum = "2ba7c918ac76704fb42afcbbb43891e72731f3dcca3bef2a19786297baf14af7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1449,9 +1438,9 @@ checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
 
 [[package]]
 name = "oorandom"
-version = "11.1.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcec7c9c2a95cacc7cd0ecb89d8a8454eca13906f6deb55258ffff0adeb9405"
+checksum = "94af325bc33c7f60191be4e2c984d48aaa21e2854f473b85398344b60c9b6358"
 
 [[package]]
 name = "openssl"
@@ -1523,18 +1512,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
+checksum = "36e3dcd42688c05a66f841d22c5d8390d9a5d4c9aaf57b9285eae4900a080063"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
+checksum = "f4d7346ac577ff1296e06a418e7618e22655bae834d4970cb6e39d6da8119969"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1621,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "plotters"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3bb8da247d27ae212529352020f3e5ee16e83c0c258061d27b08ab92675eeb"
+checksum = "f9b1d9ca091d370ea3a78d5619145d1b59426ab0c9eedbad2514a4cee08bf389"
 dependencies = [
  "js-sys",
  "num-traits",
@@ -1717,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
+checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -1838,9 +1827,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
+checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2237,9 +2226,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572dfa3a0785509e7a44b5b4bebcf94d41ba34e9ed9eb9df722545c3b3c4144a"
+checksum = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -2250,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb15a5fec93b7021b8a9e96009c5d8d51c15673569f7c0f6b7204e5b7b404f"
+checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2295,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
 dependencies = [
  "itoa",
  "ryu",
@@ -2665,6 +2654,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8038f95fc7a6f351163f4b964af631bd26c9e828f7db085f2a84aca56f70d13b"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,9 +2714,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a3c6667d3e65eb1bc3aed6fd14011c6cbc3a0665218ab7f5daf040b9ec371a"
+checksum = "45e4bc5ac99433e0dcb8b9f309dd271a165ae37dde129b9e0ce1bfdd8bfe4891"
 dependencies = [
  "serde",
  "serde_json",
@@ -2725,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ef16d072d2b6dc8b4a56c70f5c5ced1a37752116f8e7c1e80c659aa7cb6713"
+checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
 dependencies = [
  "bytes",
  "fnv",
@@ -2929,9 +2928,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc57ce05287f8376e998cbddfb4c8cb43b84a7ec55cf4551d7c00eef317a47f"
+checksum = "e3c7d40d09cdbf0f4895ae58cf57d92e1e57a9dd8ed2e8390514b54a47cc5551"
 dependencies = [
  "cfg-if",
  "serde",
@@ -2941,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d967d37bf6c16cca2973ca3af071d0a2523392e4a594548155d89a678f4237cd"
+checksum = "c3972e137ebf830900db522d6c8fd74d1900dcfc733462e9a12e942b00b4ac94"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -2956,9 +2955,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7add542ea1ac7fdaa9dc25e031a6af33b7d63376292bd24140c637d00d1c312a"
+checksum = "8a369c5e1dfb7569e14d62af4da642a3cbc2f9a3652fe586e26ac22222aa4b04"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2968,9 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
+checksum = "2cd85aa2c579e8892442954685f0d801f9129de24fa2136b2c6a539c76b65776"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2978,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
+checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2991,15 +2990,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.60"
+version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf76fe7d25ac79748a37538b7daeed1c7a6867c92d3245c12c6222e4a20d639"
+checksum = "a91c2916119c17a8e316507afaaa2dd94b47646048014bbdf6bef098c1bb58ad"
 
 [[package]]
 name = "web-sys"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6f51648d8c56c366144378a33290049eafdd784071077f6fe37dae64c1c4cb"
+checksum = "8bc359e5dd3b46cb9687a051d50a2fdd228e4ba7cf6fcf861a5365c3d671a642"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -471,7 +471,7 @@ The following text applies to code linked from these dependencies:
 [mime](https://github.com/hyperium/mime),
 [miow](https://github.com/alexcrichton/miow),
 [native-tls](https://github.com/sfackler/rust-native-tls),
-[net2](https://github.com/rust-lang-nursery/net2-rs),
+[net2](https://github.com/deprecrated/net2-rs),
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
 [openssl-probe](https://github.com/alexcrichton/openssl-probe),
@@ -1106,7 +1106,7 @@ SOFTWARE.
 ## MIT License: mio
 
 The following text applies to code linked from these dependencies:
-[mio](https://github.com/carllerche/mio)
+[mio](https://github.com/tokio-rs/mio)
 
 ```
 Copyright (c) 2014 Carl Lerche and other MIO contributors

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -8,16 +8,16 @@ exclude = ["/android", "/ios"]
 
 [dependencies]
 base64 = "0.12.0"
-byteorder = "1.3.2"
-failure = "0.1.6"
-hex = "0.4.0"
+byteorder = "1.3"
+failure = "0.1"
+hex = "0.4"
 lazy_static = "1.4.0"
 log = "0.4"
 prost = "0.6.1"
 prost-derive = "0.6.1"
-serde = { version = "1.0.104", features = ["rc"] }
-serde_derive = "1.0.104"
-serde_json = "1.0.50"
+serde = { version = "1", features = ["rc"] }
+serde_derive = "1"
+serde_json = "1"
 sync15 = { path = "../sync15" }
 url = "2.1"
 ffi-support = "0.4"
@@ -28,8 +28,8 @@ error-support = { path = "../support/error" }
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
 cli-support = { path = "../support/cli" }
-dialoguer = "0.5.1"
-webbrowser = "0.5.1"
+dialoguer = "0.6"
+webbrowser = "0.5"
 mockiato = "0.9.5"
 
 [features]

--- a/components/fxa-client/ffi/Cargo.toml
+++ b/components/fxa-client/ffi/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["lib"]
 [dependencies]
 ffi-support = "0.4"
 log = "0.4.8"
-serde_json = "1.0.50"
+serde_json = "1"
 lazy_static = "1.4.0"
 url = "2.1"
 prost = "0.6.1"

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -12,13 +12,13 @@ default = []
 
 [dependencies]
 sync15 = { path = "../sync15" }
-serde = "1.0.104"
-serde_derive = "1.0.104"
-serde_json = "1.0.50"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 log = "0.4.8"
 lazy_static = "1.4.0"
 url = "2.1"
-failure = "0.1.6"
+failure = "0.1"
 sql-support = { path = "../support/sql" }
 ffi-support = "0.4"
 interrupt-support = { path = "../support/interrupt" }
@@ -33,10 +33,10 @@ features = ["sqlcipher", "limits"]
 
 [dev-dependencies]
 more-asserts = "0.2.1"
-env_logger = "0.7.0"
+env_logger = "0.7"
 prettytable-rs = "0.8.0"
 fxa-client = { path = "../fxa-client" }
-chrono = "0.4.8"
-clap = "2.32.0"
+chrono = "0.4"
+clap = "2.33"
 cli-support = { path = "../support/cli" }
 tempdir = "0.3.7"

--- a/components/logins/ffi/Cargo.toml
+++ b/components/logins/ffi/Cargo.toml
@@ -10,7 +10,7 @@ name = "logins_ffi"
 crate-type = ["lib"]
 
 [dependencies]
-serde_json = "1.0.50"
+serde_json = "1"
 log = "0.4"
 url = "2.1"
 base16 = "0.2.1"

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -12,20 +12,20 @@ default = []
 
 [dependencies]
 sync15 = { path = "../sync15" }
-serde = "1.0.104"
-serde_derive = "1.0.104"
-serde_json = "1.0.50"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 log = "0.4"
 lazy_static = "1.4.0"
 url = { version = "2.1", features = ["serde"] }
 percent-encoding = "2.1.0"
-failure = "0.1.6"
+failure = "0.1"
 caseless = "0.2.1"
 sql-support = { path = "../support/sql" }
 ffi-support = "0.4"
 bitflags = "1.2.1"
 idna = "0.2.0"
-memchr = "2.2.1"
+memchr = "2.3"
 prost = "0.6.1"
 prost-derive = "0.6.1"
 dogear = "0.4.0"
@@ -39,12 +39,12 @@ features = ["functions", "bundled"]
 
 [dev-dependencies]
 more-asserts = "0.2.1"
-env_logger = "0.7.0"
+env_logger = "0.7"
 find-places-db = "0.1.0"
-clap = "2.32.0"
-structopt = "0.3.11"
-tempfile = "3.0.8"
-rand = "0.7.2"
+clap = "2.33"
+structopt = "0.3"
+tempfile = "3.1"
+rand = "0.7"
 fxa-client = { path = "../fxa-client" }
 criterion = "0.3.2"
 tempdir = "0.3.7"
@@ -56,7 +56,7 @@ ctrlc = "3.1.4"
 # our example doesn't work on Windows), it does get further in the compilation
 # such that "cargo test" etc shows errors in our code rather than in termion.
 [target.'cfg(not(windows))'.dev-dependencies]
-termion = "1.5.4"
+termion = "1.5"
 
 [[bench]]
 name = "match_impl"

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib"]
 default = []
 
 [dependencies]
-serde_json = "1.0.50"
+serde_json = "1"
 log = "0.4"
 url = "2.1"
 ffi-support = "0.4"

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -10,14 +10,14 @@ exclude = ["/android", "/ios"]
 default = []
 
 [dependencies]
-serde = "1.0.104"
-serde_derive = "1.0.104"
-serde_json = "1.0.50"
-bincode = "1.1.4"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
+bincode = "1.2"
 lazy_static = "1.4.0"
 base64 = "0.12.0"
-failure = "0.1.6"
-failure_derive = "0.1.5"
+failure = "0.1"
+failure_derive = "0.1"
 log = "0.4.8"
 rusqlite = { version = "0.23.1", features = ["bundled"] }
 url = "2.1"
@@ -31,6 +31,6 @@ prost-derive = "0.6.1"
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
-env_logger = "0.7.0"
+env_logger = "0.7"
 mockito = "0.25.1"
-hex = "0.4.0"
+hex = "0.4"

--- a/components/push/ffi/Cargo.toml
+++ b/components/push/ffi/Cargo.toml
@@ -10,7 +10,7 @@ name = "push_ffi"
 crate-type = ["lib"]
 
 [dependencies]
-serde_json = "1.0.50"
+serde_json = "1"
 log = "0.4"
 url = "2.1"
 ffi-support = "0.4"

--- a/components/rc_log/Cargo.toml
+++ b/components/rc_log/Cargo.toml
@@ -19,4 +19,4 @@ force_android = []
 log = "0.4.8"
 ffi-support = "0.4"
 lazy_static = "1.4.0"
-cfg-if = "0.1.9"
+cfg-if = "0.1"

--- a/components/support/cli/Cargo.toml
+++ b/components/support/cli/Cargo.toml
@@ -6,9 +6,9 @@ authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>", "Mark Hammond <mhammond@
 license = "MPL-2.0"
 
 [dependencies]
-failure = "0.1.6"
+failure = "0.1"
 fxa-client = { path = "../../fxa-client" }
 log = "0.4.8"
 sync15 = { path = "../../sync15" }
 url = "2.1"
-webbrowser = "0.5.1"
+webbrowser = "0.5"

--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 license = "MPL-2.0"
 
 [dependencies]
-failure = "0.1.6"
+failure = "0.1"
 

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -27,6 +27,6 @@ optional = true
 version = "0.3.38"
 
 [dev-dependencies]
-rand = "0.7.2"
+rand = "0.7"
 rayon = "1.3.0"
-env_logger = "0.7.0"
+env_logger = "0.7"

--- a/components/support/guid/Cargo.toml
+++ b/components/support/guid/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 rusqlite = { version = "0.23.1", optional = true }
-serde = { version = "1.0.104", optional = true }
+serde = { version = "1", optional = true }
 rand = { version = "0.7", optional = true }
 base64 = { version = "0.12.0", optional = true }
 
@@ -19,4 +19,4 @@ serde_support = ["serde"]
 default = ["serde_support"]
 
 [dev-dependencies]
-serde_test = "1.0.104"
+serde_test = "1"

--- a/components/support/rc_crypto/Cargo.toml
+++ b/components/support/rc_crypto/Cargo.toml
@@ -10,16 +10,16 @@ crate-type = ["lib"]
 
 [dependencies]
 base64 = "0.12.0"
-failure = "0.1.6"
-failure_derive = "0.1.5"
+failure = "0.1"
+failure_derive = "0.1"
 error-support = { path = "../error" }
 nss = { path = "nss" }
 libsqlite3-sys = { version = "0.18.0", features = ["bundled"] }
-hawk = { version = "3.1.0", default-features = false, optional = true }
+hawk = { version = "3.1", default-features = false, optional = true }
 ece = { version = "1.1.2", default-features = false, features = ["serializable-keys"], optional = true }
 
 [dev-dependencies]
-hex = "0.4.0"
+hex = "0.4"
 
 [features]
 default = []

--- a/components/support/rc_crypto/nss/Cargo.toml
+++ b/components/support/rc_crypto/nss/Cargo.toml
@@ -11,11 +11,11 @@ crate-type = ["lib"]
 [dependencies]
 base64 = "0.12.0"
 error-support = { path = "../../error" }
-failure = "0.1.6"
-failure_derive = "0.1.5"
+failure = "0.1"
+failure_derive = "0.1"
 nss_sys = { path = "nss_sys" }
-serde = "1.0.104"
-serde_derive = "1.0.104"
+serde = "1"
+serde_derive = "1"
 
 [features]
 default = []

--- a/components/support/sync15-traits/Cargo.toml
+++ b/components/support/sync15-traits/Cargo.toml
@@ -10,11 +10,11 @@ random-guid = ["sync-guid/random"]
 
 [dependencies]
 sync-guid = { path = "../guid" }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 log = "0.4"
 ffi-support = "0.4"
 url = "2.1"
-failure = "0.1.6"
+failure = "0.1"
 
 interrupt-support = { path = "../interrupt" }

--- a/components/support/viaduct-reqwest/Cargo.toml
+++ b/components/support/viaduct-reqwest/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 
 [dependencies]
 viaduct = { path = "../../viaduct" }
-reqwest = { version = "0.10.1", features = ["blocking", "native-tls-vendored"] }
+reqwest = { version = "0.10", features = ["blocking", "native-tls-vendored"] }
 ffi-support = "0.4.0"
 lazy_static = "1.4.0"
 log = "0.4"

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -12,14 +12,14 @@ default = []
 [dependencies]
 base64 = "0.12.0"
 ffi-support = "0.4"
-serde = "1.0.104"
-serde_derive = "1.0.104"
-serde_json = "1.0.50"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 url = "2.1"
 log = "0.4"
 lazy_static = "1.4"
 base16 = "0.2.1"
-failure = "0.1.6"
+failure = "0.1"
 rc_crypto = { path = "../support/rc_crypto", features = ["hawk"] }
 viaduct = { path = "../viaduct" }
 interrupt-support = { path = "../support/interrupt" }
@@ -28,4 +28,4 @@ sync-guid = { path = "../support/guid", features = ["random"] }
 sync15-traits = {path = "../support/sync15-traits"}
 
 [dev-dependencies]
-env_logger = "0.7.0"
+env_logger = "0.7"

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -12,7 +12,7 @@ places = { path = "../places" }
 logins = { path = "../logins" }
 tabs = { path = "../tabs" }
 ffi-support = "0.4"
-failure = "0.1.6"
+failure = "0.1"
 error-support = { path = "../support/error" }
 prost = "0.6.1"
 prost-derive = "0.6.1"
@@ -20,7 +20,7 @@ lazy_static = "1.4.0"
 log = "0.4.8"
 sql-support = { path = "../support/sql" }
 url = "2.1"
-serde = "1.0.104"
-serde_derive = "1.0.104"
-serde_json = "1.0.50"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 interrupt-support = { path = "../support/interrupt" }

--- a/components/sync_manager/ffi/Cargo.toml
+++ b/components/sync_manager/ffi/Cargo.toml
@@ -14,4 +14,4 @@ places-ffi = { path = "../../places/ffi" }
 logins_ffi = { path = "../../logins/ffi" }
 tabs_ffi = { path = "../../tabs/ffi" }
 prost = "0.6.1"
-log = "0.4.7"
+log = "0.4"

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -11,10 +11,10 @@ default = []
 
 [dependencies]
 sync15 = { path = "../sync15" }
-serde = "1.0.104"
-serde_derive = "1.0.104"
-serde_json = "1.0.50"
-failure = "0.1.6"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
+failure = "0.1"
 log = "0.4.8"
 url = "2.1"
 prost = "0.6.1"
@@ -26,6 +26,6 @@ sync-guid = { path = "../support/guid", features = ["random"] }
 
 [dev-dependencies]
 clipboard = "0.5.0"
-clap = "2.32.0"
+clap = "2.33"
 cli-support = { path = "../support/cli" }
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/tabs/ffi/Cargo.toml
+++ b/components/tabs/ffi/Cargo.toml
@@ -10,7 +10,7 @@ name = "tabs_ffi"
 crate-type = ["lib"]
 
 [dependencies]
-serde_json = "1.0.50"
+serde_json = "1"
 log = "0.4"
 url = "2.1"
 base16 = "0.2.1"

--- a/components/viaduct/Cargo.toml
+++ b/components/viaduct/Cargo.toml
@@ -13,12 +13,12 @@ crate-type = ["lib"]
 default = []
 
 [dependencies]
-failure = "0.1.6"
-failure_derive = "0.1.5"
+failure = "0.1"
+failure_derive = "0.1"
 url = "2.1"
 log = "0.4"
-serde = "1.0.104"
-serde_json = "1.0.50"
+serde = "1"
+serde_json = "1"
 once_cell = "1.3.1"
 prost = "0.6.1"
 prost-derive = "0.6.1"

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 
 [dependencies]
 error-support = { path = "../support/error" }
-failure = "0.1.6"
+failure = "0.1"
 interrupt-support = { path = "../support/interrupt" }
 lazy_static = "1.4.0"
 log = "0.4"
@@ -28,7 +28,7 @@ version = "0.23.1"
 features = ["functions", "bundled", "serde_json"]
 
 [dev-dependencies]
-env_logger = "0.7.0"
+env_logger = "0.7"
 prettytable-rs = "0.8"
 
 # A *direct* dep on the -sys crate is required for our build.rs

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -459,7 +459,7 @@ The following text applies to code linked from these dependencies:
 [lru-cache](https://github.com/contain-rs/lru-cache),
 [mime](https://github.com/hyperium/mime),
 [native-tls](https://github.com/sfackler/rust-native-tls),
-[net2](https://github.com/rust-lang-nursery/net2-rs),
+[net2](https://github.com/deprecrated/net2-rs),
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
 [percent-encoding](https://github.com/servo/rust-url/),
@@ -1029,7 +1029,7 @@ SOFTWARE.
 ## MIT License: mio
 
 The following text applies to code linked from these dependencies:
-[mio](https://github.com/carllerche/mio)
+[mio](https://github.com/tokio-rs/mio)
 
 ```
 Copyright (c) 2014 Carl Lerche and other MIO contributors

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -12,9 +12,9 @@ sync15 = { path = "../../components/sync15" }
 tabs = { path = "../../components/tabs" }
 fxa-client = { path = "../../components/fxa-client" }
 url = "2.1"
-env_logger = "0.7.0"
+env_logger = "0.7"
 log = "0.4.8"
-failure = "0.1.6"
-rand = "0.7.2"
+failure = "0.1"
+rand = "0.7"
 lazy_static = "1.4.0"
-structopt = "0.3.11"
+structopt = "0.3"

--- a/tools/protobuf-gen/Cargo.toml
+++ b/tools/protobuf-gen/Cargo.toml
@@ -8,6 +8,6 @@ license = "MPL-2.0"
 [dependencies]
 clap = "2.33.0"
 prost-build = "0.6.1"
-serde = "1.0.106"
-serde_derive = "1.0.106"
+serde = "1"
+serde_derive = "1"
 toml = "0.5.6"


### PR DESCRIPTION
I've also removed the patch version on some deps (didn't go through all of them, next time maybe) to keep the churn in `Cargo.lock` as much as possible in the future.