### PR TITLE
Leverage more of serde for autofill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,7 @@ dependencies = [
  "serde_json",
  "sql-support",
  "sync-guid",
+ "sync15",
  "sync15-traits",
  "thiserror",
  "types",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -15,7 +15,8 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 sql-support = { path = "../support/sql" }
-sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
+sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random", "serde_support"] }
+sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -50,7 +50,7 @@ dictionary Address {
 
 [Error]
 enum Error {
-   "SqlError", "IoError", "InterruptedError", "IllegalDatabasePath", "Utf8Error"
+   "SqlError", "IoError", "InterruptedError", "IllegalDatabasePath", "Utf8Error", "JsonError"
 };
 
 interface Store {

--- a/components/autofill/src/db/models/address.rs
+++ b/components/autofill/src/db/models/address.rs
@@ -10,39 +10,30 @@ use sync_guid::Guid;
 use types::Timestamp;
 
 #[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", default)]
 pub struct NewAddressFields {
     pub given_name: String,
 
-    #[serde(default)]
     pub additional_name: String,
 
     pub family_name: String,
 
-    #[serde(default)]
     pub organization: String,
 
     pub street_address: String,
 
-    #[serde(default)]
     pub address_level3: String,
 
-    #[serde(default)]
     pub address_level2: String,
 
-    #[serde(default)]
     pub address_level1: String,
 
-    #[serde(default)]
     pub postal_code: String,
 
-    #[serde(default)]
     pub country: String,
 
-    #[serde(default)]
     pub tel: String,
 
-    #[serde(default)]
     pub email: String,
 }
 

--- a/components/autofill/src/db/models/credit_card.rs
+++ b/components/autofill/src/db/models/credit_card.rs
@@ -10,7 +10,7 @@ use sync_guid::Guid;
 use types::Timestamp;
 
 #[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", default)]
 pub struct NewCreditCardFields {
     pub cc_name: String,
 

--- a/components/autofill/src/error.rs
+++ b/components/autofill/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
 
     #[error("UTF8 Error: {0}")]
     Utf8Error(#[from] std::str::Utf8Error),
+
+    #[error("JSON Error: {0}")]
+    JsonError(#[from] serde_json::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
This PR:

* allows us to use serde for guids (which my tests will want)
* exposes a new `JsonError` so we can use `?` on serde-related functions.
* Moves some serde "default" attributes from the fields to the container - if we want to insist on some fields then we should probably do something other than just causing a serde error.

Most of this is really just for tests, but I thought I'd split it out to keep that other branch less painful!