### PR TITLE
Apply fixes for XCode 12 when running a local carthage build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,9 +417,9 @@ jobs:
               # XCode tests build in Debug configuration, save us a full
               # Rust rebuild in Release mode by forcing Debug mode on
               # non-release builds.
-              XCODE_XCCONFIG_FILE=`pwd`/xcconfig/xcode-12-fix-carthage-lipo.xcconfig bash build-carthage.sh --out MozillaAppServices.framework.zip --configuration Debug
+              bash build-carthage.sh --out MozillaAppServices.framework.zip --configuration Debug
             else
-              XCODE_XCCONFIG_FILE=`pwd`/xcconfig/xcode-12-fix-carthage-lipo.xcconfig bash build-carthage.sh --out MozillaAppServices.framework.zip
+              bash build-carthage.sh --out MozillaAppServices.framework.zip
             fi
       - store_artifacts:
           path: raw_xcodebuild.log

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "apple/swift-protobuf" "1.12.0"
+github "apple/swift-protobuf" "1.14.0"
 github "jrendel/SwiftKeychainWrapper" "4.0.1"

--- a/build-carthage.sh
+++ b/build-carthage.sh
@@ -15,6 +15,9 @@ esac; done
 
 set -vx
 
+XCODE_XCCONFIG_FILE=$(pwd)/xcconfig/xcode-12-fix-carthage-lipo.xcconfig
+export XCODE_XCCONFIG_FILE
+
 carthage bootstrap --platform iOS --cache-builds
 
 set -o pipefail && \

--- a/xcconfig/xcode-12-fix-carthage-lipo.xcconfig
+++ b/xcconfig/xcode-12-fix-carthage-lipo.xcconfig
@@ -1,3 +1,6 @@
+// Carthage has an issue with XCode 12 architecture changes which doesn't allow
+// it to compile dependencies for proper architecture. This works around it.
+// Ref https://github.com/Carthage/Carthage/issues/3019
 EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64=arm64 arm64e armv7 armv7s armv6 armv8
 EXCLUDED_ARCHS=$(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT))
 IPHONEOS_DEPLOYMENT_TARGET=11.4


### PR DESCRIPTION
Carthage + XCode 12 requires some hackery to work around a build issue.
In https://github.com/mozilla/application-services/pull/3586/ we
landed said hackery as part of our CI config. This commit pushes
it down into the build script itself, since the same issue is
present when trying to do a local Carthage build.

I lost a couple of hours to inscrutable swift-protobuf build issues this morning
until I managed to track this down :-(
