### PR TITLE
Add Swift bindings for `fxa_gather_telemetry`

### DIFF
--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -329,6 +329,17 @@ open class FxAccountManager {
         }
     }
 
+    /// Returns a JSON string containing telemetry events to submit in the next
+    /// Sync ping. This is used to collect telemetry for services like Send Tab.
+    /// This method can be called anytime, and returns `nil` if the account is
+    /// not initialized or there are no events to record.
+    public func gatherTelemetry() throws -> String? {
+        guard let acct = account else {
+            return nil
+        }
+        return try acct.gatherTelemetry()
+    }
+
     let fxaFsmQueue = DispatchQueue(label: "com.mozilla.fxa-mgr-queue")
 
     internal func processEvent(event: Event, completionHandler: @escaping () -> Void) {

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -165,8 +165,8 @@ char *_Nullable fxa_get_manage_devices_url(FirefoxAccountHandle handle,
                                            const char *_Nonnull entrypoint,
                                            FxAError *_Nonnull out);
 
-char *fxa_gather_telemetry(FirefoxAccountHandle handle,
-                           FxAError *_Nonnull out);
+char *_Nullable fxa_gather_telemetry(FirefoxAccountHandle handle,
+                                     FxAError *_Nonnull out);
 
 void fxa_str_free(char *_Nullable ptr);
 void fxa_free(FirefoxAccountHandle h, FxAError *_Nonnull out);

--- a/components/fxa-client/ios/FxAClient/RustFxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/RustFxAccount.swift
@@ -342,6 +342,14 @@ open class RustFxAccount {
         }
     }
 
+    open func gatherTelemetry() throws -> String? {
+        let maybeEvents = try nullableRustCall { err in fxa_gather_telemetry(self.raw, err) }
+        guard let events = maybeEvents else {
+            return nil
+        }
+        return String(freeingFxaString: events)
+    }
+
     private func msgToBuffer(msg: SwiftProtobuf.Message) -> (Data, Int32) {
         let data = try! msg.serializedData()
         let size = Int32(data.count)


### PR DESCRIPTION
Looks like this got lost in the shuffle; just the iOS bits from #3308.