### PR TITLE
Undo behavior change of impl From<Vec<u8>> for ByteBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "ffi-support"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -750,7 +750,7 @@ name = "ffi-support-extra-test"
 version = "0.1.0"
 dependencies = [
  "env_logger",
- "ffi-support 0.4.1",
+ "ffi-support 0.4.2",
  "log 0.4.11",
  "rand 0.7.3",
  "rayon",

--- a/components/support/ffi/Cargo.toml
+++ b/components/support/ffi/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffi-support"
 edition = "2018"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 description = "A crate to help expose Rust functions over the FFI."
 repository = "https://github.com/mozilla/application-services"

--- a/components/support/ffi/src/lib.rs
+++ b/components/support/ffi/src/lib.rs
@@ -458,11 +458,6 @@ impl ByteBuffer {
     #[inline]
     pub fn from_vec(bytes: Vec<u8>) -> Self {
         use std::convert::TryFrom;
-        if bytes.is_empty() {
-            // Try and maintain the invariant that `len == 0` and
-            // `data.is_null()` are equivalent.
-            return Self::default();
-        }
         let mut buf = bytes.into_boxed_slice();
         let data = buf.as_mut_ptr();
         let len = i64::try_from(buf.len()).expect("buffer length cannot fit into a i64.");
@@ -617,12 +612,12 @@ mod test {
 
         let bb = ByteBuffer::new_with_size(0);
         assert_eq!(bb.as_slice(), &[]);
-        assert!(bb.data.is_null());
+        assert!(!bb.data.is_null());
         bb.destroy();
 
         let bb = ByteBuffer::from_vec(vec![]);
         assert_eq!(bb.as_slice(), &[]);
-        assert!(bb.data.is_null());
+        assert!(!bb.data.is_null());
         bb.destroy();
     }
 }


### PR DESCRIPTION
Ugh. The old docs indicate that you need to check the ByteBuffer's pointer for null... but in practice our Kotlin doesn't, and neither does Glean's. Swift probably doesn't either. So that's an accidental breaking change with a big impact.

So, I've yanked 0.4.1, and have verified that with this change, all our tests pass with `[patch.crates-io]\nffi-support = {path = "components/support/ffi"}`.

Annoying...

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
