### PR TITLE
Fix how webext-storage handles incoming tombstones.

### DIFF
--- a/components/webext-storage/sql/create_schema.sql
+++ b/components/webext-storage/sql/create_schema.sql
@@ -34,12 +34,17 @@ CREATE TABLE IF NOT EXISTS storage_sync_mirror (
     /* The extension_id is explicitly not the GUID used on the server.
        It can't be  a regular foreign-key relationship back to storage_sync_data
        as items with no data on the server (ie, deleted items) will not appear
-       in storage_sync_data.
+       in storage_sync_data, and the guid isn't in that table either.
+       It must allow NULL as tombstones do not carry the ext_id, so we have
+       an additional CHECK constraint.
     */
-    ext_id TEXT NOT NULL UNIQUE,
+    ext_id TEXT UNIQUE,
 
     /* The JSON payload. We *do* allow NULL here - it means "deleted" */
     data TEXT
+
+    /* tombstones have no ext_id and no data. Non tombstones must have both */
+    CHECK((ext_id IS NULL AND data IS NULL) OR (ext_id IS NOT NULL AND data IS NOT NULL))
 );
 
 -- This table holds key-value metadata - primarily for sync.

--- a/components/webext-storage/sql/create_sync_temp_tables.sql
+++ b/components/webext-storage/sql/create_sync_temp_tables.sql
@@ -63,7 +63,7 @@ BEGIN
     INSERT OR REPLACE INTO storage_sync_mirror (guid, ext_id, data)
     -- Our mirror has a constraint for tombstones, so handle that - if data is
     -- null we want a null ext_id (as that's whats on the server)
-    VALUES (NEW.guid, iif(NEW.data IS NULL, NULL, NEW.ext_id), NEW.data);
+    VALUES (NEW.guid, CASE WHEN NEW.data IS NULL THEN NULL ELSE NEW.ext_id END, NEW.data);
 END;
 
 DELETE FROM temp.storage_sync_outgoing_staging;

--- a/components/webext-storage/sql/create_sync_temp_tables.sql
+++ b/components/webext-storage/sql/create_sync_temp_tables.sql
@@ -9,11 +9,12 @@ CREATE TEMP TABLE IF NOT EXISTS storage_sync_staging (
     guid TEXT NOT NULL PRIMARY KEY,
 
     /* The extension_id is explicitly not the GUID used on the server.
-       It can't be  a regular foreign-key relationship back to storage_sync_data
-       as the ext_id for incoming items may not appear in storage_sync_data at
-       the time we populate this table.
+       It can't be  a regular foreign-key relationship back to storage_sync_data,
+       nor can it be NOT NULL, as the ext_id for incoming items may not appear
+       in storage_sync_data at the time we populate this table, and also
+       because incoming tombstones have no extension ID.
     */
-    ext_id TEXT NOT NULL UNIQUE,
+    ext_id TEXT UNIQUE,
 
     /* The JSON payload. We *do* allow NULL here - it means "deleted" */
     data TEXT
@@ -53,14 +54,16 @@ BEGIN
     -- and we'll merge them again on the next sync.
     UPDATE storage_sync_data SET
       sync_change_counter = sync_change_counter - NEW.sync_change_counter
-    WHERE ext_id = NEW.ext_id;
+    WHERE NEW.ext_id IS NOT NULL AND ext_id = NEW.ext_id;
 
     -- Delete uploaded tombstones entirely; they're only kept in the mirror.
     DELETE FROM storage_sync_data WHERE data IS NULL AND sync_change_counter = 0 AND ext_id = NEW.ext_id;
 
     -- And write the uploaded item back to the mirror.
     INSERT OR REPLACE INTO storage_sync_mirror (guid, ext_id, data)
-    VALUES (NEW.guid, NEW.ext_id, NEW.data);
+    -- Our mirror has a constraint for tombstones, so handle that - if data is
+    -- null we want a null ext_id (as that's whats on the server)
+    VALUES (NEW.guid, iif(NEW.data IS NULL, NULL, NEW.ext_id), NEW.data);
 END;
 
 DELETE FROM temp.storage_sync_outgoing_staging;

--- a/components/webext-storage/src/schema.rs
+++ b/components/webext-storage/src/schema.rs
@@ -15,7 +15,7 @@ use crate::error::Result;
 use rusqlite::{Connection, NO_PARAMS};
 use sql_support::ConnExt;
 
-const VERSION: i64 = 1; // let's avoid bumping this and migrating for now!
+const VERSION: i64 = 2;
 
 const CREATE_SCHEMA_SQL: &str = include_str!("../sql/create_schema.sql");
 const CREATE_SYNC_TEMP_TABLES_SQL: &str = include_str!("../sql/create_sync_temp_tables.sql");
@@ -30,7 +30,7 @@ pub fn init(db: &Connection) -> Result<()> {
         create(db)?;
     } else if user_version != VERSION {
         if user_version < VERSION {
-            panic!("no migrations yet!");
+            upgrade(db, user_version)?;
         } else {
             log::warn!(
                 "Loaded future schema version {} (we only understand version {}). \
@@ -56,6 +56,29 @@ fn create(db: &Connection) -> Result<()> {
         NO_PARAMS,
     )?;
 
+    Ok(())
+}
+
+fn upgrade(db: &Connection, from: i64) -> Result<()> {
+    log::debug!("Upgrading schema from {} to {}", from, VERSION);
+    if from == VERSION {
+        return Ok(());
+    }
+    // Places has a cute `migration` helper we can consider using if we get
+    // a few complicated updates, but let's KISS for now.
+    if from == 1 {
+        // We changed a not null constraint
+        log::debug!("Upgrading schema from 1 to 2");
+        db.execute_batch("ALTER TABLE storage_sync_mirror RENAME TO old_mirror;")?;
+        // just re-run the full schema commands to recreate the able.
+        db.execute_batch(CREATE_SCHEMA_SQL)?;
+        db.execute_batch(
+            "INSERT OR IGNORE INTO storage_sync_mirror(guid, ext_id, data)
+             SELECT guid, ext_id, data FROM old_mirror;",
+        )?;
+        db.execute_batch("DROP TABLE old_mirror;")?;
+        db.execute_batch("PRAGMA user_version = 2;")?;
+    }
     Ok(())
 }
 
@@ -108,6 +131,7 @@ pub mod test {
 mod tests {
     use super::*;
     use crate::db::test::new_mem_db;
+    use rusqlite::Error;
 
     #[test]
     fn test_create_schema_twice() {
@@ -147,5 +171,72 @@ mod tests {
             )
             .expect("query should work");
         assert_eq!(count, 0, "should be no rows");
+    }
+
+    #[test]
+    fn test_upgrade_1_2() -> Result<()> {
+        let _ = env_logger::try_init();
+        // This is the table definition of the table we are migrating away
+        // from - note the NOT NULL on ext_id, which no longer exists.
+        let old_create_table = "CREATE TABLE IF NOT EXISTS storage_sync_mirror (
+            guid TEXT NOT NULL PRIMARY KEY,
+            ext_id TEXT NOT NULL UNIQUE,
+            data TEXT
+        );";
+        // Create a named in-memory database.
+        let db = new_mem_db();
+        db.execute_batch("DROP TABLE storage_sync_mirror;")?;
+        db.execute_batch(old_create_table)?;
+
+        db.execute_batch(
+            "INSERT INTO storage_sync_mirror(guid, ext_id, data)
+             VALUES
+                ('guid-1', 'ext-id-1', 'data-1'),
+                ('guid-2', 'ext-id-2', 'data-2')",
+        )?;
+
+        db.execute_batch("PRAGMA user_version = 1")?;
+
+        // We are back to what a v1 database looks like. Make sure the NOT NULL
+        // constraint is honoured.
+        assert!(db
+            .execute_batch(
+                "INSERT INTO storage_sync_mirror(guid, ext_id, data)
+                 VALUES ('guid-3', NULL, NULL);"
+            )
+            .is_err());
+
+        // Ugrade
+        upgrade(&db, 1)?;
+
+        assert_eq!(get_current_schema_version(&db)?, VERSION);
+
+        // Should be able to insert the new row.
+        db.execute_batch(
+            "INSERT INTO storage_sync_mirror(guid, ext_id, data)
+             VALUES ('guid-3', NULL, NULL);",
+        )?;
+
+        let get_id_data = |guid: &str| -> Result<(Option<String>, Option<String>)> {
+            let (ext_id, data) = db
+                .try_query_row::<_, Error, _>(
+                    "SELECT ext_id, data FROM storage_sync_mirror WHERE guid = :guid",
+                    &[(":guid", &guid.to_string())],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                    true,
+                )?
+                .expect("row should exist.");
+            Ok((ext_id, data))
+        };
+        assert_eq!(
+            get_id_data("guid-1")?,
+            (Some("ext-id-1".to_string()), Some("data-1".to_string()))
+        );
+        assert_eq!(
+            get_id_data("guid-2")?,
+            (Some("ext-id-2".to_string()), Some("data-2".to_string()))
+        );
+        assert_eq!(get_id_data("guid-3")?, (None, None));
+        Ok(())
     }
 }

--- a/components/webext-storage/src/sync/bridge.rs
+++ b/components/webext-storage/src/sync/bridge.rs
@@ -176,7 +176,7 @@ mod tests {
         )?;
         engine.db.execute(
             "INSERT INTO storage_sync_mirror (guid, ext_id, data)
-                 VALUES ('guid', 'ext-a', null)",
+                 VALUES ('guid', 'ext-a', '3')",
             rusqlite::NO_PARAMS,
         )?;
         engine.set_last_sync(1)?;

--- a/components/webext-storage/src/sync/mod.rs
+++ b/components/webext-storage/src/sync/mod.rs
@@ -12,6 +12,7 @@ mod sync_tests;
 use crate::api::{StorageChanges, StorageValueChange};
 use crate::db::StorageDb;
 use crate::error::*;
+use serde::{Deserialize, Deserializer};
 use serde_derive::*;
 use sql_support::ConnExt;
 use sync_guid::Guid as SyncGuid;
@@ -23,10 +24,30 @@ type JsonMap = serde_json::Map<String, serde_json::Value>;
 
 pub const STORAGE_VERSION: usize = 1;
 
-/// For use with `#[serde(skip_serializing_if = )]`
-#[inline]
-pub fn is_default<T: PartialEq + Default>(v: &T) -> bool {
-    *v == T::default()
+// Note that we never use serde to serialize a tombstone, so it doesn't matter
+// how that looks - but we care about how a Record with RecordData::Data looks.
+// However, deserializing is trickier still - it seems tricky to tell serde
+// how to unpack a tombstone - if we used `Tombstone { deleted: bool }` and
+// enforced bool must only be ever true it might be possible, but that's quite
+// clumsy for the rest of the code. So we just capture serde's failure to
+// unpack it and treat it as a tombstone.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum RecordData {
+    Data {
+        #[serde(rename = "extId")]
+        ext_id: String,
+        data: String,
+    },
+    #[serde(skip_deserializing)]
+    Tombstone,
+}
+
+fn deserialize_record_data<'de, D>(deserializer: D) -> Result<RecordData, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(RecordData::deserialize(deserializer).unwrap_or(RecordData::Tombstone))
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -34,15 +55,19 @@ pub fn is_default<T: PartialEq + Default>(v: &T) -> bool {
 pub struct Record {
     #[serde(rename = "id")]
     guid: SyncGuid,
-    ext_id: String,
-    #[serde(default, skip_serializing_if = "is_default")]
-    data: Option<String>,
+    #[serde(flatten, deserialize_with = "deserialize_record_data")]
+    data: RecordData,
 }
 
 // Perform a 2-way or 3-way merge, where the incoming value wins on confict.
-fn merge(mut other: JsonMap, mut ours: JsonMap, parent: Option<JsonMap>) -> IncomingAction {
+fn merge(
+    ext_id: String,
+    mut other: JsonMap,
+    mut ours: JsonMap,
+    parent: Option<JsonMap>,
+) -> IncomingAction {
     if other == ours {
-        return IncomingAction::Same;
+        return IncomingAction::Same { ext_id };
     }
     let old_incoming = other.clone();
     // worst case is keys in each are unique.
@@ -121,11 +146,13 @@ fn merge(mut other: JsonMap, mut ours: JsonMap, parent: Option<JsonMap>) -> Inco
 
     if ours == old_incoming {
         IncomingAction::TakeRemote {
+            ext_id,
             data: old_incoming,
             changes,
         }
     } else {
         IncomingAction::Merge {
+            ext_id,
             data: ours,
             changes,
         }
@@ -191,6 +218,39 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[test]
+    fn test_serde_record_ser() {
+        assert_eq!(
+            serde_json::to_string(&Record {
+                guid: "guid".into(),
+                data: RecordData::Data {
+                    ext_id: "ext_id".to_string(),
+                    data: "data".to_string()
+                }
+            })
+            .unwrap(),
+            r#"{"id":"guid","extId":"ext_id","data":"data"}"#
+        );
+    }
+
+    #[test]
+    fn test_serde_record_de() {
+        let p: Record = serde_json::from_str(r#"{"id":"guid","deleted":true}"#).unwrap();
+        assert_eq!(p.data, RecordData::Tombstone);
+        let p: Record =
+            serde_json::from_str(r#"{"id":"guid","extId": "ext-id", "data":"foo"}"#).unwrap();
+        assert_eq!(
+            p.data,
+            RecordData::Data {
+                ext_id: "ext-id".into(),
+                data: "foo".into()
+            }
+        );
+        // invalid are treated as tombstones.
+        let p: Record = serde_json::from_str(r#"{"id":"guid"}"#).unwrap();
+        assert_eq!(p.data, RecordData::Tombstone);
+    }
+
     // a macro for these tests - constructs a serde_json::Value::Object
     macro_rules! map {
         ($($map:tt)+) => {
@@ -248,19 +308,24 @@ mod tests {
         // No conflict - identical local and remote.
         assert_eq!(
             merge(
+                "ext-id".to_string(),
                 map!({"one": "one", "two": "two"}),
                 map!({"two": "two", "one": "one"}),
                 Some(map!({"parent_only": "parent"})),
             ),
-            IncomingAction::Same
+            IncomingAction::Same {
+                ext_id: "ext-id".to_string()
+            }
         );
         assert_eq!(
             merge(
+                "ext-id".to_string(),
                 map!({"other_only": "other", "common": "common"}),
                 map!({"ours_only": "ours", "common": "common"}),
                 Some(map!({"parent_only": "parent", "common": "old_common"})),
             ),
             IncomingAction::Merge {
+                ext_id: "ext-id".to_string(),
                 data: map!({"other_only": "other", "ours_only": "ours", "common": "common"}),
                 changes: changes![change!("other_only", None, "other")],
             }
@@ -268,11 +333,13 @@ mod tests {
         // Simple conflict - parent value is neither local nor incoming. incoming wins.
         assert_eq!(
             merge(
+                "ext-id".to_string(),
                 map!({"other_only": "other", "common": "incoming"}),
                 map!({"ours_only": "ours", "common": "local"}),
                 Some(map!({"parent_only": "parent", "common": "parent"})),
             ),
             IncomingAction::Merge {
+                ext_id: "ext-id".to_string(),
                 data: map!({"other_only": "other", "ours_only": "ours", "common": "incoming"}),
                 changes: changes![
                     change!("common", "local", "incoming"),
@@ -283,11 +350,13 @@ mod tests {
         // Local change, no conflict.
         assert_eq!(
             merge(
+                "ext-id".to_string(),
                 map!({"other_only": "other", "common": "old_value"}),
                 map!({"ours_only": "ours", "common": "new_value"}),
                 Some(map!({"parent_only": "parent", "common": "old_value"})),
             ),
             IncomingAction::Merge {
+                ext_id: "ext-id".to_string(),
                 data: map!({"other_only": "other", "ours_only": "ours", "common": "new_value"}),
                 changes: changes![change!("other_only", None, "other")],
             }
@@ -295,11 +364,13 @@ mod tests {
         // Field was removed remotely.
         assert_eq!(
             merge(
+                "ext-id".to_string(),
                 map!({"other_only": "other"}),
                 map!({"common": "old_value"}),
                 Some(map!({"common": "old_value"})),
             ),
             IncomingAction::TakeRemote {
+                ext_id: "ext-id".to_string(),
                 data: map!({"other_only": "other"}),
                 changes: changes![
                     change!("common", "old_value", None),
@@ -310,11 +381,13 @@ mod tests {
         // Field was removed remotely but we added another one.
         assert_eq!(
             merge(
+                "ext-id".to_string(),
                 map!({"other_only": "other"}),
                 map!({"common": "old_value", "new_key": "new_value"}),
                 Some(map!({"common": "old_value"})),
             ),
             IncomingAction::Merge {
+                ext_id: "ext-id".to_string(),
                 data: map!({"other_only": "other", "new_key": "new_value"}),
                 changes: changes![
                     change!("common", "old_value", None),
@@ -325,11 +398,13 @@ mod tests {
         // Field was removed both remotely and locally.
         assert_eq!(
             merge(
+                "ext-id".to_string(),
                 map!({}),
                 map!({"new_key": "new_value"}),
                 Some(map!({"common": "old_value"})),
             ),
             IncomingAction::Merge {
+                ext_id: "ext-id".to_string(),
                 data: map!({"new_key": "new_value"}),
                 changes: changes![],
             }

--- a/components/webext-storage/src/sync/outgoing.rs
+++ b/components/webext-storage/src/sync/outgoing.rs
@@ -13,7 +13,7 @@ use sync_guid::Guid as SyncGuid;
 
 use crate::error::*;
 
-use super::Record;
+use super::{Record, RecordData};
 
 fn outgoing_from_row(row: &Row<'_>) -> Result<Payload> {
     let guid: SyncGuid = row.get("guid")?;
@@ -21,9 +21,11 @@ fn outgoing_from_row(row: &Row<'_>) -> Result<Payload> {
     let raw_data: Option<String> = row.get("data")?;
     let payload = match raw_data {
         Some(raw_data) => Payload::from_record(Record {
-            ext_id,
             guid,
-            data: Some(raw_data),
+            data: RecordData::Data {
+                ext_id,
+                data: raw_data,
+            },
         })?,
         None => Payload::new_tombstone(guid),
     };
@@ -60,8 +62,9 @@ pub fn stage_outgoing(tx: &Transaction<'_>) -> Result<()> {
         INSERT OR REPLACE INTO storage_sync_data (ext_id, data, sync_change_counter)
         SELECT ext_id, data, 0
         FROM storage_sync_staging s
-        WHERE NOT EXISTS(SELECT 1 FROM storage_sync_outgoing_staging o
-                         WHERE o.guid = s.guid);";
+        WHERE ext_id IS NOT NULL
+        AND NOT EXISTS(SELECT 1 FROM storage_sync_outgoing_staging o
+                       WHERE o.guid = s.guid);";
     tx.execute_batch(sql)?;
     Ok(())
 }

--- a/components/webext-storage/src/sync/sync_tests.rs
+++ b/components/webext-storage/src/sync/sync_tests.rs
@@ -12,7 +12,7 @@ use crate::schema::create_empty_sync_temp_tables;
 use crate::sync::incoming::{apply_actions, get_incoming, plan_incoming, stage_incoming};
 use crate::sync::outgoing::{get_outgoing, record_uploaded, stage_outgoing};
 use crate::sync::test::new_syncable_mem_db;
-use crate::sync::Record;
+use crate::sync::{Record, RecordData};
 use interrupt_support::NeverInterrupts;
 use rusqlite::{Connection, Row, Transaction};
 use serde_json::json;
@@ -23,6 +23,7 @@ use sync_guid::Guid;
 // Here we try and simulate everything done by a "full sync", just minus the
 // engine. Returns the records we uploaded.
 fn do_sync(tx: &Transaction<'_>, incoming_payloads: Vec<Payload>) -> Result<Vec<Payload>> {
+    log::info!("test do_sync() starting");
     // First we stage the incoming in the temp tables.
     stage_incoming(tx, incoming_payloads, &NeverInterrupts)?;
     // Then we process them getting a Vec of (item, state), which we turn into
@@ -31,10 +32,12 @@ fn do_sync(tx: &Transaction<'_>, incoming_payloads: Vec<Payload>) -> Result<Vec<
         .into_iter()
         .map(|(item, state)| (item, plan_incoming(state)))
         .collect();
+    log::debug!("do_sync applying {:?}", actions);
     apply_actions(&tx, actions, &NeverInterrupts)?;
     // So we've done incoming - do outgoing.
     stage_outgoing(tx)?;
     let outgoing = get_outgoing(tx, &NeverInterrupts)?;
+    log::debug!("do_sync has outgoing {:?}", outgoing);
     record_uploaded(
         tx,
         outgoing
@@ -45,6 +48,7 @@ fn do_sync(tx: &Transaction<'_>, incoming_payloads: Vec<Payload>) -> Result<Vec<
         &NeverInterrupts,
     )?;
     create_empty_sync_temp_tables(tx)?;
+    log::info!("test do_sync() complete");
     Ok(outgoing)
 }
 
@@ -52,7 +56,8 @@ fn do_sync(tx: &Transaction<'_>, incoming_payloads: Vec<Payload>) -> Result<Vec<
 fn check_finished_with(conn: &Connection, ext_id: &str, val: serde_json::Value) -> Result<()> {
     let local = get(conn, &ext_id, serde_json::Value::Null)?;
     assert_eq!(local, val);
-    let mirror = get_mirror_data(conn, ext_id);
+    let guid = get_mirror_guid(conn, ext_id)?;
+    let mirror = get_mirror_data(conn, &guid);
     assert_eq!(mirror, DbData::Data(val.to_string()));
     // and there should be zero items with a change counter.
     let count = conn.query_row_and_then(
@@ -86,11 +91,11 @@ impl DbData {
     }
 }
 
-fn _get(conn: &Connection, expected_extid: &str, table: &str) -> DbData {
-    let sql = format!("SELECT ext_id, data FROM {}", table);
+fn _get(conn: &Connection, id_name: &str, expected_extid: &str, table: &str) -> DbData {
+    let sql = format!("SELECT {} as id, data FROM {}", id_name, table);
 
     fn from_row(row: &Row<'_>) -> Result<(String, Option<String>)> {
-        Ok((row.get("ext_id")?, row.get("data")?))
+        Ok((row.get("id")?, row.get("data")?))
     }
     let mut items = conn
         .conn()
@@ -109,11 +114,11 @@ fn _get(conn: &Connection, expected_extid: &str, table: &str) -> DbData {
 }
 
 fn get_mirror_data(conn: &Connection, expected_extid: &str) -> DbData {
-    _get(conn, expected_extid, "storage_sync_mirror")
+    _get(conn, "guid", expected_extid, "storage_sync_mirror")
 }
 
 fn get_local_data(conn: &Connection, expected_extid: &str) -> DbData {
-    _get(conn, expected_extid, "storage_sync_data")
+    _get(conn, "ext_id", expected_extid, "storage_sync_data")
 }
 
 #[test]
@@ -135,8 +140,10 @@ fn test_simple_incoming_sync() -> Result<()> {
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     let payload = Payload::from_record(Record {
         guid: Guid::from("guid"),
-        ext_id: "ext-id".to_string(),
-        data: Some(data.to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: data.to_string(),
+        },
     })?;
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
     let key1_from_api = get(&tx, "ext-id", json!("key1"))?;
@@ -146,7 +153,7 @@ fn test_simple_incoming_sync() -> Result<()> {
 }
 
 #[test]
-fn test_simple_tombstone() -> Result<()> {
+fn test_outgoing_tombstone() -> Result<()> {
     // Tombstones are only kept when the mirror has that record - so first
     // test that, then arrange for the mirror to have the record.
     let mut db = new_syncable_mem_db();
@@ -164,14 +171,64 @@ fn test_simple_tombstone() -> Result<()> {
     set(&tx, "ext-id", data)?;
     assert_eq!(do_sync(&tx, vec![])?.len(), 1);
     assert!(get_local_data(&tx, "ext-id").has_data());
-    assert!(get_mirror_data(&tx, "ext-id").has_data());
+    let guid = get_mirror_guid(&tx, "ext-id")?;
+    assert!(get_mirror_data(&tx, &guid).has_data());
     clear(&tx, "ext-id")?;
     assert_eq!(get_local_data(&tx, "ext-id"), DbData::NullRow);
     // then after syncing, the tombstone will be in the mirror but the local row
     // has been removed.
     assert_eq!(do_sync(&tx, vec![])?.len(), 1);
     assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
-    assert_eq!(get_mirror_data(&tx, "ext-id"), DbData::NullRow);
+    assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
+    Ok(())
+}
+
+#[test]
+fn test_incoming_tombstone_exists() -> Result<()> {
+    // An incoming tombstone for a record we've previously synced (and thus
+    // have data for)
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let data = json!({"key1": "key1-value", "key2": "key2-value"});
+    set(&tx, "ext-id", data.clone())?;
+    assert_eq!(
+        get_local_data(&tx, "ext-id"),
+        DbData::Data(data.to_string())
+    );
+    // sync to get data in our mirror.
+    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert!(get_local_data(&tx, "ext-id").has_data());
+    let guid = get_mirror_guid(&tx, "ext-id")?;
+    assert!(get_mirror_data(&tx, &guid).has_data());
+    // Now an incoming tombstone for it.
+    let payload = Payload::new_tombstone(guid.clone());
+
+    assert_eq!(
+        do_sync(&tx, vec![payload])?.len(),
+        0,
+        "expect no outgoing records"
+    );
+    assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
+    assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
+    Ok(())
+}
+
+#[test]
+fn test_incoming_tombstone_not_exists() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    // An incoming tombstone for something that's not anywhere locally.
+    let guid = "guid";
+    let payload = Payload::new_tombstone(guid);
+
+    assert_eq!(
+        do_sync(&tx, vec![payload])?.len(),
+        0,
+        "expect no outgoing records"
+    );
+    // But we still keep the tombstone in the mirror.
+    assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
+    assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
     Ok(())
 }
 
@@ -184,8 +241,10 @@ fn test_reconciled() -> Result<()> {
     // Incoming payload with the same data
     let payload = Payload::from_record(Record {
         guid: Guid::from("guid"),
-        ext_id: "ext-id".to_string(),
-        data: Some(json!({"key1": "key1-value"}).to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: json!({"key1": "key1-value"}).to_string(),
+        },
     })?;
     // Should be no outgoing records as we reconciled.
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
@@ -203,18 +262,17 @@ fn test_reconcile_with_null_payload() -> Result<()> {
     set(&tx, "ext-id", data.clone())?;
     // We try to push this change on the next sync.
     assert_eq!(do_sync(&tx, vec![])?.len(), 1);
-    assert_eq!(
-        get_mirror_data(&tx, "ext-id"),
-        DbData::Data(data.to_string())
-    );
     let guid = get_mirror_guid(&tx, "ext-id")?;
+    assert_eq!(get_mirror_data(&tx, &guid), DbData::Data(data.to_string()));
     // Incoming payload with the same data.
     // This could happen if, for example, another client changed the
     // key and then put it back the way it was.
     let payload = Payload::from_record(Record {
         guid: Guid::from(guid),
-        ext_id: "ext-id".to_string(),
-        data: Some(data.to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: data.to_string(),
+        },
     })?;
     // Should be no outgoing records as we reconciled.
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
@@ -237,8 +295,10 @@ fn test_accept_incoming_when_local_is_deleted() -> Result<()> {
     // key1, this means another client deleted it.
     let payload = Payload::from_record(Record {
         guid: Guid::from(guid),
-        ext_id: "ext-id".to_string(),
-        data: Some(json!({"key2": "key2-value"}).to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: json!({"key2": "key2-value"}).to_string(),
+        },
     })?;
     // We completely accept the incoming record.
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
@@ -259,8 +319,10 @@ fn test_accept_incoming_when_local_is_deleted_no_mirror() -> Result<()> {
         // This test is somewhat bad because deduping might obviate
         // the need for it.
         guid: Guid::from("guid"),
-        ext_id: "ext-id".to_string(),
-        data: Some(json!({"key2": "key2-value"}).to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: json!({"key2": "key2-value"}).to_string(),
+        },
     })?;
     // We completely accept the incoming record.
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
@@ -280,8 +342,10 @@ fn test_accept_deleted_key_mirrored() -> Result<()> {
     // key1, this means another client deleted it.
     let payload = Payload::from_record(Record {
         guid: Guid::from(guid),
-        ext_id: "ext-id".to_string(),
-        data: Some(json!({"key2": "key2-value"}).to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: json!({"key2": "key2-value"}).to_string(),
+        },
     })?;
     // We completely accept the incoming record.
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
@@ -300,8 +364,10 @@ fn test_merged_no_mirror() -> Result<()> {
     // with the remote.
     let payload = Payload::from_record(Record {
         guid: Guid::from("guid"),
-        ext_id: "ext-id".to_string(),
-        data: Some(json!({"key2": "key2-value"}).to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: json!({"key2": "key2-value"}).to_string(),
+        },
     })?;
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
     check_finished_with(
@@ -329,8 +395,10 @@ fn test_merged_incoming() -> Result<()> {
     // key1 in, but otherwise keep the server's changes.
     let payload = Payload::from_record(Record {
         guid: Guid::from(guid),
-        ext_id: "ext-id".to_string(),
-        data: Some(json!({"key1": "key1-value", "key2": "key2-incoming"}).to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: json!({"key1": "key1-value", "key2": "key2-incoming"}).to_string(),
+        },
     })?;
     // We should send our 'key1'
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
@@ -350,18 +418,20 @@ fn test_merged_with_null_payload() -> Result<()> {
     set(&tx, "ext-id", old_data.clone())?;
     // Push this change remotely.
     assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    let guid = get_mirror_guid(&tx, "ext-id")?;
     assert_eq!(
-        get_mirror_data(&tx, "ext-id"),
+        get_mirror_data(&tx, &guid),
         DbData::Data(old_data.to_string())
     );
-    let guid = get_mirror_guid(&tx, "ext-id")?;
     let local_data = json!({"key1": "key1-new", "key2": "key2-value"});
     set(&tx, "ext-id", local_data.clone())?;
     // Incoming payload with the same old data.
     let payload = Payload::from_record(Record {
         guid: Guid::from(guid),
-        ext_id: "ext-id".to_string(),
-        data: Some(old_data.to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: old_data.to_string(),
+        },
     })?;
     // Three-way-merge will not detect any change in key1, so we
     // should keep our entire new value.
@@ -382,13 +452,12 @@ fn test_deleted_mirrored_object_accept() -> Result<()> {
     // We synchronize this deletion by deleting the keys we think
     // were on the server.
     let payload = Payload::from_record(Record {
-        guid: Guid::from(guid),
-        ext_id: "ext-id".to_string(),
-        data: None,
+        guid: Guid::from(guid.clone()),
+        data: RecordData::Tombstone,
     })?;
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
-    assert_eq!(get_local_data(&tx, "ext-id"), DbData::NullRow);
-    assert_eq!(get_mirror_data(&tx, "ext-id"), DbData::NullRow);
+    assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
+    assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
     Ok(())
 }
 
@@ -409,8 +478,7 @@ fn test_deleted_mirrored_object_merged() -> Result<()> {
     // were on the server.
     let payload = Payload::from_record(Record {
         guid: Guid::from(guid),
-        ext_id: "ext-id".to_string(),
-        data: None,
+        data: RecordData::Tombstone,
     })?;
     // This overrides the change to 'key1', but we still upload 'key2'.
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
@@ -430,18 +498,16 @@ fn test_deleted_mirrored_tombstone_merged() -> Result<()> {
     // Sync a delete for this data so we have a tombstone in the mirror.
     let payload = Payload::from_record(Record {
         guid: Guid::from(guid.clone()),
-        ext_id: "ext-id".to_string(),
-        data: None,
+        data: RecordData::Tombstone,
     })?;
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
-    assert_eq!(get_mirror_data(&tx, "ext-id"), DbData::NullRow);
+    assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
 
     // Set some data and sync it simultaneously with another incoming delete.
     set(&tx, "ext-id", json!({"key2": "key2-value"}))?;
     let payload = Payload::from_record(Record {
         guid: Guid::from(guid),
-        ext_id: "ext-id".to_string(),
-        data: None,
+        data: RecordData::Tombstone,
     })?;
     // We cannot delete any matching keys because there are no
     // matching keys. Instead we push our data.
@@ -459,8 +525,7 @@ fn test_deleted_not_mirrored_object_merged() -> Result<()> {
     // Incoming payload with data deleted.
     let payload = Payload::from_record(Record {
         guid: Guid::from("guid"),
-        ext_id: "ext-id".to_string(),
-        data: None,
+        data: RecordData::Tombstone,
     })?;
     // We normally delete the keys we think were on the server, but
     // here we have no information about what was on the server, so we
@@ -485,8 +550,10 @@ fn test_conflicting_incoming() -> Result<()> {
     // key1 in, but the server key2 wins.
     let payload = Payload::from_record(Record {
         guid: Guid::from("guid"),
-        ext_id: "ext-id".to_string(),
-        data: Some(json!({"key2": "key2-incoming"}).to_string()),
+        data: RecordData::Data {
+            ext_id: "ext-id".to_string(),
+            data: json!({"key2": "key2-incoming"}).to_string(),
+        },
     })?;
     // We should send our 'key1'
     assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1667985

This is a large patch because of a fundamental assumption that turns out
to be invalid and had to be un-done - that we can determine which extension
a tombstone is for. Because a tombstone record has only the GUID and the
deleted flag this isn't possible (and syncing for clients with a tombstone
was broken by that assumption)

This had wide ramifications in the code. Of note:

* The mirror table in the database previously had a not-null constraint
  for the ext-id column, but that's clearly not valid for tombstones.
  Due to sqlite limitations, this means a non-trivial migration (rename
  the old table, create the new one, populate new from old, delete old)

* Same is true for the "staging" table, but that's a temp table, so no
  migration was necessary.

* As a result, some queries got a little more complex - they had to join
  via the GUID to the mirror/stage tables.

* `IncomingItem` used to have a GUID and ext-id - but it can
  no longer assume a valid ext-id. Rather than change this to
  an `Option<>` (this meaning it could be None in contexts where
  it logically could not), I took the hit of moving it to a better place.
  This left `IncomingItem` being a wrapper for a GUID, so it's
  been deleted and replaced with a plain GUID.

* The `ext-id` that was in `IncomingItem` is now in the IncomingState
  variants - every variant except the one representing an incoming tombstone.

* Similarly for `IncomingAction` - this now carries the ext-id for most
  variants, and had a number of flow-on effects - eg it's a new param
  to merge, etc, and many tests needed to be touched, although
  most in obvious ways.

* There are new tests for all of this.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
