### PR TITLE
Remove experimental namespace for RemoteTabs

### DIFF
--- a/components/tabs/android/src/main/AndroidManifest.xml
+++ b/components/tabs/android/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.mozilla.appservices.experimental.remotetabs" />
+    package="org.mozilla.appservices.remotetabs" />

--- a/components/tabs/android/src/main/java/mozilla/appservices/remotetabs/rust/LibRemoteTabsFFI.kt
+++ b/components/tabs/android/src/main/java/mozilla/appservices/remotetabs/rust/LibRemoteTabsFFI.kt
@@ -9,7 +9,7 @@ import com.sun.jna.Library
 import com.sun.jna.Pointer
 import mozilla.appservices.support.native.RustBuffer
 import mozilla.appservices.support.native.loadIndirect
-import org.mozilla.appservices.experimental.remotetabs.BuildConfig
+import org.mozilla.appservices.remotetabs.BuildConfig
 
 @Suppress("FunctionNaming", "FunctionParameterNaming", "LongParameterList", "TooGenericExceptionThrown")
 internal interface LibRemoteTabsFFI : Library {


### PR DESCRIPTION
It doesn't matter too much (and is probably not even a breaking change) as the sources themselves / the maven package were in a different namespace, but we might as well.