### PR TITLE
Cut release 61.0.8 containing the backported fenix metrics renewals 

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 61.0.7
+libraryVersion: 61.0.8
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v61.0.8 (_2020-07-15_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...main)
+
+## General
+
+- The logins and places metrics have been renewed until early 2021. ([#3290](https://github.com/mozilla/application-services/pull/3290)).
+
 # v61.0.7 (_2020-06-29_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.6...v61.0.7)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,8 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...main)
-
-## General
-
-- The logins and places metrics have been renewed until early 2021. ([#3290](https://github.com/mozilla/application-services/pull/3290)).
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.8...main)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,7 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...main)
+
+## General
+
+- The logins and places metrics have been renewed until early 2021. ([#3290](https://github.com/mozilla/application-services/pull/3290)).

--- a/components/logins/android/metrics.yaml
+++ b/components/logins/android/metrics.yaml
@@ -31,9 +31,10 @@ logins_store:
       - https://github.com/mozilla/application-services/issues/2225
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1597895
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   unlock_error_count:
     type: labeled_counter
@@ -49,9 +50,10 @@ logins_store:
       - https://github.com/mozilla/application-services/issues/2225
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1597895
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   read_query_count:
     type: counter
@@ -64,9 +66,10 @@ logins_store:
       - https://github.com/mozilla/application-services/issues/2225
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1597895
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   read_query_error_count:
     type: labeled_counter
@@ -81,9 +84,10 @@ logins_store:
       - https://github.com/mozilla/application-services/issues/2225
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1597895
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   write_query_count:
     type: counter
@@ -96,9 +100,10 @@ logins_store:
       - https://github.com/mozilla/application-services/issues/2225
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1597895
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   write_query_error_count:
     type: labeled_counter
@@ -116,9 +121,10 @@ logins_store:
       - https://github.com/mozilla/application-services/issues/2225
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1597895
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   # These help us understand the performance of the logins store in the wild.
   # We'll use them to identify any application or platform features that are leading to unacceptably
@@ -133,9 +139,10 @@ logins_store:
       - https://github.com/mozilla/application-services/issues/2225
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1597895
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   read_query_time:
     type: timing_distribution
@@ -146,9 +153,10 @@ logins_store:
       - https://github.com/mozilla/application-services/issues/2225
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1597895
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   write_query_time:
     type: timing_distribution
@@ -159,6 +167,7 @@ logins_store:
       - https://github.com/mozilla/application-services/issues/2225
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1597895
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"

--- a/components/places/android/metrics.yaml
+++ b/components/places/android/metrics.yaml
@@ -27,9 +27,10 @@ places_manager:
       - https://github.com/mozilla/application-services/issues/2299
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1607621
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   read_query_error_count:
     type: labeled_counter
@@ -45,9 +46,10 @@ places_manager:
       - https://github.com/mozilla/application-services/issues/2299
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1607621
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   write_query_count:
     type: counter
@@ -61,9 +63,10 @@ places_manager:
       - https://github.com/mozilla/application-services/issues/2299
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1607621
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   write_query_error_count:
     type: labeled_counter
@@ -83,9 +86,10 @@ places_manager:
       - https://github.com/mozilla/application-services/issues/2299
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1607621
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   read_query_time:
     type: timing_distribution
@@ -96,9 +100,10 @@ places_manager:
       - https://github.com/mozilla/application-services/issues/2299
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1607621
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   scan_query_time:
     type: timing_distribution
@@ -110,9 +115,10 @@ places_manager:
       - https://github.com/mozilla/application-services/issues/2299
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1607621
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"
 
   write_query_time:
     type: timing_distribution
@@ -123,6 +129,7 @@ places_manager:
       - https://github.com/mozilla/application-services/issues/2299
     data_reviews:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=1607621
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1649044
     notification_emails:
       - synced-client-integrations@mozilla.com
-    expires: "2020-07-01"
+    expires: "2021-03-01"


### PR DESCRIPTION
Let's try this again!
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
