### PR TITLE
verify-android-environment script updates

### DIFF
--- a/libs/verify-android-environment.sh
+++ b/libs/verify-android-environment.sh
@@ -68,4 +68,7 @@ if [[ -z "${CI}" ]]; then
   fi
 fi
 
+echo "Installing uniffi_bindgen if missing; it's necessary for binding generation during the builds."
+cargo install uniffi_bindgen --version 0.6.1
+
 echo "Looks good! Try building with ./gradlew assembleDebug"

--- a/libs/verify-android-environment.sh
+++ b/libs/verify-android-environment.sh
@@ -24,12 +24,6 @@ if [[ -z "${ANDROID_HOME}" ]]; then
   exit 1
 fi
 
-# NDK ez-install.
-"$ANDROID_HOME/tools/bin/sdkmanager" "ndk;$(./gradlew -q printNdkVersion | tail -1)"
-
-# NDK ez-install
-"$ANDROID_HOME/tools/bin/sdkmanager" "ndk;$(./gradlew -q printNdkVersion | tail -1)"
-
 rustup target add "${RUST_TARGETS[@]}"
 
 # Determine the Java command to use to start the JVM.
@@ -58,8 +52,12 @@ fi
 JAVA_VERSION=$("$JAVACMD" -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-2)
 if [[ "${JAVA_VERSION}" != "1.8" ]]; then
   echo "Incompatible java version: ${JAVA_VERSION}. JDK 8 must be installed."
+  echo "Try switching versions and re-running. Using sdkman: sdk install java 8.0.282+8.hs-adpt || sdk use java 8.0.282+8.hs-adpt"
   exit 1
 fi
+
+# NDK ez-install
+"$ANDROID_HOME/tools/bin/sdkmanager" "ndk;$(./gradlew -q printNdkVersion | tail -1)"
 
 # CI just downloads these libs anyway.
 if [[ -z "${CI}" ]]; then


### PR DESCRIPTION
Running ANDROID_HOME/tools/bin/sdkmanager with Java 11 configured in the shell fails with an unhelpful stacktrace. So I've moved that after the java version check, removed a duplicate call, and added a hint (assuming sdkman is installed) that will switch to a required version.

Also added a call to install uniffi_bindgen which is now necessary for the builds to succeed.

Example output with these changes:
```
➜  application-services git:(verifyAndroid) ✗ ./libs/verify-android-environment.sh
rustc 1.49.0 (e1884a8e3 2020-12-29)
info: component 'rust-std' for target 'aarch64-linux-android' is up to date
info: component 'rust-std' for target 'armv7-linux-androideabi' is up to date
info: component 'rust-std' for target 'i686-linux-android' is up to date
info: component 'rust-std' for target 'x86_64-linux-android' is up to date
Incompatible java version: 11.0. JDK 8 must be installed.
Try switching versions and re-running. Using sdkman: sdk install java 8.0.282+8.hs-adpt || sdk use java 8.0.282+8.hs-adpt
➜  application-services git:(verifyAndroid) ✗ sdk install java 8.0.282+8.hs-adpt || sdk use java 8.0.282+8.hs-adpt

Stop! java 8.0.282+8.hs-adpt is already installed.

Using java version 8.0.282+8.hs-adpt in this shell.
➜  application-services git:(verifyAndroid) ✗ ./libs/verify-android-environment.sh
rustc 1.49.0 (e1884a8e3 2020-12-29)
info: component 'rust-std' for target 'aarch64-linux-android' is up to date
info: component 'rust-std' for target 'armv7-linux-androideabi' is up to date
info: component 'rust-std' for target 'i686-linux-android' is up to date
info: component 'rust-std' for target 'x86_64-linux-android' is up to date
Warning: File /Users/grishakruglov/.android/repositories.cfg could not be loaded.
[=======================================] 100% Computing updates...
Installing uniffi_bindgen if missing; it's necessary for binding generation during the builds.
    Updating crates.io index
     Ignored package `uniffi_bindgen v0.6.1` is already installed, use --force to override
Looks good! Try building with ./gradlew assembleDebug
➜  application-services git:(verifyAndroid) ✗
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
