### PR TITLE
Adding Nimbus to the iOS Megazord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,7 @@ dependencies = [
  "fxa-client",
  "glean-ffi",
  "logins_ffi",
+ "nimbus-sdk",
  "places-ffi",
  "rc_log_ffi",
  "viaduct",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,9 +3594,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "uniffi"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53678c74206450393a7d8eedf04e60193c184717d12553c7f9c0a8e19346298"
+checksum = "951741396f443adea228ef79abb846340607dfed26068ec0405dd180fd3dbaa5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3610,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b26f4b5f70aae3673ac4e03aaa1936a5ebd996360b239c2f592448ab38c23dda"
+checksum = "9fc7f411f7c8faa9d9940eb3a36e271972f4bb35d6860c920f41eca93831e10d"
 dependencies = [
  "anyhow",
  "askama",
@@ -3626,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d442a26b12b04bf1f4fb3645d5deaba9376cf117022935bebe773a03e6e8664f"
+checksum = "fa6892022dca2c387d91aced1ae78f12cca854cdf395ae8035616d100d54f18c"
 dependencies = [
  "anyhow",
  "uniffi_bindgen",
@@ -3636,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d472df0436970c100f0da4945c334e22ce78bd38ced931b3d6f1be435493e7"
+checksum = "ce261685f44e0a2448dc939baa68c2253cc69a2a38a9d487d967c90cb645f05f"
 dependencies = [
  "glob",
  "proc-macro2",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -21,7 +21,7 @@ sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.7.2"
+uniffi = "^0.8.0"
 url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -35,4 +35,4 @@ libsqlite3-sys = "0.20.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.7.2", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.8.0", features = [ "builtin-bindgen" ]}

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -26,11 +26,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.7.2"
-uniffi_macros = "^0.7.2"
+uniffi = "0.8.0"
+uniffi_macros = "0.8.0"
 
 [build-dependencies]
-uniffi_build = { version = "^0.7.2", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.8.0", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/logins/ios/Logins/Errors/LoginStoreError.swift
+++ b/components/logins/ios/Logins/Errors/LoginStoreError.swift
@@ -58,8 +58,8 @@ public enum LoginsStoreError: LocalizedError {
             return "LoginsStoreError.noSuchRecord: \(message)"
         case let .duplicateGuid(message):
             return "LoginsStoreError.duplicateGuid: \(message)"
-        case let .invalidLogin(message):
-            return "LoginsStoreError.invalidLogin: \(message)"
+        case let .invalidLogin(message, reason):
+            return "LoginsStoreError.invalidLogin(\(reason)): \(message)"
         case let .invalidKey(message):
             return "LoginsStoreError.invalidKey: \(message)"
         case let .network(message):

--- a/megazords/ios/MozillaAppServices.h
+++ b/megazords/ios/MozillaAppServices.h
@@ -13,3 +13,4 @@ FOUNDATION_EXPORT const unsigned char MegazordClientVersionString[];
 #import "RustPlacesAPI.h"
 #import "RustViaductFFI.h"
 #import "GleanFfi.h"
+#import "uniffi_nimbus-Bridging-Header.h"

--- a/megazords/ios/MozillaAppServices.h
+++ b/megazords/ios/MozillaAppServices.h
@@ -8,9 +8,9 @@ FOUNDATION_EXPORT double MegazordClientVersionNumber;
 FOUNDATION_EXPORT const unsigned char MegazordClientVersionString[];
 
 #import "uniffi_fxa_client-Bridging-Header.h"
+#import "uniffi_nimbus-Bridging-Header.h"
 #import "RustPasswordAPI.h"
 #import "RustLogFFI.h"
 #import "RustPlacesAPI.h"
 #import "RustViaductFFI.h"
 #import "GleanFfi.h"
-#import "uniffi_nimbus-Bridging-Header.h"

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1379D0692404BE1300AABD16 /* logins_msg_types.proto in Sources */ = {isa = PBXBuildFile; fileRef = 1379D0682404BE1300AABD16 /* logins_msg_types.proto */; };
 		137C5893240257340016932F /* Data+LoginsRustBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137C5892240257340016932F /* Data+LoginsRustBuffer.swift */; };
+		394A807825EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 394A807625EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		99FAA19B25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 99FAA19A25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		99FAA19F25E65CA5001E2231 /* FxAccountOAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FAA19E25E65CA5001E2231 /* FxAccountOAuth.swift */; };
 		BF1A879025064A4C00FED88E /* Dispatchers.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1A878C25064A4C00FED88E /* Dispatchers.swift */; };
@@ -150,8 +151,11 @@
 /* Begin PBXFileReference section */
 		1379D0682404BE1300AABD16 /* logins_msg_types.proto */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.protobuf; name = logins_msg_types.proto; path = ../../src/logins_msg_types.proto; sourceTree = "<group>"; };
 		137C5892240257340016932F /* Data+LoginsRustBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Data+LoginsRustBuffer.swift"; path = "Extensions/Data+LoginsRustBuffer.swift"; sourceTree = "<group>"; };
-		99FAA19125E60D57001E2231 /* fxa_client.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = fxa_client.swift; path = ../../Generated/fxa_client.swift; sourceTree = "<group>"; };
-		99FAA19A25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "uniffi_fxa_client-Bridging-Header.h"; path = "../../Generated/uniffi_fxa_client-Bridging-Header.h"; sourceTree = "<group>"; };
+		394A807325EE94C600FAF26F /* nimbus.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = nimbus.udl; path = ../src/nimbus.udl; sourceTree = "<group>"; };
+		394A807625EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uniffi_nimbus-Bridging-Header.h"; sourceTree = "<group>"; };
+		394A807725EE951D00FAF26F /* nimbus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = nimbus.swift; sourceTree = "<group>"; };
+		99FAA19125E60D57001E2231 /* fxa_client.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = fxa_client.swift; sourceTree = "<group>"; };
+		99FAA19A25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uniffi_fxa_client-Bridging-Header.h"; sourceTree = "<group>"; };
 		99FAA19E25E65CA5001E2231 /* FxAccountOAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAccountOAuth.swift; sourceTree = "<group>"; };
 		BF1A878C25064A4C00FED88E /* Dispatchers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dispatchers.swift; sourceTree = "<group>"; };
 		BF1A878D25064A4C00FED88E /* Glean.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Glean.swift; sourceTree = "<group>"; };
@@ -262,13 +266,33 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		394A807225EE927D00FAF26F /* Nimbus */ = {
+			isa = PBXGroup;
+			children = (
+				394A807525EE951D00FAF26F /* Generated */,
+				394A807325EE94C600FAF26F /* nimbus.udl */,
+			);
+			name = Nimbus;
+			path = "../../components/external/nimbus-sdk/nimbus/ios";
+			sourceTree = SOURCE_ROOT;
+		};
+		394A807525EE951D00FAF26F /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				394A807625EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h */,
+				394A807725EE951D00FAF26F /* nimbus.swift */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
 		99FAA19025E60D2C001E2231 /* Generated */ = {
 			isa = PBXGroup;
 			children = (
 				99FAA19A25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h */,
 				99FAA19125E60D57001E2231 /* fxa_client.swift */,
 			);
-			path = Generated;
+			name = Generated;
+			path = ../Generated;
 			sourceTree = "<group>";
 		};
 		BF1A877F2506490700FED88E /* Glean */ = {
@@ -505,6 +529,7 @@
 				C852EEDA220A2A2B00A6E79A /* FxAClient */,
 				C852EEC7220A29FE00A6E79A /* Logins */,
 				BF1A877F2506490700FED88E /* Glean */,
+				394A807225EE927D00FAF26F /* Nimbus */,
 				EB879D7B221234EB00753DC9 /* MozillaAppServicesTests */,
 				CE9D202120914D0D00F1C8FA /* Products */,
 				CE9D203720914D4800F1C8FA /* Frameworks */,
@@ -572,6 +597,7 @@
 				D05434A32256810200FDE4EF /* RustPasswordAPI.h in Headers */,
 				CDC21B15221DCE3700AA71E5 /* RustLogFFI.h in Headers */,
 				CE58B2F8242D54340089F091 /* RustViaductFFI.h in Headers */,
+				394A807825EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h in Headers */,
 				CD85A45522361E890099BFA9 /* RustPlacesAPI.h in Headers */,
 				99FAA19B25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h in Headers */,
 				BF1A879225064A4C00FED88E /* GleanFfi.h in Headers */,

--- a/megazords/ios/rust/Cargo.toml
+++ b/megazords/ios/rust/Cargo.toml
@@ -16,3 +16,4 @@ rc_log_ffi = { path = "../../../components/rc_log" }
 viaduct = { path = "../../../components/viaduct" }
 viaduct-reqwest = { path = "../../../components/support/viaduct-reqwest" }
 glean-ffi = { path = "../../../components/external/glean/glean-core/ffi" }
+nimbus-sdk = { path = "../../../components/external/nimbus-sdk/nimbus" }

--- a/megazords/ios/rust/src/lib.rs
+++ b/megazords/ios/rust/src/lib.rs
@@ -8,7 +8,7 @@
 pub use fxa_client;
 pub use glean_ffi;
 pub use logins_ffi;
+pub use nimbus;
 pub use places_ffi;
 pub use rc_log_ffi;
 pub use viaduct_reqwest;
-pub use nimbus;

--- a/megazords/ios/rust/src/lib.rs
+++ b/megazords/ios/rust/src/lib.rs
@@ -11,3 +11,4 @@ pub use logins_ffi;
 pub use places_ffi;
 pub use rc_log_ffi;
 pub use viaduct_reqwest;
+pub use nimbus;

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.7.2"
+uniffi_bindgen = "^0.8.0"


### PR DESCRIPTION
This adds Nimbus to the iOS megazord, fixing [SDK-206][0].

It depends on https://github.com/mozilla/uniffi-rs/pull/409, https://github.com/mozilla/application-services/pull/3876 and https://github.com/mozilla/uniffi-rs/issues/412, so we shouldn't consider landing this until both those PRs have landed.



[0]: https://jira.mozilla.com/browse/SDK-206

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
