### PR TITLE
WIP for collecting send-tab telemetry.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sync-guid",
  "sync15",
  "thiserror",
  "url",

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,6 +24,7 @@ rc_crypto = { path = "../support/rc_crypto", features = ["ece", "hawk"] }
 error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
+sync-guid = { path = "../support/guid", features = ["random"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -591,3 +591,10 @@ pub extern "C" fn fxa_send_tab(
 define_handle_map_deleter!(ACCOUNTS, fxa_free);
 define_string_destructor!(fxa_str_free);
 define_bytebuffer_destructor!(fxa_bytebuffer_free);
+
+/// Gather telemetry collected by FxA.
+#[no_mangle]
+pub extern "C" fn fxa_gather_telemetry(handle: u64, error: &mut ExternError) -> *mut c_char {
+    log::debug!("fxa_gather_telemetry");
+    ACCOUNTS.call_with_result_mut(error, handle, |fxa| fxa.gather_telemetry())
+}

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -18,9 +18,11 @@ pub use crate::{
     oauth::IntrospectInfo,
     oauth::{AccessTokenInfo, RefreshToken},
     profile::Profile,
+    telemetry::FxaTelemetry,
 };
 use serde_derive::*;
 use std::{
+    cell::RefCell,
     collections::{HashMap, HashSet},
     sync::Arc,
 };
@@ -47,6 +49,7 @@ mod scoped_keys;
 pub mod scopes;
 pub mod send_tab;
 mod state_persistence;
+mod telemetry;
 mod util;
 
 type FxAClient = dyn http_client::FxAClient + Sync + Send;
@@ -66,6 +69,9 @@ pub struct FirefoxAccount {
     flow_store: HashMap<String, OAuthFlow>,
     attached_clients_cache: Option<CachedResponse<Vec<http_client::GetAttachedClientResponse>>>,
     devices_cache: Option<CachedResponse<Vec<http_client::GetDeviceResponse>>>,
+    // 'telemetry' is only currently used by `&mut self` functions, but that's
+    // not something we want to insist on going forward, so RefCell<> it.
+    telemetry: RefCell<FxaTelemetry>,
 }
 
 impl FirefoxAccount {
@@ -76,6 +82,7 @@ impl FirefoxAccount {
             flow_store: HashMap::new(),
             attached_clients_cache: None,
             devices_cache: None,
+            telemetry: RefCell::new(FxaTelemetry::new()),
         }
     }
 
@@ -151,6 +158,7 @@ impl FirefoxAccount {
         self.state = self.state.start_over();
         self.flow_store.clear();
         self.clear_devices_and_attached_clients_cache();
+        self.telemetry.replace(FxaTelemetry::new());
     }
 
     /// Get the Sync Token Server endpoint URL.
@@ -259,6 +267,20 @@ impl FirefoxAccount {
             }
         }
         self.start_over();
+    }
+
+    /// Gathers and resets telemetry for this account instance.
+    /// This should be considered a short-term solution to telemetry gathering
+    /// and should called whenever consumers expect there might be telemetry,
+    /// and it should submit the telemetry to whatever telemetry system is in
+    /// use (probably glean).
+    ///
+    /// The data is returned as a JSON string, which consumers should parse
+    /// forgivingly (eg, be tolerant of things not existing) to try and avoid
+    /// too many changes as telemetry comes and goes.
+    pub fn gather_telemetry(&mut self) -> Result<String> {
+        let telem = self.telemetry.replace(FxaTelemetry::new());
+        Ok(serde_json::to_string(&telem)?)
     }
 }
 

--- a/components/fxa-client/src/send_tab.rs
+++ b/components/fxa-client/src/send_tab.rs
@@ -9,7 +9,9 @@ use crate::{
     },
     error::*,
     http_client::GetDeviceResponse,
