### PR TITLE
Update Nimbus to v0.10.0

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -9,3 +9,4 @@
 ### What's Changed
 
 - The bundled version of Glean has been updated to v36.0.0.
+- The bundled version of Nimbus has been updated to v0.10.0.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-sdk"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "hex",


### PR DESCRIPTION
This updates Nimbus to v0.10.0, including breaking changes to the `AppContext` object which add `app_name` and `channel` as non-optional fields.