### PR TITLE
Better bridged envelopes

### DIFF
--- a/components/support/sync15-traits/src/bridged_engine.rs
+++ b/components/support/sync15-traits/src/bridged_engine.rs
@@ -125,6 +125,8 @@ pub struct IncomingEnvelope {
     pub modified: ServerTimestamp,
     #[serde(default)]
     pub sortindex: Option<i32>,
+    #[serde(default)]
+    pub ttl: Option<u32>,
     // Don't provide access to the cleartext directly. We want all callers to
     // use `IncomingEnvelope::payload`, so that we can validate the cleartext.
     cleartext: String,
@@ -142,7 +144,10 @@ impl IncomingEnvelope {
                 payload: payload.id,
             });
         }
-        Ok(payload)
+        // Remove auto field data from payload and replace with real data
+        Ok(payload
+            .with_auto_field("ttl", self.ttl)
+            .with_auto_field("sortindex", self.sortindex))
     }
 }
 
@@ -153,14 +158,22 @@ impl IncomingEnvelope {
 pub struct OutgoingEnvelope {
     id: Guid,
     cleartext: String,
+    sortindex: Option<i32>,
+    ttl: Option<u32>,
 }
 
 impl From<Payload> for OutgoingEnvelope {
     fn from(payload: Payload) -> Self {
+        let mut payload = payload;
         let id = payload.id.clone();
+        // Remove auto field data from OutgoingEnvelope payload
+        let ttl = payload.take_auto_field("ttl");
+        let sortindex = payload.take_auto_field("sortindex");
         OutgoingEnvelope {
             id,
             cleartext: payload.into_json_string(),
+            sortindex,
+            ttl,
         }
     }
 }

--- a/components/support/sync15-traits/src/bridged_engine.rs
+++ b/components/support/sync15-traits/src/bridged_engine.rs
@@ -163,8 +163,7 @@ pub struct OutgoingEnvelope {
 }
 
 impl From<Payload> for OutgoingEnvelope {
-    fn from(payload: Payload) -> Self {
-        let mut payload = payload;
+    fn from(mut payload: Payload) -> Self {
         let id = payload.id.clone();
         // Remove auto field data from OutgoingEnvelope payload
         let ttl = payload.take_auto_field("ttl");

--- a/components/support/sync15-traits/src/payload.rs
+++ b/components/support/sync15-traits/src/payload.rs
@@ -65,7 +65,7 @@ impl Payload {
                 old_value,
             );
         }
-        return self;
+        self
     }
 
     pub fn take_auto_field<V>(&mut self, name: &str) -> Option<V>

--- a/components/support/sync15-traits/src/payload.rs
+++ b/components/support/sync15-traits/src/payload.rs
@@ -44,9 +44,9 @@ impl Payload {
     /// the future) which are:
     ///
     /// - Added to the payload automatically when deserializing if present on
-    ///   the incoming BSO.
-    /// - Removed from the payload automatically and attached to the BSO if
-    ///   present on the outgoing payload.
+    ///   the incoming BSO or envelope.
+    /// - Removed from the payload automatically and attached to the BSO or
+    ///   envelope if present on the outgoing payload.
     pub fn with_auto_field<T: Into<JsonValue>>(mut self, name: &str, v: Option<T>) -> Payload {
         let old_value: Option<JsonValue> = if let Some(value) = v {
             self.data.insert(name.into(), value.into())

--- a/components/support/sync15-traits/src/payload.rs
+++ b/components/support/sync15-traits/src/payload.rs
@@ -65,7 +65,7 @@ impl Payload {
                 old_value,
             );
         }
-        return self
+        return self;
     }
 
     pub fn take_auto_field<V>(&mut self, name: &str) -> Option<V>

--- a/components/support/sync15-traits/src/payload.rs
+++ b/components/support/sync15-traits/src/payload.rs
@@ -40,8 +40,7 @@ impl Payload {
         self
     }
 
-    /// "Auto" fields are fields like 'sortindex' (and potentially 'ttl' in
-    /// the future) which are:
+    /// "Auto" fields are fields like 'sortindex' and 'ttl', which are:
     ///
     /// - Added to the payload automatically when deserializing if present on
     ///   the incoming BSO or envelope.

--- a/components/sync15/src/bso_record.rs
+++ b/components/sync15/src/bso_record.rs
@@ -165,8 +165,8 @@ impl<T> DerefMut for BsoRecord<T> {
 impl CleartextBso {
     pub fn from_payload(mut payload: Payload, collection: impl Into<String>) -> Self {
         let id = payload.id.clone();
-        let sortindex: Option<i32> = take_auto_field(&mut payload, "sortindex");
-        let ttl: Option<u32> = take_auto_field(&mut payload, "ttl");
+        let sortindex: Option<i32> = payload.take_auto_field("sortindex");
+        let ttl: Option<u32> = payload.take_auto_field("ttl");
         BsoRecord {
             id,
             collection: collection.into(),
@@ -181,49 +181,6 @@ impl CleartextBso {
 pub type EncryptedBso = BsoRecord<EncryptedPayload>;
 pub type CleartextBso = BsoRecord<Payload>;
 
-/// "Auto" fields are fields like 'sortindex' (and potentially 'ttl' in
-/// the future) which are:
-///
-/// - Added to the payload automatically when deserializing if present on
-///   the incoming BSO.
-/// - Removed from the payload automatically and attached to the BSO if
-///   present on the outgoing payload.
-fn add_auto_field<T: Into<JsonValue>>(p: &mut Payload, name: &str, v: Option<T>) {
-    // This is a little dubious, but it seems like if we have a e.g. `sortindex` field on the payload
-    // it's going to be a bug if we use it instead of the "real" sort index.
-    if p.data.contains_key(name) {
-        log::warn!(
-            "Payload for record {} already contains 'automatic' field \"{}\"? \
-             Overwriting with 'real' value",
-            p.id,
-            name
-        );
-    }
-
-    if let Some(value) = v {
-        p.data.insert(name.into(), value.into());
-    } else {
-        p.data.remove(name);
-    }
-}
-
-fn take_auto_field<V>(p: &mut Payload, name: &str) -> Option<V>
-where
-    for<'a> V: Deserialize<'a>,
-{
-    let v = p.data.remove(name)?;
-    match serde_json::from_value(v) {
-        Ok(v) => Some(v),
-        Err(e) => {
-            log::error!(
-                "Automatic field {} exists on payload, but cannot be deserialized: {}",
-                name,
-                e
-            );
-            None
-        }
-    }
-}
 // Contains the methods to automatically deserialize the payload to/from json.
 mod as_json {
     use serde::de::{self, Deserialize, DeserializeOwned, Deserializer};
@@ -297,10 +254,11 @@ impl EncryptedPayload {
 
 impl EncryptedBso {
     pub fn decrypt(self, key: &KeyBundle) -> error::Result<CleartextBso> {
-        let mut new_payload: Payload = self.payload.decrypt_and_parse_payload(key)?;
-        // This is a slightly dodgy place to do this, but whatever.
-        add_auto_field(&mut new_payload, "sortindex", self.sortindex);
-        add_auto_field(&mut new_payload, "ttl", self.ttl);
+        let mut new_payload: Payload = self
+            .payload
+            .decrypt_and_parse_payload(key)?
+            .with_auto_field("sortindex", self.sortindex)
+            .with_auto_field("ttl", self.ttl);
 
         let result = self.with_payload(new_payload);
         Ok(result)

--- a/components/sync15/src/bso_record.rs
+++ b/components/sync15/src/bso_record.rs
@@ -9,7 +9,6 @@ use lazy_static::lazy_static;
 use serde::de::{Deserialize, DeserializeOwned};
 use serde::ser::Serialize;
 use serde_derive::*;
-use serde_json::Value as JsonValue;
 use std::ops::{Deref, DerefMut};
 pub use sync15_traits::Payload;
 use sync_guid::Guid;
@@ -254,9 +253,9 @@ impl EncryptedPayload {
 
 impl EncryptedBso {
     pub fn decrypt(self, key: &KeyBundle) -> error::Result<CleartextBso> {
-        let mut new_payload: Payload = self
+        let new_payload = self
             .payload
-            .decrypt_and_parse_payload(key)?
+            .decrypt_and_parse_payload::<Payload>(key)?
             .with_auto_field("sortindex", self.sortindex)
             .with_auto_field("ttl", self.ttl);
 
@@ -290,6 +289,7 @@ impl CleartextBso {
 mod tests {
     use super::*;
     use serde_json::json;
+    use serde_json::Value as JsonValue;
 
     #[test]
     fn test_deserialize_enc() {


### PR DESCRIPTION
Fixes #3069 

Adds`sortIndex` and `ttl` to `OutgoingEnvelope`
Adds `ttl` to `IncomingEnvelope`

Also adds proper handling for `sortIndex` and `ttl` autofields