### PR TITLE
Remove sqlcipher linkage hack to appease Rust 1.50 (fixes SYNC-1999)

### DIFF
--- a/components/autofill/build.rs
+++ b/components/autofill/build.rs
@@ -11,9 +11,7 @@ fn main() {
     uniffi_build::generate_scaffolding("./src/autofill.udl").unwrap();
 
     println!("cargo:rerun-if-changed=build.rs");
-    // Ugh. This is really really dumb. We don't care about sqlcipher at all. really
-    if nss_build_common::env_str("DEP_SQLITE3_LINK_TARGET") == Some("sqlcipher".into()) {
-        // If NSS_DIR isn't set, we don't really care, ignore the Err case.
-        let _ = nss_build_common::link_nss();
-    }
+
+    // If NSS_DIR isn't set, we don't really care, ignore the Err case.
+    let _ = nss_build_common::link_nss();
 }

--- a/components/webext-storage/build.rs
+++ b/components/webext-storage/build.rs
@@ -3,14 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 //! Work around the fact that `sqlcipher` might get enabled by a cargo feature
-//! another crate in the workspace needs, without setting up nss. (This is a
+//! another crate in the workspace needs, without setting up nss.  (This is a
 //! gross hack).
-
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    // Ugh. This is really really dumb. We don't care about sqlcipher at all. really
-    if nss_build_common::env_str("DEP_SQLITE3_LINK_TARGET") == Some("sqlcipher".into()) {
-        // If NSS_DIR isn't set, we don't really care, ignore the Err case.
-        let _ = nss_build_common::link_nss();
-    }
+
+    // If NSS_DIR isn't set, we don't really care, ignore the Err case.
+    let _ = nss_build_common::link_nss();
 }


### PR DESCRIPTION
So, the root cause of this problem is a regression between rustc 1.49 and 1.50 ([changelog](https://github.com/mozilla/application-services/blob/c0cc3c7eb6bb18c7ac8c32fef78724e5c520daf3/components/autofill/build.rs#L19)).  I think it's quite likely that rust-lang/cargo#8969 was the breaking PR.  There was a subsequent fix for some piece of the problem in rust-lang/cargo#9065, but that didn't fix the issue that we're seeing, which is still in rustc 1.52 nightly.  (BTW, I (heart) how trivial cargo makes it to test whether a given problem still exists in the nightly version of the compiler).

I haven't tried to nail down exactly what this piece is and filed a bug in rustlang because I don't have a sense of how long that's likely to take.  Furthermore, I think the cheapest way to fix this is simply to unconditionally link NSS in all cases.  It will slow down our build process a bit, but I'd be surprised if it were by an interesting amount.  My assumption is that doing this won't make any difference to the executable produced, since I wouldn't expect anything to be pulled in from NSS unless there are symbols missing at link to.

This is particularly compelling, because, as I understand it, we're considering getting rid of sqlcipher entirely in #960, which would just make the root issue go away.  Is this correct?

Note that I'm forcing everything to 1.50 in this PR to make sure that we're sure we solve the problem we're trying to.

My plan is to remove that commit before we land, just to keep things separate. I could land them all at once, though...

I have yet to test how this fix affects build in m-c, if at all...

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not.
  - _This is really just to fix stuff busted with the Rust 1.50 compiler._
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - _There are no user-facing changes._
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
  - _No dependency changes_
