### PR TITLE
Tie up the webext-storage sync loose-ends

### DIFF
--- a/components/webext-storage/src/api.rs
+++ b/components/webext-storage/src/api.rs
@@ -294,21 +294,6 @@ pub fn clear(tx: &Transaction<'_>, ext_id: &str) -> Result<StorageChanges> {
     Ok(result)
 }
 
-/// While this API isn't available to extensions, Firefox wants a way to wipe
-/// all data for all addons but not sync the deletions. We also don't report
-/// the changes caused by the deletion.
-/// That means that after doing this, the next sync is likely to drag some data
-/// back in - which is fine.
-/// This is much like what the sync support for other components calls a "wipe",
-/// so we name it similarly.
-pub fn wipe_all(tx: &Transaction<'_>) -> Result<()> {
-    // We assume the meta table is only used by sync.
-    tx.execute_batch(
-        "DELETE FROM storage_sync_data; DELETE FROM storage_sync_mirror; DELETE FROM meta;",
-    )?;
-    Ok(())
-}
-
 // TODO - get_bytes_in_use()
 
 #[cfg(test)]
@@ -542,39 +527,6 @@ mod tests {
             ErrorKind::QuotaError(QuotaReason::ItemBytes) => {}
             _ => panic!("unexpected error type"),
         };
-        Ok(())
-    }
-
-    fn query_count(conn: &Connection, table: &str) -> u32 {
-        conn.query_row_and_then(
-            &format!("SELECT COUNT(*) FROM {};", table),
-            rusqlite::NO_PARAMS,
-            |row| row.get::<_, u32>(0),
-        )
-        .expect("should work")
-    }
-
-    #[test]
-    fn test_wipe() -> Result<()> {
-        use crate::db::put_meta;
-
-        let mut db = new_mem_db();
-        let tx = db.transaction()?;
-        set(&tx, "ext-a", json!({ "x": "y" }))?;
-        set(&tx, "ext-b", json!({ "y": "x" }))?;
-        put_meta(&tx, "meta", &"meta-meta".to_string())?;
-        tx.execute(
-            "INSERT INTO storage_sync_mirror (guid, ext_id, data)
-                    VALUES ('guid', 'ext-a', null)",
-            rusqlite::NO_PARAMS,
-        )?;
-        assert_eq!(query_count(&tx, "storage_sync_data"), 2);
-        assert_eq!(query_count(&tx, "storage_sync_mirror"), 1);
-        assert_eq!(query_count(&tx, "meta"), 1);
-        wipe_all(&tx)?;
-        assert_eq!(query_count(&tx, "storage_sync_data"), 0);
-        assert_eq!(query_count(&tx, "storage_sync_mirror"), 0);
-        assert_eq!(query_count(&tx, "meta"), 0);
         Ok(())
     }
 }

--- a/components/webext-storage/src/db.rs
+++ b/components/webext-storage/src/db.rs
@@ -172,7 +172,6 @@ pub(crate) mod sql_fns {
 }
 
 // These should be somewhere else...
