### PR TITLE
Enable consuming applications to change the server `collection` being used

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -34,7 +34,6 @@ import org.mozilla.experiments.nimbus.internal.NimbusClientInterface
 import org.mozilla.experiments.nimbus.internal.RemoteSettingsConfig
 import java.io.File
 
-private const val EXPERIMENT_BUCKET_NAME = "main"
 private const val EXPERIMENT_COLLECTION_NAME = "nimbus-mobile-experiments"
 private const val NIMBUS_DATA_DIR: String = "nimbus_data"
 
@@ -189,7 +188,6 @@ interface NimbusInterface {
  */
 data class NimbusServerSettings(
     val url: Uri,
-    val bucket: String = EXPERIMENT_BUCKET_NAME,
     val collection: String = EXPERIMENT_COLLECTION_NAME
 )
 
@@ -289,7 +287,6 @@ open class Nimbus(
         val remoteSettingsConfig = server?.let {
             RemoteSettingsConfig(
                 serverUrl = it.url.toString(),
-                bucketName = it.bucket,
                 collectionName = it.collection
             )
         }

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -12,7 +12,6 @@ use std::collections::HashMap;
 use std::io::prelude::*;
 
 const DEFAULT_BASE_URL: &str = "https://firefox.settings.services.mozilla.com";
-const DEFAULT_BUCKET_NAME: &str = "main";
 const DEFAULT_COLLECTION_NAME: &str = "messaging-experiments";
 fn main() -> Result<()> {
     // We set the logging level to be `warn` here, meaning that only
@@ -170,12 +169,6 @@ fn main() -> Result<()> {
         .unwrap_or_else(|| "no-client-id-specified".to_string());
     log::info!("Client ID is {}", client_id);
 
-    let bucket_name = match config.get("bucket_name") {
-        Some(v) => v.as_str().unwrap(),
-        _ => DEFAULT_BUCKET_NAME,
-    };
-    log::info!("Bucket name is {}", bucket_name);
-
     let collection_name =
         matches
             .value_of("collection")
@@ -198,7 +191,6 @@ fn main() -> Result<()> {
     // initiate the optional config
     let config = RemoteSettingsConfig {
         server_url: server_url.to_string(),
-        bucket_name: bucket_name.to_string(),
         collection_name: collection_name.to_string(),
     };
 

--- a/components/nimbus/ios/Nimbus/NimbusApi.swift
+++ b/components/nimbus/ios/Nimbus/NimbusApi.swift
@@ -132,12 +132,16 @@ public extension Notification.Name {
 /// This struct is used during in the `create` method to point `Nimbus` at the given `RemoteSettings` server.
 ///
 public struct NimbusServerSettings {
-    public init(url: URL) {
+    public init(url: URL, collection: String = remoteSettingsCollection) {
         self.url = url
+        self.collection = collection
     }
 
     public let url: URL
+    public let collection: String
 }
+
+public let remoteSettingsCollection = "nimbus-mobile-experiments"
 
 /// Name and channel of the app, which should agree with what is specified in Experimenter.
 ///

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -4,9 +4,6 @@
 
 import Foundation
 
-private let remoteSettingsBucket = "main"
-private let remoteSettingsCollection = "nimbus-mobile-experiments"
-
 private let logTag = "Nimbus.swift"
 private let logger = Logger(tag: logTag)
 
@@ -45,11 +42,9 @@ public extension Nimbus {
 
         let context = Nimbus.buildExperimentContext(appSettings)
         let remoteSettings = server.map { server -> RemoteSettingsConfig in
-            let url = server.url.absoluteString
-            return RemoteSettingsConfig(
-                serverUrl: url,
-                bucketName: remoteSettingsBucket,
-                collectionName: remoteSettingsCollection
+            RemoteSettingsConfig(
+                serverUrl: server.url.absoluteString,
+                collectionName: server.collection
             )
         }
         let nimbusClient = try NimbusClient(

--- a/components/nimbus/src/client/http_client.rs
+++ b/components/nimbus/src/client/http_client.rs
@@ -109,10 +109,7 @@ impl SettingsClient for Client {
     }
 
     fn fetch_experiments(&self) -> Result<Vec<Experiment>> {
-        let path = format!(
-            "buckets/main/collections/{}/records",
-            &self.collection_name
-        );
+        let path = format!("buckets/main/collections/{}/records", &self.collection_name);
         let url = self.base_url.join(&path)?;
         let req = Request::get(url);
         let resp = self.make_request(req)?;

--- a/components/nimbus/src/client/http_client.rs
+++ b/components/nimbus/src/client/http_client.rs
@@ -28,7 +28,6 @@ const HEADER_RETRY_AFTER: &str = "Retry-After";
 pub struct Client {
     base_url: Url,
     collection_name: String,
-    bucket_name: String,
     remote_state: Cell<RemoteState>,
 }
 
@@ -47,7 +46,6 @@ impl Client {
         let base_url = Url::parse(&config.server_url)?;
         Ok(Self {
             base_url,
-            bucket_name: config.bucket_name,
             collection_name: config.collection_name,
             remote_state: Cell::new(RemoteState::Ok),
         })
@@ -112,8 +110,8 @@ impl SettingsClient for Client {
 
     fn fetch_experiments(&self) -> Result<Vec<Experiment>> {
         let path = format!(
-            "buckets/{}/collections/{}/records",
-            &self.bucket_name, &self.collection_name
+            "buckets/main/collections/{}/records",
+            &self.collection_name
         );
         let url = self.base_url.join(&path)?;
         let req = Request::get(url);
@@ -283,7 +281,6 @@ mod tests {
         .create();
         let config = RemoteSettingsConfig {
             server_url: mockito::server_url(),
-            bucket_name: "main".to_string(),
             collection_name: "messaging-experiments".to_string(),
         };
         let http_client = Client::new(config).unwrap();
@@ -356,7 +353,6 @@ mod tests {
         .create();
         let config = RemoteSettingsConfig {
             server_url: mockito::server_url(),
-            bucket_name: "main".to_string(),
             collection_name: "messaging-experiments".to_string(),
         };
         let http_client = Client::new(config).unwrap();
@@ -379,7 +375,6 @@ mod tests {
         .create();
         let config = RemoteSettingsConfig {
             server_url: mockito::server_url(),
-            bucket_name: "main".to_string(),
             collection_name: "messaging-experiments".to_string(),
         };
         let http_client = Client::new(config).unwrap();
@@ -402,7 +397,6 @@ mod tests {
         .create();
         let config = RemoteSettingsConfig {
             server_url: mockito::server_url(),
-            bucket_name: "main".to_string(),
             collection_name: "messaging-experiments".to_string(),
         };
         let mut http_client = Client::new(config).unwrap();

--- a/components/nimbus/src/config.rs
+++ b/components/nimbus/src/config.rs
@@ -15,6 +15,5 @@
 #[derive(Debug, Clone)]
 pub struct RemoteSettingsConfig {
     pub server_url: String,
-    pub bucket_name: String,
     pub collection_name: String,
 }

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -39,7 +39,6 @@ dictionary ExperimentBranch {
 
 dictionary RemoteSettingsConfig {
     string server_url;
-    string bucket_name;
     string collection_name;
 };
 

--- a/components/nimbus/tests/common/mod.rs
+++ b/components/nimbus/tests/common/mod.rs
@@ -18,7 +18,6 @@ pub fn new_test_client(identifier: &str) -> Result<NimbusClient> {
 
     let config = RemoteSettingsConfig {
         server_url: url.as_str().to_string(),
-        bucket_name: "doesn't matter".to_string(),
         collection_name: "doesn't matter".to_string(),
     };
     let aru = Default::default();

--- a/components/nimbus/tests/test_fs_client.rs
+++ b/components/nimbus/tests/test_fs_client.rs
@@ -26,7 +26,6 @@ fn test_simple() -> Result<()> {
 
     let config = RemoteSettingsConfig {
         server_url: url.as_str().to_string(),
-        bucket_name: "doesn't matter".to_string(),
         collection_name: "doesn't matter".to_string(),
     };
 


### PR DESCRIPTION
This removes the unnecessary `bucket` from the server config, as well as adds `collection` to the Swift `NimbusServerSettings` to match the Kotlin `NimbusServerSettings`.  

This should allow a consuming application to start-up the Nimbus-SDK pointing at the `nimbus-preview` collection for QA testing purposes.