### PR TITLE
Land changes for future 61.0.11 release

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,19 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.10...main)
+
+ ## FxA Client
+
+### What's new ###
+- Send-tab metrics are recorded. A new function, `fxa_gather_telemetry` on the
+  account object (exposed as `account.gatherTelemetry()` to Kotlin) which
+  returns a string of JSON.
+
+  This JSON might grow to support non-sendtab telemetry in the future, but in
+  this change it has:
+  - `commands_sent`, an array of objects, each with `flow_id` and `stream_id`
+    string values.
+  - `commands_received`, an array of objects, each with `flow_id`, `stream_id`
+    and `reason` string values.
+
+  [#3308](https://github.com/mozilla/application-services/pull/3308/)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sync-guid",
  "sync15",
  "thiserror",
  "url",

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,6 +24,7 @@ rc_crypto = { path = "../support/rc_crypto", features = ["ece", "hawk"] }
 error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
+sync-guid = { path = "../support/guid", features = ["random"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -587,6 +587,18 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
         }
     }
 
+    /**
+     * Gather any telemetry which has been collected internally and return
+     * the result as a JSON string.
+     *
+     * This does not make network requests, and can be used on the main thread.
+     */
+    fun gatherTelemetry(): String {
+        return rustCallWithLock { e ->
+            LibFxAFFI.INSTANCE.fxa_gather_telemetry(this.handle.get(), e)
+        }.getAndConsumeRustString()
+    }
+
     @Synchronized
     override fun close() {
         val handle = this.handle.getAndSet(0)

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/rust/LibFxAFFI.kt
@@ -103,6 +103,8 @@ internal interface LibFxAFFI : Library {
 
     fun fxa_retry_migrate_from_session_token(fxa: FxaHandle, e: RustError.ByReference): Pointer?
 
+    fun fxa_gather_telemetry(fxa: FxaHandle, e: RustError.ByReference): Pointer?
+
     fun fxa_str_free(string: Pointer)
     fun fxa_bytebuffer_free(buffer: RustBuffer.ByValue)
     fun fxa_free(fxa: FxaHandle, err: RustError.ByReference)

--- a/components/fxa-client/examples/devices_api.rs
+++ b/components/fxa-client/examples/devices_api.rs
@@ -92,7 +92,7 @@ fn main() -> Result<()> {
                 let evts = acct
                     .lock()
                     .unwrap()
-                    .poll_device_commands()
+                    .poll_device_commands(device::CommandFetchReason::Poll)
                     .unwrap_or_else(|_| vec![]); // Ignore 404 errors for now.
                 persist_fxa_state(&acct.lock().unwrap());
                 for e in evts {

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -302,6 +302,17 @@ open class FxAccountManager {
         }
     }
 
+    /// Returns a JSON string containing telemetry events to submit in the next
+    /// Sync ping. This is used to collect telemetry for services like Send Tab.
+    /// This method can be called anytime, and returns `nil` if the account is
+    /// not initialized or there are no events to record.
+    public func gatherTelemetry() throws -> String? {
+        guard let acct = account else {
+            return nil
+        }
+        return try acct.gatherTelemetry()
+    }
+
     let fxaFsmQueue = DispatchQueue(label: "com.mozilla.fxa-mgr-queue")
 
     internal func processEvent(event: Event, completionHandler: @escaping () -> Void) {

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -163,8 +163,8 @@ char *_Nullable fxa_get_manage_devices_url(FirefoxAccountHandle handle,
                                            const char *_Nonnull entrypoint,
                                            FxAError *_Nonnull out);
 
-char *fxa_gather_telemetry(FirefoxAccountHandle handle,
-                           FxAError *_Nonnull out);
+char *_Nullable fxa_gather_telemetry(FirefoxAccountHandle handle,
+                                     FxAError *_Nonnull out);
 
 void fxa_str_free(char *_Nullable ptr);
 void fxa_free(FirefoxAccountHandle h, FxAError *_Nonnull out);

--- a/components/fxa-client/ios/FxAClient/RustFxAFFI.h
+++ b/components/fxa-client/ios/FxAClient/RustFxAFFI.h
@@ -163,6 +163,9 @@ char *_Nullable fxa_get_manage_devices_url(FirefoxAccountHandle handle,
                                            const char *_Nonnull entrypoint,
                                            FxAError *_Nonnull out);
 
+char *fxa_gather_telemetry(FirefoxAccountHandle handle,
+                           FxAError *_Nonnull out);
+
 void fxa_str_free(char *_Nullable ptr);
 void fxa_free(FirefoxAccountHandle h, FxAError *_Nonnull out);
 void fxa_bytebuffer_free(FxARustBuffer buffer);

--- a/components/fxa-client/ios/FxAClient/RustFxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/RustFxAccount.swift
@@ -305,6 +305,14 @@ open class RustFxAccount {
         }
     }
 
+    open func gatherTelemetry() throws -> String? {
+        let maybeEvents = try nullableRustCall { err in fxa_gather_telemetry(self.raw, err) }
+        guard let events = maybeEvents else {
+            return nil
+        }
+        return String(freeingFxaString: events)
+    }
+
     private func msgToBuffer(msg: SwiftProtobuf.Message) -> (Data, Int32) {
         let data = try! msg.serializedData()
         let size = Int32(data.count)

--- a/components/fxa-client/src/send_tab.rs
+++ b/components/fxa-client/src/send_tab.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     error::*,
     http_client::GetDeviceResponse,
-    scopes, FirefoxAccount, IncomingDeviceCommand,
+    scopes, telemetry, FirefoxAccount, IncomingDeviceCommand,
 };
 
 impl FirefoxAccount {
@@ -38,22 +38,30 @@ impl FirefoxAccount {
     }
 
     /// Send a single tab to another device designated by its device ID.
+    /// XXX - We need a new send_tabs_to_devices() so we can correctly record
+    /// telemetry for these cases.
+    /// This probably requires a new "Tab" struct with the title and url.
+    /// android-components has SendToAllUseCase(), so this isn't just theoretical.
+    /// See https://github.com/mozilla/application-services/issues/3402
     pub fn send_tab(&mut self, target_device_id: &str, title: &str, url: &str) -> Result<()> {
         let devices = self.get_devices(false)?;
         let target = devices
             .iter()
             .find(|d| d.id == target_device_id)
             .ok_or_else(|| ErrorKind::UnknownTargetDevice(target_device_id.to_owned()))?;
-        let payload = SendTabPayload::single_tab(title, url);
+        let (payload, sent_telemetry) = SendTabPayload::single_tab(title, url);
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
         let command_payload = send_tab::build_send_command(&oldsync_key, target, &payload)?;
-        self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)
+        self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)?;
+        self.telemetry.borrow_mut().record_tab_sent(sent_telemetry);
+        Ok(())
     }
 
     pub(crate) fn handle_send_tab_command(
         &mut self,
         sender: Option<GetDeviceResponse>,
         payload: serde_json::Value,
+        reason: telemetry::ReceivedReason,
     ) -> Result<IncomingDeviceCommand> {
         let send_tab_key: PrivateSendTabKeys =
             match self.state.commands_data.get(send_tab::COMMAND_NAME) {
@@ -67,8 +75,24 @@ impl FirefoxAccount {
             };
         let encrypted_payload: EncryptedSendTabPayload = serde_json::from_value(payload)?;
         match encrypted_payload.decrypt(&send_tab_key) {
-            Ok(payload) => Ok(IncomingDeviceCommand::TabReceived { sender, payload }),
+            Ok(payload) => {
+                // It's an incoming tab, which we record telemetry for.
+                let recd_telemetry = telemetry::ReceivedCommand {
+                    flow_id: payload.flow_id.clone(),
+                    stream_id: payload.stream_id.clone(),
+                    reason,
+                };
+                self.telemetry
+                    .borrow_mut()
+                    .record_tab_received(recd_telemetry);
+                // The telemetry IDs escape to the consumer, but that's OK...
+                Ok(IncomingDeviceCommand::TabReceived { sender, payload })
+            }
             Err(e) => {
+                // XXX - this seems ripe for telemetry collection!?
+                // It also seems like it might be possible to recover - ie, one
+                // of the reasons is that there are key mismatches. Doesn't that
+                // mean the "other" key might work?
                 log::error!("Could not decrypt Send Tab payload. Diagnosing then resetting the Send Tab keys.");
                 match self.diagnose_remote_keys(send_tab_key) {
                     Ok(_) => log::error!("Could not find the cause of the Send Tab keys issue."),

--- a/components/fxa-client/src/telemetry.rs
+++ b/components/fxa-client/src/telemetry.rs
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{error::*, FirefoxAccount};
+use serde_derive::*;
+use sync_guid::Guid;
+
+impl FirefoxAccount {
+    /// Gathers and resets telemetry for this account instance.
+    /// This should be considered a short-term solution to telemetry gathering
+    /// and should called whenever consumers expect there might be telemetry,
+    /// and it should submit the telemetry to whatever telemetry system is in
+    /// use (probably glean).
+    ///
+    /// The data is returned as a JSON string, which consumers should parse
+    /// forgivingly (eg, be tolerant of things not existing) to try and avoid
+    /// too many changes as telemetry comes and goes.
+    pub fn gather_telemetry(&mut self) -> Result<String> {
+        let telem = self.telemetry.replace(FxaTelemetry::new());
+        Ok(serde_json::to_string(&telem)?)
+    }
+}
+
+// A somewhat mixed-bag of all telemetry we want to collect. The idea is that
+// the app will "pull" telemetry via a new API whenever it thinks there might
+// be something to record.
+// It's considered a temporary solution until either we can record it directly
+// (eg, via glean) or we come up with something better.
+// Note that this means we'll lose telemetry if we crash between gathering it
+// here and the app submitting it, but that should be rare (in practice,
+// apps will submit it directly after an operation that generated telememtry)
+
+/// The reason a tab/command was received.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReceivedReason {
+    /// A push notification for the command was received.
+    Push,
+    /// Discovered while handling a push notification for a later message.
+    PushMissed,
+    /// Explicit polling for missed commands.
+    Poll,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SentCommand {
+    pub flow_id: String,
+    pub stream_id: String,
+}
+
+impl Default for SentCommand {
+    fn default() -> Self {
+        Self {
+            flow_id: Guid::random().to_string(),
+            stream_id: Guid::random().to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReceivedCommand {
+    pub flow_id: String,
+    pub stream_id: String,
+    pub reason: ReceivedReason,
+}
+
+// We have a naive strategy to avoid unbounded memory growth - the intention
+// is that if any platform lets things grow to hit these limits, it's probably
+// never going to consume anything - so it doesn't matter what we discard (ie,
+// there's no good reason to have a smarter circular buffer etc)
+const MAX_TAB_EVENTS: usize = 200;
+
+#[derive(Debug, Default, Serialize)]
+pub struct FxaTelemetry {
+    commands_sent: Vec<SentCommand>,
+    commands_received: Vec<ReceivedCommand>,
+}
+
+impl FxaTelemetry {
+    pub fn new() -> Self {
+        FxaTelemetry {
+            ..Default::default()
+        }
+    }
+
+    pub fn record_tab_sent(&mut self, sent: SentCommand) {
+        if self.commands_sent.len() < MAX_TAB_EVENTS {
+            self.commands_sent.push(sent);
+        }
+    }
+
+    pub fn record_tab_received(&mut self, recd: ReceivedCommand) {
+        if self.commands_received.len() < MAX_TAB_EVENTS {
+            self.commands_received.push(recd);
+        }
+    }
+}


### PR DESCRIPTION
I think to get sendtab telemetry we will want a 61.0.11 rather than waiting for the breaking changes in 62 to land in android-components