### PR TITLE
Rate limit for update push endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,6 +1124,7 @@ dependencies = [
  "prost",
  "prost-derive",
  "rand_rccrypto",
+ "rate-limiter",
  "rc_crypto",
  "serde",
  "serde_derive",
@@ -2620,6 +2621,10 @@ checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
 ]
+
+[[package]]
+name = "rate-limiter"
+version = "0.1.0"
 
 [[package]]
 name = "rayon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "components/support/interrupt",
     "components/support/jwcrypto",
     "components/support/rand_rccrypto",
+    "components/support/rate-limiter",
     "components/support/restmail-client",
     "components/support/rc_crypto",
     "components/support/rc_crypto/nss",

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -13,6 +13,7 @@ lazy_static = "1.4"
 log = "0.4"
 prost = "0.6"
 prost-derive = "0.6"
+rate-limiter = { path = "../support/rate-limiter" }
 rand_rccrypto = { path = "../support/rand_rccrypto" }
 serde = { version = "1", features = ["rc"] }
 serde_derive = "1"

--- a/components/push/src/communications.rs
+++ b/components/push/src/communications.rs
@@ -24,6 +24,9 @@ use crate::error::{
 };
 use crate::storage::Store;
 
+mod rate_limiter;
+pub use rate_limiter::PersistedRateLimiter;
+
 #[derive(Debug)]
 pub struct RegisterResponse {
     /// The UAID associated with the request

--- a/components/push/src/communications/rate_limiter.rs
+++ b/components/push/src/communications/rate_limiter.rs
@@ -1,0 +1,168 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::storage::{Storage, Store};
+use std::{
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+// DB persisted rate limiter.
+// Implementation notes: This saves the timestamp of our latest call and the number of times we have
+// called `Self::check` within the `Self::periodic_interval` interval of time.
+pub struct PersistedRateLimiter {
+    op_name: String,
+    periodic_interval: u64, // In seconds.
+    max_requests_in_interval: u16,
+}
+
+impl PersistedRateLimiter {
+    pub fn new(op_name: &str, periodic_interval: u64, max_requests_in_interval: u16) -> Self {
+        Self {
+            op_name: op_name.to_owned(),
+            periodic_interval,
+            max_requests_in_interval,
+        }
+    }
+
+    pub fn check(&self, store: &Store) -> bool {
+        let (mut timestamp, mut count) = self.get_counters(store);
+
+        let now = now_secs();
+        if (now - timestamp) >= self.periodic_interval {
+            log::info!(
+                "Resetting. now({}) - {} < {} for {}.",
+                now,
+                timestamp,
+                self.periodic_interval,
+                &self.op_name
+            );
+            count = 0;
+            timestamp = now;
+        } else {
+            log::info!(
+                "No need to reset inner timestamp and count for {}.",
+                &self.op_name
+            )
+        }
+
+        count += 1;
+        self.persist_counters(store, timestamp, count);
+
+        // within interval counter
+        if count > self.max_requests_in_interval {
+            log::info!(
+                "Not allowed: count({}) > {} for {}.",
+                count,
+                self.max_requests_in_interval,
+                &self.op_name
+            );
+            return false;
+        }
+
+        log::info!("Allowed to pass through for {}!", &self.op_name);
+
+        true
+    }
+
+    fn db_meta_keys(&self) -> (String, String) {
+        (
+            format!("ratelimit_{}_timestamp", &self.op_name),
+            format!("ratelimit_{}_count", &self.op_name),
+        )
+    }
+
+    fn get_counters(&self, store: &Store) -> (u64, u16) {
+        let (timestamp_key, count_key) = self.db_meta_keys();
+        (
+            Self::get_meta_integer(store, &timestamp_key),
+            Self::get_meta_integer(store, &count_key),
+        )
+    }
+
+    fn get_meta_integer<T: FromStr + Default>(store: &Store, key: &str) -> T {
+        store
+            .get_meta(&key)
+            .ok()
+            .flatten()
+            .map(|s| s.parse())
+            .transpose()
+            .ok()
+            .flatten()
+            .unwrap_or_default()
+    }
+
+    fn persist_counters(&self, store: &Store, timestamp: u64, count: u16) {
+        let (timestamp_key, count_key) = self.db_meta_keys();
+        let r1 = store.set_meta(&timestamp_key, &timestamp.to_string());
+        let r2 = store.set_meta(&count_key, &count.to_string());
+        if r1.is_err() || r2.is_err() {
+            log::warn!("Error updating persisted counters for {}.", &self.op_name);
+        }
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Current date before unix epoch.")
+        .as_secs()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::error::Result;
+
+    static PERIODIC_INTERVAL: u64 = 24 * 3600;
+    static VERIFY_NOW_INTERVAL: u64 = PERIODIC_INTERVAL + 3600;
+    static MAX_REQUESTS: u16 = 500;
+
+    #[test]
+    fn test_persisted_rate_limiter_store_counters_roundtrip() -> Result<()> {
+        let limiter = PersistedRateLimiter::new("op1", PERIODIC_INTERVAL, MAX_REQUESTS);
+        let store = Store::open_in_memory()?;
+        limiter.persist_counters(&store, 123, 321);
+        assert_eq!((123, 321), limiter.get_counters(&store));
+        Ok(())
+    }
+
+    #[test]
+    fn test_persisted_rate_limiter_after_interval_counter_resets() -> Result<()> {
+        let limiter = PersistedRateLimiter::new("op1", PERIODIC_INTERVAL, MAX_REQUESTS);
+        let store = Store::open_in_memory()?;
+        limiter.persist_counters(&store, now_secs() - VERIFY_NOW_INTERVAL, 50);
+        assert!(limiter.check(&store));
+        assert_eq!(1, limiter.get_counters(&store).1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_persisted_rate_limiter_false_above_rate_limit() -> Result<()> {
+        let limiter = PersistedRateLimiter::new("op1", PERIODIC_INTERVAL, MAX_REQUESTS);
+        let store = Store::open_in_memory()?;
+        limiter.persist_counters(&store, now_secs(), MAX_REQUESTS + 1);
+        assert!(!limiter.check(&store));
+        assert_eq!(MAX_REQUESTS + 2, limiter.get_counters(&store).1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_persisted_rate_limiter_reset_above_rate_limit_and_interval() -> Result<()> {
+        let limiter = PersistedRateLimiter::new("op1", PERIODIC_INTERVAL, MAX_REQUESTS);
+        let store = Store::open_in_memory()?;
+        limiter.persist_counters(&store, now_secs() - VERIFY_NOW_INTERVAL, 501);
+        assert!(limiter.check(&store));
+        assert_eq!(1, limiter.get_counters(&store).1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_persisted_rate_limiter_no_reset_with_rate_limits() -> Result<()> {
+        let limiter = PersistedRateLimiter::new("op1", PERIODIC_INTERVAL, MAX_REQUESTS);
+        let store = Store::open_in_memory()?;
+        assert!(limiter.check(&store));
+        Ok(())
+    }
+}

--- a/components/push/src/subscriber.rs
+++ b/components/push/src/subscriber.rs
@@ -6,17 +6,22 @@
 //!
 //! "privileged" system calls may require additional handling and should be flagged as such.
 
-use crate::communications::{connect, ConnectHttp, Connection, RegisterResponse};
+use crate::communications::{
+    connect, ConnectHttp, Connection, PersistedRateLimiter, RegisterResponse,
+};
 use crate::config::PushConfiguration;
 use crate::crypto::{Crypto, Cryptography, KeyV1 as Key};
+use crate::error::{self, ErrorKind, Result};
 use crate::storage::{PushRecord, Storage, Store};
 
-use crate::error::{self, ErrorKind, Result};
+const UPDATE_RATE_LIMITER_INTERVAL: u64 = 24 * 60 * 60; // 500 calls per 24 hours.
+const UPDATE_RATE_LIMITER_MAX_CALLS: u16 = 500;
 
 pub struct PushManager {
     config: PushConfiguration,
     pub conn: ConnectHttp,
     pub store: Store,
+    update_rate_limiter: PersistedRateLimiter,
 }
 
 impl PushManager {
@@ -27,10 +32,15 @@ impl PushManager {
             Store::open_in_memory()?
         };
         let uaid = store.get_meta("uaid")?;
-        let pm = PushManager {
+        let pm = Self {
             config: config.clone(),
             conn: connect(config, uaid, store.get_meta("auth")?)?,
             store,
+            update_rate_limiter: PersistedRateLimiter::new(
+                "update_token",
+                UPDATE_RATE_LIMITER_INTERVAL,
+                UPDATE_RATE_LIMITER_MAX_CALLS,
+            ),
         };
         Ok(pm)
     }
@@ -117,6 +127,9 @@ impl PushManager {
     pub fn update(&mut self, new_token: &str) -> error::Result<bool> {
         if self.conn.uaid.is_none() {
             return Err(ErrorKind::GeneralError("No subscriptions created yet.".into()).into());
+        }
+        if !self.update_rate_limiter.check(&self.store) {
+            return Ok(false);
         }
         let result = self.conn.update(&new_token)?;
         self.store

--- a/components/support/rate-limiter/Cargo.toml
+++ b/components/support/rate-limiter/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rate-limiter"
+version = "0.1.0"
+authors = ["Edouard Oger <eoger@fastmail.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["lib"]

--- a/components/support/rate-limiter/src/lib.rs
+++ b/components/support/rate-limiter/src/lib.rs
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Simple token bucket rate-limiter implementation.
+
+#[derive(Clone, Copy)]
+pub struct RateLimiter {
+    capacity: u8,
+    tokens: u8,
+    renewal_rate: f32, // per ms.
+    last_refill: u64,  // in ms.
+}
+
+impl RateLimiter {
+    pub fn new(capacity: u8, renewal_rate: f32) -> Self {
+        Self {
+            capacity,
+            tokens: capacity,
+            renewal_rate,
+            last_refill: Self::now(),
+        }
+    }
+
+    pub fn check(&mut self) -> bool {
+        self.refill();
+        if self.tokens == 0 {
+            return false;
+        }
+        self.tokens -= 1;
+        true
+    }
+
+    fn refill(&mut self) {
+        let now = Self::now();
+        let new_tokens = ((now - self.last_refill) as f64 * self.renewal_rate as f64) as u8; // `as` is a truncating/saturing cast.
+        if new_tokens > 0 {
+            self.last_refill = now;
+            self.tokens = std::cmp::min(self.capacity, self.tokens.saturating_add(new_tokens));
+        }
+    }
+
+    #[inline]
+    fn now() -> u64 {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let since_epoch = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Current date before unix epoch.");
+        since_epoch.as_secs() * 1000 + u64::from(since_epoch.subsec_nanos()) / 1_000_000
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::RateLimiter;
+    #[test]
+    fn test_recovery() {
+        let capacity = 10;
+        let renewal_rate = 1.0 / 60.0 / 1000.0; // 1 token per second.
+        let mut breaker = RateLimiter::new(capacity, renewal_rate);
+        for _ in 0..capacity {
+            assert!(breaker.check());
+        }
+        assert!(!breaker.check());
+        assert_eq!(breaker.tokens, 0);
+        // Jump back in time (1 min).
+        let jump_ms = 60 * 1000;
+        breaker.last_refill -= jump_ms;
+        let expected_tokens_before_check: u8 = (renewal_rate * jump_ms as f32) as u8;
+        assert!(breaker.check());
+        assert_eq!(breaker.tokens, expected_tokens_before_check - 1);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/mozilla/application-services/issues/3662.

This implements the rate limiting algorithm from [Android components](https://github.com/mozilla-mobile/android-components/blob/3f1d5499dbb7d966d3c12f127bf81065f5716b11/components/feature/accounts-push/src/main/java/mozilla/components/feature/accounts/push/FxaPushSupportFeature.kt#L227-L232).