### PR TITLE
WIP for collecting send-tab telemetry.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sync-guid",
  "sync15",
  "thiserror",
  "url",

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -26,6 +26,7 @@ rc_crypto = { path = "../support/rc_crypto", features = ["ece", "hawk"] }
 error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
+sync-guid = { path = "../support/guid", features = ["random"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -632,6 +632,18 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
         }
     }
 
+    /**
+     * Gather any telemetry which has been collected internally and return
+     * the result as a JSON string.
+     *
+     * This does not make network requests, and can be used on the main thread.
+     */
+    fun gatherTelemetry(): String {
+        return rustCallWithLock { e ->
+            LibFxAFFI.INSTANCE.fxa_gather_telemetry(this.handle.get(), e)
+        }.getAndConsumeRustString()
+    }
+
     @Synchronized
     override fun close() {
         val handle = this.handle.getAndSet(0)

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -114,6 +114,8 @@ internal interface LibFxAFFI : Library {
 
     fun fxa_retry_migrate_from_session_token(fxa: FxaHandle, e: RustError.ByReference): Pointer?
 
+    fun fxa_gather_telemetry(fxa: FxaHandle, e: RustError.ByReference): Pointer?
+
     fun fxa_str_free(string: Pointer)
     fun fxa_bytebuffer_free(buffer: RustBuffer.ByValue)
     fun fxa_free(fxa: FxaHandle, err: RustError.ByReference)

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -12,7 +12,7 @@ use ffi_support::{
     ConcurrentHandleMap, ExternError, FfiStr,
 };
 use fxa_client::{
-    device::{Capability as DeviceCapability, PushSubscription},
+    device::{Capability as DeviceCapability, CommandFetchReason, PushSubscription},
     ffi::{from_protobuf_ptr, AuthorizationParameters, MetricsParams},
     migrator::MigrationState,
     msg_types, FirefoxAccount,
@@ -506,10 +506,11 @@ pub extern "C" fn fxa_handle_session_token_change(
 pub extern "C" fn fxa_poll_device_commands(handle: u64, error: &mut ExternError) -> ByteBuffer {
     log::debug!("fxa_poll_device_commands");
     ACCOUNTS.call_with_result_mut(error, handle, |fxa| {
-        fxa.poll_device_commands().map(|cmds| {
-            let commands = cmds.into_iter().map(|e| e.into()).collect();
-            fxa_client::msg_types::IncomingDeviceCommands { commands }
-        })
+        fxa.poll_device_commands(CommandFetchReason::Poll)
+            .map(|cmds| {
+                let commands = cmds.into_iter().map(|e| e.into()).collect();
+                fxa_client::msg_types::IncomingDeviceCommands { commands }
+            })
     })
 }
 
@@ -615,3 +616,10 @@ pub extern "C" fn fxa_get_ecosystem_anon_id(handle: u64, error: &mut ExternError
 define_handle_map_deleter!(ACCOUNTS, fxa_free);
 define_string_destructor!(fxa_str_free);
 define_bytebuffer_destructor!(fxa_bytebuffer_free);
+
+/// Gather telemetry collected by FxA.
+#[no_mangle]
+pub extern "C" fn fxa_gather_telemetry(handle: u64, error: &mut ExternError) -> *mut c_char {
+    log::debug!("fxa_gather_telemetry");
+    ACCOUNTS.call_with_result_mut(error, handle, |fxa| fxa.gather_telemetry())
+}

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -165,6 +165,9 @@ char *_Nullable fxa_get_manage_devices_url(FirefoxAccountHandle handle,
                                            const char *_Nonnull entrypoint,
                                            FxAError *_Nonnull out);
 
+char *fxa_gather_telemetry(FirefoxAccountHandle handle,
+                           FxAError *_Nonnull out);
+
 void fxa_str_free(char *_Nullable ptr);
 void fxa_free(FirefoxAccountHandle h, FxAError *_Nonnull out);
 void fxa_bytebuffer_free(FxARustBuffer buffer);

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -18,9 +18,11 @@ pub use crate::{
     oauth::IntrospectInfo,
     oauth::{AccessTokenInfo, RefreshToken},
     profile::Profile,
+    telemetry::FxaTelemetry,
 };
 use serde_derive::*;
 use std::{
+    cell::RefCell,
     collections::{HashMap, HashSet},
     sync::Arc,
 };
@@ -66,6 +68,9 @@ pub struct FirefoxAccount {
     flow_store: HashMap<String, OAuthFlow>,
     attached_clients_cache: Option<CachedResponse<Vec<http_client::GetAttachedClientResponse>>>,
     devices_cache: Option<CachedResponse<Vec<http_client::GetDeviceResponse>>>,
+    // 'telemetry' is only currently used by `&mut self` functions, but that's
+    // not something we want to insist on going forward, so RefCell<> it.
+    telemetry: RefCell<FxaTelemetry>,
 }
 
 impl FirefoxAccount {
@@ -76,6 +81,7 @@ impl FirefoxAccount {
             flow_store: HashMap::new(),
             attached_clients_cache: None,
             devices_cache: None,
+            telemetry: RefCell::new(FxaTelemetry::new()),
         }
     }
 
@@ -152,6 +158,7 @@ impl FirefoxAccount {
         self.state = self.state.start_over();
         self.flow_store.clear();
         self.clear_devices_and_attached_clients_cache();
+        self.telemetry.replace(FxaTelemetry::new());
     }
 
     /// Get the Sync Token Server endpoint URL.

--- a/components/fxa-client/src/send_tab.rs
+++ b/components/fxa-client/src/send_tab.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     error::*,
     http_client::GetDeviceResponse,
-    scopes, FirefoxAccount, IncomingDeviceCommand,
+    scopes, telemetry, FirefoxAccount, IncomingDeviceCommand,
 };
 
 impl FirefoxAccount {
@@ -38,22 +38,30 @@ impl FirefoxAccount {
     }
 
     /// Send a single tab to another device designated by its device ID.
+    /// XXX - We need a new send_tabs_to_devices() so we can correctly record
+    /// telemetry for these cases.
+    /// This probably requires a new "Tab" struct with the title and url.
+    /// android-components has SendToAllUseCase(), so this isn't just theoretical.
+    /// See https://github.com/mozilla/application-services/issues/3402
     pub fn send_tab(&mut self, target_device_id: &str, title: &str, url: &str) -> Result<()> {
         let devices = self.get_devices(false)?;
         let target = devices
             .iter()
             .find(|d| d.id == target_device_id)
             .ok_or_else(|| ErrorKind::UnknownTargetDevice(target_device_id.to_owned()))?;
-        let payload = SendTabPayload::single_tab(title, url);
+        let (payload, sent_telemetry) = SendTabPayload::single_tab(title, url);
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
         let command_payload = send_tab::build_send_command(&oldsync_key, target, &payload)?;
-        self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)
+        self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)?;
+        self.telemetry.borrow_mut().record_tab_sent(sent_telemetry);
+        Ok(())
     }
 
     pub(crate) fn handle_send_tab_command(
         &mut self,
         sender: Option<GetDeviceResponse>,
         payload: serde_json::Value,
+        reason: telemetry::ReceivedReason,
     ) -> Result<IncomingDeviceCommand> {
         let send_tab_key: PrivateSendTabKeys =
             match self.state.commands_data.get(send_tab::COMMAND_NAME) {
@@ -67,8 +75,24 @@ impl FirefoxAccount {
             };
         let encrypted_payload: EncryptedSendTabPayload = serde_json::from_value(payload)?;
         match encrypted_payload.decrypt(&send_tab_key) {
-            Ok(payload) => Ok(IncomingDeviceCommand::TabReceived { sender, payload }),
+            Ok(payload) => {
+                // It's an incoming tab, which we record telemetry for.
+                let recd_telemetry = telemetry::ReceivedCommand {
+                    flow_id: payload.flow_id.clone(),
+                    stream_id: payload.stream_id.clone(),
+                    reason,
+                };
+                self.telemetry
+                    .borrow_mut()
+                    .record_tab_received(recd_telemetry);
+                // The telemetry IDs escape to the consumer, but that's OK...
+                Ok(IncomingDeviceCommand::TabReceived { sender, payload })
+            }
             Err(e) => {
+                // XXX - this seems ripe for telemetry collection!?
+                // It also seems like it might be possible to recover - ie, one
+                // of the reasons is that there are key mismatches. Doesn't that
+                // mean the "other" key might work?
                 log::error!("Could not decrypt Send Tab payload. Diagnosing then resetting the Send Tab keys.");
                 match self.diagnose_remote_keys(send_tab_key) {
                     Ok(_) => log::error!("Could not find the cause of the Send Tab keys issue."),

--- a/components/fxa-client/src/telemetry.rs
+++ b/components/fxa-client/src/telemetry.rs
@@ -6,6 +6,8 @@ use crate::{error::*, scopes, FirefoxAccount};
 use jwcrypto::{EncryptionAlgorithm, EncryptionParameters, Jwk};
 use rand_rccrypto::rand::seq::SliceRandom;
 use rc_crypto::rand;
+use serde_derive::*;
+use sync_guid::Guid;
 
 impl FirefoxAccount {
     /// Get the ecosystem anon id, generating it if necessary.
@@ -66,6 +68,20 @@ impl FirefoxAccount {
             .choose(&mut rng)
             .ok_or_else(|| ErrorKind::NoAnonIdKey)?
             .clone())
+    }
+
+    /// Gathers and resets telemetry for this account instance.
+    /// This should be considered a short-term solution to telemetry gathering
+    /// and should called whenever consumers expect there might be telemetry,
+    /// and it should submit the telemetry to whatever telemetry system is in
+    /// use (probably glean).
+    ///
+    /// The data is returned as a JSON string, which consumers should parse
+    /// forgivingly (eg, be tolerant of things not existing) to try and avoid
+    /// too many changes as telemetry comes and goes.
+    pub fn gather_telemetry(&mut self) -> Result<String> {
+        let telem = self.telemetry.replace(FxaTelemetry::new());
+        Ok(serde_json::to_string(&telem)?)
     }
 }
 
@@ -265,5 +281,80 @@ mod tests {
 
         assert_eq!(fxa.get_ecosystem_anon_id().unwrap(), ecosystem_anon_id);
         assert!(fxa.state.ecosystem_user_id.is_none());
+    }
+}
+
+// A somewhat mixed-bag of all telemetry we want to collect. The idea is that
+// the app will "pull" telemetry via a new API whenever it thinks there might
+// be something to record.
+// It's considered a temporary solution until either we can record it directly
+// (eg, via glean) or we come up with something better.
+// Note that this means we'll lose telemetry if we crash between gathering it
+// here and the app submitting it, but that should be rare (in practice,
+// apps will submit it directly after an operation that generated telememtry)
+
+/// The reason a tab/command was received.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReceivedReason {
+    /// A push notification for the command was received.
+    Push,
+    /// Discovered while handling a push notification for a later message.
+    PushMissed,
+    /// Explicit polling for missed commands.
+    Poll,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SentCommand {
+    pub flow_id: String,
+    pub stream_id: String,
+}
+
+impl Default for SentCommand {
+    fn default() -> Self {
+        Self {
+            flow_id: Guid::random().to_string(),
+            stream_id: Guid::random().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReceivedCommand {
+    pub flow_id: String,
+    pub stream_id: String,
+    pub reason: ReceivedReason,
+}
+
+// We have a naive strategy to avoid unbounded memory growth - the intention
+// is that if any platform lets things grow to hit these limits, it's probably
+// never going to consume anything - so it doesn't matter what we discard (ie,
+// there's no good reason to have a smarter circular buffer etc)
+const MAX_TAB_EVENTS: usize = 200;
+
+#[derive(Debug, Default, Serialize)]
+pub struct FxaTelemetry {
+    commands_sent: Vec<SentCommand>,
+    commands_received: Vec<ReceivedCommand>,
+}
+
+impl FxaTelemetry {
+    pub fn new() -> Self {
+        FxaTelemetry {
+            ..Default::default()
+        }
+    }
+
+    pub fn record_tab_sent(&mut self, sent: SentCommand) {
+        if self.commands_sent.len() < MAX_TAB_EVENTS {
+            self.commands_sent.push(sent);
+        }
+    }
+
+    pub fn record_tab_received(&mut self, recd: ReceivedCommand) {
+        if self.commands_received.len() < MAX_TAB_EVENTS {
+            self.commands_received.push(recd);
+        }
     }
 }

--- a/examples/fxa-client/src/devices-api.rs
+++ b/examples/fxa-client/src/devices-api.rs
@@ -92,7 +92,7 @@ fn main() -> Result<()> {
                 let evts = acct
                     .lock()
                     .unwrap()
-                    .poll_device_commands()
+                    .poll_device_commands(device::CommandFetchReason::Poll)
                     .unwrap_or_else(|_| vec![]); // Ignore 404 errors for now.
                 persist_fxa_state(&acct.lock().unwrap());
                 for e in evts {


### PR DESCRIPTION
[Lina and I chatted about this and decided to collaborate - I can't work out how to change the branch in the other PR, so here we are...]

This is a WIP just to get feedback on the shape of this.

The main thing I'm trying to avoid here is to have the telemetry "pollute" the
public API - the public API should not be aware where and when we send
telemetry.

In this case, the "public API" in question is send-tab, where we can probably
suck up a public API change, but we shouldn't!

The whole "what telemetry API should we use/when can we use glean everywhere"
question is a good one, but one we aren't going resolve here. An ideal world
probably has our rust components directly using glean - in which case the
telemetry data also doesn't pollute the other public APIs - so let's try and
get a little closer to that world.

So the summuary of how this patch hangs together is:

* There's a new `FxaTelemetry` struct which is a grab-bag of all the telemetry
  we collect (which isn't much - even desktop today doesn't gather much). This
  struct is stored in a `RefCell<>` inside `FirefoxAccount`.

* There's a new `fxa_gather_telemetry()` function in the FFI. The idea is that
  android-components *telemetry* code will call this, and translate what it
  gets back into the glean calls it needs to make (ie, android-components will
  also add a couple of new events to `sync-telemetry/metrics.yaml` - note that
  the *send-tab* code doesn't really get involved here.

* Except that the *send-tab* code will need to tell the telemetry code that
  there's probably telemetry to gather. So while it's not magic or fully
  automatic, most of the responsibilities are in the right place and there's
  only a few leaky abstractions.

Assuming the "big picture" of this is OK, some "small picture" issues:

* I'm not sure if it's OK that `fxa_gather_telemetry()` returns a JSON string.
  The idea is that it should ideally be dynamic - stuff it doesn't understand
  should be ignored. Eg, you can imagine a world where some things are only
  understood/recorded by, say, iOS. Adding new telemetry shouldn't be a breaking
  change to platforms that don't want to explicitly record it.

* No tests!

* Um - I'm sure I had more than that :) I'm sure you'll find some in the patch.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
