### PR TITLE
Adds entrypoint support in beginOauthFlow [ci full]

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,9 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...main)
+
+## FxA Client
+
+### ⚠️ Breaking changes ⚠️
+
+- Adds support for `entrypoint` in oauth flow APIs: consumers of `beginOauthFlow` and `beginPairingFlow` (`beginAuthentication` and `beginPairingAuthentication` in ios) are now ***required*** to pass an `entrypoint` argument that would be used for metrics. This puts the `beginOauthFlow` and `beginPairingFlow` APIs inline with other existing APIs, like `getManageAccountUrl`.  ([#3265](https://github.com/mozilla/application-services/pull/3265))

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -99,12 +99,13 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      * This performs network requests, and should not be used on the main thread.
      *
      * @param scopes List of OAuth scopes for which the client wants access
+     * @param entrypoint to be used for metrics
      * @return String that resolves to the flow URL when complete
      */
-    fun beginOAuthFlow(scopes: Array<String>): String {
+    fun beginOAuthFlow(scopes: Array<String>, entrypoint: String): String {
         val scope = scopes.joinToString(" ")
         return rustCallWithLock { e ->
-            LibFxAFFI.INSTANCE.fxa_begin_oauth_flow(this.handle.get(), scope, e)
+            LibFxAFFI.INSTANCE.fxa_begin_oauth_flow(this.handle.get(), scope, entrypoint, e)
         }.getAndConsumeRustString()
     }
 
@@ -112,11 +113,16 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      * Begins the pairing flow.
      *
      * This performs network requests, and should not be used on the main thread.
+     *
+     * @param pairingUrl the url to initilaize the paring flow with
+     * @param scopes List of OAuth scopes for which the client wants access
+     * @param entrypoint to be used for data collection
+     * @return String that resoles to the flow URL when complete
      */
-    fun beginPairingFlow(pairingUrl: String, scopes: Array<String>): String {
+    fun beginPairingFlow(pairingUrl: String, scopes: Array<String>, entrypoint: String): String {
         val scope = scopes.joinToString(" ")
         return rustCallWithLock { e ->
-            LibFxAFFI.INSTANCE.fxa_begin_pairing_flow(this.handle.get(), pairingUrl, scope, e)
+            LibFxAFFI.INSTANCE.fxa_begin_pairing_flow(this.handle.get(), pairingUrl, scope, entrypoint, e)
         }.getAndConsumeRustString()
     }
 

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -32,6 +32,7 @@ internal interface LibFxAFFI : Library {
     fun fxa_begin_oauth_flow(
         fxa: FxaHandle,
         scopes: String,
+        entrypoint: String,
         e: RustError.ByReference
     ): Pointer?
 
@@ -39,6 +40,7 @@ internal interface LibFxAFFI : Library {
         fxa: FxaHandle,
         pairingUrl: String,
         scopes: String,
+        entrypoint: String,
         e: RustError.ByReference
     ): Pointer?
 

--- a/components/fxa-client/examples/devices_api.rs
+++ b/components/fxa-client/examples/devices_api.rs
@@ -51,7 +51,7 @@ fn persist_fxa_state(acct: &FirefoxAccount) {
 
 fn create_fxa_creds(cfg: Config) -> Result<FirefoxAccount> {
     let mut acct = FirefoxAccount::with_config(cfg);
-    let oauth_uri = acct.begin_oauth_flow(&SCOPES)?;
+    let oauth_uri = acct.begin_oauth_flow(&SCOPES, "device_api_example")?;
 
     if webbrowser::open(&oauth_uri.as_ref()).is_err() {
         println!("Please visit this URL, sign in, and then copy-paste the final URL below.");

--- a/components/fxa-client/examples/oauth_flow.rs
+++ b/components/fxa-client/examples/oauth_flow.rs
@@ -12,7 +12,7 @@ fn main() {
     viaduct_reqwest::use_reqwest_backend();
     let config = Config::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
     let mut fxa = FirefoxAccount::with_config(config);
-    let url = fxa.begin_oauth_flow(&SCOPES).unwrap();
+    let url = fxa.begin_oauth_flow(&SCOPES, "oauth_flow_example").unwrap();
     println!("Open the following URL:");
     println!("{}", url);
     let redirect_uri: String = prompt_string("Obtained redirect URI").unwrap();

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -202,6 +202,7 @@ pub extern "C" fn fxa_begin_pairing_flow(
     handle: u64,
     pairing_url: FfiStr<'_>,
     scope: FfiStr<'_>,
+    entrypoint: FfiStr<'_>,
     error: &mut ExternError,
 ) -> *mut c_char {
     log::debug!("fxa_begin_pairing_flow");
@@ -209,7 +210,7 @@ pub extern "C" fn fxa_begin_pairing_flow(
         let pairing_url = pairing_url.as_str();
         let scope = scope.as_str();
         let scopes: Vec<&str> = scope.split(' ').collect();
-        fxa.begin_pairing_flow(&pairing_url, &scopes)
+        fxa.begin_pairing_flow(&pairing_url, &scopes, entrypoint.as_str())
     })
 }
 
@@ -229,13 +230,14 @@ pub extern "C" fn fxa_begin_pairing_flow(
 pub extern "C" fn fxa_begin_oauth_flow(
     handle: u64,
     scope: FfiStr<'_>,
+    entrypoint: FfiStr<'_>,
     error: &mut ExternError,
 ) -> *mut c_char {
     log::debug!("fxa_begin_oauth_flow");
     ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
         let scope = scope.as_str();
         let scopes: Vec<&str> = scope.split(' ').collect();
-        fxa.begin_oauth_flow(&scopes)
+        fxa.begin_oauth_flow(&scopes, entrypoint.as_str())
     })
 }
 

--- a/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/FirefoxAccount.swift
@@ -30,10 +30,14 @@ open class FirefoxAccount: RustFxAccount {
     /// Once the user has confirmed the authorization grant, they will get redirected to `redirect_url`:
     /// the caller must intercept that redirection, extract the `code` and `state` query parameters and call
     /// `completeOAuthFlow(...)` to complete the flow.
-    open func beginOAuthFlow(scopes: [String], completionHandler: @escaping (URL?, Error?) -> Void) {
+    open func beginOAuthFlow(
+        scopes: [String],
+        entrypoint: String,
+        completionHandler: @escaping (URL?, Error?) -> Void
+    ) {
         DispatchQueue.global().async {
             do {
-                let url = try super.beginOAuthFlow(scopes: scopes)
+                let url = try super.beginOAuthFlow(scopes: scopes, entrypoint: entrypoint)
                 DispatchQueue.main.async { completionHandler(url, nil) }
             } catch {
                 DispatchQueue.main.async { completionHandler(nil, error) }

--- a/components/fxa-client/ios/FxAClient/FxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccount.swift
@@ -29,15 +29,15 @@ class FxAccount: RustFxAccount {
         }
     }
 
-    override func beginOAuthFlow(scopes: [String]) throws -> URL {
+    override func beginOAuthFlow(scopes: [String], entrypoint: String) throws -> URL {
         return try notifyAuthErrors {
-            try super.beginOAuthFlow(scopes: scopes)
+            try super.beginOAuthFlow(scopes: scopes, entrypoint: entrypoint)
         }
     }
 
-    override func beginPairingFlow(pairingUrl: String, scopes: [String]) throws -> URL {
+    override func beginPairingFlow(pairingUrl: String, scopes: [String], entrypoint: String) throws -> URL {
         return try notifyAuthErrors {
-            try super.beginPairingFlow(pairingUrl: pairingUrl, scopes: scopes)
+            try super.beginPairingFlow(pairingUrl: pairingUrl, scopes: scopes, entrypoint: entrypoint)
         }
     }
 

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -93,11 +93,11 @@ open class FxAccountManager {
     /// Once the user has confirmed the authorization grant, they will get redirected to `redirect_url`:
     /// the caller must intercept that redirection, extract the `code` and `state` query parameters and call
     /// `finishAuthentication(...)` to complete the flow.
-    public func beginAuthentication(completionHandler: @escaping (Result<URL, Error>) -> Void) {
+    public func beginAuthentication(entrypoint: String, completionHandler: @escaping (Result<URL, Error>) -> Void) {
         FxALog.info("beginAuthentication")
         DispatchQueue.global().async {
             let result = self.updatingLatestAuthState { account in
-                try account.beginOAuthFlow(scopes: self.applicationScopes)
+                try account.beginOAuthFlow(scopes: self.applicationScopes, entrypoint: entrypoint)
             }
             DispatchQueue.main.async { completionHandler(result) }
         }
@@ -114,11 +114,16 @@ open class FxAccountManager {
     /// `finishAuthentication(...)` to complete the flow.
     public func beginPairingAuthentication(
         pairingUrl: String,
+        entrypoint: String,
         completionHandler: @escaping (Result<URL, Error>) -> Void
     ) {
         DispatchQueue.global().async {
             let result = self.updatingLatestAuthState { account in
-                try account.beginPairingFlow(pairingUrl: pairingUrl, scopes: self.applicationScopes)
+                try account.beginPairingFlow(
+                    pairingUrl: pairingUrl,
+                    scopes: self.applicationScopes,
+                    entrypoint: entrypoint
+                )
             }
             DispatchQueue.main.async { completionHandler(result) }
         }

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -45,11 +45,13 @@ typedef uint64_t FirefoxAccountHandle;
 
 char *_Nullable fxa_begin_oauth_flow(FirefoxAccountHandle handle,
                                      const char *_Nonnull scopes,
+                                     const char *_Nonnull entrypoint,
                                      FxAError *_Nonnull out);
 
 char *_Nullable fxa_begin_pairing_flow(FirefoxAccountHandle handle,
                                        const char *_Nonnull pairing_url,
                                        const char *_Nonnull scopes,
+                                       const char *_Nonnull entrypoint,
                                        FxAError *_Nonnull out);
 
 void fxa_complete_oauth_flow(FirefoxAccountHandle handle,

--- a/components/fxa-client/ios/FxAClient/RustFxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/RustFxAccount.swift
@@ -104,18 +104,18 @@ open class RustFxAccount {
     /// Once the user has confirmed the authorization grant, they will get redirected to `redirect_url`:
     /// the caller must intercept that redirection, extract the `code` and `state` query parameters and call
     /// `completeOAuthFlow(...)` to complete the flow.
-    open func beginOAuthFlow(scopes: [String]) throws -> URL {
+    open func beginOAuthFlow(scopes: [String], entrypoint: String) throws -> URL {
         let scope = scopes.joined(separator: " ")
         let ptr = try rustCall { err in
-            fxa_begin_oauth_flow(self.raw, scope, err)
+            fxa_begin_oauth_flow(self.raw, scope, entrypoint, err)
         }
         return URL(string: String(freeingFxaString: ptr))!
     }
 
-    open func beginPairingFlow(pairingUrl: String, scopes: [String]) throws -> URL {
+    open func beginPairingFlow(pairingUrl: String, scopes: [String], entrypoint: String) throws -> URL {
         let scope = scopes.joined(separator: " ")
         let ptr = try rustCall { err in
-            fxa_begin_pairing_flow(self.raw, pairingUrl, scope, err)
+            fxa_begin_pairing_flow(self.raw, pairingUrl, scope, entrypoint, err)
         }
         return URL(string: String(freeingFxaString: ptr))!
     }

--- a/components/support/cli/src/fxa_creds.rs
+++ b/components/support/cli/src/fxa_creds.rs
@@ -42,7 +42,7 @@ fn load_or_create_fxa_creds(path: &str, cfg: Config) -> Result<FirefoxAccount> {
 
 fn create_fxa_creds(path: &str, cfg: Config) -> Result<FirefoxAccount> {
     let mut acct = FirefoxAccount::with_config(cfg);
-    let oauth_uri = acct.begin_oauth_flow(&[SYNC_SCOPE])?;
+    let oauth_uri = acct.begin_oauth_flow(&[SYNC_SCOPE], "fxa_creds")?;
 
     if webbrowser::open(&oauth_uri.as_ref()).is_err() {
         log::warn!("Failed to open a web browser D:");

--- a/megazords/ios/MozillaAppServicesTests/FxAccountManagerTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountManagerTests.swift
@@ -243,7 +243,7 @@ class FxAccountManagerTests: XCTestCase {
         let beginAuthDone = expectation(description: "beginAuthDone")
         var authURL: String?
         mgr.initialize { _ in
-            mgr.beginAuthentication { url in
+            mgr.beginAuthentication(entrypoint: "test_new_account_log_in") { url in
                 authURL = try! url.get().absoluteString
                 beginAuthDone.fulfill()
             }
@@ -276,7 +276,7 @@ class FxAccountManagerTests: XCTestCase {
         let beginAuthDone = expectation(description: "beginAuthDone")
         var authURL: String?
         mgr.initialize { _ in
-            mgr.beginAuthentication { url in
+            mgr.beginAuthentication(entrypoint: "test_auth_state_verification") { url in
                 authURL = try! url.get().absoluteString
                 beginAuthDone.fulfill()
             }

--- a/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
@@ -70,7 +70,7 @@ class MockFxAccount: FxAccount {
         return Profile(uid: "uid", email: "foo@bar.bobo")
     }
 
-    override func beginOAuthFlow(scopes _: [String]) throws -> URL {
+    override func beginOAuthFlow(scopes _: [String], entrypoint _: String) throws -> URL {
         return URL(string: "https://foo.bar/oauth?state=bobo")!
     }
 }

--- a/testing/sync-test/src/auth.rs
+++ b/testing/sync-test/src/auth.rs
@@ -225,7 +225,7 @@ impl TestClient {
     pub fn new(acct: Arc<TestAccount>) -> Result<Self> {
         log::info!("Doing oauth flow!");
         let mut fxa = FirefoxAccount::with_config(acct.cfg.clone());
-        let oauth_uri = fxa.begin_oauth_flow(&[SYNC_SCOPE])?;
+        let oauth_uri = fxa.begin_oauth_flow(&[SYNC_SCOPE], "integration_test")?;
         let redirected_to = acct.execute_oauth_flow(&oauth_uri)?;
         let final_url = Url::parse(&redirected_to)?;
         let query_params = final_url


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.



**This PR changes public APIs**
- Adds entrypoint to begin_oauth_flow and begin_pairing_flow
- Modifies the ffi and the Kotlin and Swift bindings

Since this has breaking changes to the APIs, I imagine I would need to open an issue/PR in andriod-components. firefox-ios already has an issue opened [mozilla-mobile/firefox-ios#6824](https://github.com/mozilla-mobile/firefox-ios/issues/6824)

But before I do that, I wanted to confirm that I'm on the right track and that in fact, the way to do this is to introduce breaking changes. 

fixes #3263 
