### PR TITLE
Update docs for local development on firefox-ios. [ci skip]

### DIFF
--- a/docs/howtos/locally-published-components-in-ios.md
+++ b/docs/howtos/locally-published-components-in-ios.md
@@ -6,13 +6,16 @@ consumer project. Here are our current best-practices for approaching this on iO
 1. Make a local build of the application-services framework using `./build-carthage.sh`.
 1. Checkout and `carthage bootstrap` the consuming app (for example using [these instructions with Firefox for
    iOS](https://github.com/mozilla-mobile/firefox-ios#building-the-code)).
-1. In the consuming app, replace the application-services framework with a symlink to your local build. For example:
+1. In the consuming app, replace the application-services framework with a copy of your local build. For example:
 
    ```
    rm -rf Carthage/Build/iOS/MozillaAppServices.framework
-   ln -s path/to/application-services/Carthage/Build/iOS/MozillaAppServices.framework Carthage/Build/iOS
+   rsync -ad path/to/application-services/Carthage/Build/iOS/MozillaAppServices.framework/ Carthage/Build/iOS/MozillaAppServices.framework/
    ```
 1. Open the consuming app project in XCode and build it from there.
 
-After making changes to application-services code, re-run `./build-carthage.sh` and then rebuild
-the consuming app. You may need to clear the XCode cache using Cmd+k if the app doesn't seem to pick up your changes.
+After making changes to application-services code, you will need to re-run these steps in order to
+copy the latest changes over into the consuming app.
+
+Firefox for iOS also has a helper script that automates these steps:
+[`appservices_local_dev.sh`](https://github.com/mozilla-mobile/firefox-ios/blob/main/appservices_local_dev.sh).


### PR DESCRIPTION
Due to some recent changes in how firefox-ios consumes our artifacts,
it is no longer possible to use a symlink to your local build, you need
to actually copy the files.

(I guess technically you could use a hard link? Copying seems easier
to keep straight in your head).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
