### PR TITLE
Add failing testcases to reproduce issue #3365.

### DIFF
--- a/components/push/src/crypto.rs
+++ b/components/push/src/crypto.rs
@@ -286,4 +286,20 @@ mod crypto_tests {
         let decrypted = decrypter(ciphertext, "aes128gcm", None, None).unwrap();
         assert_eq!(String::from_utf8(decrypted).unwrap(), PLAINTEXT.to_string());
     }
+
+    #[test]
+    fn test_extract_value_with_quotes() {
+        // XXX TODO: this fails because `extract_value` doesn't handle quoted values.
+        let header = "dh=\"YWJj\"";
+        let extracted = extract_value(Some(header), "dh").unwrap();
+        assert_eq!(extracted, "abc".as_bytes());
+    }
+
+    #[test]
+    fn test_extract_value_with_spaces() {
+        // XXX TODO: this fails because `extract_value` doesn't chomp whitespace between values.
+        let header = "foo=bar; dh=\"YWJj\"";
+        let extracted = extract_value(Some(header), "dh").unwrap();
+        assert_eq!(extracted, "abc".as_bytes());
+    }
 }


### PR DESCRIPTION
Our `push` component has an `extract_value` helper function that tries to parse a single item out of a HTTP header using the common "key=value; key=value" syntax.

Parsing such headers is fraught with peril. Here are two small testcases for things that we don't currently handle correctly, one of which apears to be the cause of #3364 and #3365 (I added a bunch of `panic!`s in here to confirm that it was failing with the same error messages as seen in those issues).

I don't have any more time to spend on this issue so I haven't worked on a fix, but I'm pushing them in the hope that they can be a starting point when those issues make it to the top of someone's stack.

Connects to #3365.