### PR TITLE
Update to Glean v36.0.0

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,9 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v73.0.2...main)
+
+## General
+
+### What's Changed
+
+- The bundled version of Glean has been updated to v36.0.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "glean-core"
-version = "34.0.0"
+version = "36.0.0"
 dependencies = [
  "bincode",
  "chrono",
@@ -1198,11 +1198,12 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+ "zeitstempel",
 ]
 
 [[package]]
 name = "glean-ffi"
-version = "34.0.0"
+version = "36.0.0"
 dependencies = [
  "android_logger",
  "env_logger",
@@ -3986,4 +3987,15 @@ checksum = "5e917a3f24142e9ff8be2414e36c649d47d6cc2ba81f16201cdef96e533e02de"
 dependencies = [
  "libc",
  "log 0.4.11",
+]
+
+[[package]]
+name = "zeitstempel"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeea3eb6a30ed24e374f59368d3917c5180a845fdd4ed6f1b2278811a9e826f8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "once_cell",
 ]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -60,7 +60,8 @@ The following text applies to code linked from these dependencies:
 [uniffi](https://github.com/mozilla/uniffi-rs),
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
-[uniffi_macros](https://github.com/mozilla/uniffi-rs)
+[uniffi_macros](https://github.com/mozilla/uniffi-rs),
+[zeitstempel](https://github.com/badboy/zeitstempel)
 
 ```
 Mozilla Public License Version 2.0

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -52,7 +52,8 @@ The following text applies to code linked from these dependencies:
 [uniffi](https://github.com/mozilla/uniffi-rs),
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
-[uniffi_macros](https://github.com/mozilla/uniffi-rs)
+[uniffi_macros](https://github.com/mozilla/uniffi-rs),
+[zeitstempel](https://github.com/badboy/zeitstempel)
 
 ```
 Mozilla Public License Version 2.0

--- a/megazords/ios/README.md
+++ b/megazords/ios/README.md
@@ -25,16 +25,20 @@ To update Glean:
     ```
 3. Update `Cargo.lock` to reflect any upstream changes:
     ```
-    cargo update
+    cargo update -p glean-ffi
     ```
-4. Commit the changes:
+4. Update the dependency summary:
+    ```
+    tools/regenerate_dependency_summaries.sh
+    ```
+5. Commit the changes:
 
     ```
     git add components/external/glean
     git add Cargo.lock
     git commit
     ```
-5. Run an Xcode build to ensure everything compiles.
+6. Run an Xcode build to ensure everything compiles.
 
 [Glean]: https://github.com/mozilla/glean
 [git submodule]: https://git-scm.com/docs/git-submodule


### PR DESCRIPTION
This brings a breaking change (but it's a bugfix) for iOS consumers:

Event timestamps are now correctly recorded in milliseconds.
Since the first release event timestamps were erroneously recorded with nanosecond precision.
This is now fixed and event timestamps are in milliseconds. This is equivalent to how it works in all other language bindings.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
