### PR TITLE
Update uniffi to version 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,12 +309,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
-name = "cargo_metadata"
-version = "0.11.4"
+name = "camino"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a567c24b86754d629addc2db89e340ac9398d07b5875efcff837e3878e17ec"
+checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
 dependencies = [
- "semver 0.10.0",
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "081e3f0755c1f380c2d010481b6fa2e02973586d5f2b24eebb7a2a1d98b143d8"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 0.11.0",
+ "semver-parser 0.10.2",
  "serde",
  "serde_json",
 ]
@@ -2136,6 +2157,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,16 +3046,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
 ]
 
 [[package]]
 name = "semver"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.10.2",
  "serde",
 ]
 
@@ -3034,6 +3064,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "serde"
@@ -3648,6 +3687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3700,12 +3745,12 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uniffi"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f873c330b1a5c0203d99dbb414e71b9164ba08d1d629e89c8443c9a3811341a"
+checksum = "9f5964fc421a61f6492d6da9371d2eb6f89d051ab2876bb6991467323399bd86"
 dependencies = [
  "anyhow",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "cargo_metadata",
  "ffi-support 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static",
@@ -3716,9 +3761,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b5f4e2a14871a982baa9d8cbd30cee10011866e39878be55e8b6f19175e51d"
+checksum = "f116feabd6c6fbefdb62f46fdd8a927fae67e5e5ef980f7c2eba5b20c22150b5"
 dependencies = [
  "anyhow",
  "askama",
@@ -3732,9 +3777,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffc224a409d40bcaa604685055e0f3c550a0ec0418a219eb83aa48519137b3c"
+checksum = "fb7ec3b6ba20044de8a8637a78fbba360c845656604d57fd796326be08bfc02d"
 dependencies = [
  "anyhow",
  "uniffi_bindgen",
@@ -3742,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88750acc561d2e860c1672471bdb6b25892edcdb3e0b4548947d0e3b497bb58"
+checksum = "696c743d40f7de57be19d3b8fd7c480930f49075c9fae94ed2b2af662d469094"
 dependencies = [
  "glob",
  "proc-macro2",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -23,7 +23,7 @@ sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.9"
+uniffi = "^0.10"
 url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -36,4 +36,4 @@ libsqlite3-sys = "0.20.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.9", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.10", features = [ "builtin-bindgen" ]}

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,8 +9,8 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = "0.9"
-uniffi_macros = "0.9"
+uniffi = "^0.10"
+uniffi_macros = "^0.10"
 
 [build-dependencies]
-uniffi_build = { version = "0.9", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.10", features=["builtin-bindgen"] }

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -26,11 +26,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.9"
-uniffi_macros = "^0.9"
+uniffi = "^0.10"
+uniffi_macros = "^0.10"
 
 [build-dependencies]
-uniffi_build = { version = "^0.9", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.10", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -33,10 +33,10 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "^0.9", optional = true }
+uniffi = { version = "^0.10", optional = true }
 
 [build-dependencies]
-uniffi_build = { version = "^0.9", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.10", features = [ "builtin-bindgen" ], optional = true }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.9"
+uniffi_bindgen = "^0.10"


### PR DESCRIPTION
Yet again, WCGW? :)

Some `Cargo.lock` changes surprised me, but they seem to be coming from an updated `cargo_metadata` in Uniffi, so 🤷 