### PR TITLE
Fix warnings from nightly rust

### DIFF
--- a/components/rc_log/src/lib.rs
+++ b/components/rc_log/src/lib.rs
@@ -116,11 +116,13 @@ pub extern "C" fn rc_log_adapter_set_max_level(level: i32, out_err: &mut ffi_sup
 // Can't use define_box_destructor because this can panic. TODO: Maybe we should
 // keep this around globally (as lazy_static or something) and basically just
 // turn it on/off in create/destroy... Might be more reliable?
+/// # Safety
+/// Unsafe because it frees it's argument.
 #[no_mangle]
-pub extern "C" fn rc_log_adapter_destroy(to_destroy: Option<Box<imp::LogAdapterState>>) {
+pub unsafe extern "C" fn rc_log_adapter_destroy(to_destroy: *mut imp::LogAdapterState) {
     ffi_support::abort_on_panic::call_with_output(move || {
         log::set_max_level(log::LevelFilter::Off);
-        drop(to_destroy);
+        drop(Box::from_raw(to_destroy));
         settable_log::unset_logger();
     })
 }

--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -373,10 +373,7 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
         let changes = state_machine.changes_needed.take();
         // The state machine might have updated our persisted_global_state, so
         // update the caller's repr of it.
-        let _ = mem::replace(
-            self.persisted_global_state,
-            Some(serde_json::to_string(&pgs)?),
-        );
+        *self.persisted_global_state = Some(serde_json::to_string(&pgs)?);
 
         // Now that we've gone through the state machine, store the declined list in
         // the sync_result


### PR DESCRIPTION
As part of doing #3327 I've seen these many times in nightly builds. No reason not to just fix them.

The `rc_log_adapter_destroy` is surprising but I gather it's because `imp::LogAdapterState` isn't FFI safe, even though the Option<Box<T>> construct is. Oh well.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
