### PR TITLE
Fix typo in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,7 +448,7 @@ workflows:
   swiftlint:
     jobs:
       - Check Swift formatting
-  check-formating:
+  check-formatting:
     jobs:
       - Check Rust formatting
   clippy:


### PR DESCRIPTION
It was this or re-add the typo in the mergify config.