### PR TITLE
Switch releases to taskgraph

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -5,385 +5,278 @@
 version: 1
 reporting: checks-v1
 policy:
-  pullRequests: public
+    pullRequests: public
 tasks:
-  $let:
-    taskgraph:
-      branch: taskgraph
-      revision: a8366f88fc8b35b284ad550358c89ec10133fb42
-    trustDomain: app-services
-    decision_task_id: {$eval: as_slugid("decision_task")}
-    expires_in: {$fromNow: '1 year'}
-    # We define the following variable at the very top, because they are used in the
-    # default definition
+    - $let:
+          taskgraph:
+              branch: taskgraph
+              revision: cab4565345d0d0effa66f18fe91335dd6d744031
+          trustDomain: app-services
+      in:
+          $let:
+              # Github events have this stuff in different places
+              ownerEmail:
+                  $if: 'tasks_for in ["cron", "action"]'
+                  then: '${tasks_for}@noreply.mozilla.org'
+                  else:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.pusher.email}'
+                      # Assume Pull Request
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.user.login}@users.noreply.github.com'
+                          else:
+                              $if: 'tasks_for == "github-release"'
+                              then: '${event.sender.login}@users.noreply.github.com'
 
-    head_rev:
-      $if: 'tasks_for == "github-pull-request"'
-      then: ${event.pull_request.head.sha}
-      else:
-        $if: 'tasks_for == "github-push"'
-        then: ${event.after}
-        else: ${event.release.tag_name}
-
-    repository:
-      $if: 'tasks_for == "github-pull-request"'
-      then: ${event.pull_request.head.repo.html_url}
-      else: ${event.repository.html_url}
-
-    is_repo_trusted:
-      # Pull requests on main repository can't be trusted because anybody can open a PR on it, without a review
-      $if: 'tasks_for in ["github-push", "github-release"] && event.repository.html_url == "https://github.com/mozilla/application-services"'
-      then: true
-      else: false
-
-    user:
-      $if: 'event.sender.login == "dependabot-preview[bot]"'
-      then: dependabot
-      else: ${event.sender.login}
-  in:
-    $let:
-      provisioner_id:
-        $if: 'is_repo_trusted'
-        then: 'app-services-3'
-        else: 'app-services-1'
-      # TODO: revisit once bug 1533314 is done to possibly infer better priorities
-      tasks_priority: highest
-      # Github events have this stuff in different places...
-      ownerEmail:
-          $if: 'tasks_for in ["cron", "action"]'
-          then: '${tasks_for}@noreply.mozilla.org'
-          else:
-              $if: 'tasks_for == "github-push"'
-              then: '${event.pusher.email}'
-              # Assume Pull Request
-              else:
+              baseRepoUrl:
+                  $if: 'tasks_for in ["github-push", "github-release"]'
+                  then: '${event.repository.html_url}'
+                  else:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.base.repo.html_url}'
+                      else:
+                          $if: 'tasks_for in ["cron", "action"]'
+                          then: '${repository.url}'
+              repoUrl:
+                  $if: 'tasks_for in ["github-push", "github-release"]'
+                  then: '${event.repository.html_url}'
+                  else:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.head.repo.html_url}'
+                      else:
+                          $if: 'tasks_for in ["cron", "action"]'
+                          then: '${repository.url}'
+              project:
+                  $if: 'tasks_for in ["github-push", "github-release"]'
+                  then: '${event.repository.name}'
+                  else:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.head.repo.name}'
+                      else:
+                          $if: 'tasks_for in ["cron", "action"]'
+                          then: '${repository.project}'
+              head_branch:
                   $if: 'tasks_for == "github-pull-request"'
-                  then: '${event.pull_request.user.login}@users.noreply.github.com'
+                  then: ${event.pull_request.head.ref}
                   else:
-                      $if: 'tasks_for == "github-release"'
-                      then: '${event.sender.login}@users.noreply.github.com'
-
-      baseRepoUrl:
-          $if: 'tasks_for in ["github-push", "github-release"]'
-          then: '${event.repository.html_url}'
-          else:
-              $if: 'tasks_for == "github-pull-request"'
-              then: '${event.pull_request.base.repo.html_url}'
-              else:
-                  $if: 'tasks_for in ["cron", "action"]'
-                  then: '${repository.url}'
-      repoUrl:
-          $if: 'tasks_for in ["github-push", "github-release"]'
-          then: '${event.repository.html_url}'
-          else:
-              $if: 'tasks_for == "github-pull-request"'
-              then: '${event.pull_request.head.repo.html_url}'
-              else:
-                  $if: 'tasks_for in ["cron", "action"]'
-                  then: '${repository.url}'
-      project:
-          $if: 'tasks_for in ["github-push", "github-release"]'
-          then: '${event.repository.name}'
-          else:
-              $if: 'tasks_for == "github-pull-request"'
-              then: '${event.pull_request.head.repo.name}'
-              else:
-                  $if: 'tasks_for in ["cron", "action"]'
-                  then: '${repository.project}'
-      head_branch:
-          $if: 'tasks_for == "github-pull-request"'
-          then: ${event.pull_request.head.ref}
-          else:
-              $if: 'tasks_for == "github-push"'
-              then: ${event.ref}
-              else:
-                  $if: 'tasks_for == "github-release"'
-                  then: '${event.release.target_commitish}'
+                      $if: 'tasks_for == "github-push"'
+                      then: ${event.ref}
+                      else:
+                          $if: 'tasks_for == "github-release"'
+                          then: '${event.release.target_commitish}'
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${push.branch}'
+              head_sha:
+                  $if: 'tasks_for == "github-push"'
+                  then: '${event.after}'
                   else:
