### PR TITLE
SDK-263 Add Feature Variables and tests to kotlin

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,4 +2,15 @@
 
 # Unreleased Changes
 
+## Nimbus ☁️🔬
+
+### What's New
+
+ - Android gains a `nimbus.getVariables(featureId: String)` and a new wrapper around JSON data coming straight from Remote Settings.
+ - Application features can only have a maximum of one experiment running at a time.
+
+### What's Changed
+
+ - Android and iOS `Branch` objects no longer have access to a `FeatureConfig` object.
+
 [Full Changelog](https://github.com/mozilla/application-services/compare/v76.0.0...main)

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeatureVariables.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeatureVariables.kt
@@ -71,7 +71,7 @@ private fun Context.getResource(resName: String, defType: String): Int? {
 }
 
 /**
- * A thin wrapper around the JSON produced by the `get_feature_variables_json(feature_id)` call, useful
+ * A thin wrapper around the JSON produced by the `get_feature_config_variables_json(feature_id)` call, useful
  * for configuring a feature, but without needing the developer to know about experiment specifics.
  */
 class JSONVariables(
@@ -94,10 +94,7 @@ class JSONVariables(
 // returns `null`.
 private inline fun <reified T> JSONObject.value(key: String): T? {
     if (!this.isNull(key)) {
-        val value = this.get(key)
-        if (value is T) {
-            return value
-        }
+        return this.get(key) as? T
     }
     return null
 }

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeatureVariables.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeatureVariables.kt
@@ -1,0 +1,118 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.experiments.nimbus
+
+import android.content.Context
+import android.graphics.Color
+import org.json.JSONObject
+
+/**
+ * It provides the type-coercion tooling and resource look-up to be immediately useful to feature
+ * developers.
+ *
+ * The feature developer requests a typed value with a specific `key`. If the key is present, and
+ * the value is of the correct type, then it is returned. If neither of these are true, then `null`
+ * is returned.
+ *
+ * ```
+ * val config = nimbus.getFeatureVariables("submitButton")
+ *
+ * submitButton.text = config.getText("submitButton.text") ?: R.string.submit_button_label
+ * submitButton.color = config.getColor("submitButton.color") ?: R.color.button_default
+ *
+ * ```
+ *
+ * This may become the basis of a generated-from-manifest solution.
+ */
+interface Variables {
+    fun getString(key: String): String?
+    fun getInt(key: String): Int?
+    fun getBool(key: String): Boolean?
+
+    // Get a child configuration object.
+    fun getVariables(key: String): Variables?
+    // This may be important when transforming in to a code generated object.
+    fun <T> getVariables(key: String, transform: (Variables) -> T) = getVariables(key)?.let(transform)
+}
+
+interface VariablesWithContext : Variables {
+    val context: Context
+    // Lower level accessors that can come across the FFI.
+    // Platform specific types, deserialized from the lower level types.
+    fun getColor(key: String) = getString(key)?.let(this::asColor)
+    fun getTextResource(key: String, context: Context = this.context): Int? = getString(key)?.let {
+        context.getResource(it, "string")
+    }
+    fun getText(key: String, context: Context = this.context) = getString(key)?.let(this::asText)
+    fun getDrawableResource(key: String, context: Context = this.context) = getString(key)?.let(this::asDrawableResource)
+
+    // These `as*` methods become useful when transforming values found in JSON to actual values
+    // the app will use. They're broken out here so they can be re-used by codegen generating
+    // defaults from manifest information.
+    fun asColor(string: String) = Color.parseColor(string)
+    fun asText(res: Int) = context.getString(res)
+    fun asText(string: String) = context.getResource(string, "string")?.let(this::asText)
+        ?: string
+    fun asDrawableResource(string: String) = context.getResource(string, "drawable")
+}
+
+// Get a resource Int if it exists from the context resources.
+// Here we're using it for icons and strings.
+// This will help us look after translations, dark mode, screen size, pixel density etc etc.
+private fun Context.getResource(resName: String, defType: String): Int? {
+    val res = resources.getIdentifier(resName, defType, packageName)
+    return if (res != 0) {
+        res
+    } else {
+        null
+    }
+}
+
+/**
+ * A thin wrapper around the JSON produced by the `get_feature_variables_json(feature_id)` call, useful
+ * for configuring a feature, but without needing the developer to know about experiment specifics.
+ */
+class JSONVariables(
+    override val context: Context,
+    private val json: JSONObject = JSONObject()
+) : VariablesWithContext {
+    // These `get*` methods get values from the wrapped JSON object, and transform them using the
+    // `as*` methods.
+    override fun getString(key: String) = json.value<String>(key)
+
+    override fun getInt(key: String) = json.value<Int>(key)
+
+    override fun getBool(key: String) = json.value<Boolean>(key)
+
+    // Methods used to get sub-objects. We immediately re-wrap an JSON object if it exists.
+    override fun getVariables(key: String) = json.value<JSONObject>(key)?.let { JSONVariables(context, it) }
+}
+
+// A typed getter. If the key is not present, or the value is JSONNull, or the wrong type
+// returns `null`.
+private inline fun <reified T> JSONObject.value(key: String): T? {
+    if (!this.isNull(key)) {
+        val value = this.get(key)
+        if (value is T) {
+            return value
+        }
+    }
+    return null
+}
+
+// Another implementation of `Variables` may just return null for everything.
+class NullVariables : Variables {
+    companion object {
+        val instance = NullVariables()
+    }
+
+    override fun getString(key: String): String? = null
+
+    override fun getInt(key: String): Int? = null
+
+    override fun getBool(key: String): Boolean? = null
+
+    override fun getVariables(key: String): Variables? = null
+}

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -80,6 +80,9 @@ interface NimbusInterface {
      */
     fun getExperimentBranches(experimentId: String): List<Branch>? = listOf()
 
+    @AnyThread
+    fun getVariables(featureId: String): Variables = NullVariables.instance
+
     /**
      * Open the database and populate the SDK so as make it usable by feature developers.
      *
@@ -322,6 +325,12 @@ open class Nimbus(
         recordExposure(experimentId)
         return nimbusClient.getExperimentBranch(experimentId)
     }
+
+    override fun getVariables(featureId: String): Variables =
+        withCatchAll {
+            val json = JSONObject("{}")
+            JSONVariables(context = context, json = json)
+        } ?: NullVariables.instance
 
     @WorkerThread
     override fun getExperimentBranches(experimentId: String): List<Branch>? = withCatchAll {

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -327,10 +327,10 @@ open class Nimbus(
     }
 
     override fun getVariables(featureId: String): Variables =
-        withCatchAll {
-            val json = JSONObject("{}")
-            JSONVariables(context = context, json = json)
-        } ?: NullVariables.instance
+        getFeatureConfigVariablesJson(featureId)?.let { json ->
+            JSONVariables(context, json)
+        }
+        ?: NullVariables.instance
 
     @WorkerThread
     override fun getExperimentBranches(experimentId: String): List<Branch>? = withCatchAll {

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/FeatureVariablesTest.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/FeatureVariablesTest.kt
@@ -1,0 +1,79 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.experiments.nimbus
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class FeatureVariablesTest {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `test values coerce into simple types`() {
+        val json = JSONObject("""
+            {"stringVariable": "string", "intVariable": 3, "booleanVariable": true}
+        """.trimIndent())
+
+        val variables: Variables = JSONVariables(context, json)
+
+        assertEquals(variables.getInt("intVariable"), 3)
+        assertEquals(variables.getString("stringVariable"), "string")
+        assertEquals(variables.getBool("booleanVariable"), true)
+    }
+
+    @Test
+    fun `test values are null if the wrong type`() {
+        val json = JSONObject("""
+            {"stringVariable": "string", "intVariable": 3, "booleanVariable": true}
+        """.trimIndent())
+
+        val variables: Variables = JSONVariables(context, json)
+
+        assertNull(variables.getString("intVariable"))
+        assertNull(variables.getBool("intVariable"))
+
+        assertNull(variables.getInt("stringVariable"))
+        assertNull(variables.getBool("stringVariable"))
+
+        assertEquals(variables.getBool("booleanVariable"), true)
+        assertNull(variables.getInt("booleanVariable"))
+        assertNull(variables.getString("booleanVariable"))
+    }
+
+    @Test
+    fun `test nested values are make another variables object`() {
+        val json = JSONObject("""
+            {
+                "inner": {
+                    "stringVariable": "string",
+                    "intVariable": 3, 
+                    "booleanVariable": true
+                },
+                "really-a-string": "a string"
+            }
+        """.trimIndent())
+
+        val outer: Variables = JSONVariables(context, json)
+
+        assertNull(outer.getVariables("not-there"))
+        val inner = outer.getVariables("inner")
+
+        assertNotNull(inner)
+        assertEquals(inner!!.getInt("intVariable"), 3)
+        assertEquals(inner.getString("stringVariable"), "string")
+        assertEquals(inner.getBool("booleanVariable"), true)
+
+        assertNull(outer.getVariables("really-a-string"))
+    }
+}


### PR DESCRIPTION
This PR introduces the feature API to Nimbus.

It fixes [SDK-263][1].

It is blocked on https://github.com/mozilla/uniffi-rs/pull/440 and https://github.com/mozilla/application-services/pull/4074 to wire it up to Rust.

[1]: https://jira.mozilla.com/browse/SDK-263


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.