### PR TITLE
[nobug, build] Update XCode from 12.0 to 12.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ commands:
 jobs:
   Check Swift formatting:
     macos:
-      xcode: "12.0.0"
+      xcode: "12.3.0"
     steps:
       - full-checkout
       - run: brew install swiftlint swiftformat
@@ -320,7 +320,7 @@ jobs:
   Check Rust dependencies:
     # This check has to be done on a mac, to be able to detect iOS-specific dependencies.
     macos:
-      xcode: "12.0.0"
+      xcode: "12.3.0"
     steps:
       - install-rust
       - setup-rust-toolchain
@@ -368,7 +368,7 @@ jobs:
       - save-sccache-cache
   iOS build and test:
     macos:
-      xcode: "12.0.0"
+      xcode: "12.3.0"
     steps:
       # We do not use the ssccache cache helper commands as
       # the macOS cache is in a different folder.
@@ -453,7 +453,7 @@ jobs:
             - MozillaAppServices.framework.zip
   Carthage release:
     macos:
-      xcode: "12.0.0"
+      xcode: "12.3.0"
     steps:
       - full-checkout
       - attach_workspace:


### PR DESCRIPTION
We are planning to move to new XCode 12.3 on our firefox-ios branch for which we'll need to update A~S to support new XCode 12.3

cc @mhammond 