### PR TITLE
Add specific EndpointError for unhandled push error

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,9 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v68.1.0...main)
+
+## Push
+
+### Breaking Changes
+
+- `PushManager.subscribe` now throws an `EndpointRegistrationError` instead of a `CommunicationServerError` when retrieving an endpoint.

--- a/components/push/android/src/main/java/mozilla/appservices/push/RustError.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/RustError.kt
@@ -27,6 +27,7 @@ open class TranscodingError(msg: String) : PushError(msg)
 open class RecordNotFoundError(msg: String) : PushError(msg)
 open class UrlParseError(msg: String) : PushError(msg)
 open class GeneralError(msg: String) : PushError(msg)
+open class EndpointRegistrationError(msg: String) : PushError(msg)
 
 /**
  * This should be considered private, but it needs to be public for JNA.
@@ -73,6 +74,7 @@ open class RustError : Structure() {
             31 -> return TranscodingError(message)
             32 -> return RecordNotFoundError(message)
             33 -> return UrlParseError(message)
+            34 -> return EndpointRegistrationError(message)
             -1 -> return InternalPanic(message)
             // Note: `1` is used as a generic catch all, but we
             // might as well handle the others the same way.

--- a/components/push/src/communications.rs
+++ b/components/push/src/communications.rs
@@ -20,7 +20,9 @@ use viaduct::{header_names, status_codes, Headers, Request};
 use crate::config::PushConfiguration;
 use crate::error::{
     self,
-    ErrorKind::{AlreadyRegisteredError, CommunicationError, CommunicationServerError},
+    ErrorKind::{
+        AlreadyRegisteredError, CommunicationError, CommunicationServerError, EndpointRegistrationError,
+    },
 };
 use crate::storage::Store;
 
@@ -200,9 +202,7 @@ impl Connection for ConnectHttp {
         {
             Ok(v) => v,
             Err(e) => {
-                return Err(
-                    CommunicationServerError(format!("Could not fetch endpoint: {}", e)).into(),
-                );
+                return Err(EndpointRegistrationError(format!("Could not fetch endpoint: {}", e)).into());
             }
         };
         if requested.is_server_error() {

--- a/components/push/src/error.rs
+++ b/components/push/src/error.rs
@@ -56,6 +56,10 @@ pub enum ErrorKind {
     /// A failure to parse a URL.
     #[error("URL parse error: {0:?}")]
     UrlParseError(#[from] url::ParseError),
+
+    /// An error if the endpoint could not be fetched
+    #[error("Endpoint Error: {0:?}")]
+    EndpointRegistrationError(String),
 }
 
 // Note, be sure to duplicate errors in the Kotlin side
@@ -74,6 +78,7 @@ impl ErrorKind {
             ErrorKind::TranscodingError(_) => 31,
             ErrorKind::RecordNotFoundError(_, _) => 32,
             ErrorKind::UrlParseError(_) => 33,
+            ErrorKind::EndpointRegistrationError(_) => 34,
         };
         ffi_support::ErrorCode::new(code)
     }


### PR DESCRIPTION
We're treating the failure to retrieve a push endpoint as a separate
error so that we can handle the exception explicitly on the consumer
end (e.g. re-try).

I looked into adding tests, but I ran into the same [issues](https://github.com/mozilla/application-services/blob/main/components/push/src/communications.rs#L441-L443) as mentioned in the test code of `communications.rs`.

Closes #3737

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
