### PR TITLE
Remove an orphaned comment about installing uniffi-bindgen.

### DIFF
--- a/libs/verify-common.sh
+++ b/libs/verify-common.sh
@@ -7,8 +7,6 @@ if ! [[ -x "$(command -v rustc)" ]]; then
   exit 1
 fi
 
-echo "Installing uniffi_bindgen if missing; it's necessary for binding generation during the builds."
-
 # Print the rustc version (we don't update it because our CI and official
 # builds we will often be pinned on an ealier rust version, but should still
 # work OK with later ones.)


### PR DESCRIPTION
We deleted the line in this script that installed `uniffi-bindgen`, but we didn't delete the thing that says we're going to install `uniffi-bindgen`.