### PR TITLE
Bug 1657393 - add resource-monitoring toolchain

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -10,7 +10,7 @@ tasks:
     - $let:
           taskgraph:
               branch: taskgraph
-              revision: cab4565345d0d0effa66f18fe91335dd6d744031
+              revision: 0c74426138739b1cad3bb4ff169af67eef6003fc
           trustDomain: app-services
       in:
           $let:
@@ -220,7 +220,7 @@ tasks:
                                         REPOSITORIES: {$json: {appservices: "Application Services", taskgraph: "Taskgraph"}}
                                         HG_STORE_PATH: /builds/worker/checkouts/hg-store
                                         ANDROID_SDK_ROOT: /builds/worker/android-sdk
-                                        MOZ_FETCHES_DIR: /builds/worker/checkouts/src
+                                        MOZ_FETCHES_DIR: /builds/worker/fetches
                                       - $if: 'tasks_for in ["github-pull-request"]'
                                         then:
                                             APPSERVICES_PULL_REQUEST_TITLE: '${event.pull_request.title}'
@@ -266,6 +266,14 @@ tasks:
                                       type: 'directory'
                                       path: '/builds/worker/artifacts'
                                       expires: {$fromNow: '1 year'}
+                                  'public/docker-contexts':
+                                      type: 'directory'
+                                      path: '/builds/worker/checkouts/src/docker-contexts'
+                                      # This needs to be at least the deadline of the
+                                      # decision task + the docker-image task deadlines.
+                                      # It is set to a week to allow for some time for
+                                      # debugging, but they are not useful long-term.
+                                      expires: {$fromNow: '7 day'}
                           extra:
                             $merge:
                                 - treeherder:

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -17,6 +17,7 @@ jobs:
   pr:
     attributes:
       run-on-pr-type: normal-ci
+      resource-monitor: true
     needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
     run-on-tasks-for: [github-pull-request]
     description: Build and test (Android - linux-x86-64)

--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.fetch:transforms
+    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.task:transforms
+
+job-defaults:
+    docker-image: {in-tree: linux}
+
+jobs:
+    go-1.14.4:
+        description: Golang 1.14.4 build tools
+        fetch:
+            type: static-url
+            url: https://dl.google.com/go/go1.14.4.linux-amd64.tar.gz
+            sha256: aed845e4185a0b2a3c3d5e1d0a35491702c55889192bb9c30e67a3de6849c067
+            size: 123711003
+    resource-monitor:
+        description: Resource monitoring tools
+        fetch:
+            type: git
+            repo: https://github.com/mozilla-releng/resource-monitor
+            revision: 17371502a3b04579375d707844e6bf08dee95d22

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -18,6 +18,7 @@ kind-dependencies:
 job-defaults:
   attributes:
     run-on-pr-type: full-ci
+    resource-monitor: true
   run-on-tasks-for: [github-pull-request, github-push]
   description: "{module_name} - Build and test"
   scopes:
@@ -27,6 +28,7 @@ job-defaults:
     chain-of-trust: true
     docker-image: { in-tree: linux }
     max-run-time: 1800
+    env: {}
   run:
     pre-gradlew:
       # XXX: scripts subshell at runtime so we need to source this here

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -4,6 +4,9 @@
 ---
 loader: taskgraph.loader.transform:loader
 
+kind-dependencies:
+  - fetch
+
 transforms:
   - app_services_taskgraph.transforms.toolchain:transforms
   - taskgraph.transforms.job:transforms
@@ -27,3 +30,4 @@ job-defaults:
 jobs-from:
     - android.yml
     - desktop.yml
+    - resourcemonitor.yml

--- a/taskcluster/ci/toolchain/resourcemonitor.yml
+++ b/taskcluster/ci/toolchain/resourcemonitor.yml
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+job-defaults:
+    fetches:
+        fetch:
+            - go-1.14.4
+            - resource-monitor
+    run:
+        script: build-resourcemonitor.sh
+        sparse-profile: null
+        toolchain-artifact: public/build/resource-monitor.tar.xz
+
+linux64-resource-monitor:
+    description: "linux64 resourcemonitor toolchain build"
+    run:
+        arguments: ['linux64']

--- a/taskcluster/scripts/toolchain/build-resourcemonitor.sh
+++ b/taskcluster/scripts/toolchain/build-resourcemonitor.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -x -e -v
+
+COMPRESS_EXT=xz
+EXE_SUFFIX=""
+
+PATH="$MOZ_FETCHES_DIR/go/bin:$PATH"
+export PATH
+
+# Bug 1425787: in the Github world we're only building Linux toolchain for now,
+# but for consistency we're backporting all platforms
+case "$1" in
+    linux64)   GOOS=linux; GOARCH=amd64 ;;
+    macos64)   GOOS=darwin; GOARCH=amd64 ;;
+    windows64) GOOS=windows; GOARCH=amd64; EXE_SUFFIX=".exe" ;;
+    windows32) GOOS=windows; GOARCH=386;   EXE_SUFFIX=".exe" ;;
+    *)
+        echo "Unknown architecture $1 not recognized in build-resourcemonitor.sh" >&2
+        exit 1
+    ;;
+esac
+
+export GOOS
+export GOARCH
+export EXE_SUFFIX
+
+echo "GOOS=$GOOS"
+echo "GOARCH=$GOARCH"
+
+# XXX: make sure we're in the right repo to be able to build
+cd "$MOZ_FETCHES_DIR"/resource-monitor || exit 1
+go build .
+
+STAGING_DIR="resource-monitor"
+mv "resource-monitor${EXE_SUFFIX}" resource-monitor.tmp
+mkdir "${STAGING_DIR}"
+
+cp resource-monitor.tmp "${STAGING_DIR}/resource-monitor${EXE_SUFFIX}"
+
+tar -acf "resource-monitor.tar.$COMPRESS_EXT" "${STAGING_DIR}"/
+mkdir -p "$UPLOAD_DIR"
+cp "resource-monitor.tar.$COMPRESS_EXT" "$UPLOAD_DIR"


### PR DESCRIPTION
RelEng has developed a tool to collect CPU/memory/DiskIO/Network usage for any tasks running `runtask`. It's now live and we're turning it on in this repo. This means that from now on, in Github-pull requests, master pushes and releases, the jobs are creating a `resource-monitor.json` at the end. This is collected automatically in BigQuery for us to analyze in order to infer better-fitted (price, powerload, etC) instance types for our workers. 

Once this lands on master pushes and the level-3 toolchains are generated, we'll no longer schedule the individual fetch/toolchain tasks but cache instead.

This has been previously tested in staging releases: 
* pushed this https://treeherder.mozilla.org/#/jobs?repo=taskgraph-try&revision=8d9597fbd50c1d62a6682e61acaa98c2d170679b 
* tested in app-services via https://firefox-ci-tc.services.mozilla.com/tasks/groups/dBwQFm4pSwy2lZC3KsuDRg staging release.
* worked like a charm producing the following artifacts: https://firefoxci.taskcluster-artifacts.net/CIMEsTtIRq-VXQslIvCnbg/0/public/monitoring/resource-monitor.json