### PR TITLE
Support scrubbing encrypted data

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -7,4 +7,7 @@
 The main credit-cards is dropped and recreated to ensure already existing
 databases will continue to work.
 
+Added support to scrub encrypted data to handle lost/corrupted client keys.
+Scrubbed data will be replaced with remote data on the next sync.
+
 [Full Changelog](https://github.com/mozilla/application-services/compare/v75.1.0...main)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -4,10 +4,10 @@
 
 ## Autofill
 
-The main credit-cards is dropped and recreated to ensure already existing
-databases will continue to work.
+- The main credit-cards is dropped and recreated to ensure already existing
+  databases will continue to work.
 
-Added support to scrub encrypted data to handle lost/corrupted client keys.
-Scrubbed data will be replaced with remote data on the next sync.
+- Added support to scrub encrypted data to handle lost/corrupted client keys.
+  Scrubbed data will be replaced with remote data on the next sync.
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v75.1.0...main)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<a href="https://codecov.io/gh/mozilla/application-services"> <img src="https://codecov.io/gh/mozilla/application-services/branch/main/graph/badge.svg?token=HxeUysUWqx"/> </a>
+
 ## Firefox Application Services
 
 Application Services (a-s) is collection of Rust Components that are used to enable Firefox applications to integrate with Firefox accounts, sync, experimentation, etc. Each component is built using a core of shared code written in Rust, wrapped with native language bindings for different platforms.

--- a/components/autofill/sql/create_shared_schema.sql
+++ b/components/autofill/sql/create_shared_schema.sql
@@ -51,7 +51,10 @@ CREATE TABLE IF NOT EXISTS credit_cards_data (
     -- numbers are 19 chars or less, and a base64 encoded JWE is always going to
     -- be longer than thus, so we add a CHECK designed to ensure we don't
     -- accidentally store unencrypted numbers here.
-    cc_number_enc       TEXT NOT NULL CHECK(length(cc_number_enc) > 20),
+    -- The one exception is a completely blank value, which indicates that we
+    -- lost the key to decrypt the card number and need to refetch the value from
+    -- the sync server.
+    cc_number_enc       TEXT NOT NULL CHECK(length(cc_number_enc) > 20 OR cc_number_enc == ''),
     -- last 4 digits unencrypted. Check no larger than 4 to avoid the full number.
     cc_number_last_4    TEXT NOT NULL CHECK(length(cc_number_last_4) <= 4),
     cc_exp_month        INTEGER,

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -131,5 +131,8 @@ interface Store {
     [Throws=Error]
     void touch_address(string guid);
 
+    [Throws=Error]
+    void scrub_encrypted_data();
+
     void register_with_sync_manager();
 };

--- a/components/autofill/src/db/credit_cards.rs
+++ b/components/autofill/src/db/credit_cards.rs
@@ -205,6 +205,13 @@ pub fn delete_credit_card(conn: &Connection, guid: &Guid) -> Result<bool> {
     Ok(exists)
 }
 
+pub fn scrub_encrypted_credit_card_data(conn: &Connection) -> Result<()> {
+    let tx = conn.unchecked_transaction()?;
+    tx.execute("UPDATE credit_cards_data SET cc_number_enc = ''", NO_PARAMS)?;
+    tx.commit()?;
+    Ok(())
+}
+
 pub fn touch(conn: &Connection, guid: &Guid) -> Result<()> {
     let tx = conn.unchecked_transaction()?;
     let now_ms = Timestamp::now();
@@ -566,6 +573,34 @@ pub(crate) mod tests {
                 ":guid": cc2_guid,
             },
         )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_scrub_encrypted_credit_card_data() -> Result<()> {
+        let db = new_mem_db();
+        let encdec = EncryptorDecryptor::new_test_key();
+        let mut saved_credit_cards = Vec::with_capacity(10);
+        for _ in 0..5 {
+            saved_credit_cards.push(add_credit_card(
+                &db,
+                UpdatableCreditCardFields {
+                    cc_name: "john deer".to_string(),
+                    cc_number_enc: encdec.encrypt("1234567812345678")?,
+                    cc_number_last_4: "5678".to_string(),
+                    cc_exp_month: 10,
+                    cc_exp_year: 2025,
+                    cc_type: "mastercard".to_string(),
+                },
+            )?);
+        }
+
+        scrub_encrypted_credit_card_data(&db)?;
+        for saved_credit_card in saved_credit_cards.into_iter() {
+            let retrieved_credit_card = get_credit_card(&db, &saved_credit_card.guid)?;
+            assert_eq!(retrieved_credit_card.cc_number_enc, "");
+        }
 
         Ok(())
     }

--- a/components/autofill/src/db/models/credit_card.rs
+++ b/components/autofill/src/db/models/credit_card.rs
@@ -99,4 +99,8 @@ impl InternalCreditCard {
             },
         })
     }