-                      $if: 'tasks_for in ["cron", "action"]'
-                      then: '${push.branch}'
-      head_sha:
-          $if: 'tasks_for == "github-push"'
-          then: '${event.after}'
-          else:
-              $if: 'tasks_for == "github-pull-request"'
-              then: '${event.pull_request.head.sha}'
-              else:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: '${event.pull_request.head.sha}'
+                      else:
+                          $if: 'tasks_for == "github-release"'
+                          then: '${event.release.tag_name}'
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${push.revision}'
+              head_tag:
                   $if: 'tasks_for == "github-release"'
                   then: '${event.release.tag_name}'
+                  else: ''
+              ownTaskId:
+                  $if: '"github" in tasks_for'
+                  then: {$eval: as_slugid("decision_task")}
                   else:
-                      $if: 'tasks_for in ["cron", "action"]'
-                      then: '${push.revision}'
-      ownTaskId:
-          $if: '"github" in tasks_for'
-          then: {$eval: as_slugid("decision_task")}
-          else:
-              $if: 'tasks_for == "cron"'
-              then: '${ownTaskId}'
-      pullRequestAction:
-          $if: 'tasks_for == "github-pull-request"'
-          then: ${event.action}
-          else: 'UNDEFINED'
-
-      releaseAction:
-          $if: 'tasks_for == "github-release"'
-          then: ${event.action}
-          else: 'UNDEFINED'
-    in:
-      $let:
-        default_task_definition:
-          taskId: ${decision_task_id}
-          taskGroupId: ${decision_task_id}
-          # because we're not using `reporting: checks-v1`, we need to keep using taskcluster-github as scheduler_id.
-          # This will change in the near future when https://github.com/mozilla/application-services/pull/1945 lands
-          schedulerId: taskcluster-github
-          created: {$fromNow: ''}
-          deadline: {$fromNow: '4 hours'}
-          expires: ${expires_in}
-          provisionerId: ${provisioner_id}
-          workerType: 'decision'
-          priority: ${tasks_priority}
-          requires: all-completed
-          retries: 5
-          scopes:
-            - queue:scheduler-id:taskcluster-github
-          routes:
-            - checks
-          metadata:
-            owner: &task_owner ${user}@users.noreply.github.com
-            source: &task_source ${repository}/raw/${head_rev}/.taskcluster.yml
-          extra:
-            tasks_for: ${tasks_for}
-          payload:
-            artifacts:
-              public/task-graph.json:
-                type: file
-                path: /repo/task-graph.json
-                expires: ${expires_in}
-              public/actions.json:
-                type: file
-                path: /repo/actions.json
-                expires: ${expires_in}
-              public/parameters.yml:
-                type: file
-                path: /repo/parameters.yml
-                expires: ${expires_in}
-            maxRunTime: {$eval: '20 * 60'}
-            # https://github.com/servo/taskcluster-bootstrap-docker-images#decision-task
-            image: "servobrowser/taskcluster-bootstrap:decision-task@sha256:28045b7ec0485ef363f8cb14f194008b47e9ede99f2ea40a1e945e921fce976e"
-            command: # TODO: servo decision-task image doesn't include pyyaml.
-              - /bin/bash
-              - --login
-              - -cx
-              - >-
-                python3 -m pip install --upgrade pip &&
-                python3 -m pip install pyyaml &&
-                git init repo &&
-                cd repo &&
-                git fetch --tags ${repository} ${head_branch} &&
-                git reset --hard ${head_rev} &&
-                python3 automation/taskcluster/decision_task.py
-            env:
-              APPSERVICES_HEAD_REPOSITORY: ${repository}
-              APPSERVICES_HEAD_BRANCH: ${head_branch}
-              APPSERVICES_HEAD_REV: ${head_rev}
-              BUILD_WORKER_TYPE: b-linux
-              IMAGES_WORKER_TYPE: images
-              TASK_FOR: ${tasks_for}
-              TASK_OWNER: *task_owner
-              TASK_SOURCE: *task_source
-              SCHEDULER_ID: taskcluster-github
-              PROVISIONER_ID: ${provisioner_id}
-            features:
-              taskclusterProxy: true
-      in:
-        $match:
-          "(tasks_for == 'github-pull-request' && event['action'] in ['opened', 'reopened', 'synchronize']) || (tasks_for == 'github-push' && head_branch == 'refs/heads/master')":
-            $let:
-              level:
-                $if: 'tasks_for in ["github-push", "github-release"] && repoUrl == "https://github.com/mozilla/application-services"'
-                then: '3'
-                else: '1'
-              short_head_branch:
-                $if: 'head_branch[:11] == "refs/heads/"'
-                then: {$eval: 'head_branch[11:]'}
-            in:
-              $mergeDeep:
-                - taskGroupId:
-                    $if: 'tasks_for == "action"'
-                    then:
-                        '${action.taskGroupId}'
-                    else:
-                        '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
-                  taskId: '${ownTaskId}'
-                  schedulerId: '${trustDomain}-level-${level}'
-                  created: {$fromNow: ''}
-                  deadline: {$fromNow: '1 day'}
-                  expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first, despite rounding errors
-                  metadata:
-                    $merge:
-                      - owner: "${ownerEmail}"
-                        source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
-                      - $if: 'tasks_for in ["github-push", "github-pull-request", "github-release"]'
-                        then:
-                          name: "Decision Task"
-                          description: 'The task that creates all of the other tasks in the task graph'
-                  provisionerId: "app-services-${level}"
-                  workerType: "decision"
-                  tags:
-                    $if: 'tasks_for in ["github-push", "github-pull-request"]'
-                    then:
-                      kind: decision-task
-                  routes:
-                    $flattenDeep:
-                      - checks
-                      - $if: 'level == "3"'
-                        then:
-                          # TODO Bug 1601928: Make this scope fork-friendly once ${project} is better defined. This will enable
-                          # staging release promotion on forks.
-                          - $if: 'tasks_for == "github-push"'
-                            then:
-                              - index.project.${project}.v2.branch.${short_head_branch}.latest.taskgraph.decision
-                              - index.project.${project}.v2.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
-                          - $if: 'tasks_for == "cron"'
-                            then:
-                              # cron context provides ${head_branch} as a short one
-                              - index.project.${project}.v2.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
-                              - index.project.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
-                              - index.project.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
-                  scopes:
-                    $if: 'tasks_for == "github-push"'
-                    then:
-                      # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
-                      - 'assume:repo:${repoUrl[8:]}:branch:${short_head_branch}'
-                    else:
-                      $if: 'tasks_for == "github-pull-request"'
-                      then:
-                        - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
-                      else:
-                        $if: 'tasks_for == "github-release"'
-                        then:
-                          - 'assume:repo:${repoUrl[8:]}:release'
-                        else:
-                          $if: 'tasks_for == "action"'
+                      $if: 'tasks_for == "cron"'
+                      then: '${ownTaskId}'
+              pullRequestAction:
+                  $if: 'tasks_for == "github-pull-request"'
+                  then: ${event.action}
+                  else: 'UNDEFINED'
+              releaseAction:
+                  $if: 'tasks_for == "github-release"'
+                  then: ${event.action}
+                  else: 'UNDEFINED'
+          in:
+              $if: >
+                tasks_for in ["action", "cron"]
+                || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "synchronize"])
+                || (tasks_for == "github-push" && head_branch == 'refs/heads/master')
+                || (tasks_for == "github-release" && releaseAction == "published")
+              then:
+                  $let:
+                      level:
+                          $if: 'tasks_for in ["github-push", "github-release", "action", "cron"] && repoUrl == "https://github.com/mozilla/application-services"'
+                          then: '3'
+                          else: '1'
+                      short_head_branch:
+                          $if: 'head_branch[:11] == "refs/heads/"'
+                          then: {$eval: 'head_branch[11:]'}
+                  in:
+                    $mergeDeep:
+                        - $if: 'tasks_for != "action"'
                           then:
