### PR TITLE
Revert "Automagically add rustup mobile targets via toolchain config" [ci full]

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,7 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v74.0.0...main)
+
+## General
+
+- Revert a Rust toolchain config change that turned out to cause build issues in our release pipeline. 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,11 +1,1 @@
-[toolchain]
-channel = "1.50"
-targets = [
-    "aarch64-linux-android",
-    "armv7-linux-androideabi",
-    "i686-linux-android",
-    "x86_64-linux-android", 
-    "aarch64-apple-ios",
-    "x86_64-apple-ios"
-]
-profile = "default"
+1.50.0


### PR DESCRIPTION
This reverts commit 02bf1a0b7c951896e715a5b00d43d5af80bfe479.

The change from #3936 seems to be causing some issues with building releases, let's roll it back until we can debug properly.
