### PR TITLE
Move uniffi installation into verify-common.sh

### DIFF
--- a/libs/verify-android-environment.sh
+++ b/libs/verify-android-environment.sh
@@ -68,7 +68,4 @@ if [[ -z "${CI}" ]]; then
   fi
 fi
 
-echo "Installing uniffi_bindgen if missing; it's necessary for binding generation during the builds."
-cargo install uniffi_bindgen --version 0.6.1
-
 echo "Looks good! Try building with ./gradlew assembleDebug"

--- a/libs/verify-common.sh
+++ b/libs/verify-common.sh
@@ -6,6 +6,10 @@ if ! [[ -x "$(command -v rustc)" ]]; then
   echo 'Error: The Rust compiler needs to be installed. See https://rustup.rs/ for install instructions.' >&2
   exit 1
 fi
+
+echo "Installing uniffi_bindgen if missing; it's necessary for binding generation during the builds."
+cargo install uniffi_bindgen --version 0.7.0
+
 # Print the rustc version (we don't update it because our CI and official
 # builds we will often be pinned on an ealier rust version, but should still
 # work OK with later ones.)


### PR DESCRIPTION
A quick follow-up to https://github.com/mozilla/application-services/pull/3832, to move the uniffi installation logic in to the shared helpers and update the version number.
