### PR TITLE
Run CI dependency checks on a Mac, to properly detect iOS-specific dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,10 +303,11 @@ jobs:
           name: Lint Bash scripts with shellcheck
           command: sh automation/lint_bash_scripts.sh
   Check Rust dependencies:
-    docker:
-      - image: circleci/rust:latest
+    # This check has to be done on a mac, to be able to detect iOS-specific dependencies.
+    macos:
+      xcode: "11.7.0"
     steps:
-      - run: sudo apt-get install python3-pip
+      - install-rust
       - setup-rust-toolchain
       - checkout
       - dependency-checks

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -17,6 +17,7 @@ import subprocess
 import hashlib
 import json
 import textwrap
+import difflib
 import itertools
 import collections
 from urllib.parse import urlparse, urlunparse
@@ -1086,7 +1087,13 @@ if __name__ == "__main__":
         print_dependency_summary_markdown(deps, file=output)
 
     if args.check:
+        output.seek(0)
+        outlines = output.readlines()
         with open(args.check, 'r') as f:
-            if f.read() != output.getvalue():
+            checklines = f.readlines()
+            if outlines != checklines:
                 raise RuntimeError(
-                    "Dependency details have changed from those in {}".format(args.check))
+                    "Dependency details have changed from those in {}:\n{}".format(
+                        args.check,
+                        "".join(difflib.unified_diff(checklines, outlines))
+                    ))


### PR DESCRIPTION
Trying to debug failing dependency checks in CI that we can't reproduce locally.
