### PR TITLE
Configure detekt to ignore uniffi-generated files.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -253,7 +253,7 @@ ext.cargoExecWithSQLCipher = { spec, toolchain ->
 detekt {
     toolVersion = "1.7.4"
     input = files(
-        fileTree(dir: "${projectDir}/components", excludes: ["external"]),
+        fileTree(dir: "${projectDir}/components", excludes: ["external", "**/generated"]),
         "${projectDir}/gradle-plugin",
         "buildSrc"
     )


### PR DESCRIPTION
The files generated by uniffi are not the sort of files that
detekt will like and there's not really any point in having
it scan them, so let's ignore anything under `generated` for
all the components.
