### PR TITLE
Use defaults from storageArea.get() despite an empty store

### DIFF
--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -728,7 +728,7 @@ mod tests {
 
         // Check that a second call to get_devices doesn't hit the server
         assert!(fxa.get_devices(false).is_ok());
-        assert!(fxa.devices_cache.clone().is_some());
+        assert!(fxa.devices_cache.is_some());
 
         let cache2 = fxa.devices_cache.unwrap();
         let cached_devices2 = cache2.response;

--- a/components/places/src/bookmark_sync/incoming.rs
+++ b/components/places/src/bookmark_sync/incoming.rs
@@ -298,7 +298,7 @@ impl<'a> IncomingApplicator<'a> {
                         // need to add excludeItems, and I guess we should do
                         // it properly without resorting to string manipulation...
                         let tail = url::form_urlencoded::Serializer::new(String::new())
-                            .extend_pairs(parse.clone())
+                            .extend_pairs(parse)
                             .append_pair("excludeItems", "1")
                             .finish();
                         set_reupload(validity);

--- a/components/support/cli/src/fxa_creds.rs
+++ b/components/support/cli/src/fxa_creds.rs
@@ -108,7 +108,7 @@ pub fn get_cli_fxa(config: Config, cred_file: &str) -> Result<CliFxa> {
 
     let client_init = Sync15StorageClientInit {
         key_id: key.kid.clone(),
-        access_token: token_info.token.clone(),
+        access_token: token_info.token,
         tokenserver_url: tokenserver_url.clone(),
     };
     let root_sync_key = KeyBundle::from_ksync_bytes(&key.key_bytes()?)?;


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1645598, by fixing the issue, adding a few clarifying comments and a few unit tests.

I didn't add a changelog because this patch should be merged with m-c, so I kept the changes at a minimum. I will send a separate PR for merging with the master branch.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
