### PR TITLE
Update typenum licence location to use its new 'main' branch

### DIFF
--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -338,7 +338,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: typenum</name>
-    <url>https://github.com/paholg/typenum/blob/master/LICENSE</url>
+    <url>https://github.com/paholg/typenum/blob/main/LICENSE</url>
   </license>
   <license>
     <name>Apache License 2.0: unicode-bidi</name>


### PR DESCRIPTION
From my other PR:

```
Traceback (most recent call last):
  File "/Users/distiller/project/./tools/dependency_summary.py", line 1197, in <module>
    raise RuntimeError(
RuntimeError: Dependency details have changed from those in megazords/full/android/dependency-licenses.xml:
--- 
+++ 
@@ -338,7 +338,7 @@
   </license>
   <license>
     <name>Apache License 2.0: typenum</name>
-    <url>https://github.com/paholg/typenum/blob/master/LICENSE</url>
+    <url>https://github.com/paholg/typenum/blob/main/LICENSE</url>
   </license>
   <license>
     <name>Apache License 2.0: unicode-bidi</name>
```