### PR TITLE
WIP spike for the FeatureConfig value getter (SDK-261); currently to paused waiting on SDK-260.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ components/**/ios/Generated
 megazords/ios/MozillaAppServices/Generated/Metrics.swift
 megazords/ios/.venv
 
+# Nimbus generated artifacts
+components/nimbus/db
+
 # Carthage generated artifacts
 Carthage
 MozillaAppServices.framework.zip

--- a/components/nimbus/src/client/http_client.rs
+++ b/components/nimbus/src/client/http_client.rs
@@ -324,6 +324,7 @@ mod tests {
                         feature: Some(FeatureConfig {
                             feature_id: "first_switch".to_string(),
                             enabled: false,
+                            value: None,
                         }),
                     },
                     Branch {
@@ -332,6 +333,7 @@ mod tests {
                         feature: Some(FeatureConfig {
                             feature_id: "first_switch".to_string(),
                             enabled: true,
+                            value: None,
                         }),
                     },
                 ],

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -429,6 +429,10 @@ pub enum EnrollmentStatus {
         // default it to "" for persisted enrollments where it is missing.
         #[serde(default)]
         feature_id: String,
+        // The `feature_id` field was added later. To avoid a db migration we
+        // default it to "" for persisted enrollments where it is missing.
+        #[serde(default)]
+        feature_value: String,
     },
     NotEnrolled {
         reason: NotEnrolledReason,
@@ -520,6 +524,7 @@ pub fn get_enrollments<'r>(
                     user_facing_description: experiment.user_facing_description,
                     branch_slug: branch.to_string(),
                     enrollment_id: enrollment_id.to_string(),
+
                 });
             } else {
                 log::warn!(
@@ -605,6 +610,7 @@ impl<'a> EnrollmentsEvolver<'a> {
         let existing_experiments = map_experiments(&existing_experiments);
         let updated_experiments = map_experiments(&updated_experiments);
         let existing_enrollments = map_enrollments(&existing_enrollments);
+        // XXX maybe create existing_feature_configs here, pass
 
         let mut all_slugs = HashSet::with_capacity(existing_experiments.len());
         all_slugs.extend(existing_experiments.keys());

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -56,6 +56,8 @@ pub fn evaluate_enrollment(
         });
     }
 
+    // XXX reject duplicate use of feature_id before or after this
+
     // Get targeting out of the way - "if let chains" are experimental,
     // otherwise we could improve this.
     if let Some(expr) = &exp.targeting {

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -97,6 +97,10 @@ impl NimbusClient {
         Ok(())
     }
 
+    pub fn get_feature_config_variables(&self, feature_id: String) -> Result<Option<String>> {
+        self.database_cache.get_feature_config_variables(&feature_id)
+    }
+
     // Note: the contract for this function is that it never blocks on IO.
     pub fn get_experiment_branch(&self, slug: String) -> Result<Option<String>> {
         self.database_cache.get_experiment_branch(&slug)
@@ -193,8 +197,8 @@ impl NimbusClient {
         let settings_client = self.settings_client.lock().unwrap();
         let new_experiments = settings_client.fetch_experiments()?;
         let db = self.db()?;
-        let mut writer = db.write()?;
         write_pending_experiments(&db, &mut writer, new_experiments)?;
+        let mut writer = db.write()?;
         writer.commit()?;
         Ok(())
     }
@@ -313,6 +317,7 @@ pub struct EnrolledExperiment {
     pub user_facing_description: String,
     pub branch_slug: String,
     pub enrollment_id: String,
+    pub feature_value: Option<String>,
 }
 
 /// This is the currently supported major schema version.
@@ -374,7 +379,9 @@ pub struct FeatureConfig {
     pub enabled: bool,
     // There is a nullable `value` field that can contain key-value config options
     // that modify the behaviour of an application feature, but we don't support
-    // it yet and the details are still being finalized, so we ignore it for now.
+    // it yet and the details are still being finalized, so we ignore it for
+    // now.
+    pub value: Option<String>,
 }
 
 // ⚠️ Attention : Changes to this type should be accompanied by a new test  ⚠️

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -40,6 +40,7 @@ dictionary Branch {
 
 dictionary FeatureConfig {
     string feature_id;
+    string? value;
     boolean enabled;
 };
 
@@ -101,6 +102,9 @@ interface NimbusClient {
     // the minimum amount of work to achieve that.
     [Throws=NimbusError]
     void initialize();
+
+    [Throws=NimbusError]
+    string? get_feature_config_variables(string feature_id);
 
     // Returns the branch allocated for a given feature_id or experiment_slug.
     // Search first by feature_id, then by experiment_slug, returning the

--- a/components/nimbus/tests/common/mod.rs
+++ b/components/nimbus/tests/common/mod.rs
@@ -146,6 +146,7 @@ pub fn experiments_testing_feature_ids() -> String {
                         "ratio": 1,
                         "feature": {
                             "featureId": "aboutmonkeys",
+                            "value": {"hands": "green"},
                             "enabled": false
                         }
                     },
@@ -154,6 +155,7 @@ pub fn experiments_testing_feature_ids() -> String {
                         "ratio":1,
                         "feature": {
                             "featureId": "aboutmonkeys",
+                            "value": {"hands": "red"},
                             "enabled": true
                         },
 
@@ -191,6 +193,7 @@ pub fn experiments_testing_feature_ids() -> String {
                         "ratio": 1,
                         "feature": {
                             "featureId": "aboutwelcome",
+                            "value": {"welcome_string": "hi"},
                             "enabled": false
                         },
                     },
@@ -199,6 +202,7 @@ pub fn experiments_testing_feature_ids() -> String {
                         "ratio":1,
                         "feature": {
                             "featureId": "aboutwelcome",
+                            "value": {"welcome_string": "h"},
                             "enabled": true
                         },
                     }

--- a/components/nimbus/tests/test_get_feature_config_variables.rs
+++ b/components/nimbus/tests/test_get_feature_config_variables.rs
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Testing featured-based get_experiment_branch semantics.
+
+mod common;
+#[allow(unused_imports)]
+use nimbus::error::Result;
+
+#[cfg(feature = "rkv-safe-mode")]
+#[test]
+fn test_enrolled_feature2() -> Result<()> {
+    let _ = env_logger::try_init();
+    let client = common::new_test_client("test_enrolled_feature2")?;
+    client.initialize()?;
+    client.set_experiments_locally(common::experiments_testing_feature_ids())?;
+
+    client.apply_pending_experiments()?;
+
+    // client.opt_out("secure-gold".to_string())?;
+    // assert_eq!(
+    //     client.get_experiment_branch("aboutwelcome".to_string())?,
+    //     None,
+    //     "should not return a branch we've just opted out of"
+    // );
+
+    // client.opt_in_with_branch("secure-gold".to_string(), "treatment".to_string())?;
+    // assert_eq!(
+    //     client.get_experiment_branch("aboutwelcome".to_string())?,
+    //     Some("treatment".to_string()),
+    //     "should return a treatment branch we've just opted into"
+    // );
+
+    // XXX variables in getter versus value in schema
+    client.opt_in_with_branch("secure-gold".to_string(), "control".to_string())?;
+    assert_eq!(
+        client.get_feature_config_variables("aboutwelcome".to_string())?.unwrap(),
+        r#"{"welcome_string": "hi"}"#,
+        "should return the right feature_config value 'control' branch"
+    );
+
+    client.opt_in_with_branch("secure-gold".to_string(), "treatment".to_string())?;
+    assert_eq!(
+        client.get_feature_config_variables("aboutwelcome".to_string())?.unwrap(),
+        r#"{"welcome_string": "hello"}"#,
+        "should return the right feature_config value for 'treatment' branch"
+    );
+
+    // assert_eq!(
+    //     client.get_experiment_branch("aboutwelcome".to_string())?,
+    //     Some("control".to_string()),
+    //     "should return a second branch we've just opted into"
+    // );
+
+    // client.set_global_user_participation(false)?;
+    // assert_eq!(
+    //     client.get_experiment_branch("aboutwelcome".to_string())?,
+    //     None,
+    //     "should not return a branch if we've globally opted out"
+    // );
+
+    Ok(())
+}


### PR DESCRIPTION
After discussion last week, it became clear that things would net out to less work if we did SDK-260 (#4041) first, so this partly done and paused for now.
.
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.

    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
