### PR TITLE
Automagically add rustup mobile targets via toolchain config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,6 @@ version: 2.1
 
 # ⚠️ If you add, rename or delete a job here, please also update .mergify.yml! ⚠️
 
-parameters:
-  # See also ../taskcluster/scripts/toolchain/rustup-setup.sh
-  stable-rust-version:
-    type: string
-    default: 1.50.0
-
 commands:
   full-checkout:
     steps:
@@ -77,8 +71,8 @@ commands:
           name: Install Rust
           command: |
             RUSTUP_PLATFORM=x86_64-apple-darwin
-            RUSTUP_VERSION=1.18.3
-            RUSTUP_SHA256=16734a9a2d87a3054bd4eea962642687e50a34b6e73e17df6f3361c2c534dc30
+            RUSTUP_VERSION=1.23.1
+            RUSTUP_SHA256=39101feb178a7e3e4443b09b36338e794a9e00385e5f44a2f7789aefb91354a9
             curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"
             echo "${RUSTUP_SHA256} *rustup-init" | shasum -a 256 -c -
             chmod +x rustup-init
@@ -86,21 +80,12 @@ commands:
             rm rustup-init
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $BASH_ENV
   setup-rust-toolchain:
-    parameters:
-      rust-version:
-        type: string
-        default: << pipeline.parameters.stable-rust-version >>
     steps:
       - run:
           name: Set up Rust toolchain
           command: |
             rustup update
-            rustup install <<parameters.rust-version>>
-            rustup default <<parameters.rust-version>>
             rustc --version
-      - run:
-          name: Install UniFFI
-          command: cargo install --version 0.7.1 uniffi_bindgen
   build-libs:
     parameters:
       platform:
@@ -159,15 +144,10 @@ commands:
           paths:
             - Carthage
   test-setup:
-    parameters:
-      rust-version:
-        type: string
-        default: << pipeline.parameters.stable-rust-version >>
     steps:
       - full-checkout
       - build-desktop-libs
-      - setup-rust-toolchain:
-          rust-version: <<parameters.rust-version>>
+      - setup-rust-toolchain
       - setup-sccache
       # clipboard crate depends on some x11 libs.
       - run: sudo apt-get install libxcb-shape0-dev libxcb-xfixes0-dev
@@ -183,22 +163,19 @@ commands:
     parameters:
       rust-version:
         type: string
-        default: << pipeline.parameters.stable-rust-version >>
+        default: ""
     steps:
-      - test-setup:
-          rust-version: <<parameters.rust-version>>
+      - test-setup
       # Test with 1. only default features on, 2. all features on, 3. no features on.
       # This is not perfect (really we want the cartesian product), but is good enough in practice.
       - run:
           name: Test (default features, no features, and all features)
-          command: bash automation/all_rust_tests.sh --verbose
+          command: RUSTUP_TOOLCHAIN="<<parameters.rust-version>>" automation/all_rust_tests.sh --verbose
   dependency-checks:
     steps:
       - run:
           name: Check for security vulnerabilities in dependencies
           command: |
-            rustup install nightly
-            rustup default nightly
             cargo install cargo-audit
             # Explanation for ignored issues:
             #  * RUSTSEC-2021-0019:  Soundness issues in `xcb`, a clipboard library we only use for examples.
@@ -208,8 +185,6 @@ commands:
           name: Check for any unrecorded changes in our dependency trees
           command: |
             pip3 install --require-hashes -r ./tools/requirements.txt
-            rustup install nightly
-            rustup default nightly
             cargo metadata --locked > /dev/null
             python3 ./tools/dependency_summary.py --check ./DEPENDENCIES.md
             python3 ./tools/dependency_summary.py --all-ios-targets --package megazord_ios --check megazords/ios/DEPENDENCIES.md
@@ -261,7 +236,6 @@ jobs:
     steps:
       - full-checkout
       - setup-rust-toolchain
-      - run: rustup component add rustfmt
       - run: rustfmt --version
       - run: cargo fmt --all -- --check
   Lint Rust with clippy:
@@ -270,7 +244,6 @@ jobs:
     steps:
       - test-setup
       - restore-sccache-cache
-      - run: rustup component add clippy
       - run: cargo clippy --version
       - run: bash automation/all_clippy_checks.sh
       - save-sccache-cache
