### PR TITLE
Update rust-ece to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,9 +602,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "ece"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b4aa60de558deb8a5c2f803ac354ba733189a5dddeb19323144a540410497"
+checksum = "53d97f19730c1eb3332d0657d0f3ca72795d77c61d8eb26bdd7f15edc0c61eb2"
 dependencies = [
  "base64",
  "byteorder",


### PR DESCRIPTION
Includes https://github.com/mozilla/rust-ece/pull/45.