### PR TITLE
SDK-264 Add feature variables to swift

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -6,7 +6,7 @@
 
 ### What's New
 
- - Android gains a `nimbus.getVariables(featureId: String)` and a new wrapper around JSON data coming straight from Remote Settings.
+ - Both Android and iOS gain a `nimbus.getVariables(featureId: String)` and a new wrapper around JSON data coming straight from Remote Settings.
  - Application features can only have a maximum of one experiment running at a time.
 
 ### What's Changed

--- a/components/nimbus/ios/Nimbus/FeatureVariables.swift
+++ b/components/nimbus/ios/Nimbus/FeatureVariables.swift
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/// `Variables` provides a type safe key-value style interface to configure application features
+///
+/// The feature developer requests a typed value with a specific `key`. If the key is present, and
+/// the value is of the correct type, then it is returned. If neither of these are true, then `null`
+/// is returned.
+///
+/// The values may be under experimental control, but if not, `nil` is returned. In this case, the app should
+/// provide the default value.
+///
+/// ```
+/// let variables = nimbus.getVariables("about_welcome")
+///
+/// let title = variables.getString("title") ?? "Welcome, oo vudge"
+/// let numSections = variables.getInt("num-sections") ?? 2
+/// let isEnabled = variables.getBool("isEnabled") ?? true
+/// ```
+///
+/// This may become the basis of a generated-from-manifest solution.
+public protocol Variables {
+    func getString(_ key: String) -> String?
+    func getInt(_ key: String) -> Int?
+    func getBool(_ key: String) -> Bool?
+
+    // Get a child configuration object.
+    func getVariables(_ key: String) -> Variables?
+}
+
+public extension Variables {
+    // This may be important when transforming in to a code generated object.
+    func getVariables<T>(_ key: String, transform: (Variables) -> T) -> T? {
+        if let value = getVariables(key) {
+            return transform(value)
+        } else {
+            return nil
+        }
+    }
+}
+
+/// A thin wrapper around the JSON produced by the `get_feature_variables_json(feature_id)` call, useful
+/// for configuring a feature, but without needing the developer to know about experiment specifics.
+internal class JSONVariables: Variables {
+    private let json: [String: Any]
+
+    init(with json: [String: Any]) {
+        self.json = json
+    }
+
+    // These `get*` methods get values from the wrapped JSON object, and transform them using the
+    // `as*` methods.
+    func getString(_ key: String) -> String? {
+        return value(key)
+    }
+
+    func getInt(_ key: String) -> Int? {
+        return value(key)
+    }
+
+    func getBool(_ key: String) -> Bool? {
+        return value(key)
+    }
+
+    // Methods used to get sub-objects. We immediately re-wrap an JSON object if it exists.
+    func getVariables(_ key: String) -> Variables? {
+        if let dictionary: [String: Any] = value(key) {
+            return JSONVariables(with: dictionary)
+        } else {
+            return nil
+        }
+    }
+
+    private func value<T>(_ key: String) -> T? {
+        return json[key] as? T
+    }
+}
+
+// Another implementation of `Variables` may just return null for everything.
+class NilVariables: Variables {
+    static let instance: Variables = NilVariables()
+
+    func getString(_: String) -> String? {
+        return nil
+    }
+
+    func getInt(_: String) -> Int? {
+        return nil
+    }
+
+    func getBool(_: String) -> Bool? {
+        return nil
+    }
+
+    func getVariables(_: String) -> Variables? {
+        return nil
+    }
+}

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -183,6 +183,13 @@ extension Nimbus: NimbusFeatureConfiguration {
             }
         }
     }
