### PR TITLE
Allow the sync manager to accept local encryption keys to pass to engines

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -17,9 +17,9 @@
 
 - Addition of the `Nimbus` helper object for interacting with the Nimbus SDK; this introduces some ergonomics around threading and error reporting.
 
-## Autofill
-
 ### ⚠️ Breaking changes ⚠️
+
+## Autofill
 
 * The credit-cards API has changed to support card numbers being encrypted.
   The card dictionary now has `cc_number_enc`, which is encrypted, and
@@ -30,5 +30,13 @@
 
   The exception is when syncing, where the key is needed, so support has
   been added to allow the engine to know the key during a sync.
+
+## Sync Manager
+
+* The SyncParams struct has a new map named `local_encryption_keys` (or
+  `localEncryptionKeys` in Kotlin) to support credit-card encryption. Due to
+  limitations in the Kotlin support for protobufs, this new map must be
+  specified - an emptyMap() is fine (although an entry will need to be
+  specified once credit-card syncing is enabled.)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v74.0.1...main)

--- a/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncParams.kt
+++ b/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncParams.kt
@@ -99,6 +99,25 @@ data class SyncParams(
     val enabledChanges: Map<String, Boolean>,
 
     /**
+     * A map of local encryption keys to use for engines. Only some engines
+     * use local encryption, so it's expected that many engines will not have
+     * entries. If an engine that requires a key does not find one, it will
+     * fail to sync.
+     *
+     * Note that this is for local encryption in the local databases and is not
+     * at all related to Sync encryption. The keys are needed to sync because
+     * sync will need to decrypt records from the local store before
+     * re-encrypting them using sync encryption to store on the server, and
+     * vice-versa, records read from the server will be decrypted using sync
+     * encryption and then encrypted before being stored locally.
+     *
+     * The keys of the map are the engine names as used by all other maps
+     * and lists here. The value is a string "key" which will have been
+     * previously obtained from the engine directly.
+     */
+    val localEncryptionKeys: Map<String, String>,
+
+    /**
      * The information used to authenticate with the sync server.
      */
     val authInfo: SyncAuthInfo,
@@ -135,6 +154,7 @@ data class SyncParams(
         }
 
         builder.putAllEnginesToChangeState(this.enabledChanges)
+        builder.putAllLocalEncryptionKeys(this.localEncryptionKeys)
 
         builder.acctAccessToken = this.authInfo.fxaAccessToken
         builder.acctSyncKey = this.authInfo.syncKey

--- a/components/sync_manager/src/manager.rs
+++ b/components/sync_manager/src/manager.rs
@@ -339,6 +339,13 @@ impl SyncManager {
             Some(&params.engines_to_change_state)
         };
 
+        // tell engines about the local encryption key.
+        for engine in &engine_refs {
+            if let Some(key) = params.local_encryption_keys.get(&*engine.collection_name()) {
+                engine.set_local_encryption_key(key)?
+            }
+        }
+
         let settings = Settings {
             fxa_device_id: params.fxa_device_id,
             device_name: params.device_name,

--- a/components/sync_manager/src/manager_msg_types.proto
+++ b/components/sync_manager/src/manager_msg_types.proto
@@ -45,6 +45,8 @@ message SyncParams {
     required string fxa_device_id = 10;
     required string device_name = 11;
     required DeviceType device_type = 12;
+
+    map<string, string> local_encryption_keys = 13;
 }
 
 enum ServiceStatus {

--- a/components/sync_manager/src/mozilla.appservices.syncmanager.protobuf.rs
+++ b/components/sync_manager/src/mozilla.appservices.syncmanager.protobuf.rs
@@ -26,6 +26,8 @@ pub struct SyncParams {
     pub device_name: std::string::String,
     #[prost(enumeration="DeviceType", required, tag="12")]
     pub device_type: i32,
+    #[prost(map="string, string", tag="13")]
+    pub local_encryption_keys: ::std::collections::HashMap<std::string::String, std::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SyncResult {


### PR DESCRIPTION
I've tested this change on Fenix and it seems to work OK.

This is a breaking change because I can't work out how to treat the map as optional - the `optional` keyword doesn't work:

> Field labels (required/optional/repeated) are not allowed on map fields.

And [this reference](https://kotlin.github.io/kotlinx.serialization/kotlinx-serialization-protobuf/kotlinx-serialization-protobuf/kotlinx.serialization.protobuf/index.html) says:

> Lists are represented as repeated fields. Because format spec says that if the list is empty, there are no elements in the stream with such tag, you must explicitly mark any field of list type with default = emptyList(). Same for maps. 

I'll reference an a-c PR to add support for unbreaking this breaking change.

cc @rfk just in-case he has a secret protobuf dossier that might make this slightly less painful.