### PR TITLE
Remove old node references from sync-test test code

### DIFF
--- a/testing/sync-test/README.md
+++ b/testing/sync-test/README.md
@@ -10,10 +10,6 @@ Run the tests using `cargo run`.
 
 Use `cargo run -- --help` to see the available options.
 
-Running the tests currently requires nodejs, in order to drive a headless browser.
-There is an [open issue](https://github.com/mozilla/application-services/issues/2403)
-to investigate how to remove this dependency.
-
 ## Adding tests
 
 For each datatype managed by sync, there should be a suite of corresponding tests.

--- a/testing/sync-test/src/auth.rs
+++ b/testing/sync-test/src/auth.rs
@@ -20,27 +20,6 @@ pub const SYNC_SCOPE: &str = "https://identity.mozilla.com/apps/oldsync";
 // TODO: This is wrong for dev?
 pub const REDIRECT_URI: &str = "https://stable.dev.lcip.org/oauth/success/3c49430b43dfba77";
 
-lazy_static::lazy_static! {
-    // Figures out where `sync-test/helper` lives. This is pretty gross, but once
-    // https://github.com/rust-lang/cargo/issues/2841 is resolved it should be simpler.
-    // That said, it's possible we should probably just rewrite that script in rust instead :p.
-    static ref HELPER_SCRIPT_DIR: std::path::PathBuf = {
-        let mut path = std::env::current_exe().expect("Failed to get current exe path...");
-        // Find `target` which should contain this program.
-        while path.file_name().expect("Failed to find target!") != "target" {
-            path.pop();
-        }
-        // And go up once more, to the root of the workspace.
-        path.pop();
-        // TODO: it would be nice not to hardcode these given that we're
-        // planning on moving stuff around, but such is life.
-        path.push("testing");
-        path.push("sync-test");
-        path.push("helper");
-        path
-    };
-}
-
 // It's important that this doesn't implement Clone! (It destroys it's temporary fxaccount on drop)
 #[derive(Debug)]
 pub struct TestAccount {


### PR DESCRIPTION
tarek removed the node requirement from sync-test a few months ago, but I found these references left behind which confused me a little.