### PR TITLE
Automagically add rustup mobile targets via toolchain config.

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,11 @@
-1.50.0
+[toolchain]
+channel = "1.50"
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android", 
+    "aarch64-apple-ios",
+    "x86_64-apple-ios"
+]
+profile = "default"


### PR DESCRIPTION
Today I learned that the `rust-toolchain` file actually has a whole
toml syntax where you can express what rustup config is required to
build the stuff in the containing directory. I propose we use this
to help ensure that the mobile target are installed by default.

Our `verify-X-environment.sh` scripts will install these targets for
you, but you have to remember to run them and you have to re-add them
if you switch to a different Rust version. By putting it in the
toolchain config, we can have cargo just do the Right Thing by default.

The downside of this is that all users of this repo will download and
install all six of the mobile toolchains, even if they never intend
to build for some subset of those platforms. IMHO this worth the cost
to pay for a less fragile local development experience.

It's not clear to me if this will also result in additional unnecessary
downloads performed in CI, but again, I don't feel too bad about
that.