### PR TITLE
Clear devices and client cache more aggressively

### DIFF
--- a/components/fxa-client/src/oauth.rs
+++ b/components/fxa-client/src/oauth.rs
@@ -429,6 +429,7 @@ impl FirefoxAccount {
         });
         self.state.session_token = Some(session_token.to_owned());
         self.clear_access_token_cache();
+        self.clear_devices_and_attached_clients_cache();
         // When our keys change, we might need to re-register device capabilities with the server.
         // Ensure that this happens on the next call to ensure_capabilities.
         self.state.device_capabilities.clear();

--- a/components/fxa-client/src/profile.rs
+++ b/components/fxa-client/src/profile.rs
@@ -27,6 +27,7 @@ impl FirefoxAccount {
                         "Access token rejected, clearing the tokens cache and trying again."
                     );
                     self.clear_access_token_cache();
+                    self.clear_devices_and_attached_clients_cache();
                     self.get_profile_helper(ignore_cache)
                 }
                 _ => Err(e),


### PR DESCRIPTION
Adds this improvement to minimize the cases where we show cached data and the account had a password reset.

@lougeniaC64 r?

Fixes #3348
