### PR TITLE
Disable building win32 release artifacts. [ci full]

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,9 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v73.0.0...main)
+
+# Android
+
+- The `-forUnitTest` build no longer includes code compiled for Windows, meaning that
+  it is no longer possible to run appservices Kotlin unit tests on Windows. We hope
+  this will be a temporary measure while we resolve some build issues.

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -38,7 +38,9 @@ job-defaults:
       # `source rustup_setup.sh` gets inserted here by the `rustup_setup` transform.
       - [source, taskcluster/scripts/toolchain/cross-compile-setup.sh]
       - [rsync, '-a', /builds/worker/fetches/libs/, /builds/worker/checkouts/src/libs/]
-      - [bash, '-c', 'echo "rust.targets=arm,arm64,x86_64,x86,darwin,linux-x86-64,win32-x86-64-gnu\n" > local.properties']
+      # Once https://github.com/mozilla/application-services/issues/3917 is resolved,
+      # add `win32-x86-64-gnu` back in to the list of targets here.
+      - [bash, '-c', 'echo "rust.targets=arm,arm64,x86_64,x86,darwin,linux-x86-64\n" > local.properties']
     gradlew:
       - ':{module_name}:testDebug'
       - ':{module_name}:assembleRelease'


### PR DESCRIPTION
We are hitting some build errors on win32 with the latest release.
I think this may be due to the upgrade to Rust 1.50, and will see
what I can do to resolve it. But in the meantime we need to be
able to cut releases, and disabling the win32 artifacts seems like
the shortest path to that outcome.

In practise, this will mean that Android developers will not be
able to run unittests that use Application Services code if they
are on a Windows machine, since they won't have an appropriate
`.so` file from which to load the appservices code.

It's my expectation that adding `[ci full]` to the PR title here
will cause taskcluster to execute the jobs that failed in the release,
and I will manually confirm that before landing.