-    scopes, FirefoxAccount, IncomingDeviceCommand,
+    scopes,
+    telemetry::SentReceivedTab,
+    FirefoxAccount, IncomingDeviceCommand,
 };
 
 impl FirefoxAccount {
@@ -38,16 +40,21 @@ impl FirefoxAccount {
     }
 
     /// Send a single tab to another device designated by its device ID.
+    /// XXX - this should change to taking a Vec of device IDs, because
+    /// collecting telemetry relies on a multi-device send happening in a single
+    /// operation.
     pub fn send_tab(&mut self, target_device_id: &str, title: &str, url: &str) -> Result<()> {
         let devices = self.get_devices(false)?;
         let target = devices
             .iter()
             .find(|d| d.id == target_device_id)
             .ok_or_else(|| ErrorKind::UnknownTargetDevice(target_device_id.to_owned()))?;
-        let payload = SendTabPayload::single_tab(title, url);
+        let (payload, sent_telemetry) = SendTabPayload::single_tab(title, url);
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
         let command_payload = send_tab::build_send_command(&oldsync_key, target, &payload)?;
-        self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)
+        self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)?;
+        self.telemetry.borrow_mut().record_tab_sent(sent_telemetry);
+        Ok(())
     }
 
     pub(crate) fn handle_send_tab_command(
@@ -67,8 +74,23 @@ impl FirefoxAccount {
             };
         let encrypted_payload: EncryptedSendTabPayload = serde_json::from_value(payload)?;
         match encrypted_payload.decrypt(&send_tab_key) {
-            Ok(payload) => Ok(IncomingDeviceCommand::TabReceived { sender, payload }),
+            Ok(payload) => {
+                // It's an incoming tab, which we record telemetry for.
+                let recd_telemetry = SentReceivedTab {
+                    flow_id: payload.flow_id.clone(),
+                    stream_id: payload.stream_id.clone(),
+                };
+                self.telemetry
+                    .borrow_mut()
+                    .record_tab_received(recd_telemetry);
+                // The telemetry IDs escape to the consumer, but that's OK...
+                Ok(IncomingDeviceCommand::TabReceived { sender, payload })
+            }
             Err(e) => {
+                // XXX - this seems ripe for telemetry collection!?
+                // It also seems like it might be possible to recover - ie, one
+                // of the reasons is that there are key mismatches. Doesn't that
+                // mean the "other" key might work?
                 log::error!("Could not decrypt Send Tab payload. Diagnosing then resetting the Send Tab keys.");
                 match self.diagnose_remote_keys(send_tab_key) {
                     Ok(_) => log::error!("Could not find the cause of the Send Tab keys issue."),

--- a/components/fxa-client/src/telemetry.rs
+++ b/components/fxa-client/src/telemetry.rs
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// A somewhat mixed-bag of all telemetry we want to collect. The idea is that
+// the app will "pull" telemetry via a new API whenever it thinks there might
+// be something to record.
+// It's considered a temporary solution until either we can record it directly
+// (eg, via glean) or we come up with something better.
+
+use serde_derive::*;
+
+// First, constituent parts
+#[derive(Debug, Serialize)]
+pub struct SentReceivedTab {
+    pub flow_id: String,
+    pub stream_id: String,
+}
+
+// We have a naive strategy to avoid unbounded memory growth - the intention
+// is that if any platform lets things grow to hit these limits, it's probably
+// never going to consume anything - so it doesn't matter what we discard (ie,
+// there's no good reason to have a smarter circular buffer etc)
+const MAX_TAB_EVENTS: usize = 20;
+
+#[derive(Debug, Serialize)]
+pub struct FxaTelemetry {
+    sent_tabs: Vec<SentReceivedTab>,
+    received_tabs: Vec<SentReceivedTab>,
+}
+
+impl FxaTelemetry {
+    pub fn new() -> Self {
+        FxaTelemetry {
+            sent_tabs: Vec::new(),
+            received_tabs: Vec::new(),
+        }
+    }
+
+    pub fn record_tab_sent(&mut self, sent: SentReceivedTab) {
+        if self.sent_tabs.len() < MAX_TAB_EVENTS {
+            self.sent_tabs.push(sent);
+        }
+    }
+
+    pub fn record_tab_received(&mut self, recd: SentReceivedTab) {
+        if self.received_tabs.len() < MAX_TAB_EVENTS {
+            self.received_tabs.push(recd);
+        }
+    }
+}


### PR DESCRIPTION
This is a WIP just to get feedback on the shape of this.

The main thing I'm trying to avoid here is to have the telemetry "pollute" the
public API - the public API should not be aware where and when we send
telemetry.

In this case, the "public API" in question is send-tab, where we can probably
suck up a public API change, but we shouldn't!

The whole "what telemetry API should we use/when can we use glean everywhere"
question is a good one, but one we aren't going resolve here. An ideal world
probably has our rust components directly using glean - in which case the
telemetry data also doesn't pollute the other public APIs - so let's try and
get a little closer to that world.

So the summary of how this patch hangs together is:

* There's a new `FxaTelemetry` struct which is a grab-bag of all the telemetry
  we collect (which isn't much - even desktop today doesn't gather much). This
  struct is stored in a `RefCell<>` inside `FirefoxAccount`.

* There's a new `fxa_gather_telemetry()` function in the FFI. The idea is that
  android-components *telemetry* code will call this, and translate what it
  gets back into the glean calls it needs to make (ie, android-components will
  also add a couple of new events to `sync-telemetry/metrics.yaml` - note that
  the *send-tab* code doesn't really get involved here.

* Except that the *send-tab* code will need to tell the telemetry code that
  there's probably telemetry to gather. So while it's not magic or fully
  automatic, most of the responsibilities are in the right place and there's
  only a few leaky abstractions.

* There will obviously need to be a corresponding android-components PR

Assuming the "big picture" of this is OK, some "small picture" issues:

* I'm not sure if it's OK that `fxa_gather_telemetry()` returns a JSON string.
  The idea is that it should ideally be dynamic - stuff it doesn't understand
  should be ignored. Eg, you can imagine a world where some things are only
  understood/recorded by, say, iOS. Adding new telemetry shouldn't be a breaking
  change to platforms that don't want to explicitly record it.

* No tests!

* Um - I'm sure I had more than that :) I'm sure you'll find some in the patch.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
