### PR TITLE
Use thiserror and anyhow to replace failure

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -4,6 +4,10 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.59.0...master)
 
+## General
+
+- Replaced `failure` with `anyhow` and `thiserror`. ([#3132](https://github.com/mozilla/application-services/pull/3132))
+
 ## FxA Client
 
 ### What's new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ dependencies = [
 name = "cli-support"
 version = "0.1.0"
 dependencies = [
- "failure",
+ "anyhow",
  "fxa-client",
  "log 0.4.8",
  "sync15",
@@ -493,6 +493,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+dependencies = [
+ "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "dogear"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,16 +532,15 @@ checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
 name = "ece"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e831571186ec514efc697af518eee5e4aaecc13edeb4a918227f7bcba2c20b1"
+checksum = "bc1b4aa60de558deb8a5c2f803ac354ba733189a5dddeb19323144a540410497"
 dependencies = [
  "base64 0.12.1",
  "byteorder",
- "failure",
- "failure_derive",
  "once_cell",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -560,7 +581,8 @@ dependencies = [
 name = "error-support"
 version = "0.1.0"
 dependencies = [
- "failure",
+ "backtrace",
+ "thiserror",
 ]
 
 [[package]]
@@ -646,12 +668,12 @@ dependencies = [
 
 [[package]]
 name = "find-places-db"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "156072cf5b7e3974da51941bf050f5b8ab5a8df56ad5c1adbd8c07e9d9455b95"
+checksum = "1594bf39a5c2a21fb4ea7fd6f6cfeeeba9ece09012d9c6081349c5de1c441076"
 dependencies = [
- "dirs",
- "failure",
+ "anyhow",
+ "dirs 2.0.2",
  "log 0.4.8",
 ]
 
@@ -759,12 +781,12 @@ dependencies = [
 name = "fxa-client"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base64 0.12.1",
  "byteorder",
  "cli-support",
  "dialoguer",
  "error-support",
- "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "lazy_static",
@@ -777,6 +799,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sync15",
+ "thiserror",
  "url",
  "viaduct",
  "viaduct-reqwest",
@@ -835,15 +858,16 @@ dependencies = [
 
 [[package]]
 name = "hawk"
-version = "3.1.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57528ce5133f688e1bc4daadc3e50bf9093d40e8a1f64c6e506ccbae005e57e6"
+checksum = "c6daf498213ee89a0f94bcd0d90b4a36fa422fbbc751599cb73fa67d921014c8"
 dependencies = [
+ "anyhow",
  "base64 0.12.1",
- "failure",
  "log 0.4.8",
  "once_cell",
  "rand 0.7.3",
+ "thiserror",
  "url",
 ]
 
@@ -1081,12 +1105,12 @@ dependencies = [
 name = "logins"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
  "clap",
  "cli-support",
  "env_logger",
  "error-support",
- "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fxa-client",
  "interrupt-support",
@@ -1104,6 +1128,7 @@ dependencies = [
  "sync-guid",
  "sync15",
  "tempdir",
+ "thiserror",
  "url",
 ]
 
@@ -1358,11 +1383,10 @@ version = "0.1.0"
 dependencies = [
  "base64 0.12.1",
  "error-support",
- "failure",
- "failure_derive",
  "nss_sys",
  "serde",
  "serde_derive",
+ "thiserror",
 ]
 
 [[package]]
@@ -1568,6 +1592,7 @@ checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 name = "places"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bitflags 1.2.1",
  "caseless",
  "clap",
@@ -1577,7 +1602,6 @@ dependencies = [
  "dogear",
  "env_logger",
  "error-support",
- "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "find-places-db",
  "fxa-client",
@@ -1603,6 +1627,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "termion",
+ "thiserror",
  "url",
 ]
 
@@ -1773,8 +1798,6 @@ dependencies = [
  "bincode",
  "env_logger",
  "error-support",
- "failure",
- "failure_derive",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
  "lazy_static",
@@ -1788,6 +1811,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sql-support",
+ "thiserror",
  "url",
  "viaduct",
  "viaduct-reqwest",
@@ -2015,12 +2039,11 @@ dependencies = [
  "base64 0.12.1",
  "ece",
  "error-support",
- "failure",
- "failure_derive",
  "hawk",
  "hex",
  "libsqlite3-sys",
  "nss",
+ "thiserror",
 ]
 
 [[package]]
@@ -2418,11 +2441,11 @@ dependencies = [
 name = "sync15"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "base16",
  "base64 0.12.1",
  "env_logger",
  "error-support",
- "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt-support",
  "lazy_static",
@@ -2433,6 +2456,7 @@ dependencies = [
  "serde_json",
  "sync-guid",
  "sync15-traits",
+ "thiserror",
  "url",
  "viaduct",
 ]
@@ -2441,13 +2465,14 @@ dependencies = [
 name = "sync15-traits"
 version = "0.1.0"
 dependencies = [
- "failure",
+ "anyhow",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt-support",
  "log 0.4.8",
  "serde",
  "serde_json",
  "sync-guid",
+ "thiserror",
  "url",
 ]
 
@@ -2455,8 +2480,8 @@ dependencies = [
 name = "sync_manager"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "error-support",
- "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt-support",
  "lazy_static",
@@ -2471,6 +2496,7 @@ dependencies = [
  "sql-support",
  "sync15",
  "tabs",
+ "thiserror",
  "url",
 ]
 
@@ -2554,11 +2580,11 @@ dependencies = [
 name = "tabs"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "cli-support",
  "clipboard",
  "error-support",
- "failure",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt-support",
  "log 0.4.8",
@@ -2569,6 +2595,7 @@ dependencies = [
  "serde_json",
  "sync-guid",
  "sync15",
+ "thiserror",
  "url",
  "viaduct-reqwest",
 ]
@@ -2630,7 +2657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
- "dirs",
+ "dirs 1.0.5",
  "winapi 0.3.8",
 ]
 
@@ -2681,6 +2708,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2860,8 +2907,6 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 name = "viaduct"
 version = "0.1.0"
 dependencies = [
- "failure",
- "failure_derive",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8",
  "once_cell",
@@ -2869,6 +2914,7 @@ dependencies = [
  "prost-derive",
  "serde",
  "serde_json",
+ "thiserror",
  "url",
 ]
 
@@ -3010,7 +3056,6 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "error-support",
- "failure",
  "interrupt-support",
  "lazy_static",
  "libsqlite3-sys",
@@ -3025,6 +3070,7 @@ dependencies = [
  "sync-guid",
  "sync15-traits",
  "tempfile",
+ "thiserror",
  "url",
 ]
 

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -22,7 +22,6 @@ the details of which are reproduced below.
 * [MIT License: openssl-sys](#mit-license-openssl-sys)
 * [MIT License: schannel](#mit-license-schannel)
 * [MIT License: slab](#mit-license-slab)
-* [MIT License: synstructure](#mit-license-synstructure)
 * [MIT License: tokio, tokio-tls, tokio-util](#mit-license-tokio-tokio-tls-tokio-util)
 * [MIT License: tower-service](#mit-license-tower-service)
 * [MIT License: try-lock](#mit-license-try-lock)
@@ -438,8 +437,6 @@ The following text applies to code linked from these dependencies:
 [dtoa](https://github.com/dtolnay/dtoa),
 [either](https://github.com/bluss/either),
 [encoding_rs](https://github.com/hsivonen/encoding_rs),
-[failure](https://github.com/rust-lang-nursery/failure),
-[failure_derive](https://github.com/rust-lang-nursery/failure),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
 [ffi-support](https://github.com/mozilla/application-services),
@@ -510,6 +507,8 @@ The following text applies to code linked from these dependencies:
 [swift-protobuf](https://github.com/apple/swift-protobuf),
 [syn](https://github.com/dtolnay/syn),
 [tempfile](https://github.com/Stebalien/tempfile),
+[thiserror-impl](https://github.com/dtolnay/thiserror),
+[thiserror](https://github.com/dtolnay/thiserror),
 [thread_local](https://github.com/Amanieu/thread_local-rs),
 [time](https://github.com/time-rs/time),
 [unicase](https://github.com/seanmonstar/unicase),
@@ -1214,22 +1213,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: synstructure
-
-The following text applies to code linked from these dependencies:
-[synstructure](https://github.com/mystor/synstructure)
-
-```
-Copyright 2016 Nika Layzell
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -9,7 +9,6 @@ exclude = ["/android", "/ios"]
 [dependencies]
 base64 = "0.12"
 byteorder = "1.3"
-failure = "0.1"
 hex = "0.4"
 lazy_static = "1.4"
 log = "0.4"
@@ -24,6 +23,7 @@ ffi-support = "0.4"
 viaduct = { path = "../viaduct" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece", "hawk"] }
 error-support = { path = "../support/error" }
+thiserror = "1.0"
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
@@ -31,6 +31,7 @@ cli-support = { path = "../support/cli" }
 dialoguer = "0.6"
 webbrowser = "0.5"
 mockiato = "0.9"
+anyhow = "1.0"
 
 [features]
 default = []

--- a/components/fxa-client/examples/devices_api.rs
+++ b/components/fxa-client/examples/devices_api.rs
@@ -21,14 +21,16 @@ static REDIRECT_URI: &str = "https://accounts.firefox.com/oauth/success/a2270f72
 static SCOPES: &[&str] = &["profile", "https://identity.mozilla.com/apps/oldsync"];
 static DEFAULT_DEVICE_NAME: &str = "Bobo device";
 
-fn load_fxa_creds() -> Result<FirefoxAccount, failure::Error> {
+use anyhow::Result;
+
+fn load_fxa_creds() -> Result<FirefoxAccount> {
     let mut file = fs::File::open(CREDENTIALS_PATH)?;
     let mut s = String::new();
     file.read_to_string(&mut s)?;
     Ok(FirefoxAccount::from_json(&s)?)
 }
 
-fn load_or_create_fxa_creds(cfg: Config) -> Result<FirefoxAccount, failure::Error> {
+fn load_or_create_fxa_creds(cfg: Config) -> Result<FirefoxAccount> {
     let acct = load_fxa_creds().or_else(|_e| create_fxa_creds(cfg))?;
     persist_fxa_state(&acct);
     Ok(acct)
@@ -47,7 +49,7 @@ fn persist_fxa_state(acct: &FirefoxAccount) {
     file.flush().unwrap();
 }
 
-fn create_fxa_creds(cfg: Config) -> Result<FirefoxAccount, failure::Error> {
+fn create_fxa_creds(cfg: Config) -> Result<FirefoxAccount> {
     let mut acct = FirefoxAccount::with_config(cfg);
     let oauth_uri = acct.begin_oauth_flow(&SCOPES)?;
 
@@ -68,7 +70,7 @@ fn create_fxa_creds(cfg: Config) -> Result<FirefoxAccount, failure::Error> {
     Ok(acct)
 }
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<()> {
     viaduct_reqwest::use_reqwest_backend();
     let cfg = Config::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
     let mut acct = load_or_create_fxa_creds(cfg)?;

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -2,115 +2,107 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use failure::Fail;
 use rc_crypto::hawk;
 use std::string;
-
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    #[fail(display = "Unknown OAuth State")]
+    #[error("Unknown OAuth State")]
     UnknownOAuthState,
 
-    #[fail(display = "The client requested keys alongside the token but they were not included")]
+    #[error("The client requested keys alongside the token but they were not included")]
     TokenWithoutKeys,
 
-    #[fail(display = "Login state needs to be Married for the current operation")]
+    #[error("Login state needs to be Married for the current operation")]
     NotMarried,
 
-    #[fail(display = "Multiple OAuth scopes requested")]
+    #[error("Multiple OAuth scopes requested")]
     MultipleScopesRequested,
 
-    #[fail(display = "No cached token for scope {}", _0)]
+    #[error("No cached token for scope {0}")]
     NoCachedToken(String),
 
-    #[fail(display = "No cached scoped keys for scope {}", _0)]
+    #[error("No cached scoped keys for scope {0}")]
     NoScopedKey(String),
 
-    #[fail(display = "No stored refresh token")]
+    #[error("No stored refresh token")]
     NoRefreshToken,
 
-    #[fail(display = "No stored session token")]
+    #[error("No stored session token")]
     NoSessionToken,
 
-    #[fail(display = "No stored migration data")]
+    #[error("No stored migration data")]
     NoMigrationData,
 
-    #[fail(display = "No stored current device id")]
+    #[error("No stored current device id")]
     NoCurrentDeviceId,
 
-    #[fail(display = "Could not find a refresh token in the server response")]
+    #[error("Could not find a refresh token in the server response")]
     RefreshTokenNotPresent,
 
-    #[fail(display = "Action requires a prior device registration")]
+    #[error("Action requires a prior device registration")]
     DeviceUnregistered,
 
-    #[fail(display = "Device target is unknown (Device ID: {})", _0)]
+    #[error("Device target is unknown (Device ID: {0})")]
     UnknownTargetDevice(String),
 
-    #[fail(display = "Unrecoverable server error {}", _0)]
+    #[error("Unrecoverable server error {0}")]
     UnrecoverableServerError(&'static str),
 
-    #[fail(display = "Invalid OAuth scope value {}", _0)]
+    #[error("Invalid OAuth scope value {0}")]
     InvalidOAuthScopeValue(String),
 
-    #[fail(display = "Illegal state: {}", _0)]
+    #[error("Illegal state: {0}")]
     IllegalState(&'static str),
 
-    #[fail(display = "Unknown command: {}", _0)]
+    #[error("Unknown command: {0}")]
     UnknownCommand(String),
 
-    #[fail(display = "Send Tab diagnosis error: {}", _0)]
+    #[error("Send Tab diagnosis error: {0}")]
     SendTabDiagnosisError(&'static str),
 
-    #[fail(display = "Empty names")]
+    #[error("Empty names")]
     EmptyOAuthScopeNames,
 
-    #[fail(display = "Key {} had wrong length, got {}, expected {}", _0, _1, _2)]
+    #[error("Key {0} had wrong length, got {1}, expected {2}")]
     BadKeyLength(&'static str, usize, usize),
 
-    #[fail(
-        display = "Cannot xor arrays with different lengths: {} and {}",
-        _0, _1
-    )]
+    #[error("Cannot xor arrays with different lengths: {0} and {1}")]
     XorLengthMismatch(usize, usize),
 
-    #[fail(display = "Audience URL without a host")]
+    #[error("Audience URL without a host")]
     AudienceURLWithoutHost,
 
-    #[fail(display = "Origin mismatch")]
+    #[error("Origin mismatch")]
     OriginMismatch,
 
-    #[fail(display = "JWT signature validation failed")]
+    #[error("JWT signature validation failed")]
     JWTSignatureValidationFailed,
 
-    #[fail(display = "ECDH key generation failed")]
+    #[error("ECDH key generation failed")]
     KeyGenerationFailed,
 
-    #[fail(display = "Public key computation failed")]
+    #[error("Public key computation failed")]
     PublicKeyComputationFailed,
 
-    #[fail(display = "Remote key and local key mismatch")]
+    #[error("Remote key and local key mismatch")]
     MismatchedKeys,
 
-    #[fail(display = "Key import failed")]
+    #[error("Key import failed")]
     KeyImportFailed,
 
-    #[fail(display = "AEAD open failure")]
+    #[error("AEAD open failure")]
     AEADOpenFailure,
 
-    #[fail(display = "Random number generation failure")]
+    #[error("Random number generation failure")]
     RngFailure,
 
-    #[fail(display = "HMAC mismatch")]
+    #[error("HMAC mismatch")]
     HmacMismatch,
 
-    #[fail(display = "Unsupported command: {}", _0)]
+    #[error("Unsupported command: {0}")]
     UnsupportedCommand(&'static str),
 
-    #[fail(
-        display = "Remote server error: '{}' '{}' '{}' '{}' '{}'",
-        code, errno, error, message, info
-    )]
+    #[error("Remote server error: '{code}' '{errno}' '{error}' '{message}' '{info}'")]
     RemoteError {
         code: u64,
         errno: u64,
@@ -120,41 +112,41 @@ pub enum ErrorKind {
     },
 
     // Basically reimplement error_chain's foreign_links. (Ugh, this sucks).
-    #[fail(display = "Crypto/NSS error: {}", _0)]
-    CryptoError(#[fail(cause)] rc_crypto::Error),
+    #[error("Crypto/NSS error: {0}")]
+    CryptoError(#[from] rc_crypto::Error),
 
-    #[fail(display = "http-ece encryption error: {}", _0)]
-    EceError(#[fail(cause)] rc_crypto::ece::Error),
+    #[error("http-ece encryption error: {0}")]
+    EceError(#[from] rc_crypto::ece::Error),
 
-    #[fail(display = "Hex decode error: {}", _0)]
-    HexDecodeError(#[fail(cause)] hex::FromHexError),
+    #[error("Hex decode error: {0}")]
+    HexDecodeError(#[from] hex::FromHexError),
 
-    #[fail(display = "Base64 decode error: {}", _0)]
-    Base64Decode(#[fail(cause)] base64::DecodeError),
+    #[error("Base64 decode error: {0}")]
+    Base64Decode(#[from] base64::DecodeError),
 
-    #[fail(display = "JSON error: {}", _0)]
-    JsonError(#[fail(cause)] serde_json::Error),
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
 
-    #[fail(display = "UTF8 decode error: {}", _0)]
-    UTF8DecodeError(#[fail(cause)] string::FromUtf8Error),
+    #[error("UTF8 decode error: {0}")]
+    UTF8DecodeError(#[from] string::FromUtf8Error),
 
-    #[fail(display = "Network error: {}", _0)]
-    RequestError(#[fail(cause)] viaduct::Error),
+    #[error("Network error: {0}")]
+    RequestError(#[from] viaduct::Error),
 
-    #[fail(display = "Malformed URL error: {}", _0)]
-    MalformedUrl(#[fail(cause)] url::ParseError),
+    #[error("Malformed URL error: {0}")]
+    MalformedUrl(#[from] url::ParseError),
 
-    #[fail(display = "Unexpected HTTP status: {}", _0)]
-    UnexpectedStatus(#[fail(cause)] viaduct::UnexpectedStatus),
+    #[error("Unexpected HTTP status: {0}")]
+    UnexpectedStatus(#[from] viaduct::UnexpectedStatus),
 
-    #[fail(display = "Sync15 error: {}", _0)]
-    SyncError(#[fail(cause)] sync15::Error),
+    #[error("Sync15 error: {0}")]
+    SyncError(#[from] sync15::Error),
 
-    #[fail(display = "HAWK error: {}", _0)]
-    HawkError(#[fail(cause)] hawk::Error),
+    #[error("HAWK error: {0}")]
+    HawkError(#[from] hawk::Error),
 
-    #[fail(display = "Protobuf decode error: {}", _0)]
-    ProtobufDecodeError(#[fail(cause)] prost::DecodeError),
+    #[error("Protobuf decode error: {0}")]
+    ProtobufDecodeError(#[from] prost::DecodeError),
 }
 
 error_support::define_error! {

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -18,7 +18,6 @@ serde_json = "1"
 log = "0.4"
 lazy_static = "1.4"
 url = "2.1"
-failure = "0.1"
 sql-support = { path = "../support/sql" }
 ffi-support = "0.4"
 interrupt-support = { path = "../support/interrupt" }
@@ -26,6 +25,8 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 prost = "0.6"
 prost-derive = "0.6"
+thiserror = "1.0"
+anyhow = "1.0"
 
 [dependencies.rusqlite]
 version = "0.23.1"

--- a/components/logins/examples/sync_pass_sql.rs
+++ b/components/logins/examples/sync_pass_sql.rs
@@ -8,7 +8,6 @@
 
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
 use cli_support::prompt::{prompt_char, prompt_string, prompt_usize};
-use failure::Fail;
 
 use logins::{Login, PasswordEngine};
 use prettytable::{cell, row, Cell, Row, Table};
@@ -17,7 +16,7 @@ use sync15::StoreSyncAssociation;
 use sync_guid::Guid;
 
 // I'm completely punting on good error handling here.
-type Result<T> = std::result::Result<T, failure::Error>;
+use anyhow::Result;
 
 fn read_login() -> Login {
     let username = prompt_string("username").unwrap_or_default();

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use failure::Fail;
-
 // TODO: this is (IMO) useful and was dropped from `failure`, consider moving it
 // into `error_support`.
 macro_rules! throw {
@@ -12,50 +10,44 @@ macro_rules! throw {
     };
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    #[fail(display = "Invalid login: {}", _0)]
+    #[error("Invalid login: {0}")]
     InvalidLogin(InvalidLogin),
 
-    #[fail(
-        display = "The `sync_status` column in DB has an illegal value: {}",
-        _0
-    )]
+    #[error("The `sync_status` column in DB has an illegal value: {0}")]
     BadSyncStatus(u8),
 
-    #[fail(display = "A duplicate GUID is present: {:?}", _0)]
+    #[error("A duplicate GUID is present: {0:?}")]
     DuplicateGuid(String),
 
-    #[fail(
-        display = "No record with guid exists (when one was required): {:?}",
-        _0
-    )]
+    #[error("No record with guid exists (when one was required): {0:?}")]
     NoSuchRecord(String),
 
     // Fennec import only works on empty logins tables.
-    #[fail(display = "The logins tables are not empty")]
+    #[error("The logins tables are not empty")]
     NonEmptyTable,
 
-    #[fail(display = "The provided salt is invalid")]
+    #[error("The provided salt is invalid")]
     InvalidSalt,
 
-    #[fail(display = "Error synchronizing: {}", _0)]
-    SyncAdapterError(#[fail(cause)] sync15::Error),
+    #[error("Error synchronizing: {0}")]
+    SyncAdapterError(#[from] sync15::Error),
 
-    #[fail(display = "Error parsing JSON data: {}", _0)]
-    JsonError(#[fail(cause)] serde_json::Error),
+    #[error("Error parsing JSON data: {0}")]
+    JsonError(#[from] serde_json::Error),
 
-    #[fail(display = "Error executing SQL: {}", _0)]
-    SqlError(#[fail(cause)] rusqlite::Error),
+    #[error("Error executing SQL: {0}")]
+    SqlError(#[from] rusqlite::Error),
 
-    #[fail(display = "Error parsing URL: {}", _0)]
-    UrlParseError(#[fail(cause)] url::ParseError),
+    #[error("Error parsing URL: {0}")]
+    UrlParseError(#[from] url::ParseError),
 
-    #[fail(display = "{}", _0)]
-    Interrupted(#[fail(cause)] interrupt_support::Interrupted),
+    #[error("{0}")]
+    Interrupted(#[from] interrupt_support::Interrupted),
 
-    #[fail(display = "Protobuf decode error: {}", _0)]
-    ProtobufDecodeError(#[fail(cause)] prost::DecodeError),
+    #[error("Protobuf decode error: {0}")]
+    ProtobufDecodeError(#[from] prost::DecodeError),
 }
 
 error_support::define_error! {
@@ -70,20 +62,20 @@ error_support::define_error! {
     }
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum InvalidLogin {
     // EmptyOrigin error occurs when the login's hostname field is empty.
-    #[fail(display = "Origin is empty")]
+    #[error("Origin is empty")]
     EmptyOrigin,
-    #[fail(display = "Password is empty")]
+    #[error("Password is empty")]
     EmptyPassword,
-    #[fail(display = "Login already exists")]
+    #[error("Login already exists")]
     DuplicateLogin,
-    #[fail(display = "Both `formSubmitUrl` and `httpRealm` are present")]
+    #[error("Both `formSubmitUrl` and `httpRealm` are present")]
     BothTargets,
-    #[fail(display = "Neither `formSubmitUrl` or `httpRealm` are present")]
+    #[error("Neither `formSubmitUrl` or `httpRealm` are present")]
     NoTarget,
-    #[fail(display = "Login has illegal field: {}", _0)]
+    #[error("Login has illegal field: {field_info}")]
     IllegalFieldValue { field_info: String },
 }
 

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -19,7 +19,6 @@ log = "0.4"
 lazy_static = "1.4"
 url = { version = "2.1", features = ["serde"] }
 percent-encoding = "2.1"
-failure = "0.1"
 caseless = "0.2"
 sql-support = { path = "../support/sql" }
 ffi-support = "0.4"
@@ -32,6 +31,8 @@ dogear = "0.4"
 interrupt-support = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
+thiserror = "1.0"
+anyhow = "1.0"
 
 [dependencies.rusqlite]
 version = "0.23.1"
@@ -40,7 +41,7 @@ features = ["functions", "bundled"]
 [dev-dependencies]
 more-asserts = "0.2"
 env_logger = "0.7"
-find-places-db = "0.1"
+find-places-db = "0.2"
 clap = "2.33"
 structopt = "0.3"
 tempfile = "3.1"

--- a/components/places/examples/autocomplete.rs
+++ b/components/places/examples/autocomplete.rs
@@ -6,7 +6,6 @@
 #![warn(rust_2018_idioms)]
 
 use clap::value_t;
-use failure::bail;
 use places::{PlacesDb, VisitObservation, VisitTransition};
 use rusqlite::NO_PARAMS;
 use serde_derive::*;
@@ -18,7 +17,7 @@ use std::{
 };
 use url::Url;
 
-type Result<T> = std::result::Result<T, failure::Error>;
+use anyhow::Result;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
@@ -816,7 +815,9 @@ fn main() -> Result<()> {
                 info
             } else {
                 log::error!("Failed to locate your firefox profile!");
-                bail!("--import-places=auto specified, but couldn't find a `places.sqlite`");
+                anyhow::bail!(
+                    "--import-places=auto specified, but couldn't find a `places.sqlite`"
+                );
             };
             log::info!(
                 "Using a {} places.sqlite from profile '{}' (places path = {:?})",
@@ -832,7 +833,7 @@ fn main() -> Result<()> {
         } else {
             let path = Path::new(import_places_arg);
             if !path.exists() {
-                bail!(
+                anyhow::bail!(
                     "Provided path to --import-places doesn't exist and isn't 'auto': {:?}",
                     import_places_arg
                 );

--- a/components/places/examples/check-coop-tx.rs
+++ b/components/places/examples/check-coop-tx.rs
@@ -14,7 +14,7 @@ use std::sync::mpsc::sync_channel;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-type Result<T> = std::result::Result<T, failure::Error>;
+use anyhow::Result;
 
 fn update(t: &PlacesDb, n: u32) -> Result<()> {
     t.execute(

--- a/components/places/examples/places-utils.rs
+++ b/components/places/examples/places-utils.rs
@@ -16,7 +16,6 @@ use places::types::{BookmarkType, Timestamp};
 use places::{ConnectionType, PlacesApi, PlacesDb};
 use sync_guid::Guid as SyncGuid;
 
-use failure::Fail;
 use serde_derive::*;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
@@ -27,7 +26,7 @@ use sync15::{
 };
 use url::Url;
 
-type Result<T> = std::result::Result<T, failure::Error>;
+use anyhow::Result;
 
 fn init_logging() {
     // Explicitly ignore some rather noisy crates. Turn on trace for everyone else.

--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -30,7 +30,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
-use std::result;
 use sync15::{
     telemetry, CollSyncIds, CollectionRequest, IncomingChangeset, OutgoingChangeset, Payload,
     ServerTimestamp, Store, StoreSyncAssociation,
@@ -932,7 +931,7 @@ impl<'a> Store for BookmarksStore<'a> {
         &self,
         inbound: Vec<IncomingChangeset>,
         telem: &mut telemetry::Engine,
-    ) -> result::Result<OutgoingChangeset, failure::Error> {
+    ) -> anyhow::Result<OutgoingChangeset> {
         assert_eq!(inbound.len(), 1, "bookmarks only requests one item");
         let inbound = inbound.into_iter().next().unwrap();
         // Stage all incoming items.
@@ -958,7 +957,7 @@ impl<'a> Store for BookmarksStore<'a> {
         &self,
         new_timestamp: ServerTimestamp,
         records_synced: Vec<SyncGuid>,
-    ) -> result::Result<(), failure::Error> {
+    ) -> anyhow::Result<()> {
         self.push_synced_items(new_timestamp, records_synced)?;
         self.update_frecencies()?;
         self.db.pragma_update(None, "wal_checkpoint", &"PASSIVE")?;
@@ -968,7 +967,7 @@ impl<'a> Store for BookmarksStore<'a> {
     fn get_collection_requests(
         &self,
         server_timestamp: ServerTimestamp,
-    ) -> result::Result<Vec<CollectionRequest>, failure::Error> {
+    ) -> anyhow::Result<Vec<CollectionRequest>> {
         let since =
             ServerTimestamp(get_meta::<i64>(self.db, LAST_SYNC_META_KEY)?.unwrap_or_default());
         Ok(if since == server_timestamp {
@@ -980,7 +979,7 @@ impl<'a> Store for BookmarksStore<'a> {
         })
     }
 
-    fn get_sync_assoc(&self) -> result::Result<StoreSyncAssociation, failure::Error> {
+    fn get_sync_assoc(&self) -> anyhow::Result<StoreSyncAssociation> {
         let global = get_meta(self.db, GLOBAL_SYNCID_META_KEY)?;
         let coll = get_meta(self.db, COLLECTION_SYNCID_META_KEY)?;
         Ok(if let (Some(global), Some(coll)) = (global, coll) {
@@ -990,7 +989,7 @@ impl<'a> Store for BookmarksStore<'a> {
         })
     }
 
-    fn reset(&self, assoc: &StoreSyncAssociation) -> result::Result<(), failure::Error> {
+    fn reset(&self, assoc: &StoreSyncAssociation) -> anyhow::Result<()> {
         BookmarksStore::reset(self, assoc)?;
         Ok(())
     }
@@ -1001,7 +1000,7 @@ impl<'a> Store for BookmarksStore<'a> {
     ///
     /// Conceptually, the next sync will merge an empty local tree, and a full
     /// remote tree.
-    fn wipe(&self) -> result::Result<(), failure::Error> {
+    fn wipe(&self) -> anyhow::Result<()> {
         let tx = self.db.begin_transaction()?;
         let sql = format!(
             "INSERT INTO moz_bookmarks_deleted(guid, dateRemoved)
@@ -3522,7 +3521,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reset() -> result::Result<(), failure::Error> {
+    fn test_reset() -> anyhow::Result<()> {
         let api = new_mem_api();
         let writer = api.open_connection(ConnectionType::ReadWrite)?;
 
@@ -3579,7 +3578,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dedupe_local_newer() -> result::Result<(), failure::Error> {
+    fn test_dedupe_local_newer() -> anyhow::Result<()> {
         let _ = env_logger::try_init();
 
         let api = new_mem_api();
@@ -3698,7 +3697,7 @@ mod tests {
     }
 
     #[test]
-    fn test_deduping_remote_newer() -> result::Result<(), failure::Error> {
+    fn test_deduping_remote_newer() -> anyhow::Result<()> {
         let _ = env_logger::try_init();
 
         let api = new_mem_api();

--- a/components/places/src/types.rs
+++ b/components/places/src/types.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use failure::Fail;
 use rusqlite::types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::Result as RusqliteResult;
 use serde::ser::{Serialize, Serializer};
@@ -100,8 +99,8 @@ impl FromSql for Timestamp {
     }
 }
 
-#[derive(Fail, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[fail(display = "Invalid visit type")]
+#[derive(thiserror::Error, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[error("Invalid visit type")]
 pub struct InvalidVisitType;
 
 // NOTE: These discriminator values are the same as those used by Desktop

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -16,8 +16,6 @@ serde_json = "1"
 bincode = "1.2"
 lazy_static = "1.4"
 base64 = "0.12"
-failure = "0.1"
-failure_derive = "0.1"
 log = "0.4"
 rusqlite = { version = "0.23.1", features = ["bundled"] }
 url = "2.1"
@@ -28,6 +26,7 @@ error-support = { path = "../support/error" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }
 prost = "0.6"
 prost-derive = "0.6"
+thiserror = "1.0"
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/push/src/error.rs
+++ b/components/push/src/error.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use failure::Fail;
-
 impl From<Error> for ffi_support::ExternError {
     fn from(e: Error) -> ffi_support::ExternError {
         ffi_support::ExternError::new_error(e.kind().error_code(), format!("{:?}", e))
@@ -17,47 +15,47 @@ error_support::define_error! {
     }
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
     /// An unspecified general error has occured
-    #[fail(display = "General Error: {:?}", _0)]
+    #[error("General Error: {0:?}")]
     GeneralError(String),
 
-    #[fail(display = "Crypto error: {}", _0)]
+    #[error("Crypto error: {0}")]
     CryptoError(String),
 
     /// A Client communication error
-    #[fail(display = "Communication Error: {:?}", _0)]
+    #[error("Communication Error: {0:?}")]
     CommunicationError(String),
 
     /// An error returned from the registration Server
-    #[fail(display = "Communication Server Error: {:?}", _0)]
+    #[error("Communication Server Error: {0:?}")]
     CommunicationServerError(String),
 
     /// Channel is already registered, generate new channelID
-    #[fail(display = "Channel already registered.")]
+    #[error("Channel already registered.")]
     AlreadyRegisteredError,
 
     /// An error with Storage
-    #[fail(display = "Storage Error: {:?}", _0)]
+    #[error("Storage Error: {0:?}")]
     StorageError(String),
 
-    #[fail(display = "No record for uaid:chid {:?}:{:?}", _0, _1)]
+    #[error("No record for uaid:chid {0:?}:{1:?}")]
     RecordNotFoundError(String, String),
 
     /// A failure to encode data to/from storage.
-    #[fail(display = "Error executing SQL: {}", _0)]
-    StorageSqlError(#[fail(cause)] rusqlite::Error),
+    #[error("Error executing SQL: {0}")]
+    StorageSqlError(#[from] rusqlite::Error),
 
-    #[fail(display = "Missing Registration Token")]
+    #[error("Missing Registration Token")]
     MissingRegistrationTokenError,
 
-    #[fail(display = "Transcoding Error: {}", _0)]
+    #[error("Transcoding Error: {0}")]
     TranscodingError(String),
 
     /// A failure to parse a URL.
-    #[fail(display = "URL parse error: {:?}", _0)]
-    UrlParseError(#[fail(cause)] url::ParseError),
+    #[error("URL parse error: {0:?}")]
+    UrlParseError(#[from] url::ParseError),
 }
 
 // Note, be sure to duplicate errors in the Kotlin side

--- a/components/support/cli/Cargo.toml
+++ b/components/support/cli/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>", "Mark Hammond <mhammond@
 license = "MPL-2.0"
 
 [dependencies]
-failure = "0.1"
+anyhow = "1.0"
 fxa-client = { path = "../../fxa-client" }
 log = "0.4"
 sync15 = { path = "../../sync15" }

--- a/components/support/cli/src/fxa_creds.rs
+++ b/components/support/cli/src/fxa_creds.rs
@@ -14,7 +14,7 @@ use std::{
 use sync15::{KeyBundle, Sync15StorageClientInit};
 use url::Url;
 
-type Result<T> = std::result::Result<T, failure::Error>;
+use anyhow::Result;
 
 // Defaults - not clear they are the best option, but they are a currently
 // working option.
@@ -102,7 +102,7 @@ pub fn get_cli_fxa(config: Config, cred_file: &str) -> Result<CliFxa> {
     let tokenserver_url = config.token_server_endpoint_url()?;
     let (acct, token_info) = match get_account_and_token(config, cred_file) {
         Ok(v) => v,
-        Err(e) => failure::bail!("Failed to use saved credentials. {}", e),
+        Err(e) => anyhow::bail!("Failed to use saved credentials. {}", e),
     };
     let key = token_info.key.unwrap();
 

--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2018"
 license = "MPL-2.0"
 
 [dependencies]
-failure = "0.1"
-
+thiserror = "1.0"
+backtrace = "0.3"

--- a/components/support/rc_crypto/Cargo.toml
+++ b/components/support/rc_crypto/Cargo.toml
@@ -10,13 +10,12 @@ crate-type = ["lib"]
 
 [dependencies]
 base64 = "0.12"
-failure = "0.1"
-failure_derive = "0.1"
+thiserror = "1.0"
 error-support = { path = "../error" }
 nss = { path = "nss" }
 libsqlite3-sys = { version = "0.18.0", features = ["bundled"] }
-hawk = { version = "3.1", default-features = false, optional = true }
-ece = { version = "1.1", default-features = false, features = ["serializable-keys"], optional = true }
+hawk = { version = "3.2", default-features = false, optional = true }
+ece = { version = "1.2" , default-features = false, features = ["serializable-keys"], optional = true }
 
 [dev-dependencies]
 hex = "0.4"

--- a/components/support/rc_crypto/nss/Cargo.toml
+++ b/components/support/rc_crypto/nss/Cargo.toml
@@ -10,9 +10,8 @@ crate-type = ["lib"]
 
 [dependencies]
 base64 = "0.12"
+thiserror = "1.0"
 error-support = { path = "../../error" }
-failure = "0.1"
-failure_derive = "0.1"
 nss_sys = { path = "nss_sys" }
 serde = "1"
 serde_derive = "1"

--- a/components/support/rc_crypto/nss/src/error.rs
+++ b/components/support/rc_crypto/nss/src/error.rs
@@ -2,20 +2,18 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use failure::Fail;
-
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    #[fail(display = "NSS could not be initialized")]
+    #[error("NSS could not be initialized")]
     NSSInitFailure,
-    #[fail(display = "NSS error: {} {}", _0, _1)]
+    #[error("NSS error: {0} {1}")]
     NSSError(i32, String),
-    #[fail(display = "Internal crypto error")]
+    #[error("Internal crypto error")]
     InternalError,
-    #[fail(display = "Conversion error: {}", _0)]
-    ConversionError(#[fail(cause)] std::num::TryFromIntError),
-    #[fail(display = "Base64 decode error: {}", _0)]
-    Base64Decode(#[fail(cause)] base64::DecodeError),
+    #[error("Conversion error: {0}")]
+    ConversionError(#[from] std::num::TryFromIntError),
+    #[error("Base64 decode error: {0}")]
+    Base64Decode(#[from] base64::DecodeError),
 }
 
 error_support::define_error! {

--- a/components/support/rc_crypto/src/ece_crypto.rs
+++ b/components/support/rc_crypto/src/ece_crypto.rs
@@ -11,7 +11,7 @@ use ece::crypto::{Cryptographer, EcKeyComponents, LocalKeyPair, RemotePublicKey}
 
 impl From<crate::Error> for ece::Error {
     fn from(_: crate::Error) -> Self {
-        ece::ErrorKind::CryptoError.into()
+        ece::Error::CryptoError
     }
 }
 
@@ -380,8 +380,8 @@ mod tests {
             "45b74d2b69be9b074de3b35aa87e7c15611d",
         )
         .unwrap_err();
-        match err.kind() {
-            ErrorKind::HeaderTooShort => {}
+        match err {
+            Error::HeaderTooShort => {}
             _ => panic!("Unexpected error type!"),
         };
     }
@@ -396,8 +396,8 @@ mod tests {
             "de5b696b87f1a15cb6adebdd79d6f99e000000120100b6bc1826c37c9f73dd6b4859c2b505181952",
         )
         .unwrap_err();
-        match err.kind() {
-            ErrorKind::InvalidKeyLength => {}
+        match err {
+            Error::InvalidKeyLength => {}
             _ => panic!("Unexpected error type!"),
         };
     }
@@ -411,8 +411,8 @@ mod tests {
             "355a38cd6d9bef15990e2d3308dbd600",
             "8115f4988b8c392a7bacb43c8f1ac5650000001241041994483c541e9bc39a6af03ff713aa7745c284e138a42a2435b797b20c4b698cf5118b4f8555317c190eabebfab749c164d3f6bdebe0d441719131a357d8890a13c4dbd4b16ff3dd5a83f7c91ad6e040ac42730a7f0b3cd3245e9f8d6ff31c751d410cfd"
         ).unwrap_err();
-        match err.kind() {
-            ece::ErrorKind::CryptoError => {}
+        match err {
+            Error::CryptoError => {}
             _ => panic!("Unexpected error type!"),
         };
     }
@@ -426,8 +426,8 @@ mod tests {
             "40c241fde4269ee1e6d725592d982718",
             "dbe215507d1ad3d2eaeabeae6e874d8f0000001241047bc4343f34a8348cdc4e462ffc7c40aa6a8c61a739c4c41d45125505f70e9fc5f9efa86852dd488dcf8e8ea2cafb75e07abd5ee7c9d5c038bafef079571b0bda294411ce98c76dd031c0e580577a4980a375e45ed30429be0e2ee9da7e6df8696d01b8ec"
         ).unwrap_err();
-        match err.kind() {
-            ErrorKind::DecryptPadding => {}
+        match err {
+            Error::DecryptPadding => {}
             _ => panic!("Unexpected error type!"),
         };
     }

--- a/components/support/rc_crypto/src/error.rs
+++ b/components/support/rc_crypto/src/error.rs
@@ -2,16 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use failure::Fail;
-
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    #[fail(display = "NSS error: {}", _0)]
-    NSSError(#[fail(cause)] nss::Error),
-    #[fail(display = "Internal crypto error")]
+    #[error("NSS error: {0}")]
+    NSSError(#[from] nss::Error),
+    #[error("Internal crypto error")]
     InternalError,
-    #[fail(display = "Conversion error: {}", _0)]
-    ConversionError(#[fail(cause)] std::num::TryFromIntError),
+    #[error("Conversion error: {0}")]
+    ConversionError(#[from] std::num::TryFromIntError),
 }
 
 error_support::define_error! {

--- a/components/support/sync15-traits/Cargo.toml
+++ b/components/support/sync15-traits/Cargo.toml
@@ -15,6 +15,6 @@ serde_json = "1"
 log = "0.4"
 ffi-support = "0.4"
 url = "2.1"
-failure = "0.1"
-
+thiserror = "1.0"
+anyhow = "1.0"
 interrupt-support = { path = "../interrupt" }

--- a/components/support/sync15-traits/src/store.rs
+++ b/components/support/sync15-traits/src/store.rs
@@ -6,7 +6,7 @@ use crate::{
     client::ClientData, telemetry, CollectionRequest, Guid, IncomingChangeset, OutgoingChangeset,
     ServerTimestamp,
 };
-use failure::Error;
+use anyhow::Result;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CollSyncIds {
@@ -44,7 +44,7 @@ pub trait Store {
     /// TODO(issue #2590): This is pretty cludgey and will be hard to extend for
     /// any case other than the tabs case. We should find another way to support
     /// tabs...
-    fn prepare_for_sync(&self, _get_client_data: &dyn Fn() -> ClientData) -> Result<(), Error> {
+    fn prepare_for_sync(&self, _get_client_data: &dyn Fn() -> ClientData) -> Result<()> {
         Ok(())
     }
 
@@ -58,13 +58,13 @@ pub trait Store {
         &self,
         inbound: Vec<IncomingChangeset>,
         telem: &mut telemetry::Engine,
-    ) -> Result<OutgoingChangeset, Error>;
+    ) -> Result<OutgoingChangeset>;
 
     fn sync_finished(
         &self,
         new_timestamp: ServerTimestamp,
         records_synced: Vec<Guid>,
-    ) -> Result<(), Error>;
+    ) -> Result<()>;
 
     /// The store is responsible for building the collection request. Engines
     /// typically will store a lastModified timestamp and use that to build a
@@ -83,15 +83,15 @@ pub trait Store {
     fn get_collection_requests(
         &self,
         server_timestamp: ServerTimestamp,
-    ) -> Result<Vec<CollectionRequest>, Error>;
+    ) -> Result<Vec<CollectionRequest>>;
 
     /// Get persisted sync IDs. If they don't match the global state we'll be
     /// `reset()` with the new IDs.
-    fn get_sync_assoc(&self) -> Result<StoreSyncAssociation, Error>;
+    fn get_sync_assoc(&self) -> Result<StoreSyncAssociation>;
 
     /// Reset the store without wiping local data, ready for a "first sync".
     /// `assoc` defines how this store is to be associated with sync.
-    fn reset(&self, assoc: &StoreSyncAssociation) -> Result<(), Error>;
+    fn reset(&self, assoc: &StoreSyncAssociation) -> Result<()>;
 
-    fn wipe(&self) -> Result<(), Error>;
+    fn wipe(&self) -> Result<()>;
 }

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -19,13 +19,14 @@ url = "2.1"
 log = "0.4"
 lazy_static = "1.4"
 base16 = "0.2"
-failure = "0.1"
 rc_crypto = { path = "../support/rc_crypto", features = ["hawk"] }
 viaduct = { path = "../viaduct" }
 interrupt-support = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 sync15-traits = {path = "../support/sync15-traits"}
+thiserror = "1.0"
+anyhow = "1.0"
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/components/sync15/src/clients/engine.rs
+++ b/components/sync15/src/clients/engine.rs
@@ -347,9 +347,9 @@ impl<'a> Engine<'a> {
 mod tests {
     use crate::clients::{CommandStatus, DeviceType, Settings};
     use crate::util::ServerTimestamp;
+    use anyhow::Result;
     use interrupt_support::NeverInterrupts;
     use serde_json::{json, Value};
-    use std::result;
 
     use super::*;
 
@@ -363,10 +363,7 @@ mod tests {
             &self.settings
         }
 
-        fn apply_incoming_command(
-            &self,
-            command: Command,
-        ) -> result::Result<CommandStatus, failure::Error> {
+        fn apply_incoming_command(&self, command: Command) -> Result<CommandStatus> {
             Ok(if let Command::Reset(name) = command {
                 if name == "forms" {
                     CommandStatus::Unsupported
@@ -378,7 +375,7 @@ mod tests {
             })
         }
 
-        fn fetch_outgoing_commands(&self) -> result::Result<HashSet<Command>, failure::Error> {
+        fn fetch_outgoing_commands(&self) -> Result<HashSet<Command>> {
             Ok(self.outgoing_commands.clone())
         }
     }

--- a/components/sync15/src/clients/mod.rs
+++ b/components/sync15/src/clients/mod.rs
@@ -8,6 +8,7 @@ mod engine;
 mod record;
 mod ser;
 
+use anyhow::Result;
 pub use engine::Engine;
 pub use sync15_traits::client::{ClientData, DeviceType, RemoteClient};
 
@@ -31,7 +32,7 @@ pub trait CommandProcessor {
 
     /// Fetches commands to send to other clients. An error return value means
     /// commands couldn't be fetched, and halts the sync.
-    fn fetch_outgoing_commands(&self) -> Result<HashSet<Command>, failure::Error>;
+    fn fetch_outgoing_commands(&self) -> Result<HashSet<Command>>;
 
     /// Applies a command sent to this client from another client. This method
     /// should return a `CommandStatus` indicating whether the command was
@@ -41,7 +42,7 @@ pub trait CommandProcessor {
     /// applying the command, and halts the sync to prevent unexpected behavior
     /// (for example, merging local and remote bookmarks, when we were told to
     /// wipe our local bookmarks).
-    fn apply_incoming_command(&self, command: Command) -> Result<CommandStatus, failure::Error>;
+    fn apply_incoming_command(&self, command: Command) -> Result<CommandStatus>;
 }
 
 /// Indicates if a command was applied successfully, ignored, or not supported.

--- a/components/sync15/src/coll_state.rs
+++ b/components/sync15/src/coll_state.rs
@@ -170,6 +170,7 @@ mod tests {
     use crate::record_types::{MetaGlobalEngine, MetaGlobalRecord};
     use crate::request::{CollectionRequest, InfoCollections, InfoConfiguration};
     use crate::telemetry;
+    use anyhow::Result;
     use std::cell::{Cell, RefCell};
     use std::collections::HashMap;
     use sync_guid::Guid;
@@ -230,7 +231,7 @@ mod tests {
             &self,
             _inbound: Vec<IncomingChangeset>,
             _telem: &mut telemetry::Engine,
-        ) -> Result<OutgoingChangeset, failure::Error> {
+        ) -> Result<OutgoingChangeset> {
             unreachable!("these tests shouldn't call these");
         }
 
@@ -238,28 +239,28 @@ mod tests {
             &self,
             _new_timestamp: ServerTimestamp,
             _records_synced: Vec<Guid>,
-        ) -> Result<(), failure::Error> {
+        ) -> Result<()> {
             unreachable!("these tests shouldn't call these");
         }
 
         fn get_collection_requests(
             &self,
             _server_timestamp: ServerTimestamp,
-        ) -> Result<Vec<CollectionRequest>, failure::Error> {
+        ) -> Result<Vec<CollectionRequest>> {
             unreachable!("these tests shouldn't call these");
         }
 
-        fn get_sync_assoc(&self) -> Result<StoreSyncAssociation, failure::Error> {
+        fn get_sync_assoc(&self) -> Result<StoreSyncAssociation> {
             Ok(self.assoc.replace(StoreSyncAssociation::Disconnected))
         }
 
-        fn reset(&self, new_assoc: &StoreSyncAssociation) -> Result<(), failure::Error> {
+        fn reset(&self, new_assoc: &StoreSyncAssociation) -> Result<()> {
             self.assoc.replace(new_assoc.clone());
             *self.num_resets.borrow_mut() += 1;
             Ok(())
         }
 
-        fn wipe(&self) -> Result<(), failure::Error> {
+        fn wipe(&self) -> Result<()> {
             unreachable!("these tests shouldn't call these");
         }
     }

--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -14,7 +14,6 @@ use crate::state::{EngineChangesNeeded, GlobalState, PersistedGlobalState, Setup
 use crate::status::{ServiceStatus, SyncResult};
 use crate::sync::{self, Store};
 use crate::telemetry;
-use failure::Fail;
 use interrupt_support::Interruptee;
 use std::collections::HashMap;
 use std::mem;

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -12,7 +12,8 @@ places = { path = "../places" }
 logins = { path = "../logins" }
 tabs = { path = "../tabs" }
 ffi-support = "0.4"
-failure = "0.1"
+thiserror = "1.0"
+anyhow = "1.0"
 error-support = { path = "../support/error" }
 prost = "0.6"
 prost-derive = "0.6"

--- a/components/sync_manager/src/error.rs
+++ b/components/sync_manager/src/error.rs
@@ -1,35 +1,34 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use failure::Fail;
-use interrupt_support::Interrupted;
 
-#[derive(Debug, Fail)]
+use interrupt_support::Interrupted;
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    #[fail(display = "Unknown engine: {}", _0)]
+    #[error("Unknown engine: {0}")]
     UnknownEngine(String),
-    #[fail(display = "Manager was compiled without support for {:?}", _0)]
+    #[error("Manager was compiled without support for {0:?}")]
     UnsupportedFeature(String),
-    #[fail(display = "Database connection for '{}' is not open", _0)]
+    #[error("Database connection for '{0}' is not open")]
     ConnectionClosed(String),
-    #[fail(display = "Handle is invalid: {}", _0)]
-    InvalidHandle(#[fail(cause)] ffi_support::HandleError),
-    #[fail(display = "Protobuf decode error: {}", _0)]
-    ProtobufDecodeError(#[fail(cause)] prost::DecodeError),
+    #[error("Handle is invalid: {0}")]
+    InvalidHandle(#[from] ffi_support::HandleError),
+    #[error("Protobuf decode error: {0}")]
+    ProtobufDecodeError(#[from] prost::DecodeError),
     // Used for things like 'failed to decode the provided sync key because it's
     // completely the wrong format', etc.
-    #[fail(display = "Sync error: {}", _0)]
-    Sync15Error(#[fail(cause)] sync15::Error),
-    #[fail(display = "URL parse error: {}", _0)]
-    UrlParseError(#[fail(cause)] url::ParseError),
-    #[fail(display = "Operation interrupted")]
-    InterruptedError(#[fail(cause)] Interrupted),
-    #[fail(display = "Error parsing JSON data: {}", _0)]
-    JsonError(#[fail(cause)] serde_json::Error),
-    #[fail(display = "Logins error: {}", _0)]
-    LoginsError(#[fail(cause)] logins::Error),
-    #[fail(display = "Places error: {}", _0)]
-    PlacesError(#[fail(cause)] places::Error),
+    #[error("Sync error: {0}")]
+    Sync15Error(#[from] sync15::Error),
+    #[error("URL parse error: {0}")]
+    UrlParseError(#[from] url::ParseError),
+    #[error("Operation interrupted")]
+    InterruptedError(#[from] Interrupted),
+    #[error("Error parsing JSON data: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("Logins error: {0}")]
+    LoginsError(#[from] logins::Error),
+    #[error("Places error: {0}")]
+    PlacesError(#[from] places::Error),
 }
 
 error_support::define_error! {

--- a/components/sync_manager/src/manager.rs
+++ b/components/sync_manager/src/manager.rs
@@ -8,7 +8,6 @@ use crate::{reset, reset_all, wipe, wipe_all};
 use logins::PasswordEngine;
 use places::{bookmark_sync::store::BookmarksStore, history_sync::store::HistoryStore, PlacesApi};
 use std::collections::{HashMap, HashSet};
-use std::result;
 use std::sync::{atomic::AtomicUsize, Arc, Mutex, Weak};
 use std::time::SystemTime;
 use sync15::{
@@ -476,10 +475,7 @@ impl CommandProcessor for SyncClient {
         &self.0
     }
 
-    fn apply_incoming_command(
-        &self,
-        command: Command,
-    ) -> result::Result<CommandStatus, failure::Error> {
+    fn apply_incoming_command(&self, command: Command) -> anyhow::Result<CommandStatus> {
         let result = match command {
             Command::Wipe(engine) => wipe(&engine),
             Command::WipeAll => wipe_all(),
@@ -495,7 +491,7 @@ impl CommandProcessor for SyncClient {
         }
     }
 
-    fn fetch_outgoing_commands(&self) -> result::Result<HashSet<Command>, failure::Error> {
+    fn fetch_outgoing_commands(&self) -> anyhow::Result<HashSet<Command>> {
         Ok(HashSet::new())
     }
 }

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -14,7 +14,6 @@ sync15 = { path = "../sync15" }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
-failure = "0.1"
 log = "0.4"
 url = "2.1"
 prost = "0.6"
@@ -23,6 +22,8 @@ ffi-support = "0.4"
 error-support = { path = "../support/error" }
 interrupt-support = { path = "../support/interrupt" }
 sync-guid = { path = "../support/guid", features = ["random"] }
+thiserror = "1.0"
+anyhow = "1.0"
 
 [dev-dependencies]
 clipboard = "0.5"

--- a/components/tabs/examples/tabs_sync.rs
+++ b/components/tabs/examples/tabs_sync.rs
@@ -10,7 +10,7 @@ use cli_support::prompt::prompt_char;
 use clipboard::{ClipboardContext, ClipboardProvider};
 use tabs::{RemoteTab, TabsEngine};
 
-type Result<T> = std::result::Result<T, failure::Error>;
+use anyhow::Result;
 
 fn main() -> Result<()> {
     viaduct_reqwest::use_reqwest_backend();

--- a/components/tabs/src/error.rs
+++ b/components/tabs/src/error.rs
@@ -2,21 +2,19 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use failure::Fail;
-
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    #[fail(display = "Error synchronizing: {}", _0)]
-    SyncAdapterError(#[fail(cause)] sync15::Error),
+    #[error("Error synchronizing: {0}")]
+    SyncAdapterError(#[from] sync15::Error),
 
-    #[fail(display = "Error parsing JSON data: {}", _0)]
-    JsonError(#[fail(cause)] serde_json::Error),
+    #[error("Error parsing JSON data: {0}")]
+    JsonError(#[from] serde_json::Error),
 
-    #[fail(display = "Error parsing URL: {}", _0)]
-    UrlParseError(#[fail(cause)] url::ParseError),
+    #[error("Error parsing URL: {0}")]
+    UrlParseError(#[from] url::ParseError),
 
-    #[fail(display = "Protobuf decode error: {}", _0)]
-    ProtobufDecodeError(#[fail(cause)] prost::DecodeError),
+    #[error("Protobuf decode error: {0}")]
+    ProtobufDecodeError(#[from] prost::DecodeError),
 }
 
 error_support::define_error! {

--- a/components/viaduct/Cargo.toml
+++ b/components/viaduct/Cargo.toml
@@ -13,8 +13,6 @@ crate-type = ["lib"]
 default = []
 
 [dependencies]
-failure = "0.1"
-failure_derive = "0.1"
 url = "2.1"
 log = "0.4"
 serde = "1"
@@ -23,3 +21,4 @@ once_cell = "1.4"
 prost = "0.6"
 prost-derive = "0.6"
 ffi-support = "0.4"
+thiserror = "1.0"

--- a/components/viaduct/src/error.rs
+++ b/components/viaduct/src/error.rs
@@ -2,31 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use failure::Fail;
-
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[fail(display = "Illegal characters in request header '{}'", _0)]
+    #[error("Illegal characters in request header '{0}'")]
     RequestHeaderError(crate::HeaderName),
 
-    #[fail(display = "Backend error: {}", _0)]
+    #[error("Backend error: {0}")]
     BackendError(String),
 
-    #[fail(display = "Network error: {}", _0)]
+    #[error("Network error: {0}")]
     NetworkError(String),
 
-    #[fail(display = "The rust-components network backend must be initialized before use!")]
+    #[error("The rust-components network backend must be initialized before use!")]
     BackendNotInitialized,
 
-    #[fail(display = "Backend already initialized.")]
+    #[error("Backend already initialized.")]
     SetBackendError,
 
     /// Note: we return this if the server returns a bad URL with
     /// its response. This *probably* should never happen, but who knows.
-    #[fail(display = "URL Parse Error: {}", _0)]
-    UrlError(#[fail(cause)] url::ParseError),
+    #[error("URL Parse Error: {0}")]
+    UrlError(#[source] url::ParseError),
 
-    #[fail(display = "Validation error: URL does not use TLS protocol.")]
+    #[error("Validation error: URL does not use TLS protocol.")]
     NonTlsUrl,
 }
 
@@ -41,8 +39,8 @@ impl From<url::ParseError> for Error {
 ///
 /// Note that it's not a variant on `Error` to distinguish between errors
 /// caused by the network, and errors returned from the server.
-#[derive(failure::Fail, Debug, Clone, PartialEq)]
-#[fail(display = "Error: {} {} returned {}", method, url, status)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
+#[error("Error: {method} {url} returned {status}")]
 pub struct UnexpectedStatus {
     pub status: u16,
     pub method: crate::Method,

--- a/components/viaduct/src/headers/name.rs
+++ b/components/viaduct/src/headers/name.rs
@@ -17,8 +17,8 @@ pub struct HeaderName(pub(super) Cow<'static, str>);
 /// instead. This is because it would likely come through as
 /// a network error if we emitted it for local headers, when
 /// it's actually a bug that we'd need to fix.
-#[derive(failure::Fail, Debug, Clone, PartialEq)]
-#[fail(display = "Invalid header name: {:?}", _0)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
+#[error("Invalid header name: {0:?}")]
 pub struct InvalidHeaderName(Cow<'static, str>);
 
 impl From<&'static str> for HeaderName {

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 
 [dependencies]
 error-support = { path = "../support/error" }
-failure = "0.1"
+thiserror = "1.0"
 interrupt-support = { path = "../support/interrupt" }
 lazy_static = "1.4"
 log = "0.4"

--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use failure::Fail;
 use interrupt_support::Interrupted;
 use sync15_traits::bridged_engine;
 
@@ -13,49 +12,49 @@ pub enum QuotaReason {
     MaxItems,
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, thiserror::Error)]
 pub enum ErrorKind {
-    #[fail(display = "Quota exceeded: {:?}", _0)]
+    #[error("Quota exceeded: {0:?}")]
     QuotaError(QuotaReason),
 
-    #[fail(display = "Error parsing JSON data: {}", _0)]
-    JsonError(#[fail(cause)] serde_json::Error),
+    #[error("Error parsing JSON data: {0}")]
+    JsonError(#[from] serde_json::Error),
 
-    #[fail(display = "Error executing SQL: {}", _0)]
-    SqlError(#[fail(cause)] rusqlite::Error),
+    #[error("Error executing SQL: {0}")]
+    SqlError(#[from] rusqlite::Error),
 
-    #[fail(display = "A connection of this type is already open")]
+    #[error("A connection of this type is already open")]
     ConnectionAlreadyOpen,
 
-    #[fail(display = "An invalid connection type was specified")]
+    #[error("An invalid connection type was specified")]
     InvalidConnectionType,
 
-    #[fail(display = "IO error: {}", _0)]
-    IoError(#[fail(cause)] std::io::Error),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
 
-    #[fail(display = "Operation interrupted")]
-    InterruptedError(#[fail(cause)] Interrupted),
+    #[error("Operation interrupted")]
+    InterruptedError(#[from] Interrupted),
 
-    #[fail(display = "Tried to close connection on wrong StorageApi instance")]
+    #[error("Tried to close connection on wrong StorageApi instance")]
     WrongApiForClose,
 
     // This will happen if you provide something absurd like
     // "/" or "" as your database path. For more subtley broken paths,
     // we'll likely return an IoError.
-    #[fail(display = "Illegal database path: {:?}", _0)]
+    #[error("Illegal database path: {0:?}")]
     IllegalDatabasePath(std::path::PathBuf),
 
-    #[fail(display = "UTF8 Error: {}", _0)]
-    Utf8Error(#[fail(cause)] std::str::Utf8Error),
+    #[error("UTF8 Error: {0}")]
+    Utf8Error(#[from] std::str::Utf8Error),
 
-    #[fail(display = "Database cannot be upgraded")]
+    #[error("Database cannot be upgraded")]
     DatabaseUpgradeError,
 
-    #[fail(display = "Database version {} is not supported", _0)]
+    #[error("Database version {0} is not supported")]
     UnsupportedDatabaseVersion(i64),
 
-    #[fail(display = "{}", _0)]
-    IncomingPayloadError(#[fail(cause)] bridged_engine::PayloadError),
+    #[error("{0}")]
+    IncomingPayloadError(#[from] bridged_engine::PayloadError),
 }
 
 error_support::define_error! {

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -12,7 +12,6 @@ the details of which are reproduced below.
 * [MIT License: caseless](#mit-license-caseless)
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
 * [MIT License: matches](#mit-license-matches)
-* [MIT License: synstructure](#mit-license-synstructure)
 * [CC0-1.0 License: base16](#cc0-10-license-base16)
 * [ISC License: ring](#isc-license-ring)
 * [BSD-3-Clause License: protobuf](#bsd-3-clause-license-protobuf)
@@ -416,8 +415,6 @@ The following text applies to code linked from these dependencies:
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [dogear](https://github.com/mozilla/dogear),
 [either](https://github.com/bluss/either),
-[failure](https://github.com/rust-lang-nursery/failure),
-[failure_derive](https://github.com/rust-lang-nursery/failure),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
 [ffi-support](https://github.com/mozilla/application-services),
@@ -455,6 +452,8 @@ The following text applies to code linked from these dependencies:
 [smallbitvec](https://github.com/servo/smallbitvec),
 [smallvec](https://github.com/servo/rust-smallvec),
 [syn](https://github.com/dtolnay/syn),
+[thiserror-impl](https://github.com/dtolnay/thiserror),
+[thiserror](https://github.com/dtolnay/thiserror),
 [thread_local](https://github.com/Amanieu/thread_local-rs),
 [time](https://github.com/time-rs/time),
 [unicode-bidi](https://github.com/servo/unicode-bidi),
@@ -856,22 +855,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: synstructure
-
-The following text applies to code linked from these dependencies:
-[synstructure](https://github.com/mystor/synstructure)
-
-```
-Copyright 2016 Nika Layzell
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -57,14 +57,6 @@ the details of which are reproduced below.
     <url>https://github.com/bluss/either/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
-    <name>Apache License 2.0: failure</name>
-    <url>https://github.com/rust-lang-nursery/failure/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: failure_derive</name>
-    <url>https://github.com/rust-lang-nursery/failure/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
     <name>Apache License 2.0: fallible-iterator</name>
     <url>https://github.com/sfackler/rust-fallible-iterator/blob/master/LICENSE-APACHE</url>
   </license>
@@ -213,6 +205,14 @@ the details of which are reproduced below.
     <url>https://github.com/dtolnay/syn/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: thiserror</name>
+    <url>https://github.com/dtolnay/thiserror/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: thiserror-impl</name>
+    <url>https://github.com/dtolnay/thiserror/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: thread_local</name>
     <url>https://github.com/Amanieu/thread_local-rs/blob/master/LICENSE-APACHE</url>
   </license>
@@ -279,10 +279,6 @@ the details of which are reproduced below.
   <license>
     <name>MIT License: matches</name>
     <url>https://github.com/SimonSapin/rust-std-candidates/blob/master/LICENSE</url>
-  </license>
-  <license>
-    <name>MIT License: synstructure</name>
-    <url>https://github.com/mystor/synstructure/blob/master/LICENSE</url>
   </license>
   <license>
     <name>CC0-1.0 License: base16</name>

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -18,7 +18,6 @@ the details of which are reproduced below.
 * [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: slab](#mit-license-slab)
-* [MIT License: synstructure](#mit-license-synstructure)
 * [MIT License: tokio, tokio-tls, tokio-util](#mit-license-tokio-tokio-tls-tokio-util)
 * [MIT License: tower-service](#mit-license-tower-service)
 * [MIT License: try-lock](#mit-license-try-lock)
@@ -430,8 +429,6 @@ The following text applies to code linked from these dependencies:
 [dtoa](https://github.com/dtolnay/dtoa),
 [either](https://github.com/bluss/either),
 [encoding_rs](https://github.com/hsivonen/encoding_rs),
-[failure](https://github.com/rust-lang-nursery/failure),
-[failure_derive](https://github.com/rust-lang-nursery/failure),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
 [ffi-support](https://github.com/mozilla/application-services),
@@ -495,6 +492,8 @@ The following text applies to code linked from these dependencies:
 [swift-protobuf](https://github.com/apple/swift-protobuf),
 [syn](https://github.com/dtolnay/syn),
 [tempfile](https://github.com/Stebalien/tempfile),
+[thiserror-impl](https://github.com/dtolnay/thiserror),
+[thiserror](https://github.com/dtolnay/thiserror),
 [thread_local](https://github.com/Amanieu/thread_local-rs),
 [time](https://github.com/time-rs/time),
 [unicase](https://github.com/seanmonstar/unicase),
@@ -1087,22 +1086,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: synstructure
-
-The following text applies to code linked from these dependencies:
-[synstructure](https://github.com/mystor/synstructure)
-
-```
-Copyright 2016 Nika Layzell
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------

--- a/megazords/lockbox/DEPENDENCIES.md
+++ b/megazords/lockbox/DEPENDENCIES.md
@@ -10,7 +10,6 @@ the details of which are reproduced below.
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
 * [MIT License: matches](#mit-license-matches)
-* [MIT License: synstructure](#mit-license-synstructure)
 * [CC0-1.0 License: base16](#cc0-10-license-base16)
 * [ISC License: ring](#isc-license-ring)
 * [BSD-3-Clause License: protobuf](#bsd-3-clause-license-protobuf)
@@ -413,8 +412,6 @@ The following text applies to code linked from these dependencies:
 [cc](https://github.com/alexcrichton/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [either](https://github.com/bluss/either),
-[failure](https://github.com/rust-lang-nursery/failure),
-[failure_derive](https://github.com/rust-lang-nursery/failure),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
 [ffi-support](https://github.com/mozilla/application-services),
@@ -449,6 +446,8 @@ The following text applies to code linked from these dependencies:
 [serde_json](https://github.com/serde-rs/json),
 [smallvec](https://github.com/servo/rust-smallvec),
 [syn](https://github.com/dtolnay/syn),
+[thiserror-impl](https://github.com/dtolnay/thiserror),
+[thiserror](https://github.com/dtolnay/thiserror),
 [time](https://github.com/time-rs/time),
 [unicode-bidi](https://github.com/servo/unicode-bidi),
 [unicode-normalization](https://github.com/unicode-rs/unicode-normalization),
@@ -787,22 +786,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: synstructure
-
-The following text applies to code linked from these dependencies:
-[synstructure](https://github.com/mystor/synstructure)
-
-```
-Copyright 2016 Nika Layzell
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------

--- a/megazords/lockbox/android/dependency-licenses.xml
+++ b/megazords/lockbox/android/dependency-licenses.xml
@@ -53,14 +53,6 @@ the details of which are reproduced below.
     <url>https://github.com/bluss/either/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
-    <name>Apache License 2.0: failure</name>
-    <url>https://github.com/rust-lang-nursery/failure/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: failure_derive</name>
-    <url>https://github.com/rust-lang-nursery/failure/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
     <name>Apache License 2.0: fallible-iterator</name>
     <url>https://github.com/sfackler/rust-fallible-iterator/blob/master/LICENSE-APACHE</url>
   </license>
@@ -197,6 +189,14 @@ the details of which are reproduced below.
     <url>https://github.com/dtolnay/syn/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: thiserror</name>
+    <url>https://github.com/dtolnay/thiserror/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: thiserror-impl</name>
+    <url>https://github.com/dtolnay/thiserror/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: time</name>
     <url>https://github.com/time-rs/time/blob/master/LICENSE-Apache</url>
   </license>
@@ -247,10 +247,6 @@ the details of which are reproduced below.
   <license>
     <name>MIT License: matches</name>
     <url>https://github.com/SimonSapin/rust-std-candidates/blob/master/LICENSE</url>
-  </license>
-  <license>
-    <name>MIT License: synstructure</name>
-    <url>https://github.com/mystor/synstructure/blob/master/LICENSE</url>
   </license>
   <license>
     <name>CC0-1.0 License: base16</name>


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md]
- [x] **Dependencies**: This PR follows our [dependency management guidelines]

Although tons of files are changed, 99.9% of it is boilerplate changing #[derive(failure::Fail)] into deriving thiserror instead. Was hoping to start off by one component and put a draft on that, but some were dependent on each other and having a full change allowed me to uncover a few things:

- Some small (Mozilla written) dependencies that still use failure, and should probably be changed before this is merged.
  - ~~hawk~~
  - ~~ece~~
  - ~~find_places_db~~

- I had to use [backtrace](https://crates.io/crates/backtrace) to support backtracing since [std::backtrace](https://doc.rust-lang.org/std/backtrace/index.html) is only available on nightly
- Implemented my own Context to replace failure::Context

Files that have the main changes:
components/support/error/src/lib.rs
all the component's src/error.rs
Cargo.toml's to replace failure with thiserror and anyhow

~~Note: There are a couple of places (namely where the failure::Fail using dependencies are consumed) that I'll need to make a small edit in once the dependencies are updated.~~

