### PR TITLE
adds cargo aliasing to use asdev

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,6 @@
 [alias]
 regen-protobufs = ["run", "--bin", "protobuf-gen", "tools/protobuf_files.toml"]
+dev-install = ["install", "asdev"]
+all_tests = ["asdev", "test"]
+rust_tests = ["asdev", "test_rust"]
+verify_env = ["asdev", "verify_env"]

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,8 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.5...master)
+
+
+## General
+
+- Adds cargo aliases to download and use `asdev` ([#3218](https://github.com/mozilla/application-services/pull/3218))

--- a/docs/building.md
+++ b/docs/building.md
@@ -49,3 +49,17 @@ The following command will ensure your environment is ready to build the project
 ````
 
 The Xcode project is located at `megazords/ios/MozillaAppServices.xcodeproj`.
+
+## (Optional) Dev tool
+You can also install and use `asdev` to help you run the above commands, you can do that by running the following:
+
+```
+cargo dev-install
+```
+
+This will allow your to run all the above commands without having to remember where the scripts are. You will be able to do 
+
+```
+cargo verify_env
+``` 
+Which would run all three verification scrips. To check what other commands the dev tool supports, run `cargo asdev -h` or open the dialog using `cargo asdev`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -6,6 +6,28 @@ Anyone is welcome to help with the Application Services project. Feel free to ge
 - Mailing list: <https://mail.mozilla.org/listinfo/sync-dev>
 - and of course, [the issues list](https://github.com/mozilla/application-services/issues)
 
+We recommend installing the `asdev` tool, it will help you navigate a variety of tasks in this repository. You can do that by running the following:
+```
+$ cargo dev-install
+```
+
+You can then view the possible commands using the dialog by running
+```
+$ cargo asdev
+```
+If you would like to run commands directly without the dialog, you can run commands using
+```
+$ cargo [SUBCOMMAND]
+```
+or
+```
+$ cargo asdev [SUBCOMMAND]
+```
+To view possible subcommands, you can check the aliases in `.cargo/config`, or run
+```
+$ cargo asdev -h
+```
+
 
 Participation in this project is governed by the
 [Mozilla Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/).
@@ -37,7 +59,7 @@ Before submitting a PR:
 - Run `cargo fmt` to ensure your Rust code is correctly formatted.
   - If you have modified any Swift code, also run `swiftformat --swiftversion 4` on the modified code.
 - Your code must run and pass all the automated tests before you submit your PR for review.
-  - The simplest way to confirm this is to use the `./automation/all_tests.sh` script, which runs all test suites
+  - The simplest way to confirm this is to run `cargo all_tests` which uses the `./automation/all_tests.sh` script, that runs all test suites
     and linters for Rust, Kotlin and Swift code.
   - "Work in progress" pull requests are welcome, but should be clearly labeled as such and should not be merged until all tests pass and the code has been reviewed.
 - Your patch should include new tests that cover your changes, or be accompanied by explanation for why it doesn't need any. It is your


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

The aliases as shown in the demo. Still need to add documentation, and would love to get any ideas on why you would or wouldn't use this. On that note, **any ideas where is the best place to document this?**

An alternative would be **not** to add this, and just document that users can use the asdev tool using `cargo asdev [subcommand]` 
