### PR TITLE
Improve ByteBuffer API clarity and update docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,18 +729,18 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 [[package]]
 name = "ffi-support"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "087be066eb6e85d7150f0c5400018a32802f99d688b2d3868c526f7bbfe17960"
 dependencies = [
- "backtrace",
  "lazy_static",
  "log 0.4.11",
 ]
 
 [[package]]
 name = "ffi-support"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "087be066eb6e85d7150f0c5400018a32802f99d688b2d3868c526f7bbfe17960"
+version = "0.4.1"
 dependencies = [
+ "backtrace",
  "lazy_static",
  "log 0.4.11",
 ]
@@ -750,7 +750,7 @@ name = "ffi-support-extra-test"
 version = "0.1.0"
 dependencies = [
  "env_logger",
- "ffi-support 0.4.0",
+ "ffi-support 0.4.1",
  "log 0.4.11",
  "rand 0.7.3",
  "rayon",
@@ -874,7 +874,7 @@ dependencies = [
  "anyhow",
  "base64 0.12.3",
  "error-support",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "hex",
  "jwcrypto",
  "lazy_static",
@@ -900,7 +900,7 @@ dependencies = [
 name = "fxaclient_ffi"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "fxa-client",
  "lazy_static",
  "log 0.4.11",
@@ -1231,7 +1231,7 @@ dependencies = [
  "anyhow",
  "env_logger",
  "error-support",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "interrupt-support",
  "lazy_static",
  "log 0.4.11",
@@ -1255,7 +1255,7 @@ name = "logins_ffi"
 version = "0.1.0"
 dependencies = [
  "base16",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "lazy_static",
  "log 0.4.11",
  "logins",
@@ -1725,7 +1725,7 @@ dependencies = [
  "dogear",
  "env_logger",
  "error-support",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "idna",
  "interrupt-support",
  "lazy_static",
@@ -1763,7 +1763,7 @@ dependencies = [
 name = "places-ffi"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "interrupt-support",
  "lazy_static",
  "log 0.4.11",
@@ -1941,7 +1941,7 @@ dependencies = [
  "base64 0.12.3",
  "bincode",
  "error-support",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "hex",
  "lazy_static",
  "log 0.4.11",
@@ -1965,7 +1965,7 @@ name = "push-ffi"
 version = "0.1.0"
 dependencies = [
  "base64 0.12.3",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "lazy_static",
  "log 0.4.11",
  "prost",
@@ -2202,7 +2202,7 @@ name = "rc_log_ffi"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "lazy_static",
  "log 0.4.11",
 ]
@@ -2533,7 +2533,7 @@ dependencies = [
 name = "sql-support"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "interrupt-support",
  "lazy_static",
  "log 0.4.11",
@@ -2639,7 +2639,7 @@ dependencies = [
  "base64 0.12.3",
  "env_logger",
  "error-support",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "interrupt-support",
  "lazy_static",
  "log 0.4.11",
@@ -2659,7 +2659,7 @@ name = "sync15-traits"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "log 0.4.11",
  "serde",
  "serde_json",
@@ -2673,7 +2673,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "error-support",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "interrupt-support",
  "lazy_static",
  "log 0.4.11",
@@ -2695,7 +2695,7 @@ dependencies = [
 name = "sync_manager_ffi"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "log 0.4.11",
  "logins_ffi",
  "places-ffi",
@@ -2761,7 +2761,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "error-support",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "interrupt-support",
  "log 0.4.11",
  "prost",
@@ -2780,7 +2780,7 @@ name = "tabs_ffi"
 version = "0.1.0"
 dependencies = [
  "base16",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "lazy_static",
  "log 0.4.11",
  "prost",
@@ -3108,7 +3108,7 @@ checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 name = "viaduct"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "log 0.4.11",
  "once_cell",
  "prost",
@@ -3123,7 +3123,7 @@ dependencies = [
 name = "viaduct-reqwest"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "lazy_static",
  "log 0.4.11",
  "reqwest",
@@ -3258,7 +3258,7 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "error-support",
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "interrupt-support",
  "lazy_static",
  "libsqlite3-sys",
@@ -3281,7 +3281,7 @@ dependencies = [
 name = "webext-storage-ffi"
 version = "0.1.0"
 dependencies = [
- "ffi-support 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ffi-support 0.4.0",
  "lazy_static",
  "log 0.4.11",
  "serde_json",

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffi-support"
 edition = "2018"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 description = "A crate to help expose Rust functions over the FFI."
 repository = "https://github.com/mozilla/application-services"

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -348,13 +348,26 @@ fn init_panic_handling_once() {}
 /// `i64` is used for the length instead of `u64` and `usize` because JNA has interop
 /// issues with both these types.
 ///
-/// ByteBuffer does not implement Drop. This is intentional. Memory passed into it will
-/// be leaked if it is not explicitly destroyed by calling [`ByteBuffer::destroy`]. This
-/// is because in the future, we may allow it's use for passing data into Rust code.
-/// ByteBuffer assuming ownership of the data would make this a problem.
+/// ### `Drop` is not implemented
 ///
-/// Note that alling `destroy` manually is not typically needed or recommended,
-/// and instead you should use [`define_bytebuffer_destructor!`].
+/// ByteBuffer does not implement Drop. This is intentional. Memory passed into it will
+/// be leaked if it is not explicitly destroyed by calling [`ByteBuffer::destroy`], or
+/// [`ByteBuffer::destroy_into_vec`]. This is for two reasons:
+///
+/// 1. In the future, we may allow it's use for passing data into Rust code, and
+///    `ByteBuffer` assuming ownership of the data would make this a problem.
+///
+/// 2. Automatically running destructors in unsafe code is a
+///    [frequent footgun](https://without.boats/blog/two-memory-bugs-from-ringbahn/)
+///    (among many similar issues across many crates).
+///
+/// Note that calling `destroy` manually is often not needed, as usually you should
+/// be passing these to the function defined by [`define_bytebuffer_destructor!`] from
+/// the other side of the FFI.
+///
+/// Because this type is essentially *only* useful in unsafe or FFI code (and because
+/// the most common usage pattern does not require manually managing the memory), it
+/// does not implement `Drop`.
 ///
 /// ## Layout/fields
 ///
@@ -367,21 +380,28 @@ fn init_panic_handling_once() {}
 ///
 /// ```c,no_run
 /// struct ByteBuffer {
+///     // Note: This should never be negative, but values above
+///     // INT64_MAX / i64::MAX are not allowed.
 ///     int64_t len;
-///     uint8_t *data; // note: nullable
+///     // Note: nullable!
+///     uint8_t *data;
 /// };
 /// ```
 ///
 /// In rust, there are two fields, in this order: `len: i64`, and `data: *mut u8`.
 ///
+/// For clarity, the fact that the data pointer is nullable means that `Option<ByteBuffer>` is not
+/// the same size as ByteBuffer, and additionally is not FFI-safe (the latter point is not
+/// currently guaranteed anyway as of the time of writing this comment).
+///
 /// ### Description of fields
 ///
-/// `data` is a pointer to an array of `len` bytes. Not that data can be a null pointer and therefore
+/// `data` is a pointer to an array of `len` bytes. Note that data can be a null pointer and therefore
 /// should be checked.
 ///
 /// The bytes array is allocated on the heap and must be freed on it as well. Critically, if there
-/// are multiple rust packages using being used in the same application, it *must be freed on the
-/// same heap that allocated it*, or you will corrupt both heaps.
+/// are multiple rust shared libraries using being used in the same application, it *must be freed
+/// on the same heap that allocated it*, or you will corrupt both heaps.
 ///
 /// Typically, this object is managed on the other side of the FFI (on the "FFI consumer"), which
 /// means you must expose a function to release the resources of `data` which can be done easily
@@ -410,6 +430,9 @@ impl ByteBuffer {
     /// This will panic if the buffer length (`usize`) cannot fit into a `i64`.
     #[inline]
     pub fn new_with_size(size: usize) -> Self {
+        // Note: `Vec` requires this internally on 64 bit platforms (and has a
+        // stricter requirement on 32 bit ones), so this is just to be explicit.
+        assert!(size < i64::MAX as usize);
         let mut buf = vec![];
         buf.reserve_exact(size);
         buf.resize(size, 0);
@@ -427,6 +450,11 @@ impl ByteBuffer {
     #[inline]
     pub fn from_vec(bytes: Vec<u8>) -> Self {
         use std::convert::TryFrom;
+        if bytes.is_empty() {
+            // Try and maintain the invariant that `len == 0` and
+            // `data.is_null()` are equivalent.
+            return Self::default();
+        }
         let mut buf = bytes.into_boxed_slice();
         let data = buf.as_mut_ptr();
         let len = i64::try_from(buf.len()).expect("buffer length cannot fit into a i64.");
@@ -434,16 +462,67 @@ impl ByteBuffer {
         Self { data, len }
     }
 
-    /// Convert this `ByteBuffer` into a Vec<u8>. This is the only way
-    /// to access the data from inside the buffer.
+    /// View the data inside this `ByteBuffer` as a `&[u8]`.
+    // TODO: Is it worth implementing `Deref`? Patches welcome if you need this.
     #[inline]
+    pub fn as_slice(&self) -> &[u8] {
+        if self.data.is_null() {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(self.data, self.len()) }
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        use std::convert::TryInto;
+        self.len
+            .try_into()
+            .expect("ByteBuffer length negative or overflowed")
+    }
+
+    /// View the data inside this `ByteBuffer` as a `&mut [u8]`.
+    // TODO: Is it worth implementing `DerefMut`? Patches welcome if you need this.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        if self.data.is_null() {
+            &mut []
+        } else {
+            unsafe { std::slice::from_raw_parts_mut(self.data, self.len()) }
+        }
+    }
+
+    /// Deprecated alias for [`ByteBuffer::destroy_into_vec`].
+    #[inline]
+    #[deprecated = "Name is confusing, please use `destroy_into_vec` instead"]
     pub fn into_vec(self) -> Vec<u8> {
+        self.destroy_into_vec()
+    }
+
+    /// Convert this `ByteBuffer` into a Vec<u8>, taking ownership of the
+    /// underlying memory, which will be freed using the rust allocator once the
+    /// `Vec<u8>`'s lifetime is done.
+    ///
+    /// If this is undesirable, you can do `bb.as_slice().to_vec()` to get a
+    /// `Vec<u8>` containing the this `ByteBuffer`'s underlying data.
+    ///
+    /// ## Caveats
+    ///
+    /// This is safe so long as the buffer is empty, or the data was allocated
+    /// by Rust code, e.g. this is a ByteBuffer created by
+    /// `ByteBuffer::from_vec` or `Default::default`.
+    ///
+    /// If the ByteBuffer is not allocated by the Rust allocator, then calling
+    /// this function is undefined behavior.
+    #[inline]
+    pub fn destroy_into_vec(self) -> Vec<u8> {
         if self.data.is_null() {
             vec![]
         } else {
-            // This is correct because we convert to a Box<[u8]> first, which is
-            // a design constraint of RawVec.
-            unsafe { Vec::from_raw_parts(self.data, self.len as usize, self.len as usize) }
+            let len = self.len();
+            // Safety: This is correct because we convert to a Box<[u8]> first,
+            // which is a design constraint of RawVec.
+            unsafe { Vec::from_raw_parts(self.data, len, len) }
         }
     }
 
@@ -458,12 +537,12 @@ impl ByteBuffer {
     /// by Rust code, e.g. this is a ByteBuffer created by
     /// `ByteBuffer::from_vec` or `Default::default`.
     ///
-    /// If the ByteBuffer were passed into Rust (which you shouldn't do, since
-    /// theres no way to see the data in Rust currently), then calling `destroy`
-    /// is fundamentally broken.
+    /// If the ByteBuffer were passed into Rust, then calling `destroy` is
+    /// fundamentally broken.
     #[inline]
     pub fn destroy(self) {
-        drop(self.into_vec())
+        // Note: the drop is just for clarity, of course.
+        drop(self.destroy_into_vec())
     }
 }
 
@@ -474,5 +553,48 @@ impl Default for ByteBuffer {
             len: 0 as i64,
             data: std::ptr::null_mut(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_bb_access() {
+        let mut bb = ByteBuffer::from(vec![1u8, 2, 3]);
+        assert_eq!(bb.as_slice(), &[1u8, 2, 3]);
+        assert_eq!(bb.as_mut_slice(), &mut [1u8, 2, 3]);
+        bb.as_mut_slice()[2] = 4;
+
+        // Use into_vec to cover both into_vec and destroy_into_vec.
+        #[allow(deprecated)]
+        {
+            assert_eq!(bb.into_vec(), &[1u8, 2, 4]);
+        }
+    }
+
+    #[test]
+    fn test_bb_empty() {
+        let mut bb = ByteBuffer::default();
+        assert_eq!(bb.as_slice(), &[]);
+        assert_eq!(bb.as_mut_slice(), &[]);
+        assert_eq!(bb.destroy_into_vec(), &[]);
+    }
+
+    #[test]
+    fn test_bb_new() {
+        let bb = ByteBuffer::new_with_size(5);
+        assert_eq!(bb.as_slice(), &[0u8, 0, 0, 0, 0]);
+        bb.destroy();
+
+        let bb = ByteBuffer::new_with_size(0);
+        assert_eq!(bb.as_slice(), &[]);
+        assert!(bb.data.is_null());
+        bb.destroy();
+
+        let bb = ByteBuffer::from_vec(vec![]);
+        assert_eq!(bb.as_slice(), &[]);
+        assert!(bb.data.is_null());
+        bb.destroy();
     }
 }


### PR DESCRIPTION
This is an attempt to address the confusion in https://github.com/mozilla/uniffi-rs/issues/194

I also had forgotten some things about this API, and have attempted to make it less foot-gunney (`into_vec` assuming that you own the memory is uh, quite surprising, although sound, strictly speaking. That said, it's just a rename, so I've just deprecated rather than removed the old API for now).

I've also improved test coverage here, which I think was missing before. Additionally, the code should be more consistent about what the value of `data` for empty Vecs are, and should detect cases where the length field has overflowed or an invalid length has been passed in.

Note a second PR is going to have to be made after this lands and a release of ffi-support is cut, to update the usage of it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
