### PR TITLE
Cut release 61.0.9 containing backported logins empty string fix

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 61.0.8
+libraryVersion: 61.0.9
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+# v61.0.9 (_2020-07-15_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.8...v61.0.9)
+
+## Logins
+
+- Empty strings are now correctly handled in login validation. ([#3331](https://github.com/mozilla/application-services/pull/3331)).
+
 # v61.0.8 (_2020-07-15_)
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...v61.0.8)
 
 ## General
 

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.8...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.9...main)


### PR DESCRIPTION
Request in slack from @grigoryk 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
