### PR TITLE
Gets closer to uniffi working.

### DIFF
--- a/components/autofill/src/api/addresses.rs
+++ b/components/autofill/src/api/addresses.rs
@@ -61,7 +61,7 @@ pub struct Address {
 
     #[serde(default)]
     #[serde(rename = "timeLastUsed")]
-    pub time_last_used: Timestamp,
+    pub time_last_used: Option<Timestamp>,
 
     #[serde(default)]
     #[serde(rename = "timeLastModified")]

--- a/components/autofill/src/api/addresses.rs
+++ b/components/autofill/src/api/addresses.rs
@@ -106,8 +106,8 @@ impl Address {
 }
 
 #[allow(dead_code)]
-pub fn add_address(conn: &mut Connection, new_address: NewAddressFields) -> Result<Address> {
-    let tx = conn.transaction()?;
+pub fn add_address(conn: &Connection, new_address: NewAddressFields) -> Result<Address> {
+    let tx = conn.unchecked_transaction()?;
 
     let address = Address {
         guid: Guid::random(),
@@ -172,8 +172,8 @@ pub fn add_address(conn: &mut Connection, new_address: NewAddressFields) -> Resu
 }
 
 #[allow(dead_code)]
-pub fn get_address(conn: &mut Connection, guid: &Guid) -> Result<Address> {
-    let tx = conn.transaction()?;
+pub fn get_address(conn: &Connection, guid: &Guid) -> Result<Address> {
+    let tx = conn.unchecked_transaction()?;
     let sql = format!(
         "SELECT
             {common_cols}
@@ -189,8 +189,8 @@ pub fn get_address(conn: &mut Connection, guid: &Guid) -> Result<Address> {
 }
 
 #[allow(dead_code)]
-pub fn get_all_addresses(conn: &mut Connection) -> Result<Vec<Address>> {
-    let tx = conn.transaction()?;
+pub fn get_all_addresses(conn: &Connection) -> Result<Vec<Address>> {
+    let tx = conn.unchecked_transaction()?;
     let mut addresses = Vec::new();
     let sql = format!(
         "SELECT
@@ -213,8 +213,8 @@ pub fn get_all_addresses(conn: &mut Connection) -> Result<Vec<Address>> {
 }
 
 #[allow(dead_code)]
-pub fn update_address(conn: &mut Connection, address: Address) -> Result<()> {
-    let tx = conn.transaction()?;
+pub fn update_address(conn: &Connection, address: Address) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
     tx.execute_named(
         "UPDATE addresses_data
         SET given_name         = :given_name,
@@ -252,8 +252,8 @@ pub fn update_address(conn: &mut Connection, address: Address) -> Result<()> {
     Ok(())
 }
 
-pub fn delete_address(conn: &mut Connection, guid: &Guid) -> Result<bool> {
-    let tx = conn.transaction()?;
+pub fn delete_address(conn: &Connection, guid: &Guid) -> Result<bool> {
+    let tx = conn.unchecked_transaction()?;
 
     // check that guid exists
     let exists = tx.query_row(

--- a/components/autofill/src/api/credit_cards.rs
+++ b/components/autofill/src/api/credit_cards.rs
@@ -77,12 +77,11 @@ impl CreditCard {
     }
 }
 
-#[allow(dead_code)]
 pub fn add_credit_card(
-    conn: &mut Connection,
+    conn: &Connection,
     new_credit_card_fields: NewCreditCardFields,
 ) -> Result<CreditCard> {
-    let tx = conn.transaction()?;
+    let tx = conn.unchecked_transaction()?;
 
     let credit_card = CreditCard {
         guid: Guid::random(),
@@ -132,9 +131,8 @@ pub fn add_credit_card(
     Ok(credit_card)
 }
 
-#[allow(dead_code)]
-pub fn get_credit_card(conn: &mut Connection, guid: &Guid) -> Result<CreditCard> {
-    let tx = conn.transaction()?;
+pub fn get_credit_card(conn: &Connection, guid: &Guid) -> Result<CreditCard> {
+    let tx = conn.unchecked_transaction()?;
     let sql = format!(
         "SELECT
             {common_cols}
@@ -149,9 +147,8 @@ pub fn get_credit_card(conn: &mut Connection, guid: &Guid) -> Result<CreditCard>
     Ok(credit_card)
 }
 
-#[allow(dead_code)]
-pub fn get_all_credit_cards(conn: &mut Connection) -> Result<Vec<CreditCard>> {
-    let tx = conn.transaction()?;
+pub fn get_all_credit_cards(conn: &Connection) -> Result<Vec<CreditCard>> {
+    let tx = conn.unchecked_transaction()?;
     let credit_cards;
     let sql = format!(
         "SELECT
@@ -171,9 +168,8 @@ pub fn get_all_credit_cards(conn: &mut Connection) -> Result<Vec<CreditCard>> {
     Ok(credit_cards)
 }
 
-#[allow(dead_code)]
-pub fn update_credit_card(conn: &mut Connection, credit_card: CreditCard) -> Result<()> {
-    let tx = conn.transaction()?;
+pub fn update_credit_card(conn: &Connection, credit_card: CreditCard) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
     tx.execute_named(
         "UPDATE credit_cards_data
         SET cc_name                     = :cc_name,
@@ -205,9 +201,8 @@ pub fn update_credit_card(conn: &mut Connection, credit_card: CreditCard) -> Res
     Ok(())
 }
 
-#[allow(dead_code)]
-pub fn delete_credit_card(conn: &mut Connection, guid: &Guid) -> Result<bool> {
-    let tx = conn.transaction()?;
+pub fn delete_credit_card(conn: &Connection, guid: &Guid) -> Result<bool> {
+    let tx = conn.unchecked_transaction()?;
 
     // check that guid exists
     let exists = tx.query_row(

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -1,3 +1,5 @@
+namespace autofill {};
+
 dictionary NewCreditCardFields {
     string cc_name;
     string cc_number;
@@ -45,7 +47,10 @@ enum ErrorKind {
    "SqlError", "IoError", "InterruptedError", "Utf8Error"
 };
 
-namespace autofill {
+interface AutofillDb {
+    [Throws=ErrorKind]
+    constructor(string dbpath);
+
     [Throws=ErrorKind]
     CreditCard add_credit_card(NewCreditCardFields a);
 

--- a/components/autofill/src/db.rs
+++ b/components/autofill/src/db.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use url::Url;
 
-use crate::api::{addresses::*, credit_cards::*};
+use crate::api::{addresses, credit_cards};
 use sync_guid::Guid;
 
 pub struct AutofillDb {
@@ -29,54 +29,57 @@ impl AutofillDb {
     #[allow(dead_code)]
     pub fn add_credit_card(
         &self,
-        new_credit_card_fields: NewCreditCardFields,
-    ) -> Result<CreditCard> {
-        credit_cards::add_credit_card(self.unchecked_transaction()?, new_credit_card_fields)
+        new_credit_card_fields: credit_cards::NewCreditCardFields,
+    ) -> Result<credit_cards::CreditCard> {
+        credit_cards::add_credit_card(&self.writer, new_credit_card_fields)
     }
 
     #[allow(dead_code)]
-    pub fn get_credit_card(&self, guid: &Guid) -> Result<CreditCard> {
-        credit_cards::get_credit_card(self.unchecked_transaction()?, guid)
+    pub fn get_credit_card(&self, guid: &Guid) -> Result<credit_cards::CreditCard> {
+        credit_cards::get_credit_card(&self.writer, guid)
     }
 
     #[allow(dead_code)]
-    pub fn get_all_credit_cards(&self) -> Result<Vec<CreditCard>> {
-        credit_cards::get_all_credit_cards(self.unchecked_transaction()?)
+    pub fn get_all_credit_cards(&self) -> Result<Vec<credit_cards::CreditCard>> {
+        credit_cards::get_all_credit_cards(&self.writer)
     }
 
     #[allow(dead_code)]
-    pub fn update_credit_card(&self, credit_card: CreditCard) -> Result<()> {
-        credit_card::update_credit_card(self.unchecked_transaction()?, credit_card)
+    pub fn update_credit_card(&self, credit_card: credit_cards::CreditCard) -> Result<()> {
+        credit_cards::update_credit_card(&self.writer, credit_card)
     }
 
     #[allow(dead_code)]
     pub fn delete_credit_card(&self, guid: &Guid) -> Result<bool> {
-        credit_card::delete_credit_card(self.unchecked_transaction()?, guid)
+        credit_cards::delete_credit_card(&self.writer, guid)
     }
 
     #[allow(dead_code)]
-    pub fn add_address(&self, new_address: NewAddressFields) -> Result<Address> {
-        addresses::add_address(self.unchecked_transaction()?, new_address)
+    pub fn add_address(
+        &self,
+        new_address: addresses::NewAddressFields,
+    ) -> Result<addresses::Address> {
+        addresses::add_address(&self.writer, new_address)
     }
 
     #[allow(dead_code)]
-    pub fn get_address(&self, guid: &Guid) -> Result<Address> {
-        addresses::get_address(self.unchecked_transaction()?, guid)
+    pub fn get_address(&self, guid: &Guid) -> Result<addresses::Address> {
+        addresses::get_address(&self.writer, guid)
     }
 
     #[allow(dead_code)]
-    pub fn get_all_addresses(&self) -> Result<Vec<Address>> {
-        addresses::get_all_addresses(self.unchecked_transaction()?)
+    pub fn get_all_addresses(&self) -> Result<Vec<addresses::Address>> {
+        addresses::get_all_addresses(&self.writer)
     }
 
     #[allow(dead_code)]
-    pub fn update_address(&self, address: Address) -> Result<()> {
-        addresses::update_address(self.unchecked_transaction()?, address)
+    pub fn update_address(&self, address: addresses::Address) -> Result<()> {
+        addresses::update_address(&self.writer, address)
     }
 
     #[allow(dead_code)]
     pub fn delete_address(&self, guid: &Guid) -> Result<bool> {
-        addresses::delete_address(self.unchecked_transaction()?, guid)
+        addresses::delete_address(&self.writer, guid)
     }
 
     #[cfg(test)]

--- a/components/autofill/src/lib.rs
+++ b/components/autofill/src/lib.rs
@@ -12,4 +12,10 @@ pub mod error;
 mod schema;
 pub mod store;
 
+// Expose stuff needed by the uniffi generated code.
+use api::addresses::*;
+use api::credit_cards::*;
+use db::AutofillDb;
+use error::ErrorKind;
+
 include!(concat!(env!("OUT_DIR"), "/autofill.uniffi.rs"));


### PR DESCRIPTION
This is much closer, but it leaves us with 3 main problems:

* Types we use but want to hide from the ffi. Eg, our rust API uses `SyncGuid`
  and `Timestamp`, but our FFI should use `String` and `i64`. It might be
  that we can abuse traits to hide this?

* Fields in our struct that shouldn't go across the FFI - `syncChangeCounter`
  is the obvious one. This field is needed for interacting with the database,
  but probably should not be part of the API - eg, even for a rust consumer,
  we don't want to expose this field.

  I think the general answer here is that there should be 2 (or more) distinct
  types - "internal implementation" types used for reading and writing the DB,
  and a different type used for the API. This would be far more obvious if our
  database was more complex (eg, had many relations) - you might have 1 struct
  per *table* at the implementation level, but a combined struct at the API
  level. Places does exactly this - it actually goes much further - different
  structs for *reads* vs *writes* (basically better handling optional fields
  which don't need to be specified when writing, but always exist when reading)
  It's not as obvious for autofill because the 2 structs are so similar, but I
  think this is probably what we should do.

* Errors are a but wierd for reasons I need to better understand. app-services
  has this error support stuff - eg, components/support/error/src/lib.rs.
  All our existing components use this, but uniffi doesn't want us to. nimbus
  seems to avoid this complexity. I'm really not sure what to do here.

And we should also take a step back and discuss the names we are exposing
to clients here. Specifically, the main "interface" exposed to consumers is
`AutofillDb` - which doesn't seem quite right. Thom, Lina and myself had
a big discussion about this, which I can't find, but I think we landed on
"Store" as the name. IOW, I think it might make sense to:

* Add a new store struct, that takes a path in ::new()
* It creates a DB object and stores it in a private val.
* The "api like" functions on the DB move to here.
* We change the imports in lib and name in the udl to refer
  to the new struct instead of DB. This effectively makes db
  private to the crate.

