### PR TITLE
Add a changelog entry for the (breaking) change to Xcode 12.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,11 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v63.0.0...main)
+
+## iOS
+
+### ⚠️ Breaking changes ⚠️
+
+- The `MozillaAppServices.framework` is now built using Xcode 12, so consumers will need
+  update their own build accordingly.
+  ([#3586](https://github.com/mozilla/application-services/pull/3586))


### PR DESCRIPTION
So we don't forget this is a breaking change when cutting the release.