### PR TITLE
Resetting a store should reset its last sync time

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,8 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.3...master)
+
+* Fix an issue where a node reassignment or signing out and signing back in
+  wouldn't clear the locally stored last sync time for engines
+  ([#3150](https://github.com/mozilla/application-services/issues/3150),
+  PR [#3241](https://github.com/mozilla/application-services/pull/3241)).

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -420,11 +420,8 @@ impl PlacesApi {
         // simpler if we can just reuse the existing path.
         HistoryStore::migrate_v1_global_state(&conn)?;
 
-        // We'd rather you didn't interrupt this, but it's a required arg for
-        // HistoryStore
-        let scope = conn.begin_interrupt_scope();
-        let store = HistoryStore::new(&conn, &scope);
-        store.do_reset(&sync15::StoreSyncAssociation::Disconnected)
+        history_sync::reset(&conn, &sync15::StoreSyncAssociation::Disconnected)?;
+        Ok(())
     }
 
     /// Get a new interrupt handle for the sync connection.

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -6,7 +6,9 @@ use crate::bookmark_sync::store::BookmarksStore;
 use crate::db::db::PlacesDb;
 use crate::error::*;
 use crate::history_sync::store::HistoryStore;
-use crate::storage::{self, delete_meta, get_meta, put_meta};
+use crate::storage::{
+    self, bookmarks::bookmark_sync, delete_meta, get_meta, history::history_sync, put_meta,
+};
 use crate::util::normalize_path;
 use lazy_static::lazy_static;
 use rusqlite::OpenFlags;
@@ -390,12 +392,7 @@ impl PlacesApi {
         // simpler if we can just reuse the existing path.
         HistoryStore::migrate_v1_global_state(&conn)?;
 
-        // We'd rather you didn't interrupt this, but it's a required arg for
-        // BookmarksStore.
-        let scope = conn.begin_interrupt_scope();
-        let store = BookmarksStore::new(&conn, &scope);
-        store.reset(&sync15::StoreSyncAssociation::Disconnected)?;
-
+        bookmark_sync::reset(&conn, &sync15::StoreSyncAssociation::Disconnected)?;
         Ok(())
     }
 

--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -976,7 +976,7 @@ impl<'a> Store for BookmarksStore<'a> {
 
     /// Erases all local items. Unlike `reset`, this keeps all synced items
     /// until the next sync, when they will be replaced with tombstones. This
-    /// also preserves the last sync time.
+    /// also preserves the sync ID and last sync time.
     ///
     /// Conceptually, the next sync will merge an empty local tree, and a full
     /// remote tree.

--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -14,7 +14,7 @@ use crate::error::*;
 use crate::frecency::{calculate_frecency, DEFAULT_FRECENCY_SETTINGS};
 use crate::storage::{
     bookmarks::{
-        bookmark_sync::{create_synced_bookmark_roots, reset, reset_meta},
+        bookmark_sync::{create_synced_bookmark_roots, reset},
         BookmarkRootGuid,
     },
     delete_pending_temp_tables, get_meta, put_meta,
@@ -899,26 +899,6 @@ impl<'a> BookmarksStore<'a> {
 
         Ok(())
     }
-
-    /// Removes all sync metadata, such that the next sync is treated as a
-    /// first sync. Unlike `wipe`, this keeps all local items, but clears
-    /// all synced items and pending tombstones. This also forgets the last
-    /// sync time, and either updates or removes the sync ID.
-    pub(crate) fn reset(&self, assoc: &StoreSyncAssociation) -> Result<()> {
-        match assoc {
-            StoreSyncAssociation::Disconnected => {
-                reset(self.db)?;
-            }
-            StoreSyncAssociation::Connected(ids) => {
-                let tx = self.db.begin_transaction()?;
-                reset_meta(self.db)?;
-                put_meta(self.db, GLOBAL_SYNCID_META_KEY, &ids.global)?;
-                put_meta(self.db, COLLECTION_SYNCID_META_KEY, &ids.coll)?;
-                tx.commit()?;
-            }
-        }
-        Ok(())
-    }
 }
 
 impl<'a> Store for BookmarksStore<'a> {
@@ -990,7 +970,7 @@ impl<'a> Store for BookmarksStore<'a> {
     }
 
     fn reset(&self, assoc: &StoreSyncAssociation) -> anyhow::Result<()> {
-        BookmarksStore::reset(self, assoc)?;
+        reset(&self.db, assoc)?;
         Ok(())
     }
 
@@ -3553,12 +3533,22 @@ mod tests {
             let synced_ids: Vec<Guid> = outgoing.changes.iter().map(|c| c.id.clone()).collect();
             assert_eq!(synced_ids.len(), 5, "should be 4 roots + 1 outgoing item");
             store.sync_finished(ServerTimestamp(2_000), synced_ids)?;
+            assert_eq!(get_meta::<i64>(&syncer, LAST_SYNC_META_KEY)?, Some(2_000));
 
-            // now reset
-            store.reset(&StoreSyncAssociation::Connected(CollSyncIds {
+            let sync_ids = CollSyncIds {
                 global: Guid::random(),
                 coll: Guid::random(),
-            }))?;
+            };
+            store.reset(&StoreSyncAssociation::Connected(sync_ids.clone()))?;
+            assert_eq!(
+                get_meta::<Guid>(&syncer, GLOBAL_SYNCID_META_KEY)?,
+                Some(sync_ids.global)
+            );
+            assert_eq!(
+                get_meta::<Guid>(&syncer, COLLECTION_SYNCID_META_KEY)?,
+                Some(sync_ids.coll)
+            );
+            assert_eq!(get_meta::<i64>(&syncer, LAST_SYNC_META_KEY)?, Some(0));
         }
         // do it all again - after the reset we should get the same results.
         {
@@ -3572,6 +3562,18 @@ mod tests {
             let synced_ids: Vec<Guid> = outgoing.changes.iter().map(|c| c.id.clone()).collect();
             assert_eq!(synced_ids.len(), 5, "should be 4 roots + 1 outgoing item");
             store.sync_finished(ServerTimestamp(2_000), synced_ids)?;
+            assert_eq!(get_meta::<i64>(&syncer, LAST_SYNC_META_KEY)?, Some(2_000));
+
+            store.reset(&StoreSyncAssociation::Disconnected)?;
+            assert_eq!(
+                get_meta::<Option<String>>(&syncer, GLOBAL_SYNCID_META_KEY)?,
+                None
+            );
+            assert_eq!(
+                get_meta::<Option<String>>(&syncer, COLLECTION_SYNCID_META_KEY)?,
+                None
+            );
+            assert_eq!(get_meta::<i64>(&syncer, LAST_SYNC_META_KEY)?, Some(0));
         }
 
         Ok(())

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -21,6 +21,7 @@ use rusqlite::types::ToSql;
 use rusqlite::Result as RusqliteResult;
 use rusqlite::{Row, NO_PARAMS};
 use sql_support::{self, ConnExt};
+use sync15::StoreSyncAssociation;
 use sync_guid::Guid as SyncGuid;
 use url::Url;
 
@@ -427,9 +428,7 @@ pub fn delete_everything(db: &PlacesDb) -> Result<()> {
     wipe_local_in_tx(db)?;
 
     // Remove Sync metadata, too.
-    put_meta(db, LAST_SYNC_META_KEY, &0)?;
-    delete_meta(db, GLOBAL_SYNCID_META_KEY)?;
-    delete_meta(db, COLLECTION_SYNCID_META_KEY)?;
+    reset_in_tx(&db, &StoreSyncAssociation::Disconnected)?;
 
     tx.commit()?;
 
@@ -641,6 +640,39 @@ fn cleanup_pages(db: &PlacesDb, pages: &[PageToClean]) -> Result<()> {
         )?;
         Ok(())
     })?;
+
+    Ok(())
+}
+
+fn reset_in_tx(db: &PlacesDb, assoc: &StoreSyncAssociation) -> Result<()> {
+    // Reset change counters and sync statuses for all URLs.
+    db.execute_cached(
+        &format!(
+            "
+            UPDATE moz_places
+                SET sync_change_counter = 0,
+                sync_status = {}",
+            (SyncStatus::New as u8)
+        ),
+        NO_PARAMS,
+    )?;
+
+    // Reset the last sync time, so that the next sync fetches fresh records
+    // from the server.
+    put_meta(db, LAST_SYNC_META_KEY, &0)?;
+
+    // Clear the sync ID if we're signing out, or set it to whatever the
+    // server gave us if we're signing in.
+    match assoc {
+        StoreSyncAssociation::Disconnected => {
+            delete_meta(db, GLOBAL_SYNCID_META_KEY)?;
+            delete_meta(db, COLLECTION_SYNCID_META_KEY)?;
+        }
+        StoreSyncAssociation::Connected(ids) => {
+            put_meta(db, GLOBAL_SYNCID_META_KEY, &ids.global)?;
+            put_meta(db, COLLECTION_SYNCID_META_KEY, &ids.coll)?;
+        }
+    }
 
     Ok(())
 }
@@ -1072,28 +1104,10 @@ pub mod history_sync {
     /// Resets all sync metadata, including change counters, sync statuses,
     /// the last sync time, and sync ID. This should be called when the user
     /// signs out of Sync.
-    pub(crate) fn reset(db: &PlacesDb) -> Result<()> {
+    pub(crate) fn reset(db: &PlacesDb, assoc: &StoreSyncAssociation) -> Result<()> {
         let tx = db.begin_transaction()?;
-        reset_meta(db)?;
-        put_meta(db, LAST_SYNC_META_KEY, &0)?;
-        delete_meta(db, GLOBAL_SYNCID_META_KEY)?;
-        delete_meta(db, COLLECTION_SYNCID_META_KEY)?;
+        reset_in_tx(db, assoc)?;
         tx.commit()?;
-        Ok(())
-    }
-
-    pub(crate) fn reset_meta(db: &PlacesDb) -> Result<()> {
-        db.conn().execute_cached(
-            &format!(
-                "
-                UPDATE moz_places
-                    SET sync_change_counter = 0,
-                    sync_status = {}",
-                (SyncStatus::New as u8)
-            ),
-            NO_PARAMS,
-        )?;
-        put_meta(db, LAST_SYNC_META_KEY, &0)?;
         Ok(())
     }
 } // end of sync module.
@@ -1338,6 +1352,7 @@ mod tests {
     use crate::types::{Timestamp, VisitTransitionSet};
     use pretty_assertions::assert_eq;
     use std::time::{Duration, SystemTime};
+    use sync15::CollSyncIds;
 
     #[test]
     fn test_get_visited_urls() {
@@ -2093,7 +2108,18 @@ mod tests {
     }
 
     #[test]
-    fn test_sync_reset() -> Result<()> {
+    fn test_reset() -> Result<()> {
+        fn mark_all_as_synced(db: &PlacesDb) -> Result<()> {
+            db.execute_cached(
+                &format!(
+                    "UPDATE moz_places set sync_status = {}",
+                    (SyncStatus::Normal as u8)
+                ),
+                NO_PARAMS,
+            )?;
+            Ok(())
+        }
+
         let _ = env_logger::try_init();
         let mut conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite)?;
         let _ = env_logger::try_init();
@@ -2108,19 +2134,30 @@ mod tests {
         delete_everything(&conn)?;
 
         let mut pi = get_observed_page(&mut conn, "http://example.com")?;
-        conn.execute_cached(
-            &format!(
-                "UPDATE moz_places set sync_status = {}",
-                (SyncStatus::Normal as u8)
-            ),
-            NO_PARAMS,
-        )?;
+        mark_all_as_synced(&conn)?;
         pi = fetch_page_info(&conn, &pi.url)?
             .expect("page should exist")
             .page;
         assert_eq!(pi.sync_change_counter, 1);
         assert_eq!(pi.sync_status, SyncStatus::Normal);
-        history_sync::reset(&conn)?;
+
+        let sync_ids = CollSyncIds {
+            global: SyncGuid::random(),
+            coll: SyncGuid::random(),
+        };
+        history_sync::reset(&conn, &StoreSyncAssociation::Connected(sync_ids.clone()))?;
+
+        assert_eq!(
+            get_meta::<SyncGuid>(&conn, GLOBAL_SYNCID_META_KEY)?,
+            Some(sync_ids.global)
+        );
+        assert_eq!(
+            get_meta::<SyncGuid>(&conn, COLLECTION_SYNCID_META_KEY)?,
+            Some(sync_ids.coll)
+        );
+        assert_eq!(get_meta::<i64>(&conn, LAST_SYNC_META_KEY)?, Some(0));
+        assert!(get_meta::<Timestamp>(&conn, DELETION_HIGH_WATER_MARK_META_KEY)?.is_some());
+
         pi = fetch_page_info(&conn, &pi.url)?
             .expect("page should exist")
             .page;
@@ -2130,15 +2167,21 @@ mod tests {
         let outgoing = fetch_outgoing(&conn, 100, 100)?;
         assert_eq!(outgoing.len(), 1);
 
-        // Ensure we reset Sync metadata, too.
-        let global = get_meta::<SyncGuid>(&conn, GLOBAL_SYNCID_META_KEY)?;
-        assert!(global.is_none());
-        let coll = get_meta::<SyncGuid>(&conn, COLLECTION_SYNCID_META_KEY)?;
-        assert!(coll.is_none());
-        let since = get_meta::<i64>(&conn, LAST_SYNC_META_KEY)?;
-        assert_eq!(since, Some(0));
-        let mark = get_meta::<Timestamp>(&conn, DELETION_HIGH_WATER_MARK_META_KEY)?;
-        assert!(mark.is_some());
+        mark_all_as_synced(&conn)?;
+        assert!(fetch_outgoing(&conn, 100, 100)?.is_empty());
+        // ...
+
+        // Now simulate a reset on disconnect, and verify we've removed all Sync
+        // metadata again.
+        history_sync::reset(&conn, &StoreSyncAssociation::Disconnected)?;
+
+        assert_eq!(get_meta::<SyncGuid>(&conn, GLOBAL_SYNCID_META_KEY)?, None);
+        assert_eq!(
+            get_meta::<SyncGuid>(&conn, COLLECTION_SYNCID_META_KEY)?,
+            None
+        );
+        assert_eq!(get_meta::<i64>(&conn, LAST_SYNC_META_KEY)?, Some(0));
+        assert!(get_meta::<Timestamp>(&conn, DELETION_HIGH_WATER_MARK_META_KEY)?.is_some());
 
         Ok(())
     }

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -86,11 +86,12 @@ impl TabsStorage {
         remote_tabs.replace(new_remote_tabs);
     }
 
-    pub fn wipe(&self, delete_local_tabs: bool) {
+    pub fn wipe_remote_tabs(&self) {
         self.remote_tabs.replace(None);
-        if delete_local_tabs {
-            self.local_tabs.replace(None);
-        }
+    }
+
+    pub fn wipe_local_tabs(&self) {
+        self.local_tabs.replace(None);
     }
 }
 


### PR DESCRIPTION
(And also some light refactoring to merge `Store::reset` and `storage::sync::reset`, which was super confusing before).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
