### PR TITLE
Upgrade to Glean 33.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - The bundled version of Nimbus SDK has been updated to v0.6.4.
 - The internal traits used by `sync15` have been renamed for consistency and clarity
   (and the README has been updated with docs to help explain them).
+- The bundled version of Glean has been updated to v33.10.3.
 
 # v68.0.0 (_2020-12-08_)
 
@@ -1807,7 +1808,7 @@ This release exists only to rectify a publishing error that occurred with v0.33.
 ### Features
 
 * Added `migrateFromSessionToken` to allow creating a refreshToken from an existing sessionToken.
-Useful for Fennec to Fenix bootstrap flow, where the user can just reuse the existing sessionToken to 
+Useful for Fennec to Fenix bootstrap flow, where the user can just reuse the existing sessionToken to
 create a new session with a refreshToken.
 
 # v0.29.0 (_2019-05-23_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "glean-core"
-version = "33.10.1"
+version = "33.10.3"
 dependencies = [
  "bincode",
  "chrono",
@@ -1201,7 +1201,7 @@ dependencies = [
  "flate2",
  "log 0.4.11",
  "once_cell",
- "rkv 0.16.1",
+ "rkv 0.17.0",
  "serde",
  "serde_json",
  "uuid",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "glean-ffi"
-version = "33.10.1"
+version = "33.10.3"
 dependencies = [
  "android_logger",
  "env_logger",
@@ -2809,15 +2809,14 @@ dependencies = [
 
 [[package]]
 name = "rkv"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917d7a01f8c1ae46226e9d8dd24314279be7b04dfd0b24340d420e6927c2e687"
+checksum = "28e2e15d3fff125cfc4fb3f1b226ff83af057c4715061ded16193b7142beefc9"
 dependencies = [
  "arrayref",
  "bincode",
  "bitflags 1.2.1",
  "byteorder",
- "failure",
  "id-arena",
  "lazy_static",
  "lmdb-rkv",
@@ -2826,6 +2825,7 @@ dependencies = [
  "paste 0.1.18",
  "serde",
  "serde_derive",
+ "thiserror",
  "url",
  "uuid",
 ]

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -24,7 +24,6 @@ the details of which are reproduced below.
 * [MIT License: ordered-float](#mit-license-ordered-float)
 * [MIT License: oslog](#mit-license-oslog)
 * [MIT License: slab](#mit-license-slab)
-* [MIT License: synstructure](#mit-license-synstructure)
 * [MIT License: tokio, tokio-tls, tokio-util, tracing, tracing-core, tracing-futures](#mit-license-tokio-tokio-tls-tokio-util-tracing-tracing-core-tracing-futures)
 * [MIT License: tower-service](#mit-license-tower-service)
 * [MIT License: try-lock](#mit-license-try-lock)
@@ -442,8 +441,6 @@ The following text applies to code linked from these dependencies:
 [either](https://github.com/bluss/either),
 [encoding_rs](https://github.com/hsivonen/encoding_rs),
 [env_logger](https://github.com/sebasmagri/env_logger/),
-[failure](https://github.com/rust-lang-nursery/failure),
-[failure_derive](https://github.com/rust-lang-nursery/failure),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
 [ffi-support](https://github.com/mozilla/application-services),
@@ -1299,22 +1296,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: synstructure
-
-The following text applies to code linked from these dependencies:
-[synstructure](https://github.com/mystor/synstructure)
-
-```
-Copyright 2016 Nika Layzell
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------


### PR DESCRIPTION
Would be good to land the Glean update before a release (#3826), so we can get that into Firefox iOS as well.