### PR TITLE
Cut release v73.0.2

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 73.0.1
+libraryVersion: 73.0.2
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v73.0.2 (_2021-03-16_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v73.0.1...v73.0.2)
+
+* This is a deliberately empty release, designed to help test some downstream automation
+  that picks up new appservices releases.  
+
 # v73.0.1 (_2021-03-10_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v73.0.0...v73.0.1)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,4 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v73.0.1...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v73.0.2...main)


### PR DESCRIPTION
This is a deliberately empty release, designed to help test some downstream automation
that picks up new appservices releases.