### PR TITLE
Optimize frecency, and make similar things easier.

### DIFF
--- a/components/places/benches/search.rs
+++ b/components/places/benches/search.rs
@@ -34,6 +34,8 @@ fn init_db(db: &mut PlacesDb) -> places::Result<()> {
             places::storage::history::apply_observation_direct(&db, obs)?;
         }
     }
+    places::storage::delete_pending_temp_tables(&db)?;
+    places::storage::run_maintenance(&db)?;
     tx.commit()?;
     Ok(())
 }

--- a/components/places/sql/create_shared_schema.sql
+++ b/components/places/sql/create_shared_schema.sql
@@ -77,6 +77,8 @@ CREATE INDEX IF NOT EXISTS fromindex ON moz_historyvisits(from_visit);
 CREATE INDEX IF NOT EXISTS dateindex ON moz_historyvisits(visit_date);
 CREATE INDEX IF NOT EXISTS islocalindex ON moz_historyvisits(is_local);
 
+-- Greatly helps the multi-join query in frecency.
+CREATE INDEX IF NOT EXISTS visits_from_type_idx ON moz_historyvisits(from_visit, visit_type);
 
 CREATE TABLE IF NOT EXISTS moz_historyvisit_tombstones (
     place_id INTEGER NOT NULL,

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -36,6 +36,7 @@ static DELETION_HIGH_WATER_MARK_META_KEY: &str = "history_deleted_hwm";
 pub fn apply_observation(db: &PlacesDb, visit_ob: VisitObservation) -> Result<Option<RowId>> {
     let tx = db.begin_transaction()?;
     let result = apply_observation_direct(db, visit_ob)?;
+    delete_pending_temp_tables(db)?;
     tx.commit()?;
     Ok(result)
 }
@@ -122,7 +123,6 @@ pub fn apply_observation_direct(
             Some(visit_ob.get_redirect_frecency_boost()),
         )?;
     }
-    delete_pending_temp_tables(db)?;
     Ok(visit_row_id)
 }
 

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -233,7 +233,7 @@ pub(crate) fn delete_meta(db: &PlacesDb, key: &str) -> Result<()> {
 }
 
 /// Delete all items in the temp tables we use for staging changes.
-pub(crate) fn delete_pending_temp_tables(conn: &PlacesDb) -> Result<()> {
+pub fn delete_pending_temp_tables(conn: &PlacesDb) -> Result<()> {
     conn.execute_batch(
         "DELETE FROM moz_updateoriginsupdate_temp;
          DELETE FROM moz_updateoriginsdelete_temp;

--- a/components/support/sql/src/query_plan.rs
+++ b/components/support/sql/src/query_plan.rs
@@ -168,6 +168,10 @@ mod plan_log {
         if sql.starts_with("EXPLAIN") {
             return;
         }
+        let _ = conn.set_db_config(
+            rusqlite::config::DbConfig::SQLITE_DBCONFIG_TRIGGER_EQP,
+            true,
+        );
         let plan = match QueryPlan::new(conn, sql, params) {
             Ok(plan) => plan,
             Err(e) => {


### PR DESCRIPTION
- Add an magic index which frecency queries literally 1000x faster (... in my demo earlier).

- Cache sql statements in frecency (and clean them up so they're slightly easier to copy/paste into the CLI -- e.g. move `now()` into the caller)

- Additionally make it so that running the bulk history import can be completed within human lifetimes by deferring expensive operations, and periodically reanalyzing the DB.

    Note: This changes no semantics of code other than `examples/autocomplete` and `benches/search`. It does make a couple functions public, but the functions it's calling were already internals which were exposed... because it was more efficient to do things in bulk.

- Finally, ensure SQL triggers are included in the query plan when dumping query plans (only certain builds during testing).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
