### PR TITLE
autofill: Use a custom struct for serializing and deserializing sync payload

### DIFF
--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -64,7 +64,7 @@ dictionary Address {
 
 [Error]
 enum Error {
-   "SqlError", "IoError", "InterruptedError", "IllegalDatabasePath", "Utf8Error", "JsonError"
+   "SqlError", "IoError", "InterruptedError", "IllegalDatabasePath", "Utf8Error", "JsonError", "InvalidSyncPayload",
 };
 
 interface Store {

--- a/components/autofill/src/db/addresses.rs
+++ b/components/autofill/src/db/addresses.rs
@@ -293,20 +293,6 @@ mod tests {
         )
     }
 
-    #[allow(dead_code)]
-    fn insert_mirror_record(conn: &Connection, address: &InternalAddress) {
-        let payload = serde_json::to_value(address).expect("should serialize");
-        conn.execute_named(
-            "INSERT OR IGNORE INTO addresses_mirror (guid, payload)
-             VALUES (:guid, :payload)",
-            rusqlite::named_params! {
-                ":guid": address.guid,
-                ":payload": payload,
-            },
-        )
-        .expect("should create it");
-    }
-
     #[test]
     fn test_address_create_and_read() {
         let db = new_mem_db();

--- a/components/autofill/src/db/models/address.rs
+++ b/components/autofill/src/db/models/address.rs
@@ -5,7 +5,6 @@
 
 use super::Metadata;
 use rusqlite::Row;
-use serde_derive::*;
 use sync_guid::Guid;
 
 // UpdatableAddressFields contains the fields we support for creating a new
@@ -14,8 +13,7 @@ use sync_guid::Guid;
 // (such as timeCreated) because it doesn't make sense for these things to be
 // specified as an item is created - any meta fields which can be updated
 // have special methods for doing so.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
+#[derive(Debug, Clone, Default)]
 pub struct UpdatableAddressFields {
     pub given_name: String,
     pub additional_name: String,
@@ -85,13 +83,9 @@ impl From<InternalAddress> for Address {
     }
 }
 
-// An "internal" address is used by the public APIs and by sync. This is what
-// Sync de-serializes as a payload.
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
-#[serde(default)] // not ideal, but helps for tests.
+// An "internal" address is used by the public APIs and by sync.
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct InternalAddress {
-    #[serde(rename = "id")]
     pub guid: Guid,
     pub given_name: String,
     pub additional_name: String,
@@ -105,7 +99,6 @@ pub struct InternalAddress {
     pub country: String,
     pub tel: String,
     pub email: String,
-    #[serde(flatten)]
     pub metadata: Metadata,
 }
 
@@ -130,7 +123,6 @@ impl InternalAddress {
                 time_last_used: row.get("time_last_used")?,
                 time_last_modified: row.get("time_last_modified")?,
                 times_used: row.get("times_used")?,
-                version: 1,
                 sync_change_counter: row.get("sync_change_counter")?,
             },
         })

--- a/components/autofill/src/db/models/credit_card.rs
+++ b/components/autofill/src/db/models/credit_card.rs
@@ -5,12 +5,9 @@
 
 use super::Metadata;
 use rusqlite::Row;
-use serde::Serialize;
-use serde_derive::*;
 use sync_guid::Guid;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case", default)]
+#[derive(Debug, Clone, Default)]
 pub struct UpdatableCreditCardFields {
     pub cc_name: String,
     pub cc_number: String,
@@ -64,10 +61,8 @@ impl From<InternalCreditCard> for CreditCard {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
-#[serde(default, rename_all = "kebab-case")]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct InternalCreditCard {
-    #[serde(rename = "id")]
     pub guid: Guid,
     pub cc_name: String,
     pub cc_number: String,
@@ -76,7 +71,6 @@ pub struct InternalCreditCard {
     // Credit card types are a fixed set of strings as defined in the link below
     // (https://searchfox.org/mozilla-central/rev/7ef5cefd0468b8f509efe38e0212de2398f4c8b3/toolkit/modules/CreditCard.jsm#9-22)
     pub cc_type: String,
-    #[serde(flatten)]
     pub metadata: Metadata,
 }
 
@@ -94,7 +88,6 @@ impl InternalCreditCard {
                 time_last_used: row.get("time_last_used")?,
                 time_last_modified: row.get("time_last_modified")?,
                 times_used: row.get("times_used")?,
-                version: 1,
                 sync_change_counter: row.get("sync_change_counter")?,
             },
         })

--- a/components/autofill/src/db/models/mod.rs
+++ b/components/autofill/src/db/models/mod.rs
@@ -5,28 +5,14 @@
 
 pub mod address;
 pub mod credit_card;
-use serde::{Deserialize, Serialize};
 use types::Timestamp;
 
 /// Metadata that's common between the records.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Copy, Clone, Default)]
-// Ideally we would not have `serde(default)` but some tests only supply
-// partial json. I guess it doesn't matter much in practice.
-#[serde(default)]
+#[derive(Debug, PartialEq, Copy, Clone, Default)]
 pub struct Metadata {
-    // metadata isn't kebab-case for some reason...
-    #[serde(rename = "timeCreated")]
     pub time_created: Timestamp,
-    #[serde(rename = "timeLastUsed")]
     pub time_last_used: Timestamp,
-    #[serde(rename = "timeLastModified")]
     pub time_last_modified: Timestamp,
-    #[serde(rename = "timesUsed")]
     pub times_used: i64,
-    // Version is always 1 - it's a field to make sync's life easy.
-    //??    #[serde(default="1")]
-    pub version: u32,
-    // Change counter is never in json.
-    #[serde(skip)]
     pub sync_change_counter: i64,
 }

--- a/components/autofill/src/error.rs
+++ b/components/autofill/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
 
     #[error("JSON Error: {0}")]
     JsonError(#[from] serde_json::Error),
+
+    #[error("Invalid sync payload: {0}")]
+    InvalidSyncPayload(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/components/autofill/src/sync/engine.rs
+++ b/components/autofill/src/sync/engine.rs
@@ -276,7 +276,7 @@ mod tests {
             ..Default::default()
         };
         add_internal_credit_card(&tx, &cc)?;
-        insert_mirror_record(&tx, &cc);
+        insert_mirror_record(&tx, cc.clone());
         insert_tombstone_record(&tx, Guid::random().to_string())?;
         tx.commit()?;
 
@@ -340,7 +340,7 @@ mod tests {
             // re-populating the tables
             let tx = conn.unchecked_transaction()?;
             add_internal_credit_card(&tx, &cc)?;
-            insert_mirror_record(&tx, &cc);
+            insert_mirror_record(&tx, cc);
             insert_tombstone_record(&tx, Guid::random().to_string())?;
             tx.commit()?;
         }

--- a/components/autofill/src/sync/mod.rs
+++ b/components/autofill/src/sync/mod.rs
@@ -87,6 +87,10 @@ pub trait SyncRecord {
     fn merge(incoming: &Self, local: &Self, mirror: &Option<Self>) -> MergeResult<Self>
     where
         Self: Sized;
+    fn to_record(p: sync15::Payload) -> Result<Self>
+    where
+        Self: Sized;
+    fn to_payload(self) -> Result<sync15::Payload>;
 }
 
 impl Metadata {


### PR DESCRIPTION
Because Address and CreditCard records on the server have an "odd" shape,
reusing the InternalAddress and InternalCreditCard structs for Sync was
becoming more trouble than it's worth - custom structs are a little
more code, but do make for a cleaner separation of concerns (eg, the
'version' field from the 'Internal' structs has been removed)

This meant that the serialization support from the InternalStructs
could be removed - it might be more confusing to have these
structs being serializable from JSON when there's no actual
use case for it - people might assume it's for Sync.

Except the autofill sample was the one use-case :) I toyed with
the idea of having that also use the sync15 payload, but that
seems wrong and would mean making more things pub than I'd like,
so I bit the bullet and changed that to "prompt" for values just
like the logins sample does.

With this patch, the sample syncs and correctly applies the records!
