### PR TITLE
Introduce FeatureConfig.value to foreign languages

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -20,7 +20,7 @@ the details of which are reproduced below.
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
 * [MIT License: kernel32-sys, winapi-build, ws2_32-sys](#mit-license-kernel32-sys-winapi-build-ws2_32-sys)
-* [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
+* [MIT License: libsqlite3-sys](#mit-license-libsqlite3-sys)
 * [MIT License: matches](#mit-license-matches)
 * [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: miniz_oxide](#mit-license-miniz_oxide)
@@ -29,6 +29,7 @@ the details of which are reproduced below.
 * [MIT License: openssl-sys](#mit-license-openssl-sys)
 * [MIT License: ordered-float](#mit-license-ordered-float)
 * [MIT License: oslog](#mit-license-oslog)
+* [MIT License: rusqlite](#mit-license-rusqlite)
 * [MIT License: schannel](#mit-license-schannel)
 * [MIT License: slab](#mit-license-slab)
 * [MIT License: textwrap](#mit-license-textwrap)
@@ -1221,14 +1222,13 @@ SOFTWARE.
 
 ```
 -------------
-## MIT License: libsqlite3-sys, rusqlite
+## MIT License: libsqlite3-sys
 
 The following text applies to code linked from these dependencies:
-[libsqlite3-sys](https://github.com/rusqlite/rusqlite),
-[rusqlite](https://github.com/rusqlite/rusqlite)
+[libsqlite3-sys](https://github.com/rusqlite/rusqlite)
 
 ```
-Copyright (c) 2014-2020 The rusqlite developers
+Copyright (c) 2014-2021 The rusqlite developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1497,6 +1497,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+```
+-------------
+## MIT License: rusqlite
+
+The following text applies to code linked from these dependencies:
+[rusqlite](https://github.com/rusqlite/rusqlite)
+
+```
+Copyright (c) 2014-2020 The rusqlite developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ```
 -------------

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -19,15 +19,15 @@ import androidx.core.content.pm.PackageInfoCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import mozilla.components.service.glean.Glean
+import org.json.JSONObject
 import org.mozilla.experiments.nimbus.GleanMetrics.NimbusEvents
 import org.mozilla.experiments.nimbus.internal.AppContext
 import org.mozilla.experiments.nimbus.internal.AvailableExperiment
 import org.mozilla.experiments.nimbus.internal.AvailableRandomizationUnits
-import org.mozilla.experiments.nimbus.internal.Branch
 import org.mozilla.experiments.nimbus.internal.EnrolledExperiment
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEvent
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEventType
-import org.mozilla.experiments.nimbus.internal.FeatureConfig
+import org.mozilla.experiments.nimbus.internal.ExperimentBranch
 import org.mozilla.experiments.nimbus.internal.NimbusErrorException
 import org.mozilla.experiments.nimbus.internal.NimbusClient
 import org.mozilla.experiments.nimbus.internal.NimbusClientInterface
@@ -39,10 +39,9 @@ private const val EXPERIMENT_COLLECTION_NAME = "nimbus-mobile-experiments"
 private const val NIMBUS_DATA_DIR: String = "nimbus_data"
 
 // Republish these classes from this package.
-typealias Branch = Branch
+typealias Branch = ExperimentBranch
 typealias AvailableExperiment = AvailableExperiment
 typealias EnrolledExperiment = EnrolledExperiment
-typealias FeatureConfig = FeatureConfig
 
 /**
  * This is the main experiments API, which is exposed through the global [Nimbus] object.
@@ -311,6 +310,13 @@ open class Nimbus(
     @WorkerThread
     override fun getAvailableExperiments(): List<AvailableExperiment> =
         nimbusClient.getAvailableExperiments()
+
+    @AnyThread
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun getFeatureConfigVariablesJson(featureId: String) =
+        withCatchAll {
+            nimbusClient.getFeatureConfigVariables(featureId)?.let { JSONObject(it) }
+        }
 
     override fun getExperimentBranch(experimentId: String): String? {
         recordExposure(experimentId)

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTest.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTest.kt
@@ -184,10 +184,19 @@ class NimbusTest {
                   "schemaVersion": "1.0.0",
                   "slug": "test-experiment",
                   "endDate": null,
+                  "featureIds": ["about_welcome"],
                   "branches": [
                     {
                       "slug": "test-branch",
-                      "ratio": 1
+                      "ratio": 1,
+                      "feature": {
+                          "featureId": "about_welcome",
+                          "enabled": false,
+                          "value": {
+                            "text": "OK then",
+                            "number": 42
+                          }
+                      }
                     }
                   ],
                   "probeSets": [],
@@ -221,6 +230,18 @@ class NimbusTest {
         assertEquals(appInfo.appName, expContext.appName)
         assertEquals(appInfo.channel, expContext.channel)
         // If we could control more of the context here we might be able to better test it
+    }
+
+    @Test
+    fun `Receiving JSON features`() {
+        // Load the experiment in nimbus so and optIn so that it will be active. This is necessary
+        // because recordExposure checks for active experiments before recording.
+        nimbus.setUpTestExperiments(packageName, appInfo)
+
+        val json = nimbus.getFeatureConfigVariablesJson("about_welcome")
+        assertNotNull(json)
+        assertEquals(42, json!!["number"])
+        assertEquals("OK then", json["text"])
     }
 
     @Test

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTest.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTest.kt
@@ -17,6 +17,7 @@ import mozilla.components.service.glean.net.ConceptFetchHttpUploader
 import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -233,15 +234,18 @@ class NimbusTest {
     }
 
     @Test
-    fun `Receiving JSON features`() {
-        // Load the experiment in nimbus so and optIn so that it will be active. This is necessary
-        // because recordExposure checks for active experiments before recording.
+    fun `Smoke test— receiving JSON features`() {
         nimbus.setUpTestExperiments(packageName, appInfo)
-
+        // The test experiment has exactly one branch with 100% enrollment
+        // We should be able to get feature variables for the feature in this
+        // experiment.
         val json = nimbus.getFeatureConfigVariablesJson("about_welcome")
         assertNotNull(json)
         assertEquals(42, json!!["number"])
         assertEquals("OK then", json["text"])
+
+        val json2 = nimbus.getFeatureConfigVariablesJson("non-existent-feature")
+        assertNull(json2)
     }
 
     @Test

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -171,6 +171,17 @@ extension Nimbus: NimbusFeatureConfiguration {
             try nimbusClient.getExperimentBranch(id: featureId)
         }
     }
+
+    internal func getFeatureConfigVariablesJson(featureId: String) -> [String: Any]? {
+        return catchAll {
+            if let string = try nimbusClient.getFeatureConfigVariables(featureId: featureId),
+                   let data = string.data(using: .utf8) {
+                return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+            } else {
+                return nil
+            }
+        }
+    }
 }
 
 extension Nimbus: NimbusUserConfiguration {

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -175,8 +175,9 @@ extension Nimbus: NimbusFeatureConfiguration {
     internal func getFeatureConfigVariablesJson(featureId: String) -> [String: Any]? {
         return catchAll {
             if let string = try nimbusClient.getFeatureConfigVariables(featureId: featureId),
-                   let data = string.data(using: .utf8) {
-                return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+               let data = string.data(using: .utf8)
+            {
+                return try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
             } else {
                 return nil
             }

--- a/components/nimbus/ios/Nimbus/NimbusApi.swift
+++ b/components/nimbus/ios/Nimbus/NimbusApi.swift
@@ -154,3 +154,6 @@ public struct NimbusAppSettings {
 /// This error reporter is passed to `Nimbus` and any errors that are caught are reported via this type.
 ///
 public typealias NimbusErrorReporter = (Error) -> Void
+
+/// `ExperimentBranch` is a copy of the `Branch` without the `FeatureConfig`.
+public typealias Branch = ExperimentBranch

--- a/components/nimbus/src/client/http_client.rs
+++ b/components/nimbus/src/client/http_client.rs
@@ -324,6 +324,7 @@ mod tests {
                         feature: Some(FeatureConfig {
                             feature_id: "first_switch".to_string(),
                             enabled: false,
+                            value: "{}".to_string(),
                         }),
                     },
                     Branch {
@@ -332,6 +333,7 @@ mod tests {
                         feature: Some(FeatureConfig {
                             feature_id: "first_switch".to_string(),
                             enabled: true,
+                            value: "{}".to_string(),
                         }),
                     },
                 ],

--- a/components/nimbus/src/client/http_client.rs
+++ b/components/nimbus/src/client/http_client.rs
@@ -324,7 +324,7 @@ mod tests {
                         feature: Some(FeatureConfig {
                             feature_id: "first_switch".to_string(),
                             enabled: false,
-                            value: "{}".to_string(),
+                            value: Default::default(),
                         }),
                     },
                     Branch {
@@ -333,7 +333,7 @@ mod tests {
                         feature: Some(FeatureConfig {
                             feature_id: "first_switch".to_string(),
                             enabled: true,
-                            value: "{}".to_string(),
+                            value: Default::default(),
                         }),
                     },
                 ],

--- a/components/nimbus/src/dbcache.rs
+++ b/components/nimbus/src/dbcache.rs
@@ -6,6 +6,7 @@ use crate::enrollment::{get_enrollments, map_features_by_feature_id, EnrolledFea
 use crate::error::{NimbusError, Result};
 use crate::persistence::{Database, StoreId, Writer};
 use crate::{enrollment::ExperimentEnrollment, Experiment};
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::sync::RwLock;
 
@@ -116,7 +117,7 @@ impl DatabaseCache {
         })
     }
 
-    pub fn get_feature_config_variables(&self, feature_id: &str) -> Result<Option<String>> {
+    pub fn get_feature_config_variables(&self, feature_id: &str) -> Result<Option<Map<String, Value>>> {
         self.get_data(|data| {
             if let Some(enrolled_feature) = data.features_by_feature_id.get(feature_id) {
                 Some(enrolled_feature.feature.value.clone())

--- a/components/nimbus/src/dbcache.rs
+++ b/components/nimbus/src/dbcache.rs
@@ -65,6 +65,12 @@ impl DatabaseCache {
 
         let features_by_feature_id = map_features_by_feature_id(&enrollments, &experiments);
 
+        // This is where testing tools would override i.e. replace experimental feature configurations.
+        // i.e. testing tools would cause custom feature configs to be stored in a Store.
+        // Here, we get those overrides out of the store, and merge it with this map.
+
+        // This is where rollouts (promoted experiments on a given feature) will be merged in to the feature variables.
+
         let data = CachedData {
             branches_by_experiment,
             features_by_feature_id,

--- a/components/nimbus/src/dbcache.rs
+++ b/components/nimbus/src/dbcache.rs
@@ -6,7 +6,6 @@ use crate::enrollment::{get_enrollments, map_features_by_feature_id, EnrolledFea
 use crate::error::{NimbusError, Result};
 use crate::persistence::{Database, StoreId, Writer};
 use crate::{enrollment::ExperimentEnrollment, Experiment};
-use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::sync::RwLock;
 
@@ -117,10 +116,11 @@ impl DatabaseCache {
         })
     }
 
-    pub fn get_feature_config_variables(&self, feature_id: &str) -> Result<Option<Map<String, Value>>> {
+    pub fn get_feature_config_variables(&self, feature_id: &str) -> Result<Option<String>> {
         self.get_data(|data| {
             if let Some(enrolled_feature) = data.features_by_feature_id.get(feature_id) {
-                Some(enrolled_feature.feature.value.clone())
+                let string = serde_json::to_string(&enrolled_feature.feature.value).unwrap();
+                Some(string)
             } else {
                 None
             }

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -1026,7 +1026,11 @@ mod tests {
                         "ratio": 1,
                         "feature": {
                             "featureId": "some_control",
-                            "enabled": false
+                            "enabled": false,
+                            "value": {
+                                "text": "OK then",
+                                "number": 42
+                            }
                         }
                     },
                     {
@@ -1034,7 +1038,11 @@ mod tests {
                         "ratio":1,
                         "feature": {
                             "featureId": "some_control",
-                            "enabled": true
+                            "enabled": true,
+                            "value": {
+                                "text": "OK then",
+                                "number": 42
+                            }
                         }
                     }
                 ],
@@ -1115,13 +1123,17 @@ mod tests {
                 "slug": "secure-gold",
                 "endDate": null,
                 "featureIds": ["about_welcome"],
-                "branches":[
+                "branches": [
                     {
                         "slug": "control",
                         "ratio": 1,
                         "feature": {
                             "featureId": "about_welcome",
-                            "enabled": false
+                            "enabled": false,
+                            "value": {
+                                "text": "OK then",
+                                "number": 42
+                            },
                         }
                     },
                     {
@@ -1129,7 +1141,11 @@ mod tests {
                         "ratio":1,
                         "feature": {
                             "featureId": "about_welcome",
-                            "enabled": true
+                            "enabled": true,
+                            "value": {
+                                "text": "OK then",
+                                "number": 42
+                            },
                         }
                     }
                 ],
@@ -1159,9 +1175,31 @@ mod tests {
                 "schemaVersion": "1.0.0",
                 "slug": "secure-silver",
                 "endDate": null,
-                "branches":[
-                    {"slug": "control", "ratio": 1}, // XXX add feature
-                    {"slug": "treatment","ratio":1}, // XXX add feature
+                "branches": [
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                        "feature": {
+                            "featureId": "about_welcome",
+                            "enabled": false,
+                            "value": {
+                                "text": "OK then",
+                                "number": 42
+                            },
+                        }
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio":1,
+                        "feature": {
+                            "featureId": "about_welcome",
+                            "enabled": true,
+                            "value": {
+                                "text": "OK then",
+                                "number": 42
+                            },
+                        }
+                    }
                 ],
                 "featureIds": ["about_welcome"],
                 "channel": "nightly",
@@ -1798,6 +1836,21 @@ mod tests {
         assert_eq!(1, enrolled.len());
 
         let enrolled1 = enrolled;
+
+        // Test to ensure that features are being de-serialized and copied into EnrolledFeatureConfig and mapped
+        // properly to the feature id.
+        let features = map_features_by_feature_id(&enrollments, &updated_experiments);
+        assert_eq!(features.len(), 1);
+        assert!(features.contains_key("about_welcome"));
+
+        let enrolled_feature = features.get("about_welcome").unwrap();
+        assert_eq!(
+            serde_json::Value::Object(enrolled_feature.feature.value.clone()),
+            json!({ "text": "OK then", "number": 42})
+        );
+
+        let string = serde_json::to_string(&enrolled_feature.feature.value).unwrap();
+        assert_eq!(string, "{\"number\":42,\"text\":\"OK then\"}");
 
         // Now let's keep the same number of experiments.
         // We should get the same results as before.

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -823,7 +823,7 @@ fn map_enrollments(enrollments: &[ExperimentEnrollment]) -> HashMap<String, &Exp
 
 /// Take a list of enrollments and a map of experiments, and generate mapping of `feature_id` to
 /// `EnrolledFeatureConfig` structs.
-pub fn map_features(
+fn map_features(
     enrollments: &[ExperimentEnrollment],
     experiments: &HashMap<String, &Experiment>,
 ) -> HashMap<String, EnrolledFeatureConfig> {
@@ -839,6 +839,13 @@ pub fn map_features(
     }
 
     map
+}
+
+pub fn map_features_by_feature_id(
+    enrollments: &[ExperimentEnrollment],
+    experiments: &[Experiment],
+) -> HashMap<String, EnrolledFeatureConfig> {
+    map_features(enrollments, &map_experiments(experiments))
 }
 
 fn get_feature_config(
@@ -879,10 +886,10 @@ fn get_feature_config(
 /// and enrollments.
 #[derive(Debug, Clone, PartialEq)]
 pub struct EnrolledFeatureConfig {
-    feature: FeatureConfig,
-    slug: String,
-    branch: String,
-    feature_id: String,
+    pub feature: FeatureConfig,
+    pub slug: String,
+    pub branch: String,
+    pub feature_id: String,
 }
 
 #[derive(Debug)]

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -887,29 +887,25 @@ mod test_schema_deserialization {
         );
         assert_eq!(with_object_value.value.get("color").unwrap(), "blue");
 
-        let rejects_scalar_value = match serde_json::from_value::<FeatureConfig>(json!(
+        let rejects_scalar_value = serde_json::from_value::<FeatureConfig>(json!(
             {
                 "featureId": "some_control",
                 "enabled": true,
                 "value": 1,
             }
-        )) {
-            Ok(_) => false,
-            _ => true,
-        };
+        ))
+        .is_err();
 
         assert!(rejects_scalar_value);
 
-        let rejects_array_value = match serde_json::from_value::<FeatureConfig>(json!(
+        let rejects_array_value = serde_json::from_value::<FeatureConfig>(json!(
             {
                 "featureId": "some_control",
                 "enabled": true,
-                "value": [1,2,3],
+                "value": [1, 2, 3],
             }
-        )) {
-            Ok(_) => false,
-            _ => true,
-        };
+        ))
+        .is_err();
 
         assert!(rejects_array_value);
 

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -860,16 +860,14 @@ mod test_schema_deserialization {
 
     #[test]
     fn test_deserialize_untyped_json() -> Result<()> {
-        let without_value = serde_json::from_value::<FeatureConfigProposed>(json!(
+        let without_value = serde_json::from_value::<FeatureConfig>(json!(
             {
                 "featureId": "some_control",
                 "enabled": true,
             }
         ))?;
 
-        log::debug!("default value: {:?}", without_value);
-
-        let with_value = serde_json::from_value::<FeatureConfigProposed>(json!(
+        let with_object_value = serde_json::from_value::<FeatureConfig>(json!(
             {
                 "featureId": "some_control",
                 "enabled": true,
@@ -879,7 +877,41 @@ mod test_schema_deserialization {
             }
         ))?;
 
-        assert_eq!(with_value.value.get("color").unwrap(), "blue");
+        assert_eq!(
+            serde_json::to_string(&without_value.value)?,
+            "{}".to_string()
+        );
+        assert_eq!(
+            serde_json::to_string(&with_object_value.value)?,
+            "{\"color\":\"blue\"}"
+        );
+        assert_eq!(with_object_value.value.get("color").unwrap(), "blue");
+
+        let rejects_scalar_value = match serde_json::from_value::<FeatureConfig>(json!(
+            {
+                "featureId": "some_control",
+                "enabled": true,
+                "value": 1,
+            }
+        )) {
+            Ok(_) => false,
+            _ => true,
+        };
+
+        assert!(rejects_scalar_value);
+
+        let rejects_array_value = match serde_json::from_value::<FeatureConfig>(json!(
+            {
+                "featureId": "some_control",
+                "enabled": true,
+                "value": [1,2,3],
+            }
+        )) {
+            Ok(_) => false,
+            _ => true,
+        };
+
+        assert!(rejects_array_value);
 
         Ok(())
     }

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -41,6 +41,7 @@ dictionary Branch {
 dictionary FeatureConfig {
     string feature_id;
     boolean enabled;
+    string value;
 };
 
 dictionary RemoteSettingsConfig {

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -41,7 +41,7 @@ dictionary Branch {
 dictionary FeatureConfig {
     string feature_id;
     boolean enabled;
-    string value;
+    JSONObject value;
 };
 
 dictionary RemoteSettingsConfig {

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -28,20 +28,13 @@ dictionary AvailableExperiment {
     string slug;
     string user_facing_name;
     string user_facing_description;
-    sequence<Branch> branches;
+    sequence<ExperimentBranch> branches;
     string? reference_branch;
 };
 
-dictionary Branch {
+dictionary ExperimentBranch {
     string slug;
-    i32 ratio; // ideally would be u32, but kotlin considers unsigned experimental - see SDK-175.
-    FeatureConfig? feature;
-};
-
-dictionary FeatureConfig {
-    string feature_id;
-    boolean enabled;
-    JSONObject value;
+    i32 ratio;
 };
 
 dictionary RemoteSettingsConfig {
@@ -111,9 +104,12 @@ interface NimbusClient {
     [Throws=NimbusError]
     string? get_experiment_branch(string id);
 
+    [Throws=NimbusError]
+    string? get_feature_config_variables(string feature_id);
+
     // Returns a list of experiment branches for a given experiment ID.
     [Throws=NimbusError]
-    sequence<Branch> get_experiment_branches(string experiment_slug);
+    sequence<ExperimentBranch> get_experiment_branches(string experiment_slug);
 
     // Returns a list of experiments this user is enrolled in.
     [Throws=NimbusError]

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -13,10 +13,11 @@ the details of which are reproduced below.
 * [MIT License: caseless](#mit-license-caseless)
 * [MIT License: clap](#mit-license-clap)
 * [MIT License: generic-array](#mit-license-generic-array)
-* [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
+* [MIT License: libsqlite3-sys](#mit-license-libsqlite3-sys)
 * [MIT License: matches](#mit-license-matches)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
+* [MIT License: rusqlite](#mit-license-rusqlite)
 * [MIT License: textwrap](#mit-license-textwrap)
 * [MIT License: weedle](#mit-license-weedle)
 * [CC0-1.0 License: base16](#cc0-10-license-base16)
@@ -924,14 +925,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 -------------
-## MIT License: libsqlite3-sys, rusqlite
+## MIT License: libsqlite3-sys
 
 The following text applies to code linked from these dependencies:
-[libsqlite3-sys](https://github.com/rusqlite/rusqlite),
-[rusqlite](https://github.com/rusqlite/rusqlite)
+[libsqlite3-sys](https://github.com/rusqlite/rusqlite)
 
 ```
-Copyright (c) 2014-2020 The rusqlite developers
+Copyright (c) 2014-2021 The rusqlite developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1047,6 +1047,34 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: rusqlite
+
+The following text applies to code linked from these dependencies:
+[rusqlite](https://github.com/rusqlite/rusqlite)
+
+```
+Copyright (c) 2014-2020 The rusqlite developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ```
 -------------

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -417,10 +417,6 @@ the details of which are reproduced below.
     <url>https://github.com/rusqlite/rusqlite/blob/master/LICENSE</url>
   </license>
   <license>
-    <name>MIT License: rusqlite</name>
-    <url>https://github.com/rusqlite/rusqlite/blob/master/LICENSE</url>
-  </license>
-  <license>
     <name>MIT License: matches</name>
     <url>https://github.com/SimonSapin/rust-std-candidates/blob/master/LICENSE</url>
   </license>
@@ -431,6 +427,10 @@ the details of which are reproduced below.
   <license>
     <name>MIT License: ordered-float</name>
     <url>https://github.com/reem/rust-ordered-float/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: rusqlite</name>
+    <url>https://github.com/rusqlite/rusqlite/blob/master/LICENSE</url>
   </license>
   <license>
     <name>MIT License: textwrap</name>

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -19,7 +19,7 @@ the details of which are reproduced below.
 * [MIT License: h2](#mit-license-h2)
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
-* [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
+* [MIT License: libsqlite3-sys](#mit-license-libsqlite3-sys)
 * [MIT License: matches](#mit-license-matches)
 * [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: miniz_oxide](#mit-license-miniz_oxide)
@@ -27,6 +27,7 @@ the details of which are reproduced below.
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
 * [MIT License: oslog](#mit-license-oslog)
+* [MIT License: rusqlite](#mit-license-rusqlite)
 * [MIT License: slab](#mit-license-slab)
 * [MIT License: textwrap](#mit-license-textwrap)
 * [MIT License: tokio, tokio-tls, tokio-util, tracing, tracing-core, tracing-futures](#mit-license-tokio-tokio-tls-tokio-util-tracing-tracing-core-tracing-futures)
@@ -1172,14 +1173,13 @@ THE SOFTWARE.
 
 ```
 -------------
-## MIT License: libsqlite3-sys, rusqlite
+## MIT License: libsqlite3-sys
 
 The following text applies to code linked from these dependencies:
-[libsqlite3-sys](https://github.com/rusqlite/rusqlite),
-[rusqlite](https://github.com/rusqlite/rusqlite)
+[libsqlite3-sys](https://github.com/rusqlite/rusqlite)
 
 ```
-Copyright (c) 2014-2020 The rusqlite developers
+Copyright (c) 2014-2021 The rusqlite developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1414,6 +1414,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+```
+-------------
+## MIT License: rusqlite
+
+The following text applies to code linked from these dependencies:
+[rusqlite](https://github.com/rusqlite/rusqlite)
+
+```
+Copyright (c) 2014-2020 The rusqlite developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ```
 -------------

--- a/megazords/ios/MozillaAppServicesTests/NimbusTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/NimbusTests.swift
@@ -38,7 +38,11 @@ class NimbusTests: XCTestCase {
                         "ratio": 1,
                         "feature": {
                             "featureId": "aboutwelcome",
-                            "enabled": false
+                            "enabled": false,
+                            "value": {
+                                "text": "OK then",
+                                "number": 42
+                            }
                         }
                     },
                     {
@@ -46,7 +50,11 @@ class NimbusTests: XCTestCase {
                         "ratio": 1,
                         "feature": {
                             "featureId": "aboutwelcome",
-                            "enabled": true
+                            "enabled": true,
+                            "value": {
+                                "text": "OK then",
+                                "number": 42
+                            }
                         }
                     }
                 ],
@@ -105,6 +113,14 @@ class NimbusTests: XCTestCase {
 
         let experiments = nimbus.getActiveExperiments()
         XCTAssertEqual(experiments.count, 1)
+
+        let json = nimbus.getFeatureConfigVariablesJson(featureId: "aboutwelcome")
+        if let json = json {
+            XCTAssertEqual(json["text"] as? String, "OK then")
+            XCTAssertEqual(json["number"] as? Int, 42)
+        } else {
+            XCTAssertNotNil(json)
+        }
 
         try nimbus.setExperimentsLocallyOnThisThread(emptyExperimentJSON())
         try nimbus.applyPendingExperimentsOnThisThread()


### PR DESCRIPTION
Fixes [SDK-261].

This introduces a `value` property to `FeatureConfig`.

In this state it builds with the current version of uniffi, and expects value to be a `String`.

Thus: it is not ready to land, since `value` is supposed to be a `serde_json::Value`.

It is ready to review, however.

[1]: https://jira.mozilla.com/browse/SDK-261

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.