### PR TITLE
Remove scheduled CircleCI jobs on `master` branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,36 +469,6 @@ workflows:
           filters:
             branches:
               only: master
-  check-dependencies-periodically:
-    jobs:
-      - Check Rust dependencies
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only:
-                - master
-  run-beta-tests-periodically:
-    jobs:
-      - Rust tests - beta
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only:
-                - master
-  mirror-bugzilla-to-github-periodically:
-    jobs:
-      - Mirror Bugzilla issues into GitHub
-    triggers:
-      - schedule:
-          cron: "0,30 * * * *"
-          filters:
-            branches:
-              only:
-                - master
   run-tests:
     jobs:
       - Rust tests


### PR DESCRIPTION
**Nota bene** this PR targets the old `master` branch rather than `main`.

CircleCI seems to still be running the scheduled jobs on our `master` branch, causing duplicates in the bugzilla mirroring script. I'm hopeful that summarily deleting the CircleCI jobs will fix the problem. I don't know enough about CircleCI to be able to find out whether it has the wrong default branch name, or if it's just following the instructions in the files on this branch which do clearly say they should be run on `master`.