### PR TITLE
Cut release v61.0.7

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 61.0.6
+libraryVersion: 61.0.7
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v61.0.7 (_2020-06-29_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.6...v61.0.7)
+
+## General
+
+- The default branch has been renamed from `master` to `main`
+
 # v61.0.6 (_2020-06-24_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.5...v61.0.6)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,8 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.6...main)
-
-## General
-
-- The default branch has been renamed from `master` to `main`
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...main)


### PR DESCRIPTION
This is both to get the synced-tabs JSON changes done as well as to check that releases from the `main`  branch work okay