### PR TITLE
Update rust and rustup config in CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,8 @@ commands:
           name: Install Rust
           command: |
             RUSTUP_PLATFORM=x86_64-apple-darwin
-            RUSTUP_VERSION=1.23.1
-            RUSTUP_SHA256=39101feb178a7e3e4443b09b36338e794a9e00385e5f44a2f7789aefb91354a9
+            RUSTUP_VERSION=1.24.1
+            RUSTUP_SHA256=d53e8000c8663e1704a2071f7042be917bc90cbc89c11e11c5dfdcb35b84c00e
             curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"
             echo "${RUSTUP_SHA256} *rustup-init" | shasum -a 256 -c -
             chmod +x rustup-init
@@ -97,6 +97,7 @@ commands:
             - libs/<<parameters.platform>>
   build-desktop-libs:
     steps:
+      - run: sudo apt-get update
       - run: sudo apt-get install tcl
       - run:
           name: Install NSS build system dependencies
@@ -207,10 +208,19 @@ commands:
           path: /tmp/sccache.log
           destination: logs/sccache.log
 
-jobs:
-  Check Swift formatting:
+executors:
+  # Where possible we want to run jobs using docker, because it's cheaper.
+  # Unfortunately some of our jobs can only run successfully on macos.
+  docker:
+    docker:
+      - image: cimg/rust:1.50.0
+  macos:
     macos:
       xcode: "12.3.0"
+
+jobs:
+  Check Swift formatting:
+    executor: macos
     steps:
       - full-checkout
       # swiftlint moved? See https://github.com/Homebrew/discussions/discussions/691
@@ -219,24 +229,21 @@ jobs:
       - run: ./automation/tests.py swiftlint
       - run: ./automation/tests.py swiftformat
   Check Rust formatting:
-    docker:
-      - image: circleci/rust:latest
+    executor: docker
     resource_class: small
     steps:
       - full-checkout
       - setup-rust-toolchain
       - run: ./automation/tests.py rust-fmt
   Lint Rust with clippy:
-    docker:
-      - image: circleci/rust:latest
+    executor: docker
     steps:
       - test-setup
       - restore-sccache-cache
       - run: ./automation/tests.py rust-clippy
       - save-sccache-cache
   Generate code coverage:
-    docker:
-      - image: circleci/rust:latest
+    executor: docker
     resource_class: large
     steps:
       - test-setup
@@ -251,8 +258,7 @@ jobs:
           name: Upload to codecov.io
           command: bash <(curl -s https://codecov.io/bash) -f lcov.info
   Check Protobuf files are up-to-date:
-    docker:
-      - image: circleci/rust:latest
+    executor: docker
     resource_class: small
     steps:
       - full-checkout
@@ -268,16 +274,14 @@ jobs:
           command: sh automation/lint_bash_scripts.sh
   Check Rust dependencies:
     # This check has to be done on a mac, to be able to detect iOS-specific dependencies.
-    macos:
-      xcode: "12.3.0"
+    executor: macos
     steps:
       - install-rust
       - setup-rust-toolchain
       - full-checkout
       - dependency-checks
   Rust tests:
-    docker:
-      - image: circleci/rust:latest
+    executor: docker
     # We have to use a machine with more RAM for tests so we don't run out of memory.
     resource_class: large
     steps:
@@ -286,8 +290,7 @@ jobs:
       - save-sccache-cache
   # These run periodically (driven by cron).
   Rust tests - beta:
-    docker:
-      - image: circleci/rust:latest
+    executor: docker
     resource_class: large
     steps:
       - restore-sccache-cache
@@ -295,16 +298,14 @@ jobs:
           rust-version: "beta"
       - save-sccache-cache
   Rust benchmarks:
-    docker:
-      - image: circleci/rust:latest
+    executor: docker
     resource_class: large
     steps:
       - restore-sccache-cache
       - bench-all
       - save-sccache-cache
   iOS build and test:
-    macos:
-      xcode: "12.3.0"
+    executor: macos
     steps:
       # We do not use the ssccache cache helper commands as
       # the macOS cache is in a different folder.
@@ -387,8 +388,7 @@ jobs:
           paths:
             - MozillaAppServices.framework.zip
   Carthage release:
-    macos:
-      xcode: "12.3.0"
+    executor: macos
     steps:
       - full-checkout
       - attach_workspace:
@@ -402,6 +402,7 @@ jobs:
             echo "${GHR_SHA256} *${GHR}.zip" | shasum -a 256 -c -
             unzip "${GHR}.zip"
             ./${GHR}/ghr -replace "${CIRCLE_TAG}" MozillaAppServices.framework.zip
+
 workflows:
   version: 2
   swiftlint:

--- a/taskcluster/scripts/toolchain/rustup-setup.sh
+++ b/taskcluster/scripts/toolchain/rustup-setup.sh
@@ -19,8 +19,8 @@ export RUST_LOG='sccache=info'
 # Rust
 set -eux; \
     RUSTUP_PLATFORM='x86_64-unknown-linux-gnu'; \
-    RUSTUP_VERSION='1.23.1'; \
-    RUSTUP_SHA256='ed7773edaf1d289656bdec2aacad12413b38ad0193fff54b2231f5140a4b07c5'; \
+    RUSTUP_VERSION='1.24.1'; \
+    RUSTUP_SHA256='fb3a7425e3f10d51f0480ac3cdb3e725977955b2ba21c9bdac35309563b115e8'; \
     curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init; \


### PR DESCRIPTION
This fixes #4108, getting our CircleCI tests passing again with
RUSTUP_TOOLCHAIN="beta". It's a bit of a circuitous fix but I
think it's worthwhile taking this approach.

As noted over in #4108, the `circleci/rust` docker image configures
rustup to use its "minimal" profile by default, which means it doesn't
automatically install `rustup` into non-default toolchains, which was
causing problems for our tests.

According to a Google search for "CircleCI Rust" and to the note at
the top of [1], the `circleci/rust` image is considered legacy and has
been replaced by `cimg/rust`. This new image uses the "default" rustup
profile, meaning it will more closely match the experience of executing
Rust tooling on your local machine, and in particular will install
`rustfmt` by default in all toolchains.

This new `cimg/rust` image does not support a `:latest` tag, and instead
requires you to specify an explicit version of the Rust toolchain to
use. To avoid duplicating this information in many places, I've used the
"executors" feature of CircleCI to consolidate the details of the docker
image in a single place.

Since I was defining some executors anyway, I also took the opportunity
to consolidate the details of the "macos" executor, so if we want to
bump the version of xcode in future it can be done in a single place.

Finally, I updated the version of `rustup-init` that is used to boostrap
the Rust tooling on the macos executor and in taskcluster. This isn't
necessary, but I did it as part of investigating the fix here and it
seemed worthwhile to keep.

[1] https://circleci.com/developer/images/image/cimg/rust
