### PR TITLE
Resolve latest `cargo audit` warnings.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,10 @@ commands:
             rustup install nightly
             rustup default nightly
             cargo install cargo-audit
-            cargo audit
+            # Explanation for ignored issues:
+            #  * RUSTSEC-2021-0019:  Soundness issues in `xcb`, a clipboard library we only use for examples.
+            #                        There is currently no fixed version available.
+            cargo audit --ignore RUSTSEC-2021-0019
       - run:
           name: Check for any unrecorded changes in our dependency trees
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
+checksum = "8a6f157065790a3ed2f88679250419b5cdd96e714a0d65f7797fd337186e96bb"
 dependencies = [
  "bytes",
  "futures-channel",


### PR DESCRIPTION
Two warnings for `cargo audit` today:

* One [for hyper](https://rustsec.org/advisories/RUSTSEC-2021-0020), which only affects the HTTP server code and thus isn't an issue for us in practice.
* One [for xcb](https://rustsec.org/advisories/RUSTSEC-2021-0019), which seems to cover a grab-bag of soundness/safety issues. No updated version is available, but we only use it for example code (it's a clipboard support library) so I'm going to see if I can tell `cargo audit` to ignore it.