+
+    public func getVariables(featureId: String) -> Variables {
+        guard let json = getFeatureConfigVariablesJson(featureId: featureId) else {
+            return NilVariables.instance
+        }
+        return JSONVariables(with: json)
+    }
 }
 
 extension Nimbus: NimbusUserConfiguration {
@@ -287,6 +294,10 @@ public extension NimbusDisabled {
 
     func getExperimentBranch(featureId _: String) -> String? {
         return nil
+    }
+
+    func getVariables(featureId _: String) -> Variables {
+        return NilVariables.instance
     }
 
     func initialize() {}

--- a/components/nimbus/ios/Nimbus/NimbusApi.swift
+++ b/components/nimbus/ios/Nimbus/NimbusApi.swift
@@ -14,7 +14,7 @@ import Foundation
 /// enrollment will mostly use `NimbusUserConfiguration` methods. Application developers integrating
 /// `Nimbus` into their app should use the methods in `NimbusStartup`.
 ///
-public protocol NimbusApi: class, NimbusStartup, NimbusFeatureConfiguration, NimbusUserConfiguration {}
+public protocol NimbusApi: AnyObject, NimbusStartup, NimbusFeatureConfiguration, NimbusUserConfiguration {}
 
 public protocol NimbusFeatureConfiguration {
     /// Get the currently enrolled branch for the given experiment
@@ -23,6 +23,12 @@ public protocol NimbusFeatureConfiguration {
     /// - Returns A String representing the branch-id or "slug"; or `nil` if not enrolled in this experiment.
     ///
     func getExperimentBranch(featureId: String) -> String?
+
+    /// Get the variables needed to configure the feature given by `featureId`.
+    ///
+    /// - Parameter featureId The string feature id that identifies to the feature under experiment.
+    /// - Returns a `Variables` object used to configure the feature.
+    func getVariables(featureId: String) -> Variables
 }
 
 public protocol NimbusStartup {

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		394D6C622600E64E008F9CE5 /* NimbusCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394D6C612600E64E008F9CE5 /* NimbusCreate.swift */; };
 		395992B625FBC91500E3185F /* NimbusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395992B525FBC91500E3185F /* NimbusTests.swift */; };
 		395992B825FBE40300E3185F /* NimbusApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395992B725FBE40300E3185F /* NimbusApi.swift */; };
+		398A4149264986E200AA22F1 /* FeatureVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398A4148264986E200AA22F1 /* FeatureVariables.swift */; };
+		39C13795264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C13794264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift */; };
 		9908639E25F9CC5F00032083 /* crashtest.udl in Sources */ = {isa = PBXBuildFile; fileRef = 9908639B25F9CC3600032083 /* crashtest.udl */; };
 		990863A125F9D25A00032083 /* uniffi_crashtest-Bridging-Header.h in Headers */ = {isa = PBXBuildFile; fileRef = 9908639F25F9D25A00032083 /* uniffi_crashtest-Bridging-Header.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		990863A425F9D48400032083 /* CrashTestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990863A325F9D48400032083 /* CrashTestTests.swift */; };
@@ -167,6 +169,8 @@
 		394D6C612600E64E008F9CE5 /* NimbusCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusCreate.swift; sourceTree = "<group>"; };
 		395992B525FBC91500E3185F /* NimbusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusTests.swift; sourceTree = "<group>"; };
 		395992B725FBE40300E3185F /* NimbusApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusApi.swift; sourceTree = "<group>"; };
+		398A4148264986E200AA22F1 /* FeatureVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureVariables.swift; sourceTree = "<group>"; };
+		39C13794264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusFeatureVariablesTests.swift; sourceTree = "<group>"; };
 		9908639B25F9CC3600032083 /* crashtest.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = crashtest.udl; path = ../../src/crashtest.udl; sourceTree = "<group>"; };
 		9908639F25F9D25A00032083 /* uniffi_crashtest-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "uniffi_crashtest-Bridging-Header.h"; sourceTree = "<group>"; };
 		990863A025F9D25A00032083 /* crashtest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = crashtest.swift; sourceTree = "<group>"; };
@@ -292,6 +296,7 @@
 				394A809725F94E1300FAF26F /* Nimbus.swift */,
 				395992B725FBE40300E3185F /* NimbusApi.swift */,
 				394D6C612600E64E008F9CE5 /* NimbusCreate.swift */,
+				398A4148264986E200AA22F1 /* FeatureVariables.swift */,
 			);
 			name = Nimbus;
 			path = ../../components/nimbus/ios/Nimbus;
