### PR TITLE
Use uniffi's [Self=ByArc] and kill the Store/StoreImpl split

### DIFF
--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -131,8 +131,9 @@ interface Store {
     [Throws=Error]
     void touch_address(string guid);
 
-    [Throws=Error]
+    [Throws=Error, Self=ByArc]
     void scrub_encrypted_data();
 
+    [Self=ByArc]
     void register_with_sync_manager();
 };

--- a/components/autofill/src/lib.rs
+++ b/components/autofill/src/lib.rs
@@ -12,12 +12,11 @@ pub mod error;
 pub mod sync;
 
 // Re-export stuff the sync manager needs.
-pub use crate::db::store::{StoreImpl, STORE_FOR_MANAGER};
+pub use crate::db::store::{Store, STORE_FOR_MANAGER};
 
 // Expose stuff needed by the uniffi generated code.
 use crate::db::models::address::*;
 use crate::db::models::credit_card::*;
-use crate::db::store::Store;
 use crate::encryption::{create_key, decrypt_string, encrypt_string};
 use error::Error;
 

--- a/components/autofill/src/lib.rs
+++ b/components/autofill/src/lib.rs
@@ -12,11 +12,12 @@ pub mod error;
 pub mod sync;
 
 // Re-export stuff the sync manager needs.
-pub use crate::db::store::{Store, STORE_FOR_MANAGER};
+pub use crate::db::store::get_registered_sync_engine;
 
 // Expose stuff needed by the uniffi generated code.
 use crate::db::models::address::*;
 use crate::db::models::credit_card::*;
+use crate::db::store::Store;
 use crate::encryption::{create_key, decrypt_string, encrypt_string};
 use error::Error;
 

--- a/components/autofill/src/sync/address/mod.rs
+++ b/components/autofill/src/sync/address/mod.rs
@@ -22,7 +22,7 @@ use sync_guid::Guid;
 use types::Timestamp;
 
 // The engine.
-pub fn create_engine(store: Arc<crate::StoreImpl>) -> ConfigSyncEngine<InternalAddress> {
+pub fn create_engine(store: Arc<crate::Store>) -> ConfigSyncEngine<InternalAddress> {
     ConfigSyncEngine::new(
         EngineConfig {
             namespace: "addresses".to_string(),

--- a/components/autofill/src/sync/address/mod.rs
+++ b/components/autofill/src/sync/address/mod.rs
@@ -22,7 +22,7 @@ use sync_guid::Guid;
 use types::Timestamp;
 
 // The engine.
-pub fn create_engine(store: Arc<crate::Store>) -> ConfigSyncEngine<InternalAddress> {
+pub(crate) fn create_engine(store: Arc<crate::Store>) -> ConfigSyncEngine<InternalAddress> {
     ConfigSyncEngine::new(
         EngineConfig {
             namespace: "addresses".to_string(),

--- a/components/autofill/src/sync/credit_card/mod.rs
+++ b/components/autofill/src/sync/credit_card/mod.rs
@@ -24,7 +24,7 @@ use sync_guid::Guid;
 use types::Timestamp;
 
 // The engine.
-pub fn create_engine(store: Arc<crate::Store>) -> ConfigSyncEngine<InternalCreditCard> {
+pub(crate) fn create_engine(store: Arc<crate::Store>) -> ConfigSyncEngine<InternalCreditCard> {
     ConfigSyncEngine::new(
         EngineConfig {
             namespace: "credit_cards".to_string(),

--- a/components/autofill/src/sync/credit_card/mod.rs
+++ b/components/autofill/src/sync/credit_card/mod.rs
@@ -24,7 +24,7 @@ use sync_guid::Guid;
 use types::Timestamp;
 
 // The engine.
-pub fn create_engine(store: Arc<crate::StoreImpl>) -> ConfigSyncEngine<InternalCreditCard> {
+pub fn create_engine(store: Arc<crate::Store>) -> ConfigSyncEngine<InternalCreditCard> {
     ConfigSyncEngine::new(
         EngineConfig {
             namespace: "credit_cards".to_string(),

--- a/components/autofill/src/sync/engine.rs
+++ b/components/autofill/src/sync/engine.rs
@@ -4,7 +4,7 @@
 
 use super::{plan_incoming, ProcessIncomingRecordImpl, ProcessOutgoingRecordImpl, SyncRecord};
 use crate::error::*;
-use crate::StoreImpl as Store;
+use crate::Store;
 use rusqlite::{
     types::{FromSql, ToSql},
     Connection, Transaction,
@@ -241,7 +241,7 @@ mod tests {
 
     // We use the credit-card engine here.
     fn create_engine() -> ConfigSyncEngine<InternalCreditCard> {
-        let store = crate::db::store::StoreImpl::new_memory();
+        let store = crate::db::store::Store::new_memory();
         crate::sync::credit_card::create_engine(Arc::new(store))
     }
 

--- a/components/sync_manager/src/manager.rs
+++ b/components/sync_manager/src/manager.rs
@@ -73,15 +73,7 @@ impl SyncManager {
     }
 
     pub fn autofill_engine(engine: &str) -> Option<Box<dyn SyncEngine>> {
-        let weak = autofill::STORE_FOR_MANAGER.lock().unwrap();
-        match weak.upgrade() {
-            None => None,
-            Some(arc) => match engine {
-                "addresses" => Some(Box::new(autofill::sync::address::create_engine(arc))),
-                "creditcards" => Some(Box::new(autofill::sync::credit_card::create_engine(arc))),
-                _ => unreachable!("can't process unknown engine: {}", engine),
-            },
-        }
+        autofill::get_registered_sync_engine(engine)
     }
 
     pub fn wipe(&mut self, engine: &str) -> Result<()> {

--- a/components/sync_manager/src/manager.rs
+++ b/components/sync_manager/src/manager.rs
@@ -73,11 +73,8 @@ impl SyncManager {
     }
 
     pub fn autofill_engine(engine: &str) -> Option<Box<dyn SyncEngine>> {
-        let cell = autofill::STORE_FOR_MANAGER.lock().unwrap();
-        // The cell holds a `Weak` - borrow it (which is safe as we have the
-        // mutex) and upgrade it to a real Arc.
-        let r = cell.borrow();
-        match r.upgrade() {
+        let weak = autofill::STORE_FOR_MANAGER.lock().unwrap();
+        match weak.upgrade() {
             None => None,
             Some(arc) => match engine {
                 "addresses" => Some(Box::new(autofill::sync::address::create_engine(arc))),


### PR DESCRIPTION
Here's a partial alternative to @bendk's #4142 which uses the new `[Self=ByArc]` annotation in uniffi. I say "partial" as it doesn't include some of the other cleanups and doc changes, which I think are great, but I ran out of time and wanted this to focus mainly on the Arc stuff. I also stole a test I added in the logins-uniffi work (and bad me for not adding it here before) - it also checks the weak reference implementation.

It's still not *quite* as clean in terms of still having `STORE_FOR_MANAGER: Mutex<RefCell<Weak<Store>>>` but I think the ability to have weak references is important. I'd be totally fine if you'd like to take this over or integrate it into your other PR, or happy to discuss this more.