### PR TITLE
Add `usage` API to webext-storage. Fixes #3158

### DIFF
--- a/components/webext-storage/src/api.rs
+++ b/components/webext-storage/src/api.rs
@@ -330,6 +330,45 @@ pub fn get_bytes_in_use(conn: &Connection, ext_id: &str, keys: JsonValue) -> Res
     Ok(size)
 }
 
+/// Information about the usage of a single extension.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UsageInfo {
+    /// The extension id.
+    pub ext_id: String,
+    /// The number of keys the extension uses.
+    pub num_keys: usize,
+    /// The number of bytes used by the extension. This result is somewhat rough
+    /// -- it doesn't bother counting the size of the extension ID, or data in
+    /// the mirror, and favors returning the exact number of bytes used by the
+    /// column (that is, the size of the JSON object) rather than replicating
+    /// the `get_bytes_in_use` return value for all keys.
+    pub num_bytes: usize,
+}
+
+/// Exposes information about per-collection usage for the purpose of telemetry.
+/// (Doesn't map to an actual `chrome.storage.sync` API).
+pub fn usage(db: &Connection) -> Result<Vec<UsageInfo>> {
+    type JsonObject = Map<String, JsonValue>;
+    let sql = "
+        SELECT ext_id, data
+        FROM storage_sync_data
+        WHERE data IS NOT NULL
+        -- for tests and determinism
+        ORDER BY ext_id
+    ";
+    db.query_rows_into(sql, &[], |row| {
+        let ext_id: String = row.get("ext_id")?;
+        let data: String = row.get("data")?;
+        let num_bytes = data.len();
+        let num_keys = serde_json::from_str::<JsonObject>(&data)?.len();
+        Ok(UsageInfo {
+            ext_id,
+            num_bytes,
+            num_keys,
+        })
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -599,5 +638,36 @@ mod tests {
         );
         assert_eq!(get_bytes_in_use(&tx, &ext_id, json!(null))?, 22);
         Ok(())
+    }
+
+    #[test]
+    fn test_usage() {
+        let mut db = new_mem_db();
+        let tx = db.transaction().unwrap();
+        // '{"a":"a","b":"bb","c":"ccc","n":999999}': 39 bytes
+        set(&tx, "xyz", json!({ "a": "a" })).unwrap();
+        set(&tx, "xyz", json!({ "b": "bb" })).unwrap();
+        set(&tx, "xyz", json!({ "c": "ccc" })).unwrap();
+        set(&tx, "xyz", json!({ "n": 999_999 })).unwrap();
+
+        // '{"a":"a"}': 9 bytes
+        set(&tx, "abc", json!({ "a": "a" })).unwrap();
+
+        tx.commit().unwrap();
+
+        let usage = usage(&db).unwrap();
+        let expect = [
+            UsageInfo {
+                ext_id: "abc".to_string(),
+                num_keys: 1,
+                num_bytes: 9,
+            },
+            UsageInfo {
+                ext_id: "xyz".to_string(),
+                num_keys: 4,
+                num_bytes: 39,
+            },
+        ];
+        assert_eq!(&usage, &expect);
     }
 }

--- a/components/webext-storage/src/lib.rs
+++ b/components/webext-storage/src/lib.rs
@@ -19,3 +19,5 @@ pub use sync::STORAGE_VERSION;
 pub use api::SYNC_MAX_ITEMS;
 pub use api::SYNC_QUOTA_BYTES;
 pub use api::SYNC_QUOTA_BYTES_PER_ITEM;
+
+pub use api::UsageInfo;

--- a/components/webext-storage/src/store.rs
+++ b/components/webext-storage/src/store.rs
@@ -59,6 +59,11 @@ impl Store {
         Ok(result)
     }
 
+    /// Returns information about per-extension usage
+    pub fn usage(&self) -> Result<Vec<crate::UsageInfo>> {
+        api::usage(&self.db)
+    }
+
     /// Returns the values for one or more keys `keys` can be:
     ///
     /// - `null`, in which case all key-value pairs for the extension are


### PR DESCRIPTION
Fixes #3158.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
