### PR TITLE
Document breaking API change in autofill module

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,3 +9,10 @@
 - The bundled version of the Nimbus SDK has been updated to v0.8.2. 
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v71.0.0...main)
+
+## Autofill
+
+### ⚠️ Breaking changes ⚠️
+
+- The autofill Kotlin package as been renamed from `org.mozilla.appservices.autofill`
+  to `mozilla.appservices.autofill`, for consistency with other components.


### PR DESCRIPTION
I didn't notice this when it happened in https://github.com/mozilla/application-services/pull/3878, but I think it's a good change for consistency purpose.