### PR TITLE
Merge v77.0.2 to main

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 77.0.1
+libraryVersion: 77.0.2
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v77.0.2 (_2021-05-31_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v77.0.1...v77.0.2)
+
+## Autofill
+
+ - Fixed a failing assertion when handling local dupes during a sync (#4154)
+
 # v77.0.1 (_2021-05-24_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v77.0.0...v77.0.1)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v77.0.1...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v77.0.2...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 


### PR DESCRIPTION
I made `v77.0.2` as a point-release so that we didn't pick up a bunch of UniFFI and other dependency changes, this merges it back into main for completeness.