### PR TITLE
Merge v61.0.12 back into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@
 - Tab records now have an explicit TTL set when storing on the server, to match the behaviour
   of Firefox Desktop clients ([#3322](https://github.com/mozilla/application-services/pull/3322)).
 
+# v61.0.12 (_2020-08-07_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.11...v61.0.12)
+
+## General
+
+- This release only exists to correct issues that occured when publishing a v61.0.11, which failed to produce an artifact because of a warning which occured during the build process. (It contains a small number of additional cherry-picked patches which correct these warnings).
+
 # v61.0.11 (_2020-08-07_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.10...v61.0.11)


### PR DESCRIPTION
Almost forgot to do this (last step of making point release of existing release behind main: https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
