### PR TITLE
Wrap the autofill implementation in an Arc<> to help the sync manager.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3191,6 +3191,7 @@ name = "sync_manager"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "autofill",
  "error-support",
  "ffi-support 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "interrupt-support",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1.0"
 error-support = { path = "../support/error" }
 interrupt-support = { path = "../support/interrupt" }
 jwcrypto = { path = "../support/jwcrypto" }
+lazy_static = "1.4"
 log = "0.4"
 serde = "1"
 serde_derive = "1"
@@ -31,7 +32,6 @@ features = ["functions", "bundled", "serde_json", "unlock_notify"]
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }
-lazy_static = "1.4"
 libsqlite3-sys = "0.20.1"
 
 [build-dependencies]

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -86,6 +86,11 @@ enum Error {
    "CryptoError",
 };
 
+// We don't really *need* this to be `Threadsafe` because we have a mutex to
+// manage concurrent DB connections - but we might as well so our Mutexes
+// do what we thing they are doing rather than being controlled by the hidden
+// mutexes non-threadsafe uniffi gives us.
+[Threadsafe]
 interface Store {
     [Throws=Error]
     constructor(string dbpath);
@@ -125,4 +130,6 @@ interface Store {
 
     [Throws=Error]
     void touch_address(string guid);
+
+    void register_with_sync_manager();
 };

--- a/components/autofill/src/lib.rs
+++ b/components/autofill/src/lib.rs
@@ -11,6 +11,9 @@ pub mod encryption;
 pub mod error;
 pub mod sync;
 
+// Re-export stuff the sync manager needs.
+pub use crate::db::store::{StoreImpl, STORE_FOR_MANAGER};
+
 // Expose stuff needed by the uniffi generated code.
 use crate::db::models::address::*;
 use crate::db::models::credit_card::*;

--- a/components/autofill/src/sync/address/mod.rs
+++ b/components/autofill/src/sync/address/mod.rs
@@ -17,18 +17,18 @@ use incoming::IncomingAddressesImpl;
 use outgoing::OutgoingAddressesImpl;
 use rusqlite::Transaction;
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use sync_guid::Guid;
 use types::Timestamp;
 
 // The engine.
-pub fn create_engine(db: Arc<Mutex<crate::db::AutofillDb>>) -> ConfigSyncEngine<InternalAddress> {
+pub fn create_engine(store: Arc<crate::StoreImpl>) -> ConfigSyncEngine<InternalAddress> {
     ConfigSyncEngine::new(
         EngineConfig {
             namespace: "addresses".to_string(),
             collection: "addresses",
         },
-        db,
+        store,
         Box::new(AddressesEngineStorageImpl {}),
     )
 }

--- a/components/autofill/src/sync/credit_card/mod.rs
+++ b/components/autofill/src/sync/credit_card/mod.rs
@@ -19,20 +19,18 @@ use incoming::IncomingCreditCardsImpl;
 use outgoing::OutgoingCreditCardsImpl;
 use rusqlite::Transaction;
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use sync_guid::Guid;
 use types::Timestamp;
 
 // The engine.
-pub fn create_engine(
-    db: Arc<Mutex<crate::db::AutofillDb>>,
-) -> ConfigSyncEngine<InternalCreditCard> {
+pub fn create_engine(store: Arc<crate::StoreImpl>) -> ConfigSyncEngine<InternalCreditCard> {
     ConfigSyncEngine::new(
         EngineConfig {
             namespace: "credit_cards".to_string(),
             collection: "creditcards",
         },
-        db,
+        store,
         Box::new(CreditCardsEngineStorageImpl {}),
     )
 }

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 exclude = ["/android", "/ios"]
 
 [dependencies]
+autofill = { path = "../autofill" }
 sync15 = { path = "../sync15" }
 places = { path = "../places" }
 logins = { path = "../logins" }

--- a/components/sync_manager/src/error.rs
+++ b/components/sync_manager/src/error.rs
@@ -29,6 +29,10 @@ pub enum ErrorKind {
     LoginsError(#[from] logins::Error),
     #[error("Places error: {0}")]
     PlacesError(#[from] places::Error),
+    // We should probably upgrade this crate to anyhow, which would mean this
+    // gets replaced with AutofillError or similar.
+    #[error("External error: {0}")]
+    AnyhowError(#[from] anyhow::Error),
 }
 
 error_support::define_error! {
@@ -41,5 +45,6 @@ error_support::define_error! {
         (JsonError, serde_json::Error),
         (LoginsError, logins::Error),
         (PlacesError, places::Error),
+        (AnyhowError, anyhow::Error),
     }
 }


### PR DESCRIPTION
This patch works-around the lack of the functionality described
in https://github.com/mozilla/uniffi-rs/issues/417.

In short, it splits the store into 2 parts - the
uniffi-exposed "wrapper" and the actual implementation.
This "wrapper" wraps the implementation in an `Arc<Mutex>>`, so
that it can hand a clone of this `Arc<>` to the sync manager, so
that it can construct sync engines, causing us to end up with
multiple references to the `Store` being alive but without any
being actual `&` references.

(Thinking some more about it, I probably could have done this
slightly differently, and just wrapped the DB itself, but I
ended up somewhat automatically taking this route because this
is what the shape would naturally be if uniffi helped us.
I think passing the entire store around does make more sense
in the longer term anyway (eg, there might be other state beyond
the DB) and is what the other components do, but it does make
this patch bigger than it would otherwise be)

It also makes some changes in the sync manager, really just
enough to convince me that it will work - there will be plenty
of other places that will need similar treatment. I chose to
use the `SyncEngine` trait exclusively there, which I think makes
sense because ideally we'd use that trait *everywhere* to avoid the
Sync Manager knowing about the implementation (but it would still
require it to link to all those crates, so that's just a
code-simplicity issue)
