### PR TITLE
Update uniffi for autofill

### DIFF
--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -21,7 +21,7 @@ sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "0.7"
+uniffi = "^0.7.1"
 url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -35,4 +35,4 @@ libsqlite3-sys = "0.20.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = "0.7"
+uniffi_build = "^0.7.1"

--- a/components/autofill/uniffi.toml
+++ b/components/autofill/uniffi.toml
@@ -1,2 +1,3 @@
 [bindings.kotlin]
-package_name = "org.mozilla.appservices.autofill"
+package_name = "mozilla.appservices.autofill"
+cdylib_name = "megazord"


### PR DESCRIPTION
Bumping autofill's uniffi version to 0.7.1 in order to take advantage of changes that allow the uniffi default library to be set to `libmegazord.so` as described in #3874

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