-#[allow(dead_code)]
 pub fn put_meta(db: &Connection, key: &str, value: &dyn ToSql) -> Result<()> {
     db.conn().execute_named_cached(
         "REPLACE INTO meta (key, value) VALUES (:key, :value)",
@@ -181,7 +180,6 @@ pub fn put_meta(db: &Connection, key: &str, value: &dyn ToSql) -> Result<()> {
     Ok(())
 }
 
-#[allow(dead_code)]
 pub fn get_meta<T: FromSql>(db: &Connection, key: &str) -> Result<Option<T>> {
     let res = db.conn().try_query_one(
         "SELECT value FROM meta WHERE key = :key",
@@ -191,7 +189,6 @@ pub fn get_meta<T: FromSql>(db: &Connection, key: &str) -> Result<Option<T>> {
     Ok(res)
 }
 
-#[allow(dead_code)]
 pub fn delete_meta(db: &Connection, key: &str) -> Result<()> {
     db.conn()
         .execute_named_cached("DELETE FROM meta WHERE key = :key", &[(":key", &key)])?;

--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -56,9 +56,6 @@ pub enum ErrorKind {
 
     #[fail(display = "{}", _0)]
     IncomingPayloadError(#[fail(cause)] bridged_engine::PayloadError),
-
-    #[fail(display = "This operation isn't implemented yet")]
-    NotImplemented,
 }
 
 error_support::define_error! {

--- a/components/webext-storage/src/lib.rs
+++ b/components/webext-storage/src/lib.rs
@@ -12,6 +12,9 @@ mod schema;
 pub mod store;
 mod sync;
 
+// We publish this constant from a non-public module.
+pub use sync::STORAGE_VERSION;
+
 // This is what we roughly expect the "bridge" used by desktop to do.
 // It's primarily here to avoid dead-code warnings (but I don't want to disable
 // those warning, as stuff that remains after this is suspect!)
@@ -23,7 +26,5 @@ pub fn delme_demo_usage() -> error::Result<()> {
     store.get("ext-id", json!({}))?;
     store.remove("ext-id", json!({}))?;
     store.clear("ext-id")?;
-    // and it might even...
-    store.wipe_all()?;
     Ok(())
 }

--- a/components/webext-storage/src/store.rs
+++ b/components/webext-storage/src/store.rs
@@ -100,15 +100,6 @@ impl Store {
         Ok(result)
     }
 
-    /// Wipe all local data without syncing or returning any information about
-    /// the deletion.
-    pub fn wipe_all(&self) -> Result<()> {
-        let tx = self.db.unchecked_transaction()?;
-        api::wipe_all(&tx)?;
-        tx.commit()?;
-        Ok(())
-    }
-
     /// Returns a bridged sync engine for Desktop for this store.
     pub fn bridged_engine(&self) -> sync::BridgedEngine<'_> {
         sync::BridgedEngine::new(&self.db)

--- a/components/webext-storage/src/sync/bridge.rs
+++ b/components/webext-storage/src/sync/bridge.rs
@@ -2,15 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use rusqlite::Transaction;
 use sync15_traits::{self, ApplyResults, IncomingEnvelope, OutgoingEnvelope};
 use sync_guid::Guid as SyncGuid;
 
-use crate::api;
-use crate::db::StorageDb;
-use crate::error::{Error, ErrorKind, Result};
+use crate::db::{delete_meta, get_meta, put_meta, StorageDb};
+use crate::error::{Error, Result};
 use crate::schema;
 use crate::sync::incoming::{apply_actions, get_incoming, plan_incoming, stage_incoming};
 use crate::sync::outgoing::{get_outgoing, record_uploaded, stage_outgoing};
+
+const LAST_SYNC_META_KEY: &str = "last_sync_time";
+const SYNC_ID_META_KEY: &str = "sync_id";
 
 /// A bridged engine implements all the methods needed to make the
 /// `storage.sync` store work with Desktop's Sync implementation.
@@ -25,29 +28,55 @@ impl<'a> BridgedEngine<'a> {
     pub fn new(db: &'a StorageDb) -> Self {
         BridgedEngine { db }
     }
+
+    fn do_reset(&self, tx: &Transaction<'_>) -> Result<()> {
+        tx.execute_batch(
+            "DELETE FROM storage_sync_mirror;
+             UPDATE storage_sync_data SET sync_change_counter = 1;",
+        )?;
+        delete_meta(tx, LAST_SYNC_META_KEY)?;
+        Ok(())
+    }
 }
 
 impl<'a> sync15_traits::BridgedEngine for BridgedEngine<'a> {
     type Error = Error;
 
     fn last_sync(&self) -> Result<i64> {
-        Err(ErrorKind::NotImplemented.into())
+        Ok(get_meta(self.db, LAST_SYNC_META_KEY)?.unwrap_or(0))
     }
 
-    fn set_last_sync(&self, _last_sync_millis: i64) -> Result<()> {
-        Err(ErrorKind::NotImplemented.into())
+    fn set_last_sync(&self, last_sync_millis: i64) -> Result<()> {
+        put_meta(self.db, LAST_SYNC_META_KEY, &last_sync_millis)?;
+        Ok(())
     }
 
     fn sync_id(&self) -> Result<Option<String>> {
-        Err(ErrorKind::NotImplemented.into())
+        Ok(get_meta(self.db, SYNC_ID_META_KEY)?)
     }
 
     fn reset_sync_id(&self) -> Result<String> {
-        Err(ErrorKind::NotImplemented.into())
+        let tx = self.db.unchecked_transaction()?;
+        let new_id = SyncGuid::random().to_string();
+        self.do_reset(&tx)?;
+        put_meta(self.db, SYNC_ID_META_KEY, &new_id)?;
+        tx.commit()?;
+        Ok(new_id)
     }
 
-    fn ensure_current_sync_id(&self, _new_sync_id: &str) -> Result<String> {
-        Err(ErrorKind::NotImplemented.into())
+    fn ensure_current_sync_id(&self, sync_id: &str) -> Result<String> {
+        let current: Option<String> = get_meta(self.db, SYNC_ID_META_KEY)?;
+        Ok(match current {
+            Some(current) if current == sync_id => current,
+            _ => {
+                let tx = self.db.unchecked_transaction()?;
+                self.do_reset(&tx)?;
+                let result = sync_id.to_string();
+                put_meta(self.db, SYNC_ID_META_KEY, &result)?;
+                tx.commit()?;
+                result
+            }
+        })
     }
 
     fn sync_started(&self) -> Result<()> {
@@ -105,13 +134,187 @@ impl<'a> sync15_traits::BridgedEngine for BridgedEngine<'a> {
     }
 
     fn reset(&self) -> Result<()> {
-        Err(ErrorKind::NotImplemented.into())
+        let tx = self.db.unchecked_transaction()?;
+        self.do_reset(&tx)?;
+        delete_meta(&tx, SYNC_ID_META_KEY)?;
+        tx.commit()?;
+        Ok(())
     }
 
     fn wipe(&self) -> Result<()> {
         let tx = self.db.unchecked_transaction()?;
-        api::wipe_all(&tx)?;
+        // We assume the meta table is only used by sync.
+        tx.execute_batch(
+            "DELETE FROM storage_sync_data; DELETE FROM storage_sync_mirror; DELETE FROM meta;",
+        )?;
         tx.commit()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test::new_mem_db;
+    use sync15_traits::bridged_engine::BridgedEngine;
+
+    fn query_count(conn: &StorageDb, table: &str) -> u32 {
+        conn.query_row_and_then(
+            &format!("SELECT COUNT(*) FROM {};", table),
+            rusqlite::NO_PARAMS,
+            |row| row.get::<_, u32>(0),
+        )
+        .expect("should work")
+    }
+
+    // Sets up mock data for the tests here.
+    fn setup_mock_data(engine: &super::BridgedEngine<'_>) -> Result<()> {
+        engine.db.execute(
+            "INSERT INTO storage_sync_data (ext_id, data, sync_change_counter)
+                 VALUES ('ext-a', 'invalid-json', 2)",
+            rusqlite::NO_PARAMS,
+        )?;
+        engine.db.execute(
+            "INSERT INTO storage_sync_mirror (guid, ext_id, data)
+                 VALUES ('guid', 'ext-a', null)",
+            rusqlite::NO_PARAMS,
+        )?;
+        engine.set_last_sync(1)?;
+
+        // and assert we wrote what we think we did.
+        assert_eq!(query_count(engine.db, "storage_sync_data"), 1);
+        assert_eq!(query_count(engine.db, "storage_sync_mirror"), 1);
+        assert_eq!(query_count(engine.db, "meta"), 1);
+        Ok(())
+    }
+
+    // Assuming a DB setup with setup_mock_data, assert it was correctly reset.
+    fn assert_reset(engine: &super::BridgedEngine<'_>) -> Result<()> {
+        // A reset never wipes data...
+        assert_eq!(query_count(engine.db, "storage_sync_data"), 1);
+
+        // But did reset the change counter.
+        let cc = engine.db.query_row_and_then(
+            "SELECT sync_change_counter FROM storage_sync_data WHERE ext_id = 'ext-a';",
+            rusqlite::NO_PARAMS,
+            |row| row.get::<_, u32>(0),
+        )?;
+        assert_eq!(cc, 1);
+        // But did wipe the mirror...
+        assert_eq!(query_count(engine.db, "storage_sync_mirror"), 0);
+        // And the last_sync should have been wiped.
+        assert!(get_meta::<i64>(engine.db, LAST_SYNC_META_KEY)?.is_none());
+        Ok(())
+    }
+
+    // Assuming a DB setup with setup_mock_data, assert it has not been reset.
+    fn assert_not_reset(engine: &super::BridgedEngine<'_>) -> Result<()> {
+        assert_eq!(query_count(engine.db, "storage_sync_data"), 1);
+        let cc = engine.db.query_row_and_then(
+            "SELECT sync_change_counter FROM storage_sync_data WHERE ext_id = 'ext-a';",
+            rusqlite::NO_PARAMS,
+            |row| row.get::<_, u32>(0),
+        )?;
+        assert_eq!(cc, 2);
+        assert_eq!(query_count(engine.db, "storage_sync_mirror"), 1);
+        // And the last_sync should remain.
+        assert!(get_meta::<i64>(engine.db, LAST_SYNC_META_KEY)?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn test_wipe() -> Result<()> {
+        let db = new_mem_db();
+        let engine = super::BridgedEngine::new(&db);
+
+        setup_mock_data(&engine)?;
+
+        engine.wipe()?;
+        assert_eq!(query_count(engine.db, "storage_sync_data"), 0);
+        assert_eq!(query_count(engine.db, "storage_sync_mirror"), 0);
+        assert_eq!(query_count(engine.db, "meta"), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn test_reset() -> Result<()> {
+        let db = new_mem_db();
+        let engine = super::BridgedEngine::new(&db);
+
+        setup_mock_data(&engine)?;
+        put_meta(engine.db, SYNC_ID_META_KEY, &"sync-id".to_string())?;
+
+        engine.reset()?;
+        assert_reset(&engine)?;
+        // Only an explicit reset kills the sync-id, so check that here.
+        assert_eq!(get_meta::<String>(engine.db, SYNC_ID_META_KEY)?, None);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_ensure_missing_sync_id() -> Result<()> {
+        let db = new_mem_db();
+        let engine = super::BridgedEngine::new(&db);
+
+        setup_mock_data(&engine)?;
+
+        assert_eq!(engine.sync_id()?, None);
+        // We don't have a sync ID - so setting one should reset.
+        engine.ensure_current_sync_id("new-id")?;
+        // should have cause a reset.
+        assert_reset(&engine)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_ensure_new_sync_id() -> Result<()> {
+        let db = new_mem_db();
+        let engine = super::BridgedEngine::new(&db);
+
+        setup_mock_data(&engine)?;
+
+        put_meta(engine.db, SYNC_ID_META_KEY, &"old-id".to_string())?;
+        assert_not_reset(&engine)?;
+        assert_eq!(engine.sync_id()?, Some("old-id".to_string()));
+
+        engine.ensure_current_sync_id("new-id")?;
+        // should have cause a reset.
+        assert_reset(&engine)?;
+        // should have the new id.
+        assert_eq!(engine.sync_id()?, Some("new-id".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_ensure_same_sync_id() -> Result<()> {
+        let db = new_mem_db();
+        let engine = super::BridgedEngine::new(&db);
+
+        setup_mock_data(&engine)?;
+        assert_not_reset(&engine)?;
+
+        put_meta(engine.db, SYNC_ID_META_KEY, &"sync-id".to_string())?;
+
+        engine.ensure_current_sync_id("sync-id")?;
+        // should not have reset.
+        assert_not_reset(&engine)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_reset_sync_id() -> Result<()> {
+        let db = new_mem_db();
+        let engine = super::BridgedEngine::new(&db);
+
+        setup_mock_data(&engine)?;
+        put_meta(engine.db, SYNC_ID_META_KEY, &"sync-id".to_string())?;
+
+        assert_eq!(engine.sync_id()?, Some("sync-id".to_string()));
+        let new_id = engine.reset_sync_id()?;
+        // should have cause a reset.
+        assert_reset(&engine)?;
+        assert_eq!(engine.sync_id()?, Some(new_id));
         Ok(())
     }
 }

--- a/components/webext-storage/src/sync/mod.rs
+++ b/components/webext-storage/src/sync/mod.rs
@@ -17,6 +17,8 @@ use incoming::IncomingAction;
 
 type JsonMap = serde_json::Map<String, serde_json::Value>;
 
+pub const STORAGE_VERSION: usize = 1;
+
 /// For use with `#[serde(skip_serializing_if = )]`
 #[inline]
 pub fn is_default<T: PartialEq + Default>(v: &T) -> bool {


### PR DESCRIPTION
Note that this is a little rushed as I ran out of time, so haven't self-reviewed as closely as I would normally. Feel free to take this over if you want it landed ASAP, otherwise I'll have another look tomorrow.

I took the opportunity to move the `wipe` functionality into the engine (see bug 1635688, which will need to land before this gets vendored)

I also added STORAGE_VERSION, but I suspect it's not exposed correctly yet - it's a pub const in a non-pub module :(