### PR TITLE
Don't IGNORE sql errors when inserting records

### DIFF
--- a/components/autofill/src/db/addresses.rs
+++ b/components/autofill/src/db/addresses.rs
@@ -45,7 +45,7 @@ pub(crate) fn add_address(
 pub(crate) fn add_internal_address(tx: &Transaction<'_>, address: &InternalAddress) -> Result<()> {
     tx.execute_named(
         &format!(
-            "INSERT OR IGNORE INTO addresses_data (
+            "INSERT INTO addresses_data (
                 {common_cols},
                 sync_change_counter
             ) VALUES (
@@ -279,7 +279,7 @@ mod tests {
         guid: String,
     ) -> rusqlite::Result<usize, rusqlite::Error> {
         conn.execute_named(
-            "INSERT OR IGNORE INTO addresses_tombstones (
+            "INSERT INTO addresses_tombstones (
                 guid,
                 time_deleted
             ) VALUES (

--- a/components/autofill/src/db/credit_cards.rs
+++ b/components/autofill/src/db/credit_cards.rs
@@ -43,7 +43,7 @@ pub(crate) fn add_internal_credit_card(
 ) -> Result<()> {
     tx.execute_named(
         &format!(
-            "INSERT OR IGNORE INTO credit_cards_data (
+            "INSERT INTO credit_cards_data (
                 {common_cols},
                 sync_change_counter
             ) VALUES (
@@ -238,7 +238,7 @@ pub(crate) mod tests {
         guid: String,
     ) -> rusqlite::Result<usize, rusqlite::Error> {
         conn.execute_named(
-            "INSERT OR IGNORE INTO credit_cards_tombstones (
+            "INSERT INTO credit_cards_tombstones (
                 guid,
                 time_deleted
             ) VALUES (
@@ -261,7 +261,7 @@ pub(crate) mod tests {
             .expect("is json")
             .into_json_string();
         conn.execute_named(
-            "INSERT OR IGNORE INTO credit_cards_mirror (guid, payload)
+            "INSERT INTO credit_cards_mirror (guid, payload)
              VALUES (:guid, :payload)",
             rusqlite::named_params! {
                 ":guid": guid,


### PR DESCRIPTION
As part of the creditcard encryption work I added some constraints - and then had mysterious test failures. It turns out the "OR IGNORE" part of the SQL means that we completely ignored sqlite failing to add a record, which caused lots of confusion. I don't think there's any good reason to "OR IGNORE" in most cases (although "OR REPLACE" probably is more useful in come cases, but not for us). Many other components do this, which I suspect is just copy-pasta, but changing them at the same time is alot more risky, so this changes just autofill.