### PR TITLE
Manage autofill tombstones via triggers (fixes #3846)

### DIFF
--- a/components/autofill/sql/create_shared_triggers.sql
+++ b/components/autofill/sql/create_shared_triggers.sql
@@ -19,6 +19,14 @@ BEGIN
     SELECT RAISE(FAIL, 'guid exists in `addresses_data`');
 END;
 
+CREATE TEMP TRIGGER addresses_tombstones_create_trigger
+AFTER DELETE ON addresses_data
+WHEN OLD.guid IN (SELECT guid FROM addresses_mirror)
+BEGIN
+    INSERT INTO addresses_tombstones(guid, time_deleted)
+    VALUES (OLD.guid, now());
+END;
+
 CREATE TEMP TRIGGER credit_cards_data_afterinsert_trigger
 AFTER INSERT ON credit_cards_data
 FOR EACH ROW WHEN NEW.guid IN (SELECT guid FROM credit_cards_tombstones)
@@ -31,4 +39,12 @@ AFTER INSERT ON credit_cards_tombstones
 WHEN NEW.guid IN (SELECT guid FROM credit_cards_data)
 BEGIN
     SELECT RAISE(FAIL, 'guid exists in `credit_cards_data`');
+END;
+
+CREATE TEMP TRIGGER credit_cards_tombstones_create_trigger
+AFTER DELETE ON credit_cards_data
+WHEN OLD.guid IN (SELECT guid FROM credit_cards_mirror)
+BEGIN
+    INSERT INTO credit_cards_tombstones(guid, time_deleted)
+    VALUES (OLD.guid, now());
 END;

--- a/components/autofill/src/db/mod.rs
+++ b/components/autofill/src/db/mod.rs
@@ -125,17 +125,25 @@ fn define_functions(c: &Connection) -> Result<()> {
         FunctionFlags::SQLITE_UTF8,
         sql_fns::generate_guid,
     )?;
+    c.create_scalar_function("now", 0, FunctionFlags::SQLITE_UTF8, sql_fns::now)?;
+
     Ok(())
 }
 
 pub(crate) mod sql_fns {
     use rusqlite::{functions::Context, Result};
     use sync_guid::Guid as SyncGuid;
+    use types::Timestamp;
 
     #[inline(never)]
     #[allow(dead_code)]
     pub fn generate_guid(_ctx: &Context<'_>) -> Result<SyncGuid> {
         Ok(SyncGuid::random())
+    }
+
+    #[inline(never)]
+    pub fn now(_ctx: &Context<'_>) -> Result<Timestamp> {
+        Ok(Timestamp::now())
     }
 }
 


### PR DESCRIPTION
(The lengths I'll go to to avoid writing docs :)

I didn't notice creditcards already had good tests here, so I didn't copy them for address - but also didn't change creditcard, so they've diverged for those tests, but that doesn't matter.

Also noticed a couple of places the new `CREDIT_CARD_COMMON_VALS` can be used...