### PR TITLE
Make webext migration public API consistent wrt paths

### DIFF
--- a/components/webext-storage/src/migration.rs
+++ b/components/webext-storage/src/migration.rs
@@ -6,7 +6,7 @@ use crate::error::*;
 use rusqlite::{Connection, OpenFlags, Transaction, NO_PARAMS};
 use serde_json::{Map, Value};
 use sql_support::ConnExt;
-use std::path::PathBuf;
+use std::path::Path;
 
 // Simple migration from the "old" kinto-with-sqlite-backing implementation
 // to ours.
@@ -101,7 +101,7 @@ struct Parsed<'a> {
     data: serde_json::Value,
 }
 
-pub fn migrate(tx: &Transaction<'_>, filename: &PathBuf) -> Result<usize> {
+pub fn migrate(tx: &Transaction<'_>, filename: impl AsRef<Path>) -> Result<usize> {
     // We do the grouping manually, collecting string values as we go.
     let mut last_ext_id = "".to_string();
     let mut curr_values: Vec<(String, serde_json::Value)> = Vec::new();
@@ -152,7 +152,7 @@ pub fn migrate(tx: &Transaction<'_>, filename: &PathBuf) -> Result<usize> {
     Ok(num_extensions)
 }
 
-fn read_rows(filename: &PathBuf) -> Result<Vec<LegacyRow>> {
+fn read_rows(filename: impl AsRef<Path>) -> Result<Vec<LegacyRow>> {
     let flags = OpenFlags::SQLITE_OPEN_NO_MUTEX | OpenFlags::SQLITE_OPEN_READ_ONLY;
     let src_conn = Connection::open_with_flags(&filename, flags)?;
     let mut stmt = src_conn.prepare(

--- a/components/webext-storage/src/migration.rs
+++ b/components/webext-storage/src/migration.rs
@@ -101,7 +101,7 @@ struct Parsed<'a> {
     data: serde_json::Value,
 }
 
-pub fn migrate(tx: &Transaction<'_>, filename: impl AsRef<Path>) -> Result<usize> {
+pub fn migrate(tx: &Transaction<'_>, filename: &Path) -> Result<usize> {
     // We do the grouping manually, collecting string values as we go.
     let mut last_ext_id = "".to_string();
     let mut curr_values: Vec<(String, serde_json::Value)> = Vec::new();
@@ -152,7 +152,7 @@ pub fn migrate(tx: &Transaction<'_>, filename: impl AsRef<Path>) -> Result<usize
     Ok(num_extensions)
 }
 
-fn read_rows(filename: impl AsRef<Path>) -> Result<Vec<LegacyRow>> {
+fn read_rows(filename: &Path) -> Result<Vec<LegacyRow>> {
     let flags = OpenFlags::SQLITE_OPEN_NO_MUTEX | OpenFlags::SQLITE_OPEN_READ_ONLY;
     let src_conn = Connection::open_with_flags(&filename, flags)?;
     let mut stmt = src_conn.prepare(

--- a/components/webext-storage/src/store.rs
+++ b/components/webext-storage/src/store.rs
@@ -7,7 +7,7 @@ use crate::db::StorageDb;
 use crate::error::*;
 use crate::migration::migrate;
 use crate::sync;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::result;
 
 use serde_json::Value as JsonValue;
@@ -121,9 +121,10 @@ impl Store {
     /// Migrates data from a database in the format of the "old" kinto
     /// implementation. Returns the count of webextensions for whom data was
     /// migrated.
-    pub fn migrate(self, filename: &str) -> Result<usize> {
+    /// Note that `filename` isn't normalized or canonicalized.
+    pub fn migrate(&self, filename: impl AsRef<Path>) -> Result<usize> {
         let tx = self.db.unchecked_transaction()?;
-        let result = migrate(&tx, &PathBuf::from(filename))?;
+        let result = migrate(&tx, filename)?;
         tx.commit()?;
         Ok(result)
     }

--- a/components/webext-storage/src/store.rs
+++ b/components/webext-storage/src/store.rs
@@ -124,7 +124,7 @@ impl Store {
     /// Note that `filename` isn't normalized or canonicalized.
     pub fn migrate(&self, filename: impl AsRef<Path>) -> Result<usize> {
         let tx = self.db.unchecked_transaction()?;
-        let result = migrate(&tx, filename)?;
+        let result = migrate(&tx, filename.as_ref())?;
         tx.commit()?;
         Ok(result)
     }


### PR DESCRIPTION
`migrate()` and `new()` both take file-system paths - they should be consistent.