### PR TITLE
Add formatting guidance to `CHANGES_UNRELEASED.MD`

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -3,3 +3,18 @@
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v77.0.1...main)
+
+<!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
+
+Use the template below to make assigning a version number during the release cutting process easier.
+
+## [Component Name]
+
+### ⚠️ Breaking Changes ⚠️
+  - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
+### What's Changed
+  - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
+### What's New
+  - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
+
+-->

--- a/automation/prepare-release.py
+++ b/automation/prepare-release.py
@@ -86,9 +86,10 @@ with open(BUILDCONFIG_FILE, "w") as stream:
 with open(UNRELEASED_CHANGES_FILE, "r") as stream:
     unreleased_changes = stream.read()
 
-# Copy the text after the "Full Changelog" line in the unreleased changes file.
-to_find = re.escape("[Full Changelog]")
-changes = re.split(f"^{to_find}.+$", unreleased_changes, flags=re.MULTILINE)[1].strip()
+# Copy the text after the end of the header comment section in the unreleased changes file.
+to_find = re.escape("-->")
+
+changes = re.split(f"^{to_find}$", unreleased_changes, flags=re.MULTILINE)[1].strip()
 
 with open(CHANGELOG_FILE, "r") as stream:
     changelog = stream.read()
@@ -108,6 +109,21 @@ new_changes_unreleased = f"""**See [the release process docs](docs/howtos/cut-a-
 # Unreleased Changes
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/{next_version_full}...main)
+
+<!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
+
+Use the template below to make assigning a version number during the release cutting process easier.
+
+## [Component Name]
+
+### ⚠️ Breaking Changes ⚠️
+  - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
+### What's Changed
+  - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
+### What's New
+  - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
+
+-->
 """
 
 with open(CHANGELOG_FILE, "w") as stream:


### PR DESCRIPTION
Our [prepare release](https://github.com/mozilla/application-services/blob/main/automation/prepare-release.py) script expects that the `Full Changelog` line will be at the top of the `CHANGES_UNRELEASED` file. Lately we've been adding new entries above that line, which moves the changelog line to the bottom of the file and prevents the script from copying unreleased change entries to `CHANGELOG.md`. 

I've added a comment to the unreleased changes file that makes note of this. On a somewhat unrelated note, I've also provided some guidance on entry structure to make it easier for whoever's cutting the next release to gauge the correct version number. 

My guess is that the placement of the comment, let alone the verbiage, will provide a visual cue that additions should be entered below, but this may be too light-handed. Either way, I'm open to alternatives.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - Consider running `automation/all_tests.sh` to execute these tests locally.
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
