### PR TITLE
autofill: rename a couple of functions and add some comments

### DIFF
--- a/components/autofill/src/db/credit_cards.rs
+++ b/components/autofill/src/db/credit_cards.rs
@@ -268,8 +268,11 @@ pub(crate) mod tests {
         )
     }
 
-    pub(crate) fn insert_mirror_record(conn: &Connection, payload: sync15::Payload) {
-        // This should probably be in the sync module, but it's used here.
+    pub(crate) fn test_insert_mirror_record(conn: &Connection, payload: sync15::Payload) {
+        // This test function is a bit suspect, because credit-cards always
+        // store encrypted records, which this ignores entirely, and stores the
+        // raw payload with a cleartext cc_number.
+        // It's OK for all current test consumers, but it's a bit of a smell...
         let guid = payload.id.clone();
         let payload_string = payload.into_json_string();
         conn.execute_named(
@@ -537,7 +540,7 @@ pub(crate) mod tests {
         let cc2_guid = saved_credit_card2.guid.clone();
         let payload = saved_credit_card2.into_payload(&encdec).expect("is json");
 
-        insert_mirror_record(&db, payload);
+        test_insert_mirror_record(&db, payload);
 
         let delete_result2 = delete_credit_card(&db, &cc2_guid);
         assert!(delete_result2.is_ok());

--- a/components/autofill/src/sync/address/outgoing.rs
+++ b/components/autofill/src/sync/address/outgoing.rs
@@ -76,12 +76,12 @@ impl ProcessOutgoingRecordImpl for OutgoingAddressesImpl {
         Ok(outgoing)
     }
 
-    fn push_synced_items(
+    fn finish_synced_items(
         &self,
         tx: &Transaction<'_>,
         records_synced: Vec<SyncGuid>,
     ) -> anyhow::Result<()> {
-        common_push_synced_items(
+        common_finish_synced_items(
             &tx,
             DATA_TABLE_NAME,
             MIRROR_TABLE_NAME,
@@ -103,7 +103,7 @@ mod tests {
 
     const COLLECTION_NAME: &str = "addresses";
 
-    fn insert_mirror_record(conn: &Connection, address: InternalAddress) {
+    fn test_insert_mirror_record(conn: &Connection, address: InternalAddress) {
         // This should probably be in the sync module, but it's used here.
         let guid = address.guid.clone();
         let payload = address.into_payload().expect("is json").into_json_string();
@@ -221,7 +221,7 @@ mod tests {
         let initial_change_counter_val = 2;
         test_record.metadata.sync_change_counter = initial_change_counter_val;
         assert!(add_internal_address(&tx, &test_record).is_ok());
-        insert_mirror_record(&tx, test_record.clone());
+        test_insert_mirror_record(&tx, test_record.clone());
         exists_with_counter_value_in_table(
             &tx,
             DATA_TABLE_NAME,
@@ -249,7 +249,7 @@ mod tests {
         // create synced record with no changes (sync_change_counter = 0)
         let test_record = test_record('C');
         assert!(add_internal_address(&tx, &test_record).is_ok());
-        insert_mirror_record(&tx, test_record.clone());
+        test_insert_mirror_record(&tx, test_record.clone());
 
         do_test_outgoing_synced_with_no_change(
             &tx,

--- a/components/autofill/src/sync/credit_card/outgoing.rs
+++ b/components/autofill/src/sync/credit_card/outgoing.rs
@@ -78,12 +78,12 @@ impl ProcessOutgoingRecordImpl for OutgoingCreditCardsImpl {
         Ok(outgoing)
     }
 
-    fn push_synced_items(
+    fn finish_synced_items(
         &self,
         tx: &Transaction<'_>,
         records_synced: Vec<SyncGuid>,
     ) -> anyhow::Result<()> {
-        common_push_synced_items(
+        common_finish_synced_items(
             &tx,
             DATA_TABLE_NAME,
             MIRROR_TABLE_NAME,
@@ -98,7 +98,7 @@ impl ProcessOutgoingRecordImpl for OutgoingCreditCardsImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::credit_cards::{add_internal_credit_card, tests::insert_mirror_record};
+    use crate::db::credit_cards::{add_internal_credit_card, tests::test_insert_mirror_record};
     use crate::sync::{common::tests::*, test::new_syncable_mem_db};
     use serde_json::{json, Map, Value};
     use types::Timestamp;
@@ -214,7 +214,7 @@ mod tests {
         let initial_change_counter_val = 2;
         test_record.metadata.sync_change_counter = initial_change_counter_val;
         assert!(add_internal_credit_card(&tx, &test_record).is_ok());
-        insert_mirror_record(
+        test_insert_mirror_record(
             &tx,
             test_record
                 .clone()
@@ -250,7 +250,7 @@ mod tests {
         // create synced record with no changes (sync_change_counter = 0)
         let test_record = test_record('C', &co.encdec);
         assert!(add_internal_credit_card(&tx, &test_record).is_ok());
-        insert_mirror_record(
+        test_insert_mirror_record(
             &tx,
             test_record
                 .clone()

--- a/components/autofill/src/sync/engine.rs
+++ b/components/autofill/src/sync/engine.rs
@@ -161,7 +161,7 @@ impl<T: SyncRecord + std::fmt::Debug> SyncEngine for ConfigSyncEngine<T> {
         let outgoing_impl = self
             .storage_impl
             .get_outgoing_impl(&self.local_enc_key.borrow())?;
-        outgoing_impl.push_synced_items(&tx, records_synced)?;
+        outgoing_impl.finish_synced_items(&tx, records_synced)?;
         tx.commit()?;
         Ok(())
     }
@@ -229,7 +229,9 @@ impl<T: SyncRecord + std::fmt::Debug> SyncEngine for ConfigSyncEngine<T> {
 mod tests {
     use super::*;
     use crate::db::credit_cards::add_internal_credit_card;
-    use crate::db::credit_cards::tests::{get_all, insert_mirror_record, insert_tombstone_record};
+    use crate::db::credit_cards::tests::{
+        get_all, insert_tombstone_record, test_insert_mirror_record,
+    };
     use crate::db::models::credit_card::InternalCreditCard;
     use crate::db::{schema::create_empty_sync_temp_tables, test::new_mem_db};
     use crate::encryption::EncryptorDecryptor;
@@ -326,7 +328,7 @@ mod tests {
             ..Default::default()
         };
         add_internal_credit_card(&tx, &cc)?;
-        insert_mirror_record(&tx, cc.clone().into_payload(&encdec).expect("is json"));
+        test_insert_mirror_record(&tx, cc.clone().into_payload(&encdec).expect("is json"));
         insert_tombstone_record(&tx, Guid::random().to_string())?;
         tx.commit()?;
 
@@ -379,7 +381,7 @@ mod tests {
             // re-populating the tables
             let tx = conn.unchecked_transaction()?;
             add_internal_credit_card(&tx, &cc)?;
-            insert_mirror_record(&tx, cc.into_payload(&encdec).expect("is json"));
+            test_insert_mirror_record(&tx, cc.into_payload(&encdec).expect("is json"));
             insert_tombstone_record(&tx, Guid::random().to_string())?;
             tx.commit()?;
         }

--- a/components/autofill/src/sync/mod.rs
+++ b/components/autofill/src/sync/mod.rs
@@ -98,7 +98,7 @@ pub trait ProcessOutgoingRecordImpl {
         timestamp: ServerTimestamp,
     ) -> anyhow::Result<OutgoingChangeset>;
 
-    fn push_synced_items(
+    fn finish_synced_items(
         &self,
         tx: &Transaction<'_>,
         records_synced: Vec<Guid>,


### PR DESCRIPTION
* insert_mirror_record kept tricking me into thinking it was the "correct"
  way of adding mirror records, but it's actually test-only

* push_synced_items confused me a little because I kept
  thinking it was pushing them to the server, but really
  it's just pushing them to the mirror.

* A few other misc comments.
