### PR TITLE
Cut release v73.0.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 72.1.0
+libraryVersion: 73.0.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# v73.0.0 (_2021-03-10_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v72.1.0...v73.0.0)
+
+## General 
+
+- The bundled version of the Nimbus SDK has been updated to v0.9.0.
+- The top-level Rust workspace now builds with Rust 1.50
+- The top-level Rust workspace is now stapled to Rust 1.50, so all developers
+  will build with 1.50, as will the continuous integration for this repo.
+
+## iOS 
+
+- The Nimbus SDK is now available as part of the `MozillaAppServices` Swift module.
+
+## FxA Client
+
+### ⚠️ Breaking changes ⚠️
+
+- The Kotlin and Swift bindings are now generated automatically using UniFFI.
+  As a result many small details of the API surface have changed, such as some
+  classes changing names to be consistent between Rust, Kotlin and Swift.
+  ([#3876](https://github.com/mozilla/application-services/pull/3876))
+
 # v72.1.0 (_2021-02-25_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v72.0.0...v72.1.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,24 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v72.1.0...main)
-
-## General 
-
-- The bundled version of the Nimbus SDK has been updated to v0.9.0.
-- The top-level Rust workspace now builds with Rust 1.50
-- The top-level Rust workspace is now stapled to Rust 1.50, so all developers
-  will build with 1.50, as will the continuous integration for this repo.
-
-## iOS 
-
-- The Nimbus SDK is now available as part of the `MozillaAppServices` Swift module.
-
-## FxA Client
-
-### ⚠️ Breaking changes ⚠️
-
-- The Kotlin and Swift bindings are now generated automatically using UniFFI.
-  As a result many small details of the API surface have changed, such as some
-  classes changing names to be consistent between Rust, Kotlin and Swift.
-  ([#3876](https://github.com/mozilla/application-services/pull/3876))
+[Full Changelog](https://github.com/mozilla/application-services/compare/v73.0.0...main)


### PR DESCRIPTION
I've locally tested this with a build of Fenix and a build of Firefox iOS and they both appear to be working (with some b/w compat fixes which I have ready to push in separate PRs to those repos, once the release is out).