### PR TITLE
Merge the "v61.0.8" release tag back into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@
 - Tab records now have an explicit TTL set when storing on the server, to match the behaviour
   of Firefox Desktop clients ([#3322](https://github.com/mozilla/application-services/pull/3322)).
 
+# v61.0.8 (_2020-07-15_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...v61.0.8)
+
+## General
+
+- The logins and places metrics have been renewed until early 2021. ([#3290](https://github.com/mozilla/application-services/pull/3290)).
+
 # v61.0.7 (_2020-06-29_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.6...v61.0.7)


### PR DESCRIPTION
Last step of https://github.com/mozilla/application-services/blob/master/docs/howtos/cut-a-new-release.md#make-a-new-point-release-from-an-existing-release-that-is-behind-latest-master
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
