### PR TITLE
Correctly source `android_defaults.sh` when uploading android symbols.

### DIFF
--- a/automation/upload_android_symbols.sh
+++ b/automation/upload_android_symbols.sh
@@ -17,8 +17,10 @@ fi
 
 PROJECT_PATH=${1}
 
+pushd libs
 # shellcheck disable=SC1091
-source "libs/android_defaults.sh"
+source "android_defaults.sh"
+popd
 
 OUTPUT_FOLDER="crashreporter-symbols"
 DUMP_SYMS_DIR="automation/symbols-generation/bin"


### PR DESCRIPTION
The `android_defaults.sh` script expects to be run from with the `./libs`
directory, while `upload_android_symbols.sh` expects to be run from the
repository root. Adjust paths to match expectations when trying to source
the former from the latter.

Fixes #3244.