### PR TITLE
Kotlin temporary account API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "prost",
  "prost-derive",
  "rc_crypto",
+ "restmail-client",
  "serde",
  "serde_derive",
  "serde_json",

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -20,6 +20,7 @@ sync15 = { path = "../sync15" }
 url = "2.1"
 ffi-support = "0.4"
 viaduct = { path = "../viaduct" }
+restmail-client = { path = "../support/restmail-client" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece", "hawk"] }
 error-support = { path = "../support/error" }
 thiserror = "1.0"
@@ -36,4 +37,3 @@ mockito = "0.26"
 [features]
 default = []
 gecko = [ "rc_crypto/gecko" ]
-integration_test = []

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -631,7 +631,7 @@ private inline fun <U> nullableRustCall(callback: (RustError.ByReference) -> U?)
     }
 }
 
-private inline fun <U> rustCall(callback: (RustError.ByReference) -> U?): U {
+internal inline fun <U> rustCall(callback: (RustError.ByReference) -> U?): U {
     return nullableRustCall(callback)!!
 }
 

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -105,6 +105,24 @@ internal interface LibFxAFFI : Library {
 
     fun fxa_retry_migrate_from_session_token(fxa: FxaHandle, e: RustError.ByReference): Pointer?
 
+    fun fxa_testing_create_temp_account(
+        contentUrl: String,
+        clientId: String,
+        redirectUri: String,
+        tokenServerUrlOverride: String?,
+        e: RustError.ByReference
+    ): RustBuffer.ByValue
+
+    fun fxa_testing_destroy_temp_account(
+        contentUrl: String,
+        clientId: String,
+        redirectUri: String,
+        tokenServerUrlOverride: String?,
+        email: String,
+        password: String,
+        e: RustError.ByReference
+    )
+
     fun fxa_str_free(string: Pointer)
     fun fxa_bytebuffer_free(buffer: RustBuffer.ByValue)
     fun fxa_free(fxa: FxaHandle, err: RustError.ByReference)

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/testing/TempTestAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/testing/TempTestAccount.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.fxaclient.testing
+
+import mozilla.appservices.fxaclient.Config
+import mozilla.appservices.fxaclient.MsgTypes
+import mozilla.appservices.fxaclient.rust.LibFxAFFI
+import mozilla.appservices.fxaclient.rustCall
+
+/**
+ * A test helper for live accounts testing:
+ * - Creating an instance of `TempTestAccount` will create an account.
+ * - When `TempTestAccount` goes out of scope the account will be destroyed.
+ */
+class TempTestAccount(private val config: Config, val email: String, val password: String): AutoCloseable {
+    companion object {
+        fun create(config: Config): TempTestAccount {
+            val buffer = rustCall { e ->
+                LibFxAFFI.INSTANCE.fxa_testing_create_temp_account(
+                    config.contentUrl,
+                    config.clientId,
+                    config.redirectUri,
+                    config.tokenServerUrlOverride,
+                    e
+                )
+            }
+            try {
+                val msg = MsgTypes.TempAccountDetails.parseFrom(buffer.asCodedInputStream()!!)
+                return TempTestAccount(config, msg.email, msg.password)
+            } finally {
+                LibFxAFFI.INSTANCE.fxa_bytebuffer_free(buffer)
+            }
+        }
+    }
+
+    override fun close() {
+        rustCall { e ->
+            LibFxAFFI.INSTANCE.fxa_testing_destroy_temp_account(
+                config.contentUrl,
+                config.clientId,
+                config.redirectUri,
+                config.tokenServerUrlOverride,
+                email,
+                password,
+                e
+            )
+        }
+    }
+}

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -590,6 +590,65 @@ pub extern "C" fn fxa_send_tab(
     ACCOUNTS.call_with_result_mut(error, handle, |fxa| fxa.send_tab(target, title, url))
 }
 
+/// Create a temporary Firefox Account for testing.
+///
+/// # Safety
+///
+/// A destructor [fxa_bytebuffer_free] is provided for releasing the memory for this
+/// pointer type.
+#[no_mangle]
+pub extern "C" fn fxa_testing_create_temp_account(
+    content_url: FfiStr<'_>,
+    client_id: FfiStr<'_>,
+    redirect_uri: FfiStr<'_>,
+    token_server_url_override: FfiStr<'_>,
+    error: &mut ExternError,
+) -> ByteBuffer {
+    log::debug!("fxa_testing_create_temp_account");
+    let content_url = content_url.as_str();
+    let client_id = client_id.as_str();
+    let redirect_uri = redirect_uri.as_str();
+    let token_server_url_override = token_server_url_override.as_opt_str();
+    ffi_support::call_with_result(error, || {
+        fxa_client::testing::create_temp_account(
+            content_url,
+            client_id,
+            redirect_uri,
+            token_server_url_override,
+        )
+    })
+}
+
+/// Destroy a temporary Firefox Account.
+#[no_mangle]
+pub extern "C" fn fxa_testing_destroy_temp_account(
+    content_url: FfiStr<'_>,
+    client_id: FfiStr<'_>,
+    redirect_uri: FfiStr<'_>,
+    token_server_url_override: FfiStr<'_>,
+    email: FfiStr<'_>,
+    password: FfiStr<'_>,
+    error: &mut ExternError,
+) {
+    log::debug!("fxa_testing_destroy_temp_account");
+    let content_url = content_url.as_str();
+    let client_id = client_id.as_str();
+    let redirect_uri = redirect_uri.as_str();
+    let token_server_url_override = token_server_url_override.as_opt_str();
+    let email = email.as_str();
+    let password = password.as_str();
+    ffi_support::call_with_result(error, || {
+        fxa_client::testing::destroy_account(
+            content_url,
+            client_id,
+            redirect_uri,
+            token_server_url_override,
+            email,
+            password,
+        )
+    })
+}
+
 define_handle_map_deleter!(ACCOUNTS, fxa_free);
 define_string_destructor!(fxa_str_free);
 define_bytebuffer_destructor!(fxa_bytebuffer_free);

--- a/components/fxa-client/src/config.rs
+++ b/components/fxa-client/src/config.rs
@@ -79,12 +79,21 @@ impl Config {
     }
 
     pub fn new(content_url: &str, client_id: &str, redirect_uri: &str) -> Self {
+        Self::new_with_token_server_override(content_url, client_id, redirect_uri, None)
+    }
+
+    pub fn new_with_token_server_override(
+        content_url: &str,
+        client_id: &str,
+        redirect_uri: &str,
+        token_server_url_override: Option<&str>,
+    ) -> Self {
         Self {
             content_url: content_url.to_string(),
             client_id: client_id.to_string(),
             redirect_uri: redirect_uri.to_string(),
             remote_config: RefCell::new(None),
-            token_server_url_override: None,
+            token_server_url_override: token_server_url_override.map(|s| s.to_owned()),
         }
     }
 

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -150,6 +150,9 @@ pub enum ErrorKind {
 
     #[error("Protobuf decode error: {0}")]
     ProtobufDecodeError(#[from] prost::DecodeError),
+
+    #[error("Restmail client error: {0}")]
+    RestmailClientError(#[from] restmail_client::RestmailClientError),
 }
 
 error_support::define_error! {
@@ -165,6 +168,7 @@ error_support::define_error! {
         (MalformedUrl, url::ParseError),
         (SyncError, sync15::Error),
         (ProtobufDecodeError, prost::DecodeError),
+        (RestmailClientError, restmail_client::RestmailClientError),
     }
 }
 

--- a/components/fxa-client/src/ffi.rs
+++ b/components/fxa-client/src/ffi.rs
@@ -15,8 +15,10 @@
 use crate::{
     commands,
     device::{Capability as DeviceCapability, Device, PushSubscription, Type as DeviceType},
-    msg_types, send_tab, AccessTokenInfo, AccountEvent, Error, ErrorKind, IncomingDeviceCommand,
-    IntrospectInfo, Profile, ScopedKey,
+    msg_types, send_tab,
+    testing::TempAccountDetails,
+    AccessTokenInfo, AccountEvent, Error, ErrorKind, IncomingDeviceCommand, IntrospectInfo,
+    Profile, ScopedKey,
 };
 use ffi_support::{
     implement_into_ffi_by_delegation, implement_into_ffi_by_protobuf, ErrorCode, ExternError,
@@ -266,6 +268,15 @@ impl msg_types::Capabilities {
     }
 }
 
+impl From<TempAccountDetails> for msg_types::TempAccountDetails {
+    fn from(details: TempAccountDetails) -> Self {
+        Self {
+            email: details.email,
+            password: details.password,
+        }
+    }
+}
+
 unsafe fn get_buffer<'a>(data: *const u8, len: i32) -> &'a [u8] {
     assert!(len >= 0, "Bad buffer len: {}", len);
     if len == 0 {
@@ -291,3 +302,5 @@ implement_into_ffi_by_protobuf!(msg_types::AccountEvents);
 implement_into_ffi_by_delegation!(IncomingDeviceCommand, msg_types::IncomingDeviceCommand);
 implement_into_ffi_by_protobuf!(msg_types::IncomingDeviceCommand);
 implement_into_ffi_by_protobuf!(msg_types::IncomingDeviceCommands);
+implement_into_ffi_by_protobuf!(msg_types::TempAccountDetails);
+implement_into_ffi_by_delegation!(TempAccountDetails, msg_types::TempAccountDetails);

--- a/components/fxa-client/src/fxa_msg_types.proto
+++ b/components/fxa-client/src/fxa_msg_types.proto
@@ -122,3 +122,8 @@ message AccountEvent {
 message AccountEvents {
     repeated AccountEvent events = 1;
 }
+
+message TempAccountDetails {
+    required string email = 1;
+    required string password = 2;
+}

--- a/components/fxa-client/src/http_client.rs
+++ b/components/fxa-client/src/http_client.rs
@@ -492,7 +492,6 @@ pub fn derive_auth_key_from_session_token(session_token: &str) -> Result<Vec<u8>
     Ok(out)
 }
 
-#[cfg(feature = "integration_test")]
 #[derive(Serialize, Deserialize)]
 pub struct AuthorizationParameters {
     access_type: String,
@@ -504,7 +503,6 @@ pub struct AuthorizationParameters {
     state: String,
 }
 
-#[cfg(feature = "integration_test")]
 impl AuthorizationParameters {
     pub fn new(
         client_id: String,
@@ -530,7 +528,6 @@ impl AuthorizationParameters {
 // FxAClient trate with a `test only` feature upsets the mockiato proc macro
 // And it's okay since they are only used in tests. (if they were not test only
 // Mockiato would not complain)
-#[cfg(feature = "integration_test")]
 pub fn send_authorization_request(
     config: &Config,
     auth_params: AuthorizationParameters,
@@ -550,7 +547,6 @@ pub fn send_authorization_request(
         .to_string())
 }
 
-#[cfg(feature = "integration_test")]
 pub fn get_scoped_key_data_response(
     scope: &str,
     client_id: &str,
@@ -570,7 +566,6 @@ pub fn get_scoped_key_data_response(
     Ok(resp)
 }
 
-#[cfg(feature = "integration_test")]
 pub fn get_keys_bundle(config: &Config, hkdf_sha256_key: &[u8]) -> Result<Vec<u8>> {
     let keys_url = config.auth_url_path("v1/account/keys").unwrap();
     let req = HawkRequestBuilder::new(Method::Get, keys_url, hkdf_sha256_key).build()?;
@@ -584,7 +579,6 @@ pub fn get_keys_bundle(config: &Config, hkdf_sha256_key: &[u8]) -> Result<Vec<u8
     Ok(bundle)
 }
 
-#[cfg(feature = "integration_test")]
 pub fn send_verification(config: &Config, body: serde_json::Value) -> Result<Response> {
     let verify_endpoint = config
         .auth_url_path("v1/recovery_email/verify_code")

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -32,8 +32,8 @@ pub mod device;
 pub mod error;
 pub mod ffi;
 pub mod migrator;
+pub mod testing;
 
-#[cfg(feature = "integration_test")]
 pub mod auth;
 // Include the `msg_types` module, which is generated from msg_types.proto.
 pub mod msg_types {
@@ -113,10 +113,12 @@ impl FirefoxAccount {
         redirect_uri: &str,
         token_server_url_override: Option<&str>,
     ) -> Self {
-        let mut config = Config::new(content_url, client_id, redirect_uri);
-        if let Some(token_server_url_override) = token_server_url_override {
-            config.override_token_server_url(token_server_url_override);
-        }
+        let config = Config::new_with_token_server_override(
+            content_url,
+            client_id,
+            redirect_uri,
+            token_server_url_override,
+        );
         Self::with_config(config)
     }
 

--- a/components/fxa-client/src/mozilla.appservices.fxaclient.protobuf.rs
+++ b/components/fxa-client/src/mozilla.appservices.fxaclient.protobuf.rs
@@ -179,3 +179,10 @@ pub struct AccountEvents {
     #[prost(message, repeated, tag="1")]
     pub events: ::std::vec::Vec<AccountEvent>,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TempAccountDetails {
+    #[prost(string, required, tag="1")]
+    pub email: std::string::String,
+    #[prost(string, required, tag="2")]
+    pub password: std::string::String,
+}

--- a/components/fxa-client/src/testing.rs
+++ b/components/fxa-client/src/testing.rs
@@ -1,0 +1,112 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{
+    error::{ErrorKind, Result},
+    Config,
+};
+use rc_crypto::rand;
+use serde_json::json;
+use viaduct::Request;
+
+pub struct TempAccountDetails {
+    pub email: String,
+    pub password: String,
+}
+
+pub fn create_temp_account(
+    content_url: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    token_server_url_override: Option<&str>,
+) -> Result<TempAccountDetails> {
+    let config = Config::new_with_token_server_override(
+        content_url,
+        client_id,
+        redirect_uri,
+        token_server_url_override,
+    );
+
+    let account_details = rand_account_details()?;
+
+    restmail_client::clear_mailbox(&account_details.email)?;
+
+    // XXX: This needs to be consolidated with `auth.rs` in sync-test,
+    // to be done in a follow-up.
+    let create_endpoint = config.auth_url_path("v1/account/create")?;
+    let body = json!({
+        "email": &account_details.email,
+        "authPW": crate::auth::auth_pwd(&account_details.email, &account_details.password)?,
+        "service": &config.client_id,
+    });
+    let req = Request::post(create_endpoint).json(&body).send()?;
+    let resp: serde_json::Value = req.json()?;
+    let uid = resp["uid"]
+        .as_str()
+        .ok_or_else(|| ErrorKind::UnrecoverableServerError("no uid in response"))?;
+
+    verify_account(&account_details.email, &config, &uid)?;
+
+    Ok(account_details)
+}
+
+pub fn destroy_account(
+    content_url: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    token_server_url_override: Option<&str>,
+    email: &str,
+    password: &str,
+) -> Result<()> {
+    let config = Config::new_with_token_server_override(
+        content_url,
+        client_id,
+        redirect_uri,
+        token_server_url_override,
+    );
+
+    let destroy_endpoint = config.auth_url_path("v1/account/destroy").unwrap();
+    let body = json!({
+        "email": email,
+        "authPW": crate::auth::auth_pwd(&email, &password).unwrap()
+    });
+    Request::post(destroy_endpoint)
+        .json(&body)
+        .send()?
+        .require_success()?;
+    Ok(())
+}
+
+// TODO: Copy pasta from auth.rs.
+fn verify_account(email_in: &str, config: &Config, uid: &str) -> Result<()> {
+    let verification_email = restmail_client::find_email(
+        email_in,
+        |email| email["headers"]["x-uid"] == uid && email["headers"]["x-template-name"] == "verify",
+        10,
+    )?;
+    let code = verification_email["headers"]["x-verify-code"]
+        .as_str()
+        .ok_or_else(|| ErrorKind::IllegalState("No verify code in headers"))?;
+    let body = json!({
+        "uid": uid,
+        "code": code,
+    });
+    crate::auth::send_verification(&config, body)?.require_success()?;
+    Ok(())
+}
+
+fn rand_account_details() -> Result<TempAccountDetails> {
+    let username = rand_str()?;
+    let email = format!("{}@restmail.net", username);
+    // Use the same as username so we can inspect the email manually easily.
+    let password = username;
+
+    Ok(TempAccountDetails { email, password })
+}
+
+fn rand_str() -> Result<String> {
+    let mut buf = vec![0; 16];
+    rand::fill(&mut buf)?;
+    Ok(base64::encode_config(buf, base64::URL_SAFE_NO_PAD))
+}

--- a/components/support/restmail-client/src/lib.rs
+++ b/components/support/restmail-client/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use error::RestmailClientError;
+pub use error::RestmailClientError;
 use serde_json::Value as EmailJson;
 use url::Url;
 use viaduct::Request;

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -13,7 +13,7 @@ sync15 = { path = "../../components/sync15" }
 sync15-traits = { path = "../../components/support/sync15-traits" }
 restmail-client = { path = "../../components/support/restmail-client" }
 tabs = { path = "../../components/tabs" }
-fxa-client = { path = "../../components/fxa-client", features = ["integration_test"] }
+fxa-client = { path = "../../components/fxa-client" }
 sync-guid = { path = "../../components/support/guid", features = ["rusqlite_support", "random"]}
 interrupt-support = { path = "../../components/support/interrupt" }
 url = "2.1"


### PR DESCRIPTION
Connects to https://github.com/mozilla/application-services/issues/3306.

This PR tackles the problem of creating test accounts:
In `TempTestAccount.create` the Rust layer creates a temporary email address and does the account verification step without showing UI. When `TempTestAccount` goes out of scope, the account is destroyed.

In a following PR, I intend to create a `TempTestAccount.login` method that returns a `FirefoxAccount`.

f? @rfk @grigoryk 