-                            # when all actions are hooks, we can calculate this directly rather than using a variable
-                            - '${action.repo_scope}'
-                          else:
-                            - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
-                  requires: all-completed
-                  priority: lowest
-                  retries: 5
-
-                  payload:
-                    env:
-                      # run-task uses these to check out the source; the inputs
-                      # to `mach taskgraph decision` are all on the command line.
-                      $merge:
-                        - APPSERVICES_BASE_REPOSITORY: '${baseRepoUrl}'
-                          APPSERVICES_HEAD_REPOSITORY: '${repoUrl}'
-                          APPSERVICES_HEAD_REF: '${head_branch}'
-                          APPSERVICES_HEAD_REV: '${head_sha}'
-                          APPSERVICES_REPOSITORY_TYPE: git
-                          TASKGRAPH_BASE_REPOSITORY: https://hg.mozilla.org/ci/taskgraph
-                          TASKGRAPH_HEAD_REPOSITORY: https://hg.mozilla.org/ci/${taskgraph.branch}
-                          TASKGRAPH_HEAD_REV: ${taskgraph.revision}
-                          TASKGRAPH_REPOSITORY_TYPE: hg
-                          REPOSITORIES: {$json: {appservices: "Application Services", taskgraph: "Taskgraph"}}
-                          HG_STORE_PATH: /builds/worker/checkouts/hg-store
-                          ANDROID_SDK_ROOT: /builds/worker/android-sdk
-                          MOZ_FETCHES_DIR: /builds/worker/checkouts/src
-                        - $if: 'tasks_for in ["github-pull-request"]'
-                          then:
-                            APPSERVICES_PULL_REQUEST_TITLE: '${event.pull_request.title}'
-                            APPSERVICES_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
-                    features:
-                      taskclusterProxy: true
-                      chainOfTrust: true
-                    # Note: This task is built server side without the context or tooling that
-                    # exist in tree so we must hard code the hash
-                    image:
-                      mozillareleases/taskgraph:decision-mobile-6020473b1a928d8df50e234a7ca2e81ade2220a4fb5fbe16b02477dd64a49728@sha256:98d226736b7d03907114bf37938002b90e8a37cbe3a297690e349f1ddddb1d7c
-
-                    maxRunTime: 1800
-
-                    command:
-                      - /usr/local/bin/run-task
-                      - '--appservices-checkout=/builds/worker/checkouts/src'
-                      - '--taskgraph-checkout=/builds/worker/checkouts/taskgraph'
-                      - '--task-cwd=/builds/worker/checkouts/src'
-                      - '--'
-                      - bash
-                      - -cx
-                      - >
-                        PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
-                        PIP_IGNORE_INSTALLED=0 pip install --user arrow taskcluster pyyaml &&
-                        ln -s /builds/worker/artifacts artifacts &&
-                        ~/.local/bin/taskgraph decision
-                        --pushlog-id='0'
-                        --pushdate='0'
-                        --project='${project}'
-                        --message=""
-                        --owner='${ownerEmail}'
-                        --level='${level}'
-                        --base-repository="$APPSERVICES_BASE_REPOSITORY"
-                        --head-repository="$APPSERVICES_HEAD_REPOSITORY"
-                        --head-ref="$APPSERVICES_HEAD_REF"
-                        --head-rev="$APPSERVICES_HEAD_REV"
-                        --repository-type="$APPSERVICES_REPOSITORY_TYPE"
-                        --tasks-for='${tasks_for}'
-                    artifacts:
-                      'public':
-                        type: 'directory'
-                        path: '/builds/worker/artifacts'
-                        expires: {$fromNow: '1 year'}
-                  extra:
-                    $merge:
-                        - treeherder:
+                              taskId: '${ownTaskId}'
+                        - taskGroupId:
+                              $if: 'tasks_for == "action"'
+                              then:
+                                  '${action.taskGroupId}'
+                              else:
+                                  '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
+                          schedulerId: '${trustDomain}-level-${level}'
+                          created: {$fromNow: ''}
+                          deadline: {$fromNow: '1 day'}
+                          expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first, despite rounding errors
+                          metadata:
                               $merge:
