### PR TITLE
Implements pbkdf2 for rc_crypto

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,8 @@
 
 # Unreleased Changes
 
+## General
+
+- Adds an implementation for [pbkdf2](https://www.ietf.org/rfc/rfc2898.txt). ([#3193](https://github.com/mozilla/application-services/pull/3193))
+
 [Full Changelog](https://github.com/mozilla/application-services/compare/v60.0.0...master)

--- a/components/support/rc_crypto/nss/nss_sys/src/bindings/pk11pub.rs
+++ b/components/support/rc_crypto/nss/nss_sys/src/bindings/pk11pub.rs
@@ -110,4 +110,20 @@ extern "C" {
         attr: CK_ATTRIBUTE_TYPE,
         item: *mut SECItem,
     ) -> SECStatus;
+    pub fn PK11_CreatePBEV2AlgorithmID(
+        pbeAlgTag: u32,    /* SECOidTag */
+        cipherAlgTag: u32, /* SECOidTag */
+        prfAlgTag: u32,    /* SECOidTag */
+        keyLength: c_int,
+        iteration: c_int,
+        salt: *mut SECItem,
+    ) -> *mut SECAlgorithmID;
+
+    pub fn PK11_PBEKeyGen(
+        slot: *mut PK11SlotInfo,
+        algid: *mut SECAlgorithmID,
+        pwitem: *mut SECItem,
+        faulty3DES: PRBool,
+        wincx: *mut c_void,
+    ) -> *mut PK11SymKey;
 }

--- a/components/support/rc_crypto/nss/nss_sys/src/bindings/secoid.rs
+++ b/components/support/rc_crypto/nss/nss_sys/src/bindings/secoid.rs
@@ -6,4 +6,5 @@ pub use crate::*;
 
 extern "C" {
     pub fn SECOID_FindOIDByTag(tagnum: u32 /* SECOidTag */) -> *mut SECOidData;
+    pub fn SECOID_DestroyAlgorithmID(aid: *mut SECAlgorithmID, freeit: PRBool);
 }

--- a/components/support/rc_crypto/nss/nss_sys/src/bindings/secoidt.rs
+++ b/components/support/rc_crypto/nss/nss_sys/src/bindings/secoidt.rs
@@ -7,6 +7,15 @@ use std::os::raw::{c_char, c_ulong};
 
 #[repr(C)]
 #[derive(Copy, Clone)]
+pub struct SECAlgorithmIDStr {
+    pub algorithm: SECItem,
+    pub parameters: SECItem,
+}
+
+pub type SECAlgorithmID = SECAlgorithmIDStr;
+
+#[repr(C)]
+#[derive(Copy, Clone)]
 pub struct SECOidDataStr {
     pub oid: SECItem,
     pub offset: u32, /* SECOidTag */

--- a/components/support/rc_crypto/nss/src/lib.rs
+++ b/components/support/rc_crypto/nss/src/lib.rs
@@ -10,6 +10,7 @@ pub mod aes;
 pub mod ec;
 pub mod ecdh;
 mod error;
+pub mod pbkdf2;
 pub mod pk11;
 pub mod secport;
 pub use crate::error::{Error, ErrorKind, Result};

--- a/components/support/rc_crypto/nss/src/pbkdf2.rs
+++ b/components/support/rc_crypto/nss/src/pbkdf2.rs
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::util::{ensure_nss_initialized, map_nss_secstatus, sec_item_as_slice, ScopedPtr};
+use crate::{
+    error::*,
+    pk11::{
+        slot::get_internal_slot,
+        types::{AlgorithmID, SymKey},
+    },
+};
+
+// Expose for consumers to choose the hashing algorithm
+// Currently only SHA256 supported
+pub use crate::pk11::context::HashAlgorithm;
+use nss_sys::SECOidTag;
+use std::convert::TryFrom;
+
+// ***** BASED ON THE FOLLOWING IMPLEMENTATION *****
+// https://searchfox.org/mozilla-central/rev/8ccea36c4fb09412609fb738c722830d7098602b/dom/crypto/WebCryptoTask.cpp#2567
+
+pub fn pbkdf2_key_derive(
+    password: &[u8],
+    salt: &[u8],
+    iterations: u32,
+    hash_algorithm: HashAlgorithm,
+    out: &mut [u8],
+) -> Result<()> {
+    ensure_nss_initialized();
+    let oid_tag = match hash_algorithm {
+        HashAlgorithm::SHA256 => SECOidTag::SEC_OID_HMAC_SHA256 as u32,
+    };
+    let mut sec_salt = nss_sys::SECItem {
+        len: u32::try_from(salt.len())?,
+        data: salt.as_ptr() as *mut u8,
+        type_: 0,
+    };
+    let alg_id = unsafe {
+        AlgorithmID::from_ptr(nss_sys::PK11_CreatePBEV2AlgorithmID(
+            SECOidTag::SEC_OID_PKCS5_PBKDF2 as u32,
+            SECOidTag::SEC_OID_HMAC_SHA1 as u32,
+            oid_tag,
+            i32::try_from(out.len())?,
+            i32::try_from(iterations)?,
+            &mut sec_salt as *mut nss_sys::SECItem,
+        ))?
+    };
+
+    let slot = get_internal_slot()?;
+    let mut sec_pw = nss_sys::SECItem {
+        len: u32::try_from(password.len())?,
+        data: password.as_ptr() as *mut u8,
+        type_: 0,
+    };
+    let sym_key = unsafe {
+        SymKey::from_ptr(nss_sys::PK11_PBEKeyGen(
+            slot.as_mut_ptr(),
+            alg_id.as_mut_ptr(),
+            &mut sec_pw as *mut nss_sys::SECItem,
+            nss_sys::PR_FALSE,
+            std::ptr::null_mut(),
+        ))?
+    };
+    map_nss_secstatus(|| unsafe { nss_sys::PK11_ExtractKeyValue(sym_key.as_mut_ptr()) })?;
+
+    // This doesn't leak, because the SECItem* returned by PK11_GetKeyData
+    // just refers to a buffer managed by `sym_key` which we copy into `buf`
+    let mut key_data = unsafe { *nss_sys::PK11_GetKeyData(sym_key.as_mut_ptr()) };
+    let buf = unsafe { sec_item_as_slice(&mut key_data)? };
+    // Stop panic in swap_with_slice by returning an error if the sizes mismatch
+    if buf.len() != out.len() {
+        return Err(ErrorKind::InternalError.into());
+    }
+    out.swap_with_slice(buf);
+    Ok(())
+}

--- a/components/support/rc_crypto/nss/src/pk11/types.rs
+++ b/components/support/rc_crypto/nss/src/pk11/types.rs
@@ -33,6 +33,17 @@ scoped_ptr!(
 scoped_ptr!(Context, nss_sys::PK11Context, pk11_destroy_context_true);
 scoped_ptr!(Slot, nss_sys::PK11SlotInfo, nss_sys::PK11_FreeSlot);
 
+scoped_ptr!(
+    AlgorithmID,
+    nss_sys::SECAlgorithmID,
+    secoid_destroy_algorithm_id_true
+);
+
+#[inline]
+unsafe fn secoid_destroy_algorithm_id_true(alg_id: *mut nss_sys::SECAlgorithmID) {
+    nss_sys::SECOID_DestroyAlgorithmID(alg_id, nss_sys::PR_TRUE);
+}
+
 #[inline]
 unsafe fn pk11_destroy_context_true(context: *mut nss_sys::PK11Context) {
     nss_sys::PK11_DestroyContext(context, nss_sys::PR_TRUE);

--- a/components/support/rc_crypto/src/lib.rs
+++ b/components/support/rc_crypto/src/lib.rs
@@ -35,6 +35,7 @@ mod error;
 mod hawk_crypto;
 pub mod hkdf;
 pub mod hmac;
+pub mod pbkdf2;
 pub mod rand;
 
 // Expose `hawk` if the hawk feature is on. This avoids consumers needing to

--- a/components/support/rc_crypto/src/pbkdf2.rs
+++ b/components/support/rc_crypto/src/pbkdf2.rs
@@ -1,0 +1,196 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::error::*;
+use nss::pbkdf2::pbkdf2_key_derive;
+pub use nss::pbkdf2::HashAlgorithm;
+/// Extend passwords using pbkdf2, based on the following [rfc](https://www.ietf.org/rfc/rfc2898.txt) it runs the NSS implementation
+/// # Arguments
+///
+///  * `passphrase` - The password to stretch
+///  * `salt` - A salt to use in the generation process
+///  * `iterations` - The number of iterations the hashing algorithm will run on each section of the key
+///  * `hash_algorithm` - The hash algorithm to use
+///  * `out` - The slice the algorithm will populate
+///
+/// # Examples
+///
+/// ```
+/// use rc_crypto::pbkdf2;
+/// let password = b"password";
+/// let salt = b"salt";
+/// let mut out = vec![0u8; 32];
+/// let iterations = 2; // Real code should have a MUCH higher number of iterations (Think 1000+)
+/// pbkdf2::derive(password, salt, iterations, pbkdf2::HashAlgorithm::SHA256, &mut out).unwrap(); // Oh oh should handle the error!
+/// assert_eq!(hex::encode(out), "ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43");
+//
+///```
+///
+/// # Errors
+///
+/// Could possibly return an error if the HMAC algorithm fails, or if the NSS algorithm returns an error
+pub fn derive(
+    passphrase: &[u8],
+    salt: &[u8],
+    iterations: u32,
+    hash_algorithm: HashAlgorithm,
+    out: &mut [u8],
+) -> Result<()> {
+    pbkdf2_key_derive(passphrase, salt, iterations, hash_algorithm, out)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_generate_correct_out() {
+        let expected = "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b";
+        let mut out = vec![0u8; 32];
+        let password = b"password";
+        let salt = b"salt";
+        derive(password, salt, 1, HashAlgorithm::SHA256, &mut out).unwrap();
+        assert_eq!(expected, hex::encode(out));
+    }
+
+    #[test]
+    fn test_longer_key() {
+        let expected = "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b4dbf3a2f3dad3377264bb7b8e8330d4efc7451418617dabef683735361cdc18c";
+        let password = b"password";
+        let salt = b"salt";
+        let mut out = vec![0u8; 64];
+        derive(password, salt, 1, HashAlgorithm::SHA256, &mut out).unwrap();
+        assert_eq!(expected, hex::encode(out));
+    }
+
+    #[test]
+    fn test_more_iterations() {
+        let expected = "ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43";
+        let password = b"password";
+        let salt = b"salt";
+        let mut out = vec![0u8; 32];
+        derive(password, salt, 2, HashAlgorithm::SHA256, &mut out).unwrap();
+        assert_eq!(expected, hex::encode(out));
+    }
+
+    #[test]
+    fn test_odd_length() {
+        let expected = "ad35240ac683febfaf3cd49d845473fbbbaa2437f5f82d5a415ae00ac76c6bfccf";
+        let password = b"password";
+        let salt = b"salt";
+        let mut out = vec![0u8; 33];
+        derive(password, salt, 3, HashAlgorithm::SHA256, &mut out).unwrap();
+        assert_eq!(expected, hex::encode(out));
+    }
+
+    #[test]
+    fn test_nulls() {
+        let expected = "e25d526987819f966e324faa4a";
+        let password = b"passw\x00rd";
+        let salt = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+        let mut out = vec![0u8; 13];
+        derive(password, salt, 5, HashAlgorithm::SHA256, &mut out).unwrap();
+        assert_eq!(expected, hex::encode(out));
+    }
+
+    #[test]
+    fn test_password_null() {
+        let expected = "62384466264daadc4144018c6bd864648272b34da8980d31521ffcce92ae003b";
+        let password = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+        let salt = b"salt";
+        let mut out = vec![0u8; 32];
+        derive(password, salt, 2, HashAlgorithm::SHA256, &mut out).unwrap();
+        assert_eq!(expected, hex::encode(out));
+    }
+
+    #[test]
+    fn test_empty_password() {
+        let expected = "f135c27993baf98773c5cdb40a5706ce6a345cde61b000a67858650cd6a324d7";
+        let mut out = vec![0u8; 32];
+        let password = b"";
+        let salt = b"salt";
+        derive(password, salt, 1, HashAlgorithm::SHA256, &mut out).unwrap();
+        assert_eq!(expected, hex::encode(out));
+    }
+
+    #[test]
+    fn test_empty_salt() {
+        let expected = "c1232f10f62715fda06ae7c0a2037ca19b33cf103b727ba56d870c11f290a2ab";
+        let mut out = vec![0u8; 32];
+        let password = b"password";
+        let salt = b"";
+        derive(password, salt, 1, HashAlgorithm::SHA256, &mut out).unwrap();
+        assert_eq!(expected, hex::encode(out));
+    }
+
+    #[test]
+    fn test_tiny_out() {
+        let expected = "12";
+        let mut out = vec![0u8; 1];
+        let password = b"password";
+        let salt = b"salt";
+        derive(password, salt, 1, HashAlgorithm::SHA256, &mut out).unwrap();
+        assert_eq!(expected, hex::encode(out));
+    }
+
+    #[test]
+    fn test_rejects_zero_iterations() {
+        let mut out = vec![0u8; 32];
+        let password = b"password";
+        let salt = b"salt";
+        assert!(derive(password, salt, 0, HashAlgorithm::SHA256, &mut out).is_err());
+    }
+
+    #[test]
+    fn test_rejects_empty_out() {
+        let mut out = vec![0u8; 0];
+        let password = b"password";
+        let salt = b"salt";
+        assert!(derive(password, salt, 1, HashAlgorithm::SHA256, &mut out).is_err());
+    }
+
+    #[test]
+    fn test_rejects_gaigantic_salt() {
+        if (std::u32::MAX as usize) < std::usize::MAX {
+            let salt = vec![0; (std::u32::MAX as usize) + 1];
+            let mut out = vec![0u8; 1];
+            let password = b"password";
+            assert!(derive(password, &salt, 1, HashAlgorithm::SHA256, &mut out).is_err());
+        }
+    }
+    #[test]
+    fn test_rejects_gaigantic_password() {
+        if (std::u32::MAX as usize) < std::usize::MAX {
+            let password = vec![0; (std::u32::MAX as usize) + 1];
+            let mut out = vec![0u8; 1];
+            let salt = b"salt";
+            assert!(derive(&password, salt, 1, HashAlgorithm::SHA256, &mut out).is_err());
+        }
+    }
+
+    #[test]
+    fn test_rejects_gaigantic_out() {
+        if (std::u32::MAX as usize) < std::usize::MAX {
+            let password = b"password";
+            let mut out = vec![0; (std::u32::MAX as usize) + 1];
+            let salt = b"salt";
+            assert!(derive(password, salt, 1, HashAlgorithm::SHA256, &mut out).is_err());
+        }
+    }
+
+    #[test]
+    fn test_rejects_gaigantic_iterations() {
+        let password = b"password";
+        let mut out = vec![0; 32];
+        let salt = b"salt";
+        assert!(derive(
+            password,
+            salt,
+            std::u32::MAX,
+            HashAlgorithm::SHA256,
+            &mut out
+        )
+        .is_err());
+    }
+}


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

fixes #3190 
Adds [pbkdf2](https://www.ietf.org/rfc/rfc2898.txt) to rc_crypto. To be used by #3187 and any future uses for extending passwords.
