### PR TITLE
[ci skip] Bug 1563169 - get-secret should use python3

### DIFF
--- a/taskcluster/app_services_taskgraph/job.py
+++ b/taskcluster/app_services_taskgraph/job.py
@@ -102,7 +102,10 @@ def _extract_gradlew_command(run):
 
 
 def _generate_secret_command(secret):
+    # TODO: Bug 1563169 - when we update Docker image, we should ensure we run
+    # the up-to-date `taskcluster` python pacakge
     secret_command = [
+        "python3",
         "taskcluster/scripts/get-secret.py",
         "-s", secret["name"],
         "-k", secret["key"],


### PR DESCRIPTION
We're currently hitting importing `taskcluster` errors in [here](https://firefox-ci-tc.services.mozilla.com/tasks/AsIcTV4jR12N8T-sBevteQ/runs/0/logs/https%3A%2F%2Ffirefox-ci-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FAsIcTV4jR12N8T-sBevteQ%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log#L185). That's because in the upstream Docker [image](https://github.com/mozilla/application-services/blob/master/taskcluster/docker/linux/Dockerfile#L91) we install that as python3 dependency. 

Would've liked to get to the lattest `taskcluster` version as well but I want to run additional tests for that so I'll address in a follow-up, I already have that on my list. For now, I want to unblock releases and master pushes.

I ran this change against all types of taskgraph and it adds the `python3` in front of the `get-secret.py` script. 

Importing the image locally, I got the following:
```
> docker run -it 0a3f662d0bb9
root@3b6298d17c4d:~# python --version
Python 2.7.17
root@3b6298d17c4d:~# python
>>> import taskcluster  
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named taskcluster
>>> 
root@3b6298d17c4d:~# python3 --version
Python 3.6.9
root@3b6298d17c4d:~# python3 
>>> import taskcluster

```

CC: @JohanLorenzo @eoger 