@@ -626,6 +631,7 @@
 				CE34DB3C23D0C9640027AD63 /* FxAccountManagerTests.swift */,
 				EB879D8A22123FD900753DC9 /* LoginsTests.swift */,
 				CD4CFDD2221DFA5100EB3B33 /* LogTest.swift */,
+				39C13794264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift */,
 				395992B525FBC91500E3185F /* NimbusTests.swift */,
 				CE3A2F37225BDE5300EA569C /* PlacesTests.swift */,
 			);
@@ -827,6 +833,7 @@
 				BF1A87BA25064A8100FED88E /* StringMetric.swift in Sources */,
 				99FAA19F25E65CA5001E2231 /* FxAccountOAuth.swift in Sources */,
 				C852EED7220A29FE00A6E79A /* LoginStoreError.swift in Sources */,
+				398A4149264986E200AA22F1 /* FeatureVariables.swift in Sources */,
 				BF1A87D025064AC000FED88E /* Sysctl.swift in Sources */,
 				CD02CF3922568BCC00124DA2 /* SyncUnlockInfo.swift in Sources */,
 				CD85A45A22361E890099BFA9 /* PlacesError.swift in Sources */,
@@ -873,6 +880,7 @@
 			files = (
 				CE3A2F38225BDE5300EA569C /* PlacesTests.swift in Sources */,
 				CEB1A06823D8A42D005BD4DD /* FxAccountMocks.swift in Sources */,
+				39C13795264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift in Sources */,
 				CD4CFDD3221DFA5100EB3B33 /* LogTest.swift in Sources */,
 				EB879D8B22123FD900753DC9 /* LoginsTests.swift in Sources */,
 				CE90D1BB23D7570A00FD9A5F /* FxAccountManagerTests.swift in Sources */,

--- a/megazords/ios/MozillaAppServicesTests/NimbusFeatureVariablesTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/NimbusFeatureVariablesTests.swift
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+@testable import MozillaAppServices
+
+class NimbusFeatureVariablesTests: XCTestCase {
+    func testScalarTypeCoercion() throws {
+        let variables = JSONVariables(with: [
+            "intVariable": 3,
+            "stringVariable": "string",
+            "booleanVariable": true,
+        ])
+
+        XCTAssertEqual(variables.getInt("intVariable"), 3)
+        XCTAssertEqual(variables.getString("stringVariable"), "string")
+        XCTAssertEqual(variables.getBool("booleanVariable"), true)
+    }
+
+    func testScalarValuesOfWrongTypeAreNil() throws {
+        let variables = JSONVariables(with: [
+            "intVariable": 3,
+            "stringVariable": "string",
+            "booleanVariable": true,
+        ])
+        XCTAssertNil(variables.getString("intVariable"))
+        XCTAssertNil(variables.getBool("intVariable"))
+
+        XCTAssertNil(variables.getInt("stringVariable"))
+        XCTAssertNil(variables.getBool("stringVariable"))
+
+        XCTAssertEqual(variables.getBool("booleanVariable"), true)
+        XCTAssertNil(variables.getInt("booleanVariable"))
+        XCTAssertNil(variables.getString("booleanVariable"))
+    }
+
+    func testNestedObjectsMakeVariablesObjects() throws {
+        let outer = JSONVariables(with: [
+            "inner": [
+                "stringVariable": "string",
+                "intVariable": 3,
+                "booleanVariable": true,
+            ],
+            "really-a-string": "a string",
+        ])
+
+        XCTAssertNil(outer.getVariables("not-there"))
+        let inner = outer.getVariables("inner")
+
+        XCTAssertNotNil(inner)
+        XCTAssertEqual(inner!.getInt("intVariable"), 3)
+        XCTAssertEqual(inner!.getString("stringVariable"), "string")
+        XCTAssertEqual(inner!.getBool("booleanVariable"), true)
+
+        XCTAssertNil(outer.getVariables("really-a-string"))
+    }
+}


### PR DESCRIPTION
Fixes [SDK-264][1].

This introduces a `getVariables` method to `nimbus`, which is part of the Feature API work.

This is the corresponding iOS piece to the Android work in [SDK-263][2].

[1]: https://jira.mozilla.com/browse/SDK-264
[1]: https://jira.mozilla.com/browse/SDK-263

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.