### PR TITLE
Specify version for ece crate when it's a dev dependency.

### DIFF
--- a/components/support/rc_crypto/Cargo.toml
+++ b/components/support/rc_crypto/Cargo.toml
@@ -20,6 +20,7 @@ ece = { version = "2.0", default-features = false, features = ["serializable-key
 hex = "0.4"
 
 [dev-dependencies.ece]
+version = "2.0"
 default-features = false
 features = ["serializable-keys", "backend-test-helper"]
 


### PR DESCRIPTION
Otherwise cargo prints a scary warning:

"""
dependency (ece) specified without providing a local path, Git
repository, or version to use. This will be considered an error
in future versions
"""
