### PR TITLE
Hack around nss-sys's --all-features situation and run far fewer redundant tests in CI

### DIFF
--- a/components/support/rc_crypto/nss/nss_sys/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_sys/src/lib.rs
@@ -12,5 +12,5 @@ pub use bindings::*;
 // So we link against the SQLite lib imported by parent crates
 // such as places and logins.
 #[allow(unused_extern_crates)]
-#[cfg(not(feature = "gecko"))]
+#[cfg(any(not(feature = "gecko"), __appsvc_ci_hack))]
 extern crate libsqlite3_sys;


### PR DESCRIPTION
Previously we were building and running every package with --no-default-features. Each of these builds caused a recomputation of dependency feature sets, which in practice caused a pretty substantial number of them to require rebuilding a decent chunk of our dep graph.

We only have 1 package out of 35 that needs this, so I changed it to detect and only run the ones that need it, e.g. that one (sync-guid).

I added a hack for the situation with --default-features in NSS, and the fact that the test was just commented out is very frustrating, since it was trying to catch things like this (and we need the --all-feature test way more than the --no-default-features test.

The way nss-sys does this completely backwards (it's a mistake to have features that disable something as part of their function), but I don't have the energy right now to go into a gecko build system debugging session so I added a --cfg to hack around it.

I suspect that even if running coverage bumps up our CI bill, this will more than cover the difference.

Anyway, one last note is I added back the jq dependency to run our tests. It's ubiquitous, easy to install, and I don't have the `tr`/`sed` skill to figure the other way out. (@rfk can rewrite it if he cares to do so in the future).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
