### PR TITLE
Don't reset the local ID in `TabsStore::reset()`

### DIFF
--- a/components/tabs/src/sync/store.rs
+++ b/components/tabs/src/sync/store.rs
@@ -202,7 +202,6 @@ impl<'a> Store for TabsStore<'a> {
         self.remote_clients.borrow_mut().clear();
         self.sync_store_assoc.replace(assoc.clone());
         self.last_sync.set(None);
-        self.local_id.borrow_mut().clear();
         self.storage.wipe_remote_tabs();
         Ok(())
     }


### PR DESCRIPTION
If we're syncing with the sync manager, the ID will get reset when it
calls `prepare_for_sync`. If we're syncing without, `TabsEngine::sync`
will set the local ID each time it's called, before calling
`sync_multiple`.

Resetting the local ID inside of `reset` when syncing with
`TabsEngine::sync` will clear the local ID that it set, and won't get
a new ID from `prepare_for_sync` (since that never gets called in a
standalone sync), meaning we'll try to upload a record for our tabs
without an ID. This causes the server to return the 500 that we saw
in integration tests.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
