### PR TITLE
Put `backtrace` behind a Cargo feature

### DIFF
--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -7,4 +7,7 @@ license = "MPL-2.0"
 
 [dependencies]
 thiserror = "1.0"
-backtrace = "0.3"
+
+[dependencies.backtrace]
+optional = true
+version = "0.3"


### PR DESCRIPTION
`backtrace` brings lots of dependencies with it, some of which
(like `gimli`) we can't vendor in Firefox Desktop because they're too
big. We could work around that, but we never log backtraces on Desktop,
anyway, and pulling in the library adds bloat there. So let's put it behind
a Cargo feature flag, with a compatibility shim.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
