### PR TITLE
Downgrade network errors into warnings when passing through rc_log

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -8,3 +8,7 @@
 ## General
 
 - Adds cargo aliases to download and use `asdev` ([#3218](https://github.com/mozilla/application-services/pull/3218))
+
+## RustLog
+
+- Network errors should come through as warnings and not errors. ([#3254](https://github.com/mozilla/application-services/issues/3254)).

--- a/components/rc_log/src/android.rs
+++ b/components/rc_log/src/android.rs
@@ -79,8 +79,9 @@ impl<'a, 'b> From<&'b log::Record<'a>> for LogRecord {
             thread_id
         };
         let message = format!("{} {}", thread_id, r.args());
+        let level = LogLevel::from_level_and_message(r.level(), &message);
         Self {
-            level: r.level().into(),
+            level,
             tag: r
                 .module_path()
                 .and_then(|mp| CString::new(mp.to_owned()).ok()),

--- a/components/rc_log/src/ios.rs
+++ b/components/rc_log/src/ios.rs
@@ -53,15 +53,15 @@ impl log::Log for Logger {
             .and_then(|mp| CString::new(mp.as_bytes()).ok());
 
         // TODO: use SmallVec<[u8; 4096]> or something?
-        let msg_str = crate::string_to_cstring_lossy(format!("{}", record.args()));
+        let msg_string = format!("{}", record.args());
+        let level = LogLevel::from_level_and_message(record.level(), &msg_string);
+        let msg_cstring = crate::string_to_cstring_lossy(msg_string);
 
         let tag_ptr = tag
             .as_ref()
             .map(|s| s.as_ptr())
             .unwrap_or_else(std::ptr::null);
-        let msg_ptr = msg_str.as_ptr() as *const c_char;
-
-        let level: LogLevel = record.level().into();
+        let msg_ptr = msg_cstring.as_ptr() as *const c_char;
 
         unsafe { (self.callback)(level as i32, tag_ptr, msg_ptr) };
     }

--- a/components/support/viaduct-reqwest/src/lib.rs
+++ b/components/support/viaduct-reqwest/src/lib.rs
@@ -65,10 +65,9 @@ impl Backend for ReqwestBackend {
         viaduct::note_backend("reqwest (untrusted)");
         let request_method = request.method;
         let req = into_reqwest(request)?;
-        let mut resp = CLIENT.execute(req).map_err(|e| {
-            log::error!("Reqwest error: {:?}", e);
-            viaduct::Error::NetworkError(e.to_string())
-        })?;
+        let mut resp = CLIENT
+            .execute(req)
+            .map_err(|e| viaduct::Error::NetworkError(e.to_string()))?;
         let status = resp.status().as_u16();
         let url = resp.url().clone();
         let mut body = Vec::with_capacity(resp.content_length().unwrap_or_default() as usize);

--- a/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/HttpConfig.kt
+++ b/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/HttpConfig.kt
@@ -91,8 +91,7 @@ object RustHttpConfig {
                     }
                     rb
                 } catch (e: Throwable) {
-                    LibViaduct.INSTANCE.viaduct_log_error("Network error: ${e.message}")
-                    MsgTypes.Response.newBuilder().setExceptionMessage(e.message)
+                    MsgTypes.Response.newBuilder().setExceptionMessage("fetch error: ${e.message ?: e.javaClass.canonicalName}")
                 }
                 val built = rb.build()
                 val needed = built.serializedSize

--- a/components/viaduct/src/backend/ffi.rs
+++ b/components/viaduct/src/backend/ffi.rs
@@ -64,11 +64,6 @@ impl Backend for FfiBackend {
         };
 
         if let Some(exn) = response.exception_message {
-            log::error!(
-                // Well, we caught *something* java wanted to tell us about, anyway.
-                "Caught network error (presumably). Message: {:?}",
-                exn
-            );
             return Err(Error::NetworkError(format!("Java error: {:?}", exn)));
         }
         let status = response

--- a/components/viaduct/src/error.rs
+++ b/components/viaduct/src/error.rs
@@ -4,13 +4,13 @@
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Illegal characters in request header '{0}'")]
+    #[error("[no-sentry] Illegal characters in request header '{0}'")]
     RequestHeaderError(crate::HeaderName),
 
-    #[error("Backend error: {0}")]
+    #[error("[no-sentry] Backend error: {0}")]
     BackendError(String),
 
-    #[error("Network error: {0}")]
+    #[error("[no-sentry] Network error: {0}")]
     NetworkError(String),
 
     #[error("The rust-components network backend must be initialized before use!")]
@@ -21,10 +21,10 @@ pub enum Error {
 
     /// Note: we return this if the server returns a bad URL with
     /// its response. This *probably* should never happen, but who knows.
-    #[error("URL Parse Error: {0}")]
+    #[error("[no-sentry] URL Parse Error: {0}")]
     UrlError(#[source] url::ParseError),
 
-    #[error("Validation error: URL does not use TLS protocol.")]
+    #[error("[no-sentry] Validation error: URL does not use TLS protocol.")]
     NonTlsUrl,
 }
 


### PR DESCRIPTION
Haven't actually tested this but it's the idea eoger sketched out in https://github.com/mozilla/application-services/issues/3254#issuecomment-648410952.

I felt compelled to do it since I have some opinions on it, and said that it was going to be a problem, which clearly ended up not being the case. Anyway, getting it done now means maybe it can be in time for the fenix release, which it could be problematic for...

The tests are superficial but at least it has some. In principal we could test this on either the iOS or the Android tests by creating a log at error level that contains the string [no-sentry], and ensuring that its actual log level comes through as a warning. This is somewhat tricky, given that both sets of logging test infrastructure aren't set up in a way to allow this sort of testing...

As a result, superficial tests. 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/master/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
