### PR TITLE
Install correct version of uniffi on taskcluster.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,10 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v72.0.0...main)
+
+## General
+
+### What's Changed
+
+- This release fixes an "unsatisfied link error" problem with autofill and nimbus,
+  stemming from a misconfiguration in the Android build setup.

--- a/taskcluster/scripts/toolchain/rustup-setup.sh
+++ b/taskcluster/scripts/toolchain/rustup-setup.sh
@@ -35,7 +35,7 @@ rustup toolchain install "$RUST_STABLE_VERSION"
 rustup default "$RUST_STABLE_VERSION"
 rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android
 
-cargo install --version 0.7.0 uniffi_bindgen
+cargo install --version 0.7.1 uniffi_bindgen
 
 # This is not the right place for it, but also it's as good a place as any.
 # Make sure git submodules are initialized.


### PR DESCRIPTION
Over in https://github.com/mozilla/application-services/pull/3880 I missed one of the many locations in which you need to update the uniffi version, so the `v72.0.0` release is a bust. Trying it out in conjunction with the a-c tests gives me failures like:

```
java.lang.UnsatisfiedLinkError: Error looking up function 'ffi_autofill_7af3_rustbuffer_alloc': dlsym(0x7f83cb0ad490, ffi_autofill_7af3_rustbuffer_alloc): symbol not found
```

It's actually really good that this failed with a linker error, because the bump to uniffi 0.7.1 *did* include a change to how values are passed over the FFI that could have otherwise lead to us silently doing the wrong thing! Still a PITA though.