### PR TITLE
Tell mergify not to dismiss reviews on trusted collaborator PRs.

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,6 +3,7 @@ pull_request_rules:
     conditions:
       - base=main
       - author!=@mozilla/application-services
+      - author!=@mozilla/application-services-collaborators
     actions:
       dismiss_reviews:
         message: The pull request has been modified, dismissing previous reviews.


### PR DESCRIPTION
With luck, this will mean that trusted collaborators like @badboy don't need to re-request review after trivial changes to their PRs.

(I'm not entirely sure that this syntax will work, but we can try it out. It doesn't seem to give me any validation errors in mergify's online verification tool).