### PR TITLE
Replace failure with anyhow in the sync_tests

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -6,6 +6,8 @@
 
 ## General
 
+- Remove `failure` from the sync_tests and replace it with `anyhow`. ([#3188](https://github.com/mozilla/application-services/pull/3188))
+
 - Adds an alias for generating protobuf files, you can now use `cargo regen-protobufs` to generate them. ([#3178](https://github.com/mozilla/application-services/pull/3178))
 
 - Replaced `failure` with `anyhow` and `thiserror`. ([#3132](https://github.com/mozilla/application-services/pull/3132))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,28 +611,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,8 +2400,8 @@ dependencies = [
 name = "sync-test"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "env_logger",
- "failure",
  "fxa-client",
  "lazy_static",
  "log 0.4.8",
@@ -2511,18 +2489,6 @@ dependencies = [
  "sync15",
  "sync_manager",
  "tabs_ffi",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid 0.2.0",
 ]
 
 [[package]]

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -14,7 +14,7 @@ fxa-client = { path = "../../components/fxa-client" }
 url = "2.1"
 env_logger = "0.7"
 log = "0.4"
-failure = "0.1"
+anyhow = "1.0"
 rand = "0.7"
 lazy_static = "1.4"
 structopt = "0.3"

--- a/testing/sync-test/src/logins.rs
+++ b/testing/sync-test/src/logins.rs
@@ -3,8 +3,8 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 
 use crate::auth::TestClient;
 use crate::testing::TestGroup;
+use anyhow::Result;
 use logins::{Login, PasswordEngine, Result as LoginResult};
-
 // helpers...
 
 // Doesn't check metadata fields
@@ -74,7 +74,7 @@ pub fn touch_login(e: &PasswordEngine, id: &str, times: usize) -> LoginResult<Lo
     Ok(e.get(&id)?.unwrap())
 }
 
-pub fn sync_logins(client: &mut TestClient) -> Result<(), failure::Error> {
+pub fn sync_logins(client: &mut TestClient) -> Result<()> {
     let (init, key, _device_id) = client.data_for_sync()?;
     client.logins_engine.sync(&init, &key)?;
     Ok(())

--- a/testing/sync-test/src/tabs.rs
+++ b/testing/sync-test/src/tabs.rs
@@ -3,8 +3,8 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 
 use crate::auth::TestClient;
 use crate::testing::TestGroup;
+use anyhow::Result;
 use tabs::{ClientRemoteTabs, DeviceType, RemoteTab, TabsEngine};
-
 // helpers...
 
 pub fn verify_tabs(tabs_engine: &TabsEngine, expected: &ClientRemoteTabs) {
@@ -33,7 +33,7 @@ pub fn assert_remote_tabs_equiv(l: &ClientRemoteTabs, r: &ClientRemoteTabs) {
     }
 }
 
-pub fn sync_tabs(client: &mut TestClient) -> Result<(), failure::Error> {
+pub fn sync_tabs(client: &mut TestClient) -> Result<()> {
     let (init, key, device_id) = client.data_for_sync()?;
     client.tabs_engine.sync(&init, &key, &device_id)?;
     Ok(())


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

Continuation to #3132 to remove the failure crate from the sync integration tests
