### PR TITLE
Use Android SDK's side-by-side NDK [ci full]

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -10,5 +10,11 @@
 - Adds jwe encryption in scoped_keys. ([#3195](https://github.com/mozilla/application-services/pull/3195))
 - Adds an implementation for [pbkdf2](https://www.ietf.org/rfc/rfc2898.txt). ([#3193](https://github.com/mozilla/application-services/pull/3193))
 
+## Android
+
+- From now on the project uses the Android SDK manager side-by-side NDK. ([#3222](https://github.com/mozilla/application-services/pull/3222))
+  - Download the new NDK by running `./verify-android-environment.sh` in the `libs` directory.
+    - Alternatively, you can download the NDK in Android Studio by going in Tools > SDK Manager > SDK Tools > NDK (check Show Package Details) and check `21.3.6528147`.
+  - The `ANDROID_NDK_ROOT`, `ANDROID_NDK_HOME` environment variables (and the directory they point to) can be removed.
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v60.0.0...master)

--- a/automation/taskcluster/docker/build.dockerfile
+++ b/automation/taskcluster/docker/build.dockerfile
@@ -101,21 +101,8 @@ RUN curl -sfSL --retry 5 --retry-delay 10 https://dl.google.com/android/reposito
         "platforms;android-${ANDROID_PLATFORM_VERSION}" \
         "build-tools;${ANDROID_BUILD_TOOLS}" \
         "extras;android;m2repository" \
-        "extras;google;m2repository"
-
-# Android NDK
-
-ENV ANDROID_NDK_VERSION "r21"
-
-# $ANDROID_NDK_ROOT is the preferred name, but the android gradle plugin uses $ANDROID_NDK_HOME.
-ENV ANDROID_NDK_ROOT /build/android-ndk
-ENV ANDROID_NDK_HOME /build/android-ndk
-ENV ANDROID_NDK_API_VERSION 21
-
-RUN curl -sfSL --retry 5 --retry-delay 10 https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip > ndk.zip \
-    && unzip -q ndk.zip -d /build \
-    && rm ndk.zip \
-    && mv /build/android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_ROOT}
+        "extras;google;m2repository" \
+        "ndk;21.3.6528147"
 
 # Rust
 RUN set -eux; \

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
     ext.glean_version = '21.3.0'
 
     ext.build = [
+        ndkVersion: "21.3.6528147", // Keep it in sync in TC Dockerfile.
         compileSdkVersion: 29,
         targetSdkVersion: 28,
         minSdkVersion: 21, // So that we can publish for aarch64.
@@ -292,4 +293,10 @@ task ktlintFormat(type: JavaExec, group: "formatting") {
 // interface  for consumers.
 task autoPublishForLocalDevelopment(type: Exec) {
   commandLine "./automation/publish_to_maven_local_if_modified.py"
+}
+
+task printNdkVersion {
+    doLast {
+        println project.ext.build.ndkVersion
+    }
 }

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.protobuf'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -8,6 +8,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.protobuf'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.protobuf'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.protobuf'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/components/rc_log/android/build.gradle
+++ b/components/rc_log/android/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/components/support/android/build.gradle
+++ b/components/support/android/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/components/sync15/android/build.gradle
+++ b/components/sync15/android/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.protobuf'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/components/tabs/android/build.gradle
+++ b/components/tabs/android/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.protobuf'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.protobuf'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/docs/building.md
+++ b/docs/building.md
@@ -23,7 +23,7 @@ cargo test
 
 ## Android development
 
-Roughly you need Java 8, the Android SDK, the NDK R20 and a bunch of environment variables.  
+Roughly you need Java 8, the Android SDK and a bunch of environment variables.  
 Your best friend is the following command:
 
 ```

--- a/libs/android_defaults.sh
+++ b/libs/android_defaults.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+# Find the NDK.
+pushd ..
+NDK_VERSION=$(./gradlew -q printNdkVersion | tail -1)
+export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$NDK_VERSION"
+export ANDROID_NDK_ROOT="$ANDROID_NDK_HOME"
+popd || exit
+
 if [[ -z "${ANDROID_NDK_API_VERSION:-}" ]]; then
     export ANDROID_NDK_API_VERSION=21
     echo "The ANDROID_NDK_API_VERSION environment variable is not set. Defaulting to ${ANDROID_NDK_API_VERSION}"

--- a/libs/verify-android-environment.sh
+++ b/libs/verify-android-environment.sh
@@ -7,7 +7,6 @@
 
 set -e
 
-NDK_VERSION=21
 RUST_TARGETS=("aarch64-linux-android" "armv7-linux-androideabi" "i686-linux-android" "x86_64-linux-android")
 
 if [[ ! -f "$(pwd)/libs/build-all.sh" ]]; then
@@ -25,28 +24,8 @@ if [[ -z "${ANDROID_HOME}" ]]; then
   exit 1
 fi
 
-if [[ -z "${ANDROID_NDK_ROOT}" ]]; then
-  echo "Could not find Android NDK:"
-  echo 'Please install Android NDK r21 and then set ANDROID_NDK_ROOT.'
-  exit 1
-fi
-
-if [[ -z "${ANDROID_NDK_HOME}" ]]; then
-  echo "Environment variable \$ANDROID_NDK_HOME is not set:"
-  echo "Please export ANDROID_NDK_HOME=\$ANDROID_NDK_ROOT for compatibility with the android gradle plugin."
-  exit 1
-elif [[ "${ANDROID_NDK_HOME}" != "${ANDROID_NDK_ROOT}" ]]; then
-  echo "Environment variable \$ANDROID_NDK_HOME is different from \$ANDROID_NDK_ROOT."
-  echo "Please adjust your environment variables to ensure they are the same."
-  exit 1
-fi
-
-INSTALLED_NDK_VERSION=$(sed -En -e 's/^Pkg.Revision[ \t]*=[ \t]*([0-9a-f]+).*/\1/p' "${ANDROID_NDK_ROOT}/source.properties")
-if [[ "${INSTALLED_NDK_VERSION}" != "${NDK_VERSION}" ]]; then
-  echo "Wrong Android NDK version:"
-  echo "Expected version ${NDK_VERSION}, got ${INSTALLED_NDK_VERSION}"
-  exit 1
-fi
+# NDK ez-install.
+"$ANDROID_HOME/tools/bin/sdkmanager" "ndk;$(./gradlew -q printNdkVersion | tail -1)"
 
 rustup target add "${RUST_TARGETS[@]}"
 

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/megazords/lockbox/android/build.gradle
+++ b/megazords/lockbox/android/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
+    ndkVersion rootProject.ext.build.ndkVersion
     compileSdkVersion rootProject.ext.build.compileSdkVersion
 
     defaultConfig {

--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -113,23 +113,10 @@ RUN curl -sfSL --retry 5 --retry-delay 10 https://dl.google.com/android/reposito
         "platforms;android-${ANDROID_PLATFORM_VERSION}" \
         "build-tools;${ANDROID_BUILD_TOOLS}" \
         "extras;android;m2repository" \
-        "extras;google;m2repository"
+        "extras;google;m2repository" \
+        "ndk;21.3.6528147"
 
 RUN chown -R worker:worker /builds/worker/android-sdk
-
-# Android NDK
-
-ENV ANDROID_NDK_VERSION "r21"
-
-# $ANDROID_NDK_ROOT is the preferred name, but the android gradle plugin uses $ANDROID_NDK_HOME.
-ENV ANDROID_NDK_ROOT /builds/worker/android-ndk
-ENV ANDROID_NDK_HOME /builds/worker/android-ndk
-ENV ANDROID_NDK_API_VERSION 21
-
-RUN curl -sfSL --retry 5 --retry-delay 10 https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip > ndk.zip \
-    && unzip -q ndk.zip -d /builds/worker \
-    && rm ndk.zip \
-    && mv /builds/worker/android-ndk-${ANDROID_NDK_VERSION} ${ANDROID_NDK_ROOT}
 
 # sccache
 RUN \


### PR DESCRIPTION
This makes it easier for contributors to install the Android NDK as it now comes bundled with the Android SDK. This PR also removes the `ANDROID_NDK_HOME` `ANDROID_NDK_ROOT` env variables requirement which only leaves `ANDROID_HOME`, just like a pretty classic Android build environment.

EDIT:
Also takes cares of the following warning we've been seeing for a while:
```
WARNING: Support for ANDROID_NDK_HOME is deprecated and will be removed in the future. Use android.ndkVersion in build.gradle instead.
Support for ANDROID_NDK_HOME is deprecated and will be removed in the future. Use android.ndkVersion in build.gradle instead.
```