### PR TITLE
Remove to_payload() and to_record() from the trait

### DIFF
--- a/components/autofill/src/db/credit_cards.rs
+++ b/components/autofill/src/db/credit_cards.rs
@@ -254,10 +254,9 @@ pub(crate) mod tests {
 
     pub(crate) fn insert_mirror_record(conn: &Connection, credit_card: InternalCreditCard) {
         // This should probably be in the sync module, but it's used here.
-        use crate::sync::SyncRecord;
         let guid = credit_card.guid.clone();
         let payload = credit_card
-            .to_payload()
+            .into_payload()
             .expect("is json")
             .into_json_string();
         conn.execute_named(

--- a/components/autofill/src/sync/address/mod.rs
+++ b/components/autofill/src/sync/address/mod.rs
@@ -89,6 +89,68 @@ struct PayloadEntry {
     pub version: u32, // always 3 for credit-cards
 }
 
+impl InternalAddress {
+    fn from_payload(sync_payload: sync15::Payload) -> Result<Self> {
+        let p: AddressPayload = sync_payload.into_record()?;
+        if p.entry.version != 1 {
+            // Always been version 1
+            return Err(Error::InvalidSyncPayload(format!(
+                "invalid version - {}",
+                p.entry.version
+            )));
+        }
+
+        Ok(InternalAddress {
+            guid: p.id,
+            given_name: p.entry.given_name,
+            additional_name: p.entry.additional_name,
+            family_name: p.entry.family_name,
+            organization: p.entry.organization,
+            street_address: p.entry.street_address,
+            address_level3: p.entry.address_level3,
+            address_level2: p.entry.address_level2,
+            address_level1: p.entry.address_level1,
+            postal_code: p.entry.postal_code,
+            country: p.entry.country,
+            tel: p.entry.tel,
+            email: p.entry.email,
+            metadata: Metadata {
+                time_created: p.entry.time_created,
+                time_last_used: p.entry.time_last_used,
+                time_last_modified: p.entry.time_last_modified,
+                times_used: p.entry.times_used,
+                sync_change_counter: 0,
+            },
+        })
+    }
+
+    pub fn into_payload(self) -> Result<sync15::Payload> {
+        let p = AddressPayload {
+            id: self.guid,
+            entry: PayloadEntry {
+                given_name: self.given_name,
+                additional_name: self.additional_name,
+                family_name: self.family_name,
+                organization: self.organization,
+                street_address: self.street_address,
+                address_level3: self.address_level3,
+                address_level2: self.address_level2,
+                address_level1: self.address_level1,
+                postal_code: self.postal_code,
+                country: self.country,
+                tel: self.tel,
+                email: self.email,
+                time_created: self.metadata.time_created,
+                time_last_used: self.metadata.time_last_used,
+                time_last_modified: self.metadata.time_last_modified,
+                times_used: self.metadata.times_used,
+                version: 1,
+            },
+        };
+        Ok(sync15::Payload::from_record(p)?)
+    }
+}
+
 impl SyncRecord for InternalAddress {
     fn record_name() -> &'static str {
         "Address"
@@ -146,66 +208,6 @@ impl SyncRecord for InternalAddress {
         MergeResult::Merged {
             merged: merged_record,
         }
-    }
-
-    fn to_record(sync_payload: sync15::Payload) -> Result<Self> {
-        let p: AddressPayload = sync_payload.into_record()?;
-        if p.entry.version != 1 {
-            // Always been version 1
-            return Err(Error::InvalidSyncPayload(format!(
-                "invalid version - {}",
-                p.entry.version
-            )));
-        }
-
-        Ok(InternalAddress {
-            guid: p.id,
-            given_name: p.entry.given_name,
-            additional_name: p.entry.additional_name,
-            family_name: p.entry.family_name,
-            organization: p.entry.organization,
-            street_address: p.entry.street_address,
-            address_level3: p.entry.address_level3,
-            address_level2: p.entry.address_level2,
-            address_level1: p.entry.address_level1,
-            postal_code: p.entry.postal_code,
-            country: p.entry.country,
-            tel: p.entry.tel,
-            email: p.entry.email,
-            metadata: Metadata {
-                time_created: p.entry.time_created,
-                time_last_used: p.entry.time_last_used,
-                time_last_modified: p.entry.time_last_modified,
-                times_used: p.entry.times_used,
-                sync_change_counter: 0,
-            },
-        })
-    }
-
-    fn to_payload(self) -> Result<sync15::Payload> {
-        let p = AddressPayload {
-            id: self.guid,
-            entry: PayloadEntry {
-                given_name: self.given_name,
-                additional_name: self.additional_name,
-                family_name: self.family_name,
-                organization: self.organization,
-                street_address: self.street_address,
-                address_level3: self.address_level3,
-                address_level2: self.address_level2,
-                address_level1: self.address_level1,
-                postal_code: self.postal_code,
-                country: self.country,
-                tel: self.tel,
-                email: self.email,
-                time_created: self.metadata.time_created,
-                time_last_used: self.metadata.time_last_used,
-                time_last_modified: self.metadata.time_last_modified,
-                times_used: self.metadata.times_used,
-                version: 1,
-            },
-        };
-        Ok(sync15::Payload::from_record(p)?)
     }
 }
 

--- a/components/autofill/src/sync/credit_card/outgoing.rs
+++ b/components/autofill/src/sync/credit_card/outgoing.rs
@@ -7,9 +7,7 @@ use crate::db::models::credit_card::InternalCreditCard;
 use crate::db::schema::CREDIT_CARD_COMMON_COLS;
 use crate::error::*;
 use crate::sync::common::*;
-use crate::sync::{
-    OutgoingChangeset, Payload, ProcessOutgoingRecordImpl, ServerTimestamp, SyncRecord,
-};
+use crate::sync::{OutgoingChangeset, Payload, ProcessOutgoingRecordImpl, ServerTimestamp};
 use rusqlite::{Row, Transaction};
 use sync_guid::Guid as SyncGuid;
 
@@ -45,7 +43,7 @@ impl ProcessOutgoingRecordImpl for OutgoingCreditCardsImpl {
             common_cols = CREDIT_CARD_COMMON_COLS,
         );
         let payload_from_data_row: &dyn Fn(&Row<'_>) -> Result<Payload> =
-            &|row| Ok(InternalCreditCard::from_row(row)?.to_payload()?);
+            &|row| Ok(InternalCreditCard::from_row(row)?.into_payload()?);
 
         let tombstones_sql = "SELECT guid FROM credit_cards_tombstones";
 
@@ -90,7 +88,7 @@ impl ProcessOutgoingRecordImpl for OutgoingCreditCardsImpl {
 mod tests {
     use super::*;
     use crate::db::credit_cards::{add_internal_credit_card, tests::insert_mirror_record};
-    use crate::sync::{common::tests::*, test::new_syncable_mem_db, SyncRecord};
+    use crate::sync::{common::tests::*, test::new_syncable_mem_db};
     use serde_json::{json, Map, Value};
     use types::Timestamp;
 
@@ -131,7 +129,7 @@ mod tests {
     fn test_record(guid_prefix: char) -> InternalCreditCard {
         let json = test_json_record(guid_prefix);
         let sync_payload = sync15::Payload::from_json(json).unwrap();
-        InternalCreditCard::to_record(sync_payload).expect("should be valid")
+        InternalCreditCard::from_payload(sync_payload).expect("should be valid")
     }
 
     #[test]

--- a/components/autofill/src/sync/mod.rs
+++ b/components/autofill/src/sync/mod.rs
@@ -106,10 +106,6 @@ pub trait SyncRecord {
     fn merge(incoming: &Self, local: &Self, mirror: &Option<Self>) -> MergeResult<Self>
     where
         Self: Sized;
-    fn to_record(p: sync15::Payload) -> Result<Self>
-    where
-        Self: Sized;
-    fn to_payload(self) -> Result<sync15::Payload>;
 }
 
 impl Metadata {


### PR DESCRIPTION
And also rename them to keep clippy happy.

As discussed quickly in slack, this is to make the "encryption" work easier and PR easier to review - the CC impl of these functions needs to manage encryption and addresses do not. Even without that, I think this is still a bit clearer and avoids passing closures etc around.

Once approved and merged, I'll put up a PR for your outgoing PR.