-                                  - machine:
-                                        platform: gecko-decision
-                                  - $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                                  - owner: "${ownerEmail}"
+                                    source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
+                                  - $if: 'tasks_for in ["github-push", "github-pull-request", "github-release"]'
                                     then:
-                                        symbol: D
-                        - tasks_for: '${tasks_for}'
-          "tasks_for == 'github-release' && event['action'] == 'published'":
-            $let:
-              is_staging:
-                $if: 'event.repository.html_url != "https://github.com/mozilla/application-services"'
-                then: true
-                else: false
-            in:
-              $let:
-                beetmover_worker_type:
-                  $if: 'is_staging'
-                  then: appservices-1-beetmover
-                  else: appservices-3-beetmover
-                beetmover_bucket:
-                  $if: 'is_staging'
-                  then: maven-staging
-                  else: maven-production
-                beetmover_bucket_public_url:
-                  $if: 'is_staging'
-                  then: https://maven-default.stage.mozaws.net/
-                  else: https://maven.mozilla.org/
-                tag: ${event.release.tag_name}
-                release_task_definition:
-                  payload:
-                    features:
-                      chainOfTrust: true
-              in:
-                $mergeDeep:
-                  - {$eval: 'default_task_definition'}
-                  - {$eval: 'release_task_definition'}
-                  - scopes:
-                    - assume:repo:${event.repository.html_url[8:]}:release
-                  - payload:
-                      env:
-                        IS_STAGING: ${is_staging}
-                        BEETMOVER_WORKER_TYPE: ${beetmover_worker_type}
-                        BEETMOVER_BUCKET: ${beetmover_bucket}
-                        BEETMOVER_BUCKET_PUBLIC_URL: ${beetmover_bucket_public_url}
-                  - metadata:
-                      name: Application Services - Decision task (${tag})
-                      description: Build and publish release versions.
+                                        name: "Decision Task"
+                                        description: 'The task that creates all of the other tasks in the task graph'
+                                    else:
+                                        $if: 'tasks_for == "action"'
+                                        then:
+                                            name: "Action: ${action.title}"
+                                            description: |
+                                                ${action.description}
+
+                                                Action triggered by clientID `${clientId}`
+                                        else:
+                                            name: "Decision Task for cron job ${cron.job_name}"
+                                            description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
+                          provisionerId: "app-services-${level}"
+                          workerType: "decision"
+                          tags:
+                              $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                              then:
+                                  kind: decision-task
+                              else:
+                                  $if: 'tasks_for == "action"'
+                                  then:
+                                      kind: 'action-callback'
+                                  else:
+                                      $if: 'tasks_for == "cron"'
+                                      then:
+                                          kind: cron-task
+                          routes:
+                            $flattenDeep:
+                              - checks
+                              - $if: 'level == "3"'
+                                then:
+                                    # TODO Bug 1601928: Make this scope fork-friendly once ${project} is better defined. This will enable
+                                    # staging release promotion on forks.
+                                    - $if: 'tasks_for == "github-push"'
+                                      then:
+                                          - index.project.${project}.v2.branch.${short_head_branch}.latest.taskgraph.decision
+                                          - index.project.${project}.v2.branch.${short_head_branch}.revision.${head_sha}.taskgraph.decision
+                                    - $if: 'tasks_for == "cron"'
+                                      then:
+                                          # cron context provides ${head_branch} as a short one
+                                          - index.project.${project}.v2.branch.${head_branch}.latest.taskgraph.decision-${cron.job_name}
+                                          - index.project.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.decision-${cron.job_name}
+                                          - index.project.${project}.v2.branch.${head_branch}.revision.${head_sha}.taskgraph.cron.${ownTaskId}
+                          scopes:
+                              $if: 'tasks_for == "github-push"'
+                              then:
+                                  # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
+                                  - 'assume:repo:${repoUrl[8:]}:branch:${short_head_branch}'
+                              else:
+                                  $if: 'tasks_for == "github-pull-request"'
+                                  then:
+                                      - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
+                                  else:
+                                      $if: 'tasks_for == "github-release"'
+                                      then:
+                                          - 'assume:repo:${repoUrl[8:]}:release'
+                                      else:
+                                          $if: 'tasks_for == "action"'
+                                          then:
+                                              # when all actions are hooks, we can calculate this directly rather than using a variable
+                                              - '${action.repo_scope}'
+                                          else:
+                                              - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
+                          requires: all-completed
+                          priority: lowest
+                          retries: 5
+
+                          payload:
+                              env:
+                                  # run-task uses these to check out the source; the inputs
+                                  # to `mach taskgraph decision` are all on the command line.
+                                  $merge:
+                                      - APPSERVICES_BASE_REPOSITORY: '${baseRepoUrl}'
+                                        APPSERVICES_HEAD_REPOSITORY: '${repoUrl}'
+                                        APPSERVICES_HEAD_REF: '${head_branch}'
+                                        APPSERVICES_HEAD_REV: '${head_sha}'
+                                        APPSERVICES_HEAD_TAG: '${head_tag}'
+                                        APPSERVICES_REPOSITORY_TYPE: git
+                                        TASKGRAPH_BASE_REPOSITORY: https://hg.mozilla.org/ci/taskgraph
+                                        TASKGRAPH_HEAD_REPOSITORY: https://hg.mozilla.org/ci/${taskgraph.branch}
+                                        TASKGRAPH_HEAD_REV: ${taskgraph.revision}
+                                        TASKGRAPH_REPOSITORY_TYPE: hg
+                                        REPOSITORIES: {$json: {appservices: "Application Services", taskgraph: "Taskgraph"}}
+                                        HG_STORE_PATH: /builds/worker/checkouts/hg-store
+                                        ANDROID_SDK_ROOT: /builds/worker/android-sdk
+                                        MOZ_FETCHES_DIR: /builds/worker/checkouts/src
+                                      - $if: 'tasks_for in ["github-pull-request"]'
+                                        then:
+                                            APPSERVICES_PULL_REQUEST_TITLE: '${event.pull_request.title}'
+                                            APPSERVICES_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
+                              features:
+                                  taskclusterProxy: true
+                                  chainOfTrust: true
+                              # Note: This task is built server side without the context or tooling that
+                              # exist in tree so we must hard code the hash
+                              image:
+                                  mozillareleases/taskgraph:decision-mobile-6020473b1a928d8df50e234a7ca2e81ade2220a4fb5fbe16b02477dd64a49728@sha256:98d226736b7d03907114bf37938002b90e8a37cbe3a297690e349f1ddddb1d7c
+
+                              maxRunTime: 1800
+
+                              command:
+                                  - /usr/local/bin/run-task
+                                  - '--appservices-checkout=/builds/worker/checkouts/src'
+                                  - '--taskgraph-checkout=/builds/worker/checkouts/taskgraph'
+                                  - '--task-cwd=/builds/worker/checkouts/src'
+                                  - '--'
+                                  - bash
+                                  - -cx
+                                  - >
+                                    PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
+                                    PIP_IGNORE_INSTALLED=0 pip install --user arrow taskcluster pyyaml &&
+                                    ln -s /builds/worker/artifacts artifacts &&
+                                    ~/.local/bin/taskgraph decision
+                                    --pushlog-id='0'
+                                    --pushdate='0'
+                                    --project='${project}'
+                                    --message=""
+                                    --owner='${ownerEmail}'
+                                    --level='${level}'
+                                    --base-repository="$APPSERVICES_BASE_REPOSITORY"
+                                    --head-repository="$APPSERVICES_HEAD_REPOSITORY"
+                                    --head-ref="$APPSERVICES_HEAD_REF"
+                                    --head-rev="$APPSERVICES_HEAD_REV"
+                                    --head-tag="$APPSERVICES_HEAD_TAG"
+                                    --repository-type="$APPSERVICES_REPOSITORY_TYPE"
+                                    --tasks-for='${tasks_for}'
+                              artifacts:
+                                  'public':
+                                      type: 'directory'
+                                      path: '/builds/worker/artifacts'
+                                      expires: {$fromNow: '1 year'}
+                          extra:
+                            $merge:
+                                - treeherder:
+                                      $merge:
+                                          - machine:
+                                                platform: gecko-decision
+                                          - $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                                            then:
+                                                symbol: D
+                                            else:
+                                                $if: 'tasks_for == "github-release"'
+                                                then:
+                                                    symbol: 'ship_app_services'
+                                - tasks_for: '${tasks_for}'

