### PR TITLE
Fix clippy complaining about `matches!()`.

### DIFF
--- a/components/fxa-client/src/migrator.rs
+++ b/components/fxa-client/src/migrator.rs
@@ -214,20 +214,11 @@ mod tests {
         FirefoxAccount::with_config(config)
     }
 
-    macro_rules! assert_match {
-        ($value:expr, $pattern:pat) => {
-            assert!(match $value {
-                $pattern => true,
-                _ => false,
-            });
-        };
-    }
-
     #[test]
     fn test_migration_can_retry_after_network_errors() {
         let mut fxa = setup();
 
-        assert_match!(fxa.is_in_migration_state(), MigrationState::None);
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
 
         // Initial attempt fails with a server-side failure, which we can retry.
         let mut client = FxAClientMock::new();
@@ -246,11 +237,11 @@ mod tests {
         let err = fxa
             .migrate_from_session_token("session", "aabbcc", "ddeeff", true)
             .unwrap_err();
-        assert_match!(err.kind(), ErrorKind::RemoteError { code: 500, .. });
-        assert_match!(
+        assert!(matches!(err.kind(), ErrorKind::RemoteError { code: 500, .. }));
+        assert!(matches!(
             fxa.is_in_migration_state(),
             MigrationState::CopySessionToken
-        );
+        ));
 
         // Retrying can succeed.
         // It makes a lot of network requests, so we have a lot to mock!
@@ -300,14 +291,14 @@ mod tests {
         fxa.set_client(Arc::new(client));
 
         fxa.try_migration().unwrap();
-        assert_match!(fxa.is_in_migration_state(), MigrationState::None);
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
     }
 
     #[test]
     fn test_migration_cannot_retry_after_other_errors() {
         let mut fxa = setup();
 
-        assert_match!(fxa.is_in_migration_state(), MigrationState::None);
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
 
         let mut client = FxAClientMock::new();
         client
@@ -325,26 +316,26 @@ mod tests {
         let err = fxa
             .migrate_from_session_token("session", "aabbcc", "ddeeff", true)
             .unwrap_err();
-        assert_match!(err.kind(), ErrorKind::RemoteError { code: 400, .. });
-        assert_match!(fxa.is_in_migration_state(), MigrationState::None);
+        assert!(matches!(err.kind(), ErrorKind::RemoteError { code: 400, .. }));
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
     }
 
     #[test]
     fn try_migration_fails_if_nothing_in_flight() {
         let mut fxa = setup();
 
-        assert_match!(fxa.is_in_migration_state(), MigrationState::None);
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
 
         let err = fxa.try_migration().unwrap_err();
-        assert_match!(err.kind(), ErrorKind::NoMigrationData);
-        assert_match!(fxa.is_in_migration_state(), MigrationState::None);
+        assert!(matches!(err.kind(), ErrorKind::NoMigrationData));
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
     }
 
     #[test]
     fn test_migration_state_remembers_whether_to_copy_session_token() {
         let mut fxa = setup();
 
-        assert_match!(fxa.is_in_migration_state(), MigrationState::None);
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
 
         let mut client = FxAClientMock::new();
         client
@@ -367,11 +358,11 @@ mod tests {
         let err = fxa
             .migrate_from_session_token("session", "aabbcc", "ddeeff", false)
             .unwrap_err();
-        assert_match!(err.kind(), ErrorKind::RemoteError { code: 500, .. });
-        assert_match!(
+        assert!(matches!(err.kind(), ErrorKind::RemoteError { code: 500, .. }));
+        assert!(matches!(
             fxa.is_in_migration_state(),
             MigrationState::ReuseSessionToken
-        );
+        ));
 
         // Retrying should fail again in the same way (as opposed to, say, trying
         // to duplicate the sessionToken rather than reusing it).
@@ -394,10 +385,10 @@ mod tests {
         fxa.set_client(Arc::new(client));
 
         let err = fxa.try_migration().unwrap_err();
-        assert_match!(err.kind(), ErrorKind::RemoteError { code: 500, .. });
-        assert_match!(
+        assert!(matches!(err.kind(), ErrorKind::RemoteError { code: 500, .. }));
+        assert!(matches!(
             fxa.is_in_migration_state(),
             MigrationState::ReuseSessionToken
-        );
+        ));
     }
 }

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -1540,9 +1540,9 @@ mod tests {
             .into_iter()
             .map(|l| l.hostname)
             .collect::<Vec<String>>();
-        results.sort();
+        results.sort_unstable();
         let mut sorted = expected.to_owned();
-        sorted.sort();
+        sorted.sort_unstable();
         assert_eq!(sorted, results);
     }
 

--- a/components/places/src/bookmark_sync/store.rs
+++ b/components/places/src/bookmark_sync/store.rs
@@ -3651,7 +3651,7 @@ mod tests {
             .into_iter()
             .map(|p| p.id.as_str())
             .collect::<Vec<_>>();
-        outgoing_record_ids.sort();
+        outgoing_record_ids.sort_unstable();
         assert_eq!(
             outgoing_record_ids,
             &["bookmarkFFFF", "menu", "mobile", "toolbar", "unfiled"],

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -361,10 +361,10 @@ mod tests {
             visits: vec![],
         };
 
-        assert!(match plan_incoming_record(&conn, record, 10) {
-            IncomingPlan::Invalid(_) => true,
-            _ => false,
-        });
+        assert!(matches!(
+            plan_incoming_record(&conn, record, 10),
+            IncomingPlan::Invalid(_)
+        ));
         Ok(())
     }
 
@@ -381,10 +381,10 @@ mod tests {
             visits: vec![],
         };
 
-        assert!(match plan_incoming_record(&conn, record, 10) {
-            IncomingPlan::Invalid(_) => true,
-            _ => false,
-        });
+        assert!(matches!(
+            plan_incoming_record(&conn, record, 10),
+            IncomingPlan::Invalid(_)
+        ));
         Ok(())
     }
 
@@ -405,10 +405,7 @@ mod tests {
             visits,
         };
 
-        assert!(match plan_incoming_record(&conn, record, 10) {
-            IncomingPlan::Apply { .. } => true,
-            _ => false,
-        });
+        assert!(matches!(plan_incoming_record(&conn, record, 10), IncomingPlan::Apply{..}));
         Ok(())
     }
 
@@ -442,10 +439,10 @@ mod tests {
             visits,
         };
         // We should have reconciled it.
-        assert!(match plan_incoming_record(&conn, record, 10) {
-            IncomingPlan::Reconciled => true,
-            _ => false,
-        });
+        assert!(matches!(
+            plan_incoming_record(&conn, record, 10),
+            IncomingPlan::Reconciled
+        ));
         Ok(())
     }
 
@@ -474,10 +471,7 @@ mod tests {
         };
         // Even though there are no visits we should record that it will be
         // applied with the guid change.
-        assert!(match plan_incoming_record(&conn, record, 10) {
-            IncomingPlan::Apply { .. } => true,
-            _ => false,
-        });
+        assert!(matches!(plan_incoming_record(&conn, record, 10), IncomingPlan::Apply{..}));
     }
 
     // These "dupe" tests all do the full application of the plan and checks
@@ -745,10 +739,7 @@ mod tests {
         let plan = plan_incoming_record(&db, record, 10);
         // We expect "Reconciled" because after skipping the invalid visit
         // we found nothing to apply.
-        assert!(match plan {
-            IncomingPlan::Reconciled => true,
-            _ => false,
-        });
+        assert!(matches!(plan, IncomingPlan::Reconciled));
         Ok(())
     }
 

--- a/components/places/src/storage/tags.rs
+++ b/components/places/src/storage/tags.rs
@@ -26,10 +26,7 @@ impl<'a> ValidatedTag<'a> {
     /// Returns `true` if the original tag is valid; `false` if it's invalid or
     /// normalized.
     pub fn is_original(&self) -> bool {
-        match &self {
-            ValidatedTag::Original(_) => true,
-            _ => false,
-        }
+        matches!(&self, ValidatedTag::Original(_))
     }
 
     /// Returns the tag string if the tag is valid or normalized, or an error

--- a/components/support/ffi/src/handle_map.rs
+++ b/components/support/ffi/src/handle_map.rs
@@ -120,10 +120,7 @@ enum EntryState<T> {
 impl<T> EntryState<T> {
     #[cfg(any(debug_assertions, test))]
     fn is_end_of_list(&self) -> bool {
-        match self {
-            EntryState::EndOfFreeList => true,
-            _ => false,
-        }
+        matches!(self, EntryState::EndOfFreeList)
     }
 
     #[inline]

--- a/components/sync15/src/request.rs
+++ b/components/sync15/src/request.rs
@@ -253,10 +253,7 @@ where
 
     #[inline]
     fn in_batch(&self) -> bool {
-        match &self.batch {
-            BatchState::Unsupported | BatchState::NoBatch => false,
-            _ => true,
-        }
+        !matches!(&self.batch, BatchState::Unsupported | BatchState::NoBatch)
     }
 
     pub fn enqueue(&mut self, record: &EncryptedBso) -> Result<bool> {

--- a/components/webext-storage/src/sync/sync_tests.rs
+++ b/components/webext-storage/src/sync/sync_tests.rs
@@ -82,11 +82,7 @@ enum DbData {
 
 impl DbData {
     fn has_data(&self) -> bool {
-        if let DbData::Data(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, DbData::Data(_))
     }
 }
 


### PR DESCRIPTION
CI is currently broken because we treat clippy warnings as errors; this should fix it.