### PR TITLE
Rename 'engine' and 'store' to conform with the sync15 readme.

### DIFF
--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -10,8 +10,8 @@ mod error;
 mod login;
 
 mod db;
-mod engine;
 pub mod schema;
+mod store;
 mod update_plan;
 mod util;
 
@@ -20,9 +20,9 @@ mod ffi;
 // Mostly exposed for the sync manager.
 pub use crate::db::LoginDb;
 pub use crate::db::LoginStore;
-pub use crate::engine::*;
 pub use crate::error::*;
 pub use crate::login::*;
+pub use crate::store::*;
 
 pub mod msg_types {
     include!("mozilla.appservices.logins.protobuf.rs");

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -236,9 +236,9 @@ impl PlacesApi {
             "history",
             move |conn, mem_cached_state, disk_cached_state| {
                 let interruptee = conn.begin_interrupt_scope();
-                let store = HistoryEngine::new(&conn, &interruptee);
+                let engine = HistoryEngine::new(&conn, &interruptee);
                 sync_multiple(
-                    &[&store],
+                    &[&engine],
                     disk_cached_state,
                     mem_cached_state,
                     client_init,
@@ -259,9 +259,9 @@ impl PlacesApi {
             "bookmarks",
             move |conn, mem_cached_state, disk_cached_state| {
                 let interruptee = conn.begin_interrupt_scope();
-                let store = BookmarksEngine::new(&conn, &interruptee);
+                let engine = BookmarksEngine::new(&conn, &interruptee);
                 sync_multiple(
-                    &[&store],
+                    &[&engine],
                     disk_cached_state,
                     mem_cached_state,
                     client_init,
@@ -342,14 +342,14 @@ impl PlacesApi {
         HistoryEngine::migrate_v1_global_state(&conn)?;
 
         let interruptee = conn.begin_interrupt_scope();
-        let bm_store = BookmarksEngine::new(&conn, &interruptee);
-        let history_store = HistoryEngine::new(&conn, &interruptee);
+        let bm_engine = BookmarksEngine::new(&conn, &interruptee);
+        let history_engine = HistoryEngine::new(&conn, &interruptee);
         let mut mem_cached_state = sync_state.mem_cached_state.take();
         let mut disk_cached_state = sync_state.disk_cached_state.take();
 
         // NOTE: After here we must never return Err()!
         let result = sync15::sync_multiple(
-            &[&history_store, &bm_store],
+            &[&history_engine, &bm_engine],
             &mut disk_cached_state,
             &mut mem_cached_state,
             client_init,

--- a/components/places/src/bookmark_sync/mod.rs
+++ b/components/places/src/bookmark_sync/mod.rs
@@ -2,9 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+pub mod engine;
 mod incoming;
 pub mod record;
-pub mod store;
 
 #[cfg(test)]
 mod tests;

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -8,7 +8,7 @@
 // db.rs.
 
 use crate::api::places_api::ConnectionType;
-use crate::bookmark_sync::store::LAST_SYNC_META_KEY;
+use crate::bookmark_sync::engine::LAST_SYNC_META_KEY;
 use crate::db::PlacesDb;
 use crate::error::*;
 use crate::storage::bookmarks::{

--- a/components/places/src/history_sync/mod.rs
+++ b/components/places/src/history_sync/mod.rs
@@ -7,9 +7,9 @@ use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 use types::Timestamp;
 
+pub mod engine;
 mod plan;
 pub mod record;
-pub mod store;
 
 const MAX_INCOMING_PLACES: usize = 5000;
 const MAX_OUTGOING_PLACES: usize = 5000;

--- a/components/places/src/import/fennec/bookmarks.rs
+++ b/components/places/src/import/fennec/bookmarks.rs
@@ -4,7 +4,7 @@
 
 use crate::api::places_api::PlacesApi;
 use crate::bookmark_sync::{
-    store::{BookmarksStore, Merger},
+    engine::{BookmarksEngine, Merger},
     SyncedBookmarkKind,
 };
 use crate::db::db::PlacesDb;
@@ -115,8 +115,8 @@ fn do_import(places_api: &PlacesApi, fennec_db_file_url: Url) -> Result<Bookmark
     conn.execute_batch(&POPULATE_MIRROR_STRUCTURE)?;
     scope.err_if_interrupted()?;
 
-    let store = BookmarksStore::new(&conn, &scope);
-    let mut merger = Merger::new(&store, Default::default());
+    let engine = BookmarksEngine::new(&conn, &scope);
+    let mut merger = Merger::new(&engine, Default::default());
     // We're already in a transaction.
     merger.set_external_transaction(true);
     log::debug!("Merging with local records");
@@ -135,7 +135,7 @@ fn do_import(places_api: &PlacesApi, fennec_db_file_url: Url) -> Result<Bookmark
     // Note: update_frecencies manages its own transaction, which is fine,
     // since nothing that bad will happen if it is aborted.
     log::debug!("Updating frecencies");
-    store.update_frecencies()?;
+    engine.update_frecencies()?;
 
     log::debug!("Counting Fenix bookmarks");
     let num_succeeded = select_count(&conn, &COUNT_FENIX_BOOKMARKS);

--- a/components/places/src/import/fennec/history.rs
+++ b/components/places/src/import/fennec/history.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::api::places_api::PlacesApi;
-use crate::bookmark_sync::store::BookmarksStore;
+use crate::bookmark_sync::engine::BookmarksEngine;
 use crate::db::db::PlacesDb;
 use crate::error::*;
 use crate::import::common::attached_database;
@@ -83,8 +83,8 @@ fn do_import(places_api: &PlacesApi, android_db_file_url: Url) -> Result<History
     // Note: update_frecencies manages its own transaction, which is fine,
     // since nothing that bad will happen if it is aborted.
     log::debug!("Updating frecencies");
-    let store = BookmarksStore::new(&conn, &scope);
-    store.update_frecencies()?;
+    let engine = BookmarksEngine::new(&conn, &scope);
+    engine.update_frecencies()?;
 
     log::info!("Successfully imported history visits!");
 

--- a/components/places/src/import/ios_bookmarks.rs
+++ b/components/places/src/import/ios_bookmarks.rs
@@ -4,7 +4,7 @@
 
 use crate::api::places_api::PlacesApi;
 use crate::bookmark_sync::{
-    store::{BookmarksStore, Merger},
+    engine::{BookmarksEngine, Merger},
     SyncedBookmarkKind,
 };
 use crate::error::*;
@@ -140,8 +140,8 @@ fn do_import_ios_bookmarks(places_api: &PlacesApi, ios_db_file_url: Url) -> Resu
     // drop(auto_detach);
     // scope.err_if_interrupted()?;
 
-    let store = BookmarksStore::new(&conn, &scope);
-    let mut merger = Merger::new(&store, Default::default());
+    let engine = BookmarksEngine::new(&conn, &scope);
+    let mut merger = Merger::new(&engine, Default::default());
     // We're already in a transaction.
     merger.set_external_transaction(true);
     log::debug!("Merging with local records");
@@ -160,7 +160,7 @@ fn do_import_ios_bookmarks(places_api: &PlacesApi, ios_db_file_url: Url) -> Resu
     // Note: update_frecencies manages its own transaction, which is fine,
     // since nothing that bad will happen if it is aborted.
     log::debug!("Updating frecencies");
-    store.update_frecencies()?;
+    engine.update_frecencies()?;
 
     log::info!("Successfully imported bookmarks!");
 

--- a/components/support/sync15-traits/src/lib.rs
+++ b/components/support/sync15-traits/src/lib.rs
@@ -6,18 +6,18 @@
 pub mod bridged_engine;
 mod changeset;
 pub mod client;
+mod engine;
 mod payload;
 pub mod request;
 mod server_timestamp;
-mod store;
 pub mod telemetry;
 
 pub use bridged_engine::{ApplyResults, BridgedEngine, IncomingEnvelope, OutgoingEnvelope};
 pub use changeset::{IncomingChangeset, OutgoingChangeset, RecordChangeset};
+pub use engine::{CollSyncIds, EngineSyncAssociation, SyncEngine};
 pub use payload::Payload;
 pub use request::{CollectionRequest, RequestOrder};
 pub use server_timestamp::ServerTimestamp;
-pub use store::{CollSyncIds, Store, StoreSyncAssociation};
 pub use sync_guid::Guid;
 
 // For skip_serializing_if

--- a/components/sync15/src/lib.rs
+++ b/components/sync15/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::changeset::{IncomingChangeset, OutgoingChangeset, RecordChangeset
 pub use crate::client::{
     SetupStorageClient, Sync15ClientResponse, Sync15StorageClient, Sync15StorageClientInit,
 };
-pub use crate::coll_state::{CollState, CollSyncIds, StoreSyncAssociation};
+pub use crate::coll_state::{CollState, CollSyncIds, EngineSyncAssociation};
 pub use crate::collection_keys::CollectionKeys;
 pub use crate::error::{Error, ErrorKind, Result};
 pub use crate::key_bundle::KeyBundle;
@@ -38,7 +38,7 @@ pub use crate::migrate_state::extract_v1_state;
 pub use crate::request::CollectionRequest;
 pub use crate::state::{GlobalState, SetupStateMachine};
 pub use crate::status::{ServiceStatus, SyncResult};
-pub use crate::sync::{synchronize, Store};
+pub use crate::sync::{synchronize, SyncEngine};
 pub use crate::sync_multiple::{
     sync_multiple, sync_multiple_with_command_processor, MemoryCachedState, SyncRequestInfo,
 };

--- a/components/sync_manager/ffi/src/lib.rs
+++ b/components/sync_manager/ffi/src/lib.rs
@@ -28,7 +28,7 @@ pub extern "C" fn sync_manager_set_places(_places_api_handle: u64, error: &mut E
 pub extern "C" fn sync_manager_set_logins(_logins_handle: u64, error: &mut ExternError) {
     ffi_support::call_with_result(error, || -> MgrResult<()> {
         log::debug!("sync_manager_set_logins");
-        let api = logins_ffi::ENGINES.get_u64(_logins_handle, |api| -> Result<_, HandleError> {
+        let api = logins_ffi::STORES.get_u64(_logins_handle, |api| -> Result<_, HandleError> {
             Ok(std::sync::Arc::clone(api))
         })?;
         sync_manager::set_logins(api);
@@ -40,7 +40,7 @@ pub extern "C" fn sync_manager_set_logins(_logins_handle: u64, error: &mut Exter
 pub extern "C" fn sync_manager_set_tabs(_tabs_handle: u64, error: &mut ExternError) {
     ffi_support::call_with_result(error, || -> MgrResult<()> {
         log::debug!("sync_manager_set_tabs");
-        let api = tabs_ffi::ENGINES.get_u64(_tabs_handle, |api| -> Result<_, HandleError> {
+        let api = tabs_ffi::STORES.get_u64(_tabs_handle, |api| -> Result<_, HandleError> {
             Ok(std::sync::Arc::clone(api))
         })?;
         sync_manager::set_tabs(api);

--- a/components/sync_manager/src/lib.rs
+++ b/components/sync_manager/src/lib.rs
@@ -15,12 +15,12 @@ pub mod msg_types {
     include!("mozilla.appservices.syncmanager.protobuf.rs");
 }
 
-use logins::PasswordEngine;
+use logins::PasswordStore;
 use manager::SyncManager;
 use places::PlacesApi;
 use std::sync::Arc;
 use std::sync::Mutex;
-use tabs::TabsEngine;
+use tabs::TabsStore;
 
 lazy_static::lazy_static! {
     static ref MANAGER: Mutex<SyncManager> = Mutex::new(SyncManager::new());
@@ -31,12 +31,12 @@ pub fn set_places(places: Arc<PlacesApi>) {
     manager.set_places(places);
 }
 
-pub fn set_logins(places: Arc<Mutex<PasswordEngine>>) {
+pub fn set_logins(places: Arc<Mutex<PasswordStore>>) {
     let mut manager = MANAGER.lock().unwrap();
     manager.set_logins(places);
 }
 
-pub fn set_tabs(tabs: Arc<Mutex<TabsEngine>>) {
+pub fn set_tabs(tabs: Arc<Mutex<TabsStore>>) {
     let mut manager = MANAGER.lock().unwrap();
     manager.set_tabs(tabs);
 }

--- a/components/tabs/ffi/src/lib.rs
+++ b/components/tabs/ffi/src/lib.rs
@@ -13,13 +13,13 @@ use std::{
     os::raw::c_char,
     sync::{Arc, Mutex},
 };
-use tabs::{Result, TabsEngine};
+use tabs::{Result, TabsStore};
 
 lazy_static::lazy_static! {
     // TODO: this is basically a RwLock<HandleMap<Mutex<Arc<Mutex<...>>>>.
     // but could just be a `RwLock<HandleMap<Arc<Mutex<...>>>>`.
     // Find a way to express this cleanly in ffi_support?
-    pub static ref ENGINES: ConcurrentHandleMap<Arc<Mutex<TabsEngine>>> = ConcurrentHandleMap::new();
+    pub static ref STORES: ConcurrentHandleMap<Arc<Mutex<TabsStore>>> = ConcurrentHandleMap::new();
 }
 
 fn parse_url(url: &str) -> Result<url::Url> {
@@ -29,8 +29,8 @@ fn parse_url(url: &str) -> Result<url::Url> {
 #[no_mangle]
 pub extern "C" fn remote_tabs_new(error: &mut ExternError) -> u64 {
     log::debug!("remote_tabs_new");
-    ENGINES.insert_with_result(error, || -> Result<_> {
-        Ok(Arc::new(Mutex::new(TabsEngine::new())))
+    STORES.insert_with_result(error, || -> Result<_> {
+        Ok(Arc::new(Mutex::new(TabsStore::new())))
     })
 }
 
@@ -45,8 +45,8 @@ pub extern "C" fn remote_tabs_sync(
     error: &mut ExternError,
 ) -> *mut c_char {
     log::debug!("remote_tabs_sync");
-    ENGINES.call_with_result(error, handle, |engine| -> Result<_> {
-        let ping = engine.lock().unwrap().sync(
+    STORES.call_with_result(error, handle, |store| -> Result<_> {
+        let ping = store.lock().unwrap().sync(
             &sync15::Sync15StorageClientInit {
                 key_id: key_id.into_string(),
                 access_token: access_token.into_string(),
@@ -68,9 +68,9 @@ pub unsafe extern "C" fn remote_tabs_update_local(
     error: &mut ExternError,
 ) {
     log::debug!("remote_tabs_update_local");
-    ENGINES.call_with_result(error, handle, |engine| -> Result<_> {
+    STORES.call_with_result(error, handle, |store| -> Result<_> {
         let remote_tabs = serde_json::from_str(local_state.as_str())?;
-        engine.lock().unwrap().update_local_state(remote_tabs);
+        store.lock().unwrap().update_local_state(remote_tabs);
         Ok(())
     })
 }
@@ -79,8 +79,8 @@ pub unsafe extern "C" fn remote_tabs_update_local(
 pub extern "C" fn remote_tabs_get_all(handle: u64, error: &mut ExternError) -> ByteBuffer {
     log::debug!("remote_tabs_get_all");
     use tabs::msg_types::ClientsTabs;
-    ENGINES.call_with_result(error, handle, |engine| -> Result<_> {
-        Ok(engine
+    STORES.call_with_result(error, handle, |store| -> Result<_> {
+        Ok(store
             .lock()
             .unwrap()
             .remote_tabs()
@@ -90,4 +90,4 @@ pub extern "C" fn remote_tabs_get_all(handle: u64, error: &mut ExternError) -> B
 
 define_string_destructor!(remote_tabs_destroy_string);
 define_bytebuffer_destructor!(remote_tabs_destroy_bytebuffer);
-define_handle_map_deleter!(ENGINES, remote_tabs_destroy);
+define_handle_map_deleter!(STORES, remote_tabs_destroy);

--- a/components/tabs/src/sync/engine.rs
+++ b/components/tabs/src/sync/engine.rs
@@ -2,76 +2,216 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::error::*;
-use crate::storage::{ClientRemoteTabs, RemoteTab, TabsStorage};
-use crate::sync::store::TabsStore;
-use interrupt_support::NeverInterrupts;
+use crate::storage::TabsStorage;
+use crate::storage::{ClientRemoteTabs, RemoteTab};
+use crate::sync::record::{TabsRecord, TabsRecordTab};
+use anyhow::Result;
 use std::cell::{Cell, RefCell};
-use sync15::{sync_multiple, telemetry, KeyBundle, MemoryCachedState, Sync15StorageClientInit};
+use std::collections::HashMap;
+use sync15::{
+    clients::{self, DeviceType, RemoteClient},
+    telemetry, CollectionRequest, EngineSyncAssociation, IncomingChangeset, OutgoingChangeset,
+    Payload, ServerTimestamp, SyncEngine,
+};
+use sync_guid::Guid;
 
-pub struct TabsEngine {
-    pub storage: TabsStorage,
-    mem_cached_state: Cell<MemoryCachedState>,
-}
+const TTL_1_YEAR: u32 = 31_622_400;
 
-impl Default for TabsEngine {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl TabsEngine {
-    pub fn new() -> Self {
+impl RemoteTab {
+    fn from_record_tab(tab: &TabsRecordTab) -> Self {
         Self {
-            storage: TabsStorage::new(),
-            mem_cached_state: Cell::default(),
+            title: tab.title.clone(),
+            url_history: tab.url_history.clone(),
+            icon: tab.icon.clone(),
+            last_used: tab.last_used.checked_mul(1000).unwrap_or_default(),
+        }
+    }
+    fn to_record_tab(&self) -> TabsRecordTab {
+        TabsRecordTab {
+            title: self.title.clone(),
+            url_history: self.url_history.clone(),
+            icon: self.icon.clone(),
+            last_used: self.last_used.checked_div(1000).unwrap_or_default(),
+        }
+    }
+}
+
+impl ClientRemoteTabs {
+    fn from_record_with_remote_client(
+        client_id: String,
+        remote_client: &RemoteClient,
+        record: TabsRecord,
+    ) -> Self {
+        Self {
+            client_id,
+            client_name: remote_client.device_name.clone(),
+            device_type: remote_client.device_type.unwrap_or(DeviceType::Mobile),
+            remote_tabs: record.tabs.iter().map(RemoteTab::from_record_tab).collect(),
         }
     }
 
-    pub fn update_local_state(&mut self, local_state: Vec<RemoteTab>) {
-        self.storage.update_local_state(local_state);
+    fn from_record(client_id: String, record: TabsRecord) -> Self {
+        Self {
+            client_id,
+            client_name: record.client_name,
+            device_type: DeviceType::Mobile,
+            remote_tabs: record.tabs.iter().map(RemoteTab::from_record_tab).collect(),
+        }
+    }
+    fn to_record(&self) -> TabsRecord {
+        TabsRecord {
+            id: self.client_id.clone(),
+            client_name: self.client_name.clone(),
+            tabs: self
+                .remote_tabs
+                .iter()
+                .map(RemoteTab::to_record_tab)
+                .collect(),
+            ttl: TTL_1_YEAR,
+        }
+    }
+}
+
+pub struct TabsEngine<'a> {
+    storage: &'a TabsStorage,
+    remote_clients: RefCell<HashMap<String, RemoteClient>>,
+    last_sync: Cell<Option<ServerTimestamp>>, // We use a cell because `sync_finished` doesn't take a mutable reference to &self.
+    sync_store_assoc: RefCell<EngineSyncAssociation>,
+    pub(crate) local_id: RefCell<String>,
+}
+
+impl<'a> TabsEngine<'a> {
+    pub fn new(storage: &'a TabsStorage) -> Self {
+        Self {
+            storage,
+            remote_clients: RefCell::default(),
+            last_sync: Cell::default(),
+            sync_store_assoc: RefCell::new(EngineSyncAssociation::Disconnected),
+            local_id: RefCell::default(), // Will get replaced in `prepare_for_sync`.
+        }
+    }
+}
+
+impl<'a> SyncEngine for TabsEngine<'a> {
+    fn collection_name(&self) -> std::borrow::Cow<'static, str> {
+        "tabs".into()
     }
 
-    pub fn remote_tabs(&self) -> Option<Vec<ClientRemoteTabs>> {
-        self.storage.get_remote_tabs()
+    fn prepare_for_sync(&self, get_client_data: &dyn Fn() -> clients::ClientData) -> Result<()> {
+        let data = get_client_data();
+        self.remote_clients.replace(data.recent_clients);
+        self.local_id.replace(data.local_client_id);
+        Ok(())
     }
 
-    /// A convenience wrapper around sync_multiple.
-    pub fn sync(
+    fn apply_incoming(
         &self,
-        storage_init: &Sync15StorageClientInit,
-        root_sync_key: &KeyBundle,
-        local_id: &str,
-    ) -> Result<telemetry::SyncTelemetryPing> {
-        let mut mem_cached_state = self.mem_cached_state.take();
-        let mut store = TabsStore::new(&self.storage);
-        // Since we are syncing without the sync manager, there's no
-        // command processor, therefore no clients engine, and in
-        // consequence `TabsStore::prepare_for_sync` is never called
-        // which means our `local_id` will never be set.
-        // Do it here.
-        store.local_id = RefCell::new(local_id.to_owned());
+        inbound: Vec<IncomingChangeset>,
+        telem: &mut telemetry::Engine,
+    ) -> Result<OutgoingChangeset> {
+        assert_eq!(inbound.len(), 1, "only requested one item");
+        let inbound = inbound.into_iter().next().unwrap();
+        let mut incoming_telemetry = telemetry::EngineIncoming::new();
+        let local_id = self.local_id.borrow().clone();
+        let mut remote_tabs = Vec::with_capacity(inbound.changes.len());
 
-        let mut result = sync_multiple(
-            &[&store],
-            &mut None,
-            &mut mem_cached_state,
-            storage_init,
-            root_sync_key,
-            &NeverInterrupts,
-            None,
+        for incoming in inbound.changes {
+            if incoming.0.id() == local_id {
+                // That's our own record, ignore it.
+                continue;
+            }
+            let record = match TabsRecord::from_payload(incoming.0) {
+                Ok(record) => record,
+                Err(e) => {
+                    log::warn!("Error deserializing incoming record: {}", e);
+                    incoming_telemetry.failed(1);
+                    continue;
+                }
+            };
+            let id = record.id.clone();
+            let tab = if let Some(remote_client) = self.remote_clients.borrow().get(&id) {
+                ClientRemoteTabs::from_record_with_remote_client(
+                    remote_client
+                        .fxa_device_id
+                        .as_ref()
+                        .unwrap_or(&id)
+                        .to_owned(),
+                    remote_client,
+                    record,
+                )
+            } else {
+                ClientRemoteTabs::from_record(id, record)
+            };
+            remote_tabs.push(tab);
+        }
+        self.storage.replace_remote_tabs(remote_tabs);
+        let mut outgoing = OutgoingChangeset::new("tabs", inbound.timestamp);
+        if let Some(local_tabs) = self.storage.prepare_local_tabs_for_upload() {
+            let (client_name, device_type) = self
+                .remote_clients
+                .borrow()
+                .get(&local_id)
+                .map(|client| {
+                    (
+                        client.device_name.clone(),
+                        client.device_type.unwrap_or(DeviceType::Mobile),
+                    )
+                })
+                .unwrap_or_else(|| (String::new(), DeviceType::Mobile));
+            let local_record = ClientRemoteTabs {
+                client_id: local_id,
+                client_name,
+                device_type,
+                remote_tabs: local_tabs.to_vec(),
+            };
+            let payload = Payload::from_record(local_record.to_record())?;
+            log::trace!("outgoing {:?}", payload);
+            outgoing.changes.push(payload);
+        }
+        telem.incoming(incoming_telemetry);
+        Ok(outgoing)
+    }
+
+    fn sync_finished(
+        &self,
+        new_timestamp: ServerTimestamp,
+        records_synced: Vec<Guid>,
+    ) -> Result<()> {
+        log::info!(
+            "sync completed after uploading {} records",
+            records_synced.len()
         );
+        self.last_sync.set(Some(new_timestamp));
+        Ok(())
+    }
 
-        // for b/w compat reasons, we do some dances with the result.
-        // XXX - note that this means telemetry isn't going to be reported back
-        // to the app - we need to check with lockwise about whether they really
-        // need these failures to be reported or whether we can loosen this.
-        if let Err(e) = result.result {
-            return Err(e.into());
-        }
-        match result.engine_results.remove("tabs") {
-            None | Some(Ok(())) => Ok(result.telemetry),
-            Some(Err(e)) => Err(e.into()),
-        }
+    fn get_collection_requests(
+        &self,
+        server_timestamp: ServerTimestamp,
+    ) -> Result<Vec<CollectionRequest>> {
+        let since = self.last_sync.get().unwrap_or_default();
+        Ok(if since == server_timestamp {
+            vec![]
+        } else {
+            vec![CollectionRequest::new("tabs").full().newer_than(since)]
+        })
+    }
+
+    fn get_sync_assoc(&self) -> Result<EngineSyncAssociation> {
+        Ok(self.sync_store_assoc.borrow().clone())
+    }
+
+    fn reset(&self, assoc: &EngineSyncAssociation) -> Result<()> {
+        self.remote_clients.borrow_mut().clear();
+        self.sync_store_assoc.replace(assoc.clone());
+        self.last_sync.set(None);
+        self.storage.wipe_remote_tabs();
+        Ok(())
+    }
+
+    fn wipe(&self) -> Result<()> {
+        self.reset(&EngineSyncAssociation::Disconnected)?;
+        self.storage.wipe_local_tabs();
+        Ok(())
     }
 }

--- a/components/tabs/src/sync/store.rs
+++ b/components/tabs/src/sync/store.rs
@@ -2,216 +2,76 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::storage::TabsStorage;
-use crate::storage::{ClientRemoteTabs, RemoteTab};
-use crate::sync::record::{TabsRecord, TabsRecordTab};
-use anyhow::Result;
+use crate::error::*;
+use crate::storage::{ClientRemoteTabs, RemoteTab, TabsStorage};
+use crate::sync::engine::TabsEngine;
+use interrupt_support::NeverInterrupts;
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
-use sync15::{
-    clients::{self, DeviceType, RemoteClient},
-    telemetry, CollectionRequest, IncomingChangeset, OutgoingChangeset, Payload, ServerTimestamp,
-    Store, StoreSyncAssociation,
-};
-use sync_guid::Guid;
+use sync15::{sync_multiple, telemetry, KeyBundle, MemoryCachedState, Sync15StorageClientInit};
 
-const TTL_1_YEAR: u32 = 31_622_400;
+pub struct TabsStore {
+    pub storage: TabsStorage,
+    mem_cached_state: Cell<MemoryCachedState>,
+}
 
-impl RemoteTab {
-    fn from_record_tab(tab: &TabsRecordTab) -> Self {
-        Self {
-            title: tab.title.clone(),
-            url_history: tab.url_history.clone(),
-            icon: tab.icon.clone(),
-            last_used: tab.last_used.checked_mul(1000).unwrap_or_default(),
-        }
-    }
-    fn to_record_tab(&self) -> TabsRecordTab {
-        TabsRecordTab {
-            title: self.title.clone(),
-            url_history: self.url_history.clone(),
-            icon: self.icon.clone(),
-            last_used: self.last_used.checked_div(1000).unwrap_or_default(),
-        }
+impl Default for TabsStore {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-impl ClientRemoteTabs {
-    fn from_record_with_remote_client(
-        client_id: String,
-        remote_client: &RemoteClient,
-        record: TabsRecord,
-    ) -> Self {
+impl TabsStore {
+    pub fn new() -> Self {
         Self {
-            client_id,
-            client_name: remote_client.device_name.clone(),
-            device_type: remote_client.device_type.unwrap_or(DeviceType::Mobile),
-            remote_tabs: record.tabs.iter().map(RemoteTab::from_record_tab).collect(),
+            storage: TabsStorage::new(),
+            mem_cached_state: Cell::default(),
         }
     }
 
-    fn from_record(client_id: String, record: TabsRecord) -> Self {
-        Self {
-            client_id,
-            client_name: record.client_name,
-            device_type: DeviceType::Mobile,
-            remote_tabs: record.tabs.iter().map(RemoteTab::from_record_tab).collect(),
-        }
-    }
-    fn to_record(&self) -> TabsRecord {
-        TabsRecord {
-            id: self.client_id.clone(),
-            client_name: self.client_name.clone(),
-            tabs: self
-                .remote_tabs
-                .iter()
-                .map(RemoteTab::to_record_tab)
-                .collect(),
-            ttl: TTL_1_YEAR,
-        }
-    }
-}
-
-pub struct TabsStore<'a> {
-    storage: &'a TabsStorage,
-    remote_clients: RefCell<HashMap<String, RemoteClient>>,
-    last_sync: Cell<Option<ServerTimestamp>>, // We use a cell because `sync_finished` doesn't take a mutable reference to &self.
-    sync_store_assoc: RefCell<StoreSyncAssociation>,
-    pub(crate) local_id: RefCell<String>,
-}
-
-impl<'a> TabsStore<'a> {
-    pub fn new(storage: &'a TabsStorage) -> Self {
-        Self {
-            storage,
-            remote_clients: RefCell::default(),
-            last_sync: Cell::default(),
-            sync_store_assoc: RefCell::new(StoreSyncAssociation::Disconnected),
-            local_id: RefCell::default(), // Will get replaced in `prepare_for_sync`.
-        }
-    }
-}
-
-impl<'a> Store for TabsStore<'a> {
-    fn collection_name(&self) -> std::borrow::Cow<'static, str> {
-        "tabs".into()
+    pub fn update_local_state(&mut self, local_state: Vec<RemoteTab>) {
+        self.storage.update_local_state(local_state);
     }
 
-    fn prepare_for_sync(&self, get_client_data: &dyn Fn() -> clients::ClientData) -> Result<()> {
-        let data = get_client_data();
-        self.remote_clients.replace(data.recent_clients);
-        self.local_id.replace(data.local_client_id);
-        Ok(())
+    pub fn remote_tabs(&self) -> Option<Vec<ClientRemoteTabs>> {
+        self.storage.get_remote_tabs()
     }
 
-    fn apply_incoming(
+    /// A convenience wrapper around sync_multiple.
+    pub fn sync(
         &self,
-        inbound: Vec<IncomingChangeset>,
-        telem: &mut telemetry::Engine,
-    ) -> Result<OutgoingChangeset> {
-        assert_eq!(inbound.len(), 1, "only requested one item");
-        let inbound = inbound.into_iter().next().unwrap();
-        let mut incoming_telemetry = telemetry::EngineIncoming::new();
-        let local_id = self.local_id.borrow().clone();
-        let mut remote_tabs = Vec::with_capacity(inbound.changes.len());
+        storage_init: &Sync15StorageClientInit,
+        root_sync_key: &KeyBundle,
+        local_id: &str,
+    ) -> Result<telemetry::SyncTelemetryPing> {
+        let mut mem_cached_state = self.mem_cached_state.take();
+        let mut engine = TabsEngine::new(&self.storage);
+        // Since we are syncing without the sync manager, there's no
+        // command processor, therefore no clients engine, and in
+        // consequence `TabsStore::prepare_for_sync` is never called
+        // which means our `local_id` will never be set.
+        // Do it here.
+        engine.local_id = RefCell::new(local_id.to_owned());
 
-        for incoming in inbound.changes {
-            if incoming.0.id() == local_id {
-                // That's our own record, ignore it.
-                continue;
-            }
-            let record = match TabsRecord::from_payload(incoming.0) {
-                Ok(record) => record,
-                Err(e) => {
-                    log::warn!("Error deserializing incoming record: {}", e);
-                    incoming_telemetry.failed(1);
-                    continue;
-                }
-            };
-            let id = record.id.clone();
-            let tab = if let Some(remote_client) = self.remote_clients.borrow().get(&id) {
-                ClientRemoteTabs::from_record_with_remote_client(
-                    remote_client
-                        .fxa_device_id
-                        .as_ref()
-                        .unwrap_or(&id)
-                        .to_owned(),
-                    remote_client,
-                    record,
-                )
-            } else {
-                ClientRemoteTabs::from_record(id, record)
-            };
-            remote_tabs.push(tab);
-        }
-        self.storage.replace_remote_tabs(remote_tabs);
-        let mut outgoing = OutgoingChangeset::new("tabs", inbound.timestamp);
-        if let Some(local_tabs) = self.storage.prepare_local_tabs_for_upload() {
-            let (client_name, device_type) = self
-                .remote_clients
-                .borrow()
-                .get(&local_id)
-                .map(|client| {
-                    (
-                        client.device_name.clone(),
-                        client.device_type.unwrap_or(DeviceType::Mobile),
-                    )
-                })
-                .unwrap_or_else(|| (String::new(), DeviceType::Mobile));
-            let local_record = ClientRemoteTabs {
-                client_id: local_id,
-                client_name,
-                device_type,
-                remote_tabs: local_tabs.to_vec(),
-            };
-            let payload = Payload::from_record(local_record.to_record())?;
-            log::trace!("outgoing {:?}", payload);
-            outgoing.changes.push(payload);
-        }
-        telem.incoming(incoming_telemetry);
-        Ok(outgoing)
-    }
-
-    fn sync_finished(
-        &self,
-        new_timestamp: ServerTimestamp,
-        records_synced: Vec<Guid>,
-    ) -> Result<()> {
-        log::info!(
-            "sync completed after uploading {} records",
-            records_synced.len()
+        let mut result = sync_multiple(
+            &[&engine],
+            &mut None,
+            &mut mem_cached_state,
+            storage_init,
+            root_sync_key,
+            &NeverInterrupts,
+            None,
         );
-        self.last_sync.set(Some(new_timestamp));
-        Ok(())
-    }
 
-    fn get_collection_requests(
-        &self,
-        server_timestamp: ServerTimestamp,
-    ) -> Result<Vec<CollectionRequest>> {
-        let since = self.last_sync.get().unwrap_or_default();
-        Ok(if since == server_timestamp {
-            vec![]
-        } else {
-            vec![CollectionRequest::new("tabs").full().newer_than(since)]
-        })
-    }
-
-    fn get_sync_assoc(&self) -> Result<StoreSyncAssociation> {
-        Ok(self.sync_store_assoc.borrow().clone())
-    }
-
-    fn reset(&self, assoc: &StoreSyncAssociation) -> Result<()> {
-        self.remote_clients.borrow_mut().clear();
-        self.sync_store_assoc.replace(assoc.clone());
-        self.last_sync.set(None);
-        self.storage.wipe_remote_tabs();
-        Ok(())
-    }
-
-    fn wipe(&self) -> Result<()> {
-        self.reset(&StoreSyncAssociation::Disconnected)?;
-        self.storage.wipe_local_tabs();
-        Ok(())
+        // for b/w compat reasons, we do some dances with the result.
+        // XXX - note that this means telemetry isn't going to be reported back
+        // to the app - we need to check with lockwise about whether they really
+        // need these failures to be reported or whether we can loosen this.
+        if let Err(e) = result.result {
+            return Err(e.into());
+        }
+        match result.engine_results.remove("tabs") {
+            None | Some(Ok(())) => Ok(result.telemetry),
+            Some(Err(e)) => Err(e.into()),
+        }
     }
 }

--- a/testing/sync-test/src/auth.rs
+++ b/testing/sync-test/src/auth.rs
@@ -4,13 +4,13 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 use crate::Opts;
 use anyhow::Result;
 use fxa_client::{self, auth, Config as FxaConfig, FirefoxAccount};
-use logins::PasswordEngine;
+use logins::PasswordStore;
 use serde_json::json;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use sync15::{KeyBundle, Sync15StorageClientInit};
-use tabs::TabsEngine;
+use tabs::TabsStore;
 use url::Url;
 use viaduct::Request;
 
@@ -223,8 +223,8 @@ pub struct TestClient {
     pub fxa: fxa_client::FirefoxAccount,
     pub test_acct: Arc<TestAccount>,
     // XXX do this more generically...
-    pub logins_engine: PasswordEngine,
-    pub tabs_engine: TabsEngine,
+    pub logins_store: PasswordStore,
+    pub tabs_store: TabsStore,
 }
 
 impl TestClient {
@@ -262,8 +262,8 @@ impl TestClient {
         Ok(Self {
             fxa,
             test_acct: acct,
-            logins_engine: PasswordEngine::new_in_memory(None)?,
-            tabs_engine: TabsEngine::new(),
+            logins_store: PasswordStore::new_in_memory(None)?,
+            tabs_store: TabsStore::new(),
         })
     }
 
@@ -303,8 +303,8 @@ impl TestClient {
 
     pub fn fully_reset_local_db(&mut self) -> Result<()> {
         // Not great...
-        self.logins_engine = PasswordEngine::new_in_memory(None)?;
-        self.tabs_engine = TabsEngine::new();
+        self.logins_store = PasswordStore::new_in_memory(None)?;
+        self.tabs_store = TabsStore::new();
         Ok(())
     }
 }

--- a/testing/sync-test/src/logins.rs
+++ b/testing/sync-test/src/logins.rs
@@ -4,7 +4,7 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 use crate::auth::TestClient;
 use crate::testing::TestGroup;
 use anyhow::Result;
-use logins::{Login, PasswordEngine, Result as LoginResult};
+use logins::{Login, PasswordStore, Result as LoginResult};
 // helpers...
 
 // Doesn't check metadata fields
@@ -28,55 +28,55 @@ pub fn assert_logins_equiv(a: &Login, b: &Login) {
     );
 }
 
-pub fn times_used_for_id(e: &PasswordEngine, id: &str) -> i64 {
-    e.get(id)
+pub fn times_used_for_id(s: &PasswordStore, id: &str) -> i64 {
+    s.get(id)
         .expect("get() failed")
         .expect("Login doesn't exist")
         .times_used
 }
 
-pub fn add_login(e: &PasswordEngine, l: Login) -> LoginResult<Login> {
-    let id = e.add(l)?;
-    Ok(e.get(&id)?.expect("Login we just added to exist"))
+pub fn add_login(s: &PasswordStore, l: Login) -> LoginResult<Login> {
+    let id = s.add(l)?;
+    Ok(s.get(&id)?.expect("Login we just added to exist"))
 }
 
-pub fn verify_login(e: &PasswordEngine, l: &Login) {
-    let equivalent = e
+pub fn verify_login(s: &PasswordStore, l: &Login) {
+    let equivalent = s
         .get(&l.guid)
         .expect("get() to succeed")
         .expect("Expected login to be present");
     assert_logins_equiv(&equivalent, l);
 }
 
-pub fn verify_missing_login(e: &PasswordEngine, id: &str) {
+pub fn verify_missing_login(s: &PasswordStore, id: &str) {
     assert!(
-        e.get(id).expect("get() to succeed").is_none(),
+        s.get(id).expect("get() to succeed").is_none(),
         "Login {} should not exist",
         id
     );
 }
 
 pub fn update_login<F: FnMut(&mut Login)>(
-    e: &PasswordEngine,
+    s: &PasswordStore,
     id: &str,
     mut callback: F,
 ) -> LoginResult<Login> {
-    let mut login = e.get(id)?.expect("No such login!");
+    let mut login = s.get(id)?.expect("No such login!");
     callback(&mut login);
-    e.update(login)?;
-    Ok(e.get(id)?.expect("Just updated this"))
+    s.update(login)?;
+    Ok(s.get(id)?.expect("Just updated this"))
 }
 
-pub fn touch_login(e: &PasswordEngine, id: &str, times: usize) -> LoginResult<Login> {
+pub fn touch_login(s: &PasswordStore, id: &str, times: usize) -> LoginResult<Login> {
     for _ in 0..times {
-        e.touch(&id)?;
+        s.touch(&id)?;
     }
-    Ok(e.get(&id)?.unwrap())
+    Ok(s.get(&id)?.unwrap())
 }
 
 pub fn sync_logins(client: &mut TestClient) -> Result<()> {
     let (init, key, _device_id) = client.data_for_sync()?;
-    client.logins_engine.sync(&init, &key)?;
+    client.logins_store.sync(&init, &key)?;
     Ok(())
 }
 
@@ -89,7 +89,7 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     let l1id = "bbbbbbbbbbbb";
 
     add_login(
-        &c0.logins_engine,
+        &c0.logins_store,
         Login {
             guid: l0id.into(),
             hostname: "http://www.example.com".into(),
@@ -103,11 +103,11 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     )
     .expect("add l0");
 
-    let login0_c0 = touch_login(&c0.logins_engine, l0id, 2).expect("touch0 c0");
+    let login0_c0 = touch_login(&c0.logins_store, l0id, 2).expect("touch0 c0");
     assert_eq!(login0_c0.times_used, 3);
 
     let login1_c0 = add_login(
-        &c0.logins_engine,
+        &c0.logins_store,
         Login {
             guid: l1id.into(),
             hostname: "http://www.example.com".into(),
@@ -123,19 +123,19 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     sync_logins(c0).expect("c0 sync to work");
 
     // Should be the same after syncing.
-    verify_login(&c0.logins_engine, &login0_c0);
-    verify_login(&c0.logins_engine, &login1_c0);
+    verify_login(&c0.logins_store, &login0_c0);
+    verify_login(&c0.logins_store, &login1_c0);
 
     log::info!("Syncing client1");
     sync_logins(c1).expect("c1 sync to work");
 
     log::info!("Check state");
 
-    verify_login(&c1.logins_engine, &login0_c0);
-    verify_login(&c1.logins_engine, &login1_c0);
+    verify_login(&c1.logins_store, &login0_c0);
+    verify_login(&c1.logins_store, &login1_c0);
 
     assert_eq!(
-        times_used_for_id(&c1.logins_engine, l0id),
+        times_used_for_id(&c1.logins_store, l0id),
         3,
         "Times used is wrong (first sync)"
     );
@@ -143,18 +143,18 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Update logins");
 
     // Change login0 on both
-    update_login(&c1.logins_engine, l0id, |l| {
+    update_login(&c1.logins_store, l0id, |l| {
         l.password = "testtesttest".into();
     })
     .unwrap();
 
-    let login0_c0 = update_login(&c0.logins_engine, l0id, |l| {
+    let login0_c0 = update_login(&c0.logins_store, l0id, |l| {
         l.username_field = "users_name".into();
     })
     .unwrap();
 
     // and login1 on remote.
-    let login1_c1 = update_login(&c1.logins_engine, l1id, |l| {
+    let login1_c1 = update_login(&c1.logins_store, l1id, |l| {
         l.username = "less_cool_username".into();
     })
     .unwrap();
@@ -167,11 +167,11 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Check state again");
 
     // Ensure the remotely changed password change made it through
-    verify_login(&c0.logins_engine, &login1_c1);
+    verify_login(&c0.logins_store, &login1_c1);
 
     // And that the conflicting one did too.
     verify_login(
-        &c0.logins_engine,
+        &c0.logins_store,
         &Login {
             username_field: "users_name".into(),
             password: "testtesttest".into(),
@@ -180,7 +180,7 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     );
 
     assert_eq!(
-        c0.logins_engine.get(l0id).unwrap().unwrap().times_used,
+        c0.logins_store.get(l0id).unwrap().unwrap().times_used,
         5, // initially 1, touched twice, updated twice (on two accounts!
         // doing this right requires 3WM)
         "Times used is wrong (final)"
@@ -196,7 +196,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     let l3id = "dddddddddddd";
 
     let login0 = add_login(
-        &c0.logins_engine,
+        &c0.logins_store,
         Login {
             guid: l0id.into(),
             hostname: "http://www.example.com".into(),
@@ -211,7 +211,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     .expect("add l0");
 
     let login1 = add_login(
-        &c0.logins_engine,
+        &c0.logins_store,
         Login {
             guid: l1id.into(),
             hostname: "http://www.example.com".into(),
@@ -224,7 +224,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     .expect("add l1");
 
     let login2 = add_login(
-        &c0.logins_engine,
+        &c0.logins_store,
         Login {
             guid: l2id.into(),
             hostname: "https://www.example.org".into(),
@@ -237,7 +237,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     .expect("add l2");
 
     let login3 = add_login(
-        &c0.logins_engine,
+        &c0.logins_store,
         Login {
             guid: l3id.into(),
             hostname: "https://www.example.net".into(),
@@ -254,19 +254,19 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     sync_logins(c0).expect("c0 sync to work");
 
     // Should be the same after syncing.
-    verify_login(&c0.logins_engine, &login0);
-    verify_login(&c0.logins_engine, &login1);
-    verify_login(&c0.logins_engine, &login2);
-    verify_login(&c0.logins_engine, &login3);
+    verify_login(&c0.logins_store, &login0);
+    verify_login(&c0.logins_store, &login1);
+    verify_login(&c0.logins_store, &login2);
+    verify_login(&c0.logins_store, &login3);
 
     log::info!("Syncing client1");
     sync_logins(c1).expect("c1 sync to work");
 
     log::info!("Check state");
-    verify_login(&c1.logins_engine, &login0);
-    verify_login(&c1.logins_engine, &login1);
-    verify_login(&c1.logins_engine, &login2);
-    verify_login(&c1.logins_engine, &login3);
+    verify_login(&c1.logins_store, &login0);
+    verify_login(&c1.logins_store, &login1);
+    verify_login(&c1.logins_store, &login2);
+    verify_login(&c1.logins_store, &login3);
 
     // The 4 logins are for the for possible scenarios. All of them should result in the record
     // being deleted.
@@ -278,37 +278,37 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
 
     // case 1. (c1 deletes record, c0 should have deleted on the other side)
     log::info!("Deleting {} from c1", l0id);
-    assert!(c1.logins_engine.delete(l0id).expect("Delete should work"));
-    verify_missing_login(&c1.logins_engine, l0id);
+    assert!(c1.logins_store.delete(l0id).expect("Delete should work"));
+    verify_missing_login(&c1.logins_store, l0id);
 
     // case 2. Both delete l1 separately
     log::info!("Deleting {} from both", l1id);
-    assert!(c0.logins_engine.delete(l1id).expect("Delete should work"));
-    assert!(c1.logins_engine.delete(l1id).expect("Delete should work"));
+    assert!(c0.logins_store.delete(l1id).expect("Delete should work"));
+    assert!(c1.logins_store.delete(l1id).expect("Delete should work"));
 
     // case 3a. c0 modifies record (c1 will delete it after c0 syncs so the timestamps line up)
     log::info!("Updating {} on c0", l2id);
-    let login2_new = update_login(&c0.logins_engine, l2id, |l| {
+    let login2_new = update_login(&c0.logins_store, l2id, |l| {
         l.username = "foobar".into();
     })
     .unwrap();
 
     // case 4a. c1 deletes record (c0 will modify it after c1 syncs so the timestamps line up)
-    assert!(c1.logins_engine.delete(l3id).expect("Delete should work"));
+    assert!(c1.logins_store.delete(l3id).expect("Delete should work"));
 
     // Sync c1
     log::info!("Syncing c1");
     sync_logins(c1).expect("c1 sync to work");
     log::info!("Checking c1 state after sync");
 
-    verify_missing_login(&c1.logins_engine, l0id);
-    verify_missing_login(&c1.logins_engine, l1id);
-    verify_login(&c1.logins_engine, &login2);
-    verify_missing_login(&c1.logins_engine, l3id);
+    verify_missing_login(&c1.logins_store, l0id);
+    verify_missing_login(&c1.logins_store, l1id);
+    verify_login(&c1.logins_store, &login2);
+    verify_missing_login(&c1.logins_store, l3id);
 
     log::info!("Update {} on c0", l3id);
     // 4b
-    update_login(&c0.logins_engine, l3id, |l| {
+    update_login(&c0.logins_store, l3id, |l| {
         l.password = "quux".into();
     })
     .unwrap();
@@ -319,26 +319,26 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
 
     log::info!("Checking c0 state after sync");
 
-    verify_missing_login(&c0.logins_engine, l0id);
-    verify_missing_login(&c0.logins_engine, l1id);
-    verify_login(&c0.logins_engine, &login2_new);
-    verify_missing_login(&c0.logins_engine, l3id);
+    verify_missing_login(&c0.logins_store, l0id);
+    verify_missing_login(&c0.logins_store, l1id);
+    verify_login(&c0.logins_store, &login2_new);
+    verify_missing_login(&c0.logins_store, l3id);
 
     log::info!("Delete {} on c1", l2id);
     // 3b
-    assert!(c1.logins_engine.delete(l2id).expect("Delete should work"));
+    assert!(c1.logins_store.delete(l2id).expect("Delete should work"));
 
     log::info!("Syncing c1");
     sync_logins(c1).expect("c1 sync to work");
 
     log::info!("{} should stay dead", l2id);
     // Ensure we didn't revive it.
-    verify_missing_login(&c1.logins_engine, l2id);
+    verify_missing_login(&c1.logins_store, l2id);
 
     log::info!("Syncing c0");
     sync_logins(c0).expect("c0 sync to work");
     log::info!("Should delete {}", l2id);
-    verify_missing_login(&c0.logins_engine, l2id);
+    verify_missing_login(&c0.logins_store, l2id);
 }
 
 pub fn get_test_group() -> TestGroup {


### PR DESCRIPTION
In many cases, this was literally changing 'engine' to 'store' and
'store' to 'engine', but now we have mostly consistent naming
throughout the repo, and consistency with desktop.

The sync trait is now called `SyncEngine` just to drive home the
fact that 'engine' relates to syncing.

This was largely a mechanical change. No changes were made to
the FFI functions, so this is not a breaking change.
