### PR TITLE
Update uniffi dependency to v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,9 +3700,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uniffi"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951741396f443adea228ef79abb846340607dfed26068ec0405dd180fd3dbaa5"
+checksum = "5f873c330b1a5c0203d99dbb414e71b9164ba08d1d629e89c8443c9a3811341a"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -3716,9 +3716,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc7f411f7c8faa9d9940eb3a36e271972f4bb35d6860c920f41eca93831e10d"
+checksum = "00b5f4e2a14871a982baa9d8cbd30cee10011866e39878be55e8b6f19175e51d"
 dependencies = [
  "anyhow",
  "askama",
@@ -3732,9 +3732,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6892022dca2c387d91aced1ae78f12cca854cdf395ae8035616d100d54f18c"
+checksum = "0ffc224a409d40bcaa604685055e0f3c550a0ec0418a219eb83aa48519137b3c"
 dependencies = [
  "anyhow",
  "uniffi_bindgen",
@@ -3742,9 +3742,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce261685f44e0a2448dc939baa68c2253cc69a2a38a9d487d967c90cb645f05f"
+checksum = "b88750acc561d2e860c1672471bdb6b25892edcdb3e0b4548947d0e3b497bb58"
 dependencies = [
  "glob",
  "proc-macro2",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -23,7 +23,7 @@ sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.8.0"
+uniffi = "^0.9"
 url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -36,4 +36,4 @@ libsqlite3-sys = "0.20.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.8.0", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.9", features = [ "builtin-bindgen" ]}

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,8 +9,8 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = "0.8"
-uniffi_macros = "0.8"
+uniffi = "0.9"
+uniffi_macros = "0.9"
 
 [build-dependencies]
-uniffi_build = { version = "0.8", features=["builtin-bindgen"] }
+uniffi_build = { version = "0.9", features=["builtin-bindgen"] }

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -26,11 +26,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.8"
-uniffi_macros = "^0.8"
+uniffi = "^0.9"
+uniffi_macros = "^0.9"
 
 [build-dependencies]
-uniffi_build = { version = "^0.8.0", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.9", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -94,6 +94,7 @@ enum FxaError {
 // user's Firefox Account, and provides methods for inspecting the state of the
 // account and accessing other services on behalf of the user.
 //
+[Threadsafe]
 interface FirefoxAccount {
 
   // Create a new [`FirefoxAccount`] instance, not connected to any account.

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -33,10 +33,10 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "^0.8.0", optional = true }
+uniffi = { version = "^0.9", optional = true }
 
 [build-dependencies]
-uniffi_build = { version = "^0.8.0", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.9", features = [ "builtin-bindgen" ], optional = true }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.8.0"
+uniffi_bindgen = "^0.9"


### PR DESCRIPTION
There was a bit of churn here in the `fxa-client` component to make it `[Threadsafe]` and avoid the new deprecation warning, but otherwise this seems straightforward. Pinging both Sync and Nimbus folks for review from a risk-mitigation perspective, given any upcoming releases.