--- a/automation/upload_android_symbols.sh
+++ b/automation/upload_android_symbols.sh
@@ -49,4 +49,4 @@ done
 
 # 2. Upload them.
 pip3 install --user -r automation/symbols-generation/requirements.txt
-python3 automation/symbols-generation/upload_symbols.py "${OUTPUT_FOLDER}"
+python3 automation/symbols-generation/upload_symbols.py "${OUTPUT_FOLDER}" -t "$PWD/.symbols_upload_token"

--- a/taskcluster/app_services_taskgraph/__init__.py
+++ b/taskcluster/app_services_taskgraph/__init__.py
@@ -16,7 +16,11 @@ def register(graph_config):
     Import all modules that are siblings of this one, triggering decorators in
     the process.
     """
-    _import_modules(["job", "target_tasks", "worker_types"])
+    _import_modules([
+        "job",
+        "target_tasks",
+        "worker_types"
+    ])
 
 
 def _import_modules(modules):
@@ -25,7 +29,15 @@ def _import_modules(modules):
 
 
 def get_decision_parameters(graph_config, parameters):
-    if parameters["tasks_for"] == "github-pull-request":
+    if parameters["tasks_for"] == "github-release":
+        head_tag = parameters["head_tag"].decode("utf-8")
+        if not head_tag:
+            raise ValueError(
+                "Cannot run github-release if `head_tag` is not defined.Got {}".format(
+                    head_tag
+                )
+            )
+    elif parameters["tasks_for"] == "github-pull-request":
         pr_title = os.environ.get("APPSERVICES_PULL_REQUEST_TITLE", "").decode("UTF-8")
         if "[ci full]" in pr_title:
             parameters["target_tasks_method"] = "pr-full"

--- a/taskcluster/app_services_taskgraph/build_config.py
+++ b/taskcluster/app_services_taskgraph/build_config.py
@@ -23,6 +23,12 @@ def get_components():
     return [{
         'name': name,
         'path': project['path'],
+        'artifactId': project['artifactId'],
+	'uploadSymbols': project.get('uploadSymbols'),
+	'publications': [{
+	    'name': publication['name'],
+            'type': publication['type'],
+        } for publication in project['publications']]
     } for (name, project) in build_config['projects'].items()]
 
 

--- a/taskcluster/app_services_taskgraph/transforms/__init__.py
+++ b/taskcluster/app_services_taskgraph/transforms/__init__.py
@@ -1,0 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from ..build_config import EXTENSIONS
+
+def _extensions(type, secondary_extensions):
+    primary_extensions = EXTENSIONS[type]
+    return [package_ext + secondary_ext for package_ext in primary_extensions for secondary_ext in secondary_extensions]
+
+
+def _artifact_filename(name, version, extension):
+    return "{}-{}{}".format(name, version, extension)
+
+
+def publications_to_artifact_paths(name, version, publications, secondary_extensions=("",)):
+    paths = []
+    for publication in publications:
+        for extension in _extensions(publication["type"], secondary_extensions):
+            artifact_filename = _artifact_filename(publication['name'], version, extension)
+            paths.append("public/build/{}".format(artifact_filename))
+
+    return paths
+
+
+def publications_to_artifact_map_paths(name, version, publications, secondary_extensions):
+    build_map_paths = {}
+    for publication in publications:
+        for extension in _extensions(publication["type"], secondary_extensions):
+            artifact_filename = _artifact_filename(publication['name'], version, extension)
+            build_map_paths["public/build/{}".format(artifact_filename)] = {
+                "checksums_path": "",  # XXX beetmover marks this as required, but it's not needed
+                "destinations": ["maven2/org/mozilla/appservices/{}/{}/{}".format(publication['name'], version, artifact_filename)]
+            }
+
+    return build_map_paths

--- a/taskcluster/app_services_taskgraph/transforms/beetmover.py
+++ b/taskcluster/app_services_taskgraph/transforms/beetmover.py
@@ -1,0 +1,83 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+from . import (
+    publications_to_artifact_paths, publications_to_artifact_map_paths
+)
+from ..build_config import get_version
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def build_upstream_artifacts(config, tasks):
+    for task in tasks:
+        module_info = task["attributes"]["buildconfig"]
+        name = module_info["name"]
+        version = get_version()
+        publications = module_info["publications"]
+
+        worker_definition = {"upstream-artifacts": [{
+            "taskId": {"task-reference": "<module-build>"},
+            "taskType": "build",
+            "paths": (publications_to_artifact_paths(name, version, publications,
+                                                     ("", ".sha1", ".md5"))),
+        }, {
+            "taskId": {"task-reference": "<signing>"},
+            "taskType": "signing",
+            "paths": (publications_to_artifact_paths(name, version, publications, (".asc",))),
+        }]}
+
+        task.setdefault("worker", {})
+        task["worker"].update(worker_definition)
+        yield task
+
+
+@transforms.add
+def build_artifact_map(config, tasks):
+    for task in tasks:
+        module_info = task["attributes"]["buildconfig"]
+        name = module_info["name"]
+        version = get_version()
+
+        publications = module_info["publications"]
+
+        artifact_map = [{
+            "locale": "en-US",
+            "task-id": {"task-reference": "<module-build>"},
+            "paths": (publications_to_artifact_map_paths(name, version, publications,
+                                                         ("", ".sha1", ".md5")))
+        }, {
+            "locale": "en-US",
+            "task-id": {"task-reference": "<signing>"},
+            "paths": publications_to_artifact_map_paths(name, version, publications, (".asc",))
+        }]
+
+        task["worker"]["artifact-map"] = artifact_map
+        yield task
+
+
+@transforms.add
+def beetmover_task(config, tasks):
+    for task in tasks:
+        task["worker"]["max-run-time"] = 600
+        task["worker"]["version"] = get_version()
+        task["description"] = task["description"].format(task["attributes"]["buildconfig"]["name"])
+        resolve_keyed_by(task, "worker.bucket", item_name=task["name"], **{
+            "level": config.params["level"],
+        })
+        yield task
+
+
+@transforms.add
+def remove_dependent_tasks(config, tasks):
+    for task in tasks:
+        del task["primary-dependency"]
+        del task["dependent-tasks"]
+        yield task

--- a/taskcluster/app_services_taskgraph/transforms/module_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/module_build.py
@@ -13,6 +13,23 @@ transforms = TransformSequence()
 
 
 @transforms.add
+def release_upload_symbols(config, tasks):
+    for task in tasks:
+        if (config.params["tasks_for"] == u"github-release" and
+            task["attributes"]["buildconfig"]["uploadSymbols"]):
+                task["run"].setdefault("post-gradlew", [])
+                task["run"]["post-gradlew"].append(
+                    [
+                        "source",
+                        "automation/upload_android_symbols.sh",
+                        unicode(task["attributes"]["buildconfig"]["path"])
+                    ]
+                )
+
+        yield task
+
+
+@transforms.add
 def build_task(config, tasks):
     for task in tasks:
         module_info = task["attributes"]["buildconfig"]
@@ -30,7 +47,7 @@ def build_task(config, tasks):
                 artifact_filename = "{}-{}{}".format(publication_name, version, extension)
                 artifacts.append({
                     "name": "public/build/{}".format(artifact_filename),
-                    "path": "/builds/worker/checkouts/src/build/maven/org/mozilla/appservices/{}/{}/{}".format(name, version, artifact_filename),
+                    "path": "/builds/worker/checkouts/src/build/maven/org/mozilla/appservices/{}/{}/{}".format(publication_name, version, artifact_filename),
                     "type": "file",
                 })
 

--- a/taskcluster/app_services_taskgraph/transforms/secrets.py
+++ b/taskcluster/app_services_taskgraph/transforms/secrets.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Resolve secrets and dummy secrets
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def resolve_keys(config, tasks):
+    for task in tasks:
+        for key in ("run.secrets", "run.dummy-secrets"):
+            resolve_keyed_by(
+                task,
+                key,
+                item_name=task["name"],
+                level=config.params["level"]
+            )
+        yield task

--- a/taskcluster/app_services_taskgraph/transforms/signing.py
+++ b/taskcluster/app_services_taskgraph/transforms/signing.py
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+from . import publications_to_artifact_paths
+from ..build_config import get_version
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def build_upstream_artifacts(config, tasks):
+    for task in tasks:
+        dep = task.pop("primary-dependency")
+        module_info = task["attributes"]["buildconfig"]
+        name = module_info["name"]
+        version = get_version()
+
+        worker_definition = {"upstream-artifacts": [{
+            "taskId": {"task-reference": "<{}>".format(dep.kind)},
+            "taskType": "build",
+            "paths": publications_to_artifact_paths(name, version, module_info["publications"]),
+            "formats": ["autograph_gpg"],
+        }]}
+
+        task.setdefault("worker", {})
+        task["worker"].update(worker_definition)
+        yield task
+
+
+@transforms.add
+def signing_task(config, tasks):
+    for task in tasks:
+        task["description"] = task["description"].format(task["attributes"]["buildconfig"]["name"])
+        resolve_keyed_by(task, "worker.cert", item_name=task["name"], **{
+            "level": config.params["level"],
+        })
+        yield task
+
+
+@transforms.add
+def remove_dependent_tasks(config, tasks):
+    for task in tasks:
+        del task["dependent-tasks"]
+        yield task

--- a/taskcluster/app_services_taskgraph/worker_types.py
+++ b/taskcluster/app_services_taskgraph/worker_types.py
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from six import text_type
+
+from voluptuous import Required
+
+from taskgraph.util.schema import taskref_or_string
+from taskgraph.transforms.task import payload_builder
+
+
+@payload_builder(
+    "scriptworker-signing",
+    schema={
+        Required("max-run-time"): int,
+        Required("cert"): text_type,
+        Required("upstream-artifacts"): [{
+            Required("taskId"): taskref_or_string,
+            Required("taskType"): text_type,
+            Required("paths"): [text_type],
+            Required("formats"): [text_type],
+        }]
+    }
+)
+def build_scriptworker_signing_payload(config, task, task_def):
+    worker = task["worker"]
+    task_def["tags"]["worker-implementation"] = "scriptworker"
+    task_def["payload"] = {
+        "maxRunTime": worker["max-run-time"],
+        "upstreamArtifacts": worker["upstream-artifacts"],
+    }
+
+    formats = set()
+    for artifacts in worker["upstream-artifacts"]:
+        formats.update(artifacts["formats"])
+
+    scope_prefix = config.graph_config["scriptworker"]["scope-prefix"]
+    task_def["scopes"].append(
+        "{}:signing:cert:{}".format(scope_prefix, worker["cert"])
+    )
+    task_def["scopes"].extend([
+        "{}:signing:format:{}".format(scope_prefix, signing_format) for signing_format in sorted(formats)
+    ])
+
+
+@payload_builder(
+    "scriptworker-beetmover",
+    schema={
+        Required("bucket"): text_type,
+        Required("max-run-time"): int,
+        Required("version"): str,
+        Required("app-name"): text_type,
+        Required("upstream-artifacts"): [{
+            Required("taskId"): taskref_or_string,
+            Required("taskType"): text_type,
+            Required("paths"): [text_type],
+        }],
+        Required("artifact-map"): [{
+            Required("task-id"): taskref_or_string,
+            Required("locale"): text_type,
+            Required("paths"): {text_type: dict},
+        }],
+    }
+)
+def build_scriptworker_beetmover_payload(config, task, task_def):
+    worker = task["worker"]
+    task_def["tags"]["worker-implementation"] = "scriptworker"
+    task_def["payload"] = {
+        "maxRunTime": worker["max-run-time"],
+        "upstreamArtifacts": worker["upstream-artifacts"],
+        "artifactMap": [{
+            "taskId": entry["task-id"],
+            "locale": entry["locale"],
+            "paths": entry["paths"],
+        } for entry in worker["artifact-map"]],
+        "version": worker["version"],
+        "releaseProperties": {
+            "appName": worker["app-name"]
+        }
+    }
+
+    scope_prefix = config.graph_config["scriptworker"]["scope-prefix"]
+    task_def["scopes"].append(
+        "{}:beetmover:bucket:{}".format(scope_prefix, worker["bucket"])
+    )
+    task_def["scopes"].append(
+        "{}:beetmover:action:push-to-maven".format(scope_prefix)
+    )
+

--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: app_services_taskgraph.loader.multi_dep:loader
+
+transforms:
+  - app_services_taskgraph.transforms.multi_dep:transforms
+  - app_services_taskgraph.transforms.beetmover:transforms
+  - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+  - module-build
+  - signing
+
+primary-dependency: module-build
+group-by: component
+
+job-template:
+  run-on-tasks-for: [github-release]
+  description: 'Publish release module {}'
+  worker-type: beetmover
+  worker:
+    app-name: appservices
+    bucket:
+      by-level:
+        "3":
+          maven-production
+        default:
+          maven-staging
+  routes:
+    - notify.email.a-s-ci-failures@mozilla.com.on-failed
+

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -25,6 +25,19 @@ workers:
       implementation: docker-worker
       os: linux
       worker-type: 'images'
+    signing:
+      provisioner: scriptworker-k8s
+      implementation: scriptworker-signing
+      os: scriptworker
+      worker-type:
+        by-level:
+          "3": app-services-3-signing
+          default: app-services-t-signing
+    beetmover:
+      provisioner: scriptworker-k8s
+      implementation: scriptworker-beetmover
+      os: scriptworker
+      worker-type: 'app-services-{level}-beetmover'
 
 scriptworker:
-  scope-prefix: project:mozilla:application-services:releng
+  scope-prefix: project:mozilla:app-services:releng

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -7,6 +7,7 @@
 loader: app_services_taskgraph.loader.build_config:loader
 
 transforms:
+  - app_services_taskgraph.transforms.secrets:transforms
   - app_services_taskgraph.transforms.module_build:transforms
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.task:transforms
@@ -23,6 +24,7 @@ job-defaults:
     - project:releng:services/tooltool/api/download/internal
   worker-type: b-linux
   worker:
+    chain-of-trust: true
     docker-image: { in-tree: linux }
     max-run-time: 1800
   run:
@@ -40,6 +42,19 @@ job-defaults:
       - ':{module_name}:assembleRelease'
       - ':{module_name}:publish'
       - ':{module_name}:checkMavenArtifacts'
+    dummy-secrets:
+        by-level:
+            '3': []
+            default:
+                - content: "faketoken"
+                  path: .symbols_upload_token
+    secrets:
+        by-level:
+            '3':
+                - name: project/application-services/symbols-token
+                  key: token
+                  path: .symbols_upload_token
+            default: []
     using: gradlew
     use-caches: true
 

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: app_services_taskgraph.loader.multi_dep:loader
+
+transforms:
+  - app_services_taskgraph.transforms.multi_dep:transforms
+  - app_services_taskgraph.transforms.signing:transforms
+  - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+  - module-build
+
+primary-dependency: module-build
+group-by: component
+
+job-template:
+  run-on-tasks-for: [github-release]
+  description: 'Sign release module {}'
+  worker-type: signing
+  worker:
+    cert:
+      by-level:
+        "3":
+          release-signing
+        default:
+          dep-signing
+  routes:
+    - notify.email.a-s-ci-failures@mozilla.com.on-failed
+

--- a/taskcluster/scripts/get-secret.py
+++ b/taskcluster/scripts/get-secret.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import argparse
+import base64
+import errno
+import json
+import os
+import taskcluster
+
+
+def write_secret_to_file(path, data, key, base64decode=False, json_secret=False, append=False, prefix=''):
+    path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../' + path))
+    try:
+        os.makedirs(os.path.dirname(path))
+    except OSError as error:
+        if error.errno != errno.EEXIST:
+            raise
+    print("Outputting secret to: {}".format(path))
+
+    with open(path, 'a' if append else 'w') as f:
+        value = data['secret'][key]
+        if base64decode:
+            value = base64.b64decode(value)
+        if json_secret:
+            value = json.dumps(value)
+        f.write(prefix + value)
+
+
+def fetch_secret_from_taskcluster(name):
+    try:
+        secrets = taskcluster.Secrets({
+            # BaseUrl is still needed for tasks that haven't migrated to taskgraph yet.
+            'baseUrl': 'http://taskcluster/secrets/v1',
+        })
+    except taskcluster.exceptions.TaskclusterFailure:
+        # taskcluster library >=5 errors out when `baseUrl` is used
+        secrets = taskcluster.Secrets({
+            'rootUrl': os.environ.get('TASKCLUSTER_PROXY_URL', 'https://taskcluster.net'),
+        })
+
+    return secrets.get(name)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Fetch a taskcluster secret value and save it to a file.')
+
+    parser.add_argument('-s', dest="secret", action="store", help="name of the secret")
+    parser.add_argument('-k', dest='key', action="store", help='key of the secret')
+    parser.add_argument('-f', dest="path", action="store", help='file to save secret to')
+    parser.add_argument('--decode', dest="decode", action="store_true", default=False, help='base64 decode secret before saving to file')
+    parser.add_argument('--json', dest="json", action="store_true", default=False, help='serializes the secret to JSON format')
+    parser.add_argument('--append', dest="append", action="store_true", default=False, help='append secret to existing file')
+    parser.add_argument('--prefix', dest="prefix", action="store", default="", help='add prefix when writing secret to file')
+
+    result = parser.parse_args()
+
+    secret = fetch_secret_from_taskcluster(result.secret)
+    write_secret_to_file(result.path, secret, result.key, result.decode, result.json, result.append, result.prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/taskcluster/scripts/write-dummy-secret.py
+++ b/taskcluster/scripts/write-dummy-secret.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import argparse
+import errno
+import os
+
+
+def write_secret_to_file(path, secret):
+    path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../' + path))
+    try:
+        os.makedirs(os.path.dirname(path))
+    except OSError as error:
+        if error.errno != errno.EEXIST:
+            raise
+    print("Outputting secret to: {}".format(path))
+
+    with open(path, 'w') as f:
+        f.write(secret)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Store a dummy secret to a file")
+
+    parser.add_argument("-c", dest="content", action="store", help="content of the secret")
+    parser.add_argument("-f", dest="path", action="store", help="file to save secret to")
+
+    result = parser.parse_args()
+
+    write_secret_to_file(result.path, result.content)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Last PR that references https://github.com/mozilla/application-services/pull/1945/ and adds taskgraph support for releases.