### PR TITLE
Add a "crashtest" component for helping test crash-related behaviours.

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -8,6 +8,13 @@ projects:
     - name: autofill
       type: aar
     description: Addresses and Credit Cards autofill.
+  crashtest:
+    path: components/crashtest/android
+    artifactId: crashtest
+    publications:
+    - name: crashtest
+      type: aar
+    description: Helper APIs to trigger an application crash.
   fxaclient:
     path: components/fxa-client/android
     artifactId: fxaclient

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,6 +497,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
+name = "crashtest"
+version = "0.1.0"
+dependencies = [
+ "log 0.4.11",
+ "thiserror",
+ "uniffi",
+ "uniffi_build",
+ "uniffi_macros",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,6 +1644,7 @@ name = "megazord"
 version = "0.1.0"
 dependencies = [
  "autofill",
+ "crashtest",
  "fxa-client",
  "lazy_static",
  "logins_ffi",
@@ -1648,6 +1660,7 @@ dependencies = [
 name = "megazord_ios"
 version = "0.1.0"
 dependencies = [
+ "crashtest",
  "fxa-client",
  "glean-ffi",
  "logins_ffi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 # Note: Any additions here should be repeated in default-members below.
 members = [
     "components/autofill",
+    "components/crashtest",
     "components/fxa-client",
     "components/logins",
     "components/logins/ffi",
@@ -78,6 +79,7 @@ exclude = [
 # use the full member set.
 default-members = [
     "components/autofill",
+    "components/crashtest",
     "components/fxa-client",
     "components/logins",
     "components/logins/ffi",

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "crashtest"
+edition = "2018"
+version = "0.1.0"
+authors = ["Ryan Kelly <rfkelly@mozilla.com>"]
+license = "MPL-2.0"
+exclude = ["/android", "/ios"]
+
+[dependencies]
+log = "0.4"
+thiserror = "1.0"
+uniffi = "0.8"
+uniffi_macros = "0.8"
+
+[build-dependencies]
+uniffi_build = { version = "0.8", features=["builtin-bindgen"] }

--- a/components/crashtest/README.md
+++ b/components/crashtest/README.md
@@ -1,0 +1,82 @@
+# Crash Testing Helper APIs
+
+This is a little helper component to make it easier to debug
+issues with crash reporting, by letting you deliberately
+crash a consuming app.
+
+* [Features](#features)
+* [Using the Crash Testing Helper APIs](#using-the-crash-testing-helper-apis)
+* [Working on Crash Testing Helper APIs](#working-on-the-crash-testing-helper-apis)
+
+## Features
+
+The Crash Testing Helper APIs let you deliberately crash your application
+in a variety of ways:
+
+1. By triggering a hard abort inside the Rust code of the component, which
+   should surface as a crash of the application.
+1. By triggering a panic inside the Rust code of the component, which should
+   surface as an "internal error" exception to the calling code.
+
+The component does not offer any support for crash reporting, debugging etc
+itself, it's just designed to let you more easily test those things in your
+application.
+
+## Using the Crash Testing Helper APIs
+
+### Before using this component
+
+This component does not currently integrate with the [Glean SDK](https://mozilla.github.io/glean/book/index.html)
+and does not submit any telemetry, so you do not need to request a data-review before using this component.
+
+### Prerequisites
+
+To use this component, you should be familiar with how to integrate application-services components
+into an application on your target platform:
+* **Android**: Add the `mozilla.appservices.crashtest` package as a gradle dependency, but make sure
+  you're using the same version of application-services as used by [Android Components](
+  https://github.com/mozilla-mobile/android-components/tree/master/components/service/firefox-accounts/README.md).
+* **iOS**: start with the [guide to consuming rust components on
+  iOS](https://github.com/mozilla/application-services/blob/main/docs/howtos/consuming-rust-components-on-ios.md).
+* **Other Platforms**: we don't know yet; please reach out on slack to discuss!
+
+### Component API
+
+For details on how to use this component, consult the [public interface definition](./src/crashtest.udl)
+or view the generated Rust API documentation by running:
+
+```
+cargo doc --no-deps --open
+```
+
+## Working on the Crash Testing Helper APIs
+
+### Prerequisites
+
+To effectively work on the Crash Testing Helper APIs, you will need to be familiar with:
+
+* Our general [guidelines for contributors](../../docs/contributing.md).
+* The way we use [uniffi-rs](https://github.com/mozilla/uniffi-rs) to generate API wrappers for multiple languages, such as Kotlin and Swift.
+
+### Overview
+
+This component uses [uniffi-rs](https://github.com/mozilla/uniffi-rs) to create its
+public API surface in Rust, and then generate bindings for Kotlin and Swift. The
+code is organized as follows:
+
+* The public API surface is implemented in [`./src/lib.rs`](./src/lib/rs), with matching
+  declarations in [`./src/crashtest.udl`](./src/crashtest.udl) to define how it gets
+  exposed to other languages.
+* The [`./android/`](./android) directory contains android-specific build scripts that
+  generate Kotlin wrappers and publish them as an AAR, and some Android tests.
+* The [`./ios/`](./ios) directory is a placeholder for generated Swift code. There are
+  a couple of Swift tests in `/megazords/ios/MozillaAppServicesTests/CrashTestTests.swift`.
+
+### Detailed Docs
+
+We use rustdoc to document both the public API of this component and its
+various internal implementation details. View the docs by running:
+
+```
+cargo doc --no-deps --document-private-items --open
+```

--- a/components/crashtest/android/build.gradle
+++ b/components/crashtest/android/build.gradle
@@ -1,0 +1,121 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+
+android {
+    ndkVersion rootProject.ext.build.ndkVersion
+    compileSdkVersion rootProject.ext.build.compileSdkVersion
+
+    defaultConfig {
+        minSdkVersion rootProject.ext.build['minSdkVersion']
+        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "LIBRARY_VERSION", "\"${rootProject.ext.library.version}\"")
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
+        }
+    }
+
+    sourceSets {
+        test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
+        // Add the full-megazord's build directory to our resource path so that
+        // we can actually find it during tests. (Unfortunately, each project
+        // has their own build dir)
+        test.resources.srcDirs += "${project(':full-megazord').buildDir}/rustJniLibs/desktop"
+    }
+
+    // This is required to support new AndroidX support libraries.
+    // See mozilla-mobile/android-components#842
+    compileOptions {
+        sourceCompatibility rootProject.ext.build.jvmTargetCompatibility
+        targetCompatibility rootProject.ext.build.jvmTargetCompatibility
+    }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions {
+            jvmTarget = rootProject.ext.build.jvmTargetCompatibility
+        }
+    }
+}
+
+configurations {
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
+}
+
+dependencies {
+    jnaForTest "net.java.dev.jna:jna:$jna_version@jar"
+    implementation "net.java.dev.jna:jna:$jna_version@aar"
+
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
+    api project(":full-megazord")
+    implementation project(":native-support")
+
+    // For reasons unknown, resolving the jnaForTest configuration directly
+    // trips a nasty issue with the Android-Gradle plugin 3.2.1, like `Cannot
+    // change attributes of configuration ':PROJECT:kapt' after it has been
+    // resolved`.  I think that the configuration is being made a
+    // super-configuration of the testImplementation and then the `.files` is
+    // causing it to be resolved.  Cloning first dissociates the configuration,
+    // avoiding other configurations from being resolved.  Tricky!
+    testImplementation files(configurations.jnaForTest.copyRecursive().files)
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.robolectric:robolectric:3.8'
+    testImplementation 'org.mockito:mockito-core:2.21.0'
+
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+}
+
+// We do the uniffi binding generation here:
+android.libraryVariants.all { variant ->
+    def t = tasks.register("generate${variant.name.capitalize()}UniffiBindings", Exec) {
+        workingDir project.rootDir
+        commandLine 'cargo', 'uniffi-bindgen', 'generate', "${project.projectDir}/../src/crashtest.udl", '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
+
+        inputs.file '../src/crashtest.udl'
+        outputs.dir "${buildDir}/generated/source/uniffi/${variant.name}/java/"
+    }
+    variant.javaCompileProvider.get().dependsOn(t)
+    def sourceSet = variant.sourceSets.find { it.name == variant.name }
+    sourceSet.java.srcDirs += new File(buildDir, "generated/source/uniffi/${variant.name}/java")
+}
+
+evaluationDependsOn(":full-megazord")
+afterEvaluate {
+    // The `cargoBuild` task isn't available until after evaluation.
+    android.libraryVariants.all { variant ->
+        def productFlavor = ""
+        variant.productFlavors.each {
+            productFlavor += "${it.name.capitalize()}"
+        }
+        def buildType = "${variant.buildType.name.capitalize()}"
+        tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(project(':full-megazord').tasks["cargoBuild"])
+
+        // For unit tests.
+        tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(project(':full-megazord').tasks["cargoBuild"])
+    }
+}
+
+apply from: "$rootDir/publish.gradle"
+
+ext.configurePublish()

--- a/components/crashtest/android/proguard-rules.pro
+++ b/components/crashtest/android/proguard-rules.pro
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/components/crashtest/android/src/main/AndroidManifest.xml
+++ b/components/crashtest/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.mozilla.appservices.crashtest" />

--- a/components/crashtest/android/src/test/java/mozilla/appservices/crashtest/CrashTestHelpersTest.kt
+++ b/components/crashtest/android/src/test/java/mozilla/appservices/crashtest/CrashTestHelpersTest.kt
@@ -1,0 +1,34 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package mozilla.appservices.crashtest
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class CrashTestHelpersTest {
+    @Test
+    fun testPanicsAreCaughtAndThrown() {
+        try {
+            triggerRustPanic()
+        } catch (e: InternalException) {
+            assertEquals(e.message, "Panic! In The Rust Code.")
+        }
+    }
+
+    @Test
+    fun testErrorsAreThrown() {
+        try {
+            triggerRustError()
+        } catch (e: CrashTestErrorException) {
+            assertEquals(e.message, "Error! From The Rust Code.")
+        }
+    }
+
+    // We can't test `triggerRustAbort()` here because it's a hard crash.
+}

--- a/components/crashtest/build.rs
+++ b/components/crashtest/build.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/crashtest.udl").unwrap();
+}

--- a/components/crashtest/src/crashtest.udl
+++ b/components/crashtest/src/crashtest.udl
@@ -1,0 +1,56 @@
+
+
+
+// # Crash Test Helper APIs
+//
+// The `crashtest` component offers a little helper API that lets you deliberately
+// crash the application. It's intended to help developers test the crash-handling
+// and crash-reporting capabilities of their app.
+
+namespace crashtest {
+    
+    
+  // Trigger a hard abort inside the Rust code.
+  //
+  // This function simulates some kind of uncatchable illegal operation
+  // performed inside the Rust code. After calling this function you should
+  // expect your application to be halted with e.g. a `SIGABRT` or similar.
+  //
+  void trigger_rust_abort();
+    
+    
+  // Trigger a panic inside the Rust code.
+  //
+  // This function simulates the occurence of an unexpected state inside
+  // the Rust code that causes it to panic. We build our Rust components to
+  // unwind on panic, so after calling this function through the foreign
+  // language bindings, you should expect it to intercept the panic translate
+  // it into some foreign-language-appropriate equivalent:
+  //
+  //  - In Kotlin, it will throw an exception.
+  //  - In Swift, it will fail with a `try!` runtime error.
+  //
+  void trigger_rust_panic();
+    
+    
+  // Trigger an error inside the Rust code.
+  //
+  // This function simulates the occurence of an expected error inside
+  // the Rust code. You should expect calling this function to throw the
+  // foreign-language representation of the [`CrashTestError`] class.
+  //
+  [Throws=CrashTestError]
+  void trigger_rust_error();
+    
+};
+
+
+
+// An error that can be returned from Rust code.
+//
+[Error]
+enum CrashTestError {
+  "ErrorFromTheRustCode",
+};
+
+

--- a/components/crashtest/src/lib.rs
+++ b/components/crashtest/src/lib.rs
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! # Crash Test Helper APIs
+//!
+//! The `crashtest` component offers a little helper API that lets you deliberately
+//! crash the application. It's intended to help developers test the crash-handling
+//! and crash-reporting capabilities of their app.
+
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests;
+
+uniffi_macros::include_scaffolding!("crashtest");
+
+/// Trigger a hard abort inside the Rust code.
+///
+/// This function simulates some kind of uncatchable illegal operation
+/// performed inside the Rust code. After calling this function you should
+/// expect your application to be halted with e.g. a `SIGABRT` or similar.
+///
+pub fn trigger_rust_abort() {
+    log::error!("Now triggering an abort inside the Rust code");
+    std::process::abort();
+}
+
+/// Trigger a panic inside the Rust code.
+///
+/// This function simulates the occurence of an unexpected state inside
+/// the Rust code that causes it to panic. We build our Rust components to
+/// unwind on panic, so after calling this function through the foreign
+/// language bindings, you should expect it to intercept the panic translate
+/// it into some foreign-language-appropriate equivalent:
+///
+///  - In Kotlin, it will throw an exception.
+///  - In Swift, it will fail with a `try!` runtime error.
+///
+pub fn trigger_rust_panic() {
+    log::error!("Now triggering a panic inside the Rust code");
+    panic!("Panic! In The Rust Code.");
+}
+
+/// Trigger an error inside the Rust code.
+///
+/// This function simulates the occurence of an expected error inside
+/// the Rust code. You should expect calling this function to throw the
+/// foreign-language representation of the [`CrashTestError`] class.
+///
+pub fn trigger_rust_error() -> Result<(), CrashTestError> {
+    log::error!("Now triggering an error inside the Rust code");
+    Err(CrashTestError::ErrorFromTheRustCode)
+}
+
+/// An error that can be returned from Rust code.
+///
+#[derive(Debug, Error)]
+pub enum CrashTestError {
+    #[error("Error! From The Rust Code.")]
+    ErrorFromTheRustCode,
+}

--- a/components/crashtest/src/tests.rs
+++ b/components/crashtest/src/tests.rs
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// The tests are in a separate file just to ensure that the
+// main `lib.rs` contains nothing but the public interface.
+
+#[test]
+#[should_panic]
+fn test_trigger_panic() {
+    crate::trigger_rust_panic();
+}
+
+#[test]
+fn test_trigger_error() {
+    assert!(matches!(
+        crate::trigger_rust_error(),
+        Err(crate::CrashTestError::ErrorFromTheRustCode)
+    ));
+}
+
+// We can't test `trigger_rust_abort()` here because it's a hard error.

--- a/components/crashtest/uniffi.toml
+++ b/components/crashtest/uniffi.toml
@@ -1,0 +1,3 @@
+[bindings.kotlin]
+package_name = "mozilla.appservices.crashtest"
+cdylib_name = "megazord"

--- a/megazords/full/Cargo.toml
+++ b/megazords/full/Cargo.toml
@@ -18,5 +18,6 @@ viaduct = { path = "../../components/viaduct" }
 sync_manager_ffi = { path = "../../components/sync_manager/ffi" }
 nimbus-sdk = { path = "../../components/external/nimbus-sdk/nimbus" }
 autofill = { path = "../../components/autofill" }
+crashtest = { path = "../../components/crashtest" }
 
 lazy_static = "1.4"

--- a/megazords/full/src/lib.rs
+++ b/megazords/full/src/lib.rs
@@ -9,6 +9,7 @@ use std::ffi::CString;
 use std::os::raw::c_char;
 
 pub use autofill;
+pub use crashtest;
 pub use fxa_client;
 pub use logins_ffi;
 pub use nimbus;

--- a/megazords/ios/MozillaAppServices.h
+++ b/megazords/ios/MozillaAppServices.h
@@ -7,6 +7,7 @@
 FOUNDATION_EXPORT double MegazordClientVersionNumber;
 FOUNDATION_EXPORT const unsigned char MegazordClientVersionString[];
 
+#import "uniffi_crashtest-Bridging-Header.h"
 #import "uniffi_fxa_client-Bridging-Header.h"
 #import "uniffi_nimbus-Bridging-Header.h"
 #import "RustPasswordAPI.h"

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		1379D0692404BE1300AABD16 /* logins_msg_types.proto in Sources */ = {isa = PBXBuildFile; fileRef = 1379D0682404BE1300AABD16 /* logins_msg_types.proto */; };
 		137C5893240257340016932F /* Data+LoginsRustBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137C5892240257340016932F /* Data+LoginsRustBuffer.swift */; };
 		394A807825EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 394A807625EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		9908639E25F9CC5F00032083 /* crashtest.udl in Sources */ = {isa = PBXBuildFile; fileRef = 9908639B25F9CC3600032083 /* crashtest.udl */; };
+		990863A125F9D25A00032083 /* uniffi_crashtest-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9908639F25F9D25A00032083 /* uniffi_crashtest-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		990863A425F9D48400032083 /* CrashTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990863A325F9D48400032083 /* CrashTestTests.swift */; };
 		9924024A25F789F200841837 /* nimbus.udl in Sources */ = {isa = PBXBuildFile; fileRef = 394A807325EE94C600FAF26F /* nimbus.udl */; };
 		99FAA19B25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 99FAA19A25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		99FAA19F25E65CA5001E2231 /* FxAccountOAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99FAA19E25E65CA5001E2231 /* FxAccountOAuth.swift */; };
@@ -155,6 +158,10 @@
 		394A807325EE94C600FAF26F /* nimbus.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = nimbus.udl; path = src/nimbus.udl; sourceTree = "<group>"; };
 		394A807625EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uniffi_nimbus-Bridging-Header.h"; sourceTree = "<group>"; };
 		394A807725EE951D00FAF26F /* nimbus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = nimbus.swift; sourceTree = "<group>"; };
+		9908639B25F9CC3600032083 /* crashtest.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = crashtest.udl; path = ../../src/crashtest.udl; sourceTree = "<group>"; };
+		9908639F25F9D25A00032083 /* uniffi_crashtest-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uniffi_crashtest-Bridging-Header.h"; sourceTree = "<group>"; };
+		990863A025F9D25A00032083 /* crashtest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = crashtest.swift; sourceTree = "<group>"; };
+		990863A325F9D48400032083 /* CrashTestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashTestTests.swift; sourceTree = "<group>"; };
 		99FAA19125E60D57001E2231 /* fxa_client.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = fxa_client.swift; sourceTree = "<group>"; };
 		99FAA19A25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uniffi_fxa_client-Bridging-Header.h"; sourceTree = "<group>"; };
 		99FAA19E25E65CA5001E2231 /* FxAccountOAuth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FxAccountOAuth.swift; sourceTree = "<group>"; };
@@ -285,6 +292,26 @@
 			);
 			name = Generated;
 			path = ios/Generated;
+			sourceTree = "<group>";
+		};
+		9908639825F9CB6A00032083 /* CrashTest */ = {
+			isa = PBXGroup;
+			children = (
+				9908639D25F9CC4700032083 /* Generated */,
+				9908639B25F9CC3600032083 /* crashtest.udl */,
+			);
+			name = CrashTest;
+			path = ../../components/crashtest/ios/CrashTest;
+			sourceTree = "<group>";
+		};
+		9908639D25F9CC4700032083 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				990863A025F9D25A00032083 /* crashtest.swift */,
+				9908639F25F9D25A00032083 /* uniffi_crashtest-Bridging-Header.h */,
+			);
+			name = Generated;
+			path = ../Generated;
 			sourceTree = "<group>";
 		};
 		99FAA19025E60D2C001E2231 /* Generated */ = {
@@ -528,6 +555,7 @@
 				CDC21B11221DCE3700AA71E5 /* RustLog */,
 				CE9FFA11242D4E5A0011029E /* Viaduct */,
 				C852EEB2220A285B00A6E79A /* config */,
+				9908639825F9CB6A00032083 /* CrashTest */,
 				C852EEDA220A2A2B00A6E79A /* FxAClient */,
 				C852EEC7220A29FE00A6E79A /* Logins */,
 				BF1A877F2506490700FED88E /* Glean */,
@@ -578,6 +606,7 @@
 		EB879D7B221234EB00753DC9 /* MozillaAppServicesTests */ = {
 			isa = PBXGroup;
 			children = (
+				990863A325F9D48400032083 /* CrashTestTests.swift */,
 				EB879D7E221234EB00753DC9 /* Info.plist */,
 				CEB1A06723D8A42D005BD4DD /* FxAccountMocks.swift */,
 				CE34DB3C23D0C9640027AD63 /* FxAccountManagerTests.swift */,
@@ -599,10 +628,11 @@
 				D05434A32256810200FDE4EF /* RustPasswordAPI.h in Headers */,
 				CDC21B15221DCE3700AA71E5 /* RustLogFFI.h in Headers */,
 				CE58B2F8242D54340089F091 /* RustViaductFFI.h in Headers */,
-				394A807825EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h in Headers */,
 				CD85A45522361E890099BFA9 /* RustPlacesAPI.h in Headers */,
-				99FAA19B25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h in Headers */,
 				BF1A879225064A4C00FED88E /* GleanFfi.h in Headers */,
+				990863A125F9D25A00032083 /* uniffi_crashtest-Bridging-Header.h in Headers */,
+				99FAA19B25E61D5D001E2231 /* uniffi_fxa_client-Bridging-Header.h in Headers */,
+				394A807825EE951D00FAF26F /* uniffi_nimbus-Bridging-Header.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -749,6 +779,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9908639E25F9CC5F00032083 /* crashtest.udl in Sources */,
 				9924024A25F789F200841837 /* nimbus.udl in Sources */,
 				BF1A87B625064A8100FED88E /* UuidMetric.swift in Sources */,
 				BF1A87AE25064A8100FED88E /* BooleanMetric.swift in Sources */,
@@ -825,6 +856,7 @@
 				CD4CFDD3221DFA5100EB3B33 /* LogTest.swift in Sources */,
 				EB879D8B22123FD900753DC9 /* LoginsTests.swift in Sources */,
 				CE90D1BB23D7570A00FD9A5F /* FxAccountManagerTests.swift in Sources */,
+				990863A425F9D48400032083 /* CrashTestTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -4,5 +4,7 @@
 <dict>
 	<key>BuildSystemType</key>
 	<string>Original</string>
+	<key>PreviewsEnabled</key>
+	<false/>
 </dict>
 </plist>

--- a/megazords/ios/MozillaAppServicesTests/CrashTestTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/CrashTestTests.swift
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import XCTest
+
+@testable import MozillaAppServices
+
+class CrashTestTests: XCTestCase {
+    override func setUp() {
+        // This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDown() {
+        // This method is called after the invocation of each test method in the class.
+    }
+
+    func testErrorsAreThrown() {
+        XCTAssertThrowsError(try triggerRustError())
+    }
+
+    // We can't test `triggerRustAbort()` here because it's a hard crash.
+
+    // We can't test `triggerRustPanic()` here because it fails in a `try!` and crashes.
+}

--- a/megazords/ios/rust/Cargo.toml
+++ b/megazords/ios/rust/Cargo.toml
@@ -17,3 +17,4 @@ viaduct = { path = "../../../components/viaduct" }
 viaduct-reqwest = { path = "../../../components/support/viaduct-reqwest" }
 glean-ffi = { path = "../../../components/external/glean/glean-core/ffi" }
 nimbus-sdk = { path = "../../../components/external/nimbus-sdk/nimbus" }
+crashtest = { path = "../../../components/crashtest" }

--- a/megazords/ios/rust/src/lib.rs
+++ b/megazords/ios/rust/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
+pub use crashtest;
 pub use fxa_client;
 pub use glean_ffi;
 pub use logins_ffi;


### PR DESCRIPTION
This is a definitely-for-development-purposes-only component that exposes
some functions to let you deliberately crash your application in interesting
Rust-code-related ways.

The idea is that application developers could add some developer-only UI that
deliberately triggers one of these functions, and then try out the crash or
error-handling behaviour of their app in a live setting. We hope to be able
to use this to debug symbolication issues on Firefox for iOS, ref #3907.
(/cc @nbhasin2).

As a side benefit, the very process of adding this component has let me write
a couple of nice tests that our generated bindings are working as intend around
the edges of error and panic handling.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
