### PR TITLE
Only report actual errors as errors in login telemetry

### DIFF
--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -89,10 +89,10 @@ class DatabaseLoginsStorage(private val dbPath: String) : AutoCloseable, LoginsS
     override fun unlock(encryptionKey: ByteArray) {
         return unlockCounters.measure {
             rustCall {
-                if (!isLocked()) {
-                    throw MismatchedLockException("Unlock called when we are already unlocked")
-                }
                 LoginsStoreMetrics.unlockTime.measure {
+                    if (!isLocked()) {
+                        throw MismatchedLockException("Unlock called when we are already unlocked")
+                    }
                     raw.set(PasswordSyncAdapter.INSTANCE.sync15_passwords_state_new_with_hex_key(
                             dbPath,
                             encryptionKey,
@@ -448,6 +448,9 @@ class LoginsStoreCounterMetrics(
                 throw e
             }
             when (e) {
+                is MismatchedLockException -> {
+                    errCount["mismatched_lock"].add()
+                }
                 is NoSuchRecordException -> {
                     errCount["no_such_record"].add()
                 }

--- a/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
+++ b/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
@@ -178,6 +178,16 @@ class DatabaseLoginsStorageTest {
         assert(LoginsStoreMetrics.unlockErrorCount["invalid_key"].testHasValue())
         assertEquals(LoginsStoreMetrics.unlockErrorCount["invalid_key"].testGetValue(), 1)
 
+        try {
+            store.unlock(key)
+            fail("Should have thrown")
+        } catch (e: MismatchedLockException) {
+            // All good.
+        }
+        assertEquals(LoginsStoreMetrics.unlockCount.testGetValue(), 4)
+        assert(LoginsStoreMetrics.unlockErrorCount["mismatched_lock"].testHasValue())
+        assertEquals(LoginsStoreMetrics.unlockErrorCount["mismatched_lock"].testGetValue(), 1)
+
         assert(!LoginsStoreMetrics.writeQueryTime.testHasValue())
         assert(!LoginsStoreMetrics.writeQueryCount.testHasValue())
         assert(!LoginsStoreMetrics.writeQueryErrorCount["invalid_record"].testHasValue())


### PR DESCRIPTION
I'm 100% sure there's a bug on file for this already, but I can't find it...

Essentially, we currently report all exceptions thrown from the logins component as errors. The issue with this is that the "validate login" (ensureValid) will throw even for normal usage. This pollutes our telemetry.

It's likely that this is responsible or contributing to #3461, as failing to list `invalid_record` [here](https://github.com/mozilla/application-services/blob/main/components/logins/android/metrics.yaml#L88-L90) (which is probably correct after this patch, at least for `invalid_record`) means we'd expect `invalid_record` to come through as `__other__`, which is what we see a ton of.

However, there are other things that could conceivably come through as `__other__`, so... It's hard to say.

EDIT: I also added a commit that contains a fix for the fact that according to https://github.com/mozilla/application-services/blob/main/components/logins/android/metrics.yaml#L53 we're listening for mismatched_lock errors, but there's no code that records them, and the `throw` is in the wrong place to catch them anyway.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
