### PR TITLE
Remove wipeAll support (#4006)

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,6 +2,10 @@
 
 # Unreleased Changes
 
+## Sync Manager
+
+- Removed support for the wipeAll command (#4006)
+
 ## Autofill
 
 ### What's Changed

--- a/components/sync15/src/clients/mod.rs
+++ b/components/sync15/src/clients/mod.rs
@@ -83,8 +83,6 @@ pub struct Settings {
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Command {
-    /// Erases all local data.
-    WipeAll,
     /// Erases all local data for a specific engine.
     Wipe(String),
     /// Resets local sync state for all engines.

--- a/components/sync15/src/clients/record.rs
+++ b/components/sync15/src/clients/record.rs
@@ -92,7 +92,6 @@ impl CommandRecord {
     pub fn as_command(&self) -> Option<Command> {
         match self.name.as_str() {
             "wipeEngine" => self.args.get(0).map(|e| Command::Wipe(e.into())),
-            "wipeAll" => Some(Command::WipeAll),
             "resetEngine" => self.args.get(0).map(|e| Command::Reset(e.into())),
             "resetAll" => Some(Command::ResetAll),
             _ => None,
@@ -106,11 +105,6 @@ impl From<Command> for CommandRecord {
             Command::Wipe(engine) => CommandRecord {
                 name: "wipeEngine".into(),
                 args: vec![engine],
-                flow_id: None,
-            },
-            Command::WipeAll => CommandRecord {
-                name: "wipeAll".into(),
-                args: Vec::new(),
                 flow_id: None,
             },
             Command::Reset(engine) => CommandRecord {

--- a/components/sync_manager/src/lib.rs
+++ b/components/sync_manager/src/lib.rs
@@ -51,11 +51,6 @@ pub fn wipe(engine: &str) -> Result<()> {
     manager.wipe(engine)
 }
 
-pub fn wipe_all() -> Result<()> {
-    let mut manager = MANAGER.lock().unwrap();
-    manager.wipe_all()
-}
-
 pub fn reset(engine: &str) -> Result<()> {
     let mut manager = MANAGER.lock().unwrap();
     manager.reset(engine)


### PR DESCRIPTION
- Removed the wipeAll support from the sync15 and sync_manager code.
- Didn't remove `SetupStorageClient.wipe_all_remote()`, that seemed to be doing something different to me.
- Didn't add any tests, I figured the existing tests should catch any issues with removing code.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
