### PR TITLE
Use a shared helper for gradle uniffi-bindgen tasks.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3725,9 +3725,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uniffi"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5964fc421a61f6492d6da9371d2eb6f89d051ab2876bb6991467323399bd86"
+checksum = "657fbc531f30fefafcdd40484152a35f573af0670394c8e879e113eafddc0d60"
 dependencies = [
  "anyhow",
  "bytes 1.0.1",
@@ -3741,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f116feabd6c6fbefdb62f46fdd8a927fae67e5e5ef980f7c2eba5b20c22150b5"
+checksum = "5d10d1a19352133760809d06cf69742d4baa36ef756d96b67d88438713408e32"
 dependencies = [
  "anyhow",
  "askama",
@@ -3757,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7ec3b6ba20044de8a8637a78fbba360c845656604d57fd796326be08bfc02d"
+checksum = "015624925af99e254321a257e5a51d3c5192da4fae9887770be5841c0c9c2a4c"
 dependencies = [
  "anyhow",
  "uniffi_bindgen",
@@ -3767,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696c743d40f7de57be19d3b8fd7c480930f49075c9fae94ed2b2af662d469094"
+checksum = "cbafc1d13d61d903addb3eed289510d238ba25806714f978e4a1caa45fa95b06"
 dependencies = [
  "glob",
  "proc-macro2",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -23,7 +23,7 @@ sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.10"
+uniffi = "^0.11"
 url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -36,4 +36,4 @@ libsqlite3-sys = "0.20.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.10", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.11", features = [ "builtin-bindgen" ]}

--- a/components/autofill/android/build.gradle
+++ b/components/autofill/android/build.gradle
@@ -99,17 +99,6 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
-// We do the uniffi binding generation here:
-android.libraryVariants.all { variant ->
-    def t = tasks.register("generate${variant.name.capitalize()}UniffiBindings", Exec) {
-        workingDir project.rootDir
-        commandLine 'cargo', 'uniffi-bindgen', 'generate', "${project.projectDir}/../src/autofill.udl", '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
-    }
-    variant.javaCompileProvider.get().dependsOn(t)
-    def sourceSet = variant.sourceSets.find { it.name == variant.name }
-    sourceSet.java.srcDir new File(buildDir, "generated/source/uniffi/${variant.name}/java")
-}
-
 evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
@@ -127,5 +116,5 @@ afterEvaluate {
 }
 
 apply from: "$rootDir/publish.gradle"
-
+ext.configureUniFFIBindgen("../src/autofill.udl")
 ext.configurePublish()

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -86,11 +86,6 @@ enum Error {
    "CryptoError", "NoSuchRecord",
 };
 
-// We don't really *need* this to be `Threadsafe` because we have a mutex to
-// manage concurrent DB connections - but we might as well so our Mutexes
-// do what we thing they are doing rather than being controlled by the hidden
-// mutexes non-threadsafe uniffi gives us.
-[Threadsafe]
 interface Store {
     [Throws=Error]
     constructor(string dbpath);

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,8 +9,8 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = "^0.10"
-uniffi_macros = "^0.10"
+uniffi = "^0.11"
+uniffi_macros = "^0.11"
 
 [build-dependencies]
-uniffi_build = { version = "^0.10", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.11", features=["builtin-bindgen"] }

--- a/components/crashtest/android/build.gradle
+++ b/components/crashtest/android/build.gradle
@@ -86,19 +86,6 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
-// We do the uniffi binding generation here:
-android.libraryVariants.all { variant ->
-    def t = tasks.register("generate${variant.name.capitalize()}UniffiBindings", Exec) {
-        workingDir project.rootDir
-        commandLine 'cargo', 'uniffi-bindgen', 'generate', "${project.projectDir}/../src/crashtest.udl", '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
-
-        inputs.file '../src/crashtest.udl'
-        outputs.dir "${buildDir}/generated/source/uniffi/${variant.name}/java/"
-    }
-    variant.javaCompileProvider.get().dependsOn(t)
-    def sourceSet = variant.sourceSets.find { it.name == variant.name }
-    sourceSet.java.srcDirs += new File(buildDir, "generated/source/uniffi/${variant.name}/java")
-}
 
 evaluationDependsOn(":full-megazord")
 afterEvaluate {
@@ -117,5 +104,5 @@ afterEvaluate {
 }
 
 apply from: "$rootDir/publish.gradle"
-
+ext.configureUniFFIBindgen("../src/crashtest.udl")
 ext.configurePublish()

--- a/components/crashtest/src/crashtest.udl
+++ b/components/crashtest/src/crashtest.udl
@@ -45,7 +45,6 @@ namespace crashtest {
 };
 
 
-
 // An error that can be returned from Rust code.
 //
 [Error]

--- a/components/crashtest/src/crashtest.udl
+++ b/components/crashtest/src/crashtest.udl
@@ -52,4 +52,3 @@ enum CrashTestError {
   "ErrorFromTheRustCode",
 };
 
-

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -26,11 +26,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.10"
-uniffi_macros = "^0.10"
+uniffi = "^0.11"
+uniffi_macros = "^0.11"
 
 [build-dependencies]
-uniffi_build = { version = "^0.10", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.11", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -86,20 +86,6 @@ dependencies {
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }
 
-// We do the uniffi binding generation here:
-android.libraryVariants.all { variant ->
-    def t = tasks.register("generate${variant.name.capitalize()}UniffiBindings", Exec) {
-        workingDir project.rootDir
-        commandLine 'cargo', 'uniffi-bindgen', 'generate', "${project.projectDir}/../src/fxa_client.udl", '--language', 'kotlin', '--out-dir', "${buildDir}/generated/source/uniffi/${variant.name}/java"
-
-        inputs.file '../src/fxa_client.udl'
-        outputs.dir "${buildDir}/generated/source/uniffi/${variant.name}/java/"
-    }
-    variant.javaCompileProvider.get().dependsOn(t)
-    def sourceSet = variant.sourceSets.find { it.name == variant.name }
-    sourceSet.java.srcDirs += new File(buildDir, "generated/source/uniffi/${variant.name}/java")
-}
-
 evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
@@ -117,5 +103,5 @@ afterEvaluate {
 }
 
 apply from: "$rootDir/publish.gradle"
-
+ext.configureUniFFIBindgen("../src/fxa_client.udl")
 ext.configurePublish()

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -94,7 +94,6 @@ enum FxaError {
 // user's Firefox Account, and provides methods for inspecting the state of the
 // account and accessing other services on behalf of the user.
 //
-[Threadsafe]
 interface FirefoxAccount {
 
   // Create a new [`FirefoxAccount`] instance, not connected to any account.

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -33,10 +33,10 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "^0.10", optional = true }
+uniffi = { version = "^0.11", optional = true }
 
 [build-dependencies]
-uniffi_build = { version = "^0.10", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.11", features = [ "builtin-bindgen" ], optional = true }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -104,16 +104,6 @@ dependencies {
     testImplementation "org.mozilla.telemetry:glean-forUnitTests:$glean_version"
 }
 
-// We also do the binding generation here:
-android.libraryVariants.all { variant ->
-    def uniffiGeneratedPath = "generated/source/uniffi/${variant.name}/java"
-    def t = tasks.register("generate${variant.name.capitalize()}UniffiBindings", Exec) {
-        workingDir project.rootDir
-        commandLine 'cargo', 'uniffi-bindgen', 'generate', "${project.projectDir}/../src/nimbus.udl", '--language', 'kotlin', '--out-dir', "${buildDir}/${uniffiGeneratedPath}"
-    }
-    variant.registerJavaGeneratingTask(t.get(), new File(buildDir, uniffiGeneratedPath))
-}
-
 evaluationDependsOn(":full-megazord")
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
@@ -131,4 +121,5 @@ afterEvaluate {
 }
 
 apply from: "$rootDir/publish.gradle"
+ext.configureUniFFIBindgen("../src/nimbus.udl")
 ext.configurePublish()

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -45,7 +45,7 @@ const DEFAULT_TOTAL_BUCKETS: u32 = 10000;
 const DB_KEY_NIMBUS_ID: &str = "nimbus-id";
 
 // The main `NimbusClient` struct must not expose any methods that make an `&mut self`,
-// in order to be compatible with the uniffi `[Threadsafe]` annotation. This is a helper
+// in order to be compatible with the uniffi's requirements on objects. This is a helper
 // struct to contain the bits that do actually need to be mutable, so they can be
 // protected by a Mutex.
 #[derive(Default)]

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -74,7 +74,6 @@ enum NimbusError {
     "DatabaseNotReady",
 };
 
-[Threadsafe]
 interface NimbusClient {
     [Throws=NimbusError]
     constructor(

--- a/publish.gradle
+++ b/publish.gradle
@@ -200,3 +200,27 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
         checkMavenArtifacts.dependsOn(checkFileSizeTask)
     }
 }
+
+
+
+// A convenience function for configuring a `uniffi-bindgen` task,
+// with appropriate dependency info. This fill call `uniffi-bindgen`
+// on the provided `.udl` file in order to generate Kotlin language
+// bindings and include them in the source set for the project.
+ext.configureUniFFIBindgen = { udlFilePath ->
+    android.libraryVariants.all { variant ->
+        def uniffiGeneratedPath = "generated/source/uniffi/${variant.name}/java"
+        def t = tasks.register("generate${variant.name.capitalize()}UniFFIBindings", Exec) {
+            workingDir project.rootDir
+            commandLine 'cargo', 'uniffi-bindgen', 'generate', "${project.projectDir}/${udlFilePath}", '--language', 'kotlin', '--out-dir', "${buildDir}/${uniffiGeneratedPath}"
+            outputs.dir "${buildDir}/${uniffiGeneratedPath}"
+            // Re-generate if the interface definition changes.
+            inputs.file "${project.projectDir}/${udlFilePath}"
+            // Re-generate if our uniffi-bindgen tooling changes.
+            inputs.dir "${project.rootDir}/tools/embedded-uniffi-bindgen/"
+            // Re-generate if our uniffi-bindgen version changes.
+            inputs.file "${project.rootDir}/Cargo.lock"
+        }
+        variant.registerJavaGeneratingTask(t.get(), new File(buildDir, uniffiGeneratedPath))
+    }
+}

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.10"
+uniffi_bindgen = "^0.11"


### PR DESCRIPTION
We currently have four copies of the logic for calling UniFFI
from gradle, several with their own little tweaks. Let's take
the best lessons from each and consolidate them into a single
shared helper.

This version is, I think, an improvement over all the existing
ones:

* Like the nimbus version, it registers the task as generating
  java source files, which should help things integrate cleanly
  into the broader build.
* Like the fxa-client version, it declares explicit inputs so
  that we can avoid re-running the task when nothing has changed.
* New in this version, it declares an input dependency on anything
  that would affect the version of `uniffi-bindgen` that is in use,
  since that too will change the generated outputs.

That last change should really help with smooth updates to the
version of UniFFI in use. Previously, if you changed the UniFFI
version it would not trigger a cleanup of old generated bindings,
and you'd get `java.lang.UnsatisfiedLinkError` errors like in #4054.
(This is UniFFI's last-line-of-defence measure to prevent you from
using bindings generated with one version of UniFFI on a library
compiled with another, which is very useful, but an extremely
confusing failure mode).

With this change, an updated version of UniFFI will invalidate
the gradle task that generates the bindings, causing them to
be regenerated with the new version.

Fixes some of the errors from #4054, and takes a step towards
the goal of #3988.