### PR TITLE
Introduce Swift bindings for the History Metadata storage

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -4,7 +4,7 @@
 
 ## History Metadata Storage
 
-- Introduced a new experimental metadata storage API, part of libplaces. Currently only has Android bindings.
+- Introduced a new experimental metadata storage API, part of libplaces.
 
 ## Sync Manager
 

--- a/components/places/ios/Places/HistoryMetadata.swift
+++ b/components/places/ios/Places/HistoryMetadata.swift
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/**
+ Represents a history metadata record, which describes metadata for a history visit, such as metadata
+ about the page itself as well as metadata about how the page was opened.
+ */
+public struct HistoryMetadata {
+    public let guid: String?
+    public let url: String
+    public let title: String?
+    public let createdAt: Int64
+    public let updatedAt: Int64
+    public let totalViewTime: Int32
+    public let searchTerm: String?
+    public let isMedia: Bool
+    public let parentUrl: String?
+}
+
+internal func unpackMetadataProtobuf(msg: MsgTypes_HistoryMetadata) -> HistoryMetadata {
+    // Protobuf doesn't support passing around `null` value, so these get converted to some defaults
+    // as they go from Rust to Swift. E.g. an empty string in place of a `null`.
+    // Convert them back to nils here.
+    let meta = HistoryMetadata(
+        guid: msg.guid,
+        url: msg.url,
+        title: !msg.title.isEmpty ? msg.title : nil,
+        createdAt: msg.createdAt,
+        updatedAt: msg.updatedAt,
+        totalViewTime: msg.totalViewTime,
+        searchTerm: !msg.searchTerm.isEmpty ? msg.searchTerm : nil,
+        isMedia: msg.isMedia,
+        parentUrl: !msg.parentURL.isEmpty ? msg.parentURL : nil
+    )
+
+    return meta
+}
+
+internal func unpackMetadataListProtobuf(msg: MsgTypes_HistoryMetadataList) -> [HistoryMetadata] {
+    return msg.metadata.map { node in
+        unpackMetadataProtobuf(msg: node)
+    }
+}

--- a/components/places/ios/Places/RustPlacesAPI.h
+++ b/components/places/ios/Places/RustPlacesAPI.h
@@ -208,3 +208,45 @@ void places_connection_destroy(PlacesConnectionHandle conn,
 
 void places_api_destroy(PlacesAPIHandle api,
                         PlacesRustError *_Nonnull out_err);
+
+// MARK: History metadata storage
+PlacesRustBuffer places_get_latest_history_metadata_for_url(
+                                                PlacesConnectionHandle handle,
+                                                char const *_Nonnull url,
+                                                PlacesRustError *_Nonnull out_err);
+
+PlacesRustBuffer places_get_history_metadata_between(
+                                                     PlacesConnectionHandle handle,
+                                                     int64_t start,
+                                                     int64_t end,
+                                                     PlacesRustError *_Nonnull out_err);
+
+PlacesRustBuffer places_get_history_metadata_since(
+                                                   PlacesConnectionHandle handle,
+                                                   int64_t since,
+                                                   PlacesRustError *_Nonnull out_err);
+
+
+PlacesRustBuffer places_query_history_metadata(
+                                               PlacesConnectionHandle handle,
+                                               char const *_Nonnull query,
+                                               int32_t limit,
+                                               PlacesRustError *_Nonnull out_err);
+
+char *_Nonnull places_add_history_metadata(
+                                           PlacesConnectionHandle handle,
+                                           uint8_t const *_Nonnull data,
+                                           int32_t len,
+                                           PlacesRustError *_Nonnull out_err);
+
+void places_update_history_metadata(
+                                    PlacesConnectionHandle handle,
+                                    char const *_Nonnull guid,
+                                    int32_t totalViewTime,
+                                    PlacesRustError *_Nonnull out_err);
+
+void places_metadata_delete_older_than(
+                                       PlacesConnectionHandle handle,
+                                       int64_t olderThan,
+                                       PlacesRustError *_Nonnull out_err);
+

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		CEFB1EB022EF708B0001E20F /* ResultError.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFB1EAF22EF708B0001E20F /* ResultError.swift */; };
 		D05434A1225680D900FDE4EF /* MozillaAppServices.h in Headers */ = {isa = PBXBuildFile; fileRef = C852EEF2220A3C6800A6E79A /* MozillaAppServices.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D05434A32256810200FDE4EF /* RustPasswordAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = C852EEC8220A29FE00A6E79A /* RustPasswordAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		D9FA8C542644A170008344BF /* HistoryMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9FA8C532644A170008344BF /* HistoryMetadata.swift */; };
 		EB7DE84D2214D30B00E7CF17 /* SwiftProtobuf.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB7DE84C2214D30B00E7CF17 /* SwiftProtobuf.framework */; };
 		EB879D7F221234EB00753DC9 /* MozillaAppServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE9D202020914D0D00F1C8FA /* MozillaAppServices.framework */; };
 		EB879D8B22123FD900753DC9 /* LoginsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB879D8A22123FD900753DC9 /* LoginsTests.swift */; };
@@ -249,6 +250,7 @@
 		CED443CC23CD13E5007E5FA6 /* FxAccountDeviceConstellation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FxAccountDeviceConstellation.swift; sourceTree = "<group>"; };
 		CEDDBC8D23DB4CD600CFF5AA /* PersistedFirefoxAccount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistedFirefoxAccount.swift; sourceTree = "<group>"; };
 		CEFB1EAF22EF708B0001E20F /* ResultError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultError.swift; sourceTree = "<group>"; };
+		D9FA8C532644A170008344BF /* HistoryMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryMetadata.swift; sourceTree = "<group>"; };
 		EB7DE84C2214D30B00E7CF17 /* SwiftProtobuf.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftProtobuf.framework; path = ../../Carthage/Build/iOS/SwiftProtobuf.framework; sourceTree = "<group>"; };
 		EB879D7A221234EB00753DC9 /* MozillaAppServicesTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MozillaAppServicesTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB879D7E221234EB00753DC9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -516,6 +518,7 @@
 				CD85A44C22361E880099BFA9 /* Extensions */,
 				CD85A44F22361E880099BFA9 /* Bookmark.swift */,
 				CD85A45022361E880099BFA9 /* Errors */,
+				D9FA8C532644A170008344BF /* HistoryMetadata.swift */,
 			);
 			name = Places;
 			path = ../../components/places/ios/Places;
@@ -831,6 +834,7 @@
 				CE1445AC23D6058B00B1E808 /* FxAccountConfig.swift in Sources */,
 				CD85A45422361E890099BFA9 /* Places.swift in Sources */,
 				C852EED8220A29FE00A6E79A /* LockError.swift in Sources */,
+				D9FA8C542644A170008344BF /* HistoryMetadata.swift in Sources */,
 				BF1A87AC25064A8100FED88E /* MemoryUnit.swift in Sources */,
 				BF1A87BE25064A9400FED88E /* HttpPingUploader.swift in Sources */,
 				BF1A87CF25064AC000FED88E /* Utils.swift in Sources */,


### PR DESCRIPTION
This is a copy of the Android bindings we already have. Same concerns apply as with the android bindings, e.g. - https://github.com/mozilla/application-services/issues/4067 - so this will churn a bit.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
