### PR TITLE
add osx branch to protobuf artifacts to get only x86_64

### DIFF
--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -80,7 +80,13 @@ configurations {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.4'
+        // This is a hack for Apple M1 since protobuf does not compile for M1s yet
+        // However, M1s can just use the x86_64 just fine
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.11.4:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.11.4'
+        }
     }
     generateProtoTasks {
         all().each { task ->

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -77,7 +77,13 @@ configurations {
 }
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.4'
+        // This is a hack for Apple M1 since protobuf does not compile for M1s yet
+        // However, M1s can just use the x86_64 just fine
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.11.4:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.11.4'
+        }
     }
     generateProtoTasks {
         all().each { task ->

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -70,7 +70,13 @@ configurations {
 
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.4'
+        // This is a hack for Apple M1 since protobuf does not compile for M1s yet
+        // However, M1s can just use the x86_64 just fine
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.11.4:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.11.4'
+        }
     }
     generateProtoTasks {
         all().each { task ->

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -66,7 +66,13 @@ configurations {
 }
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.4'
+        // This is a hack for Apple M1 since protobuf does not compile for M1s yet
+        // However, M1s can just use the x86_64 just fine
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.11.4:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.11.4'
+        }
     }
     generateProtoTasks {
         all().each { task ->

--- a/components/tabs/android/build.gradle
+++ b/components/tabs/android/build.gradle
@@ -66,7 +66,13 @@ configurations {
 }
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.4'
+        // This is a hack for Apple M1 since protobuf does not compile for M1s yet
+        // However, M1s can just use the x86_64 just fine
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.11.4:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.11.4'
+        }
     }
     generateProtoTasks {
         all().each { task ->

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -70,7 +70,13 @@ configurations {
 }
 protobuf {
     protoc {
-        artifact = 'com.google.protobuf:protoc:3.11.4'
+        // This is a hack for Apple M1 since protobuf does not compile for M1s yet
+        // However, M1s can just use the x86_64 just fine
+        if (osdetector.os == "osx") {
+            artifact = 'com.google.protobuf:protoc:3.11.4:osx-x86_64'
+        } else {
+            artifact = 'com.google.protobuf:protoc:3.11.4'
+        }
     }
     generateProtoTasks {
         all().each { task ->


### PR DESCRIPTION
Fixes #4092 

Apple M1 can use the x86_64 binaries fine but it's difficult to have a locally built version of protobuf and try connect it to gradle. This allows all macos systems to just grab the x86_64 version instead of trying to look for the ARM. We can remove this code once Protobuf starts pushing osx-aarch-64 to maven or we get rid of all protobufs from uniffi.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
