### PR TITLE
Add script for running `cargo` from inside XCode.

### DIFF
--- a/build-scripts/xc-cargo.sh
+++ b/build-scripts/xc-cargo.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+#
+# This is a small wrapper for running `cargo` inside of an XCode build,
+# which unfortunately doesn't seem to work quite right out-of-the-box.
+set -eEuvx
+
+
+# XCode tries to be helpful and overwrites the PATH. Reset that.
+PATH="$(bash -l -c 'echo $PATH')"
+
+"${HOME}"/.cargo/bin/cargo "${@:-help}"

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -118,7 +118,7 @@
 				"$(INPUT_FILE_DIR)/../ios/Generated/$(INPUT_FILE_BASE).swift",
 				"$(INPUT_FILE_DIR)/../ios/Generated/uniffi_$(INPUT_FILE_BASE)-Bridging-Header.h",
 			);
-			script = "$HOME/.cargo/bin/cargo uniffi-bindgen generate $INPUT_FILE_PATH --language swift --out-dir $INPUT_FILE_DIR/../ios/Generated\n";
+			script = "bash $PWD/../../build-scripts/xc-cargo.sh uniffi-bindgen generate $INPUT_FILE_PATH --language swift --out-dir $INPUT_FILE_DIR/../ios/Generated\n";
 		};
 		EB7DE84A2214D28C00E7CF17 /* PBXBuildRule */ = {
 			isa = PBXBuildRule;


### PR DESCRIPTION
Directly executing `cargo` from inside of an XCode build doesn't
seem to work quite right, e.g. on Big Sur it isn't able to properly
build any `build.rs` due to problems with library paths in the linker

This copies the same technique that we already use for running `cargo`
to build a universal binary, but as a re-useable cargo wrapper rather
than a specific command.
