### PR TITLE
Exclude slow to build crates which are unlikely to break frequently from the workspace default-members

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
       - setup-rust-toolchain
       - run: rustup component add rustfmt
       - run: rustfmt --version
-      - run: cargo fmt -- --check
+      - run: cargo fmt --all -- --check
   Lint Rust with clippy:
     docker:
       - image: circleci/rust:latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+# Note: Any additions here should be repeated in default-members below.
 members = [
     "components/fxa-client",
     "components/fxa-client/ffi",
@@ -35,6 +36,64 @@ members = [
     "megazords/full",
     "megazords/ios/rust",
     "megazords/lockbox",
+    "testing/sync-test",
+    "tools/protobuf-gen",
+]
+
+# The `default-members` are the things that are built/tested when you run `cargo
+# build`, `cargo test` (or most of the cargo commands not provided by a
+# third-party `cargo-foo` binary) from a workspace root *without* doing one of:
+#
+# - Specifying a specific package (e.g. via `-p <package>`, `--manifest-dir
+#   <path>` ...)
+#
+# - Passing `--workspace` or `--all`.
+#
+# - Running the command from within that package (e.g. running `cargo build`
+#   inside `megazords/full` will build the full megazord, default or not).
+#
+# We use this to excludes a couple that have a disproportional compile time
+# impact to how likely they are to get broken by average changes:
+#
+# - `nss_sys`'s companion test crate `systest` adds `syntex_syntax2` which is
+#   (surprisingly) by far the slowest crate to build in our dep graph, and very
+#   very rarely needs changing
+#
+# - The megazords just rexport ffi crates, which we aren't excluding, and get
+#   built freqently enough as part of gradle/xcode's build process.
+#
+# To be clear: passing the `--all` or `--workspace` arg to cargo will make use
+# the full member set.
+default-members = [
+    "components/fxa-client",
+    "components/fxa-client/ffi",
+    "components/logins",
+    "components/logins/ffi",
+    "components/places",
+    "components/places/ffi",
+    "components/push",
+    "components/push/ffi",
+    "components/rc_log",
+    "components/support/cli",
+    "components/support/error",
+    "components/support/ffi",
+    "components/support/guid",
+    "components/support/interrupt",
+    "components/support/restmail-client",
+    "components/support/rc_crypto",
+    "components/support/rc_crypto/nss",
+    "components/support/rc_crypto/nss/nss_build_common",
+    "components/support/rc_crypto/nss/nss_sys",
+    "components/support/sql",
+    "components/support/sync15-traits",
+    "components/support/viaduct-reqwest",
+    "components/sync_manager",
+    "components/sync_manager/ffi",
+    "components/sync15",
+    "components/tabs",
+    "components/tabs/ffi",
+    "components/viaduct",
+    "components/webext-storage",
     "testing/sync-test",
     "tools/protobuf-gen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,18 +52,18 @@ members = [
 # - Running the command from within that package (e.g. running `cargo build`
 #   inside `megazords/full` will build the full megazord, default or not).
 #
-# We use this to excludes a couple that have a disproportional compile time
+# We use this to exclude a couple that have a disproportional compile time
 # impact to how likely they are to get broken by average changes:
 #
 # - `nss_sys`'s companion test crate `systest` adds `syntex_syntax2` which is
 #   (surprisingly) by far the slowest crate to build in our dep graph, and very
 #   very rarely needs changing
 #
-# - The megazords just rexport ffi crates, which we aren't excluding, and get
+# - The megazords just re-export ffi crates, which we aren't excluding, and get
 #   built freqently enough as part of gradle/xcode's build process.
 #
-# To be clear: passing the `--all` or `--workspace` arg to cargo will make use
-# the full member set.
+# To be clear: passing the `--all` or `--workspace` arg to cargo will make it
+# use the full member set.
 default-members = [
     "components/fxa-client",
     "components/fxa-client/ffi",

--- a/automation/all_tests.sh
+++ b/automation/all_tests.sh
@@ -47,11 +47,11 @@ fi
 # Formatters. These should always succeed, but might leave
 # uncomitted changes in your working directory.
 
-cargo fmt
+cargo fmt --all
 
 if [[ "$(uname -s)" == "Darwin" ]]
 then
-    swiftformat megazords components/*/ios --lint --swiftversion 4 
+    swiftformat megazords components/*/ios --lint --swiftversion 4
 else
     echo "WARNING: skipping swiftformat on non-Darwin host"
 fi


### PR DESCRIPTION
That is, if you do a `cargo test` from the root, this makes it so only some crates build. `cargo test --all`, `cargo test -p thing`, and `cargo test` from somewhere other than workspace root all do the same as old behavior.

This is conservative and only changes:

- nss's systest which is very slow to build and low risk to break when you don't know you're messing with it

- the megazords, which are essentially covered by the ffi, since they basically just reexport it.

With this change cargo build is about 2x faster, e.g. 71s instead of 150s, although it fluxuates a lot.

Downside: There's a bunch of duplication. The root cause of it is https://github.com/rust-lang/cargo/issues/8460, or we could do something like:

```toml
[workspace]
members = [
    "components/*",
    "components/*/ffi",
    "components/support/*",
    "components/support/rc_crypto/nss/systest",
    "megazords/full",
    "megazords/ios/rust",
    "megazords/lockbox",
    "testing/sync-test",
    "tools/protobuf-gen",
]
default-members = [
    "components/*",
    "components/*/ffi",
    "components/support/*",
    "megazords/full",
    "megazords/ios/rust",
    "megazords/lockbox",
    "testing/sync-test",
    "tools/protobuf-gen",
]
# The globs above hit a few folders which aren't crates,
# so exclude them directly
exclude = [
    "components/support",
    "components/support/android",
]
```

However, if it looks like that cargo issue will ever get fixed, we move some projects into different folders so that globbing the rust crates would be possible.