### PR TITLE
Implement rc_crypto backed Rng for rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,6 +2027,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_rccrypto"
+version = "0.1.0"
+dependencies = [
+ "rand_core 0.5.1",
+ "rc_crypto",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "components/support/ffi",
     "components/support/guid",
     "components/support/interrupt",
+    "components/support/rand_rccrypto",
     "components/support/restmail-client",
     "components/support/rc_crypto",
     "components/support/rc_crypto/nss",

--- a/components/support/rand_rccrypto/Cargo.toml
+++ b/components/support/rand_rccrypto/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rand_rccrypto"
+version = "0.1.0"
+authors = ["Edouard Oger <eoger@fastmail.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+rc_crypto = { path = "../rc_crypto" }
+rand_core = "0.5"

--- a/components/support/rand_rccrypto/src/lib.rs
+++ b/components/support/rand_rccrypto/src/lib.rs
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub use rand_core;
+use rand_core::{impls, CryptoRng, Error, RngCore};
+
+pub struct RcCryptoRng;
+
+impl RngCore for RcCryptoRng {
+    fn next_u32(&mut self) -> u32 {
+        impls::next_u32_via_fill(self)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        impls::next_u64_via_fill(self)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.try_fill_bytes(dest).unwrap()
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Error> {
+        rc_crypto::rand::fill(dest).map_err(Error::new)
+    }
+}
+
+// NSS's `PK11_GenerateRandom` is considered a CSPRNG.
+impl CryptoRng for RcCryptoRng {}


### PR DESCRIPTION
While working on another patch, I found myself needing to pick an element at random in an array.
Of course, I could have devised an algorithm myself, but let's be honest I went to google right away and typed "random vec element rust" and picked the first answer. Great! `rand` does that. Oh wait, we can't use it for "serious stuff" because it's not backed by NSS. Well, now it is.

```
use rand::{prelude::*, seq::SliceRandom};

let mut rng = rand_rccrypto::RcCryptoRng;
let choices = [1, 2, 4, 8, 16, 32];
let rand_item = choices.choose(&mut rng);
```

We now have a higher-level API for randomness.