### PR TITLE
Verify NSS dir presence

### DIFF
--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -51,6 +51,9 @@ pub fn link_nss() -> Result<(), NoNssDir> {
 fn get_nss() -> Result<(PathBuf, PathBuf), NoNssDir> {
     let nss_dir = env("NSS_DIR").ok_or(NoNssDir)?;
     let nss_dir = Path::new(&nss_dir);
+    if !nss_dir.exists() {
+        panic!("It looks like NSS is not built. Please run `libs/verify-[platform]-environment.sh` first!");
+    }
     let lib_dir = nss_dir.join("lib");
     let include_dir = nss_dir.join("include");
     Ok((lib_dir, include_dir))


### PR DESCRIPTION
This should give the user better directions than `could not find native static library `certdb`, perhaps an -L flag is missing?` if they haven't built `libs/` yet.

cc @mhammond 