### PR TITLE
Link the docs/howto guide to docs/building.md

### DIFF
--- a/docs/howtos/building-a-rust-component.md
+++ b/docs/howtos/building-a-rust-component.md
@@ -1,6 +1,8 @@
 
 ## Guide to Building a Rust Component
 
+(Most likely you are looking for https://github.com/mozilla/application-services/blob/master/docs/building.md)
+
 Welcome!
 
 It's great that you want to build a Rust Component, but we haven't written this
@@ -15,3 +17,4 @@ In the meantime you might find these earlier blog posts to be helpful:
 * [Building and Deploying a Rust library on Android](https://mozilla.github.io/firefox-browser-architecture/experiments/2017-09-21-rust-on-android.html)
 * [Building and Deploying a Rust library on iOS](https://mozilla.github.io/firefox-browser-architecture/experiments/2017-09-06-rust-on-ios.html)
 * [Blog post re: lessons in binding to Rust code from iOS](https://discourse.mozilla.org/t/dear-diary-turns-out-x-platform-is-hard/25348)
+


### PR DESCRIPTION
Every time i search for the instructions for iOS I end up here, and have to re-look around for the correct doc.
I imagine others being in the same boat!
