### PR TITLE
Exclude uniffi-generated files from swiftlint.

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,7 @@ included: # paths to include during linting. `--path` is ignored if present.
   - components/fxa-client/ios
 excluded:
   - Carthage
+  - "**/*/ios/Generated"
   - "megazords/ios/MozillaAppServicesTests"
 
 disabled_rules:


### PR DESCRIPTION
Otherwise `./automation/all_tests.sh` might start failing with swiftlint errors after you've done an XCode build.