### PR TITLE
Cut release v0.58.3

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 0.58.2
+libraryVersion: 0.58.3
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.58.3 (_2020-05-06_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.58.2...v0.58.3)
+
+- Backported the following Send Tab fixes: [#3065](https://github.com/mozilla/application-services/pull/3065) [#3084](https://github.com/mozilla/application-services/pull/3084) to `v0.58.2`. ([#3101](https://github.com/mozilla/application-services/pull/3101))
+
 # v0.58.2 (_2020-04-29_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.58.1...v0.58.2)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v0.58.2...master)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v0.58.3...master)


### PR DESCRIPTION
Note: this is a *backport* of two patches on top of v0.58.2 and not `master`.