+
+    pub fn has_scrubbed_data(&self) -> bool {
+        self.cc_number_enc.is_empty()
+    }
 }

--- a/components/autofill/src/db/schema.rs
+++ b/components/autofill/src/db/schema.rs
@@ -75,7 +75,7 @@ const CREATE_SYNC_TEMP_TABLES_SQL: &str = include_str!("../../sql/create_sync_te
 
 // The schema version - changes to this typically require a custom
 // migration code.
-const VERSION: i64 = 1;
+const VERSION: i64 = 2;
 
 fn get_current_schema_version(db: &Connection) -> Result<i64> {
     Ok(db.query_row_and_then("PRAGMA user_version", NO_PARAMS, |row| row.get(0))?)
@@ -142,6 +142,36 @@ fn upgrade(db: &Connection, from: i64) -> Result<()> {
         // migrate them, we just drop the table so it's re-created with the
         // correct schema.
         db.execute("DROP TABLE IF EXISTS credit_cards_data", NO_PARAMS)?;
+    } else if from == 1 {
+        db.execute_batch(
+            "
+CREATE TABLE new_credit_cards_data (
+    guid                TEXT NOT NULL PRIMARY KEY CHECK(length(guid) != 0),
+    cc_name             TEXT NOT NULL,
+    cc_number_enc       TEXT NOT NULL CHECK(length(cc_number_enc) > 20 OR cc_number_enc == ''),
+    cc_number_last_4    TEXT NOT NULL CHECK(length(cc_number_last_4) <= 4),
+    cc_exp_month        INTEGER,
+    cc_exp_year         INTEGER,
+    cc_type             TEXT NOT NULL,
+    time_created        INTEGER NOT NULL,
+    time_last_used      INTEGER,
+    time_last_modified  INTEGER NOT NULL,
+    times_used          INTEGER NOT NULL,
+    sync_change_counter INTEGER NOT NULL
+);
+INSERT INTO new_credit_cards_data(guid, cc_name, cc_number_enc, cc_number_last_4, cc_exp_month,
+cc_exp_year, cc_type, time_created, time_last_used, time_last_modified, times_used,
+sync_change_counter)
+SELECT guid, cc_name, cc_number_enc, cc_number_last_4, cc_exp_month, cc_exp_year, cc_type,
+    time_created, time_last_used, time_last_modified, times_used, sync_change_counter
+FROM credit_cards_data;
+DROP TRIGGER credit_cards_tombstones_afterinsert_trigger;
+DROP TABLE credit_cards_data;
+ALTER TABLE new_credit_cards_data RENAME to credit_cards_data;
+",
+        )?;
+        // NOTE: at this point several triggers have been droped and not recreated, but that's okay
+        // because they will be recreated when we execute CREATE_SHARED_TRIGGERS_SQL
     }
     Ok(())
 }
@@ -150,6 +180,45 @@ fn upgrade(db: &Connection, from: i64) -> Result<()> {
 mod tests {
     use super::*;
     use crate::db::test::new_mem_db;
+    use rusqlite::Row;
+    use types::Timestamp;
+
+    // Define some structs to handle data in the DB during an upgrade.  This allows us to change
+    // the schema without having to update the test code.
+    #[derive(Debug, Default)]
+    struct CreditCardRowV1 {
+        guid: String,
+        cc_name: String,
+        cc_number_enc: String,
+        cc_number_last_4: String,
+        cc_type: String,
+        cc_exp_month: i64,
+        cc_exp_year: i64,
+        time_created: Timestamp,
+        time_last_used: Timestamp,
+        time_last_modified: Timestamp,
+        times_used: i64,
+        sync_change_counter: i64,
+    }
+
+    impl CreditCardRowV1 {
+        fn from_row(row: &Row<'_>) -> rusqlite::Result<CreditCardRowV1> {
+            Ok(Self {
+                guid: row.get("guid")?,
+                cc_name: row.get("cc_name")?,
+                cc_number_enc: row.get("cc_number_enc")?,
+                cc_number_last_4: row.get("cc_number_last_4")?,
+                cc_exp_month: row.get("cc_exp_month")?,
+                cc_exp_year: row.get("cc_exp_year")?,
+                cc_type: row.get("cc_type")?,
+                time_created: row.get("time_created")?,
+                time_last_used: row.get("time_last_used")?,
+                time_last_modified: row.get("time_last_modified")?,
+                times_used: row.get("times_used")?,
+                sync_change_counter: row.get("sync_change_counter")?,
+            })
+        }
+    }
 
     #[test]
     fn test_create_schema_twice() {
@@ -188,5 +257,59 @@ mod tests {
         // should have dropped and recreated the table, so this select should work.
         db.execute_batch(select_name)
             .expect("select should now work");
+    }
+
+    #[test]
+    fn test_upgrade_version_1() -> Result<()> {
+        let db = new_mem_db();
+        // Go back to version 0 of the credit_cards_data table and insert a row
+        db.execute_batch("
+DROP TABLE credit_cards_data;
+CREATE TABLE credit_cards_data (
+    guid                TEXT NOT NULL PRIMARY KEY CHECK(length(guid) != 0),
+    cc_name             TEXT NOT NULL,
+    cc_number_enc       TEXT NOT NULL CHECK(length(cc_number_enc) > 20),
+    cc_number_last_4    TEXT NOT NULL CHECK(length(cc_number_last_4) <= 4),
+    cc_exp_month        INTEGER,
+    cc_exp_year         INTEGER,
+    cc_type             TEXT NOT NULL,
+    time_created        INTEGER NOT NULL,
+    time_last_used      INTEGER,
+    time_last_modified  INTEGER NOT NULL,
+    times_used          INTEGER NOT NULL,
+    sync_change_counter INTEGER NOT NULL
+);
+INSERT INTO credit_cards_data(guid, cc_name, cc_number_enc, cc_number_last_4, cc_exp_month,
+cc_exp_year, cc_type, time_created, time_last_used, time_last_modified, times_used, sync_change_counter)
+VALUES ('A', 'Jane Doe', '012345678901234567890', '1234', 1, 2020, 'visa', 0, 1, 2, 3, 0);
+")?;
+        // Do the upgrade
+        upgrade(&db, 1)?;
+        // Check that the old data is still present
+        let query_sql = "
+SELECT guid, cc_name, cc_number_enc, cc_number_last_4, cc_exp_month, cc_exp_year, cc_type, time_created,
+    time_last_modified, time_last_used, times_used, sync_change_counter
+FROM credit_cards_data
+WHERE guid='A'";
+        let credit_card = db.query_row(query_sql, NO_PARAMS, CreditCardRowV1::from_row)?;
+        assert_eq!(credit_card.cc_name, "Jane Doe");
+        assert_eq!(credit_card.cc_number_enc, "012345678901234567890");
+        assert_eq!(credit_card.cc_number_last_4, "1234");
+        assert_eq!(credit_card.cc_exp_month, 1);
+        assert_eq!(credit_card.cc_exp_year, 2020);
+        assert_eq!(credit_card.cc_type, "visa");
+        assert_eq!(credit_card.time_created, Timestamp(0));
+        assert_eq!(credit_card.time_last_used, Timestamp(1));
+        assert_eq!(credit_card.time_last_modified, Timestamp(2));
+        assert_eq!(credit_card.times_used, 3);
+        assert_eq!(credit_card.sync_change_counter, 0);
+
+        // Test the upgraded check constraint
+        db.execute("UPDATE credit_cards_data SET cc_number_enc=''", NO_PARAMS)
+            .expect("blank cc_number_enc should be valid");
+        db.execute("UPDATE credit_cards_data SET cc_number_enc='x'", NO_PARAMS)
+            .expect_err("cc_number_enc should be invalid");
+
+        Ok(())
     }
 }

--- a/components/autofill/src/db/store.rs
+++ b/components/autofill/src/db/store.rs
@@ -110,6 +110,10 @@ impl Store {
         self.store_impl.scrub_encrypted_data()?;
         // Force the sync engine to refetch data (only need to do this for the credit cards, since the
         // addresses engine doesn't store encrypted data).
+        //
+        // It would be cleaner to put this inside the StoreImpl code, but that's tricky because
+        // create_engine needs an Arc<StoreImpl> which we have, but StoreImpl doesn't and StoreImpl
+        // can't just create one because AutofillDb.writer doesn't implement Clone.
         crate::sync::credit_card::create_engine(self.store_impl.clone()).reset_local_sync_data()?;
         Ok(())
     }

--- a/components/autofill/src/db/store.rs
+++ b/components/autofill/src/db/store.rs
@@ -110,8 +110,7 @@ impl Store {
         self.store_impl.scrub_encrypted_data()?;
         // Force the sync engine to refetch data (only need to do this for the credit cards, since the
         // addresses engine doesn't store encrypted data).
-        crate::sync::credit_card::create_engine(self.store_impl.clone())
-            .refetch_server_records()?;
+        crate::sync::credit_card::create_engine(self.store_impl.clone()).reset_local_sync_data()?;
         Ok(())
     }
 

--- a/components/autofill/src/sync/engine.rs
+++ b/components/autofill/src/sync/engine.rs
@@ -75,8 +75,8 @@ impl<T> ConfigSyncEngine<T> {
         let key = format!("{}.{}", self.config.namespace, tail);
         crate::db::store::delete_meta(conn, &key)
     }
-    // Prepare to refetch all records from the server
-    pub fn refetch_server_records(&self) -> Result<()> {
+    // Reset the local sync data so the next server request fetches all records.
+    pub fn reset_local_sync_data(&self) -> Result<()> {
         let db = &self.store.db.lock().unwrap();
         let tx = db.unchecked_transaction()?;
         self.storage_impl.reset_storage(&tx)?;

--- a/components/autofill/src/sync/engine.rs
+++ b/components/autofill/src/sync/engine.rs
@@ -75,6 +75,14 @@ impl<T> ConfigSyncEngine<T> {
         let key = format!("{}.{}", self.config.namespace, tail);
         crate::db::store::delete_meta(conn, &key)
     }
+    // Prepare to refetch all records from the server
+    pub fn refetch_server_records(&self) -> Result<()> {
+        let db = &self.store.db.lock().unwrap();
+        let tx = db.unchecked_transaction()?;
+        self.storage_impl.reset_storage(&tx)?;
+        self.put_meta(&tx, LAST_SYNC_META_KEY, &0)?;
+        Ok(())
+    }
 }
 
 // We're just an "adaptor" to the sync15 version of an 'engine'

--- a/components/autofill/src/sync/mod.rs
+++ b/components/autofill/src/sync/mod.rs
@@ -286,7 +286,7 @@ fn plan_incoming<T: std::fmt::Debug + SyncRecord>(
                 | LocalRecordInfo::Scrubbed {
                     record: local_record,
                 } => {
-                    // The local record was either unmodified, or scrubbed of it's encrypted data.
+                    // The local record was either unmodified, or scrubbed of its encrypted data.
                     // Either way we want to:
                     //   - Merge the metadata
                     //   - Update the local record using data from the server

--- a/components/autofill/src/sync/tests/test_mod.rs
+++ b/components/autofill/src/sync/tests/test_mod.rs
@@ -87,6 +87,20 @@ fn test_plan_incoming_record() -> Result<()> {
         }
     );
 
+    // LocalRecordInfo::Scrubbed - update the local with the incoming.
+    let state = IncomingState {
+        incoming: IncomingRecordInfo::Record { record: 0 },
+        local: LocalRecordInfo::Scrubbed { record: 1 },
+        mirror: None,
+    };
+    assert_eq!(
+        plan_incoming(&conn, &testimpl, state)?,
+        IncomingAction::Update {
+            record: 0,
+            was_merged: false
+        }
+    );
+
     // LocalRecordInfo::Modified - but it turns out they are identical.
     let state = IncomingState {
         incoming: IncomingRecordInfo::Record { record: 0 },


### PR DESCRIPTION
This allows scrubbing encrypted data from the local storage in order to recover from lost/corrupted encryption keys.  Right now the only piece of encrypted data is the cc_number_enc field.

It also updates the syncing logic for scrubbed data.  When we see that a local record has scrubbed data, then we always copy the remote version of that field (any any other fields that are different).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
