### PR TITLE
Prepare v70.0.0

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,6 +9,7 @@
 ### What's Changed
 
 - The bundled version of Glean has been updated to v34.0.0.
+- The bundled version of the Nimbus SDK has been updated to v0.7.2.
 
 ## Autofill
 

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -4,4 +4,20 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v69.0.0...main)
 
+## General
+
+### What's Changed
+
 - The bundled version of Glean has been updated to v34.0.0.
+
+## Autofill
+
+### ⚠️ Breaking changes ⚠️
+
+- The `NewCreditCardFields` record is now called `UpdatableCreditCardFields`.
+- The `NewAddressFields` record is now called `UpdatableAddressFields`.
+
+### What's Changed
+
+- The `CreditCard` and `Address` records now exposes additional metadata around timestampes.
+- The ability to sync incoming address records has been added.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-sdk"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "hex",


### PR DESCRIPTION
Things I need to do to make a new release with an updated version of nimbus. The major version rev here is for the changes to the API surface of autofill, and also for the major version bump of glean.

(I need these in a remote branch in order for the release script to pull them, otherwise I'd just quietly include these commits when cutting the new release)