### PR TITLE
add cargo alias for regenerating protobufs

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[alias]
+regen-protobufs = ["run", "--bin", "protobuf-gen", "tools/protobuf_files.toml"]

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ website/build
 target
 credentials.json
 *-engine.json
-.cargo
 *.db
 .*.swp
 

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ## General
 
+- Adds an alias for generating protobuf files, you can now use `cargo regen-protobufs` to generate them. ([#3178](https://github.com/mozilla/application-services/pull/3178))
+
 - Replaced `failure` with `anyhow` and `thiserror`. ([#3132](https://github.com/mozilla/application-services/pull/3132))
 
 ## FxA Client

--- a/docs/howtos/passing-protobuf-data-over-ffi.md
+++ b/docs/howtos/passing-protobuf-data-over-ffi.md
@@ -37,8 +37,13 @@ follow the examples of the other steps it takes.
     ["mylib_msg_types.proto"]
     dir = "../components/mylib/src/"
     ```
+4. Generate your Rust files from the .proto files using:
 
-6. Into your main crate's lib.rs file, add something equivalent to the following:
+    ```console
+    $ cargo regen-protobufs
+    ```
+
+5. Into your main crate's lib.rs file, add something equivalent to the following:
     ```rust
     pub mod msg_types {
         include!("mozilla.appservices.mylib.protobuf.rs");
@@ -48,7 +53,7 @@ follow the examples of the other steps it takes.
     This exposes the generated rust file (from the .proto file) as a
     rust module.
 
-7. Open your main crates's src/ffi.rs (note: *not* ffi/src/lib.rs! We'll get
+6. Open your main crates's src/ffi.rs (note: *not* ffi/src/lib.rs! We'll get
    there shortly!)
 
    For each type you declare in your .proto file, first decide if you want to
@@ -100,7 +105,7 @@ follow the examples of the other steps it takes.
       delete `Serialize` from it's `#[derive(...)]` while you're at it, unless you
       still need it.
 
-8. In your ffi crate's lib.rs, make the following changes:
+7. In your ffi crate's lib.rs, make the following changes:
 
     1. Any function that conceptually returns a protobuf type must now return
       `ffi_support::ByteBuffer` (if it returned via JSON before, this should be


### PR DESCRIPTION
fixes #3147 
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

Simply adds a .cargo/config with the alias for regen-protobufs as mentioned in #3147 
