### PR TITLE
Factor-out jwcrypto bits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "error-support",
  "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex",
+ "jwcrypto",
  "lazy_static",
  "log 0.4.11",
  "mockiato",
@@ -1135,6 +1136,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52732a3d3ad72c58ad2dc70624f9c17b46ecd0943b9a4f1ee37c4c18c5d983e2"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jwcrypto"
+version = "0.1.0"
+dependencies = [
+ "base64 0.12.3",
+ "rc_crypto",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "components/support/ffi",
     "components/support/guid",
     "components/support/interrupt",
+    "components/support/jwcrypto",
     "components/support/rand_rccrypto",
     "components/support/restmail-client",
     "components/support/rc_crypto",

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -20,6 +20,7 @@ sync15 = { path = "../sync15" }
 url = "2.1"
 ffi-support = "0.4"
 viaduct = { path = "../viaduct" }
+jwcrypto = { path = "../support/jwcrypto" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece", "hawk"] }
 error-support = { path = "../support/error" }
 thiserror = "1.0"

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -12,12 +12,6 @@ pub enum ErrorKind {
     #[error("Unknown OAuth State")]
     UnknownOAuthState,
 
-    #[error("The client requested keys alongside the token but they were not included")]
-    TokenWithoutKeys,
-
-    #[error("Login state needs to be Married for the current operation")]
-    NotMarried,
-
     #[error("Multiple OAuth scopes requested")]
     MultipleScopesRequested,
 
@@ -39,20 +33,11 @@ pub enum ErrorKind {
     #[error("No stored current device id")]
     NoCurrentDeviceId,
 
-    #[error("Could not find a refresh token in the server response")]
-    RefreshTokenNotPresent,
-
-    #[error("Action requires a prior device registration")]
-    DeviceUnregistered,
-
     #[error("Device target is unknown (Device ID: {0})")]
     UnknownTargetDevice(String),
 
     #[error("Unrecoverable server error {0}")]
     UnrecoverableServerError(&'static str),
-
-    #[error("Invalid OAuth scope value {0}")]
-    InvalidOAuthScopeValue(String),
 
     #[error("Illegal state: {0}")]
     IllegalState(&'static str),
@@ -63,44 +48,14 @@ pub enum ErrorKind {
     #[error("Send Tab diagnosis error: {0}")]
     SendTabDiagnosisError(&'static str),
 
-    #[error("Empty names")]
-    EmptyOAuthScopeNames,
-
-    #[error("Key {0} had wrong length, got {1}, expected {2}")]
-    BadKeyLength(&'static str, usize, usize),
-
     #[error("Cannot xor arrays with different lengths: {0} and {1}")]
     XorLengthMismatch(usize, usize),
-
-    #[error("Audience URL without a host")]
-    AudienceURLWithoutHost,
 
     #[error("Origin mismatch")]
     OriginMismatch,
 
-    #[error("JWT signature validation failed")]
-    JWTSignatureValidationFailed,
-
-    #[error("ECDH key generation failed")]
-    KeyGenerationFailed,
-
-    #[error("Public key computation failed")]
-    PublicKeyComputationFailed,
-
     #[error("Remote key and local key mismatch")]
     MismatchedKeys,
-
-    #[error("Key import failed")]
-    KeyImportFailed,
-
-    #[error("AEAD open failure")]
-    AEADOpenFailure,
-
-    #[error("Random number generation failure")]
-    RngFailure,
-
-    #[error("HMAC mismatch")]
-    HmacMismatch,
 
     #[error("Client: {0} is not allowed to request scope: {1}")]
     ScopeNotAllowed(String, String),
@@ -142,6 +97,9 @@ pub enum ErrorKind {
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
 
+    #[error("JWCrypto error: {0}")]
+    JwCryptoError(#[from] jwcrypto::JwCryptoError),
+
     #[error("UTF8 decode error: {0}")]
     UTF8DecodeError(#[from] string::FromUtf8Error),
 
@@ -171,6 +129,7 @@ error_support::define_error! {
         (HexDecodeError, hex::FromHexError),
         (Base64Decode, base64::DecodeError),
         (JsonError, serde_json::Error),
+        (JwCryptoError, jwcrypto::JwCryptoError),
         (UTF8DecodeError, std::string::FromUtf8Error),
         (RequestError, viaduct::Error),
         (UnexpectedStatus, viaduct::UnexpectedStatus),

--- a/components/fxa-client/src/ffi.rs
+++ b/components/fxa-client/src/ffi.rs
@@ -29,7 +29,7 @@ pub mod error_codes {
     /// Catch-all error code used for anything that's not a panic or covered by AUTHENTICATION.
     pub const OTHER: i32 = 1;
 
-    /// Used for `ErrorKind::NotMarried`, `ErrorKind::NoCachedTokens`, `ErrorKind::NoScopedKey`
+    /// Used by `ErrorKind::NoCachedTokens`, `ErrorKind::NoScopedKey`
     /// and `ErrorKind::RemoteError`'s where `code == 401`.
     pub const AUTHENTICATION: i32 = 2;
 
@@ -53,7 +53,6 @@ pub unsafe fn from_protobuf_ptr<T, F: prost::Message + Default + Into<T>>(
 fn get_code(err: &Error) -> ErrorCode {
     match err.kind() {
         ErrorKind::RemoteError { code: 401, .. }
-        | ErrorKind::NotMarried
         | ErrorKind::NoRefreshToken
         | ErrorKind::NoScopedKey(_)
         | ErrorKind::NoCachedToken(_) => {

--- a/components/fxa-client/src/http_client.rs
+++ b/components/fxa-client/src/http_client.rs
@@ -546,7 +546,7 @@ pub fn get_keys_bundle(config: &Config, hkdf_sha256_key: &[u8]) -> Result<Vec<u8
     let bundle = hex::decode(
         &resp["bundle"]
             .as_str()
-            .ok_or_else(|| ErrorKind::KeyGenerationFailed)?,
+            .ok_or_else(|| ErrorKind::UnrecoverableServerError("bundle not present"))?,
     )?;
     Ok(bundle)
 }

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -26,20 +26,19 @@ use std::{
 };
 use url::Url;
 
+#[cfg(feature = "integration_test")]
+pub mod auth;
 mod commands;
 mod config;
 pub mod device;
 pub mod error;
 pub mod ffi;
+mod http_client;
 pub mod migrator;
-
-#[cfg(feature = "integration_test")]
-pub mod auth;
 // Include the `msg_types` module, which is generated from msg_types.proto.
 pub mod msg_types {
     include!("mozilla.appservices.fxaclient.protobuf.rs");
 }
-mod http_client;
 mod oauth;
 mod profile;
 mod push;

--- a/components/fxa-client/src/scoped_keys.rs
+++ b/components/fxa-client/src/scoped_keys.rs
@@ -74,6 +74,7 @@ impl ScopedKeysFlow {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use jwcrypto::JwkKeyParameters;
     use rc_crypto::agreement::{KeyPair, PrivateKey};
 
     #[test]
@@ -99,7 +100,7 @@ mod tests {
         let key_pair = KeyPair::from(private_key).unwrap();
         let flow = ScopedKeysFlow::from_static_key_pair(key_pair).unwrap();
         let jwk = flow.get_public_key_jwk().unwrap();
-        let Jwk::EC(ec_key_params) = jwk;
+        let JwkKeyParameters::EC(ec_key_params) = jwk.key_parameters;
         assert_eq!(ec_key_params.crv, "P-256");
         assert_eq!(
             ec_key_params.x,

--- a/components/fxa-client/src/scoped_keys.rs
+++ b/components/fxa-client/src/scoped_keys.rs
@@ -3,13 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::{error::*, FirefoxAccount};
-use rc_crypto::{
-    aead, agreement,
-    agreement::{Ephemeral, InputKeyMaterial, KeyPair},
-    digest, rand,
-};
-use serde_derive::*;
-use serde_json::{self, json};
+use jwcrypto::{self, DecryptionParameters, Jwk};
+use rc_crypto::{agreement, agreement::EphemeralKeyPair};
+use serde_derive::{Deserialize, Serialize};
 
 impl FirefoxAccount {
     pub(crate) fn get_scoped_key(&self, scope: &str) -> Result<&ScopedKey> {
@@ -45,200 +41,40 @@ impl std::fmt::Debug for ScopedKey {
     }
 }
 
-#[derive(Serialize, Deserialize)]
-struct Jwk {
-    crv: String,
-    kty: String,
-    x: String,
-    y: String,
-}
-
-#[derive(Serialize, Deserialize)]
-struct JweHeader {
-    alg: String,
-    enc: String,
-    epk: Jwk,
-    apu: Option<String>,
-    apv: Option<String>,
-}
-
 pub struct ScopedKeysFlow {
-    key_pair: KeyPair<Ephemeral>,
+    key_pair: EphemeralKeyPair,
 }
 
-/// Theorically, everything done in this file could and should be done in a JWT library.
-/// However, none of the existing rust JWT libraries can handle ECDH-ES encryption, and API choices
-/// made by their authors make it difficult to add this feature.
-/// In the past, we chose cjose to do that job, but it added three C dependencies to build and link
-/// against: jansson, openssl and cjose itself.
 impl ScopedKeysFlow {
     pub fn with_random_key() -> Result<Self> {
-        let key_pair = KeyPair::<Ephemeral>::generate(&agreement::ECDH_P256)
-            .map_err(|_| ErrorKind::KeyGenerationFailed)?;
+        let key_pair = EphemeralKeyPair::generate(&agreement::ECDH_P256)?;
         Ok(Self { key_pair })
     }
 
     #[cfg(test)]
-    pub fn from_static_key_pair(key_pair: KeyPair<agreement::Static>) -> Result<Self> {
+    pub fn from_static_key_pair(key_pair: agreement::KeyPair<agreement::Static>) -> Result<Self> {
         let (private_key, _) = key_pair.split();
         let ephemeral_prv_key = private_key._tests_only_dangerously_convert_to_ephemeral();
-        let key_pair = KeyPair::from_private_key(ephemeral_prv_key)?;
+        let key_pair = agreement::KeyPair::from_private_key(ephemeral_prv_key)?;
         Ok(Self { key_pair })
     }
 
-    pub fn generate_keys_jwk(&self) -> Result<String> {
-        let pub_key_bytes = self.key_pair.public_key().to_bytes()?;
-        // Uncompressed form (see SECG SEC1 section 2.3.3).
-        // First byte is 4, then 32 bytes for x, and 32 bytes for y.
-        assert_eq!(pub_key_bytes.len(), 1 + 32 + 32);
-        assert_eq!(pub_key_bytes[0], 0x04);
-        let x = Vec::from(&pub_key_bytes[1..33]);
-        let x = base64::encode_config(&x, base64::URL_SAFE_NO_PAD);
-        let y = Vec::from(&pub_key_bytes[33..]);
-        let y = base64::encode_config(&y, base64::URL_SAFE_NO_PAD);
-        Ok(json!({
-            "crv": "P-256",
-            "kty": "EC",
-            "x": x,
-            "y": y,
-        })
-        .to_string())
-    }
-
-    fn get_peer_public_from_jwk(jwk: Jwk) -> Result<Vec<u8>> {
-        let x = base64::decode_config(jwk.x, base64::URL_SAFE_NO_PAD)?;
-        let y = base64::decode_config(jwk.y, base64::URL_SAFE_NO_PAD)?;
-        if jwk.kty != "EC" {
-            return Err(ErrorKind::UnrecoverableServerError("Only EC keys are supported.").into());
-        }
-        if jwk.crv != "P-256" {
-            return Err(
-                ErrorKind::UnrecoverableServerError("Only P-256 curves are supported.").into(),
-            );
-        }
-        if x.len() != (256 / 8) {
-            return Err(ErrorKind::UnrecoverableServerError("X must be 32 bytes long.").into());
-        }
-        if y.len() != (256 / 8) {
-            return Err(ErrorKind::UnrecoverableServerError("Y must be 32 bytes long.").into());
-        }
-        let mut peer_pub_key: Vec<u8> = vec![0x04];
-        peer_pub_key.extend_from_slice(&x);
-        peer_pub_key.extend_from_slice(&y);
-        Ok(peer_pub_key)
-    }
-
-    pub fn encrypt_keys_jwe(self, jwk: &str, data: &[u8]) -> Result<String> {
-        let jwk: Jwk = serde_json::from_str(&jwk)?;
-        let peer_public_key = Self::get_peer_public_from_jwk(jwk)?;
-        let epk_jwk: Jwk = serde_json::from_str(&self.generate_keys_jwk()?)?;
-        let (private_key, _) = self.key_pair.split();
-
-        let content_key = private_key.agree(&agreement::ECDH_P256, &peer_public_key)?;
-        let apu = "";
-        let alg = "A256GCM";
-        let apv = "";
-        let secret = Self::get_secret_from_ikm(content_key, apu, apv, alg)?;
-        let sealing_key = aead::SealingKey::new(&aead::AES_256_GCM, &secret.as_ref())?;
-        let header = JweHeader {
-            alg: "ECDH-ES".to_string(),
-            enc: "A256GCM".to_string(),
-            epk: epk_jwk,
-            apu: None,
-            apv: None,
-        };
-        let additional_data = serde_json::to_string(&header)?;
-        let additional_data =
-            base64::encode_config(additional_data.as_bytes(), base64::URL_SAFE_NO_PAD);
-        let additional_data = additional_data.as_bytes();
-        let aad = aead::Aad::from(additional_data);
-        let mut iv: Vec<u8> = vec![0; 12];
-        rand::fill(&mut iv)?;
-        let nonce = aead::Nonce::try_assume_unique_for_key(&aead::AES_256_GCM, &iv)?;
-        let encrypted = aead::seal(&sealing_key, nonce, aad, data)?;
-
-        // Assemble JWE
-        let header = serde_json::to_string(&header)?;
-        let header = base64::encode_config(header.as_bytes(), base64::URL_SAFE_NO_PAD);
-        let tag_idx = encrypted.len() - ((128 + 7) >> 3);
-        let tag = &encrypted[tag_idx..];
-        let tag = base64::encode_config(tag, base64::URL_SAFE_NO_PAD);
-        let ciphertext = &encrypted[0..tag_idx];
-        let ciphertext = base64::encode_config(ciphertext, base64::URL_SAFE_NO_PAD);
-        let iv = base64::encode_config(iv, base64::URL_SAFE_NO_PAD);
-        Ok(format!("{}..{}.{}.{}", header, iv, ciphertext, tag))
+    pub fn get_public_key_jwk(&self) -> Result<Jwk> {
+        Ok(jwcrypto::ec::extract_pub_key_jwk(&self.key_pair)?)
     }
 
     pub fn decrypt_keys_jwe(self, jwe: &str) -> Result<String> {
-        let segments: Vec<&str> = jwe.split('.').collect();
-        let header = base64::decode_config(&segments[0], base64::URL_SAFE_NO_PAD)?;
-        let protected_header: JweHeader = serde_json::from_slice(&header)?;
-        let alg = protected_header.enc;
-        let apu = protected_header.apu.unwrap_or_else(|| "".to_string());
-        let apv = protected_header.apv.unwrap_or_else(|| "".to_string());
-
-        // Part 1: Grab the x/y from the other party and construct the secret.
-        let peer_pub_key = Self::get_peer_public_from_jwk(protected_header.epk)?;
-
-        let (private_key, _) = self.key_pair.split();
-        let ikm = private_key.agree(&agreement::ECDH_P256, &peer_pub_key)?;
-        let secret = Self::get_secret_from_ikm(ikm, &apu, &apv, &alg)?;
-
-        // Part 2: decrypt the payload with the obtained secret
-        if !segments[1].is_empty() {
-            return Err(
-                ErrorKind::UnrecoverableServerError("The Encrypted Key must be empty.").into(),
-            );
-        }
-        let iv = base64::decode_config(&segments[2], base64::URL_SAFE_NO_PAD)?;
-        let ciphertext = base64::decode_config(&segments[3], base64::URL_SAFE_NO_PAD)?;
-        let auth_tag = base64::decode_config(&segments[4], base64::URL_SAFE_NO_PAD)?;
-        if auth_tag.len() != (128 / 8) {
-            return Err(
-                ErrorKind::UnrecoverableServerError("The auth tag must be 16 bytes long.").into(),
-            );
-        }
-        let opening_key = aead::OpeningKey::new(&aead::AES_256_GCM, &secret.as_ref())
-            .map_err(|_| ErrorKind::KeyImportFailed)?;
-        let mut ciphertext_and_tag = ciphertext.to_vec();
-        ciphertext_and_tag.extend(&auth_tag.to_vec());
-        let nonce = aead::Nonce::try_assume_unique_for_key(&aead::AES_256_GCM, &iv)?;
-        let aad = aead::Aad::from(segments[0].as_bytes());
-        let plaintext = aead::open(&opening_key, nonce, aad, &ciphertext_and_tag)
-            .map_err(|_| ErrorKind::AEADOpenFailure)?;
-        String::from_utf8(plaintext.to_vec()).map_err(Into::into)
-    }
-
-    fn get_secret_from_ikm(
-        ikm: InputKeyMaterial,
-        apu: &str,
-        apv: &str,
-        alg: &str,
-    ) -> Result<digest::Digest> {
-        let secret = ikm.derive(|z| {
-            let mut buf: Vec<u8> = vec![];
-            // ConcatKDF (1 iteration since keyLen <= hashLen).
-            // See rfc7518 section 4.6 for reference.
-            buf.extend_from_slice(&1u32.to_be_bytes());
-            buf.extend_from_slice(&z);
-            // otherinfo
-            buf.extend_from_slice(&(alg.len() as u32).to_be_bytes());
-            buf.extend_from_slice(alg.as_bytes());
-            buf.extend_from_slice(&(apu.len() as u32).to_be_bytes());
-            buf.extend_from_slice(apu.as_bytes());
-            buf.extend_from_slice(&(apv.len() as u32).to_be_bytes());
-            buf.extend_from_slice(apv.as_bytes());
-            buf.extend_from_slice(&256u32.to_be_bytes());
-            digest::digest(&digest::SHA256, &buf)
-        })?;
-        Ok(secret)
+        let params = DecryptionParameters::ECDH_ES {
+            local_key_pair: self.key_pair,
+        };
+        Ok(jwcrypto::decrypt_jwe(jwe, params)?)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rc_crypto::agreement::PrivateKey;
+    use rc_crypto::agreement::{KeyPair, PrivateKey};
 
     #[test]
     fn test_flow() {
@@ -262,22 +98,20 @@ mod tests {
         let private_key = PrivateKey::<rc_crypto::agreement::Static>::import(&ec_key).unwrap();
         let key_pair = KeyPair::from(private_key).unwrap();
         let flow = ScopedKeysFlow::from_static_key_pair(key_pair).unwrap();
-        let json = flow.generate_keys_jwk().unwrap();
-        assert_eq!(json, "{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"ARvGIPJ5eIFdp6YTM-INVDqwfun2R9FfCUvXbH7QCIU\",\"y\":\"hk8gP0Po8nBh-WSiTsvsyesC5c1L6fGOEVuX8FHsvTs\"}");
+        let jwk = flow.get_public_key_jwk().unwrap();
+        let Jwk::EC(ec_key_params) = jwk;
+        assert_eq!(ec_key_params.crv, "P-256");
+        assert_eq!(
+            ec_key_params.x,
+            "ARvGIPJ5eIFdp6YTM-INVDqwfun2R9FfCUvXbH7QCIU"
+        );
+        assert_eq!(
+            ec_key_params.y,
+            "hk8gP0Po8nBh-WSiTsvsyesC5c1L6fGOEVuX8FHsvTs"
+        );
 
         let jwe = "eyJhbGciOiJFQ0RILUVTIiwia2lkIjoiNFBKTTl5dGVGeUtsb21ILWd2UUtyWGZ0a0N3ak9HNHRfTmpYVXhLM1VqSSIsImVwayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6IlB3eG9Na1RjSVZ2TFlKWU4wM2R0Y3o2TEJrR0FHaU1hZWlNQ3lTZXEzb2MiLCJ5IjoiLUYtTllRRDZwNUdSQ2ZoYm1hN3NvNkhxdExhVlNub012S0pFcjFBeWlaSSJ9LCJlbmMiOiJBMjU2R0NNIn0..b9FPhjjpmAmo_rP8.ur9jTry21Y2trvtcanSFmAtiRfF6s6qqyg6ruRal7PCwa7PxDzAuMN6DZW5BiK8UREOH08-FyRcIgdDOm5Zq8KwVAn56PGfcH30aNDGQNkA_mpfjx5Tj2z8kI6ryLWew4PGZb-PsL1g-_eyXhktq7dAhetjNYttKwSREWQFokv7N3nJGpukBqnwL1ost-MjDXlINZLVJKAiMHDcu-q7Epitwid2c2JVGOSCJjbZ4-zbxVmZ4o9xhFb2lbvdiaMygH6bPlrjEK99uT6XKtaIZmyDwftbD6G3x4On-CqA2TNL6ILRaJMtmyX--ctL0IrngUIHg_F0Wz94v.zBD8NACkUcZTPLH0tceGnA";
         let keys = flow.decrypt_keys_jwe(jwe).unwrap();
         assert_eq!(keys, "{\"https://identity.mozilla.com/apps/oldsync\":{\"kty\":\"oct\",\"scope\":\"https://identity.mozilla.com/apps/oldsync\",\"k\":\"8ek1VNk4sjrNP0DhGC4crzQtwmpoR64zHuFMHb4Tw-exR70Z2SSIfMSrJDTLEZid9lD05-hbA3n2Q4Esjlu1tA\",\"kid\":\"1526414944666-zgTjf5oXmPmBjxwXWFsDWg\"}}");
-    }
-
-    #[test]
-    fn test_encrypt_decrypt_jwe() {
-        let sk = ScopedKeysFlow::with_random_key().unwrap();
-        let jwk = sk.generate_keys_jwk().unwrap();
-        let other_sk = ScopedKeysFlow::with_random_key().unwrap();
-        let data = b"The big brown fox jumped over... What?";
-        let encrypted = other_sk.encrypt_keys_jwe(&jwk, data).unwrap();
-        let decrypted = sk.decrypt_keys_jwe(&encrypted).unwrap();
-        assert_eq!(decrypted, std::str::from_utf8(data).unwrap());
     }
 }

--- a/components/fxa-client/src/util.rs
+++ b/components/fxa-client/src/util.rs
@@ -23,7 +23,7 @@ pub fn now_secs() -> u64 {
 
 pub fn random_base64_url_string(len: usize) -> Result<String> {
     let mut out = vec![0u8; len];
-    rand::fill(&mut out).map_err(|_| ErrorKind::RngFailure)?;
+    rand::fill(&mut out)?;
     Ok(base64::encode_config(&out, base64::URL_SAFE_NO_PAD))
 }
 

--- a/components/support/jwcrypto/Cargo.toml
+++ b/components/support/jwcrypto/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "jwcrypto"
+version = "0.1.0"
+authors = ["Edouard Oger <eoger@fastmail.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["lib"]
+
+[dependencies]
+base64 = "0.12"
+rc_crypto = { path = "../rc_crypto" }
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
+thiserror = "1.0"

--- a/components/support/jwcrypto/src/ec.rs
+++ b/components/support/jwcrypto/src/ec.rs
@@ -1,0 +1,193 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{
+    error::{JwCryptoError, Result},
+    Algorithm, CompactJwe, DecryptionParameters, EncryptionAlgorithm, EncryptionParameters,
+    JweHeader, Jwk,
+};
+use rc_crypto::{
+    aead,
+    agreement::{self, EphemeralKeyPair, InputKeyMaterial},
+    digest, rand,
+};
+use serde_derive::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct ECKeysParameters {
+    pub crv: String,
+    pub x: String,
+    pub y: String,
+}
+
+pub(crate) fn encrypt_to_jwe(
+    data: &[u8],
+    encryption_params: EncryptionParameters,
+) -> Result<CompactJwe> {
+    let EncryptionParameters::ECDH_ES { enc, peer_jwk } = encryption_params;
+    let local_key_pair = EphemeralKeyPair::generate(&agreement::ECDH_P256)?;
+    let local_public_key = extract_pub_key_jwk(&local_key_pair)?;
+    let protected_header = JweHeader {
+        alg: Algorithm::ECDH_ES,
+        enc,
+        epk: Some(local_public_key),
+        apu: None,
+        apv: None,
+    };
+
+    let Jwk::EC(ec_key_params) = peer_jwk;
+    let secret = derive_shared_secret(&protected_header, local_key_pair, &ec_key_params)?;
+
+    let encryption_algorithm = match protected_header.enc {
+        EncryptionAlgorithm::A256GCM => &aead::AES_256_GCM,
+    };
+    let sealing_key = aead::SealingKey::new(encryption_algorithm, &secret.as_ref())?;
+    let additional_data = serde_json::to_string(&protected_header)?;
+    let additional_data =
+        base64::encode_config(additional_data.as_bytes(), base64::URL_SAFE_NO_PAD);
+    let additional_data = additional_data.as_bytes();
+    let aad = aead::Aad::from(additional_data);
+    let mut iv: Vec<u8> = vec![0; 12];
+    rand::fill(&mut iv)?;
+    let nonce = aead::Nonce::try_assume_unique_for_key(encryption_algorithm, &iv)?;
+    let mut encrypted = aead::seal(&sealing_key, nonce, aad, data)?;
+
+    let tag_idx = encrypted.len() - encryption_algorithm.tag_len();
+    let auth_tag = encrypted.split_off(tag_idx);
+    let ciphertext = encrypted;
+
+    Ok(CompactJwe::new(
+        Some(protected_header),
+        None,
+        Some(iv),
+        ciphertext,
+        Some(auth_tag),
+    )?)
+}
+
+pub(crate) fn decrypt_jwe(
+    jwe: &CompactJwe,
+    decryption_params: DecryptionParameters,
+) -> Result<String> {
+    let DecryptionParameters::ECDH_ES { local_key_pair } = decryption_params;
+
+    let protected_header = jwe
+        .protected_header()?
+        .ok_or_else(|| JwCryptoError::IllegalState("protected_header must be present."))?;
+    if protected_header.alg != Algorithm::ECDH_ES {
+        return Err(JwCryptoError::IllegalState("alg mismatch."));
+    }
+
+    // Part 1: Reconstruct the secret.
+    let peer_jwk = protected_header
+        .epk
+        .as_ref()
+        .ok_or_else(|| JwCryptoError::IllegalState("epk not present"))?;
+    let Jwk::EC(ec_key_params) = peer_jwk;
+    let secret = derive_shared_secret(&protected_header, local_key_pair, &ec_key_params)?;
+
+    // Part 2: decrypt the payload
+    if jwe.encrypted_key()?.is_some() {
+        return Err(JwCryptoError::IllegalState(
+            "The Encrypted Key must be empty.",
+        ));
+    }
+    let encryption_algorithm = match protected_header.enc {
+        EncryptionAlgorithm::A256GCM => &aead::AES_256_GCM,
+    };
+    let auth_tag = jwe
+        .auth_tag()?
+        .ok_or_else(|| JwCryptoError::IllegalState("auth_tag must be present."))?;
+    if auth_tag.len() != encryption_algorithm.tag_len() {
+        return Err(JwCryptoError::IllegalState(
+            "The auth tag must be 16 bytes long.",
+        ));
+    }
+    let iv = jwe
+        .iv()?
+        .ok_or_else(|| JwCryptoError::IllegalState("iv must be present."))?;
+    let opening_key = aead::OpeningKey::new(&encryption_algorithm, &secret.as_ref())?;
+    let ciphertext_and_tag: Vec<u8> = [jwe.ciphertext()?, auth_tag].concat();
+    let nonce = aead::Nonce::try_assume_unique_for_key(&encryption_algorithm, &iv)?;
+    let aad = aead::Aad::from(jwe.protected_header_raw().as_bytes());
+    let plaintext = aead::open(&opening_key, nonce, aad, &ciphertext_and_tag)?;
+    Ok(String::from_utf8(plaintext.to_vec())?)
+}
+
+fn derive_shared_secret(
+    protected_header: &JweHeader,
+    local_key_pair: EphemeralKeyPair,
+    peer_key: &ECKeysParameters,
+) -> Result<digest::Digest> {
+    let (private_key, _) = local_key_pair.split();
+    let peer_public_key = public_key_from_ec_params(peer_key)?;
+    // Note: We don't support key-wrapping, but if we did `algorithm_id` would be `alg` instead.
+    let algorithm_id = protected_header.enc.algorithm_id();
+    let ikm = private_key.agree(&agreement::ECDH_P256, &peer_public_key)?;
+    let apu = protected_header.apu.as_deref().unwrap_or_default();
+    let apv = protected_header.apv.as_deref().unwrap_or_default();
+    get_secret_from_ikm(ikm, &apu, &apv, &algorithm_id)
+}
+
+fn public_key_from_ec_params(jwk: &ECKeysParameters) -> Result<Vec<u8>> {
+    let x = base64::decode_config(&jwk.x, base64::URL_SAFE_NO_PAD)?;
+    let y = base64::decode_config(&jwk.y, base64::URL_SAFE_NO_PAD)?;
+    if jwk.crv != "P-256" {
+        return Err(JwCryptoError::PartialImplementation(
+            "Only P-256 curves are supported.",
+        ));
+    }
+    if x.len() != (256 / 8) {
+        return Err(JwCryptoError::IllegalState("X must be 32 bytes long."));
+    }
+    if y.len() != (256 / 8) {
+        return Err(JwCryptoError::IllegalState("Y must be 32 bytes long."));
+    }
+    let mut peer_pub_key: Vec<u8> = vec![0x04];
+    peer_pub_key.extend_from_slice(&x);
+    peer_pub_key.extend_from_slice(&y);
+    Ok(peer_pub_key)
+}
+
+fn get_secret_from_ikm(
+    ikm: InputKeyMaterial,
+    apu: &str,
+    apv: &str,
+    alg: &str,
+) -> Result<digest::Digest> {
+    let secret = ikm.derive(|z| {
+        let mut buf: Vec<u8> = vec![];
+        // ConcatKDF (1 iteration since keyLen <= hashLen).
+        // See rfc7518 section 4.6 for reference.
+        buf.extend_from_slice(&1u32.to_be_bytes());
+        buf.extend_from_slice(&z);
+        // otherinfo
+        buf.extend_from_slice(&(alg.len() as u32).to_be_bytes());
+        buf.extend_from_slice(alg.as_bytes());
+        buf.extend_from_slice(&(apu.len() as u32).to_be_bytes());
+        buf.extend_from_slice(apu.as_bytes());
+        buf.extend_from_slice(&(apv.len() as u32).to_be_bytes());
+        buf.extend_from_slice(apv.as_bytes());
+        buf.extend_from_slice(&256u32.to_be_bytes());
+        digest::digest(&digest::SHA256, &buf)
+    })?;
+    Ok(secret)
+}
+
+pub fn extract_pub_key_jwk(key_pair: &EphemeralKeyPair) -> Result<Jwk> {
+    let pub_key_bytes = key_pair.public_key().to_bytes()?;
+    // Uncompressed form (see SECG SEC1 section 2.3.3).
+    // First byte is 4, then 32 bytes for x, and 32 bytes for y.
+    assert_eq!(pub_key_bytes.len(), 1 + 32 + 32);
+    assert_eq!(pub_key_bytes[0], 0x04);
+    let x = Vec::from(&pub_key_bytes[1..33]);
+    let x = base64::encode_config(&x, base64::URL_SAFE_NO_PAD);
+    let y = Vec::from(&pub_key_bytes[33..]);
+    let y = base64::encode_config(&y, base64::URL_SAFE_NO_PAD);
+    Ok(Jwk::EC(ECKeysParameters {
+        crv: "P-256".to_owned(),
+        x,
+        y,
+    }))
+}

--- a/components/support/jwcrypto/src/error.rs
+++ b/components/support/jwcrypto/src/error.rs
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use thiserror::Error;
+
+pub(crate) type Result<T> = std::result::Result<T, JwCryptoError>;
+
+#[derive(Error, Debug)]
+pub enum JwCryptoError {
+    #[error("Deserialization error")]
+    DeserializationError,
+    #[error("Illegal state error: {0}")]
+    IllegalState(&'static str),
+    #[error("Partial implementation error: {0}")]
+    PartialImplementation(&'static str),
+    #[error("Base64 decode error: {0}")]
+    Base64Decode(#[from] base64::DecodeError),
+    #[error("Crypto error: {0}")]
+    CryptoError(#[from] rc_crypto::Error),
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("UTF8 decode error: {0}")]
+    UTF8DecodeError(#[from] std::string::FromUtf8Error),
+}

--- a/components/support/jwcrypto/src/lib.rs
+++ b/components/support/jwcrypto/src/lib.rs
@@ -55,15 +55,27 @@ impl EncryptionAlgorithm {
 struct JweHeader {
     alg: Algorithm,
     enc: EncryptionAlgorithm,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kid: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     epk: Option<Jwk>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     apu: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     apv: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct Jwk {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kid: Option<String>,
+    #[serde(flatten)]
+    pub key_parameters: JwkKeyParameters,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 #[serde(tag = "kty")]
-pub enum Jwk {
-    #[serde(alias = "ec")]
+pub enum JwkKeyParameters {
     EC(ec::ECKeysParameters),
 }
 
@@ -214,6 +226,7 @@ fn test_compact_jwe_roundtrip() {
         Some(JweHeader {
             alg: Algorithm::ECDH_ES,
             enc: EncryptionAlgorithm::A256GCM,
+            kid: None,
             epk: None,
             apu: None,
             apv: None,

--- a/components/support/jwcrypto/src/lib.rs
+++ b/components/support/jwcrypto/src/lib.rs
@@ -1,0 +1,230 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Theorically, everything done in this crate could and should be done in a JWT library.
+//! However, none of the existing rust JWT libraries can handle ECDH-ES encryption, and API choices
+//! made by their authors make it difficult to add this feature.
+//! In the past, we chose cjose to do that job, but it added three C dependencies to build and link
+//! against: jansson, openssl and cjose itself.
+
+pub use error::JwCryptoError;
+use error::Result;
+use rc_crypto::agreement::EphemeralKeyPair;
+use serde_derive::{Deserialize, Serialize};
+use std::str::FromStr;
+
+pub mod ec;
+mod error;
+
+pub enum EncryptionParameters {
+    // ECDH-ES in Direct Key Agreement mode.
+    #[allow(non_camel_case_types)]
+    ECDH_ES {
+        enc: EncryptionAlgorithm,
+        peer_jwk: Jwk,
+    },
+}
+
+pub enum DecryptionParameters {
+    // ECDH-ES in Direct Key Agreement mode.
+    #[allow(non_camel_case_types)]
+    ECDH_ES { local_key_pair: EphemeralKeyPair },
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+enum Algorithm {
+    #[serde(rename = "ECDH-ES")]
+    #[allow(non_camel_case_types)]
+    ECDH_ES,
+}
+#[derive(Serialize, Deserialize, Debug)]
+pub enum EncryptionAlgorithm {
+    A256GCM,
+}
+
+impl EncryptionAlgorithm {
+    fn algorithm_id(&self) -> &'static str {
+        match self {
+            Self::A256GCM => "A256GCM",
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JweHeader {
+    alg: Algorithm,
+    enc: EncryptionAlgorithm,
+    epk: Option<Jwk>,
+    apu: Option<String>,
+    apv: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "kty")]
+pub enum Jwk {
+    #[serde(alias = "ec")]
+    EC(ec::ECKeysParameters),
+}
+
+#[derive(Debug)]
+pub struct CompactJwe {
+    jwe_segments: Vec<String>,
+}
+
+impl CompactJwe {
+    // A builder pattern would be nicer, but this will do for now.
+    fn new(
+        protected_header: Option<JweHeader>,
+        encrypted_key: Option<Vec<u8>>,
+        iv: Option<Vec<u8>>,
+        ciphertext: Vec<u8>,
+        auth_tag: Option<Vec<u8>>,
+    ) -> Result<Self> {
+        let protected_header = protected_header
+            .as_ref()
+            .map(|h| serde_json::to_string(&h))
+            .transpose()?
+            .map(|h| base64::encode_config(&h, base64::URL_SAFE_NO_PAD))
+            .unwrap_or_default();
+        let encrypted_key = encrypted_key
+            .as_ref()
+            .map(|k| base64::encode_config(&k, base64::URL_SAFE_NO_PAD))
+            .unwrap_or_default();
+        let iv = iv
+            .as_ref()
+            .map(|iv| base64::encode_config(&iv, base64::URL_SAFE_NO_PAD))
+            .unwrap_or_default();
+        let ciphertext = base64::encode_config(&ciphertext, base64::URL_SAFE_NO_PAD);
+        let auth_tag = auth_tag
+            .as_ref()
+            .map(|t| base64::encode_config(&t, base64::URL_SAFE_NO_PAD))
+            .unwrap_or_default();
+        let jwe_segments = vec![protected_header, encrypted_key, iv, ciphertext, auth_tag];
+        Ok(Self { jwe_segments })
+    }
+
+    fn protected_header(&self) -> Result<Option<JweHeader>> {
+        Ok(self
+            .try_deserialize_base64_segment(0)?
+            .map(|s| serde_json::from_slice(&s))
+            .transpose()?)
+    }
+
+    fn protected_header_raw(&self) -> &str {
+        &self.jwe_segments[0]
+    }
+
+    fn encrypted_key(&self) -> Result<Option<Vec<u8>>> {
+        self.try_deserialize_base64_segment(1)
+    }
+
+    fn iv(&self) -> Result<Option<Vec<u8>>> {
+        self.try_deserialize_base64_segment(2)
+    }
+
+    fn ciphertext(&self) -> Result<Vec<u8>> {
+        Ok(self
+            .try_deserialize_base64_segment(3)?
+            .ok_or_else(|| JwCryptoError::IllegalState("Ciphertext is empty"))?)
+    }
+
+    fn auth_tag(&self) -> Result<Option<Vec<u8>>> {
+        self.try_deserialize_base64_segment(4)
+    }
+
+    fn try_deserialize_base64_segment(&self, index: usize) -> Result<Option<Vec<u8>>> {
+        Ok(match self.jwe_segments[index].is_empty() {
+            true => None,
+            false => Some(base64::decode_config(
+                &self.jwe_segments[index],
+                base64::URL_SAFE_NO_PAD,
+            )?),
+        })
+    }
+}
+
+impl FromStr for CompactJwe {
+    type Err = JwCryptoError;
+    fn from_str(str: &str) -> Result<Self> {
+        let jwe_segments: Vec<String> = str.split('.').map(|s| s.to_owned()).collect();
+        if jwe_segments.len() != 5 {
+            return Err(JwCryptoError::DeserializationError);
+        }
+        Ok(Self { jwe_segments })
+    }
+}
+
+impl ToString for CompactJwe {
+    fn to_string(&self) -> String {
+        assert!(self.jwe_segments.len() == 5);
+        self.jwe_segments.join(".")
+    }
+}
+
+/// Encrypt and serialize data in the JWE compact form.
+pub fn encrypt_to_jwe(data: &[u8], encryption_params: EncryptionParameters) -> Result<String> {
+    let jwe = match encryption_params {
+        EncryptionParameters::ECDH_ES { .. } => ec::encrypt_to_jwe(data, encryption_params)?,
+    };
+    Ok(jwe.to_string())
+}
+
+/// Deserialize and decrypt data in the JWE compact form.
+pub fn decrypt_jwe(jwe: &str, decryption_params: DecryptionParameters) -> Result<String> {
+    let jwe = jwe.parse()?;
+    Ok(match decryption_params {
+        DecryptionParameters::ECDH_ES { .. } => ec::decrypt_jwe(&jwe, decryption_params)?,
+    })
+}
+
+#[test]
+fn test_encrypt_decrypt_jwe_ecdh_es() {
+    use rc_crypto::agreement;
+    let key_pair = EphemeralKeyPair::generate(&agreement::ECDH_P256).unwrap();
+    let jwk = ec::extract_pub_key_jwk(&key_pair).unwrap();
+    let data = b"The big brown fox jumped over... What?";
+    let encrypted = encrypt_to_jwe(
+        data,
+        EncryptionParameters::ECDH_ES {
+            enc: EncryptionAlgorithm::A256GCM,
+            peer_jwk: jwk,
+        },
+    )
+    .unwrap();
+    let decrypted = decrypt_jwe(
+        &encrypted,
+        DecryptionParameters::ECDH_ES {
+            local_key_pair: key_pair,
+        },
+    )
+    .unwrap();
+    assert_eq!(decrypted, std::str::from_utf8(data).unwrap());
+}
+
+#[test]
+fn test_compact_jwe_roundtrip() {
+    let mut iv = [0u8; 16];
+    rc_crypto::rand::fill(&mut iv).unwrap();
+    let mut ciphertext = [0u8; 243];
+    rc_crypto::rand::fill(&mut ciphertext).unwrap();
+    let mut auth_tag = [0u8; 16];
+    rc_crypto::rand::fill(&mut auth_tag).unwrap();
+    let jwe = CompactJwe::new(
+        Some(JweHeader {
+            alg: Algorithm::ECDH_ES,
+            enc: EncryptionAlgorithm::A256GCM,
+            epk: None,
+            apu: None,
+            apv: None,
+        }),
+        None,
+        Some(iv.to_vec()),
+        ciphertext.to_vec(),
+        Some(auth_tag.to_vec()),
+    )
+    .unwrap();
+    let compacted = jwe.to_string();
+    let jwe2: CompactJwe = compacted.parse().unwrap();
+    assert_eq!(jwe.jwe_segments, jwe2.jwe_segments);
+}

--- a/components/support/rc_crypto/src/agreement.rs
+++ b/components/support/rc_crypto/src/agreement.rs
@@ -24,6 +24,8 @@ use core::marker::PhantomData;
 pub use ec::{Curve, EcKey};
 use nss::{ec, ecdh};
 
+pub type EphemeralKeyPair = KeyPair<Ephemeral>;
+
 /// A key agreement algorithm.
 #[derive(PartialEq)]
 pub struct Algorithm {


### PR DESCRIPTION
I was trying to understand how the newest changes to our JWstuff worked, so as usual I refactored it :) Specifically, this removes the JWE bits from the Scoped Keys module to go on its own.