### PR TITLE
Cut release v62.1.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 62.0.0
+libraryVersion: 62.1.0
 groupId: org.mozilla.appservices
 projects:
   fxaclient:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+# v62.1.0 (_2020-08-21_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v62.0.0...v62.1.0)
+
+## Extension Storage
+
+### What's fixed ###
+
+- Do not check total bytes quota on storage.sync.remote operations ([Bug 1656947](https://bugzilla.mozilla.org/1656947))
+
+## FxA Client
+
+### What's new ###
+
+- Send-tab metrics are recorded. A new function, `fxa_gather_telemetry` on the
+  account object (exposed as `account.gatherTelemetry()` to Kotlin) which
+  returns a string of JSON.
+
+  This JSON might grow to support non-sendtab telemetry in the future, but in
+  this change it has:
+  - `commands_sent`, an array of objects, each with `flow_id` and `stream_id`
+    string values.
+  - `commands_received`, an array of objects, each with `flow_id`, `stream_id`
+    and `reason` string values.
+
+  [#3308](https://github.com/mozilla/application-services/pull/3308/)
+
+## Places
+
+### What's new ###
+
+- Exclude download, redirects, reload, embed and framed link visit type from the
+  `get_top_frecent_site_infos` query.
+  ([#3505](https://github.com/mozilla/application-services/pull/3505))
+
 # v62.0.0 (_2020-07-13_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v61.0.7...v62.0.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,28 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v62.0.0...main)
-
-## General
-
-- Do not check total bytes quota on storage.sync.remote operations ([Bug 1656947](https://bugzilla.mozilla.org/1656947))
-
-## FxA Client
-
-### What's new ###
-- Send-tab metrics are recorded. A new function, `fxa_gather_telemetry` on the
-  account object (exposed as `account.gatherTelemetry()` to Kotlin) which
-  returns a string of JSON.
-
-  This JSON might grow to support non-sendtab telemetry in the future, but in
-  this change it has:
-  - `commands_sent`, an array of objects, each with `flow_id` and `stream_id`
-    string values.
-  - `commands_received`, an array of objects, each with `flow_id`, `stream_id`
-    and `reason` string values.
-
-  [#3308](https://github.com/mozilla/application-services/pull/3308/)
-
-- Exclude download, redirects, reload, embed and framed link visit type from the
-  `get_top_frecent_site_infos` query.
-  ([#3505](https://github.com/mozilla/application-services/pull/3505))
+[Full Changelog](https://github.com/mozilla/application-services/compare/v62.1.0...main)


### PR DESCRIPTION
Picking up @gabrielluong's fix for the frecency query and the Send Tab telemetry addition that's already in 61.0.12.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
