### PR TITLE
Add address foreign key to credit card model

### DIFF
--- a/components/autofill/sql/create_shared_schema.sql
+++ b/components/autofill/sql/create_shared_schema.sql
@@ -3,7 +3,7 @@
 -- file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 CREATE TABLE IF NOT EXISTS addresses_data (
-    guid          TEXT NOT NULL PRIMARY KEY,
+    guid                TEXT NOT NULL PRIMARY KEY,
     given_name          TEXT NOT NULL,
     additional_name     TEXT NOT NULL,
     family_name         TEXT NOT NULL,
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS addresses_data (
 );
 
 CREATE TABLE IF NOT EXISTS addresses_mirror (
-   guid          TEXT NOT NULL PRIMARY KEY,
+    guid                TEXT NOT NULL PRIMARY KEY,
     given_name          TEXT NOT NULL,
     additional_name     TEXT NOT NULL,
     family_name         TEXT NOT NULL,
@@ -55,36 +55,38 @@ CREATE TABLE IF NOT EXISTS addresses_tombstones (
 -- whether the `cc_number` and/or other details should be encrypted or stored as plain text. Currently, we are storing
 -- them as plain text.
 CREATE TABLE IF NOT EXISTS credit_cards_data (
-    guid                TEXT NOT NULL PRIMARY KEY,
-    cc_name             TEXT NOT NULL, -- full name
-    cc_number           TEXT NOT NULL, -- TODO: consider storing this field as a hash
-    cc_exp_month        INTEGER,
-    cc_exp_year         INTEGER,
-    cc_type             TEXT NOT NULL,
-    -- cc_exp              TEXT NOT NULL, -- text format of the expiration date e.g. "[cc_exp_year]-[cc_exp_month]"
+    guid                    TEXT NOT NULL PRIMARY KEY,
+    billing_address_guid    TEXT NOT NULL,
+    cc_name                 TEXT NOT NULL, -- full name
+    cc_number               TEXT NOT NULL, -- TODO: consider storing this field as a hash
+    cc_exp_month            INTEGER,
+    cc_exp_year             INTEGER,
+    cc_type                 TEXT NOT NULL,
 
-    time_created        INTEGER NOT NULL,
-    time_last_used      INTEGER,
-    time_last_modified  INTEGER NOT NULL,
-    times_used          INTEGER NOT NULL DEFAULT 0,
+    time_created            INTEGER NOT NULL,
+    time_last_used          INTEGER,
+    time_last_modified      INTEGER NOT NULL,
+    times_used              INTEGER NOT NULL DEFAULT 0,
 
     /* Same "sync change counter" strategy used by other components. */
-    sync_change_counter INTEGER NOT NULL DEFAULT 1
+    sync_change_counter INTEGER NOT NULL DEFAULT 1,
+
+    FOREIGN KEY(billing_address_guid) REFERENCES addresses_data(guid) ON DELETE SET DEFAULT
 );
 
 CREATE TABLE IF NOT EXISTS credit_cards_mirror (
-    guid                TEXT NOT NULL PRIMARY KEY,
-    cc_name             TEXT NOT NULL, -- full name
-    cc_number           TEXT NOT NULL,
-    cc_exp_month        INTEGER,
-    cc_exp_year         INTEGER,
-    cc_type             TEXT NOT NULL,
-    -- cc_exp              TEXT NOT NULL, -- text format of the expiration date e.g. "[cc_exp_year]-[cc_exp_month]"
+    guid                    TEXT NOT NULL PRIMARY KEY,
+    billing_address_guid    TEXT NOT NULL,
+    cc_name                 TEXT NOT NULL, -- full name
+    cc_number               TEXT NOT NULL,
+    cc_exp_month            INTEGER,
+    cc_exp_year             INTEGER,
+    cc_type                 TEXT NOT NULL,
 
-    time_created        INTEGER NOT NULL,
-    time_last_used      INTEGER,
-    time_last_modified  INTEGER NOT NULL,
-    times_used          INTEGER NOT NULL DEFAULT 0
+    time_created            INTEGER NOT NULL,
+    time_last_used          INTEGER,
+    time_last_modified      INTEGER NOT NULL,
+    times_used              INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS credit_cards_tombstones (

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -1,6 +1,7 @@
 namespace autofill {};
 
 dictionary NewCreditCardFields {
+    string billing_address_guid;
     string cc_name;
     string cc_number;
     i64 cc_exp_month;
@@ -10,6 +11,7 @@ dictionary NewCreditCardFields {
 
 dictionary CreditCard {
     string guid;
+    string billing_address_guid;
     string cc_name;
     string cc_number;
     i64 cc_exp_month;

--- a/components/autofill/src/db/models/credit_card.rs
+++ b/components/autofill/src/db/models/credit_card.rs
@@ -12,6 +12,8 @@ use types::Timestamp;
 #[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct NewCreditCardFields {
+    pub billing_address_guid: String,
+
     pub cc_name: String,
 
     pub cc_number: String,
@@ -55,6 +57,7 @@ pub struct InternalCreditCard {
 impl InternalCreditCard {
     pub fn from_row(row: &Row<'_>) -> Result<InternalCreditCard, rusqlite::Error> {
         let credit_card_fields = NewCreditCardFields {
+            billing_address_guid: row.get("billing_address_guid")?,
             cc_name: row.get("cc_name")?,
             cc_number: row.get("cc_number")?,
             cc_exp_month: row.get("cc_exp_month")?,
@@ -78,6 +81,7 @@ impl InternalCreditCard {
 #[serde(rename_all = "kebab-case")]
 pub struct CreditCard {
     pub guid: String,
+    pub billing_address_guid: String,
     pub cc_name: String,
     pub cc_number: String,
     pub cc_exp_month: i64,
@@ -96,6 +100,7 @@ impl ExternalizeCreditCard for InternalCreditCard {
     fn to_external(&self) -> CreditCard {
         CreditCard {
             guid: self.guid.to_string(),
+            billing_address_guid: self.clone().fields.billing_address_guid,
             cc_name: self.clone().fields.cc_name,
             cc_number: self.clone().fields.cc_number,
             cc_exp_month: self.fields.cc_exp_month,

--- a/components/autofill/src/db/schema.rs
+++ b/components/autofill/src/db/schema.rs
@@ -27,6 +27,7 @@ pub const ADDRESS_COMMON_COLS: &str = "
 
 pub const CREDIT_CARD_COMMON_COLS: &str = "
     guid,
+    billing_address_guid,
     cc_name,
     cc_number,
     cc_exp_month,


### PR DESCRIPTION
Adding a foreign key from the addresses table in the credit cards tables. This was omitted because it wasn't clear if credit cards and addresses would be handled as two separate projects. But the relationship between these tables can be created regardless as that product decision will mainly affect the a-c and/or fenix implementation.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
