### PR TITLE
logins: split the DB from the sync engine

### DIFF
--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -3,9 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::error::*;
-use crate::login::{LocalLogin, Login, MirrorLogin, SyncLoginData, SyncStatus};
+use crate::login::{Login, SyncStatus};
 use crate::schema;
-use crate::update_plan::UpdatePlan;
 use crate::util;
 use lazy_static::lazy_static;
 use rusqlite::{
@@ -16,15 +15,10 @@ use rusqlite::{
 use serde_derive::*;
 use sql_support::{self, ConnExt};
 use sql_support::{SqlInterruptHandle, SqlInterruptScope};
-use std::collections::HashSet;
 use std::ops::Deref;
 use std::path::Path;
 use std::sync::{atomic::AtomicUsize, Arc};
 use std::time::{Duration, Instant, SystemTime};
-use sync15::{
-    extract_v1_state, telemetry, CollSyncIds, CollectionRequest, EngineSyncAssociation,
-    IncomingChangeset, OutgoingChangeset, Payload, ServerTimestamp, SyncEngine,
-};
 use sync_guid::Guid;
 use url::{Host, Url};
 
@@ -219,154 +213,36 @@ impl Deref for LoginDb {
 // login specific stuff.
 
 impl LoginDb {
-    fn mark_as_synchronized(
-        &self,
-        guids: &[&str],
-        ts: ServerTimestamp,
-        scope: &SqlInterruptScope,
-    ) -> Result<()> {
-        let tx = self.unchecked_transaction()?;
-        sql_support::each_chunk(guids, |chunk, _| -> Result<()> {
-            self.db.execute(
-                &format!(
-                    "DELETE FROM loginsM WHERE guid IN ({vars})",
-                    vars = sql_support::repeat_sql_vars(chunk.len())
-                ),
-                chunk,
-            )?;
-            scope.err_if_interrupted()?;
-
-            self.db.execute(
-                &format!(
-                    "INSERT OR IGNORE INTO loginsM (
-                         {common_cols}, is_overridden, server_modified
-                     )
-                     SELECT {common_cols}, 0, {modified_ms_i64}
-                     FROM loginsL
-                     WHERE is_deleted = 0 AND guid IN ({vars})",
-                    common_cols = schema::COMMON_COLS,
-                    modified_ms_i64 = ts.as_millis() as i64,
-                    vars = sql_support::repeat_sql_vars(chunk.len())
-                ),
-                chunk,
-            )?;
-            scope.err_if_interrupted()?;
-
-            self.db.execute(
-                &format!(
-                    "DELETE FROM loginsL WHERE guid IN ({vars})",
-                    vars = sql_support::repeat_sql_vars(chunk.len())
-                ),
-                chunk,
-            )?;
-            scope.err_if_interrupted()?;
-            Ok(())
-        })?;
-        self.set_last_sync(ts)?;
-        tx.commit()?;
+    pub(crate) fn put_meta(&self, key: &str, value: &dyn ToSql) -> Result<()> {
+        self.execute_named_cached(
+            "REPLACE INTO loginsSyncMeta (key, value) VALUES (:key, :value)",
+            named_params! { ":key": key, ":value": value },
+        )?;
         Ok(())
     }
 
-    // Fetch all the data for the provided IDs.
-    // TODO: Might be better taking a fn instead of returning all of it... But that func will likely
-    // want to insert stuff while we're doing this so ugh.
-    fn fetch_login_data(
-        &self,
-        records: &[(sync15::Payload, ServerTimestamp)],
-        telem: &mut telemetry::EngineIncoming,
-        scope: &SqlInterruptScope,
-    ) -> Result<Vec<SyncLoginData>> {
-        let mut sync_data = Vec::with_capacity(records.len());
-        {
-            let mut seen_ids: HashSet<Guid> = HashSet::with_capacity(records.len());
-            for incoming in records.iter() {
-                if seen_ids.contains(&incoming.0.id) {
-                    throw!(ErrorKind::DuplicateGuid(incoming.0.id.to_string()))
-                }
-                seen_ids.insert(incoming.0.id.clone());
-                match SyncLoginData::from_payload(incoming.0.clone(), incoming.1) {
-                    Ok(v) => sync_data.push(v),
-                    Err(e) => {
-                        log::error!("Failed to deserialize record {:?}: {}", incoming.0.id, e);
-                        // Ideally we'd track new_failed, but it's unclear how
-                        // much value it has.
-                        telem.failed(1);
-                    }
-                }
-            }
-        }
-        scope.err_if_interrupted()?;
+    pub(crate) fn get_meta<T: FromSql>(&self, key: &str) -> Result<Option<T>> {
+        self.try_query_row(
+            "SELECT value FROM loginsSyncMeta WHERE key = :key",
+            named_params! { ":key": key },
+            |row| Ok::<_, Error>(row.get(0)?),
+            true,
+        )
+    }
 
-        sql_support::each_chunk_mapped(
-            &records,
-            |r| r.0.id.as_str(),
-            |chunk, offset| -> Result<()> {
-                // pairs the bound parameter for the guid with an integer index.
-                let values_with_idx = sql_support::repeat_display(chunk.len(), ",", |i, f| {
-                    write!(f, "({},?)", i + offset)
-                });
-                let query = format!(
-                    "WITH to_fetch(guid_idx, fetch_guid) AS (VALUES {vals})
-                     SELECT
-                         {common_cols},
-                         is_overridden,
-                         server_modified,
-                         NULL as local_modified,
-                         NULL as is_deleted,
-                         NULL as sync_status,
-                         1 as is_mirror,
-                         to_fetch.guid_idx as guid_idx
-                     FROM loginsM
-                     JOIN to_fetch
-                         ON loginsM.guid = to_fetch.fetch_guid
-
-                     UNION ALL
-
-                     SELECT
-                         {common_cols},
-                         NULL as is_overridden,
-                         NULL as server_modified,
-                         local_modified,
-                         is_deleted,
-                         sync_status,
-                         0 as is_mirror,
-                         to_fetch.guid_idx as guid_idx
-                     FROM loginsL
-                     JOIN to_fetch
-                         ON loginsL.guid = to_fetch.fetch_guid",
-                    // give each VALUES item 2 entries, an index and the parameter.
-                    vals = values_with_idx,
-                    common_cols = schema::COMMON_COLS,
-                );
-
-                let mut stmt = self.db.prepare(&query)?;
-
-                let rows = stmt.query_and_then(chunk, |row| {
-                    let guid_idx_i = row.get::<_, i64>("guid_idx")?;
-                    // Hitting this means our math is wrong...
-                    assert!(guid_idx_i >= 0);
-
-                    let guid_idx = guid_idx_i as usize;
-                    let is_mirror: bool = row.get("is_mirror")?;
-                    if is_mirror {
-                        sync_data[guid_idx].set_mirror(MirrorLogin::from_row(row)?)?;
-                    } else {
-                        sync_data[guid_idx].set_local(LocalLogin::from_row(row)?)?;
-                    }
-                    scope.err_if_interrupted()?;
-                    Ok(())
-                })?;
-                // `rows` is an Iterator<Item = Result<()>>, so we need to collect to handle the errors.
-                rows.collect::<Result<_>>()?;
-                Ok(())
-            },
+    pub(crate) fn delete_meta(&self, key: &str) -> Result<()> {
+        self.execute_named_cached(
+            "DELETE FROM loginsSyncMeta WHERE key = :key",
+            named_params! { ":key": key },
         )?;
-        Ok(sync_data)
+        Ok(())
     }
 
     // It would be nice if this were a batch-ish api (e.g. takes a slice of records and finds dupes
     // for each one if they exist)... I can't think of how to write that query, though.
-    fn find_dupe(&self, l: &Login) -> Result<Option<Login>> {
+    // NOTE: currently used only by sync - maybe it should move to the sync engine?
+    // It doesn't *feel* sync specific though?
+    pub(crate) fn find_dupe(&self, l: &Login) -> Result<Option<Login>> {
         let form_submit_host_port = l
             .form_submit_url
             .as_ref()
@@ -970,31 +846,9 @@ impl LoginDb {
             .execute_named_cached(&*CLONE_SINGLE_MIRROR_SQL, &[(":guid", &guid as &dyn ToSql)])?)
     }
 
-    pub fn reset(&self, assoc: &EngineSyncAssociation) -> Result<()> {
-        log::info!("Executing reset on password engine!");
-        let tx = self.db.unchecked_transaction()?;
-        self.execute_all(&[
-            &*CLONE_ENTIRE_MIRROR_SQL,
-            "DELETE FROM loginsM",
-            &format!("UPDATE loginsL SET sync_status = {}", SyncStatus::New as u8),
-        ])?;
-        self.set_last_sync(ServerTimestamp(0))?;
-        match assoc {
-            EngineSyncAssociation::Disconnected => {
-                self.delete_meta(schema::GLOBAL_SYNCID_META_KEY)?;
-                self.delete_meta(schema::COLLECTION_SYNCID_META_KEY)?;
-            }
-            EngineSyncAssociation::Connected(ids) => {
-                self.put_meta(schema::GLOBAL_SYNCID_META_KEY, &ids.global)?;
-                self.put_meta(schema::COLLECTION_SYNCID_META_KEY, &ids.coll)?;
-            }
-        };
-        self.delete_meta(schema::GLOBAL_STATE_META_KEY)?;
-        tx.commit()?;
-        Ok(())
-    }
-
-    pub fn wipe(&self, scope: &SqlInterruptScope) -> Result<()> {
+    // Wipe is called both by Sync and also exposed publically, so it's
+    // implemented here.
+    pub(crate) fn wipe(&self, scope: &SqlInterruptScope) -> Result<()> {
         let tx = self.unchecked_transaction()?;
         log::info!("Executing wipe on password engine!");
         let now_ms = util::system_time_ms_i64(SystemTime::now());
@@ -1043,261 +897,6 @@ impl LoginDb {
         tx.commit()?;
         Ok(())
     }
-
-    fn reconcile(
-        &self,
-        records: Vec<SyncLoginData>,
-        server_now: ServerTimestamp,
-        telem: &mut telemetry::EngineIncoming,
-        scope: &SqlInterruptScope,
-    ) -> Result<UpdatePlan> {
-        let mut plan = UpdatePlan::default();
-
-        for mut record in records {
-            scope.err_if_interrupted()?;
-            log::debug!("Processing remote change {}", record.guid());
-            let upstream = if let Some(inbound) = record.inbound.0.take() {
-                inbound
-            } else {
-                log::debug!("Processing inbound deletion (always prefer)");
-                plan.plan_delete(record.guid.clone());
-                continue;
-            };
-            let upstream_time = record.inbound.1;
-            match (record.mirror.take(), record.local.take()) {
-                (Some(mirror), Some(local)) => {
-                    log::debug!("  Conflict between remote and local, Resolving with 3WM");
-                    plan.plan_three_way_merge(local, mirror, upstream, upstream_time, server_now);
-                    telem.reconciled(1);
-                }
-                (Some(_mirror), None) => {
-                    log::debug!("  Forwarding mirror to remote");
-                    plan.plan_mirror_update(upstream, upstream_time);
-                    telem.applied(1);
-                }
-                (None, Some(local)) => {
-                    log::debug!("  Conflicting record without shared parent, using newer");
-                    plan.plan_two_way_merge(&local.login, (upstream, upstream_time));
-                    telem.reconciled(1);
-                }
-                (None, None) => {
-                    if let Some(dupe) = self.find_dupe(&upstream)? {
-                        log::debug!(
-                            "  Incoming record {} was is a dupe of local record {}",
-                            upstream.guid,
-                            dupe.guid
-                        );
-                        plan.plan_two_way_merge(&dupe, (upstream, upstream_time));
-                    } else {
-                        log::debug!("  No dupe found, inserting into mirror");
-                        plan.plan_mirror_insert(upstream, upstream_time, false);
-                    }
-                    telem.applied(1);
-                }
-            }
-        }
-        Ok(plan)
-    }
-
-    fn execute_plan(&self, plan: UpdatePlan, scope: &SqlInterruptScope) -> Result<()> {
-        // Because rusqlite want a mutable reference to create a transaction
-        // (as a way to save us from ourselves), we side-step that by creating
-        // it manually.
-        let tx = self.db.unchecked_transaction()?;
-        plan.execute(&tx, scope)?;
-        tx.commit()?;
-        Ok(())
-    }
-
-    pub fn fetch_outgoing(
-        &self,
-        st: ServerTimestamp,
-        scope: &SqlInterruptScope,
-    ) -> Result<OutgoingChangeset> {
-        // Taken from iOS. Arbitrarily large, so that clients that want to
-        // process deletions first can; for us it doesn't matter.
-        const TOMBSTONE_SORTINDEX: i32 = 5_000_000;
-        const DEFAULT_SORTINDEX: i32 = 1;
-        let mut outgoing = OutgoingChangeset::new("passwords", st);
-        let mut stmt = self.db.prepare_cached(&format!(
-            "SELECT * FROM loginsL WHERE sync_status IS NOT {synced}",
-            synced = SyncStatus::Synced as u8
-        ))?;
-        let rows = stmt.query_and_then(NO_PARAMS, |row| {
-            scope.err_if_interrupted()?;
-            Ok(if row.get::<_, bool>("is_deleted")? {
-                Payload::new_tombstone(row.get::<_, String>("guid")?)
-                    .with_sortindex(TOMBSTONE_SORTINDEX)
-            } else {
-                let login = Login::from_row(row)?;
-                Payload::from_record(login)?.with_sortindex(DEFAULT_SORTINDEX)
-            })
-        })?;
-        outgoing.changes = rows.collect::<Result<_>>()?;
-
-        Ok(outgoing)
-    }
-
-    fn do_apply_incoming(
-        &self,
-        inbound: IncomingChangeset,
-        telem: &mut telemetry::Engine,
-        scope: &SqlInterruptScope,
-    ) -> Result<OutgoingChangeset> {
-        let mut incoming_telemetry = telemetry::EngineIncoming::new();
-        let data = self.fetch_login_data(&inbound.changes, &mut incoming_telemetry, scope)?;
-        let plan = {
-            let result = self.reconcile(data, inbound.timestamp, &mut incoming_telemetry, scope);
-            telem.incoming(incoming_telemetry);
-            result
-        }?;
-        self.execute_plan(plan, scope)?;
-        self.fetch_outgoing(inbound.timestamp, scope)
-    }
-
-    fn put_meta(&self, key: &str, value: &dyn ToSql) -> Result<()> {
-        self.execute_named_cached(
-            "REPLACE INTO loginsSyncMeta (key, value) VALUES (:key, :value)",
-            named_params! { ":key": key, ":value": value },
-        )?;
-        Ok(())
-    }
-
-    fn get_meta<T: FromSql>(&self, key: &str) -> Result<Option<T>> {
-        self.try_query_row(
-            "SELECT value FROM loginsSyncMeta WHERE key = :key",
-            named_params! { ":key": key },
-            |row| Ok::<_, Error>(row.get(0)?),
-            true,
-        )
-    }
-
-    fn delete_meta(&self, key: &str) -> Result<()> {
-        self.execute_named_cached(
-            "DELETE FROM loginsSyncMeta WHERE key = :key",
-            named_params! { ":key": key },
-        )?;
-        Ok(())
-    }
-
-    fn set_last_sync(&self, last_sync: ServerTimestamp) -> Result<()> {
-        log::debug!("Updating last sync to {}", last_sync);
-        let last_sync_millis = last_sync.as_millis() as i64;
-        self.put_meta(schema::LAST_SYNC_META_KEY, &last_sync_millis)
-    }
-
-    fn get_last_sync(&self) -> Result<Option<ServerTimestamp>> {
-        let millis = self.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?.unwrap();
-        Ok(Some(ServerTimestamp(millis)))
-    }
-
-    pub fn set_global_state(&self, state: &Option<String>) -> Result<()> {
-        let to_write = match state {
-            Some(ref s) => s,
-            None => "",
-        };
-        self.put_meta(schema::GLOBAL_STATE_META_KEY, &to_write)
-    }
-
-    pub fn get_global_state(&self) -> Result<Option<String>> {
-        self.get_meta::<String>(schema::GLOBAL_STATE_META_KEY)
-    }
-
-    /// A utility we can kill by the end of 2019 ;)
-    pub fn migrate_global_state(&self) -> Result<()> {
-        let tx = self.unchecked_transaction_imm()?;
-        if let Some(old_state) = self.get_meta("global_state")? {
-            log::info!("there's old global state - migrating");
-            let (new_sync_ids, new_global_state) = extract_v1_state(old_state, "passwords");
-            if let Some(sync_ids) = new_sync_ids {
-                self.put_meta(schema::GLOBAL_SYNCID_META_KEY, &sync_ids.global)?;
-                self.put_meta(schema::COLLECTION_SYNCID_META_KEY, &sync_ids.coll)?;
-                log::info!("migrated the sync IDs");
-            }
-            if let Some(new_global_state) = new_global_state {
-                self.set_global_state(&Some(new_global_state))?;
-                log::info!("migrated the global state");
-            }
-            self.delete_meta("global_state")?;
-        }
-        tx.commit()?;
-        Ok(())
-    }
-}
-
-pub struct LoginsSyncEngine<'a> {
-    pub db: &'a LoginDb,
-    pub scope: sql_support::SqlInterruptScope,
-}
-
-impl<'a> LoginsSyncEngine<'a> {
-    pub fn new(db: &'a LoginDb) -> Self {
-        Self {
-            db,
-            scope: db.begin_interrupt_scope(),
-        }
-    }
-}
-
-impl<'a> SyncEngine for LoginsSyncEngine<'a> {
-    fn collection_name(&self) -> std::borrow::Cow<'static, str> {
-        "passwords".into()
-    }
-
-    fn apply_incoming(
-        &self,
-        inbound: Vec<IncomingChangeset>,
-        telem: &mut telemetry::Engine,
-    ) -> anyhow::Result<OutgoingChangeset> {
-        assert_eq!(inbound.len(), 1, "logins only requests one item");
-        let inbound = inbound.into_iter().next().unwrap();
-        Ok(self.db.do_apply_incoming(inbound, telem, &self.scope)?)
-    }
-
-    fn sync_finished(
-        &self,
-        new_timestamp: ServerTimestamp,
-        records_synced: Vec<Guid>,
-    ) -> anyhow::Result<()> {
-        self.db.mark_as_synchronized(
-            &records_synced.iter().map(Guid::as_str).collect::<Vec<_>>(),
-            new_timestamp,
-            &self.scope,
-        )?;
-        Ok(())
-    }
-
-    fn get_collection_requests(
-        &self,
-        server_timestamp: ServerTimestamp,
-    ) -> anyhow::Result<Vec<CollectionRequest>> {
-        let since = self.db.get_last_sync()?.unwrap_or_default();
-        Ok(if since == server_timestamp {
-            vec![]
-        } else {
-            vec![CollectionRequest::new("passwords").full().newer_than(since)]
-        })
-    }
-
-    fn get_sync_assoc(&self) -> anyhow::Result<EngineSyncAssociation> {
-        let global = self.db.get_meta(schema::GLOBAL_SYNCID_META_KEY)?;
-        let coll = self.db.get_meta(schema::COLLECTION_SYNCID_META_KEY)?;
-        Ok(if let (Some(global), Some(coll)) = (global, coll) {
-            EngineSyncAssociation::Connected(CollSyncIds { global, coll })
-        } else {
-            EngineSyncAssociation::Disconnected
-        })
-    }
-
-    fn reset(&self, assoc: &EngineSyncAssociation) -> anyhow::Result<()> {
-        self.db.reset(assoc)?;
-        Ok(())
-    }
-
-    fn wipe(&self) -> anyhow::Result<()> {
-        self.db.wipe(&self.scope)?;
-        Ok(())
-    }
 }
 
 lazy_static! {
@@ -1324,7 +923,7 @@ lazy_static! {
          LIMIT 1",
         common_cols = schema::COMMON_COLS,
     );
-    static ref CLONE_ENTIRE_MIRROR_SQL: String = format!(
+    pub static ref CLONE_ENTIRE_MIRROR_SQL: String = format!(
         "INSERT OR IGNORE INTO loginsL ({common_cols}, local_modified, is_deleted, sync_status)
          SELECT {common_cols}, NULL AS local_modified, 0 AS is_deleted, 0 AS sync_status
          FROM loginsM",
@@ -1337,51 +936,6 @@ lazy_static! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[test]
-    fn test_bad_record() {
-        let db = LoginDb::open_in_memory(Some("testing")).unwrap();
-        let scope = db.begin_interrupt_scope();
-        let mut telem = sync15::telemetry::EngineIncoming::new();
-        let res = db
-            .fetch_login_data(
-                &[
-                    // tombstone
-                    (
-                        sync15::Payload::new_tombstone("dummy_000001"),
-                        sync15::ServerTimestamp(10000),
-                    ),
-                    // invalid
-                    (
-                        sync15::Payload::from_json(serde_json::json!({
-                            "id": "dummy_000002",
-                            "garbage": "data",
-                            "etc": "not a login"
-                        }))
-                        .unwrap(),
-                        sync15::ServerTimestamp(10000),
-                    ),
-                    // valid
-                    (
-                        sync15::Payload::from_json(serde_json::json!({
-                            "id": "dummy_000003",
-                            "formSubmitURL": "https://www.example.com/submit",
-                            "hostname": "https://www.example.com",
-                            "username": "test",
-                            "password": "test",
-                        }))
-                        .unwrap(),
-                        sync15::ServerTimestamp(10000),
-                    ),
-                ],
-                &mut telem,
-                &scope,
-            )
-            .unwrap();
-        assert_eq!(telem.get_failed(), 1);
-        assert_eq!(res.len(), 2);
-        assert_eq!(res[0].guid, "dummy_000001");
-        assert_eq!(res[1].guid, "dummy_000003");
-    }
 
     #[test]
     fn test_check_valid_with_no_dupes() {

--- a/components/logins/src/engine.rs
+++ b/components/logins/src/engine.rs
@@ -1,0 +1,455 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::db::CLONE_ENTIRE_MIRROR_SQL;
+use crate::error::*;
+use crate::login::{LocalLogin, Login, MirrorLogin, SyncLoginData, SyncStatus};
+use crate::schema;
+use crate::update_plan::UpdatePlan;
+use crate::LoginDb;
+use crate::PasswordStore;
+use rusqlite::NO_PARAMS;
+use sql_support::SqlInterruptScope;
+use sql_support::{self, ConnExt};
+use std::collections::HashSet;
+use sync15::{
+    telemetry, CollSyncIds, CollectionRequest, EngineSyncAssociation, IncomingChangeset,
+    OutgoingChangeset, Payload, ServerTimestamp, SyncEngine,
+};
+use sync_guid::Guid;
+
+// The sync engine.
+pub struct LoginsSyncEngine<'a> {
+    // Note that once uniffi'd, these lifetimes will go and it will be an Arc<PasswordStore>
+    pub store: &'a PasswordStore,
+    pub scope: sql_support::SqlInterruptScope,
+}
+
+impl<'a> LoginsSyncEngine<'a> {
+    pub fn new(store: &'a PasswordStore) -> Self {
+        let scope = store.db.begin_interrupt_scope();
+        Self { store, scope }
+    }
+
+    fn reconcile(
+        &self,
+        records: Vec<SyncLoginData>,
+        server_now: ServerTimestamp,
+        telem: &mut telemetry::EngineIncoming,
+        scope: &SqlInterruptScope,
+    ) -> Result<UpdatePlan> {
+        let mut plan = UpdatePlan::default();
+
+        for mut record in records {
+            scope.err_if_interrupted()?;
+            log::debug!("Processing remote change {}", record.guid());
+            let upstream = if let Some(inbound) = record.inbound.0.take() {
+                inbound
+            } else {
+                log::debug!("Processing inbound deletion (always prefer)");
+                plan.plan_delete(record.guid.clone());
+                continue;
+            };
+            let upstream_time = record.inbound.1;
+            match (record.mirror.take(), record.local.take()) {
+                (Some(mirror), Some(local)) => {
+                    log::debug!("  Conflict between remote and local, Resolving with 3WM");
+                    plan.plan_three_way_merge(local, mirror, upstream, upstream_time, server_now);
+                    telem.reconciled(1);
+                }
+                (Some(_mirror), None) => {
+                    log::debug!("  Forwarding mirror to remote");
+                    plan.plan_mirror_update(upstream, upstream_time);
+                    telem.applied(1);
+                }
+                (None, Some(local)) => {
+                    log::debug!("  Conflicting record without shared parent, using newer");
+                    plan.plan_two_way_merge(&local.login, (upstream, upstream_time));
+                    telem.reconciled(1);
+                }
+                (None, None) => {
+                    if let Some(dupe) = self.store.db.find_dupe(&upstream)? {
+                        log::debug!(
+                            "  Incoming record {} was is a dupe of local record {}",
+                            upstream.guid,
+                            dupe.guid
+                        );
+                        plan.plan_two_way_merge(&dupe, (upstream, upstream_time));
+                    } else {
+                        log::debug!("  No dupe found, inserting into mirror");
+                        plan.plan_mirror_insert(upstream, upstream_time, false);
+                    }
+                    telem.applied(1);
+                }
+            }
+        }
+        Ok(plan)
+    }
+
+    fn execute_plan(&self, plan: UpdatePlan, scope: &SqlInterruptScope) -> Result<()> {
+        // Because rusqlite want a mutable reference to create a transaction
+        // (as a way to save us from ourselves), we side-step that by creating
+        // it manually.
+        let db = &self.store.db;
+        let tx = db.unchecked_transaction()?;
+        plan.execute(&tx, scope)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    // Fetch all the data for the provided IDs.
+    // TODO: Might be better taking a fn instead of returning all of it... But that func will likely
+    // want to insert stuff while we're doing this so ugh.
+    fn fetch_login_data(
+        &self,
+        records: &[(sync15::Payload, ServerTimestamp)],
+        telem: &mut telemetry::EngineIncoming,
+        scope: &SqlInterruptScope,
+    ) -> Result<Vec<SyncLoginData>> {
+        let mut sync_data = Vec::with_capacity(records.len());
+        {
+            let mut seen_ids: HashSet<Guid> = HashSet::with_capacity(records.len());
+            for incoming in records.iter() {
+                if seen_ids.contains(&incoming.0.id) {
+                    throw!(ErrorKind::DuplicateGuid(incoming.0.id.to_string()))
+                }
+                seen_ids.insert(incoming.0.id.clone());
+                match SyncLoginData::from_payload(incoming.0.clone(), incoming.1) {
+                    Ok(v) => sync_data.push(v),
+                    Err(e) => {
+                        log::error!("Failed to deserialize record {:?}: {}", incoming.0.id, e);
+                        // Ideally we'd track new_failed, but it's unclear how
+                        // much value it has.
+                        telem.failed(1);
+                    }
+                }
+            }
+        }
+        scope.err_if_interrupted()?;
+
+        sql_support::each_chunk_mapped(
+            &records,
+            |r| r.0.id.as_str(),
+            |chunk, offset| -> Result<()> {
+                // pairs the bound parameter for the guid with an integer index.
+                let values_with_idx = sql_support::repeat_display(chunk.len(), ",", |i, f| {
+                    write!(f, "({},?)", i + offset)
+                });
+                let query = format!(
+                    "WITH to_fetch(guid_idx, fetch_guid) AS (VALUES {vals})
+                     SELECT
+                         {common_cols},
+                         is_overridden,
+                         server_modified,
+                         NULL as local_modified,
+                         NULL as is_deleted,
+                         NULL as sync_status,
+                         1 as is_mirror,
+                         to_fetch.guid_idx as guid_idx
+                     FROM loginsM
+                     JOIN to_fetch
+                         ON loginsM.guid = to_fetch.fetch_guid
+
+                     UNION ALL
+
+                     SELECT
+                         {common_cols},
+                         NULL as is_overridden,
+                         NULL as server_modified,
+                         local_modified,
+                         is_deleted,
+                         sync_status,
+                         0 as is_mirror,
+                         to_fetch.guid_idx as guid_idx
+                     FROM loginsL
+                     JOIN to_fetch
+                         ON loginsL.guid = to_fetch.fetch_guid",
+                    // give each VALUES item 2 entries, an index and the parameter.
+                    vals = values_with_idx,
+                    common_cols = schema::COMMON_COLS,
+                );
+
+                let db = &self.store.db;
+                let mut stmt = db.prepare(&query)?;
+
+                let rows = stmt.query_and_then(chunk, |row| {
+                    let guid_idx_i = row.get::<_, i64>("guid_idx")?;
+                    // Hitting this means our math is wrong...
+                    assert!(guid_idx_i >= 0);
+
+                    let guid_idx = guid_idx_i as usize;
+                    let is_mirror: bool = row.get("is_mirror")?;
+                    if is_mirror {
+                        sync_data[guid_idx].set_mirror(MirrorLogin::from_row(row)?)?;
+                    } else {
+                        sync_data[guid_idx].set_local(LocalLogin::from_row(row)?)?;
+                    }
+                    scope.err_if_interrupted()?;
+                    Ok(())
+                })?;
+                // `rows` is an Iterator<Item = Result<()>>, so we need to collect to handle the errors.
+                rows.collect::<Result<_>>()?;
+                Ok(())
+            },
+        )?;
+        Ok(sync_data)
+    }
+
+    fn fetch_outgoing(
+        &self,
+        st: ServerTimestamp,
+        scope: &SqlInterruptScope,
+    ) -> Result<OutgoingChangeset> {
+        // Taken from iOS. Arbitrarily large, so that clients that want to
+        // process deletions first can; for us it doesn't matter.
+        const TOMBSTONE_SORTINDEX: i32 = 5_000_000;
+        const DEFAULT_SORTINDEX: i32 = 1;
+        let mut outgoing = OutgoingChangeset::new("passwords", st);
+        let db = &self.store.db;
+        let mut stmt = db.prepare_cached(&format!(
+            "SELECT * FROM loginsL WHERE sync_status IS NOT {synced}",
+            synced = SyncStatus::Synced as u8
+        ))?;
+        let rows = stmt.query_and_then(NO_PARAMS, |row| {
+            scope.err_if_interrupted()?;
+            Ok(if row.get::<_, bool>("is_deleted")? {
+                Payload::new_tombstone(row.get::<_, String>("guid")?)
+                    .with_sortindex(TOMBSTONE_SORTINDEX)
+            } else {
+                let login = Login::from_row(row)?;
+                Payload::from_record(login)?.with_sortindex(DEFAULT_SORTINDEX)
+            })
+        })?;
+        outgoing.changes = rows.collect::<Result<_>>()?;
+
+        Ok(outgoing)
+    }
+
+    fn do_apply_incoming(
+        &self,
+        inbound: IncomingChangeset,
+        telem: &mut telemetry::Engine,
+        scope: &SqlInterruptScope,
+    ) -> Result<OutgoingChangeset> {
+        let mut incoming_telemetry = telemetry::EngineIncoming::new();
+        let data = self.fetch_login_data(&inbound.changes, &mut incoming_telemetry, scope)?;
+        let plan = {
+            let result = self.reconcile(data, inbound.timestamp, &mut incoming_telemetry, scope);
+            telem.incoming(incoming_telemetry);
+            result
+        }?;
+        self.execute_plan(plan, scope)?;
+        self.fetch_outgoing(inbound.timestamp, scope)
+    }
+
+    fn set_last_sync(&self, db: &LoginDb, last_sync: ServerTimestamp) -> Result<()> {
+        log::debug!("Updating last sync to {}", last_sync);
+        let last_sync_millis = last_sync.as_millis() as i64;
+        db.put_meta(schema::LAST_SYNC_META_KEY, &last_sync_millis)
+    }
+
+    fn get_last_sync(&self, db: &LoginDb) -> Result<Option<ServerTimestamp>> {
+        let millis = db.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?.unwrap();
+        Ok(Some(ServerTimestamp(millis)))
+    }
+
+    pub fn set_global_state(&self, state: &Option<String>) -> Result<()> {
+        let to_write = match state {
+            Some(ref s) => s,
+            None => "",
+        };
+        let db = &self.store.db;
+        db.put_meta(schema::GLOBAL_STATE_META_KEY, &to_write)
+    }
+
+    pub fn get_global_state(&self) -> Result<Option<String>> {
+        let db = &self.store.db;
+        db.get_meta::<String>(schema::GLOBAL_STATE_META_KEY)
+    }
+
+    fn mark_as_synchronized(
+        &self,
+        guids: &[&str],
+        ts: ServerTimestamp,
+        scope: &SqlInterruptScope,
+    ) -> Result<()> {
+        let db = &self.store.db;
+        let tx = db.unchecked_transaction()?;
+        sql_support::each_chunk(guids, |chunk, _| -> Result<()> {
+            db.execute(
+                &format!(
+                    "DELETE FROM loginsM WHERE guid IN ({vars})",
+                    vars = sql_support::repeat_sql_vars(chunk.len())
+                ),
+                chunk,
+            )?;
+            scope.err_if_interrupted()?;
+
+            db.execute(
+                &format!(
+                    "INSERT OR IGNORE INTO loginsM (
+                         {common_cols}, is_overridden, server_modified
+                     )
+                     SELECT {common_cols}, 0, {modified_ms_i64}
+                     FROM loginsL
+                     WHERE is_deleted = 0 AND guid IN ({vars})",
+                    common_cols = schema::COMMON_COLS,
+                    modified_ms_i64 = ts.as_millis() as i64,
+                    vars = sql_support::repeat_sql_vars(chunk.len())
+                ),
+                chunk,
+            )?;
+            scope.err_if_interrupted()?;
+
+            db.execute(
+                &format!(
+                    "DELETE FROM loginsL WHERE guid IN ({vars})",
+                    vars = sql_support::repeat_sql_vars(chunk.len())
+                ),
+                chunk,
+            )?;
+            scope.err_if_interrupted()?;
+            Ok(())
+        })?;
+        self.set_last_sync(&db, ts)?;
+        tx.commit()?;
+        Ok(())
+    }
+}
+
+impl<'a> SyncEngine for LoginsSyncEngine<'a> {
+    fn collection_name(&self) -> std::borrow::Cow<'static, str> {
+        "passwords".into()
+    }
+
+    fn apply_incoming(
+        &self,
+        inbound: Vec<IncomingChangeset>,
+        telem: &mut telemetry::Engine,
+    ) -> anyhow::Result<OutgoingChangeset> {
+        assert_eq!(inbound.len(), 1, "logins only requests one item");
+        let inbound = inbound.into_iter().next().unwrap();
+        Ok(self.do_apply_incoming(inbound, telem, &self.scope)?)
+    }
+
+    fn sync_finished(
+        &self,
+        new_timestamp: ServerTimestamp,
+        records_synced: Vec<Guid>,
+    ) -> anyhow::Result<()> {
+        self.mark_as_synchronized(
+            &records_synced.iter().map(Guid::as_str).collect::<Vec<_>>(),
+            new_timestamp,
+            &self.scope,
+        )?;
+        Ok(())
+    }
+
+    fn get_collection_requests(
+        &self,
+        server_timestamp: ServerTimestamp,
+    ) -> anyhow::Result<Vec<CollectionRequest>> {
+        let db = &self.store.db;
+        let since = self.get_last_sync(&db)?.unwrap_or_default();
+        Ok(if since == server_timestamp {
+            vec![]
+        } else {
+            vec![CollectionRequest::new("passwords").full().newer_than(since)]
+        })
+    }
+
+    fn get_sync_assoc(&self) -> anyhow::Result<EngineSyncAssociation> {
+        let db = &self.store.db;
+        let global = db.get_meta(schema::GLOBAL_SYNCID_META_KEY)?;
+        let coll = db.get_meta(schema::COLLECTION_SYNCID_META_KEY)?;
+        Ok(if let (Some(global), Some(coll)) = (global, coll) {
+            EngineSyncAssociation::Connected(CollSyncIds { global, coll })
+        } else {
+            EngineSyncAssociation::Disconnected
+        })
+    }
+
+    fn reset(&self, assoc: &EngineSyncAssociation) -> anyhow::Result<()> {
+        log::info!("Executing reset on password engine!");
+        let db = &self.store.db;
+        let tx = db.unchecked_transaction()?;
+        db.execute_all(&[
+            &CLONE_ENTIRE_MIRROR_SQL,
+            "DELETE FROM loginsM",
+            &format!("UPDATE loginsL SET sync_status = {}", SyncStatus::New as u8),
+        ])?;
+        self.set_last_sync(&db, ServerTimestamp(0))?;
+        match assoc {
+            EngineSyncAssociation::Disconnected => {
+                db.delete_meta(schema::GLOBAL_SYNCID_META_KEY)?;
+                db.delete_meta(schema::COLLECTION_SYNCID_META_KEY)?;
+            }
+            EngineSyncAssociation::Connected(ids) => {
+                db.put_meta(schema::GLOBAL_SYNCID_META_KEY, &ids.global)?;
+                db.put_meta(schema::COLLECTION_SYNCID_META_KEY, &ids.coll)?;
+            }
+        };
+        db.delete_meta(schema::GLOBAL_STATE_META_KEY)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    fn wipe(&self) -> anyhow::Result<()> {
+        let db = &self.store.db;
+        db.wipe(&self.scope)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::PasswordStore;
+    #[test]
+    fn test_bad_record() {
+        let store = PasswordStore::new_in_memory(Some("testing")).unwrap();
+        let engine = LoginsSyncEngine::new(&store);
+        let scope = store.db.begin_interrupt_scope();
+        let mut telem = sync15::telemetry::EngineIncoming::new();
+        let res = engine
+            .fetch_login_data(
+                &[
+                    // tombstone
+                    (
+                        sync15::Payload::new_tombstone("dummy_000001"),
+                        sync15::ServerTimestamp(10000),
+                    ),
+                    // invalid
+                    (
+                        sync15::Payload::from_json(serde_json::json!({
+                            "id": "dummy_000002",
+                            "garbage": "data",
+                            "etc": "not a login"
+                        }))
+                        .unwrap(),
+                        sync15::ServerTimestamp(10000),
+                    ),
+                    // valid
+                    (
+                        sync15::Payload::from_json(serde_json::json!({
+                            "id": "dummy_000003",
+                            "formSubmitURL": "https://www.example.com/submit",
+                            "hostname": "https://www.example.com",
+                            "username": "test",
+                            "password": "test",
+                        }))
+                        .unwrap(),
+                        sync15::ServerTimestamp(10000),
+                    ),
+                ],
+                &mut telem,
+                &scope,
+            )
+            .unwrap();
+        assert_eq!(telem.get_failed(), 1);
+        assert_eq!(res.len(), 2);
+        assert_eq!(res[0].guid, "dummy_000001");
+        assert_eq!(res[1].guid, "dummy_000003");
+    }
+}

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -10,6 +10,7 @@ mod error;
 mod login;
 
 mod db;
+mod engine;
 pub mod schema;
 mod store;
 mod update_plan;
@@ -19,7 +20,7 @@ mod ffi;
 
 // Mostly exposed for the sync manager.
 pub use crate::db::LoginDb;
-pub use crate::db::LoginsSyncEngine;
+pub use crate::engine::LoginsSyncEngine;
 pub use crate::error::*;
 pub use crate::login::*;
 pub use crate::store::*;

--- a/components/sync_manager/src/manager.rs
+++ b/components/sync_manager/src/manager.rs
@@ -346,7 +346,7 @@ impl SyncManager {
 
         if let Some(le) = ls.as_ref() {
             assert!(logins_sync, "Should have already checked");
-            engines.push(Box::new(logins::LoginsSyncEngine::new(&le.db)));
+            engines.push(Box::new(logins::LoginsSyncEngine::new(&le)));
         }
 
         if let Some(tbs) = ts.as_ref() {


### PR DESCRIPTION
This is a bit painful, but will be necessary for the uniffi work - in short, our `LoginDb` has been serving as both our database abstraction and our `SyncEngine` abstraction. This PR splits this up so that the `LoginsSyncEngine` does only sync-specific stuff, and the `LoginDb` is the more generic abstraction. Obviously the sync engine uses the DB - but now it can have a much shorter lifetime, and later, will actually use a `Mutex<LoginDb>`. This is the same pattern used by autofill.

I thought about doing the `Mutex` now, which in theory would work, but is much much riskier - attempting to take the mutex twice would deadlock and there's a risk we'd do that on the same thread (eg, take the mutex, then call another function which takes the mutex). There are a couple of things there that will make our future lives easier though - eg, lots of `let db = &self.store.db` - in the future that's going to change to `let db = self.store.db.lock().unwrap()` etc.

This is going to conflict with @bendk and @skhamis work. To help Ben out, I took the liberty of applying this to https://github.com/mhammond/application-services/tree/logins-per-field-encryption-with-engine-split - this is Ben's fork (which is ahead of the main fork), and has had applied f01f9bafa55f56425c3281dca2122c6fb6bee897 (which I added yesterday) and this PR. Feel free to do with it what you like. Obviously that only makes sense if this PR is accepted and merged.

I *nearly* got this fully working on the uniffi branch but ran out of time. I'll finish that and the sync manager work for uniffi asap.