### PR TITLE
Bug 1637695 - temporarily add old index to allow local building of appsv

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ def useDownloadedLibs = !System.getenv('CI') && ext.libsGitSha != null
 
 if (useDownloadedLibs) {
     task downloadAndroidLibs(type: Download) {
-        src "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.android.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
+        src "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.android.${rootProject.ext.libsGitSha}/artifacts/public/android.tar.gz"
         dest new File(buildDir, "libs.android.${rootProject.ext.libsGitSha}.tar.gz")
 
         doFirst {
@@ -107,11 +107,11 @@ if (useDownloadedLibs) {
         src {
             switch (DefaultPlatform.RESOURCE_PREFIX) {
                 case 'darwin':
-                    return "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.desktop.macos.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
+                    return "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.desktop.macos.${rootProject.ext.libsGitSha}/artifacts/public/macos.tar.gz"
                 case 'linux-x86-64':
-                    return "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.desktop.linux.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
+                    return "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.desktop.linux.${rootProject.ext.libsGitSha}/artifacts/public/linux.tar.gz"
                 case 'win32-x86-64':
-                    return "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.desktop.win32-x86-64.${rootProject.ext.libsGitSha}/artifacts/public/target.tar.gz"
+                    return "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.desktop.win32-x86-64.${rootProject.ext.libsGitSha}/artifacts/public/win.tar.gz"
                 default:
                     throw new GradleException("Unknown host platform '${DefaultPlatform.RESOURCE_PREFIX}'.  " +
                                               "Set `ext.libsGitSha = null` in ${rootProject.rootDir}/build.gradle and build your own libs.  " +

--- a/taskcluster/app_services_taskgraph/transforms/toolchain.py
+++ b/taskcluster/app_services_taskgraph/transforms/toolchain.py
@@ -4,10 +4,26 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 
+import subprocess
+
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by
 
 transforms = TransformSequence()
+
+# TODO: Bug 1637695 to be removed once we retire these old indexes
+TOOLCHAIN_OLD_INDEX = {
+    'android': 'index.project.application-services.application-services.build.libs.android.{sha}',
+    'desktop-linux': 'index.project.application-services.application-services.build.libs.desktop.linux.{sha}',
+    'desktop-macos': 'index.project.application-services.application-services.build.libs.desktop.macos.{sha}',
+    'desktop-win32-x86-64': 'index.project.application-services.application-services.build.libs.desktop.win32-x86-64.{sha}',
+}
+
+
+def git_sha_for_directory(directory):
+    output = subprocess.check_output(["git", "rev-parse", "HEAD:{}".format(directory)])
+    sha = output.decode("utf8").strip()
+    return sha
 
 
 @transforms.add
@@ -16,4 +32,9 @@ def resolve_keys(config, tasks):
         resolve_keyed_by(task, "routes", item_name=task["name"], **{
             "tasks-for": config.params["tasks_for"]
         })
+        # TODO: Bug 1637695 - temp solution to unblock local building of
+        # appplication-services. Once we switch to new indexes, we should clean this up
+        sha = git_sha_for_directory("libs")
+        routes = task['routes']
+        routes.append(TOOLCHAIN_OLD_INDEX[task['name']].format(sha=sha))
         yield task

--- a/taskcluster/app_services_taskgraph/transforms/toolchain.py
+++ b/taskcluster/app_services_taskgraph/transforms/toolchain.py
@@ -8,8 +8,10 @@ import subprocess
 
 from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import resolve_keyed_by
+from taskgraph.util.memoize import memoize
 
 transforms = TransformSequence()
+
 
 # TODO: Bug 1637695 to be removed once we retire these old indexes
 TOOLCHAIN_OLD_INDEX = {
@@ -20,6 +22,7 @@ TOOLCHAIN_OLD_INDEX = {
 }
 
 
+@memoize
 def git_sha_for_directory(directory):
     output = subprocess.check_output(["git", "rev-parse", "HEAD:{}".format(directory)])
     sha = output.decode("utf8").strip()


### PR DESCRIPTION
This should fix bug https://bugzilla.mozilla.org/show_bug.cgi?id=1637695 and is a temporarily change until we add the long term solution of having the local builds point to standard caching routes. 

CC: @JohanLorenzo @tomprince 

Running taskgraph-diff on application-services gives mes:
```
diff --git a/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/clean/main-repo-pull-request-ci-full.json b/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/dirty/main-repo-pull-request-ci-full.json
index 661a8247..3cb6576a 100644
--- a/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/clean/main-repo-pull-request-ci-full.json
+++ b/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/dirty/main-repo-pull-request-ci-full.json
@@ -2916,6 +2916,7 @@
             "priority": "highest", 
             "provisionerId": "app-services-1", 
             "routes": [
+                "index.project.application-services.application-services.build.libs.android.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-1.toolchains.v3.android.hash.5dc87de54c3fbe122d4777bb3606e1047a93a1a15d038ed75a58d42b4d50288b", 
                 "index.project.application-services.cache.level-1.toolchains.v3.android.latest", 
                 "index.project.application-services.cache.level-1.toolchains.v3.android.pushdate.2020.02.12.20200212190116", 
@@ -3057,6 +3058,7 @@
             "priority": "highest", 
             "provisionerId": "app-services-1", 
             "routes": [
+                "index.project.application-services.application-services.build.libs.desktop.linux.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-linux.hash.6a237544230ab46d3a79195dc0737dde03d698ad3b686d3b2f55bd15a930d992", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-linux.latest", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-linux.pushdate.2020.02.12.20200212190116", 
@@ -3198,6 +3200,7 @@
             "priority": "highest", 
             "provisionerId": "app-services-1", 
             "routes": [
+                "index.project.application-services.application-services.build.libs.desktop.macos.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-macos.hash.087492feb00bb263cc93404e29459d8e871f7381a4aae020ba0f3b75b22c24e1", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-macos.latest", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-macos.pushdate.2020.02.12.20200212190116", 
@@ -3340,6 +3343,7 @@
             "priority": "highest", 
             "provisionerId": "app-services-1", 
             "routes": [
+                "index.project.application-services.application-services.build.libs.desktop.win32-x86-64.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-win32-x86-64.hash.1f81d665f2dae63e9c197532415fd31e80f20ddbd6059ed306a0c773d9f6055a", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-win32-x86-64.latest", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-win32-x86-64.pushdate.2020.02.12.20200212190116", 
diff --git a/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/clean/main-repo-pull-request.json b/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/dirty/main-repo-pull-request.json
index dc493a98..d2ca12d4 100644
--- a/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/clean/main-repo-pull-request.json
+++ b/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/dirty/main-repo-pull-request.json
@@ -568,6 +568,7 @@
             "priority": "highest", 
             "provisionerId": "app-services-1", 
             "routes": [
+                "index.project.application-services.application-services.build.libs.android.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-1.toolchains.v3.android.hash.5dc87de54c3fbe122d4777bb3606e1047a93a1a15d038ed75a58d42b4d50288b", 
                 "index.project.application-services.cache.level-1.toolchains.v3.android.latest", 
                 "index.project.application-services.cache.level-1.toolchains.v3.android.pushdate.2020.02.12.20200212190116", 
@@ -709,6 +710,7 @@
             "priority": "highest", 
             "provisionerId": "app-services-1", 
             "routes": [
+                "index.project.application-services.application-services.build.libs.desktop.linux.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-linux.hash.6a237544230ab46d3a79195dc0737dde03d698ad3b686d3b2f55bd15a930d992", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-linux.latest", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-linux.pushdate.2020.02.12.20200212190116", 
@@ -850,6 +852,7 @@
             "priority": "highest", 
             "provisionerId": "app-services-1", 
             "routes": [
+                "index.project.application-services.application-services.build.libs.desktop.macos.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-macos.hash.087492feb00bb263cc93404e29459d8e871f7381a4aae020ba0f3b75b22c24e1", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-macos.latest", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-macos.pushdate.2020.02.12.20200212190116", 
@@ -992,6 +995,7 @@
             "priority": "highest", 
             "provisionerId": "app-services-1", 
             "routes": [
+                "index.project.application-services.application-services.build.libs.desktop.win32-x86-64.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-win32-x86-64.hash.1f81d665f2dae63e9c197532415fd31e80f20ddbd6059ed306a0c773d9f6055a", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-win32-x86-64.latest", 
                 "index.project.application-services.cache.level-1.toolchains.v3.desktop-win32-x86-64.pushdate.2020.02.12.20200212190116", 
diff --git a/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/clean/main-repo-push.json b/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/dirty/main-repo-push.json
index fe749c24..768f60cc 100644
--- a/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/clean/main-repo-push.json
+++ b/Users/mtabara/work/mozilla/clones/hg/braindump/taskcluster/taskgraph-diff/json/dirty/main-repo-push.json
@@ -2901,6 +2901,7 @@
             "provisionerId": "app-services-3", 
             "routes": [
                 "notify.email.a-s-ci-failures@mozilla.com.on-failed", 
+                "index.project.application-services.application-services.build.libs.android.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-3.toolchains.v3.android.hash.5dc87de54c3fbe122d4777bb3606e1047a93a1a15d038ed75a58d42b4d50288b", 
                 "index.project.application-services.cache.level-3.toolchains.v3.android.latest", 
                 "index.project.application-services.cache.level-3.toolchains.v3.android.pushdate.2020.02.12.20200212190116", 
@@ -3042,6 +3043,7 @@
             "provisionerId": "app-services-3", 
             "routes": [
                 "notify.email.a-s-ci-failures@mozilla.com.on-failed", 
+                "index.project.application-services.application-services.build.libs.desktop.linux.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-3.toolchains.v3.desktop-linux.hash.6a237544230ab46d3a79195dc0737dde03d698ad3b686d3b2f55bd15a930d992", 
                 "index.project.application-services.cache.level-3.toolchains.v3.desktop-linux.latest", 
                 "index.project.application-services.cache.level-3.toolchains.v3.desktop-linux.pushdate.2020.02.12.20200212190116", 
@@ -3183,6 +3185,7 @@
             "provisionerId": "app-services-3", 
             "routes": [
                 "notify.email.a-s-ci-failures@mozilla.com.on-failed", 
+                "index.project.application-services.application-services.build.libs.desktop.macos.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-3.toolchains.v3.desktop-macos.hash.087492feb00bb263cc93404e29459d8e871f7381a4aae020ba0f3b75b22c24e1", 
                 "index.project.application-services.cache.level-3.toolchains.v3.desktop-macos.latest", 
                 "index.project.application-services.cache.level-3.toolchains.v3.desktop-macos.pushdate.2020.02.12.20200212190116", 
@@ -3325,6 +3328,7 @@
             "provisionerId": "app-services-3", 
             "routes": [
                 "notify.email.a-s-ci-failures@mozilla.com.on-failed", 
+                "index.project.application-services.application-services.build.libs.desktop.win32-x86-64.a548e4c3da083f6e7de8c20f0da7218811d7c4a0", 
                 "index.project.application-services.cache.level-3.toolchains.v3.desktop-win32-x86-64.hash.1f81d665f2dae63e9c197532415fd31e80f20ddbd6059ed306a0c773d9f6055a", 
                 "index.project.application-services.cache.level-3.toolchains.v3.desktop-win32-x86-64.latest", 
                 "index.project.application-services.cache.level-3.toolchains.v3.desktop-win32-x86-64.pushdate.2020.02.12.20200212190116", 

```