### PR TITLE
WIP for exposing address metadata and rationalizing some structs

### DIFF
--- a/components/autofill/sql/create_shared_schema.sql
+++ b/components/autofill/sql/create_shared_schema.sql
@@ -3,7 +3,7 @@
 -- file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 CREATE TABLE IF NOT EXISTS addresses_data (
-    guid          TEXT NOT NULL PRIMARY KEY,
+    guid                TEXT NOT NULL PRIMARY KEY,
     given_name          TEXT NOT NULL,
     additional_name     TEXT NOT NULL,
     family_name         TEXT NOT NULL,
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS addresses_data (
 );
 
 CREATE TABLE IF NOT EXISTS addresses_mirror (
-   guid          TEXT NOT NULL PRIMARY KEY,
+    guid                TEXT NOT NULL PRIMARY KEY,
     given_name          TEXT NOT NULL,
     additional_name     TEXT NOT NULL,
     family_name         TEXT NOT NULL,

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -1,6 +1,7 @@
 namespace autofill {};
 
-dictionary NewCreditCardFields {
+// What you pass to create or update a credit-card.
+dictionary UpdatableCreditCardFields {
     string cc_name;
     string cc_number;
     i64 cc_exp_month;
@@ -8,6 +9,7 @@ dictionary NewCreditCardFields {
     string cc_type;
 };
 
+// What you get back as a credit-card.
 dictionary CreditCard {
     string guid;
     string cc_name;
@@ -15,9 +17,15 @@ dictionary CreditCard {
     i64 cc_exp_month;
     i64 cc_exp_year;
     string cc_type;
+
+    i64 time_created;
+    i64? time_last_used;
+    i64 time_last_modified;
+    i64 times_used;
 };
 
-dictionary NewAddressFields {
+// What you pass to create or update an address.
+dictionary UpdatableAddressFields {
     string given_name;
     string additional_name;
     string family_name;
@@ -32,6 +40,7 @@ dictionary NewAddressFields {
     string email;
 };
 
+// What you get back as an address.
 dictionary Address {
     string guid;
     string given_name;
@@ -46,6 +55,11 @@ dictionary Address {
     string country;
     string tel;
     string email;
+
+    i64 time_created;
+    i64? time_last_used;
+    i64 time_last_modified;
+    i64 times_used;
 };
 
 [Error]
@@ -58,7 +72,7 @@ interface Store {
     constructor(string dbpath);
 
     [Throws=Error]
-    CreditCard add_credit_card(NewCreditCardFields a);
+    CreditCard add_credit_card(UpdatableCreditCardFields cc);
 
     [Throws=Error]
     CreditCard get_credit_card(string guid);
@@ -67,7 +81,7 @@ interface Store {
     sequence<CreditCard> get_all_credit_cards();
 
     [Throws=Error]
-    void update_credit_card(CreditCard a);
+    void update_credit_card(string guid, UpdatableCreditCardFields cc);
 
     [Throws=Error]
     boolean delete_credit_card(string guid);
@@ -76,7 +90,7 @@ interface Store {
     void touch_credit_card(string guid);
 
     [Throws=Error]
-    Address add_address(NewAddressFields a);
+    Address add_address(UpdatableAddressFields a);
 
     [Throws=Error]
     Address get_address(string guid);
@@ -85,7 +99,7 @@ interface Store {
     sequence<Address> get_all_addresses();
 
     [Throws=Error]
-    void update_address(Address a);
+    void update_address(string guid, UpdatableAddressFields a);
 
     [Throws=Error]
     boolean delete_address(string guid);

--- a/components/autofill/src/db/models/address.rs
+++ b/components/autofill/src/db/models/address.rs
@@ -9,92 +9,31 @@ use serde_derive::*;
 use sync_guid::Guid;
 use types::Timestamp;
 
-#[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
+// UpdatableAddressFields contains the fields we support for creating a new
+// address or updating an existing one. It's missing the guid, our "internal"
+// meta fields (such as the change counter) and "external" meta fields
+// (such as timeCreated) because it doesn't make sense for these things to be
+// specified as an item is created - any meta fields which can be updated
+// have special methods for doing so.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default)]
-pub struct NewAddressFields {
+pub struct UpdatableAddressFields {
     pub given_name: String,
-
     pub additional_name: String,
-
     pub family_name: String,
-
     pub organization: String,
-
     pub street_address: String,
-
     pub address_level3: String,
-
     pub address_level2: String,
-
     pub address_level1: String,
-
     pub postal_code: String,
-
     pub country: String,
-
     pub tel: String,
-
     pub email: String,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
-pub struct InternalAddress {
-    pub guid: Guid,
-
-    pub fields: NewAddressFields,
-
-    #[serde(default)]
-    #[serde(rename = "timeCreated")]
-    pub time_created: Timestamp,
-
-    #[serde(default)]
-    #[serde(rename = "timeLastUsed")]
-    pub time_last_used: Option<Timestamp>,
-
-    #[serde(default)]
-    #[serde(rename = "timeLastModified")]
-    pub time_last_modified: Timestamp,
-
-    #[serde(default)]
-    #[serde(rename = "timesUsed")]
-    pub times_used: i64,
-
-    #[serde(default)]
-    #[serde(rename = "changeCounter")]
-    pub(crate) sync_change_counter: i64,
-}
-
-impl InternalAddress {
-    pub fn from_row(row: &Row<'_>) -> Result<InternalAddress, rusqlite::Error> {
-        let address_fields = NewAddressFields {
-            given_name: row.get("given_name")?,
-            additional_name: row.get("additional_name")?,
-            family_name: row.get("family_name")?,
-            organization: row.get("organization")?,
-            street_address: row.get("street_address")?,
-            address_level3: row.get("address_level3")?,
-            address_level2: row.get("address_level2")?,
-            address_level1: row.get("address_level1")?,
-            postal_code: row.get("postal_code")?,
-            country: row.get("country")?,
-            tel: row.get("tel")?,
-            email: row.get("email")?,
-        };
-
-        Ok(InternalAddress {
-            guid: Guid::from_string(row.get("guid")?),
-            fields: address_fields,
-            time_created: row.get("time_created")?,
-            time_last_used: row.get("time_last_used")?,
-            time_last_modified: row.get("time_last_modified")?,
-            times_used: row.get("times_used")?,
-            sync_change_counter: row.get("sync_change_counter")?,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+// "Address" is what we return to consumers and has most of the metadata.
+#[derive(Debug, Clone, Hash, PartialEq, Default)]
 pub struct Address {
     pub guid: String,
     pub given_name: String,
@@ -109,28 +48,101 @@ pub struct Address {
     pub country: String,
     pub tel: String,
     pub email: String,
+    // We expose the metadata
+    pub time_created: i64,
+    pub time_last_used: Option<i64>,
+    pub time_last_modified: i64,
+    pub times_used: i64,
 }
 
-pub trait ExternalizeAddress {
-    fn to_external(&self) -> Address;
-}
-
-impl ExternalizeAddress for InternalAddress {
-    fn to_external(&self) -> Address {
+// This is used to "externalize" an address, suitable for handing back to
+// consumers.
+impl From<InternalAddress> for Address {
+    fn from(ia: InternalAddress) -> Self {
         Address {
-            guid: self.guid.to_string(),
-            given_name: self.fields.given_name.to_string(),
-            additional_name: self.fields.additional_name.to_string(),
-            family_name: self.fields.family_name.to_string(),
-            organization: self.fields.organization.to_string(),
-            street_address: self.fields.street_address.to_string(),
-            address_level3: self.fields.address_level3.to_string(),
-            address_level2: self.fields.address_level2.to_string(),
-            address_level1: self.fields.address_level1.to_string(),
-            postal_code: self.fields.postal_code.to_string(),
-            country: self.fields.country.to_string(),
-            tel: self.fields.tel.to_string(),
-            email: self.fields.email.to_string(),
+            guid: ia.guid.to_string(),
+            given_name: ia.given_name,
+            additional_name: ia.additional_name,
+            family_name: ia.family_name,
+            organization: ia.organization,
+            street_address: ia.street_address,
+            address_level3: ia.address_level3,
+            address_level2: ia.address_level2,
+            address_level1: ia.address_level1,
+            postal_code: ia.postal_code,
+            country: ia.country,
+            tel: ia.tel,
+            email: ia.email,
+            // *sob* - can't use u64 in uniffi
+            time_created: u64::from(ia.time_created) as i64,
+            time_last_used: ia.time_last_used.map(|v| u64::from(v) as i64),
+            time_last_modified: u64::from(ia.time_last_modified) as i64,
+            times_used: ia.times_used,
         }
+    }
+}
+
+// An "internal" address has both the fields we expose to consumers and those
+// we do not. This is the primary struct used internally, and is serialized to
+// and from JSON for sync etc.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct InternalAddress {
+    // it sucks that we need to duplicate the fields, but we do so because
+    // uniffi forces us to use, eg, strings for guids and ints for timestamps,
+    // but we want our rust code to deal with timestamps etc.
+    pub guid: Guid,
+    pub given_name: String,
+    pub additional_name: String,
+    pub family_name: String,
+    pub organization: String,
+    pub street_address: String,
+    pub address_level3: String,
+    pub address_level2: String,
+    pub address_level1: String,
+    pub postal_code: String,
+    pub country: String,
+    pub tel: String,
+    pub email: String,
+
+    // We expose the metadata - note that for compatibility with desktop
+    // these are *not* kebab-case - for some obscure reason the sync server's
+    // records have a mix of cases.
+    #[serde(rename = "timeCreated")]
+    pub time_created: Timestamp,
+    #[serde(rename = "timeLastUsed")]
+    pub time_last_used: Option<Timestamp>,
+    #[serde(rename = "timeLastModified")]
+    pub time_last_modified: Timestamp,
+    #[serde(rename = "timesUsed")]
+    pub times_used: i64,
+
+    #[serde(default)]
+    #[serde(rename = "changeCounter")]
+    pub(crate) sync_change_counter: i64,
+}
+
+impl InternalAddress {
+    pub fn from_row(row: &Row<'_>) -> Result<InternalAddress, rusqlite::Error> {
+        Ok(Self {
+            guid: row.get("guid")?,
+            given_name: row.get("given_name")?,
+            additional_name: row.get("additional_name")?,
+            family_name: row.get("family_name")?,
+            organization: row.get("organization")?,
+            street_address: row.get("street_address")?,
+            address_level3: row.get("address_level3")?,
+            address_level2: row.get("address_level2")?,
+            address_level1: row.get("address_level1")?,
+            postal_code: row.get("postal_code")?,
+            country: row.get("country")?,
+            tel: row.get("tel")?,
+            email: row.get("email")?,
+            time_created: row.get("time_created")?,
+            time_last_used: row.get("time_last_used")?,
+            time_last_modified: row.get("time_last_modified")?,
+            times_used: row.get("times_used")?,
+            sync_change_counter: row.get("sync_change_counter")?,
+        })
     }
 }

--- a/components/autofill/src/db/models/credit_card.rs
+++ b/components/autofill/src/db/models/credit_card.rs
@@ -9,73 +9,19 @@ use serde_derive::*;
 use sync_guid::Guid;
 use types::Timestamp;
 
-#[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default)]
-pub struct NewCreditCardFields {
+pub struct UpdatableCreditCardFields {
     pub cc_name: String,
-
     pub cc_number: String,
-
     pub cc_exp_month: i64,
-
     pub cc_exp_year: i64,
-
     // Credit card types are a fixed set of strings as defined in the link below
     // (https://searchfox.org/mozilla-central/rev/7ef5cefd0468b8f509efe38e0212de2398f4c8b3/toolkit/modules/CreditCard.jsm#9-22)
     pub cc_type: String,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
-pub struct InternalCreditCard {
-    pub guid: Guid,
-
-    pub fields: NewCreditCardFields,
-
-    #[serde(default)]
-    #[serde(rename = "timeCreated")]
-    pub time_created: Timestamp,
-
-    #[serde(default)]
-    #[serde(rename = "timeLastUsed")]
-    pub time_last_used: Option<Timestamp>,
-
-    #[serde(default)]
-    #[serde(rename = "timeLastModified")]
-    pub time_last_modified: Timestamp,
-
-    #[serde(default)]
-    #[serde(rename = "timesUsed")]
-    pub times_used: i64,
-
-    #[serde(default)]
-    #[serde(rename = "changeCounter")]
-    pub(crate) sync_change_counter: i64,
-}
-
-impl InternalCreditCard {
-    pub fn from_row(row: &Row<'_>) -> Result<InternalCreditCard, rusqlite::Error> {
-        let credit_card_fields = NewCreditCardFields {
-            cc_name: row.get("cc_name")?,
-            cc_number: row.get("cc_number")?,
-            cc_exp_month: row.get("cc_exp_month")?,
-            cc_exp_year: row.get("cc_exp_year")?,
-            cc_type: row.get("cc_type")?,
-        };
-
-        Ok(InternalCreditCard {
-            guid: Guid::from_string(row.get("guid")?),
-            fields: credit_card_fields,
-            time_created: row.get("time_created")?,
-            time_last_used: row.get("time_last_used")?,
-            time_last_modified: row.get("time_last_modified")?,
-            times_used: row.get("times_used")?,
-            sync_change_counter: row.get("sync_change_counter")?,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Clone, Default)]
 pub struct CreditCard {
     pub guid: String,
     pub cc_name: String,
@@ -86,21 +32,72 @@ pub struct CreditCard {
     // Credit card types are a fixed set of strings as defined in the link below
     // (https://searchfox.org/mozilla-central/rev/7ef5cefd0468b8f509efe38e0212de2398f4c8b3/toolkit/modules/CreditCard.jsm#9-22)
     pub cc_type: String,
+
+    // The metadata
+    pub time_created: i64,
+    pub time_last_used: Option<i64>,
+    pub time_last_modified: i64,
+    pub times_used: i64,
 }
 
-pub trait ExternalizeCreditCard {
-    fn to_external(&self) -> CreditCard;
-}
-
-impl ExternalizeCreditCard for InternalCreditCard {
-    fn to_external(&self) -> CreditCard {
+// This is used to "externalize" a credit-card, suitable for handing back to
+// consumers.
+impl From<InternalCreditCard> for CreditCard {
+    fn from(icc: InternalCreditCard) -> Self {
         CreditCard {
-            guid: self.guid.to_string(),
-            cc_name: self.clone().fields.cc_name,
-            cc_number: self.clone().fields.cc_number,
-            cc_exp_month: self.fields.cc_exp_month,
-            cc_exp_year: self.fields.cc_exp_year,
-            cc_type: self.clone().fields.cc_type,
+            guid: icc.guid.to_string(),
+            cc_name: icc.cc_name,
+            cc_number: icc.cc_number,
+            cc_exp_month: icc.cc_exp_month,
+            cc_exp_year: icc.cc_exp_year,
+            cc_type: icc.cc_type,
+            // *sob* - can't use u64 in uniffi
+            time_created: u64::from(icc.time_created) as i64,
+            time_last_used: icc.time_last_used.map(|v| u64::from(v) as i64),
+            time_last_modified: u64::from(icc.time_last_modified) as i64,
+            times_used: icc.times_used,
         }
+    }
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct InternalCreditCard {
+    pub guid: Guid,
+    pub cc_name: String,
+    pub cc_number: String,
+    pub cc_exp_month: i64,
+    pub cc_exp_year: i64,
+    // Credit card types are a fixed set of strings as defined in the link below
+    // (https://searchfox.org/mozilla-central/rev/7ef5cefd0468b8f509efe38e0212de2398f4c8b3/toolkit/modules/CreditCard.jsm#9-22)
+    pub cc_type: String,
+
+    #[serde(rename = "timeCreated")]
+    pub time_created: Timestamp,
+    #[serde(rename = "timeLastUsed")]
+    pub time_last_used: Option<Timestamp>,
+    #[serde(rename = "timeLastModified")]
+    pub time_last_modified: Timestamp,
+    #[serde(rename = "timesUsed")]
+    pub times_used: i64,
+    #[serde(rename = "changeCounter")]
+    pub(crate) sync_change_counter: i64,
+}
+
+impl InternalCreditCard {
+    pub fn from_row(row: &Row<'_>) -> Result<InternalCreditCard, rusqlite::Error> {
+        Ok(Self {
+            guid: Guid::from_string(row.get("guid")?),
+            cc_name: row.get("cc_name")?,
+            cc_number: row.get("cc_number")?,
+            cc_exp_month: row.get("cc_exp_month")?,
+            cc_exp_year: row.get("cc_exp_year")?,
+            cc_type: row.get("cc_type")?,
+            time_created: row.get("time_created")?,
+            time_last_used: row.get("time_last_used")?,
+            time_last_modified: row.get("time_last_modified")?,
+            times_used: row.get("times_used")?,
+            sync_change_counter: row.get("sync_change_counter")?,
+        })
     }
 }

--- a/components/autofill/src/db/schema.rs
+++ b/components/autofill/src/db/schema.rs
@@ -25,6 +25,26 @@ pub const ADDRESS_COMMON_COLS: &str = "
     times_used,
     sync_change_counter";
 
+pub const ADDRESS_COMMON_VALS: &str = "
+    :guid,
+    :given_name,
+    :additional_name,
+    :family_name,
+    :organization,
+    :street_address,
+    :address_level3,
+    :address_level2,
+    :address_level1,
+    :postal_code,
+    :country,
+    :tel,
+    :email,
+    :time_created,
+    :time_last_used,
+    :time_last_modified,
+    :times_used,
+    :sync_change_counter";
+
 pub const CREDIT_CARD_COMMON_COLS: &str = "
     guid,
     cc_name,
@@ -37,6 +57,19 @@ pub const CREDIT_CARD_COMMON_COLS: &str = "
     time_last_modified,
     times_used,
     sync_change_counter";
+
+pub const CREDIT_CARD_COMMON_VALS: &str = "
+    :guid,
+    :cc_name,
+    :cc_number,
+    :cc_exp_month,
+    :cc_exp_year,
+    :cc_type,
+    :time_created,
+    :time_last_used,
+    :time_last_modified,
+    :times_used,
+    :sync_change_counter";
 
 #[allow(dead_code)]
 const CREATE_SHARED_SCHEMA_SQL: &str = include_str!("../../sql/create_shared_schema.sql");

--- a/components/autofill/src/db/store.rs
+++ b/components/autofill/src/db/store.rs
@@ -2,11 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::db::models::address::{Address, ExternalizeAddress, NewAddressFields};
-use crate::db::models::credit_card::{CreditCard, ExternalizeCreditCard, NewCreditCardFields};
+use crate::db::models::address::{Address, UpdatableAddressFields};
+use crate::db::models::credit_card::{CreditCard, UpdatableCreditCardFields};
 use crate::db::{addresses, credit_cards, AutofillDb};
 use crate::error::*;
 use std::path::Path;
+use sync_guid::Guid;
 
 #[allow(dead_code)]
 pub struct Store {
@@ -29,76 +30,75 @@ impl Store {
     }
 
     #[allow(dead_code)]
-    pub fn add_credit_card(
-        &self,
-        new_credit_card_fields: NewCreditCardFields,
-    ) -> Result<CreditCard> {
-        let credit_card = credit_cards::add_credit_card(&self.db.writer, new_credit_card_fields)?;
-        Ok(credit_card.to_external())
+    pub fn add_credit_card(&self, fields: UpdatableCreditCardFields) -> Result<CreditCard> {
+        let credit_card = credit_cards::add_credit_card(&self.db.writer, fields)?;
+        Ok(credit_card.into())
     }
 
     #[allow(dead_code)]
     pub fn get_credit_card(&self, guid: String) -> Result<CreditCard> {
-        let credit_card = credit_cards::get_credit_card(&self.db.writer, guid)?;
-        Ok(credit_card.to_external())
+        let credit_card = credit_cards::get_credit_card(&self.db.writer, &Guid::new(&guid))?;
+        Ok(credit_card.into())
     }
 
     #[allow(dead_code)]
     pub fn get_all_credit_cards(&self) -> Result<Vec<CreditCard>> {
         let credit_cards = credit_cards::get_all_credit_cards(&self.db.writer)?
-            .iter()
-            .map(|x| x.to_external())
+            .into_iter()
+            .map(|x| x.into())
             .collect();
         Ok(credit_cards)
     }
 
     #[allow(dead_code)]
-    pub fn update_credit_card(&self, credit_card: CreditCard) -> Result<()> {
-        credit_cards::update_credit_card(&self.db.writer, &credit_card)
+    pub fn update_credit_card(
+        &self,
+        guid: String,
+        credit_card: UpdatableCreditCardFields,
+    ) -> Result<()> {
+        credit_cards::update_credit_card(&self.db.writer, &Guid::new(&guid), &credit_card)
     }
 
     #[allow(dead_code)]
     pub fn delete_credit_card(&self, guid: String) -> Result<bool> {
-        credit_cards::delete_credit_card(&self.db.writer, guid)
+        credit_cards::delete_credit_card(&self.db.writer, &Guid::new(&guid))
     }
 
     pub fn touch_credit_card(&self, guid: String) -> Result<()> {
-        credit_cards::touch(&self.db.writer, guid)
+        credit_cards::touch(&self.db.writer, &Guid::new(&guid))
     }
 
     #[allow(dead_code)]
-    pub fn add_address(&self, new_address: NewAddressFields) -> Result<Address> {
-        let address = addresses::add_address(&self.db.writer, new_address)?;
-        Ok(address.to_external())
+    pub fn add_address(&self, new_address: UpdatableAddressFields) -> Result<Address> {
+        Ok(addresses::add_address(&self.db.writer, new_address)?.into())
     }
 
     #[allow(dead_code)]
     pub fn get_address(&self, guid: String) -> Result<Address> {
-        let address = addresses::get_address(&self.db.writer, guid)?;
-        Ok(address.to_external())
+        Ok(addresses::get_address(&self.db.writer, &Guid::new(&guid))?.into())
     }
 
     #[allow(dead_code)]
     pub fn get_all_addresses(&self) -> Result<Vec<Address>> {
         let addresses = addresses::get_all_addresses(&self.db.writer)?
-            .iter()
-            .map(|x| x.to_external())
+            .into_iter()
+            .map(|x| x.into())
             .collect();
         Ok(addresses)
     }
 
     #[allow(dead_code)]
-    pub fn update_address(&self, address: Address) -> Result<()> {
-        addresses::update_address(&self.db.writer, &address)
+    pub fn update_address(&self, guid: String, address: UpdatableAddressFields) -> Result<()> {
+        addresses::update_address(&self.db.writer, &Guid::new(&guid), &address)
     }
 
     #[allow(dead_code)]
     pub fn delete_address(&self, guid: String) -> Result<bool> {
-        addresses::delete_address(&self.db.writer, guid)
+        addresses::delete_address(&self.db.writer, &Guid::new(&guid))
     }
 
     #[allow(dead_code)]
     pub fn touch_address(&self, guid: String) -> Result<()> {
-        addresses::touch(&self.db.writer, guid)
+        addresses::touch(&self.db.writer, &Guid::new(&guid))
     }
 }

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -58,6 +58,9 @@ enum Command {
     /// Update address with given JSON address data
     #[structopt(name = "update-address")]
     UpdateAddress {
+        #[structopt(name = "guid", long)]
+        /// The guid of the item to update
+        guid: String,
         #[structopt(name = "input-file", long, short = "i")]
         /// The input file containing the address data
         input_file: String,
@@ -94,6 +97,9 @@ enum Command {
     /// Update credit card with given JSON credit card data
     #[structopt(name = "update-credit-card")]
     UpdateCreditCard {
+        #[structopt(name = "guid", long)]
+        /// The guid of the item to update
+        guid: String,
         #[structopt(name = "input-file", long, short = "i")]
         /// The input file containing the credit card data
         input_file: String,
@@ -113,7 +119,7 @@ fn run_add_address(store: &Store, filename: String) -> Result<()> {
 
     let file = File::open(filename)?;
     let reader = BufReader::new(file);
-    let address_fields: address::NewAddressFields = serde_json::from_reader(reader)?;
+    let address_fields: address::UpdatableAddressFields = serde_json::from_reader(reader)?;
 
     println!("Making `add_address` api call");
     let address = Store::add_address(store, address_fields)?;
@@ -141,16 +147,15 @@ fn run_get_all_addresses(store: &Store) -> Result<()> {
     Ok(())
 }
 
-fn run_update_address(store: &Store, filename: String) -> Result<()> {
+fn run_update_address(store: &Store, guid: String, filename: String) -> Result<()> {
     println!("Updating address data from {}", filename);
 
     let file = File::open(filename)?;
     let reader = BufReader::new(file);
-    let address_fields: address::Address = serde_json::from_reader(reader)?;
-    let guid = address_fields.guid.clone();
+    let address_fields: address::UpdatableAddressFields = serde_json::from_reader(reader)?;
 
     println!("Making `update_address` api call for guid {}", guid);
-    Store::update_address(store, address_fields)?;
+    Store::update_address(store, guid.clone(), address_fields)?;
 
     let address = Store::get_address(store, guid)?;
     println!("Updated address: {:#?}", address);
@@ -172,7 +177,8 @@ fn run_add_credit_card(store: &Store, filename: String) -> Result<()> {
 
     let file = File::open(filename)?;
     let reader = BufReader::new(file);
-    let credit_card_fields: credit_card::NewCreditCardFields = serde_json::from_reader(reader)?;
+    let credit_card_fields: credit_card::UpdatableCreditCardFields =
+        serde_json::from_reader(reader)?;
 
     println!("Making `add_credit_card` api call");
     let credit_card = Store::add_credit_card(store, credit_card_fields)?;
@@ -200,16 +206,16 @@ fn run_get_all_credit_cards(store: &Store) -> Result<()> {
     Ok(())
 }
 
-fn run_update_credit_card(store: &Store, filename: String) -> Result<()> {
+fn run_update_credit_card(store: &Store, guid: String, filename: String) -> Result<()> {
     println!("Updating credit card data from {}", filename);
 
     let file = File::open(filename)?;
     let reader = BufReader::new(file);
-    let credit_card_fields: credit_card::CreditCard = serde_json::from_reader(reader)?;
-    let guid = credit_card_fields.guid.clone();
+    let credit_card_fields: credit_card::UpdatableCreditCardFields =
+        serde_json::from_reader(reader)?;
 
     println!("Making `update_credit_card` api call for guid {}", guid);
-    Store::update_credit_card(store, credit_card_fields)?;
+    Store::update_credit_card(store, guid.clone(), credit_card_fields)?;
 
     let credit_card = Store::get_credit_card(store, guid)?;
     println!("Updated credit card: {:#?}", credit_card);
@@ -239,13 +245,15 @@ fn main() -> Result<()> {
         Command::AddAddress { input_file } => run_add_address(&store, input_file),
         Command::GetAddress { guid } => run_get_address(&store, guid),
         Command::GetAllAddresses => run_get_all_addresses(&store),
-        Command::UpdateAddress { input_file } => run_update_address(&store, input_file),
+        Command::UpdateAddress { guid, input_file } => run_update_address(&store, guid, input_file),
         Command::DeleteAddress { guid } => run_delete_address(&store, guid),
 
         Command::AddCreditCard { input_file } => run_add_credit_card(&store, input_file),
         Command::GetCreditCard { guid } => run_get_credit_card(&store, guid),
         Command::GetAllCreditCards => run_get_all_credit_cards(&store),
-        Command::UpdateCreditCard { input_file } => run_update_credit_card(&store, input_file),
+        Command::UpdateCreditCard { guid, input_file } => {
+            run_update_credit_card(&store, guid, input_file)
+        }
         Command::DeleteCreditCard { guid } => run_delete_credit_card(&store, guid),
     }
 }


### PR DESCRIPTION
In the sync branch I discovered that we need to expose some metadata to
the consuming app - eg, so Fenix knows how often an address/creditcard
has been used.

As a part of this, I tried to rationalize some of the structs used.
This is a fairly large change, but I think it simplifies things.

Of special note:

* By adding a new `guid` param to `update_address()`, I've been able to 
  reuse the same struct as `add_address()`, which is good because
  `update_address()` shouldn't be able to update that metadata.

* Only addresses so far - I'll do creditcard if you think it's worth
  continuing with.

* No tests have been updated - `cargo check` works, but tests don't.
  These should also be easy.

* I replaced the `ExternalizeAddress` trait with the builtin `From/Into`
  mechanism.

Let me know what you think!