### PR TITLE
Handle unknown push "command" values even if they have associated data

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,3 +9,4 @@
 ### What's new
 
 - Additional special case for China FxA in `getPairingAuthorityURL`. ([#3160](https://github.com/mozilla/application-services/pull/3160))
+- Silently ignore push messages for unrecognized commands, rather than reporting an error. ([#3177](https://github.com/mozilla/application-services/pull/3177))


### PR DESCRIPTION
Connects to #3145.

If we receive a push message with an unrecognized "command" field, we want to log it and ignore it. This currently works fine *unless the message also has a "data" field*, in which case serde complains about "invalid type: map, expected unit variant PushPayload::Unknown".

I've added a trivial testcase here to demonstrate the error.

Things is though...I can't figure out how to tell serde to do what we want here. The push payload struct is declared like this:

```
#[serde(tag = "command", content = "data")]
pub enum PushPayload {
    #[serde(rename = "fxaccounts:command_received")]
    CommandReceived(CommandReceivedPushPayload),
    #[serde(rename = "fxaccounts:device_connected")]
    DeviceConnected(DeviceConnectedPushPayload),
    [...various similar cases omitted...]
    #[serde(other)]
    Unknown,
}
```

From the error message, I *think* serde is complaining about the fact that it found a "data" field but doesn't have anywhere to put it in the `Unknown` variant. But the [docs](https://serde.rs/variant-attrs.html#other) insist that `#[serde(other)]` can only be applied to a unit variant, and I can't see a way to tell it to skip the "data" field in this case.

Any suggestions?