### PR TITLE
Add --force flag when installing swift-protobuf via homebrew

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ jobs:
       - run:
           name: Set up the build environment
           command: |
-            brew install swift-protobuf
+            brew install swift-protobuf --force
       - carthage-bootstrap
       - run:
           name: Verify the build environment


### PR DESCRIPTION
CI was failing on the v77 release internally trying to run `brew install swift-protobuf` due to a linking error trying to install a dependency (`six`) that failed.  The upload tasks then quietly showed success, but didn't actually find anything to upload so no framework is attached to the v77 release.  This should force the install of swift-protobuf and which will overwrite the already installed dependency, thus preventing the error.

Once successful, and this PR lands, a new dot release v77.0.1 will need to be cut in order to have an iOS framework attached to it.