### PR TITLE
Fixes broken dependencies CI

### DIFF
--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -278,7 +278,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Zlib License: tinyvec</name>
-    <url>https://github.com/Lokathor/tinyvec/blob/master/LICENSE-ZLIB.md</url>
+    <url>https://github.com/Lokathor/tinyvec/blob/main/LICENSE-ZLIB.md</url>
   </license>
   <license>
     <name>Optional Notice: SQLite</name>

--- a/megazords/lockbox/android/dependency-licenses.xml
+++ b/megazords/lockbox/android/dependency-licenses.xml
@@ -246,7 +246,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Zlib License: tinyvec</name>
-    <url>https://github.com/Lokathor/tinyvec/blob/master/LICENSE-ZLIB.md</url>
+    <url>https://github.com/Lokathor/tinyvec/blob/main/LICENSE-ZLIB.md</url>
   </license>
   <license>
     <name>Optional Notice: SQLite</name>

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -519,6 +519,15 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "https://github.com/retep998/winapi-rs/blob/master/LICENSE-MIT",
         },
     },
+    "tinyvec": {
+        "repository": {
+            "check": "https://github.com/Lokathor/tinyvec"
+        },
+        "license_url": {
+            "check": None,
+            "fixup": "https://github.com/Lokathor/tinyvec/blob/main/LICENSE-ZLIB.md"
+        }
+    }
 }
 
 # Sets of common licence file names, by license type.


### PR DESCRIPTION
Added the fixup, the changes on the other two files were autogenerated.

Not 100% sure yet why this was needed. There seems to be a release 3 days ago in `tinyvec`. Also, they changed to a `main` branch like we did, and deleted the master branch.

Anywhoo, on a related note, I wonder if we should do an audit of our `fixups` to make sure they are still okay. (since a decent chunk point to `master` branches, and I'm not sure if any owners made the switch)
