### PR TITLE
Rename LoginStore to LoginsSyncEngine.

### DIFF
--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -1225,12 +1225,12 @@ impl LoginDb {
     }
 }
 
-pub struct LoginStore<'a> {
+pub struct LoginsSyncEngine<'a> {
     pub db: &'a LoginDb,
     pub scope: sql_support::SqlInterruptScope,
 }
 
-impl<'a> LoginStore<'a> {
+impl<'a> LoginsSyncEngine<'a> {
     pub fn new(db: &'a LoginDb) -> Self {
         Self {
             db,
@@ -1239,7 +1239,7 @@ impl<'a> LoginStore<'a> {
     }
 }
 
-impl<'a> SyncEngine for LoginStore<'a> {
+impl<'a> SyncEngine for LoginsSyncEngine<'a> {
     fn collection_name(&self) -> std::borrow::Cow<'static, str> {
         "passwords".into()
     }

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -19,7 +19,7 @@ mod ffi;
 
 // Mostly exposed for the sync manager.
 pub use crate::db::LoginDb;
-pub use crate::db::LoginStore;
+pub use crate::db::LoginsSyncEngine;
 pub use crate::error::*;
 pub use crate::login::*;
 pub use crate::store::*;

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -1,7 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-use crate::db::{LoginDb, LoginStore, MigrationMetrics};
+use crate::db::{LoginDb, LoginsSyncEngine, MigrationMetrics};
 use crate::error::*;
 use crate::login::Login;
 use std::cell::Cell;
@@ -125,15 +125,15 @@ impl PasswordStore {
 
         let mut disk_cached_state = self.db.get_global_state()?;
         let mut mem_cached_state = self.mem_cached_state.take();
-        let store = LoginStore::new(&self.db);
+        let engine = LoginsSyncEngine::new(&self.db);
 
         let mut result = sync_multiple(
-            &[&store],
+            &[&engine],
             &mut disk_cached_state,
             &mut mem_cached_state,
             storage_init,
             root_sync_key,
-            &store.scope,
+            &engine.scope,
             None,
         );
         // We always update the state - sync_multiple does the right thing

--- a/components/sync_manager/src/manager.rs
+++ b/components/sync_manager/src/manager.rs
@@ -346,7 +346,7 @@ impl SyncManager {
 
         if let Some(le) = ls.as_ref() {
             assert!(logins_sync, "Should have already checked");
-            engines.push(Box::new(logins::LoginStore::new(&le.db)));
+            engines.push(Box::new(logins::LoginsSyncEngine::new(&le.db)));
         }
 
         if let Some(tbs) = ts.as_ref() {


### PR DESCRIPTION
The logins component currently has a PasswordStore and a LoginStore - the
latter is actually the "sync engine" and renaming this now makes the
uniffi work we are doing that little bit easier to understand.

The more we can do to keep stuff out of Sammy's PR , the better :)