### PR TITLE
Add basic docs for updating `nss_sys` crate.

### DIFF
--- a/components/support/rc_crypto/nss/nss_sys/README.md
+++ b/components/support/rc_crypto/nss/nss_sys/README.md
@@ -1,3 +1,21 @@
 ## nss_sys
 
-Low-level NSS bindings for Rust. They are verified using the `systest` crate in the parent directory.
+Low-level NSS bindings for Rust.
+
+This crate defines low-level FFI bindings for NSS. They are maintained by hand,
+and their correctness is verified using the `systest` crate in the parent directory.
+
+The directory structure of this crate is meant to mirror that of NSS itself.
+For each header file provided by NSS, there should be a corresponding `.rs` file
+in the `nss_sys::bindings` module that declares the corresponding functions and
+data types.
+
+To add new bindings in this crate, you'll need to:
+
+* Identify the NSS header file that contains the functionality of interest.
+* Edit the Rust file of the corresponding name under `./src/bindings`.
+    * If one doesn't currently exist then create it, and also add the corresponding
+      header to the list of headers in `../systest/build.rs`.
+* Add `#[recpr(C)]` structs and `pub extern "C"` functions as necessary to make the
+  new functionality visible to Rust.
+* Verify the correctness of your additions using `cargo run -p systest` in the repository root.

--- a/docs/howtos/upgrading-nss-guide.md
+++ b/docs/howtos/upgrading-nss-guide.md
@@ -56,6 +56,18 @@ To test out your changes:
   * Install the updates version: `./libs/verify-desktop-environment.sh`
   * Try it out: `cargo test`
 
+## Exposing new functions
+
+If the new version of NSS comes with new functions that you want to expose, you will need to:
+
+* Add low-level bindings for those functions in the [`nss_sys` crate](
+  ../../components/support/rc_crypto/nss/nss_sys); follow the instructions in
+  README for that crate.
+* Expose a safe wrapper API for the functions from the [`nss` crate](
+  ../../components/support/rc_crypto/nss);
+* Expose a convenient high-level API for the functions from the [`rc_crypto` crate](
+  ../../components/support/rc_crypto);
+
 ## Tips for Fixing Bustage
 
 On top of the primitives provided by NSS, we have built a safe Rust wrapper named [rc_crypto](https://github.com/mozilla/application-services/tree/main/components/support/rc_crypto) that links to NSS and makes these cryptographic primitives available to our components.


### PR DESCRIPTION
Fixes #4175.