### PR TITLE
Merge v61.0.11 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@
 - Tab records now have an explicit TTL set when storing on the server, to match the behaviour
   of Firefox Desktop clients ([#3322](https://github.com/mozilla/application-services/pull/3322)).
 
+# v61.0.11 (_2020-08-07_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.10...v61.0.11)
+
+## FxA Client
+
+### What's new ###
+- Send-tab metrics are recorded. A new function, `fxa_gather_telemetry` on the
+  account object (exposed as `account.gatherTelemetry()` to Kotlin) which
+  returns a string of JSON.
+
+  This JSON might grow to support non-sendtab telemetry in the future, but in
+  this change it has:
+  - `commands_sent`, an array of objects, each with `flow_id` and `stream_id`
+    string values.
+  - `commands_received`, an array of objects, each with `flow_id`, `stream_id`
+    and `reason` string values.
+
+  [#3308](https://github.com/mozilla/application-services/pull/3308/)
+
 # v61.0.10 (_2020-07-15_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.8...v61.0.10)


### PR DESCRIPTION
According to the release instructions, this is what I'm supposed to do. I'm not quite sure about how CHANGELOG.md and CHANGES_UNRELEASED.md were supposed to be resolved, but this makes the most sense to me (in particular, the stuff released in v61.0.11 is back in CHANGES_UNRELEASED.md, because it will need to be noted in the next v62.* release.)