### PR TITLE
Fix building the application services project with Apple M1 [ci full]

### DIFF
--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -15,6 +15,8 @@ NSS_SRC_DIR=${1}
 # Whether to cross compile from Linux to a different target.  Really
 # only intended for automation.
 CROSS_COMPILE_TARGET=${2-}
+# This will stay consistent with CARGO_CFG_TARGET_ARCH
+TARGET_ARCH="unknown"
 
 if [[ -n "${CROSS_COMPILE_TARGET}" ]] && [[ "$(uname -s)" != "Linux" ]]; then
   echo "Can only cross compile from 'Linux'; 'uname -s' is $(uname -s)"
@@ -33,8 +35,8 @@ elif [[ -n "${CROSS_COMPILE_TARGET}" ]]; then
 elif [[ "$(uname -s)" == "Darwin" ]]; then
   DIST_DIR=$(abspath "desktop/darwin/nss")
   TARGET_OS="macos"
-  #We need this variable for switching libs based on different macos archs (M1 vs Intel)
-  #also, keeping the naming consistent with target_arch env on the rust side
+  # We need this variable for switching libs based on different macos archs (M1 vs Intel)
+  # Renaming uname to stay consistent with CARGO_CFG_TARGET_ARCH on the rust side
   if [[ "$(uname -m)" == "arm64" ]]; then
     TARGET_ARCH="aarch64"
   else
@@ -106,7 +108,7 @@ cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libsmime.a" "${DIST_DIR}/lib"
 cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libsoftokn_static.a" "${DIST_DIR}/lib"
 cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libssl.a" "${DIST_DIR}/lib"
 
-#Apple M1 need HW specific libs copied over to successfully build
+# Apple M1 need HW specific libs copied over to successfully build
 if [[ "${TARGET_OS}" == "macos" ]] && [[ "${TARGET_ARCH}" == "aarch64" ]]; then
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libgcm-aes-aarch64_c_lib.a" "${DIST_DIR}/lib"

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -109,7 +109,7 @@ cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libsoftokn_static.a" "${DIST_DIR}/lib"
 cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libssl.a" "${DIST_DIR}/lib"
 
 # Apple M1 need HW specific libs copied over to successfully build
-if [[ "${TARGET_OS}" == "macos" ]] && [[ "${TARGET_ARCH}" == "aarch64" ]]; then
+if [[ "${TARGET_ARCH}" == "aarch64" ]]; then
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libgcm-aes-aarch64_c_lib.a" "${DIST_DIR}/lib"
 else

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -15,7 +15,8 @@ NSS_SRC_DIR=${1}
 # Whether to cross compile from Linux to a different target.  Really
 # only intended for automation.
 CROSS_COMPILE_TARGET=${2-}
-# This will stay consistent with CARGO_CFG_TARGET_ARCH
+# We only need this in a couple of places so we'll default to "unknown"
+# Othertimes, it'll match what CARGO_CFG_TARGET_ARCH is on the rust side
 TARGET_ARCH="unknown"
 
 if [[ -n "${CROSS_COMPILE_TARGET}" ]] && [[ "$(uname -s)" != "Linux" ]]; then
@@ -35,8 +36,7 @@ elif [[ -n "${CROSS_COMPILE_TARGET}" ]]; then
 elif [[ "$(uname -s)" == "Darwin" ]]; then
   DIST_DIR=$(abspath "desktop/darwin/nss")
   TARGET_OS="macos"
-  # We need this variable for switching libs based on different macos archs (M1 vs Intel)
-  # Renaming uname to stay consistent with CARGO_CFG_TARGET_ARCH on the rust side
+  # We need to set this variable for switching libs based on different macos archs (M1 vs Intel)
   if [[ "$(uname -m)" == "arm64" ]]; then
     TARGET_ARCH="aarch64"
   else

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -34,6 +34,13 @@ elif [[ "$(uname -s)" == "Darwin" ]]; then
   DIST_DIR=$(abspath "desktop/darwin/sqlcipher")
   NSS_DIR=$(abspath "desktop/darwin/nss")
   TARGET_OS="macos"
+  #We need this variable for switching libs based on different macos archs
+  #also keepping the naming consistent with target_arch env on the rust side
+  if [[ "$(uname -m)" == "arm64" ]]; then
+    TARGET_ARCH="aarch64"
+  else
+    TARGET_ARCH="x86_64"
+  fi
 elif [[ "$(uname -s)" == "Linux" ]]; then
   # This is a JNA weirdness: "x86-64" rather than "x86_64".
   DIST_DIR=$(abspath "desktop/linux-x86-64/sqlcipher")
