### PR TITLE
Special case pairing url for China FxA stack

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,9 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v0.59.0...master)
+
+## FxA Client
+
+### What's new
+
+- Additional special case for China FxA in `getPairingAuthorityURL`. ([#3160](https://github.com/mozilla/application-services/pull/3160))

--- a/components/fxa-client/src/config.rs
+++ b/components/fxa-client/src/config.rs
@@ -55,6 +55,7 @@ pub struct RemoteConfig {
 }
 
 pub(crate) const CONTENT_URL_RELEASE: &str = "https://accounts.firefox.com";
+pub(crate) const CONTENT_URL_CHINA: &str = "https://accounts.firefox.com.cn";
 
 impl Config {
     pub fn release(client_id: &str, redirect_uri: &str) -> Self {
@@ -70,7 +71,7 @@ impl Config {
     }
 
     pub fn china(client_id: &str, redirect_uri: &str) -> Self {
-        Self::new("https://accounts.firefox.com.cn", client_id, redirect_uri)
+        Self::new(CONTENT_URL_CHINA, client_id, redirect_uri)
     }
 
     pub fn localdev(client_id: &str, redirect_uri: &str) -> Self {

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -162,6 +162,10 @@ impl FirefoxAccount {
         if self.state.config.content_url()? == Url::parse(config::CONTENT_URL_RELEASE)? {
             return Ok(Url::parse("https://firefox.com/pair")?);
         }
+        // Similarly special case for the China server.
+        if self.state.config.content_url()? == Url::parse(config::CONTENT_URL_CHINA)? {
+            return Ok(Url::parse("https://firefox.com.cn/pair")?);
+        }
         Ok(self.state.config.pair_url()?)
     }
 
@@ -571,6 +575,13 @@ mod tests {
         assert_eq!(
             fxa.get_pairing_authority_url().unwrap().as_str(),
             "https://firefox.com/pair"
+        );
+
+        let config = Config::china("12345678", "https://foo.bar");
+        let fxa = FirefoxAccount::with_config(config);
+        assert_eq!(
+            fxa.get_pairing_authority_url().unwrap().as_str(),
+            "https://firefox.com.cn/pair"
         )
     }
 }


### PR DESCRIPTION
Per @rfk's suggestion in #synced-client-integrations

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
