### PR TITLE
Protect invocations array

### DIFF
--- a/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
+++ b/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift
@@ -5,6 +5,9 @@
 import Foundation
 @testable import MozillaAppServices
 
+// Arrays are not thread-safe in Swift.
+let queue = DispatchQueue(label: "InvocationsArrayQueue")
+
 class MockFxAccount: FxAccount {
     var invocations: [MethodInvocation] = []
     enum MethodInvocation {
@@ -35,38 +38,38 @@ class MockFxAccount: FxAccount {
     }
 
     override func initializeDevice(name _: String, deviceType _: DeviceType, supportedCapabilities _: [DeviceCapability]) throws {
-        invocations.append(.initializeDevice)
+        queue.sync { invocations.append(.initializeDevice) }
     }
 
     override func getDevices(ignoreCache _: Bool) throws -> [Device] {
-        invocations.append(.getDevices)
+        queue.sync { invocations.append(.getDevices) }
         return []
     }
 
     override func registerPersistCallback(_: PersistCallback) {
-        invocations.append(.registerPersistCallback)
+        queue.sync { invocations.append(.registerPersistCallback) }
     }
 
     override func ensureCapabilities(supportedCapabilities _: [DeviceCapability]) throws {
-        invocations.append(.ensureCapabilities)
+        queue.sync { invocations.append(.ensureCapabilities) }
     }
 
     override func checkAuthorizationStatus() throws -> IntrospectInfo {
-        invocations.append(.checkAuthorizationStatus)
+        queue.sync { invocations.append(.checkAuthorizationStatus) }
         return IntrospectInfo(active: true)
     }
 
     override func clearAccessTokenCache() throws {
-        invocations.append(.clearAccessTokenCache)
+        queue.sync { invocations.append(.clearAccessTokenCache) }
     }
 
     override func getAccessToken(scope _: String, ttl _: UInt64? = nil) throws -> AccessTokenInfo {
-        invocations.append(.getAccessToken)
+        queue.sync { invocations.append(.getAccessToken) }
         return AccessTokenInfo(scope: "profile", token: "toktok")
     }
 
     override func getProfile(ignoreCache _: Bool) throws -> Profile {
-        invocations.append(.getProfile)
+        queue.sync { invocations.append(.getProfile) }
         return Profile(uid: "uid", email: "foo@bar.bobo")
     }
 
@@ -76,9 +79,6 @@ class MockFxAccount: FxAccount {
 }
 
 class MockFxAccountManager: FxAccountManager {
-    var invocations: [MethodInvocation] = []
-    enum MethodInvocation {}
-
     var storedAccount: FxAccount?
 
     override func createAccount() -> FxAccount {
@@ -107,17 +107,17 @@ class MockDeviceConstellation: DeviceConstellation {
     }
 
     override func initDevice(name: String, type: DeviceType, capabilities: [DeviceCapability]) {
-        invocations.append(.initDevice)
+        queue.sync { invocations.append(.initDevice) }
         super.initDevice(name: name, type: type, capabilities: capabilities)
     }
 
     override func ensureCapabilities(capabilities: [DeviceCapability]) {
-        invocations.append(.ensureCapabilities)
+        queue.sync { invocations.append(.ensureCapabilities) }
         super.ensureCapabilities(capabilities: capabilities)
     }
 
     override func refreshState() {
-        invocations.append(.refreshState)
+        queue.sync { invocations.append(.refreshState) }
         super.refreshState()
     }
 }


### PR DESCRIPTION
Possible fix to https://github.com/mozilla/application-services/issues/3233.

We're in crazy territory here so take everything I say with a grain of salt since I couldn't reproduce on my own computer.

Symptom: The ["flaky tests failing line"](https://github.com/mozilla/application-services/blob/52a2c32ddb489f38fc0a4b6efa5ab463916c6844/megazords/ios/MozillaAppServicesTests/FxAccountManagerTests.swift#L193) that checks that [`getProfile` is in the `invocations` array](https://github.com/mozilla/application-services/blob/52a2c32ddb489f38fc0a4b6efa5ab463916c6844/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift#L69) (tracks methods calls to `FxAccounts`) is failing.

As reminder the failing test covers the [`.accountRestored` handling code](https://github.com/mozilla/application-services/blob/52a2c32ddb489f38fc0a4b6efa5ab463916c6844/components/fxa-client/ios/FxAClient/FxAccountManager.swift#L450-L458):

- This block first calls [`postAuthenticated`](https://github.com/mozilla/application-services/blob/52a2c32ddb489f38fc0a4b6efa5ab463916c6844/components/fxa-client/ios/FxAClient/FxAccountManager.swift#L606-L615) which in turns calls [`refreshState`](https://github.com/mozilla/application-services/blob/52a2c32ddb489f38fc0a4b6efa5ab463916c6844/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift#L33). Note the body of this function: everything is wrapped in a `DispatchQueue.global().async` (GCD concurent queue). This method will in turn call [`FxAccount.getDevices`](https://github.com/mozilla/application-services/blob/52a2c32ddb489f38fc0a4b6efa5ab463916c6844/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift#L37), which in the [mock writes into the `invocations` array](https://github.com/mozilla/application-services/blob/52a2c32ddb489f38fc0a4b6efa5ab463916c6844/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift#L42)

- Meanwhile (remember, because we're in a different thread) the `.accountRestored` code will lead us to the [profile fetch part](https://github.com/mozilla/application-services/blob/52a2c32ddb489f38fc0a4b6efa5ab463916c6844/components/fxa-client/ios/FxAClient/FxAccountManager.swift#L512), which also calls into the `FxAccount` mock for `getProfile` and also [writes into the `invocations` array](https://github.com/mozilla/application-services/blob/52a2c32ddb489f38fc0a4b6efa5ab463916c6844/megazords/ios/MozillaAppServicesTests/FxAccountMocks.swift#L69).

Arrays are not thread-safe in Swift, this is why I'm thinking one `invocations.append` call (`getDevices`) is somehow overwriting the other one (`getProfile`). This patch basically wraps the calls to `invocations.append` by using a **serial** queue to protect the array.

Anyway, hopefully I'm right and this fixes the problem because I'm out of ideas otherwise and I'll just remove the test assert out of frustration.