### PR TITLE
Cherry-pick linter fixes into release-v61.0.x

### DIFF
--- a/components/rc_log/src/lib.rs
+++ b/components/rc_log/src/lib.rs
@@ -116,11 +116,13 @@ pub extern "C" fn rc_log_adapter_set_max_level(level: i32, out_err: &mut ffi_sup
 // Can't use define_box_destructor because this can panic. TODO: Maybe we should
 // keep this around globally (as lazy_static or something) and basically just
 // turn it on/off in create/destroy... Might be more reliable?
+/// # Safety
+/// Unsafe because it frees it's argument.
 #[no_mangle]
-pub extern "C" fn rc_log_adapter_destroy(to_destroy: Option<Box<imp::LogAdapterState>>) {
+pub unsafe extern "C" fn rc_log_adapter_destroy(to_destroy: *mut imp::LogAdapterState) {
     ffi_support::abort_on_panic::call_with_output(move || {
         log::set_max_level(log::LevelFilter::Off);
-        drop(to_destroy);
+        drop(Box::from_raw(to_destroy));
         settable_log::unset_logger();
     })
 }

--- a/components/support/rc_crypto/nss/nss_sys/src/bindings/prtypes.rs
+++ b/components/support/rc_crypto/nss/nss_sys/src/bindings/prtypes.rs
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::os::raw::{c_int, c_uint, c_ulong};
+use std::os::raw::{c_int, c_uint};
 
 pub type PRIntn = c_int;
 pub type PRBool = PRIntn;
-pub type PRUword = c_ulong;
+pub type PRUword = usize;
 pub type PRInt32 = c_int;
 pub type PRUint32 = c_uint;
 pub const PR_FALSE: PRBool = 0;

--- a/components/support/rc_crypto/nss/nss_sys/src/bindings/secport.rs
+++ b/components/support/rc_crypto/nss/nss_sys/src/bindings/secport.rs
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::*;
-use std::os::raw::{c_int, c_ulong, c_void};
+use std::os::raw::{c_int, c_void};
+
+pub type size_t = usize;
 
 extern "C" {
     pub fn PORT_FreeArena(arena: *mut PLArenaPool, zero: PRBool);
     pub fn NSS_SecureMemcmp(a: *const c_void, b: *const c_void, n: size_t) -> c_int;
 }
-
-pub type size_t = c_ulong;

--- a/components/support/rc_crypto/nss/src/secport.rs
+++ b/components/support/rc_crypto/nss/src/secport.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::util::ensure_nss_initialized;
-use std::{convert::TryInto, os::raw::c_void};
+use std::os::raw::c_void;
 
 pub fn secure_memcmp(a: &[u8], b: &[u8]) -> bool {
     ensure_nss_initialized();
@@ -16,7 +16,7 @@ pub fn secure_memcmp(a: &[u8], b: &[u8]) -> bool {
         nss_sys::NSS_SecureMemcmp(
             a.as_ptr() as *const c_void,
             b.as_ptr() as *const c_void,
-            a.len().try_into().unwrap(),
+            a.len(),
         )
     };
     result == 0

--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -373,10 +373,7 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
         let changes = state_machine.changes_needed.take();
         // The state machine might have updated our persisted_global_state, so
         // update the caller's repr of it.
-        mem::replace(
-            self.persisted_global_state,
-            Some(serde_json::to_string(&pgs)?),
-        );
+        *self.persisted_global_state = Some(serde_json::to_string(&pgs)?);
 
         // Now that we've gone through the state machine, store the declined list in
         // the sync_result

--- a/components/viaduct/src/settings.rs
+++ b/components/viaduct/src/settings.rs
@@ -14,12 +14,12 @@ use std::time::Duration;
 /// in the concept-fetch backend it would only store the settings, and populate
 /// things on the fly.
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub struct Settings {
     pub read_timeout: Option<Duration>,
     pub connect_timeout: Option<Duration>,
     pub follow_redirects: bool,
     pub use_caches: bool,
-    _priv: (),
 }
 
 #[cfg(target_os = "ios")]
@@ -34,5 +34,4 @@ pub static GLOBAL_SETTINGS: &Settings = &Settings {
     connect_timeout: Some(TIMEOUT_DURATION),
     follow_redirects: true,
     use_caches: false,
-    _priv: (),
 };


### PR DESCRIPTION
v61.0.11 failed to produce artifacts because of https://github.com/mozilla/application-services/issues/3480. Ultimately, we should fix that, but the fixes for those linter errors are trivial and already in the repo, so in the short term this lets us get a release out sooner.

After this I'll be cutting a v61.0.12 release.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
