### PR TITLE
Ensure databases created before we encrypted card numbers still work.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,9 @@
 
 # Unreleased Changes
 
+## Autofill
+
+The main credit-cards table is dropped and recreated to ensure already existing
+databases will continue to work.
+
 [Full Changelog](https://github.com/mozilla/application-services/compare/v75.1.0...main)

--- a/components/autofill/sql/create_shared_triggers.sql
+++ b/components/autofill/sql/create_shared_triggers.sql
@@ -5,21 +5,21 @@
 
 -- This file defines triggers shared between the main and Sync connections.
 
-CREATE TEMP TRIGGER addresses_data_afterinsert_trigger
+CREATE TEMP TRIGGER IF NOT EXISTS addresses_data_afterinsert_trigger
 AFTER INSERT ON addresses_data
 FOR EACH ROW WHEN NEW.guid IN (SELECT guid FROM addresses_tombstones)
 BEGIN
     SELECT RAISE(FAIL, 'guid exists in `addresses_tombstones`');
 END;
 
-CREATE TEMP TRIGGER addresses_tombstones_afterinsert_trigger
+CREATE TEMP TRIGGER IF NOT EXISTS addresses_tombstones_afterinsert_trigger
 AFTER INSERT ON addresses_tombstones
 WHEN NEW.guid IN (SELECT guid FROM addresses_data)
 BEGIN
     SELECT RAISE(FAIL, 'guid exists in `addresses_data`');
 END;
 
-CREATE TEMP TRIGGER addresses_tombstones_create_trigger
+CREATE TEMP TRIGGER IF NOT EXISTS addresses_tombstones_create_trigger
 AFTER DELETE ON addresses_data
 WHEN OLD.guid IN (SELECT guid FROM addresses_mirror)
 BEGIN
@@ -27,21 +27,21 @@ BEGIN
     VALUES (OLD.guid, now());
 END;
 
-CREATE TEMP TRIGGER credit_cards_data_afterinsert_trigger
+CREATE TEMP TRIGGER IF NOT EXISTS credit_cards_data_afterinsert_trigger
 AFTER INSERT ON credit_cards_data
 FOR EACH ROW WHEN NEW.guid IN (SELECT guid FROM credit_cards_tombstones)
 BEGIN
     SELECT RAISE(FAIL, 'guid exists in `credit_cards_tombstones`');
 END;
 
-CREATE TEMP TRIGGER credit_cards_tombstones_afterinsert_trigger
+CREATE TEMP TRIGGER IF NOT EXISTS credit_cards_tombstones_afterinsert_trigger
 AFTER INSERT ON credit_cards_tombstones
 WHEN NEW.guid IN (SELECT guid FROM credit_cards_data)
 BEGIN
     SELECT RAISE(FAIL, 'guid exists in `credit_cards_data`');
 END;
 
-CREATE TEMP TRIGGER credit_cards_tombstones_create_trigger
+CREATE TEMP TRIGGER IF NOT EXISTS credit_cards_tombstones_create_trigger
 AFTER DELETE ON credit_cards_data
 WHEN OLD.guid IN (SELECT guid FROM credit_cards_mirror)
 BEGIN

--- a/components/autofill/src/db/schema.rs
+++ b/components/autofill/src/db/schema.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::error::Result;
-use rusqlite::Connection;
+use rusqlite::{Connection, NO_PARAMS};
 
 pub const ADDRESS_COMMON_COLS: &str = "
     guid,
@@ -69,18 +69,39 @@ pub const CREDIT_CARD_COMMON_VALS: &str = "
     :time_last_modified,
     :times_used";
 
-#[allow(dead_code)]
 const CREATE_SHARED_SCHEMA_SQL: &str = include_str!("../../sql/create_shared_schema.sql");
 const CREATE_SHARED_TRIGGERS_SQL: &str = include_str!("../../sql/create_shared_triggers.sql");
 const CREATE_SYNC_TEMP_TABLES_SQL: &str = include_str!("../../sql/create_sync_temp_tables.sql");
 
-#[allow(dead_code)]
+// The schema version - changes to this typically require a custom
+// migration code.
+const VERSION: i64 = 1;
+
+fn get_current_schema_version(db: &Connection) -> Result<i64> {
+    Ok(db.query_row_and_then("PRAGMA user_version", NO_PARAMS, |row| row.get(0))?)
+}
+
 pub fn init(db: &Connection) -> Result<()> {
-    create(db)?;
+    let version = get_current_schema_version(db)?;
+    if version != VERSION {
+        if version < VERSION {
+            upgrade(db, version)?;
+        } else {
+            log::warn!(
+                "Optimistically loaded future schema version {} (we only understand version {})",
+                version,
+                VERSION
+            );
+            // Downgrade the schema version, so that anything added with our
+            // schema is migrated forward when the newer library reads our
+            // database.
+            db.execute_batch(&format!("PRAGMA user_version = {};", VERSION))?;
+        }
+        create(db)?;
+    }
     Ok(())
 }
 
-#[allow(dead_code)]
 fn create(db: &Connection) -> Result<()> {
     log::debug!("Creating schema");
     db.execute_batch(
@@ -90,13 +111,81 @@ fn create(db: &Connection) -> Result<()> {
         )
         .as_str(),
     )?;
-
+    db.execute(
+        &format!("PRAGMA user_version = {version}", version = VERSION),
+        NO_PARAMS,
+    )?;
     Ok(())
 }
 
-#[allow(dead_code)]
 pub fn create_empty_sync_temp_tables(db: &Connection) -> Result<()> {
     log::debug!("Initializing sync temp tables");
     db.execute_batch(CREATE_SYNC_TEMP_TABLES_SQL)?;
     Ok(())
+}
+
+fn upgrade(db: &Connection, from: i64) -> Result<()> {
+    log::debug!("Upgrading schema from {} to {}", from, VERSION);
+    if from == VERSION {
+        return Ok(());
+    }
+    // Places has a cute `migration` helper we can consider using if we get
+    // a few complicated updates, but let's KISS for now.
+    if from == 0 {
+        // This is a bit painful - there are (probably 3) databases out there
+        // that have a schema of 0 but actually exist - ie, we can't assume
+        // a schema of zero implies "new database".
+        // These databases have a `cc_number` but we need them to have a
+        // `cc_number_enc` and `cc_number_last_4`.
+        // This was so very early in the Fenix nightly cycle, and before any
+        // real UI existed to create cards, so we don't bother trying to
+        // migrate them, we just drop the table so it's re-created with the
+        // correct schema.
+        db.execute("DROP TABLE IF EXISTS credit_cards_data", NO_PARAMS)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::test::new_mem_db;
+
+    #[test]
+    fn test_create_schema_twice() {
+        let db = new_mem_db();
+        db.execute_batch(CREATE_SHARED_SCHEMA_SQL)
+            .expect("should allow running main schema creation twice");
+        // sync tables aren't created by default, so do it twice here.
+        db.execute_batch(CREATE_SYNC_TEMP_TABLES_SQL)
+            .expect("should allow running sync temp tables first time");
+        db.execute_batch(CREATE_SYNC_TEMP_TABLES_SQL)
+            .expect("should allow running sync temp tables second time");
+    }
+
+    #[test]
+    fn test_upgrade_version_0() {
+        let db = new_mem_db();
+        // Manually hack things back to where we had to migrate from
+        // version 0.
+        // We don't care what the old table actually has because we drop it
+        // without a migration.
+        db.execute_batch(
+            "
+            DROP TABLE credit_cards_data;
+            CREATE TABLE credit_cards_data (guid TEXT NOT NULL PRIMARY KEY);
+            PRAGMA user_version = 0;",
+        )
+        .expect("should work");
+
+        // Just to test what we think we are testing, select a field that
+        // doesn't exist now but will after we recreate the table.
+        let select_name = "SELECT cc_name from credit_cards_data";
+        db.execute_batch(select_name)
+            .expect_err("select should fail due to bad field name");
+        init(&db).expect("re-init should work");
+        // should have dropped and recreated the table, so this select should work.
+        db.execute_batch(select_name)
+            .expect("select should now work");
+    }
 }


### PR DESCRIPTION
We just drop the data in the cards table because it's almost impossible
they have actual data, but we do this so we can recreate the table with
the correct schema.

Fixes #4026.

CC @grigoryk to check dropping the table is fine and @bendk because this adds the core migration framework he can leverage.