### PR TITLE
Update XCode version to 12.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,6 +376,9 @@ jobs:
           command: |
             rustup target add aarch64-apple-ios x86_64-apple-ios
             brew install swift-protobuf
+            # Carthage has an issue with XCode 12 architecture changes which doesn't allow
+            # it to compile dependencies for proper architecture. https://github.com/Carthage/Carthage/issues/3019
+            # Until carthage resolves this issue below is a workaround to exclude certain architecture until a fix deployed by Carthage
             echo 'EXCLUDED_ARCHS=$(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))' >> /tmp/tmp.xcconfig
             echo 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig
             echo 'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,6 +376,11 @@ jobs:
           command: |
             rustup target add aarch64-apple-ios x86_64-apple-ios
             brew install swift-protobuf
+            echo 'EXCLUDED_ARCHS=$(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))' >> /tmp/tmp.xcconfig
+            echo 'IPHONEOS_DEPLOYMENT_TARGET=11.4' >> /tmp/tmp.xcconfig
+            echo 'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
+            echo 'GCC_TREAT_WARNINGS_AS_ERRORS=NO' >> /tmp/tmp.xcconfig
+            export XCODE_XCCONFIG_FILE=/tmp/tmp.xcconfig
       - carthage-bootstrap
       - run:
           name: Verify the build environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ commands:
 jobs:
   Check Swift formatting:
     macos:
-      xcode: "11.5.0"
+      xcode: "12.0.0"
     steps:
       - checkout
       - run: brew install swiftlint swiftformat
@@ -352,7 +352,7 @@ jobs:
       - save-sccache-cache
   iOS build and test:
     macos:
-      xcode: "11.5.0"
+      xcode: "12.0.0"
     steps:
       # We do not use the ssccache cache helper commands as
       # the macOS cache is in a different folder.
@@ -437,7 +437,7 @@ jobs:
             - MozillaAppServices.framework.zip
   Carthage release:
     macos:
-      xcode: "11.5.0"
+      xcode: "12.0.0"
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
This will allow us to build iOS Firefox with latest XCode 12 

Firefox iOS now supports xcode 12 on main and need release for this version.

https://discuss.circleci.com/t/xcode-12-beta-5-released/37157

