### PR TITLE
Forward Send Tab stream and flow IDs to Swift

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "apple/swift-protobuf" "1.8.0"
+github "apple/swift-protobuf" "1.9.0"
 github "jrendel/SwiftKeychainWrapper" "3.4.0"

--- a/components/fxa-client/ios/FxAClient/FxAccountDevice.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountDevice.swift
@@ -106,7 +106,7 @@ public struct DevicePushSubscription {
 }
 
 public enum IncomingDeviceCommand {
-    case tabReceived(Device?, [TabData])
+    case tabReceived(Device?, [TabData], flowID: String?, streamID: String?)
 
     internal static func fromCollectionMsg(msg: MsgTypes_IncomingDeviceCommands) -> [IncomingDeviceCommand] {
         msg.commands.map { IncomingDeviceCommand.fromMsg(msg: $0) }
@@ -118,7 +118,9 @@ public enum IncomingDeviceCommand {
             let data = msg.tabReceivedData
             let device = data.hasFrom ? Device(msg: data.from) : nil
             let entries = data.entries.map { TabData(title: $0.title, url: $0.url) }
-            return .tabReceived(device, entries)
+            let flowID = data.hasFlowID ? data.flowID : nil
+            let streamID = data.hasStreamID ? data.streamID : nil
+            return .tabReceived(device, entries, flowID: flowID, streamID: streamID)
         }
         }
     }

--- a/components/fxa-client/src/ffi.rs
+++ b/components/fxa-client/src/ffi.rs
@@ -219,6 +219,8 @@ impl From<IncomingDeviceCommand> for msg_types::IncomingDeviceCommand {
                     msg_types::incoming_device_command::SendTabData {
                         from: sender.map(Into::into),
                         entries: payload.entries.into_iter().map(Into::into).collect(),
+                        flow_id: payload.flow_id,
+                        stream_id: payload.stream_id,
                     },
                 )),
             },

--- a/components/fxa-client/src/fxa_msg_types.proto
+++ b/components/fxa-client/src/fxa_msg_types.proto
@@ -83,6 +83,8 @@ message IncomingDeviceCommand {
         }
         optional Device from = 1;
         repeated TabHistoryEntry entries = 2;
+        optional string flow_id = 3;
+        optional string stream_id = 4;
     }
 
     oneof data {

--- a/components/fxa-client/src/mozilla.appservices.fxaclient.protobuf.rs
+++ b/components/fxa-client/src/mozilla.appservices.fxaclient.protobuf.rs
@@ -107,6 +107,10 @@ pub mod incoming_device_command {
         pub from: ::std::option::Option<super::Device>,
         #[prost(message, repeated, tag="2")]
         pub entries: ::std::vec::Vec<send_tab_data::TabHistoryEntry>,
+        #[prost(string, optional, tag="3")]
+        pub flow_id: ::std::option::Option<std::string::String>,
+        #[prost(string, optional, tag="4")]
+        pub stream_id: ::std::option::Option<std::string::String>,
     }
     pub mod send_tab_data {
         #[derive(Clone, PartialEq, ::prost::Message)]

--- a/components/fxa-client/src/send_tab.rs
+++ b/components/fxa-client/src/send_tab.rs
@@ -44,7 +44,7 @@ impl FirefoxAccount {
             .iter()
             .find(|d| d.id == target_device_id)
             .ok_or_else(|| ErrorKind::UnknownTargetDevice(target_device_id.to_owned()))?;
-        let payload = SendTabPayload::single_tab(title, url);
+        let payload = SendTabPayload::single_tab(title, url)?;
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
         let command_payload = send_tab::build_send_command(&oldsync_key, target, &payload)?;
         self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)


### PR DESCRIPTION
Another take on #3302—we'll probably want to merge that one instead, but I wanted to get it up for completeness!