### PR TITLE
Update dependency-checking script for change in license file locations

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -984,7 +984,7 @@ The following text applies to code linked from these dependencies:
 [ws2_32-sys](https://github.com/retep998/winapi-rs)
 
 ```
-Copyright (c) 2015 The winapi-rs Developers
+Copyright (c) 2015-2018 The winapi-rs Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -222,7 +222,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: winapi-x86_64-pc-windows-gnu</name>
-    <url>https://github.com/retep998/winapi-rs/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/retep998/winapi-rs/blob/0.3/LICENSE-APACHE</url>
   </license>
   <license>
     <name>MIT License: aho-corasick</name>

--- a/megazords/lockbox/android/dependency-licenses.xml
+++ b/megazords/lockbox/android/dependency-licenses.xml
@@ -202,7 +202,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: winapi-x86_64-pc-windows-gnu</name>
-    <url>https://github.com/retep998/winapi-rs/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/retep998/winapi-rs/blob/0.3/LICENSE-APACHE</url>
   </license>
   <license>
     <name>MIT License: byteorder</name>

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -300,7 +300,7 @@ PACKAGE_METADATA_FIXUPS = {
         },
         "license_file": {
             "check": None,
-            "fixup": "https://raw.githubusercontent.com/retep998/winapi-rs/master/LICENSE-MIT",
+            "fixup": "https://raw.githubusercontent.com/retep998/winapi-rs/0.3/LICENSE-MIT",
         }
     },
     "libsqlite3-sys": {
@@ -419,7 +419,7 @@ PACKAGE_METADATA_FIXUPS = {
         },
         "license_file": {
             "check": None,
-            "fixup": "https://raw.githubusercontent.com/retep998/winapi-rs/master/LICENSE-MIT",
+            "fixup": "https://raw.githubusercontent.com/retep998/winapi-rs/0.3/LICENSE-MIT",
         },
     },
     "winapi-x86_64-pc-windows-gnu": {
@@ -428,7 +428,7 @@ PACKAGE_METADATA_FIXUPS = {
         },
         "license_file": {
             "check": None,
-            "fixup": "https://raw.githubusercontent.com/retep998/winapi-rs/master/LICENSE-APACHE",
+            "fixup": "https://raw.githubusercontent.com/retep998/winapi-rs/0.3/LICENSE-APACHE",
         },
     },
     "ws2_32-sys": {
@@ -439,7 +439,7 @@ PACKAGE_METADATA_FIXUPS = {
         },
         "license_file": {
             "check": None,
-            "fixup": "https://raw.githubusercontent.com/retep998/winapi-rs/master/LICENSE-MIT",
+            "fixup": "https://raw.githubusercontent.com/retep998/winapi-rs/0.3/LICENSE-MIT",
         },
     },
     # These packages do not make it easy to infer a URL at which their license can be read,


### PR DESCRIPTION
One of our dependencies has changed the name of their mainline branch away from `master`, causing our dependency-checking script to fail. This updates to the new location.

(We might like to consider a similar move! Especially if there's some emerging consensus across Mozilla repos about what the alternative default name should be. But that can be for a separate PR).