### PR TITLE
Add `cargo uniffi-bindgen` alias for running uniffi-bindgen.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,6 @@
 [alias]
 regen-protobufs = ["run", "--bin", "protobuf-gen", "tools/protobuf_files.toml"]
+uniffi-bindgen = ["run", "--bin", "embedded-uniffi-bindgen"]
 dev-install = ["install", "asdev"]
 all_tests = ["asdev", "test"]
 rust_tests = ["asdev", "test_rust"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "embedded-uniffi-bindgen"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "uniffi_bindgen",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3592,9 +3600,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "uniffi"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31525465aa3d139f86469ebdd942fee31e8c797e92bcf6c572adff436b0b8b37"
+checksum = "e53678c74206450393a7d8eedf04e60193c184717d12553c7f9c0a8e19346298"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3608,9 +3616,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f836b13903bc6723d8549533af032464d358824201d6c18a6afc87ec0a5aa5c"
+checksum = "b26f4b5f70aae3673ac4e03aaa1936a5ebd996360b239c2f592448ab38c23dda"
 dependencies = [
  "anyhow",
  "askama",
@@ -3624,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce0c555b64138ef673e4194f657a616c6c977d18a9e27198cfa8ed0350f0b1a"
+checksum = "d442a26b12b04bf1f4fb3645d5deaba9376cf117022935bebe773a03e6e8664f"
 dependencies = [
  "anyhow",
  "uniffi_bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "megazords/ios/rust",
     "testing/sync-test",
     "tools/protobuf-gen",
+    "tools/embedded-uniffi-bindgen",
 
     "examples/*/",
     "testing/separated/*/",
@@ -109,6 +110,7 @@ default-members = [
     "components/webext-storage",
     "testing/sync-test",
     "tools/protobuf-gen",
+    "tools/embedded-uniffi-bindgen",
     "examples/*/",
     "testing/separated/*/",
 ]

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -21,7 +21,7 @@ sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.7.1"
+uniffi = "^0.7.2"
 url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -35,4 +35,4 @@ libsqlite3-sys = "0.20.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = "^0.7.1"
+uniffi_build = { version = "^0.7.2", features = [ "builtin-bindgen" ]}

--- a/components/autofill/android/build.gradle
+++ b/components/autofill/android/build.gradle
@@ -102,9 +102,8 @@ dependencies {
 // We do the uniffi binding generation here:
 android.libraryVariants.all { variant ->
     def t = tasks.register("generate${variant.name.capitalize()}UniffiBindings", Exec) {
-        workingDir "${project.projectDir}"
-        // Runs the bindings generation, note that you must have uniffi-bindgen installed and in your PATH environment variable
-        commandLine 'uniffi-bindgen', 'generate', '../src/autofill.udl', '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
+        workingDir project.rootDir
+        commandLine 'cargo', 'uniffi-bindgen', 'generate', "${project.projectDir}/../src/autofill.udl", '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
     }
     variant.javaCompileProvider.get().dependsOn(t)
     def sourceSet = variant.sourceSets.find { it.name == variant.name }

--- a/components/nimbus/build.gradle
+++ b/components/nimbus/build.gradle
@@ -120,9 +120,8 @@ dependencies {
 // We also do the binding generation here:
 android.libraryVariants.all { variant ->
     def t = tasks.register("generate${variant.name.capitalize()}UniffiBindings", Exec) {
-        workingDir "${project.projectDir}"
-        // Runs the bindings generation, note that you must have uniffi-bindgen installed and in your PATH environment variable
-        commandLine 'uniffi-bindgen', 'generate', '../external/nimbus-sdk/nimbus/src/nimbus.idl', '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
+        workingDir project.rootDir
+        commandLine 'cargo', 'uniffi-bindgen', 'generate', "${project.projectDir}/../external/nimbus-sdk/nimbus/src/nimbus.idl", '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
     }
     variant.javaCompileProvider.get().dependsOn(t)
     def sourceSet = variant.sourceSets.find { it.name == variant.name }

--- a/docs/building.md
+++ b/docs/building.md
@@ -22,10 +22,6 @@ Ensure this section works for you before jumping to the Android/iOS specific sec
   - zlib
     - Using apt: `apt install zlib1g-dev`
     - Already installed on macOS by XCode.
-  - uniffi-bindgen
-    - `cargo install uniffi_bindgen`. Note that this is being updated regularly,
-    so if you see complaints about the wrong version being installed, you
-    probably need to `cargo install -f uniffi_bindgen`.
 
 Note that we have a guide if you happen to use [WSL](howtos/wsl-build-guide.md).
 

--- a/libs/verify-common.sh
+++ b/libs/verify-common.sh
@@ -8,7 +8,6 @@ if ! [[ -x "$(command -v rustc)" ]]; then
 fi
 
 echo "Installing uniffi_bindgen if missing; it's necessary for binding generation during the builds."
-cargo install uniffi_bindgen --version 0.7.1
 
 # Print the rustc version (we don't update it because our CI and official
 # builds we will often be pinned on an ealier rust version, but should still

--- a/taskcluster/scripts/toolchain/rustup-setup.sh
+++ b/taskcluster/scripts/toolchain/rustup-setup.sh
@@ -35,8 +35,6 @@ rustup toolchain install "$RUST_STABLE_VERSION"
 rustup default "$RUST_STABLE_VERSION"
 rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android
 
-cargo install --version 0.7.1 uniffi_bindgen
-
 # This is not the right place for it, but also it's as good a place as any.
 # Make sure git submodules are initialized.
 git submodule update --init

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "embedded-uniffi-bindgen"
+version = "0.1.0"
+authors = ["The Firefox Sync Developers <sync-team@mozilla.com>"]
+edition = "2018"
+license = "MPL-2.0"
+
+[dependencies]
+anyhow = "1"
+uniffi_bindgen = "^0.7.2"

--- a/tools/embedded-uniffi-bindgen/README.md
+++ b/tools/embedded-uniffi-bindgen/README.md
@@ -1,0 +1,39 @@
+# Embedded uniffi-bingen for this workspace
+
+This crate exists entirely to support running `cargo uniffi-bindgen` in the workspace
+root and having it correctly execute the `uniffi-bindgen` command provided by the
+version of `uniffi_bindgen` that's in use in the workspace.
+
+Say what?
+
+OK, so exposing a crate to Kotlin or Swift via `uniffi` is done in two halves:
+
+* On the Rust side, the crate needs to depend on `uniffi` for runtime support code.
+* On the foreign-language side, we need to run `uniffi-bindgen` as part of the build
+  process to generate the language bindings.
+
+It's very important that both halves use the exact same version of UniFFI, and UniFFI
+will *try* to error out if it detects this. But if you *don't* detect it then using
+mismatched versions of UniFFI will lead to an inscrutable linker failure at runtime.
+
+The simple way to use UniFFI is for developers to `cargo install uniffi_bindgen`
+on their system and then use the `uniffi-bindgen` command-line tool during the build.
+But unfortunately, this makes it painful to bump the version of the `uniffi` crate
+used by the components, and it greatly complicates doing local development on UniFFI
+itself.
+
+This crate offers a more complicated way that is also more robust to UniFFI version
+changes.
+
+First, configure all UniFFI-using crates to use the `builtin-bindgen` feature
+of `uniffi_build`.
+
+Then, instead of running the system-installed `uniffi-bindgen`, run our handy
+`cargo uniffi-bindgen` alias, which delegates to this crate. This will execute
+the `uniffi-bindgen` command-line tool *provided by the version of UniFFI specified
+in this crate*, letting us avoid having to install and update `uniffi-bindgen` at
+the system level
+
+You'll still have to ensure that all crates in this workspace are using the
+same version of UniFFI, but that's much simpler than controlling what's installed
+on everybody's build machine.

--- a/tools/embedded-uniffi-bindgen/src/main.rs
+++ b/tools/embedded-uniffi-bindgen/src/main.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() -> anyhow::Result<()> {
+    uniffi_bindgen::run_main()
+}


### PR DESCRIPTION
Whelp, I've had about as many uniffi-version-mismatch-related build failures as I'm willing to tolerate. I think the requirement to have `uniffi-bindgen` installed as a separate command on the user's machine was a great way to get started quickly, but it's making it hard to iterate on our tooling, particularly when trying to co-develop features in uniffi with a consumer over here in application-services.

Inspired by how we handle protobuf files, here's a proposal for an alternative - `cargo uniffi-bindgen` alias that works in all respects like the system-level `uniffi-bindgen` command, but which always uses the version of uniffi that's currently in use by our workspace. I expect this should completely eliminate the possibility of UniFFI version mismatch errors (with the possible exception of failing to clean up files generated by a previous version).

One downside of this change, is that our compile times will get slightly longer, since you have to build `uniffi_bindgen` in the workspace rather than using the one that's already built on your system. I'll take that trade in the interests of reducing failure modes, but YMMV. (I'll add that it shouldn't really affect CI times since we `cargo install uniffi_bindgen` as part of our CI scripts anyway).

This is a draft until we get a release of UniFFI with https://github.com/mozilla/uniffi-rs/pull/406 included, but pushing it early for feedback.