### PR TITLE
Use `&mut self` instead of a RefCell for the autofill local encryption key.

### DIFF
--- a/components/support/sync15-traits/src/engine.rs
+++ b/components/support/sync15-traits/src/engine.rs
@@ -79,7 +79,7 @@ pub trait SyncEngine {
     /// This will panic if called by an engine that doesn't have explicit
     /// support for local encryption keys as that implies a degree of confusion
     /// which shouldn't be possible to ignore.
-    fn set_local_encryption_key(&self, _key: &str) -> Result<()> {
+    fn set_local_encryption_key(&mut self, _key: &str) -> Result<()> {
         unimplemented!("This engine does not support local encryption");
     }
 

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -369,7 +369,7 @@ fn run_sync(
     }
     let mut mem_cached_state = MemoryCachedState::default();
     let mut global_state: Option<String> = None;
-    let engines: Vec<Box<dyn SyncEngine>> = vec![
+    let mut engines: Vec<Box<dyn SyncEngine>> = vec![
         store.create_addresses_sync_engine(),
         store.create_credit_cards_sync_engine(),
     ];


### PR DESCRIPTION
Ben asked why we used a RefCell and there is no good answer to that
question :)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
