### PR TITLE
Add get_available_experiments for qa tooling

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,10 @@
 
 # Unreleased Changes
 
+## Nimbus SDK
+
+### What's new
+
+ - add a `get_available_experiments()` method to enable QA tooling. This should not be used for user-facing user-interfaces.
+
 [Full Changelog](https://github.com/mozilla/application-services/compare/v75.0.1...main)

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -191,6 +191,12 @@ extension Nimbus: NimbusUserConfiguration {
         } ?? []
     }
 
+    public func getAvailableExperiments() -> [AvailableExperiment] {
+        return catchAll {
+            try nimbusClient.getAvailableExperiments()
+        } ?? []
+    }
+
     public func getExperimentBranches(_ experimentId: String) -> [Branch]? {
         return catchAll {
             try nimbusClient.getExperimentBranches(experimentSlug: experimentId)
@@ -260,6 +266,10 @@ public class NimbusDisabled: NimbusApi {
 
 public extension NimbusDisabled {
     func getActiveExperiments() -> [EnrolledExperiment] {
+        return []
+    }
+
+    func getAvailableExperiments() -> [AvailableExperiment] {
         return []
     }
 

--- a/components/nimbus/ios/Nimbus/NimbusApi.swift
+++ b/components/nimbus/ios/Nimbus/NimbusApi.swift
@@ -13,7 +13,7 @@ import Foundation
 /// Developers building UI tools for the user or QA to modify experiment enrollment will mostly use `NimbusUserConfiguration` methods.
 /// Application developers integrating `Nimbus` into their app should use the methods in `NimbusStartup`.
 ///
-public protocol NimbusApi: NimbusStartup, NimbusFeatureConfiguration, NimbusUserConfiguration {}
+public protocol NimbusApi: class, NimbusStartup, NimbusFeatureConfiguration, NimbusUserConfiguration {}
 
 public protocol NimbusFeatureConfiguration {
     /// Get the currently enrolled branch for the given experiment
@@ -112,6 +112,13 @@ public protocol NimbusUserConfiguration {
     /// - Parameter experimentId the specifies the experiment.
     /// - Returns a list of one more branches for the given experiment, or `nil` if no such experiment exists.
     func getExperimentBranches(_ experimentId: String) -> [Branch]?
+
+    /// Get the list of currently available experiments for the `appName` as specified in the `AppContext`.
+    ///
+    /// - Returns  A list of `AvailableExperiment`s
+    ///
+    func getAvailableExperiments() -> [AvailableExperiment]
+
 }
 
 /// Notifications emitted by the `NotificationCenter`.

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -63,7 +63,7 @@ extension Nimbus {
         return Nimbus(nimbusClient: nimbusClient, errorReporter: errorReporter)
     }
 
-    internal static func buildExperimentContext(_ appSettings: NimbusAppSettings,
+    public static func buildExperimentContext(_ appSettings: NimbusAppSettings,
                                                 bundle: Bundle = Bundle.main,
                                                 device: UIDevice = .current) -> AppContext
     {

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -156,7 +156,7 @@ pub fn is_experiment_available(
         }
         None => log::debug!("Experiment missing channel, skipping it as a targeting parameter"),
     }
-    return true;
+    true
 }
 
 /// Chooses a branch randomly from a set of branches

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -47,54 +47,13 @@ pub fn evaluate_enrollment(
     app_context: &AppContext,
     exp: &Experiment,
 ) -> Result<ExperimentEnrollment> {
-    // Verify the app_name matches the application being targeted
-    // by the experiment.
-    match &exp.app_name {
-        Some(app_name) => {
-            if !app_name.eq(&app_context.app_name) {
-                return Ok(ExperimentEnrollment {
-                    slug: exp.slug.clone(),
-                    status: EnrollmentStatus::NotEnrolled {
-                        reason: NotEnrolledReason::NotTargeted,
-                    },
-                });
-            }
-        }
-        None => log::debug!("Experiment missing app_name, skipping it as a targeting parameter"),
-    }
-    // Verify the app_id matches the application being targeted
-    // by the experiment.
-    match &exp.app_id {
-        Some(app_id) => {
-            if !app_id.eq(&app_context.app_id) {
-                return Ok(ExperimentEnrollment {
-                    slug: exp.slug.clone(),
-                    status: EnrollmentStatus::NotEnrolled {
-                        reason: NotEnrolledReason::NotTargeted,
-                    },
-                });
-            }
-        }
-        None => log::debug!("Experiment missing app_id, skipping it as a targeting parameter"),
-    }
-    // Verify the channel matches the application being targeted
-    // by the experiment.  Note, we are intentionally comparing in a case-insensitive way.
-    // See https://jira.mozilla.com/browse/SDK-246 for more info.
-    match &exp.channel {
-        Some(channel) => {
-            if !channel
-                .to_lowercase()
-                .eq(&app_context.channel.to_lowercase())
-            {
-                return Ok(ExperimentEnrollment {
-                    slug: exp.slug.clone(),
-                    status: EnrollmentStatus::NotEnrolled {
-                        reason: NotEnrolledReason::NotTargeted,
-                    },
-                });
-            }
-        }
-        None => log::debug!("Experiment missing channel, skipping it as a targeting parameter"),
+    if !is_experiment_available(app_context, exp, true) {
+        return Ok(ExperimentEnrollment {
+            slug: exp.slug.clone(),
+            status: EnrollmentStatus::NotEnrolled {
+                reason: NotEnrolledReason::NotTargeted,
+            },
+        });
     }
 
     // Get targeting out of the way - "if let chains" are experimental,
@@ -146,6 +105,58 @@ pub fn evaluate_enrollment(
             }
         },
     })
+}
+
+/// Check if an experiment is available for this app defined by this `AppContext`.
+///
+/// `is_release` supports two modes:
+/// if `true`, available means available for enrollment: i.e. does the `app_name`, `app_id` and `channel` match.
+/// if `false`, available means available for testing: i.e. does only the `app_name` match.
+pub fn is_experiment_available(
+    app_context: &AppContext,
+    exp: &Experiment,
+    is_release: bool,
+) -> bool {
+    // Verify the app_name matches the application being targeted
+    // by the experiment.
+    match &exp.app_name {
+        Some(app_name) => {
+            if !app_name.eq(&app_context.app_name) {
+                return false;
+            }
+        }
+        None => log::debug!("Experiment missing app_name, skipping it as a targeting parameter"),
+    }
+
+    if !is_release {
+        return true;
+    }
+
+    // Verify the app_id matches the application being targeted
+    // by the experiment.
+    match &exp.app_id {
+        Some(app_id) => {
+            if !app_id.eq(&app_context.app_id) {
+                return false;
+            }
+        }
+        None => log::debug!("Experiment missing app_id, skipping it as a targeting parameter"),
+    }
+    // Verify the channel matches the application being targeted
+    // by the experiment.  Note, we are intentionally comparing in a case-insensitive way.
+    // See https://jira.mozilla.com/browse/SDK-246 for more info.
+    match &exp.channel {
+        Some(channel) => {
+            if !channel
+                .to_lowercase()
+                .eq(&app_context.channel.to_lowercase())
+            {
+                return false;
+            }
+        }
+        None => log::debug!("Experiment missing channel, skipping it as a targeting parameter"),
+    }
+    return true;
 }
 
 /// Chooses a branch randomly from a set of branches
@@ -355,6 +366,71 @@ mod tests {
         let id = uuid::Uuid::parse_str("542213c0-9aef-47eb-bc6b-3b8529736ba2").unwrap();
         let b = choose_branch(slug, &branches, &id.to_string()).unwrap();
         assert_eq!(b.slug, "control");
+    }
+
+    #[test]
+    fn test_is_experiment_available() {
+        let experiment = Experiment {
+            app_name: Some("NimbusTest".to_string()),
+            app_id: Some("org.example.app".to_string()),
+            channel: Some("production".to_string()),
+            schema_version: "1.0.0".to_string(),
+            slug: "TEST_EXP".to_string(),
+            is_enrollment_paused: false,
+            feature_ids: vec!["monkey".to_string()],
+            bucket_config: BucketConfig {
+                randomization_unit: RandomizationUnit::NimbusId,
+                start: 0,
+                count: 10000,
+                total: 10000,
+                ..Default::default()
+            },
+            branches: vec![
+                Branch {
+                    slug: "control".to_string(),
+                    ratio: 1,
+                    feature: None,
+                },
+                Branch {
+                    slug: "blue".to_string(),
+                    ratio: 1,
+                    feature: None,
+                },
+            ],
+            reference_branch: Some("control".to_string()),
+            ..Default::default()
+        };
+
+        // Application context for matching the above experiment.  If any of the `app_name`, `app_id`,
+        // or `channel` doesn't match the experiment, then the client won't be enrolled.
+        let app_context = AppContext {
+            app_name: "NimbusTest".to_string(),
+            app_id: "org.example.app".to_string(),
+            channel: "nightly".to_string(),
+            ..Default::default()
+        };
+        // If is_release is true, we should match on the exact combination of
+        // app_name, channel and app_id.
+        assert!(!is_experiment_available(&app_context, &experiment, true));
+
+        // If is_release is false, we only match on app_name.
+        // As a nightly build, we want to be able to test production experiments
+        assert!(is_experiment_available(&app_context, &experiment, false));
+
+        let experiment = Experiment {
+            channel: Some("nightly".to_string()),
+            ..experiment
+        };
+        // channels now match, so should be availble for enrollment (true) and testing (false)
+        assert!(is_experiment_available(&app_context, &experiment, true));
+        assert!(is_experiment_available(&app_context, &experiment, false));
+
+        let experiment = Experiment {
+            app_name: Some("a_different_app".to_string()),
+            ..experiment
+        };
+        assert!(!is_experiment_available(&app_context, &experiment, false));
+        assert!(!is_experiment_available(&app_context, &experiment, false));
     }
 
     #[test]

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -24,6 +24,14 @@ dictionary EnrolledExperiment {
     string enrollment_id;
 };
 
+dictionary AvailableExperiment {
+    string slug;
+    string user_facing_name;
+    string user_facing_description;
+    sequence<Branch> branches;
+    string? reference_branch;
+};
+
 dictionary Branch {
     string slug;
     i32 ratio; // ideally would be u32, but kotlin considers unsigned experimental - see SDK-175.
@@ -109,6 +117,11 @@ interface NimbusClient {
     // Returns a list of experiments this user is enrolled in.
     [Throws=NimbusError]
     sequence<EnrolledExperiment> get_active_experiments();
+
+    // Returns a list of experiments for this `app_name`, as specified in the `AppContext`.
+    // It is not intended to be used to be used for user facing applications.
+    [Throws=NimbusError]
+    sequence<AvailableExperiment> get_available_experiments();
 
     // Getter and setter for user's participation in all experiments.
     // Possible values are:


### PR DESCRIPTION
Adds a new method to nimbus.udl to `get_available_experiments()`. This provides a list of experiments that can be opted-in and out of, for QA purposes only.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - `automation/all_tests.sh` runs to completion and produces no failures
  - Note: For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
