### PR TITLE
Avoid our coverage issues by only emitting line coverage (and not branch coverage)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ jobs:
       - run: bash ./automation/emit_coverage_info.sh
       - run:
           name: Compile coverage
-          command: grcov ./target/debug/ -s . -t lcov --llvm --branch --ignore-not-existing --ignore "target/*" --ignore "/*" -o lcov.info
+          command: grcov ./target/debug/ -s . -t lcov --llvm --ignore-not-existing --ignore "target/*" --ignore "/*" -o lcov.info
       - run:
           name: Upload to codecov.io
           command: bash <(curl -s https://codecov.io/bash) -f lcov.info


### PR DESCRIPTION
Fixes #3393. It's a little unfortunate in theory, but in practice the branch coverage was inaccurate to the point of being unusable (for Rust code, anyway).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
