### PR TITLE
Ensure rust compiler is up-to-date in verify scripts

### DIFF
--- a/libs/verify-common.sh
+++ b/libs/verify-common.sh
@@ -6,3 +6,5 @@ if ! [[ -x "$(command -v rustc)" ]]; then
   echo 'Error: The Rust compiler needs to be installed. See https://rustup.rs/ for install instructions.' >&2
   exit 1
 fi
+# Ensure the rust compiler is up-to-date.
+rustup update stable


### PR DESCRIPTION
I've noticed it bit @nbhasin2 today, we might as well do it.