### PR TITLE
Move more of the syncing logic out into shared code.

### DIFF
--- a/components/autofill/sql/create_shared_schema.sql
+++ b/components/autofill/sql/create_shared_schema.sql
@@ -25,6 +25,9 @@ CREATE TABLE IF NOT EXISTS addresses_data (
     sync_change_counter INTEGER NOT NULL DEFAULT 1
 );
 
+-- Note that we don't store tombstones in the mirror - maybe we should? That
+-- would mean we need to change the schema here significantly - maybe we should
+-- just store the JSON payload?
 CREATE TABLE IF NOT EXISTS addresses_mirror (
    guid                 TEXT NOT NULL PRIMARY KEY,
     given_name          TEXT NOT NULL,

--- a/components/autofill/src/sync/address/incoming.rs
+++ b/components/autofill/src/sync/address/incoming.rs
@@ -3,8 +3,9 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/.
 */
 
-use super::{Record, RecordData};
+use super::RecordData;
 use crate::error::*;
+use crate::sync::RecordImpl;
 use interrupt_support::Interruptee;
 use rusqlite::{named_params, types::ToSql, Connection};
 use sql_support::ConnExt;
@@ -13,11 +14,14 @@ use sync_guid::Guid as SyncGuid;
 use types::Timestamp;
 
 type IncomingState = crate::sync::IncomingState<RecordData>;
+type IncomingRecordInfo = crate::sync::IncomingRecordInfo<RecordData>;
+type LocalRecordInfo = crate::sync::LocalRecordInfo<RecordData>;
 type IncomingAction = crate::sync::IncomingAction<RecordData>;
 
 /// The first step in the "apply incoming" process for syncing autofill address records.
 /// Incoming tombstones will saved in the `temp.addresses_tombstone_sync_staging` table
 /// and incoming records will be saved to the `temp.addresses_sync_staging` table.
+// XXX - will end up moving to the Impl trait??
 pub fn stage_incoming(
     conn: &Connection,
     incoming_payloads: Vec<Payload>,
@@ -27,9 +31,16 @@ pub fn stage_incoming(
     let mut incoming_tombstones = Vec::with_capacity(incoming_payloads.len());
 
     for payload in incoming_payloads {
+        log::trace!(
+            "incoming payload {} (deleted={})",
+            payload.id,
+            payload.deleted
+        );
         match payload.deleted {
-            true => incoming_tombstones.push(payload.into_record::<Record>().unwrap()),
-            false => incoming_records.push(payload.into_record::<Record>().unwrap()),
+            // XXX - unwraps below should be removed. We probably want to handle
+            // the error and log then ignore the error.
+            true => incoming_tombstones.push(payload.into_record::<RecordData>().unwrap()),
+            false => incoming_records.push(payload.into_record::<RecordData>().unwrap()),
         };
     }
     save_incoming_records(conn, incoming_records, signal)?;
@@ -41,9 +52,10 @@ pub fn stage_incoming(
 /// incoming changes for the syncing autofill address records.
 fn save_incoming_records(
     conn: &Connection,
-    incoming_records: Vec<Record>,
+    incoming_records: Vec<RecordData>,
     signal: &dyn Interruptee,
 ) -> Result<()> {
+    log::info!("staging {} incoming records", incoming_records.len());
     let chunk_size = 17;
     sql_support::each_sized_chunk(
         &incoming_records,
@@ -75,22 +87,22 @@ fn save_incoming_records(
             for record in chunk {
                 signal.err_if_interrupted()?;
                 params.push(&record.guid as &dyn ToSql);
-                params.push(&record.data.given_name);
-                params.push(&record.data.additional_name);
-                params.push(&record.data.family_name);
-                params.push(&record.data.organization);
-                params.push(&record.data.street_address);
-                params.push(&record.data.address_level3);
-                params.push(&record.data.address_level2);
-                params.push(&record.data.address_level1);
-                params.push(&record.data.postal_code);
-                params.push(&record.data.country);
-                params.push(&record.data.tel);
-                params.push(&record.data.email);
-                params.push(&record.data.time_created);
-                params.push(&record.data.time_last_used);
-                params.push(&record.data.time_last_modified);
-                params.push(&record.data.times_used);
+                params.push(&record.given_name);
+                params.push(&record.additional_name);
+                params.push(&record.family_name);
+                params.push(&record.organization);
+                params.push(&record.street_address);
+                params.push(&record.address_level3);
+                params.push(&record.address_level2);
+                params.push(&record.address_level1);
+                params.push(&record.postal_code);
+                params.push(&record.country);
+                params.push(&record.tel);
+                params.push(&record.email);
+                params.push(&record.time_created);
+                params.push(&record.time_last_used);
+                params.push(&record.time_last_modified);
+                params.push(&record.times_used);
             }
             conn.execute(&sql, &params)?;
             Ok(())
@@ -102,10 +114,11 @@ fn save_incoming_records(
 /// incoming changes for the syncing autofill address records.
 fn save_incoming_tombstones(
     conn: &Connection,
-    incoming_tombstones: Vec<Record>,
+    incoming_tombstones: Vec<RecordData>,
     signal: &dyn Interruptee,
 ) -> Result<()> {
-    let chunk_size = 1;
+    log::info!("staging {} incoming tombstones", incoming_tombstones.len());
+    let chunk_size = 1; // XXX - chunk_size of 1 seems wrong?
     sql_support::each_sized_chunk(
         &incoming_tombstones,
         sql_support::default_max_variable_number() / chunk_size,
@@ -127,21 +140,9 @@ fn save_incoming_tombstones(
     )
 }
 
-/// The second step in the "apply incoming" process for syncing autofill address records.
-/// Incoming tombstones and records are retrieved from the temp tables and assigned
-/// `IncomingState` values.
-pub fn get_incoming(conn: &Connection) -> Result<Vec<(SyncGuid, IncomingState)>> {
-    let mut incoming_states = get_incoming_tombstone_states(conn)?;
-    let mut incoming_record_states = get_incoming_record_states(conn)?;
-    incoming_states.append(&mut incoming_record_states);
-
-    Ok(incoming_states)
-}
-
 /// Incoming tombstones are retrieved from the `addresses_tombstone_sync_staging` table
 /// and assigned `IncomingState` values.
-#[allow(dead_code)]
-fn get_incoming_tombstone_states(conn: &Connection) -> Result<Vec<(SyncGuid, IncomingState)>> {
+fn get_incoming_tombstone_states(conn: &Connection) -> Result<Vec<IncomingState>> {
     Ok(conn.conn().query_rows_and_then_named(
         "SELECT
             s.guid as s_guid,
@@ -168,39 +169,40 @@ fn get_incoming_tombstone_states(conn: &Connection) -> Result<Vec<(SyncGuid, Inc
         LEFT JOIN addresses_data l ON s.guid = l.guid
         LEFT JOIN addresses_tombstones t ON s.guid = t.guid",
         &[],
-        |row| -> Result<(SyncGuid, IncomingState)> {
+        |row| -> Result<IncomingState> {
             let incoming_guid: SyncGuid = row.get_unwrap("s_guid");
-            let local_guid: Option<SyncGuid> = row.get("l_guid")?;
-            let tombstone_guid: Option<SyncGuid> = row.get("t_guid")?;
+            let have_local_record = row.get::<_, Option<SyncGuid>>("l_guid")?.is_some();
+            let have_local_tombstone = row.get::<_, Option<SyncGuid>>("t_guid")?.is_some();
 
-            Ok((
-                incoming_guid.clone(),
-                IncomingState::IncomingTombstone {
+            let local = if have_local_record {
+                let record = RecordData::from_row(row, "")?;
+                let has_local_changes = record.sync_change_counter.unwrap_or(0) != 0;
+                if has_local_changes {
+                    LocalRecordInfo::Modified { record }
+                } else {
+                    LocalRecordInfo::Unmodified { record }
+                }
+            } else if have_local_tombstone {
+                LocalRecordInfo::Tombstone {
+                    guid: incoming_guid.clone(),
+                }
+            } else {
+                LocalRecordInfo::Missing
+            };
+            Ok(IncomingState {
+                incoming: IncomingRecordInfo::Tombstone {
                     guid: incoming_guid,
-                    local: match local_guid {
-                        Some(_) => Some(RecordData::from_row(row, "")?),
-                        None => None,
-                    },
-                    has_local_changes: match local_guid {
-                        Some(_) => {
-                            RecordData::from_row(row, "")?
-                                .sync_change_counter
-                                .unwrap_or(0)
-                                != 0
-                        }
-                        None => false,
-                    },
-                    has_local_tombstone: tombstone_guid.is_some(),
                 },
-            ))
+                local,
+                mirror: None, // XXX - we *might* have a mirror record, but don't really care.
+            })
         },
     )?)
 }
 
 /// Incoming records (excluding tombstones) are retrieved from the `addresses_sync_staging` table
 /// and assigned `IncomingState` values.
-#[allow(dead_code)]
-fn get_incoming_record_states(conn: &Connection) -> Result<Vec<(SyncGuid, IncomingState)>> {
+fn get_incoming_record_states(conn: &Connection) -> Result<Vec<IncomingState>> {
     let sql_query = "
         SELECT
             s.guid as s_guid,
@@ -254,18 +256,20 @@ fn get_incoming_record_states(conn: &Connection) -> Result<Vec<(SyncGuid, Incomi
             s.times_used as s_times_used,
             m.times_used as m_times_used,
             l.times_used as l_times_used,
-            l.sync_change_counter as l_sync_change_counter
+            l.sync_change_counter as l_sync_change_counter,
+            t.guid as t_guid
         FROM temp.addresses_sync_staging s
         LEFT JOIN addresses_mirror m ON s.guid = m.guid
-        LEFT JOIN addresses_data l ON s.guid = l.guid";
+        LEFT JOIN addresses_data l ON s.guid = l.guid
+        LEFT JOIN addresses_tombstones t ON s.guid = t.guid";
 
-    Ok(conn.conn().query_rows_and_then_named(
-        sql_query,
-        &[],
-        |row| -> Result<(SyncGuid, IncomingState)> {
-            let guid: SyncGuid = row.get_unwrap("s_guid");
+    Ok(conn
+        .conn()
+        .query_rows_and_then_named(sql_query, &[], |row| -> Result<IncomingState> {
+            // XXX - change these to something like `mirror_exists` - that's how they are used.
             let mirror_guid: Option<SyncGuid> = row.get_unwrap("m_guid");
             let local_guid: Option<SyncGuid> = row.get_unwrap("l_guid");
+            let tombstone_guid: Option<SyncGuid> = row.get_unwrap("t_guid");
 
             let incoming = RecordData::from_row(row, "s_")?;
 
@@ -273,146 +277,35 @@ fn get_incoming_record_states(conn: &Connection) -> Result<Vec<(SyncGuid, Incomi
                 Some(_) => Some(RecordData::from_row(row, "m_")?),
                 None => None,
             };
-
-            let incoming_state = match local_guid {
+            let local = match local_guid {
                 Some(_) => {
-                    let local = RecordData::from_row(row, "l_")?;
-                    IncomingState::HasLocal {
-                        guid: guid.clone(),
-                        incoming: incoming.clone(),
-                        merged: merge(guid.clone(), incoming.clone(), local.clone(), mirror),
-                        has_local_changes: local.sync_change_counter.unwrap_or(0) != 0,
+                    let record = RecordData::from_row(row, "l_")?;
+                    let has_changes = record.sync_change_counter.unwrap_or(0) != 0;
+                    if has_changes {
+                        LocalRecordInfo::Modified { record }
+                    } else {
+                        LocalRecordInfo::Unmodified { record }
                     }
                 }
-                None => {
-                    let local_dupe = get_local_dupe(
-                        conn,
-                        Record {
-                            guid: guid.clone(),
-                            data: incoming.clone(),
-                        },
-                    )?;
-
-                    match local_dupe {
-                        Some(d) => IncomingState::HasLocalDupe {
-                            guid: guid.clone(),
-                            dupe_guid: d.guid,
-                            merged: merge(guid.clone(), incoming.clone(), d.data, mirror),
-                        },
-                        None => match has_local_tombstone(conn, &guid)? {
-                            true => IncomingState::NonDeletedIncoming {
-                                guid: guid.clone(),
-                                incoming,
-                            },
-                            false => IncomingState::IncomingOnly {
-                                guid: guid.clone(),
-                                incoming,
-                            },
-                        },
-                    }
-                }
+                None => match tombstone_guid {
+                    None => LocalRecordInfo::Missing,
+                    Some(guid) => LocalRecordInfo::Tombstone { guid },
+                },
             };
-
-            Ok((guid, incoming_state))
-        },
-    )?)
+            Ok(IncomingState {
+                incoming: IncomingRecordInfo::Record { record: incoming },
+                local,
+                mirror,
+            })
+        })?)
 }
 
-/// Returns a local record that has the same values as the given incoming record (with the exception
-/// of the `guid` values which should differ) that will be used as a local duplicate record for
-/// syncing.
-#[allow(dead_code)]
-fn get_local_dupe(conn: &Connection, incoming: Record) -> Result<Option<Record>> {
-    let sql = "
-        SELECT
-            guid,
-            given_name,
-            additional_name,
-            family_name,
-            organization,
-            street_address,
-            address_level3,
-            address_level2,
-            address_level1,
-            postal_code,
-            country,
-            tel,
-            email,
-            time_created,
-            time_last_used,
-            time_last_modified,
-            times_used,
-            sync_change_counter
-        FROM addresses_data
-        WHERE guid <> :guid
-            AND guid NOT IN (
-                SELECT guid
-                FROM addresses_mirror
-            )
-            AND given_name == :given_name
-            AND additional_name == :additional_name
-            AND family_name == :family_name
-            AND organization == :organization
-            AND street_address == :street_address
-            AND address_level3 == :address_level3
-            AND address_level2 == :address_level2
-            AND address_level1 == :address_level1
-            AND postal_code == :postal_code
-            AND country == :country
-            AND tel == :tel
-            AND email == :email";
-
-    let params = named_params! {
-        ":guid": incoming.guid.as_str(),
-        ":given_name": incoming.data.given_name,
-        ":additional_name": incoming.data.additional_name,
-        ":family_name": incoming.data.family_name,
-        ":organization": incoming.data.organization,
-        ":street_address": incoming.data.street_address,
-        ":address_level3": incoming.data.address_level3,
-        ":address_level2": incoming.data.address_level2,
-        ":address_level1": incoming.data.address_level1,
-        ":postal_code": incoming.data.postal_code,
-        ":country": incoming.data.country,
-        ":tel": incoming.data.tel,
-        ":email": incoming.data.email,
-    };
-
-    let result = conn.conn().query_row_named(&sql, params, |row| {
-        Ok(Record {
-            guid: row.get_unwrap("guid"),
-            data: RecordData::from_row(&row, "").unwrap(),
-        })
-    });
-
-    match result {
-        Ok(r) => Ok(Some(r)),
-        Err(e) => match e {
-            rusqlite::Error::QueryReturnedNoRows => Ok(None),
-            _ => Err(Error::SqlError(e)),
-        },
-    }
-}
-
-/// Determines if a local tombstone exists for a given GUID.
-#[allow(dead_code)]
-fn has_local_tombstone(conn: &Connection, guid: &str) -> Result<bool> {
-    Ok(conn.conn().query_row(
-        "SELECT EXISTS (
-                SELECT 1
-                FROM addresses_tombstones
-                WHERE guid = :guid
-            )",
-        &[guid],
-        |row| row.get(0),
-    )?)
-}
-
+// A macro for our merge implementation.
 // We allow all "common" fields from the sub-types to be getters on the
 // InsertableItem type.
+// This will probably move to the parent module?
 macro_rules! field_check {
     ($field_name:ident,
-    $guid:ident,
     $incoming:ident,
     $local:ident,
     $mirror:ident,
@@ -442,58 +335,180 @@ macro_rules! field_check {
         } else if should_use_local {
             $merged_record.$field_name = local_field.clone();
         } else {
-            return get_forked_record(Record {
-                guid: $guid,
-                data: $local,
-            });
+            return get_forked_record($local.clone());
         }
     };
 }
 
-/// Performs a three-way merge between an incoming, local, and mirror record. If a merge
-/// cannot be successfully completed, the local record data is returned with a new guid
-/// and sync metadata.
-fn merge(
-    guid: SyncGuid,
-    incoming: RecordData,
-    local: RecordData,
-    mirror: Option<RecordData>,
-) -> Record {
-    let mut merged_record: RecordData = Default::default();
+struct AddressesImpl {}
 
-    field_check!(given_name, guid, incoming, local, mirror, merged_record);
-    field_check!(
-        additional_name,
-        guid,
-        incoming,
-        local,
-        mirror,
+impl RecordImpl for AddressesImpl {
+    type Record = RecordData;
+
+    /// The second step in the "apply incoming" process for syncing autofill address records.
+    /// Incoming tombstones and records are retrieved from the temp tables and assigned
+    /// `IncomingState` values.
+    fn fetch_incoming_states(&self, conn: &Connection) -> Result<Vec<IncomingState>> {
+        let mut incoming_infos = get_incoming_tombstone_states(conn)?;
+        let mut incoming_record_infos = get_incoming_record_states(conn)?;
+        incoming_infos.append(&mut incoming_record_infos);
+        Ok(incoming_infos)
+    }
+
+    /// Performs a three-way merge between an incoming, local, and mirror record. If a merge
+    /// cannot be successfully completed, the local record data is returned with a new guid
+    /// and updated sync metadata.
+    fn merge(
+        &self,
+        incoming: &Self::Record,
+        local: &Self::Record,
+        mirror: &Option<Self::Record>,
+    ) -> Self::Record {
+        let mut merged_record: Self::Record = Default::default();
+
+        field_check!(given_name, incoming, local, mirror, merged_record);
+        field_check!(additional_name, incoming, local, mirror, merged_record);
+        field_check!(family_name, incoming, local, mirror, merged_record);
+        field_check!(organization, incoming, local, mirror, merged_record);
+        field_check!(street_address, incoming, local, mirror, merged_record);
+        field_check!(address_level3, incoming, local, mirror, merged_record);
+        field_check!(address_level2, incoming, local, mirror, merged_record);
+        field_check!(address_level1, incoming, local, mirror, merged_record);
+        field_check!(postal_code, incoming, local, mirror, merged_record);
+        field_check!(country, incoming, local, mirror, merged_record);
+        field_check!(tel, incoming, local, mirror, merged_record);
+        field_check!(email, incoming, local, mirror, merged_record);
+
+        set_sync_times(&mut merged_record, incoming, local, mirror);
+
         merged_record
-    );
-    field_check!(family_name, guid, incoming, local, mirror, merged_record);
-    field_check!(organization, guid, incoming, local, mirror, merged_record);
-    field_check!(street_address, guid, incoming, local, mirror, merged_record);
-    field_check!(address_level3, guid, incoming, local, mirror, merged_record);
-    field_check!(address_level2, guid, incoming, local, mirror, merged_record);
-    field_check!(address_level1, guid, incoming, local, mirror, merged_record);
-    field_check!(postal_code, guid, incoming, local, mirror, merged_record);
-    field_check!(country, guid, incoming, local, mirror, merged_record);
-    field_check!(tel, guid, incoming, local, mirror, merged_record);
-    field_check!(email, guid, incoming, local, mirror, merged_record);
+    }
 
-    set_sync_times(&mut merged_record, incoming, local, mirror);
+    /// Returns a local record that has the same values as the given incoming record (with the exception
+    /// of the `guid` values which should differ) that will be used as a local duplicate record for
+    /// syncing.
+    fn get_local_dupe(
+        &self,
+        conn: &Connection,
+        incoming: &Self::Record,
+    ) -> Result<Option<(SyncGuid, Self::Record)>> {
+        let sql = "
+            SELECT
+                guid,
+                given_name,
+                additional_name,
+                family_name,
+                organization,
+                street_address,
+                address_level3,
+                address_level2,
+                address_level1,
+                postal_code,
+                country,
+                tel,
+                email,
+                time_created,
+                time_last_used,
+                time_last_modified,
+                times_used,
+                sync_change_counter
+            FROM addresses_data
+            WHERE
+                -- `guid <> :guid` is a pre-condition for this being called, but...
+                guid <> :guid
+                -- only non-synced records are candidates, which means can't already be in the mirror.
+                AND guid NOT IN (
+                    SELECT guid
+                    FROM addresses_mirror
+                )
+                -- and sql can check the field values.
+                AND given_name == :given_name
+                AND additional_name == :additional_name
+                AND family_name == :family_name
+                AND organization == :organization
+                AND street_address == :street_address
+                AND address_level3 == :address_level3
+                AND address_level2 == :address_level2
+                AND address_level1 == :address_level1
+                AND postal_code == :postal_code
+                AND country == :country
+                AND tel == :tel
+                AND email == :email";
 
-    Record {
-        guid,
-        data: merged_record.clone(),
+        let params = named_params! {
+            ":guid": incoming.guid,
+            ":given_name": incoming.given_name,
+            ":additional_name": incoming.additional_name,
+            ":family_name": incoming.family_name,
+            ":organization": incoming.organization,
+            ":street_address": incoming.street_address,
+            ":address_level3": incoming.address_level3,
+            ":address_level2": incoming.address_level2,
+            ":address_level1": incoming.address_level1,
+            ":postal_code": incoming.postal_code,
+            ":country": incoming.country,
+            ":tel": incoming.tel,
+            ":email": incoming.email,
+        };
+
+        let result = conn.conn().query_row_named(&sql, params, |row| {
+            Ok(RecordData::from_row(&row, "").expect("wtf? '?' doesn't work :("))
+        });
+
+        match result {
+            Ok(r) => Ok(Some((incoming.guid.clone(), r))),
+            Err(e) => match e {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                _ => Err(Error::SqlError(e)),
+            },
+        }
+    }
+
+    fn apply_action(&self, conn: &Connection, action: IncomingAction) -> Result<()> {
+        log::trace!("applying action: {:?}", action);
+        match action {
+            IncomingAction::Update { record } => {
+                update_local_record(conn, record)?;
+            }
+            IncomingAction::Insert { record } => {
+                insert_local_record(conn, record)?;
+            }
+            IncomingAction::UpdateLocalGuid { old_guid, record } => {
+                // expect record to have the new guid.
+                assert_ne!(old_guid, record.guid);
+                change_local_guid(conn, &old_guid, &record.guid)?;
+                update_local_record(conn, record)?;
+            }
+
+            IncomingAction::ResurrectLocalTombstone { record } => {
+                conn.execute_named(
+                    "DELETE FROM addresses_tombstones WHERE guid = :guid",
+                    rusqlite::named_params! {
+                        ":guid": record.guid,
+                    },
+                )?;
+                insert_local_record(conn, record)?;
+            }
+            IncomingAction::DeleteLocalRecord { guid } => {
+                conn.execute_named(
+                    "DELETE FROM addresses_data
+                    WHERE guid = :guid",
+                    rusqlite::named_params! {
+                        ":guid": guid,
+                    },
+                )?;
+            }
+            IncomingAction::DoNothing => {}
+        }
+        Ok(())
     }
 }
 
 fn set_sync_times(
     merged_record: &mut RecordData,
-    incoming: RecordData,
-    local: RecordData,
-    mirror: Option<RecordData>,
+    incoming: &RecordData,
+    local: &RecordData,
+    mirror: &Option<RecordData>,
 ) {
     fn get_latest_time(times: &mut [Timestamp]) -> Timestamp {
         times.sort();
@@ -533,23 +548,22 @@ fn set_sync_times(
 
 /// Returns a with the given local record's data but with a new guid and
 /// fresh sync metadata.
-fn get_forked_record(local_record: Record) -> Record {
-    let mut local_record_data = local_record.data;
+fn get_forked_record(local_record: RecordData) -> RecordData {
+    let mut local_record_data = local_record;
+    local_record_data.guid = SyncGuid::random();
     local_record_data.time_created = Timestamp::now();
     local_record_data.time_last_used = Timestamp::now();
     local_record_data.time_last_modified = Timestamp::now();
     local_record_data.times_used = 0;
     local_record_data.sync_change_counter = Some(1);
 
-    Record {
-        guid: SyncGuid::random(),
-        data: local_record_data,
-    }
+    local_record_data
 }
 
 /// Changes the guid of the local record for the given `old_guid` to the given `new_guid` used
 /// for the `HasLocalDupe` incoming state.
-fn change_local_guid(conn: &Connection, old_guid: SyncGuid, new_guid: SyncGuid) -> Result<()> {
+fn change_local_guid(conn: &Connection, old_guid: &SyncGuid, new_guid: &SyncGuid) -> Result<()> {
+    assert_ne!(old_guid, new_guid);
     conn.conn().execute_named(
         "UPDATE addresses_data
         SET guid = :new_guid
@@ -573,7 +587,7 @@ fn change_local_guid(conn: &Connection, old_guid: SyncGuid, new_guid: SyncGuid) 
     Ok(())
 }
 
-fn update_local_record(conn: &Connection, new_record: Record) -> Result<()> {
+fn update_local_record(conn: &Connection, new_record: RecordData) -> Result<()> {
     conn.execute_named(
         "UPDATE addresses_data
         SET given_name         = :given_name,
@@ -591,18 +605,18 @@ fn update_local_record(conn: &Connection, new_record: Record) -> Result<()> {
             sync_change_counter = 0
         WHERE guid              = :guid",
         rusqlite::named_params! {
-            ":given_name": new_record.data.given_name,
-            ":additional_name": new_record.data.additional_name,
-            ":family_name": new_record.data.family_name,
-            ":organization": new_record.data.organization,
-            ":street_address": new_record.data.street_address,
-            ":address_level3": new_record.data.address_level3,
-            ":address_level2": new_record.data.address_level2,
-            ":address_level1": new_record.data.address_level1,
-            ":postal_code": new_record.data.postal_code,
-            ":country": new_record.data.country,
-            ":tel": new_record.data.tel,
-            ":email": new_record.data.email,
+            ":given_name": new_record.given_name,
+            ":additional_name": new_record.additional_name,
+            ":family_name": new_record.family_name,
+            ":organization": new_record.organization,
+            ":street_address": new_record.street_address,
+            ":address_level3": new_record.address_level3,
+            ":address_level2": new_record.address_level2,
+            ":address_level1": new_record.address_level1,
+            ":postal_code": new_record.postal_code,
+            ":country": new_record.country,
+            ":tel": new_record.tel,
+            ":email": new_record.email,
             ":guid": new_record.guid,
         },
     )?;
@@ -610,7 +624,7 @@ fn update_local_record(conn: &Connection, new_record: Record) -> Result<()> {
     Ok(())
 }
 
-fn insert_local_record(conn: &Connection, new_record: Record) -> Result<()> {
+fn insert_local_record(conn: &Connection, new_record: RecordData) -> Result<()> {
     conn.execute_named(
         "INSERT OR IGNORE INTO addresses_data (
             guid,
@@ -652,19 +666,19 @@ fn insert_local_record(conn: &Connection, new_record: Record) -> Result<()> {
             :sync_change_counter
         )",
         rusqlite::named_params! {
-            ":guid": SyncGuid::random(),
-            ":given_name": new_record.data.given_name,
-            ":additional_name": new_record.data.additional_name,
-            ":family_name": new_record.data.family_name,
-            ":organization": new_record.data.organization,
-            ":street_address": new_record.data.street_address,
-            ":address_level3": new_record.data.address_level3,
-            ":address_level2": new_record.data.address_level2,
-            ":address_level1": new_record.data.address_level1,
-            ":postal_code": new_record.data.postal_code,
-            ":country": new_record.data.country,
-            ":tel": new_record.data.tel,
-            ":email": new_record.data.email,
+            ":guid": new_record.guid,
+            ":given_name": new_record.given_name,
+            ":additional_name": new_record.additional_name,
+            ":family_name": new_record.family_name,
+            ":organization": new_record.organization,
+            ":street_address": new_record.street_address,
+            ":address_level3": new_record.address_level3,
+            ":address_level2": new_record.address_level2,
+            ":address_level1": new_record.address_level1,
+            ":postal_code": new_record.postal_code,
+            ":country": new_record.country,
+            ":tel": new_record.tel,
+            ":email": new_record.email,
             ":time_created": Timestamp::now(),
             ":time_last_used": Some(Timestamp::now()),
             ":time_last_modified": Timestamp::now(),
@@ -673,75 +687,6 @@ fn insert_local_record(conn: &Connection, new_record: Record) -> Result<()> {
         },
     )?;
 
-    Ok(())
-}
-
-fn upsert_local_record(conn: &Connection, new_record: Record) -> Result<()> {
-    let exists = conn.query_row(
-        "SELECT EXISTS (
-            SELECT 1
-            FROM addresses_data d
-            WHERE guid = :guid
-        )",
-        &[new_record.clone().guid],
-        |row| row.get(0),
-    )?;
-
-    if exists {
-        update_local_record(conn, new_record)?;
-    } else {
-        insert_local_record(conn, new_record)?;
-    }
-    Ok(())
-}
-
-/// Apply the actions necessary to fully process the incoming items
-pub fn apply_actions(
-    conn: &Connection,
-    actions: Vec<(SyncGuid, IncomingAction)>,
-    signal: &dyn Interruptee,
-) -> Result<()> {
-    for (item, action) in actions {
-        signal.err_if_interrupted()?;
-
-        log::trace!("action for '{:?}': {:?}", item, action);
-        match action {
-            IncomingAction::TakeMergedRecord { new_record } => {
-                update_local_record(conn, new_record)?;
-            }
-            IncomingAction::UpdateLocalGuid {
-                dupe_guid,
-                old_guid,
-                new_record,
-            } => {
-                change_local_guid(conn, old_guid, dupe_guid)?;
-                update_local_record(conn, new_record)?;
-            }
-            IncomingAction::TakeRemote { new_record } => {
-                upsert_local_record(conn, new_record)?;
-            }
-            IncomingAction::DeleteLocalTombstone { remote_record } => {
-                conn.execute_named(
-                    "DELETE FROM addresses_tombstones WHERE guid = :guid",
-                    rusqlite::named_params! {
-                        ":guid": remote_record.guid,
-                    },
-                )?;
-
-                insert_local_record(conn, remote_record)?;
-            }
-            IncomingAction::DeleteLocalRecord { guid } => {
-                conn.execute_named(
-                    "DELETE FROM addresses_data
-                    WHERE guid = :guid",
-                    rusqlite::named_params! {
-                        ":guid": guid,
-                    },
-                )?;
-            }
-            IncomingAction::DoNothing => {}
-        }
-    }
     Ok(())
 }
 
@@ -764,6 +709,7 @@ mod tests {
 
     #[test]
     fn test_stage_incoming() -> Result<()> {
+        let _ = env_logger::try_init();
         let mut db = new_syncable_mem_db();
         let tx = db.transaction()?;
         struct TestCase {
@@ -777,7 +723,6 @@ mod tests {
                 incoming_records: json! {[
                     {
                         "id": "AAAAAAAAAAAAAAAAA",
-                        "deleted": false,
                         "givenName": "john",
                         "additionalName": "",
                         "familyName": "doe",
@@ -804,22 +749,6 @@ mod tests {
                     {
                         "id": "AAAAAAAAAAAAAA",
                         "deleted": true,
-                        "givenName": "",
-                        "additionalName": "",
-                        "familyName": "",
-                        "organization": "",
-                        "streetAddress": "",
-                        "addressLevel3": "",
-                        "addressLevel2": "",
-                        "addressLevel1": "",
-                        "postalCode": "",
-                        "country": "",
-                        "tel": "",
-                        "email": "",
-                        "timeCreated": 0,
-                        "timeLastUsed": 0,
-                        "timeLastModified": 0,
-                        "timesUsed": 0,
                     }
                 ]},
                 expected_record_count: 0,
@@ -829,7 +758,6 @@ mod tests {
                 incoming_records: json! {[
                     {
                         "id": "AAAAAAAAAAAAAAAAA",
-                        "deleted": false,
                         "givenName": "john",
                         "additionalName": "",
                         "familyName": "doe",
@@ -849,7 +777,6 @@ mod tests {
                     },
                     {
                         "id": "CCCCCCCCCCCCCCCCCC",
-                        "deleted": false,
                         "givenName": "jane",
                         "additionalName": "",
                         "familyName": "doe",
@@ -870,22 +797,6 @@ mod tests {
                     {
                         "id": "BBBBBBBBBBBBBBBBB",
                         "deleted": true,
-                        "givenName": "",
-                        "additionalName": "",
-                        "familyName": "",
-                        "organization": "",
-                        "streetAddress": "",
-                        "addressLevel3": "",
-                        "addressLevel2": "",
-                        "addressLevel1": "",
-                        "postalCode": "",
-                        "country": "",
-                        "tel": "",
-                        "email": "",
-                        "timeCreated": 0,
-                        "timeLastUsed": 0,
-                        "timeLastModified": 0,
-                        "timesUsed": 0,
                     }
                 ]},
                 expected_record_count: 2,
@@ -894,6 +805,7 @@ mod tests {
         ];
 
         for tc in test_cases {
+            log::info!("starting new testcase");
             stage_incoming(
                 &tx,
                 array_to_incoming(tc.incoming_records),
@@ -1056,7 +968,10 @@ mod tests {
             },
         )?;
 
-        get_incoming(&tx)?;
+        let t = AddressesImpl {};
+        t.fetch_incoming_states(&tx)?;
+
+        // XXX - check we got what we expected!
 
         tx.execute_all(&[
             "DELETE FROM addresses_data;",

--- a/components/autofill/src/sync/address/mod.rs
+++ b/components/autofill/src/sync/address/mod.rs
@@ -9,14 +9,16 @@ use crate::error::*;
 use rusqlite::Row;
 use serde::Serialize;
 use serde_derive::*;
+use sync_guid::Guid as SyncGuid;
 use types::Timestamp;
-
-type Record = crate::sync::Record<RecordData>;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
 pub struct RecordData {
+    #[serde(rename = "id")]
+    pub guid: SyncGuid,
+
     pub given_name: String,
 
     pub additional_name: String,
@@ -55,6 +57,7 @@ pub struct RecordData {
 impl RecordData {
     pub fn from_row(row: &Row<'_>, column_prefix: &str) -> Result<RecordData> {
         Ok(RecordData {
+            guid: row.get::<_, SyncGuid>(format!("{}{}", column_prefix, "guid").as_str())?,
             given_name: row
                 .get::<_, String>(format!("{}{}", column_prefix, "given_name").as_str())?,
             additional_name: row

--- a/components/autofill/src/sync/mod.rs
+++ b/components/autofill/src/sync/mod.rs
@@ -6,24 +6,177 @@
 pub mod address;
 // pub mod credit_card;
 
-use serde::Serialize;
-use serde_derive::*;
+use crate::error::Result;
+use interrupt_support::Interruptee;
+use rusqlite::Connection;
 use sync_guid::Guid as SyncGuid;
 
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
-#[serde(rename_all = "camelCase")]
-pub struct Record<T> {
-    #[serde(rename = "id", default)]
-    pub guid: SyncGuid,
+// Some enums that help represent what the state of local records are.
+// The idea is that the actual implementations just need to tell you what
+// exists and what doesn't, but don't need to implement the actual policy for
+// what that means.
 
-    #[serde(flatten)]
-    data: T,
+// An "incoming" record can be in only 2 states.
+enum IncomingRecordInfo<T> {
+    Record { record: T },
+    Tombstone { guid: SyncGuid },
 }
 
-impl<T> Record<T> {
-    fn new(guid: SyncGuid, data: T) -> Record<T> {
-        Record { guid, data }
+// A local record can be in any of these 4 states.
+enum LocalRecordInfo<T> {
+    Unmodified { record: T },
+    Modified { record: T },
+    Tombstone { guid: SyncGuid },
+    Missing,
+}
+
+// This ties the 3 possible records together and is what we expect the
+// implementations to put together for us.
+pub struct IncomingState<T> {
+    incoming: IncomingRecordInfo<T>,
+    local: LocalRecordInfo<T>,
+    // We don't have an enum for the mirror - an Option<> is fine because we
+    // don't store tombstones there.
+    mirror: Option<T>,
+}
+
+/// Convert a IncomingState to an IncomingAction - this is where the "policy"
+/// lives for when we resurrect, or merge etc.
+fn plan_incoming<T>(
+    conn: &Connection,
+    rec_impl: &dyn RecordImpl<Record = T>,
+    staged_info: IncomingState<T>,
+) -> Result<IncomingAction<T>> {
+    let IncomingState {
+        incoming,
+        local,
+        mirror,
+    } = staged_info;
+
+    let state = match incoming {
+        IncomingRecordInfo::Tombstone { guid } => {
+            match local {
+                LocalRecordInfo::Unmodified { .. } => {
+                    // Note: On desktop, when there's a local record for an incoming tombstone, a local tombstone
+                    // would created. But we don't actually need to create a local tombstone here. If we did it would
+                    // immediately be deleted after being uploaded to the server.
+                    IncomingAction::DeleteLocalRecord { guid }
+                }
+                LocalRecordInfo::Modified { record } => {
+                    // Incoming tombstone with local changes should cause us to "resurrect" the local. It's
+                    // likely that the implementation of this is to do nothing, but it's better to be explicit.
+                    IncomingAction::ResurrectLocalTombstone { record }
+                }
+                LocalRecordInfo::Tombstone {
+                    guid: tombstone_guid,
+                } => {
+                    assert_eq!(guid, tombstone_guid);
+                    IncomingAction::DoNothing
+                }
+                LocalRecordInfo::Missing => IncomingAction::DoNothing,
+            }
+        }
+        IncomingRecordInfo::Record {
+            record: incoming_record,
+        } => {
+            match local {
+                LocalRecordInfo::Unmodified {
+                    record: local_record,
+                } => {
+                    // We still merge so the metadata is up-to-date.
+                    let record = rec_impl.merge(&incoming_record, &local_record, &mirror);
+                    IncomingAction::Update { record }
+                }
+                LocalRecordInfo::Modified {
+                    record: local_record,
+                } => {
+                    let merged = rec_impl.merge(&incoming_record, &local_record, &mirror);
+                    IncomingAction::Update { record: merged }
+                }
+                LocalRecordInfo::Tombstone { .. } => IncomingAction::ResurrectLocalTombstone {
+                    record: incoming_record,
+                },
+                LocalRecordInfo::Missing => {
+                    match rec_impl.get_local_dupe(conn, &incoming_record)? {
+                        None => IncomingAction::Insert {
+                            record: incoming_record,
+                        },
+                        Some((old_guid, local_dupe)) => {
+                            // *sob* - need guid fetching in the trait??? assert_ne!(incoming_record.guid, local_dupe.guid);
+                            IncomingAction::UpdateLocalGuid {
+                                old_guid,
+                                record: rec_impl.merge(&incoming_record, &local_dupe, &mirror),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    };
+    Ok(state)
+}
+
+/// The distinct incoming sync actions to be performed for incoming records.
+#[derive(Debug, PartialEq)]
+pub enum IncomingAction<T> {
+    // Remove the local record with this GUID.
+    DeleteLocalRecord { guid: SyncGuid },
+    // Insert a new record.
+    Insert { record: T },
+    // Update an existing record.
+    Update { record: T },
+    // An existing record with old_guid needs to be replaced with this record.
+    UpdateLocalGuid { old_guid: SyncGuid, record: T },
+    // There's a local tombstone - it should be removed and replaced with this.
+    ResurrectLocalTombstone { record: T },
+    // Nothing to do.
+    DoNothing,
+}
+
+// A trait that abstracts the implementation of the specific record types, and
+// must be implemented by the concrete record owners.
+trait RecordImpl {
+    type Record;
+
+    fn fetch_incoming_states(&self, conn: &Connection) -> Result<Vec<IncomingState<Self::Record>>>;
+
+    // Merge multiple records into 1.
+    fn merge(
+        &self,
+        incoming: &Self::Record,
+        local: &Self::Record,
+        mirror: &Option<Self::Record>,
+    ) -> Self::Record;
+
+    /// Returns a local record that has the same values as the given incoming record (with the exception
+    /// of the `guid` values which should differ) that will be used as a local duplicate record for
+    /// syncing.
+    fn get_local_dupe(
+        &self,
+        conn: &Connection,
+        incoming: &Self::Record,
+    ) -> Result<Option<(SyncGuid, Self::Record)>>;
+
+    // Apply a specific action
+    fn apply_action(&self, conn: &Connection, action: IncomingAction<Self::Record>) -> Result<()>;
+
+    // Will need new stuff for, "finish incoming" and all outgoing.
+}
+
+// needs a better name :) But this is how all the above ties together.
+#[allow(dead_code)]
+fn do_incoming<T>(
+    conn: &Connection,
+    rec_impl: &dyn RecordImpl<Record = T>,
+    signal: &dyn Interruptee,
+) -> Result<()> {
+    let states = rec_impl.fetch_incoming_states(conn)?;
+    for state in states {
+        signal.err_if_interrupted()?;
+        let action = plan_incoming(conn, rec_impl, state)?;
+        rec_impl.apply_action(conn, action)?;
     }
+    Ok(())
 }
 
 // Helpers for tests
@@ -39,119 +192,88 @@ pub mod test {
     }
 }
 
-/// The distinct states of records to be synced which determine the `IncomingAction` to be taken.
-#[derive(Debug, PartialEq)]
-#[allow(clippy::large_enum_variant)]
-pub enum IncomingState<T> {
-    // Only the incoming record exists. An associated local or mirror record doesn't exist.
-    IncomingOnly {
-        guid: SyncGuid,
-        incoming: T,
-    },
-    // The incoming record is a tombstone.
-    IncomingTombstone {
-        guid: SyncGuid,
-        local: Option<T>,
-        has_local_changes: bool,
-        has_local_tombstone: bool,
-    },
-    // The incoming record has an associated local record.
-    HasLocal {
-        guid: SyncGuid,
-        incoming: T,
-        merged: Record<T>,
-        has_local_changes: bool,
-    },
-    // The incoming record doesn't have an associated local record with the same GUID.
-    // A local record with the same data but a different GUID has been located.
-    HasLocalDupe {
-        guid: SyncGuid,
-        dupe_guid: SyncGuid,
-        merged: Record<T>,
-    },
-    // The incoming record doesn't have an associated local or local duplicate record but does
-    // have a local tombstone.
-    NonDeletedIncoming {
-        guid: SyncGuid,
-        incoming: T,
-    },
-}
+#[cfg(test)]
+mod tests {
+    use super::test::new_syncable_mem_db;
+    use super::*;
 
-/// The distinct incoming sync actions to be preformed for incoming records.
-#[derive(Debug, PartialEq)]
-#[allow(clippy::large_enum_variant)]
-pub enum IncomingAction<T> {
-    DeleteLocalRecord {
-        guid: SyncGuid,
-    },
-    TakeMergedRecord {
-        new_record: Record<T>,
-    },
-    UpdateLocalGuid {
-        old_guid: SyncGuid,
-        dupe_guid: SyncGuid,
-        new_record: Record<T>,
-    },
-    TakeRemote {
-        new_record: Record<T>,
-    },
-    DeleteLocalTombstone {
-        remote_record: Record<T>,
-    },
-    DoNothing,
-}
+    struct TestImpl {}
 
-/// Given an `IncomingState` returns the `IncomingAction` that should be performed.
-pub fn plan_incoming<T>(s: IncomingState<T>) -> IncomingAction<T> {
-    match s {
-        IncomingState::IncomingOnly { guid, incoming } => IncomingAction::TakeRemote {
-            new_record: Record::<T>::new(guid, incoming),
-        },
-        IncomingState::IncomingTombstone {
-            guid,
-            local,
-            has_local_changes,
-            has_local_tombstone,
-        } => match local {
-            Some(_) => {
-                // Note: On desktop, when there's a local record for an incoming tombstone, a local tombstone
-                // would created. But we don't actually need to create a local tombstone here. If we did it would
-                // immediately be deleted after being uploaded to the server.
+    impl RecordImpl for TestImpl {
+        type Record = i32;
 
-                if has_local_changes || has_local_tombstone {
-                    IncomingAction::DoNothing
-                } else {
-                    IncomingAction::DeleteLocalRecord {
-                        guid: SyncGuid::new(&guid),
-                    }
-                }
-            }
-            None => IncomingAction::DoNothing,
-        },
-        IncomingState::HasLocal {
-            guid,
-            incoming,
-            merged,
-            has_local_changes,
-        } => match has_local_changes {
-            true => IncomingAction::TakeMergedRecord { new_record: merged },
-            false => IncomingAction::TakeRemote {
-                new_record: Record::<T>::new(guid, incoming),
-            },
-        },
-        IncomingState::HasLocalDupe {
-            guid,
-            dupe_guid,
-            merged,
-        } => IncomingAction::UpdateLocalGuid {
-            old_guid: guid,
-            dupe_guid,
-            new_record: merged,
-        },
-        IncomingState::NonDeletedIncoming { guid, incoming } => {
-            IncomingAction::DeleteLocalTombstone {
-                remote_record: Record::<T>::new(guid, incoming),
-            }
+        fn fetch_incoming_states(
+            &self,
+            _conn: &Connection,
+        ) -> Result<Vec<IncomingState<Self::Record>>> {
+            unreachable!();
         }
+
+        fn merge(
+            &self,
+            _incoming: &Self::Record,
+            _local: &Self::Record,
+            _mirror: &Option<Self::Record>,
+        ) -> Self::Record {
+            unreachable!();
+        }
+
+        fn get_local_dupe(
+            &self,
+            _conn: &Connection,
+            _incoming: &Self::Record,
+        ) -> Result<Option<(SyncGuid, Self::Record)>> {
+            Ok(None)
+        }
+
+        // Apply a specific action
+        fn apply_action(
+            &self,
+            _conn: &Connection,
+            _action: IncomingAction<Self::Record>,
+        ) -> Result<()> {
+            unreachable!();
+        }
+    }
+    #[test]
+    fn test_plan_incoming() -> Result<()> {
+        let conn = new_syncable_mem_db();
+        let testimpl = TestImpl {};
+        let guid = SyncGuid::random();
+        // We just use an int for <T> here, hence the magic 0
+        let state = IncomingState {
+            incoming: IncomingRecordInfo::Record { record: 0 },
+            local: LocalRecordInfo::Missing,
+            mirror: None,
+        };
+        assert_eq!(
+            plan_incoming(&conn, &testimpl, state)?,
+            IncomingAction::Insert { record: 0 }
+        );
+
+        // Incoming tombstone with an unmodified local record deletes the local record.
+        let state = IncomingState {
+            incoming: IncomingRecordInfo::Tombstone { guid: guid.clone() },
+            local: LocalRecordInfo::Unmodified { record: 0 },
+            mirror: None,
+        };
+        assert_eq!(
+            plan_incoming(&conn, &testimpl, state)?,
+            IncomingAction::DeleteLocalRecord { guid: guid.clone() }
+        );
+
+        // Incoming with no matching local record does nothing/
+        let state = IncomingState {
+            incoming: IncomingRecordInfo::Tombstone { guid },
+            local: LocalRecordInfo::Missing,
+            mirror: None,
+        };
+        assert_eq!(
+            plan_incoming(&conn, &testimpl, state)?,
+            IncomingAction::DoNothing
+        );
+
+        // TODO - the rest
+        Ok(())
     }
 }


### PR DESCRIPTION
Hey Lougenia,
  Let me know what you think of these changes? We can talk more about it later today, but though I'd get it up before you start for your week. If you think it's OK, please just merge it and base your work on that. I think it's getting close enough that you can start work on the sync15 stuff soon (although more tests here would also be great)

* Radically rethought the IncomingState in a way that allows the "policy"
  decisions to be shared between Addresses and CreditCards

* Added a new `trait RecordImpl` which abstracts details about the
  records themselves to aid in this sharing.

* Got rid of Record and instead added guid to RecordData, mainly to avoid
  getting too confused. RecordData should probably be renamed to, say,
  AddressRecord.

* Tweaked the tests with tombstones to better reflect reality - non-tombstones
  have no `deleted` flag, while tombstones have `deleted: true` but no fields.
