### PR TITLE
Upgrade Glean to v32.4.0

### DIFF
--- a/components/logins/ios/Logins/Extensions/String+Free_Logins.swift
+++ b/components/logins/ios/Logins/Extensions/String+Free_Logins.swift
@@ -4,17 +4,9 @@
 
 import Foundation
 
-/*
- * NOTE: This is now provided by Glean.
- * Because it's all compiled into a single libmegazord.a it doesn't matter which `destroy_string` we call,
- * internally it defers to the same string implementation.
- * Because Glean is added as a submodule it's easier to change this occurence than it it to change the one of Glean.
- */
-/*
- extension String {
-     public init(freeingRustString rustString: UnsafeMutablePointer<CChar>) {
-         defer { sync15_passwords_destroy_string(rustString) }
-         self.init(cString: rustString)
-     }
- }
- */
+extension String {
+    public init(freeingRustString rustString: UnsafeMutablePointer<CChar>) {
+        defer { sync15_passwords_destroy_string(rustString) }
+        self.init(cString: rustString)
+    }
+}

--- a/megazords/ios/MozillaAppServices.h
+++ b/megazords/ios/MozillaAppServices.h
@@ -7,14 +7,6 @@
 FOUNDATION_EXPORT double MegazordClientVersionNumber;
 FOUNDATION_EXPORT const unsigned char MegazordClientVersionString[];
 
-/**
- * FIXME: Glean has a `getGleanVersion` function that uses this constant.
- * That function is not actually used (and the version wrong anyway).
- * Because Glean is added as a submodule it's easier to change this occurence than it it to change the one of Glean,
- * for now.
- */
-static double GleanVersionNumber = 0.0;
-
 #import "RustFxAFFI.h"
 #import "RustPasswordAPI.h"
 #import "RustLogFFI.h"


### PR DESCRIPTION
Glean changelog:

* General
  * Allow using quantity metric type outside of Gecko ([#1198](https://github.com/mozilla/glean/pull/1198))
  * Update `glean_parser` to 1.28.5
    * The `SUPERFLUOUS_NO_LINT` warning has been removed from the glinter. It likely did more harm than good, and makes it hard to make metrics.yaml files that pass across different versions of `glean_parser`.
    * Expired metrics will now produce a linter warning, `EXPIRED_METRIC`.
    * Expiry dates that are more than 730 days (~2 years) in the future will produce a linter warning, `EXPIRATION_DATE_TOO_FAR`.
    * Allow using the Quantity metric type outside of Gecko.
    * New parser configs `custom_is_expired` and `custom_validate_expires` added. These are both functions that take the expires value of the metric and return a bool. (See `Metric.is_expired` and `Metric.validate_expires`). These will allow FOG to provide custom validation for its version-based `expires` values.
  * Add a limit of 250 pending ping files. ([#1217](https://github.com/mozilla/glean/pull/1217)).

Note: This also gets rid of the 2 workarounds (removed code) in
AppService thanks to upstream changes.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
