### PR TITLE
Introduce History Metadata storage & API for Android

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,6 +2,10 @@
 
 # Unreleased Changes
 
+## History Metadata Storage
+
+- Introduced a new metadata storage API, part of libplaces. Currently only has Android bindings.
+
 ## Sync Manager
 
 - Removed support for the wipeAll command (#4006)

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -196,6 +196,52 @@ internal interface LibPlacesFFI : Library {
         error: RustError.ByReference
     )
 
+    fun places_get_latest_history_metadata_for_url(
+        handle: PlacesConnectionHandle,
+        url: String,
+        error: RustError.ByReference
+    ): RustBuffer.ByValue
+
+    fun places_get_history_metadata_between(
+        handle: PlacesConnectionHandle,
+        start: Long,
+        end: Long,
+        error: RustError.ByReference
+    ): RustBuffer.ByValue
+
+    fun places_get_history_metadata_since(
+        handle: PlacesConnectionHandle,
+        start: Long,
+        error: RustError.ByReference
+    ): RustBuffer.ByValue
+
+    fun places_query_history_metadata(
+        handle: PlacesConnectionHandle,
+        query: String,
+        limit: Int,
+        error: RustError.ByReference
+    ): RustBuffer.ByValue
+
+    fun places_add_history_metadata(
+        handle: PlacesConnectionHandle,
+        data: Pointer,
+        len: Int,
+        out_err: RustError.ByReference
+    ): Pointer?
+
+    fun places_update_history_metadata(
+        handle: PlacesConnectionHandle,
+        guid: String,
+        totalViewTime: Int,
+        out_err: RustError.ByReference
+    )
+
+    fun places_metadata_delete_older_than(
+        handle: PlacesConnectionHandle,
+        olderThan: Long,
+        out_err: RustError.ByReference
+    )
+
     // Returns a JSON string containing a sync ping.
     fun sync15_history_sync(
         handle: PlacesApiHandle,

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -211,7 +211,7 @@ internal interface LibPlacesFFI : Library {
 
     fun places_get_history_metadata_since(
         handle: PlacesConnectionHandle,
-        start: Long,
+        since: Long,
         error: RustError.ByReference
     ): RustBuffer.ByValue
 

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -405,11 +405,11 @@ open class PlacesReaderConnection internal constructor(connHandle: Long) :
         }
     }
 
-    override suspend fun getHistoryMetadataSince(start: Long): List<HistoryMetadata> {
+    override suspend fun getHistoryMetadataSince(since: Long): List<HistoryMetadata> {
         readQueryCounters.measure {
             val rustBuffer = rustCall { error ->
                 LibPlacesFFI.INSTANCE.places_get_history_metadata_since(
-                        this.handle.get(), start, error)
+                        this.handle.get(), since, error)
             }
             try {
                 val metadata = MsgTypes.HistoryMetadataList.parseFrom(rustBuffer.asCodedInputStream()!!)
@@ -895,12 +895,12 @@ interface ReadableHistoryMetadataConnection : InterruptibleConnection {
     suspend fun getLatestHistoryMetadataForUrl(url: String): HistoryMetadata?
 
     /**
-     * Returns all [HistoryMetadata] where [HistoryMetadata.updatedAt] is greater or equal to [start].
+     * Returns all [HistoryMetadata] where [HistoryMetadata.updatedAt] is greater or equal to [since].
      *
-     * @param start Timestmap to search by.
+     * @param since Timestmap to search by.
      * @return A `List` of matching [HistoryMetadata], empty if nothing is found.
      */
-    suspend fun getHistoryMetadataSince(start: Long): List<HistoryMetadata>
+    suspend fun getHistoryMetadataSince(since: Long): List<HistoryMetadata>
 
     /**
      * Returns all [HistoryMetadata] where [HistoryMetadata.updatedAt] is between [start] and [end], inclusive.

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -261,6 +261,7 @@ open class PlacesConnection internal constructor(connHandle: Long) : Interruptib
 open class PlacesReaderConnection internal constructor(connHandle: Long) :
         PlacesConnection(connHandle),
         ReadableHistoryConnection,
+        ReadableHistoryMetadataConnection,
         ReadableBookmarksConnection {
     override fun queryAutocomplete(query: String, limit: Int): List<SearchResult> {
         val resultBuffer = rustCall { error ->
@@ -389,6 +390,66 @@ open class PlacesReaderConnection internal constructor(connHandle: Long) :
         }
     }
 
+    override suspend fun getLatestHistoryMetadataForUrl(url: String): HistoryMetadata? {
+        val rustBuffer = rustCall { error ->
+            LibPlacesFFI.INSTANCE.places_get_latest_history_metadata_for_url(
+                this.handle.get(), url, error
+            )
+        }
+        try {
+            return rustBuffer.asCodedInputStream()?.let { stream ->
+                HistoryMetadata.fromMessage(MsgTypes.HistoryMetadata.parseFrom(stream))
+            }
+        } finally {
+            LibPlacesFFI.INSTANCE.places_destroy_bytebuffer(rustBuffer)
+        }
+    }
+
+    override suspend fun getHistoryMetadataSince(start: Long): List<HistoryMetadata> {
+        readQueryCounters.measure {
+            val rustBuffer = rustCall { error ->
+                LibPlacesFFI.INSTANCE.places_get_history_metadata_since(
+                        this.handle.get(), start, error)
+            }
+            try {
+                val metadata = MsgTypes.HistoryMetadataList.parseFrom(rustBuffer.asCodedInputStream()!!)
+                return HistoryMetadata.fromCollectionMessage(metadata)
+            } finally {
+                LibPlacesFFI.INSTANCE.places_destroy_bytebuffer(rustBuffer)
+            }
+        }
+    }
+
+    override suspend fun getHistoryMetadataBetween(start: Long, end: Long): List<HistoryMetadata> {
+        readQueryCounters.measure {
+            val rustBuffer = rustCall { error ->
+                LibPlacesFFI.INSTANCE.places_get_history_metadata_between(
+                        this.handle.get(), start, end, error)
+            }
+            try {
+                val metadata = MsgTypes.HistoryMetadataList.parseFrom(rustBuffer.asCodedInputStream()!!)
+                return HistoryMetadata.fromCollectionMessage(metadata)
+            } finally {
+                LibPlacesFFI.INSTANCE.places_destroy_bytebuffer(rustBuffer)
+            }
+        }
+    }
+
+    override suspend fun queryHistoryMetadata(query: String, limit: Int): List<HistoryMetadata> {
+        readQueryCounters.measure {
+            val rustBuffer = rustCall { error ->
+                LibPlacesFFI.INSTANCE.places_query_history_metadata(
+                        this.handle.get(), query, limit, error)
+            }
+            try {
+                val metadata = MsgTypes.HistoryMetadataList.parseFrom(rustBuffer.asCodedInputStream()!!)
+                return HistoryMetadata.fromCollectionMessage(metadata)
+            } finally {
+                LibPlacesFFI.INSTANCE.places_destroy_bytebuffer(rustBuffer)
+            }
+        }
+    }
+
     override fun getBookmark(guid: String): BookmarkTreeNode? {
         readQueryCounters.measure {
             val rustBuf = rustCall { err ->
@@ -497,6 +558,7 @@ fun visitTransitionSet(l: List<VisitType>): Int {
 class PlacesWriterConnection internal constructor(connHandle: Long, api: PlacesApi) :
         PlacesReaderConnection(connHandle),
         WritableHistoryConnection,
+        WritableHistoryMetadataConnection,
         WritableBookmarksConnection {
     // The reference to our PlacesAPI. Mostly used to know how to handle getting closed.
     val apiRef = WeakReference(api)
@@ -579,6 +641,45 @@ class PlacesWriterConnection internal constructor(connHandle: Long, api: PlacesA
             rustCall { error ->
                 val existedByte = LibPlacesFFI.INSTANCE.bookmarks_delete(this.handle.get(), guid, error)
                 existedByte.toInt() != 0
+            }
+        }
+    }
+
+    override suspend fun addHistoryMetadata(metadata: HistoryMetadata): String {
+        val builder = MsgTypes.HistoryMetadata.newBuilder()
+            .setUrl(metadata.url)
+            .setCreatedAt(metadata.createdAt)
+            .setUpdatedAt(metadata.updatedAt)
+            .setTotalViewTime(metadata.totalViewTime)
+            .setIsMedia(metadata.isMedia)
+
+        // These are optional.
+        metadata.title?.let { builder.setTitle(it) }
+        metadata.searchTerm?.let { builder.setSearchTerm(it) }
+        metadata.parentUrl?.let { builder.setParentUrl(it) }
+
+        val buf = builder.build()
+        val (nioBuf, len) = buf.toNioDirectBuffer()
+        return writeQueryCounters.measure {
+            rustCallForString { error ->
+                val ptr = Native.getDirectBufferPointer(nioBuf)
+                LibPlacesFFI.INSTANCE.places_add_history_metadata(this.handle.get(), ptr, len, error)
+            }
+        }
+    }
+
+    override suspend fun updateHistoryMetadata(guid: String, totalViewTime: Int) {
+        return writeQueryCounters.measure {
+            rustCall { err ->
+                LibPlacesFFI.INSTANCE.places_update_history_metadata(this.handle.get(), guid, totalViewTime, err)
+            }
+        }
+    }
+
+    override suspend fun deleteOlderThan(olderThan: Long) {
+        return writeQueryCounters.measure {
+            rustCall { err ->
+                LibPlacesFFI.INSTANCE.places_metadata_delete_older_than(this.handle.get(), olderThan, err)
             }
         }
     }
@@ -779,6 +880,73 @@ interface InterruptibleConnection : AutoCloseable {
      * Interrupt ongoing operations running on a separate thread.
      */
     fun interrupt()
+}
+
+/**
+ * This interface exposes the 'read' part of the [HistoryMetadata] storage API.
+ */
+interface ReadableHistoryMetadataConnection : InterruptibleConnection {
+    /**
+     * Returns the most recent [HistoryMetadata] for the provided [url].
+     *
+     * @param url Url to search by.
+     * @return [HistoryMetadata] if there's a matching record, `null` otherwise.
+     */
+    suspend fun getLatestHistoryMetadataForUrl(url: String): HistoryMetadata?
+
+    /**
+     * Returns all [HistoryMetadata] where [HistoryMetadata.updatedAt] is greater or equal to [start].
+     *
+     * @param start Timestmap to search by.
+     * @return A `List` of matching [HistoryMetadata], empty if nothing is found.
+     */
+    suspend fun getHistoryMetadataSince(start: Long): List<HistoryMetadata>
+
+    /**
+     * Returns all [HistoryMetadata] where [HistoryMetadata.updatedAt] is between [start] and [end], inclusive.
+     *
+     * @param start A `start` timestamp.
+     * @param end An `end` timestamp.
+     * @return A `List` of matching [HistoryMetadata], empty if nothing is found.
+     */
+    suspend fun getHistoryMetadataBetween(start: Long, end: Long): List<HistoryMetadata>
+
+    /**
+     * Searches through [HistoryMetadata] by [query], matching records by [HistoryMetadata.url],
+     * [HistoryMetadata.title] and [HistoryMetadata.searchTerm].
+     *
+     * @param query A search query.
+     * @param limit A maximum number of records to return.
+     * @return A `List` of matching [HistoryMetadata], empty if nothing is found.
+     */
+    suspend fun queryHistoryMetadata(query: String, limit: Int): List<HistoryMetadata>
+}
+
+/**
+ * This interface exposes the 'write' part of the [HistoryMetadata] storage API.
+ */
+interface WritableHistoryMetadataConnection : ReadableHistoryMetadataConnection {
+    /**
+     * Adds a [HistoryMetadata] record to the storage.
+     *
+     * @param metadata A [HistoryMetadata] record to add. Must not have a set [HistoryMetadata.guid].
+     * @return A [HistoryMetadata.guid] of the added record.
+     */
+    suspend fun addHistoryMetadata(metadata: HistoryMetadata): String
+
+    /**
+     * Updates a [HistoryMetadata] based on [guid].
+     *
+     * @param totalViewTime A new [HistoryMetadata.totalViewTime].
+     */
+    suspend fun updateHistoryMetadata(guid: String, totalViewTime: Int)
+
+    /**
+     * Deletes [HistoryMetadata] with [HistoryMetadata.updatedAt] older than [olderThan].
+     *
+     * @param olderThan A timestamp to delete records by. Exclusive.
+     */
+    suspend fun deleteOlderThan(olderThan: Long)
 }
 
 interface ReadableHistoryConnection : InterruptibleConnection {
@@ -1145,6 +1313,72 @@ data class SearchResult(
         }
         internal fun fromCollectionMessage(msg: MsgTypes.SearchResultList): List<SearchResult> {
             return msg.resultsList.map {
+                fromMessage(it)
+            }
+        }
+    }
+}
+
+/**
+ * Represents a history metadata record, which describes metadata for a history visit, such as metadata
+ * about the page itself as well as metadata about how the page was opened.
+ *
+ * @property guid A global unique ID assigned to a saved record.
+ * @property url A url of the page.
+ * @property title A title of the page.
+ * @property createdAt When this metadata record was created.
+ * @property updatedAt The last time this record was updated.
+ * @property totalViewTime Total time the user viewed the page associated with this record.
+ * @property searchTerm An optional search term if this record was created as part of a search by the user.
+ * @property isMedia A boolean describing if the page associated with this record is considered a media page.
+ * @property parentUrl An optional parent url if this record was created in response to a user opening a page in a new tab.
+ */
+data class HistoryMetadata(
+    val guid: String?,
+    val url: String,
+    val title: String?,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val totalViewTime: Int,
+    val searchTerm: String?,
+    val isMedia: Boolean,
+    val parentUrl: String?
+) {
+    /**
+    * Used when going from Kotlin -> Rust.
+    */
+    internal fun toJSON(): JSONObject {
+        val o = JSONObject()
+        // NB: we're not processing a `guid` here. The only time when a metadata record is passed into this
+        // API from Kotlin code is when we're adding a new one, in which case a `guid` will be generated
+        // by the Rust code at the moment we're storing this record.
+        o.put("url", this.url)
+        this.title?.let { o.put("title", it) }
+        o.put("created_at", this.createdAt)
+        o.put("updated_at", this.updatedAt)
+        o.put("total_view_time", this.totalViewTime)
+        this.searchTerm?.let { o.put("search_term", it) }
+        o.put("is_media", this.isMedia)
+        this.parentUrl?.let { o.put("parent_url", it) }
+        return o
+    }
+
+    companion object {
+        internal fun fromMessage(msg: MsgTypes.HistoryMetadata): HistoryMetadata {
+            return HistoryMetadata(
+                guid = msg.guid,
+                url = msg.url,
+                title = msg.title,
+                createdAt = msg.createdAt,
+                updatedAt = msg.updatedAt,
+                totalViewTime = msg.totalViewTime,
+                searchTerm = msg.searchTerm,
+                isMedia = msg.isMedia,
+                parentUrl = msg.parentUrl
+            )
+        }
+        internal fun fromCollectionMessage(msg: MsgTypes.HistoryMetadataList): List<HistoryMetadata> {
+            return msg.metadataList.map {
                 fromMessage(it)
             }
         }

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -929,6 +929,11 @@ interface WritableHistoryMetadataConnection : ReadableHistoryMetadataConnection 
     /**
      * Adds a [HistoryMetadata] record to the storage.
      *
+     * Note that if a corresponding history (moz_places) record already exists, we won't be updating
+     * its title. The title update is expected to happen as part of a call to
+     * [WritableHistoryConnection.noteObservation]. Titles in [HistoryMetadata] and history are expected
+     * to come from the same source (i.e. the page itself).
+     *
      * @param metadata A [HistoryMetadata] record to add. Must not have a set [HistoryMetadata.guid].
      * @return A [HistoryMetadata.guid] of the added record.
      */

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -3,6 +3,7 @@
 
 package mozilla.appservices.places
 
+import kotlinx.coroutines.runBlocking
 import androidx.test.core.app.ApplicationProvider
 import mozilla.appservices.Megazord
 import mozilla.components.service.glean.testing.GleanTestRule
@@ -426,5 +427,57 @@ class PlacesConnectionTest {
                 title = "example4")
 
         db.getBookmarksTree(folderGUID, false)
+    }
+
+    @Test
+    fun testHistoryMetadataBasics() = runBlocking {
+        val currentTime = System.currentTimeMillis()
+
+        assertEquals(0, db.getHistoryMetadataSince(0L).size)
+
+        val meta2 = HistoryMetadata(
+            guid = null,
+            url = "https://www.ifixit.com/News/35377/which-wireless-earbuds-are-the-least-evil",
+            title = "Are All Wireless Earbuds As Evil As AirPods? - iFixit",
+            createdAt = currentTime + 1000,
+            updatedAt = currentTime + 2000,
+            totalViewTime = 2000,
+            searchTerm = "repairable wireless headset",
+            isMedia = false,
+            parentUrl = "https://www.google.com/search?client=firefox-b-d&q=headsets+ifixit"
+        )
+        db.addHistoryMetadata(meta2)
+
+        val meta3 = HistoryMetadata(
+            guid = null,
+            url = "https://www.youtube.com/watch?v=Cs1b5qvCZ54",
+            title = "Тайна валдайской дачи Путина - YouTube",
+            createdAt = currentTime + 1500,
+            updatedAt = currentTime + 1700,
+            totalViewTime = 200,
+            searchTerm = "путин валдай",
+            isMedia = true,
+            parentUrl = "https://yandex.ru/query?путин+валдай"
+        )
+        db.addHistoryMetadata(meta3)
+
+        val meta4 = HistoryMetadata(
+            guid = null,
+            url = "https://www.youtube.com/watch?v=Cs1b5qvCZ54",
+            title = null,
+            createdAt = currentTime + 1500,
+            updatedAt = currentTime + 1700,
+            totalViewTime = 200,
+            searchTerm = null,
+            isMedia = true,
+            parentUrl = null
+        )
+        db.addHistoryMetadata(meta4)
+
+        assertEquals(3, db.getHistoryMetadataSince(0L).size)
+
+        db.deleteOlderThan(currentTime + 3000)
+
+        assertEquals(0, db.getHistoryMetadataSince(0L).size)
     }
 }

--- a/components/places/sql/create_shared_schema.sql
+++ b/components/places/sql/create_shared_schema.sql
@@ -237,3 +237,40 @@ CREATE TABLE IF NOT EXISTS moz_keywords(
                      ON DELETE RESTRICT,
     keyword TEXT NOT NULL UNIQUE
 );
+
+----------------------------------------------------------------------
+--------------------History Metadata----------------------------------
+----------------------------------------------------------------------
+
+-- These tables store metadata information related to moz_places.
+-- None of this data is synced for now.
+CREATE TABLE IF NOT EXISTS moz_places_metadata (
+    id INTEGER PRIMARY KEY,
+    guid TEXT NOT NULL UNIQUE CHECK(length(guid) == 12),
+    created_at INTEGER NOT NULL DEFAULT 0,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+
+    place_id INTEGER NOT NULL,
+
+    total_view_time INTEGER NOT NULL DEFAULT 0, -- a rolling aggregate
+    search_query_id INTEGER,
+    parent_domain_id INTEGER,
+    is_media INTEGER NOT NULL DEFAULT 0,
+
+    typing_time INTEGER,
+    key_presses INTEGER,
+
+    FOREIGN KEY(place_id) REFERENCES moz_places(id) ON DELETE CASCADE,
+
+    FOREIGN KEY(search_query_id) REFERENCES moz_places_metadata_search_queries(id) ON DELETE CASCADE,
+
+
+    FOREIGN KEY(parent_domain_id) REFERENCES moz_origins(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS guid_uniqueindex ON moz_places_metadata(guid);
+
+CREATE TABLE IF NOT EXISTS moz_places_metadata_search_queries (
+    id INTEGER PRIMARY KEY,
+    term TEXT NOT NULL UNIQUE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS term_uniqueindex ON moz_places_metadata_search_queries(term);

--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -338,3 +338,16 @@ BEGIN
         foreign_count = foreign_count - 1
     WHERE id = OLD.place_id;
 END;
+
+-- This trigger removes search query entries which no longer have any metadata records that point to them.
+-- Due to SQLite's lack of 'FOR EACH STATEMENT' (only 'FOR EACH ROW' is supported), in case of bulk
+-- deletes of metadata this will perform unnecessary SELECTs.
+-- In other places, this is handled by "staging" temp tables. 
+CREATE TEMP TRIGGER moz_places_metadata_afterdelete_trigger_search_queries
+AFTER DELETE ON moz_places_metadata
+FOR EACH ROW
+BEGIN
+    DELETE FROM moz_places_metadata_search_queries WHERE id = OLD.search_query_id AND NOT EXISTS (
+        SELECT id FROM moz_places_metadata pm WHERE pm.search_query_id = OLD.search_query_id
+    );
+END;

--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -342,7 +342,7 @@ END;
 -- This trigger removes search query entries which no longer have any metadata records that point to them.
 -- Due to SQLite's lack of 'FOR EACH STATEMENT' (only 'FOR EACH ROW' is supported), in case of bulk
 -- deletes of metadata this will perform unnecessary SELECTs.
--- In other places, this is handled by "staging" temp tables. 
+-- In other places, this is handled by "staging" temp tables.
 CREATE TEMP TRIGGER moz_places_metadata_afterdelete_trigger_search_queries
 AFTER DELETE ON moz_places_metadata
 FOR EACH ROW

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -143,6 +143,8 @@ implement_into_ffi_by_protobuf!(msg_types::HistoryVisitInfos);
 implement_into_ffi_by_protobuf!(msg_types::HistoryVisitInfosWithBound);
 implement_into_ffi_by_protobuf!(msg_types::BookmarkNode);
 implement_into_ffi_by_protobuf!(msg_types::BookmarkNodeList);
+implement_into_ffi_by_protobuf!(msg_types::HistoryMetadata);
+implement_into_ffi_by_protobuf!(msg_types::HistoryMetadataList);
 implement_into_ffi_by_delegation!(
     crate::storage::bookmarks::PublicNode,
     msg_types::BookmarkNode

--- a/components/places/src/mozilla.appservices.places.protobuf.rs
+++ b/components/places/src/mozilla.appservices.places.protobuf.rs
@@ -25,6 +25,32 @@ pub struct HistoryVisitInfosWithBound {
     #[prost(int64, required, tag="3")]
     pub offset: i64,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HistoryMetadata {
+    #[prost(string, optional, tag="1")]
+    pub guid: ::std::option::Option<std::string::String>,
+    #[prost(string, required, tag="2")]
+    pub url: std::string::String,
+    #[prost(string, optional, tag="3")]
+    pub title: ::std::option::Option<std::string::String>,
+    #[prost(int64, required, tag="4")]
+    pub created_at: i64,
+    #[prost(int64, required, tag="5")]
+    pub updated_at: i64,
+    #[prost(int32, required, tag="6")]
+    pub total_view_time: i32,
+    #[prost(string, optional, tag="7")]
+    pub search_term: ::std::option::Option<std::string::String>,
+    #[prost(bool, required, tag="8")]
+    pub is_media: bool,
+    #[prost(string, optional, tag="9")]
+    pub parent_url: ::std::option::Option<std::string::String>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HistoryMetadataList {
+    #[prost(message, repeated, tag="1")]
+    pub metadata: ::std::vec::Vec<HistoryMetadata>,
+}
 ///*
 /// A bookmark node.
 ///

--- a/components/places/src/places_msg_types.proto
+++ b/components/places/src/places_msg_types.proto
@@ -27,6 +27,22 @@ message HistoryVisitInfosWithBound {
     required int64 offset = 3;
 }
 
+message HistoryMetadata {
+    optional string guid = 1;
+    required string url = 2;
+    optional string title = 3;
+    required int64 created_at = 4;
+    required int64 updated_at = 5;
+    required int32 total_view_time = 6;
+    optional string search_term = 7;
+    required bool is_media = 8;
+    optional string parent_url = 9;
+}
+
+message HistoryMetadataList {
+    repeated HistoryMetadata metadata = 1;
+}
+
 /**
  * A bookmark node.
  *

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -377,6 +377,8 @@ fn wipe_local_in_tx(db: &PlacesDb) -> Result<()> {
     use crate::frecency::DEFAULT_FRECENCY_SETTINGS;
     db.execute_all(&[
         "DELETE FROM moz_places WHERE foreign_count == 0",
+        "DELETE FROM moz_places_metadata",
+        "DELETE FROM moz_places_metadata_search_queries",
         "DELETE FROM moz_historyvisits",
         "DELETE FROM moz_places_tombstones",
         "DELETE FROM moz_inputhistory AS i WHERE NOT EXISTS(

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -1,0 +1,992 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::db::{PlacesDb, PlacesTransaction};
+use crate::error::Result;
+use crate::msg_types::{HistoryMetadata, HistoryMetadataList};
+use sql_support::{self, ConnExt};
+use sync_guid::Guid as SyncGuid;
+use types::Timestamp;
+use url::Url;
+
+use lazy_static::lazy_static;
+
+enum SearchQueryEntry {
+    None,
+    Existing(i64),
+    CreateFor(String),
+}
+
+enum ParentDomainEntry {
+    None,
+    Existing(i64),
+    CreateFor(Url),
+}
+
+const MAX_QUERY_RESULTS: i32 = 1000;
+
+const COMMON_METADATA_SELECT: &str = "
+SELECT
+    m.guid as guid, p.url as url, p.title as title, m.created_at as created_at,
+    m.updated_at as updated_at, m.total_view_time as total_view_time,
+    m.is_media as is_media, o.host as parent_domain, s.term as search_term
+FROM moz_places_metadata m
+LEFT JOIN moz_places p ON m.place_id = p.id
+LEFT JOIN moz_places_metadata_search_queries s ON m.search_query_id = s.id
+LEFT JOIN moz_origins o ON o.id = m.parent_domain_id";
+
+lazy_static! {
+    static ref GET_LATEST_SQL: String = format!(
+        "{common_select_sql}
+        WHERE p.url_hash = hash(:url) AND url = :url
+        ORDER BY updated_at DESC
+        LIMIT 1",
+        common_select_sql = COMMON_METADATA_SELECT
+    );
+    static ref GET_BETWEEN_SQL: String = format!(
+        "{common_select_sql}
+        WHERE updated_at BETWEEN :start AND :end
+        ORDER BY updated_at DESC
+        LIMIT {max_limit}",
+        common_select_sql = COMMON_METADATA_SELECT,
+        max_limit = MAX_QUERY_RESULTS
+    );
+    static ref GET_SINCE_SQL: String = format!(
+        "{common_select_sql}
+        WHERE updated_at >= :start
+        ORDER BY updated_at DESC
+        LIMIT {max_limit}",
+        common_select_sql = COMMON_METADATA_SELECT,
+        max_limit = MAX_QUERY_RESULTS
+    );
+    static ref QUERY_SQL: String = format!(
+        "{common_select_sql}
+        WHERE
+            url LIKE :query OR
+            title LIKE :query OR
+            search_term LIKE :query
+        ORDER BY total_view_time DESC
+        LIMIT :limit",
+        common_select_sql = COMMON_METADATA_SELECT
+    );
+}
+
+pub fn get_latest_for_url(db: &PlacesDb, url: &Url) -> Result<Option<HistoryMetadata>> {
+    let metadata = db.try_query_row(
+        GET_LATEST_SQL.as_str(),
+        &[(":url", &url.as_str())],
+        HistoryMetadata::from_row,
+        true,
+    )?;
+    Ok(metadata)
+}
+
+pub fn get_between(db: &PlacesDb, start: i64, end: i64) -> Result<HistoryMetadataList> {
+    let metadata = db.query_rows_and_then_named_cached(
+        GET_BETWEEN_SQL.as_str(),
+        rusqlite::named_params! {
+            ":start": start,
+            ":end": end,
+        },
+        HistoryMetadata::from_row,
+    )?;
+    Ok(HistoryMetadataList { metadata })
+}
+
+pub fn get_since(db: &PlacesDb, start: i64) -> Result<HistoryMetadataList> {
+    let metadata = db.query_rows_and_then_named_cached(
+        GET_SINCE_SQL.as_str(),
+        rusqlite::named_params! {
+            ":start": start
+        },
+        HistoryMetadata::from_row,
+    )?;
+    Ok(HistoryMetadataList { metadata })
+}
+
+pub fn query(db: &PlacesDb, query: &str, limit: i64) -> Result<HistoryMetadataList> {
+    let metadata = db.query_rows_and_then_named_cached(
+        QUERY_SQL.as_str(),
+        rusqlite::named_params! {
+            ":query": format!("%{}%", query),
+            ":limit": limit
+        },
+        HistoryMetadata::from_row,
+    )?;
+    Ok(HistoryMetadataList { metadata })
+}
+
+fn insert_metadata_in_tx(
+    tx: &PlacesTransaction<'_>,
+    place_id: Option<i64>,
+    search_query_entry: SearchQueryEntry,
+    parent_domain_entry: ParentDomainEntry,
+    metadata: HistoryMetadata,
+) -> Result<SyncGuid> {
+    // If HistoryMetadata already has a guid, that's an error.
+    assert!(metadata.guid.is_none());
+
+    // Heavy lifting around moz_places inserting (e.g. updating moz_origins, frecency, etc) is performed via triggers.
+    let places_id = match place_id {
+        Some(id) => id,
+        None => {
+            let sql = "INSERT INTO moz_places (guid, url, title, url_hash)
+               VALUES (:guid, :url, :title, hash(:url))";
+
+            let guid = SyncGuid::random();
+
+            // This normalizes urls, e.g. adding trailing slashes when they're missing.
+            // We do the same when querying, to make sure we have a consistent representation
+            // of urls as they're flowing around.
+            let url = Url::parse(&metadata.url)?;
+
+            tx.execute_named_cached(
+                sql,
+                &[
+                    (":guid", &guid),
+                    (":url", &url.as_str()),
+                    (":title", &metadata.title),
+                ],
+            )?;
+            tx.conn().last_insert_rowid()
+        }
+    };
+
+    let search_query_id = match search_query_entry {
+        SearchQueryEntry::None => None,
+        SearchQueryEntry::Existing(id) => Some(id),
+        SearchQueryEntry::CreateFor(term) => {
+            tx.execute_named_cached(
+                "INSERT INTO moz_places_metadata_search_queries(term) VALUES (:term)",
+                &[(":term", &term)],
+            )?;
+            Some(tx.conn().last_insert_rowid())
+        }
+    };
+
+    let parent_domain_id = match parent_domain_entry {
+        ParentDomainEntry::None => None,
+        ParentDomainEntry::Existing(id) => Some(id),
+        ParentDomainEntry::CreateFor(url) => {
+            tx.execute_named_cached(
+                "INSERT INTO moz_origins (prefix, host, rev_host, frecency)
+            VALUES (
+                get_prefix(:url),
+                get_host_and_port(:url),
+                reverse_host(get_host_and_port(:url)),
+                -1
+            )",
+                &[(":url", &url.as_str())],
+            )?;
+            Some(tx.conn().last_insert_rowid())
+        }
+    };
+
+    let sql = "INSERT INTO moz_places_metadata
+        (guid, place_id, created_at, updated_at, total_view_time, search_query_id, is_media, parent_domain_id)
+    VALUES
+        (:guid, :place_id, :created_at, :updated_at, :total_view_time, :search_query_id, :is_media, :parent_domain_id)";
+
+    let guid = SyncGuid::random();
+    tx.execute_named_cached(
+        sql,
+        &[
+            (":guid", &guid),
+            (":place_id", &places_id),
+            (":created_at", &metadata.created_at), // we probably just want to auto-generate these.
+            (":updated_at", &metadata.updated_at),
+            (":total_view_time", &metadata.total_view_time),
+            (":search_query_id", &search_query_id),
+            (":is_media", &metadata.is_media),
+            (":parent_domain_id", &parent_domain_id),
+        ],
+    )?;
+    Ok(guid)
+}
+
+pub fn add_metadata(db: &PlacesDb, metadata: HistoryMetadata) -> Result<SyncGuid> {
+    let places_id = db.try_query_one(
+        "SELECT id FROM moz_places WHERE url_hash = hash(:url) AND url = :url",
+        &[(":url", &metadata.url)],
+        true,
+    )?;
+
+    // Look up the search query first, maybe it's already stored in the db.
+    // Do this before starting a transaction, since it's a SELECT and doesn't need to be part of a tx.
+    // We depend on having a single write connection, so we know a search term won't be inserted by another caller.
+    // NB: there is also a sync writer, but we don't currently sync any of this data.
+    let search_query = match &metadata.search_term {
+        None => SearchQueryEntry::None,
+        Some(term) => {
+            let lowercase_term = term.to_lowercase();
+            match db.try_query_one(
+                "SELECT id FROM moz_places_metadata_search_queries WHERE term = :term",
+                &[(":term", &lowercase_term)],
+                true,
+            )? {
+                Some(id) => SearchQueryEntry::Existing(id),
+                None => SearchQueryEntry::CreateFor(lowercase_term),
+            }
+        }
+    };
+
+    let parent_domain = match &metadata.parent_url {
+        None => ParentDomainEntry::None,
+        Some(parent_url) => {
+            let parent_url = Url::parse(parent_url)?;
+            match db.try_query_one(
+                "SELECT id FROM moz_origins WHERE prefix = get_prefix(:url) AND host = get_host_and_port(:url)",
+                &[(":url", &parent_url.as_str())],
+                true
+            )? {
+                Some(id) => ParentDomainEntry::Existing(id),
+                None => ParentDomainEntry::CreateFor(parent_url)
+            }
+        }
+    };
+
+    let tx = db.begin_transaction()?;
+    let result = insert_metadata_in_tx(&tx, places_id, search_query, parent_domain, metadata);
+    // Inserting into moz_places has side-effects (temp tables are populated via triggers and need to be flushed).
+    // This call "finalizes" these side-effects.
+    super::delete_pending_temp_tables(db)?;
+    match result {
+        Ok(_) => tx.commit()?,
+        Err(_) => tx.rollback()?,
+    };
+    result
+}
+
+pub fn update_metadata(db: &PlacesDb, guid: &SyncGuid, total_view_time: i32) -> Result<()> {
+    let now = Timestamp::now();
+    db.execute_named_cached(
+        "UPDATE moz_places_metadata
+         SET total_view_time = :total_view_time, updated_at = :updated_at
+         WHERE guid = :guid",
+        &[
+            (":guid", guid),
+            (":total_view_time", &total_view_time),
+            (":updated_at", &now),
+        ],
+    )?;
+    Ok(())
+}
+
+pub fn delete_older_than(db: &PlacesDb, older_than: i64) -> Result<()> {
+    db.execute_named_cached(
+        "DELETE FROM moz_places_metadata
+         WHERE updated_at < :older_than",
+        &[(":older_than", &older_than)],
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::places_api::ConnectionType;
+    use pretty_assertions::assert_eq;
+    use types::Timestamp;
+
+    #[macro_use]
+    macro_rules! add_and_assert_history_metadata {
+        ($conn:expr, url $url:expr, title $title:expr, created_at $created_at:expr, updated_at $updated_at:expr, total_time $tvt:expr, search_term $search_term:expr, is_media $is_media:expr, parent_url $parent_url:expr, parent_domain $parent_domain:expr) => {
+            // Create an object to add.
+            let metadata = HistoryMetadata {
+                guid: None,
+                url: String::from($url),
+                title: match $title as Option<&str> {
+                    Some(t) => Some(String::from(t)),
+                    None => None
+                },
+                created_at: $created_at,
+                updated_at: $updated_at,
+                total_view_time: $tvt,
+                search_term: match $search_term as Option<&str> {
+                    Some(t) => Some(String::from(t)),
+                    None => None
+                },
+                is_media: $is_media,
+                parent_url: match $parent_url as Option<&str> {
+                    Some(t) => Some(String::from(t)),
+                    None => None
+                }
+            };
+            // Add it.
+            let db_guid = add_metadata($conn, metadata).expect("should add metadata");
+
+            // Fetch it back and compare results.
+            let m = get_latest_for_url($conn, &Url::parse($url).expect("url parse")).expect("get by url should work");
+            let meta = m.expect("metadata record must be present");
+
+            assert_eq!(db_guid, meta.guid.clone().expect("must have a guid"));
+            assert_history_metadata_record!(meta, url $url, title $title, created_at $created_at, updated_at $updated_at, total_time $tvt, search_term $search_term, is_media $is_media, parent_url $parent_url, parent_domain $parent_domain);
+        };
+    }
+
+    #[macro_use]
+    macro_rules! assert_history_metadata_record {
+        ($record:expr, url $url:expr, title $title:expr, created_at $created_at:expr, updated_at $updated_at:expr, total_time $tvt:expr, search_term $search_term:expr, is_media $is_media:expr, parent_url $parent_url:expr, parent_domain $parent_domain:expr) => {
+            assert_eq!(String::from($url), $record.url, "url must match");
+            assert_eq!($created_at, $record.created_at, "created_at must match");
+            assert_eq!($updated_at, $record.updated_at, "updated_at must match");
+            assert_eq!($tvt, $record.total_view_time, "total_view_time must match");
+            assert_eq!($is_media, $record.is_media, "is_media must match");
+
+            let meta = $record.clone(); // ugh... not sure why this `clone` is necessary.
+
+            match $title as Option<&str> {
+                Some(t) => assert_eq!(
+                    String::from(t),
+                    meta.title.expect("title must be Some"),
+                    "title must match"
+                ),
+                None => assert_eq!(true, meta.title.is_none(), "title expected to be None"),
+            };
+            match $search_term as Option<&str> {
+                Some(t) => assert_eq!(
+                    String::from(t),
+                    meta.search_term.expect("search_term must be Some"),
+                    "search_term must match"
+                ),
+                None => assert_eq!(
+                    true,
+                    meta.search_term.is_none(),
+                    "search_term expected to be None"
+                ),
+            };
+            match $parent_domain as Option<&str> {
+                Some(t) => assert_eq!(
+                    String::from(t),
+                    meta.parent_url.expect("parent_url must be Some"),
+                    "parent_url must match"
+                ),
+                None => assert_eq!(
+                    true,
+                    meta.parent_url.is_none(),
+                    "parent_url expected to be None"
+                ),
+            };
+        };
+    }
+
+    #[test]
+    fn test_get_latest_for_url() {
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
+
+        let now: Timestamp = std::time::SystemTime::now().into();
+        let now_i64 = now.0 as i64;
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/",
+            title Some("Sample test page"),
+            created_at now_i64 + 10000,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://www.mozilla.org/test",
+            title Some("Another page title"),
+            created_at now_i64,
+            updated_at now_i64,
+            total_time 10000,
+            search_term Some("test search"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=some+url+ooook"),
+            parent_domain Some("www.google.com")
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://www.mozilla.org/test2",
+            title Some("Some page title"),
+            created_at now_i64 + 500,
+            updated_at now_i64 + 500,
+            total_time 15000,
+            search_term Some("another search"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=another+url+ooook"),
+            parent_domain Some("www.google.com")
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://www.example.com/video",
+            title Some("Sample test page"),
+            created_at now_i64 + 15000,
+            updated_at now_i64 + 25000,
+            total_time 200000,
+            search_term None,
+            is_media true,
+            parent_url Some("https://www.reuters.com/"),
+            parent_domain Some("www.reuters.com")
+        );
+    }
+
+    #[test]
+    fn test_get_between() {
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
+
+        let now: Timestamp = std::time::SystemTime::now().into();
+        let now_i64 = now.0 as i64;
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/1",
+            title Some("Test page 1"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/2",
+            title Some("Test page 2"),
+            created_at now_i64,
+            updated_at now_i64 + 20000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/3",
+            title Some("Test page 3"),
+            created_at now_i64,
+            updated_at now_i64 + 30000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        let start = now_i64 + 10001;
+        let end = now_i64 + 29999;
+        let meta = get_between(&conn, start, end).expect("expected results");
+
+        assert_eq!(1, meta.metadata.len(), "expected exactly one result");
+
+        let result = meta.metadata.first().expect("expected one result");
+
+        assert_eq!("http://mozilla.com/2", result.url, "url must match");
+    }
+
+    #[test]
+    fn test_get_since() {
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
+
+        let now: Timestamp = std::time::SystemTime::now().into();
+        let now_i64 = now.0 as i64;
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/1",
+            title Some("Test page 1"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/2",
+            title Some("Test page 2"),
+            created_at now_i64,
+            updated_at now_i64 + 20000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/3",
+            title Some("Test page 3"),
+            created_at now_i64,
+            updated_at now_i64 + 30000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        let start = now_i64 + 10001;
+        let meta = get_since(&conn, start).expect("expected results");
+
+        assert_eq!(2, meta.metadata.len(), "expected exactly one result");
+
+        let first_result = &meta.metadata[0];
+        assert_eq!("http://mozilla.com/3", first_result.url, "url must match");
+
+        let second_result = &meta.metadata[1];
+        assert_eq!("http://mozilla.com/2", second_result.url, "url must match");
+    }
+
+    #[test]
+    fn test_query() {
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
+
+        let now: Timestamp = std::time::SystemTime::now().into();
+        let now_i64 = now.0 as i64;
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://www.cbc.ca/news/politics/federal-budget-2021-freeland-zimonjic-1.5991021",
+            title Some("Budget vows to build &#x27;for the long term&#x27; as it promises child care cash, projects massive deficits | CBC News"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term Some("cbc federal budget 2021"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://stackoverflow.com/questions/37777675/how-to-create-a-formatted-string-out-of-a-literal-in-rust",
+            title Some("formatting - How to create a formatted String out of a literal in Rust? - Stack Overflow"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term Some("rust string format"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://www.sqlite.org/lang_corefunc.html#instr",
+            title Some("Built-In Scalar SQL Functions"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term Some("sqlite like"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        // query by title
+        let meta = query(&conn, "child care", 10).expect("query should work");
+        assert_eq!(1, meta.metadata.len(), "expected exactly one result");
+        assert_history_metadata_record!(&meta.metadata[0],
+            url "https://www.cbc.ca/news/politics/federal-budget-2021-freeland-zimonjic-1.5991021",
+            title Some("Budget vows to build &#x27;for the long term&#x27; as it promises child care cash, projects massive deficits | CBC News"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term Some("cbc federal budget 2021"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        // query by search term
+        let meta = query(&conn, "string format", 10).expect("query should work");
+        assert_eq!(1, meta.metadata.len(), "expected exactly one result");
+        assert_history_metadata_record!(&meta.metadata[0],
+            url "https://stackoverflow.com/questions/37777675/how-to-create-a-formatted-string-out-of-a-literal-in-rust",
+            title Some("formatting - How to create a formatted String out of a literal in Rust? - Stack Overflow"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term Some("rust string format"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        // query by url
+        let meta = query(&conn, "instr", 10).expect("query should work");
+        assert_history_metadata_record!(&meta.metadata[0],
+            url "https://www.sqlite.org/lang_corefunc.html#instr",
+            title Some("Built-In Scalar SQL Functions"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term Some("sqlite like"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+    }
+
+    #[test]
+    fn test_update() {
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
+
+        let now: Timestamp = std::time::SystemTime::now().into();
+        let now_i64 = now.0 as i64;
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/1",
+            title Some("Test page 1"),
+            created_at now_i64,
+            updated_at now_i64,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        let m = get_latest_for_url(
+            &conn,
+            &Url::parse("http://mozilla.com/1").expect("url parse"),
+        )
+        .expect("get by url should work");
+        let meta = m.expect("metadata record must be present");
+        let db_guid = SyncGuid::new(meta.guid.expect("Record must have a guid").as_str());
+
+        update_metadata(&conn, &db_guid, 30000).expect("update record should work");
+
+        let updated_meta = get_latest_for_url(
+            &conn,
+            &Url::parse("http://mozilla.com/1").expect("url parse"),
+        )
+        .expect("get by url should work")
+        .expect("metadata record must be present");
+
+        assert_eq!(
+            30000, updated_meta.total_view_time,
+            "total view should have been updated"
+        );
+        assert!(
+            now_i64 < updated_meta.updated_at,
+            "updated_at should have been updated"
+        );
+    }
+
+    #[test]
+    fn test_delete_older_than() {
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
+
+        let now: Timestamp = std::time::SystemTime::now().into();
+        let now_i64 = now.0 as i64;
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/1",
+            title Some("Test page 1"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/2",
+            title Some("Test page 2"),
+            created_at now_i64,
+            updated_at now_i64 + 20000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "http://mozilla.com/3",
+            title Some("Test page 3"),
+            created_at now_i64,
+            updated_at now_i64 + 30000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url None,
+            parent_domain None
+        );
+
+        // deleting nothing.
+        delete_older_than(&conn, (now_i64 - 40000) as i64).expect("delete worked");
+        assert_eq!(
+            3,
+            get_since(&conn, now_i64)
+                .expect("get worked")
+                .metadata
+                .len()
+        );
+
+        // boundary condition, should only delete the last one.
+        delete_older_than(&conn, (now_i64 + 20000) as i64).expect("delete worked");
+        assert_eq!(
+            2,
+            get_since(&conn, now_i64)
+                .expect("get worked")
+                .metadata
+                .len()
+        );
+        assert_eq!(
+            None,
+            get_latest_for_url(&conn, &Url::parse("http://mozilla.com/1").expect("url"))
+                .expect("get")
+        );
+
+        // delete everything now.
+        delete_older_than(&conn, (now_i64 + 30001) as i64).expect("delete worked");
+        assert_eq!(
+            0,
+            get_since(&conn, now_i64)
+                .expect("get worked")
+                .metadata
+                .len()
+        );
+    }
+
+    #[test]
+    fn test_metadata_deletes_do_not_affect_places() {
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
+
+        let now: Timestamp = std::time::SystemTime::now().into();
+        let now_i64 = now.0 as i64;
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://www.mozilla.org/first/",
+            title Some("Test page 0"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://www.mozilla.org/",
+            title Some("Test page 1"),
+            created_at now_i64,
+            updated_at now_i64 + 8000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        // Delete all metadata.
+        delete_older_than(&conn, now_i64 + 9000).expect("delete older than worked");
+
+        // Query places. Records there should not have been affected by the delete above.
+        assert_eq!(
+            2,
+            conn.try_query_one::<i64>("SELECT count(*) FROM moz_places", &[], true)
+                .expect("select works")
+                .expect("got count")
+        );
+    }
+
+    #[test]
+    fn test_places_delete_triggers() {
+        // The cleanup functionality lives as a TRIGGER in `create_shared_triggers`.
+        use crate::observation::VisitObservation;
+        use crate::storage::history::{apply_observation, delete_visits_between, wipe_local};
+        use crate::types::VisitTransition;
+
+        let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
+
+        let now: Timestamp = std::time::SystemTime::now().into();
+        let now_i64 = now.0 as i64;
+        let observation1 = VisitObservation::new(Url::parse("https://www.mozilla.org/").unwrap())
+            .with_at(now)
+            .with_title(Some(String::from("Test page 1")))
+            .with_is_remote(false)
+            .with_visit_type(VisitTransition::Link);
+        let observation2 =
+            VisitObservation::new(Url::parse("https://www.mozilla.org/another/").unwrap())
+                .with_at(Timestamp((now_i64 + 10000) as u64))
+                .with_title(Some(String::from("Test page 3")))
+                .with_is_remote(false)
+                .with_visit_type(VisitTransition::Link);
+        let observation3 =
+            VisitObservation::new(Url::parse("https://www.mozilla.org/first/").unwrap())
+                .with_at(Timestamp((now_i64 - 10000) as u64))
+                .with_title(Some(String::from("Test page 0")))
+                .with_is_remote(true)
+                .with_visit_type(VisitTransition::Link);
+        apply_observation(&conn, observation1).expect("Should apply visit");
+        apply_observation(&conn, observation2).expect("Should apply visit");
+        apply_observation(&conn, observation3).expect("Should apply visit");
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://www.mozilla.org/first/",
+            title Some("Test page 0"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://www.mozilla.org/",
+            title Some("Test page 1"),
+            created_at now_i64,
+            updated_at now_i64 + 8000,
+            total_time 20000,
+            search_term None,
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://www.mozilla.org/",
+            title Some("Test page 1"),
+            created_at now_i64,
+            updated_at now_i64 + 9000,
+            total_time 20000,
+            search_term Some("mozilla"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://www.mozilla.org/",
+            title Some("Test page 1"),
+            created_at now_i64 + 2000,
+            updated_at now_i64 + 11000,
+            total_time 25000,
+            search_term Some("firefox"),
+            is_media true,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        add_and_assert_history_metadata!(
+            &conn,
+            url "https://www.mozilla.org/another/",
+            title Some("Test page 3"),
+            created_at now_i64,
+            updated_at now_i64 + 10000,
+            total_time 20000,
+            search_term Some("mozilla"),
+            is_media false,
+            parent_url Some("https://www.google.com/search?client=firefox-b-d&q=mozilla+firefox"),
+            parent_domain Some("www.google.com")
+        );
+
+        // double-check that we have the 'firefox' search query entry.
+        assert!(conn
+            .try_query_one::<i64>(
+                "SELECT id FROM moz_places_metadata_search_queries WHERE term = :term",
+                &[(":term", &String::from("firefox"))],
+                true
+            )
+            .expect("select works")
+            .is_some());
+
+        // Delete our first page & its visits. Note that /another/ page will remain in place.
+        delete_visits_between(
+            &conn,
+            Timestamp((now_i64 - 1000) as u64),
+            Timestamp((now_i64 + 1000) as u64),
+        )
+        .expect("delete worked");
+
+        let meta1 =
+            get_latest_for_url(&conn, &Url::parse("https://www.mozilla.org/").expect("url"))
+                .expect("get worked");
+        let meta2 = get_latest_for_url(
+            &conn,
+            &Url::parse("https://www.mozilla.org/another/").expect("url"),
+        )
+        .expect("get worked");
+
+        assert!(meta1.is_none(), "expected metadata to have been deleted");
+        assert!(
+            meta2.is_some(),
+            "expected metadata to not have been deleted"
+        );
+
+        // still have a 'mozilla' search query entry, since one meta entry points to it.
+        assert!(
+            conn.try_query_one::<i64>(
+                "SELECT id FROM moz_places_metadata_search_queries WHERE term = :term",
+                &[(":term", &String::from("mozilla"))],
+                true
+            )
+            .expect("select works")
+            .is_some(),
+            "search_query records with related metadata should not have been deleted"
+        );
+
+        // don't have the 'firefox' search query entry anymore, nothing points to it.
+        assert!(
+            conn.try_query_one::<i64>(
+                "SELECT id FROM moz_places_metadata_search_queries WHERE term = :term",
+                &[(":term", &String::from("firefox"))],
+                true
+            )
+            .expect("select works")
+            .is_none(),
+            "search_query records without related metadata should have been deleted"
+        );
+
+        // now, let's wipe places, and make sure none of the metadata stuff remains.
+        wipe_local(&conn).expect("places wipe succeeds");
+
+        let all_metadata = conn
+            .query_rows_and_then_named_cached(
+                COMMON_METADATA_SELECT,
+                rusqlite::named_params! {},
+                HistoryMetadata::from_row,
+            )
+            .expect("select all metadata worked");
+
+        assert_eq!(0, all_metadata.len());
+
+        assert_eq!(
+            0,
+            conn.try_query_one::<i64>(
+                "SELECT count(*) FROM moz_places_metadata_search_queries",
+                &[],
+                true
+            )
+            .expect("select works")
+            .expect("got count")
+        );
+    }
+}

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -7,11 +7,12 @@
 
 pub mod bookmarks;
 pub mod history;
+pub mod history_metadata;
 pub mod tags;
 
 use crate::db::PlacesDb;
 use crate::error::{ErrorKind, InvalidPlaceInfo, Result};
-use crate::msg_types::{HistoryVisitInfo, TopFrecentSiteInfo};
+use crate::msg_types::{HistoryMetadata, HistoryVisitInfo, TopFrecentSiteInfo};
 use crate::types::{SyncStatus, VisitTransition};
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::Result as RusqliteResult;
@@ -198,6 +199,25 @@ impl TopFrecentSiteInfo {
         Ok(Self {
             url: row.get("url")?,
             title: row.get("title")?,
+        })
+    }
+}
+
+impl HistoryMetadata {
+    pub(crate) fn from_row(row: &rusqlite::Row<'_>) -> Result<Self> {
+        let created_at: Timestamp = row.get("created_at")?;
+        let updated_at: Timestamp = row.get("updated_at")?;
+
+        Ok(Self {
+            guid: row.get("guid")?,
+            url: row.get("url")?,
+            title: row.get("title")?,
+            created_at: created_at.0 as i64,
+            updated_at: updated_at.0 as i64,
+            total_view_time: row.get("total_view_time")?,
+            search_term: row.get("search_term")?,
+            is_media: row.get("is_media")?,
+            parent_url: row.get("parent_domain")?,
         })
     }
 }


### PR DESCRIPTION
This introduces a new History Metadata storage along with Android bindings for it. Swift bindings to come soon.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
