### PR TITLE
Document how to use default ttl in get_access_token FFI call.

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FirefoxAccount.kt
@@ -295,6 +295,7 @@ class FirefoxAccount(handle: FxaHandle, persistCallback: PersistCallback?) : Aut
      */
     fun getAccessToken(scope: String, ttl: Long? = null): AccessTokenInfo {
         val buffer = rustCallWithLock { e ->
+            // A zero ttl here means to use the server-controlled default.
             LibFxAFFI.INSTANCE.fxa_get_access_token(this.handle.get(), scope, ttl ?: 0L, e)
         }
         this.tryPersistState()

--- a/components/fxa-client/ffi/src/lib.rs
+++ b/components/fxa-client/ffi/src/lib.rs
@@ -327,6 +327,11 @@ pub extern "C" fn fxa_retry_migrate_from_session_token(
 ///
 /// If not, the caller must start an OAuth flow with [fxa_begin_oauth_flow].
 ///
+/// Arguments:
+///   * scope: space-separated list of scopes that the token should have
+///   * ttl: the time in seconds for which the token should be valid
+///          (or zero to use the server-controlled default ttl)
+///
 /// # Safety
 ///
 /// A destructor [fxa_bytebuffer_free] is provided for releasing the memory for this

--- a/components/fxa-client/ios/FxAClient/RustFxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/RustFxAccount.swift
@@ -168,6 +168,7 @@ open class RustFxAccount {
     /// the desired scope.
     open func getAccessToken(scope: String, ttl: UInt64? = nil) throws -> AccessTokenInfo {
         let ptr = try rustCall { err in
+            // A zero ttl here means to use the server-controlled default.
             fxa_get_access_token(self.raw, scope, ttl ?? .zero, err)
         }
         defer { fxa_bytebuffer_free(ptr) }


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/3628

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
