### PR TITLE
Enable the `bundled` feature of `rusqlite` when building `support/guid`.

### DIFF
--- a/components/support/guid/Cargo.toml
+++ b/components/support/guid/Cargo.toml
@@ -6,7 +6,7 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
-rusqlite = { version = "0.24.2", optional = true }
+rusqlite = { version = "0.24.2", optional = true, features = ["bundled"] }
 serde = { version = "1", optional = true }
 rand = { version = "0.7", optional = true }
 base64 = { version = "0.12", optional = true }


### PR DESCRIPTION
Most of our other crates enable either `bundled` or `sqlite` when building
`rusqlite`, but the `support/guid` crate does neither. This seems to result
in build errors when the user doesn't have a system-level build of sqlite
available. Let's be consistent across all the crates.

Unless this is going to subtly break something in other parts of the build..?
