### PR TITLE
Update fxa client-id for command-line example apps from lockwise to the reference browser

### DIFF
--- a/examples/cli-support/src/fxa_creds.rs
+++ b/examples/cli-support/src/fxa_creds.rs
@@ -18,8 +18,8 @@ use anyhow::Result;
 
 // Defaults - not clear they are the best option, but they are a currently
 // working option.
-const CLIENT_ID: &str = "e7ce535d93522896";
-const REDIRECT_URI: &str = "https://lockbox.firefox.com/fxa/android-redirect.html";
+const CLIENT_ID: &str = "3c49430b43dfba77";
+const REDIRECT_URI: &str = "https://accounts.firefox.com/oauth/success/3c49430b43dfba77";
 const SYNC_SCOPE: &str = "https://identity.mozilla.com/apps/oldsync";
 
 fn load_fxa_creds(path: &str) -> Result<FirefoxAccount> {


### PR DESCRIPTION
It looks like the lockwise redirect URL no longer exists