@@ -279,11 +252,11 @@ jobs:
       - image: circleci/rust:latest
     resource_class: large
     steps:
-      # Need to use nightly for this.
-      - test-setup:
-          rust-version: "nightly"
+      - test-setup
       - install-grcov
-      - run: bash ./automation/emit_coverage_info.sh
+      # Test coverage support in Rust has been evolving rapidly, use nightly
+      # in the hope of getting the best support/features on that front.
+      - run: RUSTUP_TOOLCHAIN="nightly" bash ./automation/emit_coverage_info.sh
       - run:
           name: Compile coverage
           command: grcov ./target/debug/ -s . -t lcov --llvm --ignore-not-existing --ignore "target/*" --ignore "/*" -o lcov.info
@@ -366,7 +339,6 @@ jobs:
       - run:
           name: Set up the build environment
           command: |
-            rustup target add aarch64-apple-ios x86_64-apple-ios
             brew install swift-protobuf
       - carthage-bootstrap
       - run:

--- a/automation/all_rust_tests.sh
+++ b/automation/all_rust_tests.sh
@@ -19,6 +19,9 @@ fi
 
 EXTRA_ARGS=( "$@" )
 
+echo "Testing with rustc version:"
+rustc --version
+
 cargo test --all ${EXTRA_ARGS[@]:+"${EXTRA_ARGS[@]}"}
 
 # Apparently --no-default-features doesn't work in the root, even with -p to select a specific package.

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,13 @@
-1.50.0
+# See https://rust-lang.github.io/rustup/overrides.html for details on how this file works
+# and how you can override the choices made herein.
+[toolchain]
+channel = "1.50.0"
+targets = [
+    "aarch64-linux-android",
+    "armv7-linux-androideabi",
+    "i686-linux-android",
+    "x86_64-linux-android", 
+    "aarch64-apple-ios",
+    "x86_64-apple-ios"
+]
+components = ["clippy", "rustfmt"]

--- a/taskcluster/scripts/toolchain/cross-compile-setup.sh
+++ b/taskcluster/scripts/toolchain/cross-compile-setup.sh
@@ -25,7 +25,11 @@ tooltool.py \
   --manifest="/builds/worker/checkouts/src/libs/macos-cc-tools.manifest" \
   fetch
 
+popd || exit
+
+# It's important that we execute rustup in the checkout directory, so that it can see
+# any `rust-toolchain` override file that might be present.
+rustup --version
 rustup target add x86_64-apple-darwin
 rustup target add x86_64-pc-windows-gnu
 
-popd || exit

--- a/taskcluster/scripts/toolchain/rustup-setup.sh
+++ b/taskcluster/scripts/toolchain/rustup-setup.sh
@@ -15,25 +15,18 @@ export SCCACHE_IDLE_TIMEOUT='1200'
 export SCCACHE_CACHE_SIZE='40G'
 export SCCACHE_ERROR_LOG='/builds/worker/sccache.log'
 export RUST_LOG='sccache=info'
-# We are pinned at this rust stable version (see also ../.circleci/config.yml)
-export RUST_STABLE_VERSION='1.50.0'
 
 # Rust
 set -eux; \
     RUSTUP_PLATFORM='x86_64-unknown-linux-gnu'; \
-    RUSTUP_VERSION='1.18.3'; \
-    RUSTUP_SHA256='a46fe67199b7bcbbde2dcbc23ae08db6f29883e260e23899a88b9073effc9076'; \
+    RUSTUP_VERSION='1.23.1'; \
+    RUSTUP_SHA256='ed7773edaf1d289656bdec2aacad12413b38ad0193fff54b2231f5140a4b07c5'; \
     curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \
     ./rustup-init -y --no-modify-path --default-toolchain none; \
     rm rustup-init
 export PATH=$HOME/.cargo/bin:$PATH
-
-
-rustup toolchain install "$RUST_STABLE_VERSION"
-rustup default "$RUST_STABLE_VERSION"
-rustup target add x86_64-linux-android i686-linux-android armv7-linux-androideabi aarch64-linux-android
 
 # This is not the right place for it, but also it's as good a place as any.
 # Make sure git submodules are initialized.


### PR DESCRIPTION
We originally landed this change in #3936 but had to revert it due to release build issues. Let's bring it back, but after making sure that everything builds fine end-to-end. This PR is marked `[ci full]` for said debugging purposes.