### PR TITLE
sync15: Don't use our memory-cached state if there's no persisted state

### DIFF
--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -459,16 +459,17 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
     }
 
     fn prepare_persisted_state(&mut self) -> PersistedGlobalState {
+        // Note that any failure to use a persisted state means we also decline
+        // to use our memory cached state, so that we fully rebuild that
+        // persisted state for next time.
         match self.persisted_global_state {
-            Some(persisted_string) => {
+            Some(persisted_string) if !persisted_string.is_empty() => {
                 match serde_json::from_str::<PersistedGlobalState>(&persisted_string) {
                     Ok(state) => {
                         log::trace!("Read persisted state: {:?}", state);
-                        // TODO: we might want to consider setting `result.declined`
-                        // to what `state` has in it's declined list. I've opted not
-                        // to do that so that `result.declined == null` can be used
-                        // to determine whether or not we managed to update the
-                        // remote declined list.
+                        // Note that we don't set `result.declined` from the
+                        // data in state - it remains None, which explicitly
+                        // indicates "we don't have updated info".
                         state
                     }
                     _ => {
@@ -477,15 +478,17 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
                         log::error!(
                             "Failed to parse PersistedGlobalState from JSON! Falling back to default"
                         );
+                        *self.mem_cached_state = MemoryCachedState::default();
                         PersistedGlobalState::default()
                     }
                 }
             }
-            None => {
+            _ => {
                 log::info!(
                     "The application didn't give us persisted state - \
                      this is only expected on the very first run for a given user."
                 );
+                *self.mem_cached_state = MemoryCachedState::default();
                 PersistedGlobalState::default()
             }
         }


### PR DESCRIPTION
Otherwise we tend to assume the lack of persisted state is the
canonical state rather than simply missing - eg, we thing there are
no declined engines rather than asking the server what the declined
engines are.

This fixes the worst symptoms of #3205
