### PR TITLE
Upgrade to Xcode 11.7 (0.59)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,7 @@ commands:
 jobs:
   Check Swift formatting:
     macos:
-      xcode: "11.4.1"
+      xcode: "11.7"
     steps:
       - checkout
       - run: brew install swiftlint swiftformat
@@ -322,7 +322,7 @@ jobs:
       - save-sccache-cache
   iOS build and test:
     macos:
-      xcode: "11.4.1"
+      xcode: "11.7"
     steps:
       # We do not use the ssccache cache helper commands as
       # the macOS cache is in a different folder.
@@ -407,7 +407,7 @@ jobs:
             - MozillaAppServices.framework.zip
   Carthage release:
     macos:
-      xcode: "11.4.1"
+      xcode: "11.7"
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
This patch updates Xcode from 11.4.2 to 11.7 on the 0.59 branch. This is because it is likely we need to do a Lockwise iOS update, and Xcode 11.4 is not available anymore on BuddyBuild.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
