### PR TITLE
CircleCI must install Python in order to build system libs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ commands:
   build-desktop-libs:
     steps:
       - run: sudo apt-get update
-      - run: sudo apt-get install tcl
+      - run: sudo apt-get install python tcl
       - run:
           name: Install NSS build system dependencies
           command: sudo apt-get install ninja-build gyp zlib1g-dev

--- a/libs/README.md
+++ b/libs/README.md
@@ -18,3 +18,4 @@ This directory builds the required libraries for iOS, Android and desktop platfo
 
 * Android: `TARGET_ARCHS=("x86" "x86_64" "arm64" "arm")`
 * iOS: `TARGET_ARCHS=("x86_64" "arm64")`
+


### PR DESCRIPTION
The docker image change in #4110 seems to mean that `python` is no
longer available in the Docker image by default, which means that
the build scripts in `./libs` no longer run successfully on CircleCI.

We did not notice this change because CircleCI usually restores
these from a cache. But if we do something that invalidates that
cache (like modifying the files in `./libs`) then CircleCI starts
failing.

This commit fixes the issue by explicily installing `python` as
part of the dependencies for the system lib builds. It also includes
a cosmetic change to `./libs/README.md` to clear the CircleCI cache
and test that the fix actually works.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
