### PR TITLE
fix swiftformat after update

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -20,6 +20,8 @@ disabled_rules:
   - todo
   # It disagrees with swiftformat on this, and thinks trailing commas are bad...
   - trailing_comma
+  # It disagrees with swiftformat on this, and wants the opening braces to be on the same line in multiline declarations
+  - opening_brace
 
 identifier_name:
   # Turn off it complaining about `id` or `let t = title`, etc, but keep

--- a/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
@@ -119,7 +119,8 @@ public class DeviceConstellation {
     /// Once Push has decrypted a payload, send the payload to this method
     /// which will tell the app what to do with it in form of `DeviceEvents`.
     public func processRawIncomingAccountEvent(pushPayload: String,
-                                               completionHandler: @escaping (Result<[AccountEvent], Error>) -> Void) {
+                                               completionHandler: @escaping (Result<[AccountEvent], Error>) -> Void)
+    {
         DispatchQueue.global().async {
             do {
                 let events = try self.account.handlePushMessage(payload: pushPayload)

--- a/components/logins/ios/Logins/LoginRecord.swift
+++ b/components/logins/ios/Logins/LoginRecord.swift
@@ -156,7 +156,8 @@ open class LoginRecord {
          timeCreated: Int64?,
          timePasswordChanged: Int64?,
          usernameField: String,
-         passwordField: String) {
+         passwordField: String)
+    {
         self.id = id
         self.password = password
         self.hostname = hostname
@@ -179,7 +180,8 @@ open class LoginRecord {
 
     public static func fromJSONArray(_ jsonArray: String) throws -> [LoginRecord] {
         if let arr = try JSONSerialization.jsonObject(with: jsonArray.data(using: .utf8)!,
-                                                      options: []) as? [[String: Any]] {
+                                                      options: []) as? [[String: Any]]
+        {
             return arr.map { (dict) -> LoginRecord in
                 LoginRecord(fromJSONDict: dict)
             }

--- a/components/places/ios/Places/Bookmark.swift
+++ b/components/places/ios/Places/Bookmark.swift
@@ -80,7 +80,8 @@ public class BookmarkNode {
                      dateAdded: Int64,
                      lastModified: Int64,
                      parentGUID: String?,
-                     position: UInt32) {
+                     position: UInt32)
+    {
         self.type = type
         self.guid = guid
         self.dateAdded = dateAdded
@@ -146,7 +147,8 @@ public class BookmarkItem: BookmarkNode {
                 parentGUID: String?,
                 position: UInt32,
                 url: String,
-                title: String) {
+                title: String)
+    {
         self.url = url
         self.title = title
         super.init(
@@ -198,7 +200,8 @@ public class BookmarkFolder: BookmarkNode {
                 position: UInt32,
                 title: String,
                 childGUIDs: [String],
-                children: [BookmarkNode]?) {
+                children: [BookmarkNode]?)
+    {
         self.title = title
         self.childGUIDs = childGUIDs
         self.children = children

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -629,7 +629,8 @@ public class PlacesWriteConnection: PlacesReadConnection {
     @discardableResult
     open func createFolder(parentGUID: String,
                            title: String,
-                           position: UInt32? = nil) throws -> String {
+                           position: UInt32? = nil) throws -> String
+    {
         return try queue.sync {
             try self.checkApi()
             var msg = insertionMsg(type: .folder, parentGUID: parentGUID, position: position)
@@ -707,7 +708,8 @@ public class PlacesWriteConnection: PlacesReadConnection {
     open func createBookmark(parentGUID: String,
                              url: String,
                              title: String?,
-                             position: UInt32? = nil) throws -> String {
+                             position: UInt32? = nil) throws -> String
+    {
         return try queue.sync {
             try self.checkApi()
             var msg = insertionMsg(type: .bookmark, parentGUID: parentGUID, position: position)
@@ -774,7 +776,8 @@ public class PlacesWriteConnection: PlacesReadConnection {
                                  parentGUID: String? = nil,
                                  position: UInt32? = nil,
                                  title: String? = nil,
-                                 url: String? = nil) throws {
+                                 url: String? = nil) throws
+    {
         try queue.sync {
             try self.checkApi()
             var msg = MsgTypes_BookmarkNode()
@@ -818,7 +821,8 @@ public class PlacesWriteConnection: PlacesReadConnection {
     // Remove the boilerplate common for all insertion messages
     private func insertionMsg(type: BookmarkNodeType,
                               parentGUID: String,
-                              position: UInt32?) -> MsgTypes_BookmarkNode {
+                              position: UInt32?) -> MsgTypes_BookmarkNode
+    {
         var msg = MsgTypes_BookmarkNode()
         msg.nodeType = type.rawValue
         msg.parentGuid = parentGUID


### PR DESCRIPTION
Runs updated `swiftformat` to fix lint errors that showed up after `swiftformat` got an update.

Also modifies the `swiftlint` rules to exclude `opening_braces` which contradicts with what `swiftformat` wants
