### PR TITLE
Update documentation to reflect that iOS now builds a dylib.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
  - Updated nimbus-sdk to 0.7.1
  - Updated Android Components to 71.0.0
 
+## iOS
+
+### What's Changed
+ - The `MozillaAppServices.framework` artifact now contains a dynamically-linked library
+   rather than a static library.
+
 # v68.1.0 (_2020-12-17_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v68.0.0...v68.1.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,5 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v69.0.0...main)
+
+- The bundled version of Glean has been updated to v34.0.0.

--- a/docs/design/megazords.md
+++ b/docs/design/megazords.md
@@ -11,16 +11,13 @@ has a number of advantages:
 
 This process is affectionately known as "megazording" and the resulting artifact as a ***megazord library***.
 
-On iOS, this process is quite straightforward: we build all the rust code into a single statically-linked
-framework, and the consuming application can import the corresponding Swift wrappers and link in just the
-parts of the framework that it needs at compile time.
-
-On Android, the situation is more complex due to the way packages and dependencies are managed.
+On Android, the situation is quite complex due to the way packages and dependencies are managed.
 We need to distribute each component as a separate Android ARchive (AAR) that can be managed as a dependency
 via gradle, we need to provide a way for the application to avoid shipping rust code for components that it
 isn't using, and we need to do it in a way that maintanins the advantages listed above.
 
-This document describes our current approach to meeting all those requirements on Android.
+This document describes our current approach to meeting all those requirements on Android. Other platforms
+such as iOS are not considered.
 
 ## AAR Dependency Graph
 

--- a/docs/howtos/consuming-rust-components-on-ios.md
+++ b/docs/howtos/consuming-rust-components-on-ios.md
@@ -1,8 +1,7 @@
 # Guide to Consuming Rust Components on iOS
 
-The application services libraries are published as a single zip file containing all the individual component frameworks (such as *Logins.framework*, *FxAClient.framework*) and also a single composite (megazord) framework called *MozillaAppServices.framework* containing all the components.
-
-The client-side can choose to use a single component framework, or the composite.
+The application services libraries are published as a zip file containing a single composite (megazord) framework called *MozillaAppServices.framework*,
+which contains the compiled code for all components.
 
 The package is published as a release on github: https://github.com/mozilla/application-services/releases
 
@@ -14,8 +13,8 @@ The package is published as a release on github: https://github.com/mozilla/appl
 - Add additional dependencies, see [below](#additional-dependencies).
 
 ### Adding a carthage provided framework to Xcode
-- In general, to do this, add *XXX.framework* from *Carthage/Build/iOS* to *Link binary with Libraries* for the Xcode target
-- `MozillaAppServices.framework` is being built as a static lib; therefore, do _not_ follow the standard Carthage procedure of adding it to your `carthage copy-frameworks` script.
+- In general, to do this, add *XXX.framework* from *Carthage/Build/iOS* to *Link binary with Libraries* for the Xcode target.
+- Update the list of additional dependencies below, so that consumers know to include the framework in their final build.
 
 ### Using a Circle-CI built framework
 

--- a/docs/howtos/locally-published-components-in-ios.md
+++ b/docs/howtos/locally-published-components-in-ios.md
@@ -10,7 +10,7 @@ consumer project. Here are our current best-practices for approaching this on iO
 
    ```
    rm -rf Carthage/Build/iOS/MozillaAppServices.framework
-   ln -s path/to/application-services/Carthage/Build/iOS/Static/MozillaAppServices.framework Carthage/Build/iOS
+   ln -s path/to/application-services/Carthage/Build/iOS/MozillaAppServices.framework Carthage/Build/iOS
    ```
 1. Open the consuming app project in XCode and build it from there.
 

--- a/megazords/ios/README.md
+++ b/megazords/ios/README.md
@@ -1,4 +1,5 @@
-The iOS 'megazord' builds all the components into a single library. This is built as a static framework.
+The iOS 'megazord' builds all the components into a single library.
+This is published as a `.framework` containing a dynamic library.
 
 ### Adding new components
 


### PR DESCRIPTION
Because:
* We recently switched from building a static library on iOS to
  building dynamic library (ref #3822).
* Several places in our docs explicitly mention that iOS builds
  are static libraries.

This commit:
* Updates the documentation to note that iOS builds are dynamic
  libraries.
* Deliberately doesn't try to say anything clever about custom megazords
  on iOS, since that's very much still to do.
