### PR TITLE
Fixing change detection in tests.py

### DIFF
--- a/automation/tests.py
+++ b/automation/tests.py
@@ -59,7 +59,7 @@ def yellow_text(text):
 
 def get_output(cmdline, **kwargs):
     output = subprocess.check_output(cmdline, **kwargs).decode('utf8')
-    return output.strip()
+    return output
 
 def run_command(cmdline, **kwargs):
     print(yellow_text(' '.join(shlex.quote(str(part)) for part in cmdline)))
@@ -92,7 +92,7 @@ class BranchChanges:
         # branch that's present in this branch.
         self.merge_base = get_output([
             'git', 'merge-base', 'HEAD', base_branch,
-        ])
+        ]).strip()
         # Use the merge base to calculate which files have changed from the
         # base branch.
         raw_paths = get_output([
@@ -203,9 +203,12 @@ def touch_changed_paths(branch_changes):
 
 def print_rust_environment():
     print('platform: {}'.format(platform.uname()))
-    print('rustc version: {}'.format(get_output(['rustc', '--version'])))
-    print('cargo version: {}'.format(get_output(['cargo', '--version'])))
-    print('rustfmt version: {}'.format(get_output(['rustfmt', '--version'])))
+    print('rustc version: {}'.format(
+        get_output(['rustc', '--version']).strip()))
+    print('cargo version: {}'.format(
+        get_output(['cargo', '--version']).strip()))
+    print('rustfmt version: {}'.format(
+        get_output(['rustfmt', '--version']).strip()))
     print('GCC version: {}'.format(
         get_output(['gcc', '--version']).split('\n')[0]))
     print()


### PR DESCRIPTION
Don't call strip() on the command output, it altered the git status
output and made the script think that `rust fmt` didn't make any changes
when it did.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
