### PR TITLE
Update to Android Components 71.0.0 on v67 release

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,8 @@
 
 # Unreleased Changes
 
+## General
+
+ - Updated Android Components to 71.0.0
+
 [Full Changelog](https://github.com/mozilla/application-services/compare/v67.2.0...main)

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext.kotlin_version = '1.3.71'
     ext.jna_version = '5.6.0'
     ext.android_gradle_plugin_version = '4.0.1'
-    ext.android_components_version = '63.0.0'
+    ext.android_components_version = '71.0.0'
 
     ext.build = [
         ndkVersion: "21.3.6528147", // Keep it in sync in TC Dockerfile.


### PR DESCRIPTION
Android Components/Fenix currently uses v67.2.0, so this optional PR might be helpful if we decide to do a minor upgrade for now instead.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