@@ -87,8 +94,6 @@ LIBS="\
   -lcerthi \
   -lcryptohi \
   -lfreebl_static \
-  -lhw-acc-crypto-avx \
-  -lhw-acc-crypto-avx2 \
   -lnspr4 \
   -lnss_static \
   -lnssb \
@@ -99,13 +104,16 @@ LIBS="\
   -lplc4 \
   -lplds4 \
   -lsoftokn_static \
-  -lgcm-aes-x86_c_lib \
 "
 
 if [[ "${TARGET_OS}" == "windows" ]]; then
   LIBS="${LIBS} -lintel-gcm-wrap_c_lib"
 elif [[ "${TARGET_OS}" == "linux" ]]; then
   LIBS="${LIBS} -lintel-gcm-wrap_c_lib -lintel-gcm-s_lib"
+elif [[ "${TARGET_OS}" == "macos" ]] && [[ "${TARGET_ARCH}" == "aarch64" ]]; then
+  LIBS="${LIBS} -lgcm-aes-aarch64_c_lib -larmv8_c_lib"
+else
+  LIBS="${LIBS} -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 -lgcm-aes-x86_c_lib"
 fi
 
 BUILD_DIR=$(mktemp -d)

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -13,7 +13,8 @@ SQLCIPHER_SRC_DIR=${1}
 # Whether to cross compile from Linux to a different target.  Really
 # only intended for automation.
 CROSS_COMPILE_TARGET=${2-}
-# This will mimic CARGO_CFG_TARGET_ARCH
+# We only need this in a couple of places so we'll default to "unknown"
+# Othertimes, it'll match what CARGO_CFG_TARGET_ARCH is on the rust side
 TARGET_ARCH="unknown"
 
 if [[ -n "${CROSS_COMPILE_TARGET}" ]] && [[ "$(uname -s)" != "Linux" ]]; then
@@ -36,8 +37,7 @@ elif [[ "$(uname -s)" == "Darwin" ]]; then
   DIST_DIR=$(abspath "desktop/darwin/sqlcipher")
   NSS_DIR=$(abspath "desktop/darwin/nss")
   TARGET_OS="macos"
-  # We need this variable for switching libs based on different macos archs (M1 vs Intel)
-  # Rename to stay consistent with CARGO_CFG_TARGET_ARCH on the rust side
+  # We need to set this variable for switching libs based on different macos archs (M1 vs Intel)
   if [[ "$(uname -m)" == "arm64" ]]; then
     TARGET_ARCH="aarch64"
   else

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -112,7 +112,7 @@ if [[ "${TARGET_OS}" == "windows" ]]; then
   LIBS="${LIBS} -lintel-gcm-wrap_c_lib"
 elif [[ "${TARGET_OS}" == "linux" ]]; then
   LIBS="${LIBS} -lintel-gcm-wrap_c_lib -lintel-gcm-s_lib"
-elif [[ "${TARGET_OS}" == "macos" ]] && [[ "${TARGET_ARCH}" == "aarch64" ]]; then
+elif [[ "${TARGET_ARCH}" == "aarch64" ]]; then
   LIBS="${LIBS} -lgcm-aes-aarch64_c_lib -larmv8_c_lib"
 else
   LIBS="${LIBS} -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 -lgcm-aes-x86_c_lib"

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -13,6 +13,8 @@ SQLCIPHER_SRC_DIR=${1}
 # Whether to cross compile from Linux to a different target.  Really
 # only intended for automation.
 CROSS_COMPILE_TARGET=${2-}
+# This will mimic CARGO_CFG_TARGET_ARCH
+TARGET_ARCH="unknown"
 
 if [[ -n "${CROSS_COMPILE_TARGET}" ]] && [[ "$(uname -s)" != "Linux" ]]; then
   echo "Can only cross compile from 'Linux'; 'uname -s' is $(uname -s)"
@@ -34,8 +36,8 @@ elif [[ "$(uname -s)" == "Darwin" ]]; then
   DIST_DIR=$(abspath "desktop/darwin/sqlcipher")
   NSS_DIR=$(abspath "desktop/darwin/nss")
   TARGET_OS="macos"
-  #We need this variable for switching libs based on different macos archs
-  #also keepping the naming consistent with target_arch env on the rust side
+  # We need this variable for switching libs based on different macos archs (M1 vs Intel)
+  # Rename to stay consistent with CARGO_CFG_TARGET_ARCH on the rust side
   if [[ "$(uname -m)" == "arm64" ]]; then
     TARGET_ARCH="aarch64"
   else


### PR DESCRIPTION
- project does not build cleanly on Apple M1 hardware
- Adjusted build scripts to correctly link the right libraries for Apple Silicon (M1)
- Added new var in the scripts to keep track of the two current macos hardware

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
