### PR TITLE
Add Places API call to retrieve recently modified bookmark nodes

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -4,6 +4,16 @@
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v78.0.0...main)
 
+## Places
+
+### What's New
+- A new `getRecentlyUpdatedBookmarks` API call was added to return the list of most 
+  recently updated bookmark items.
+
+### Breaking Changes
+- The addition of `getRecentlyUpdatedBookmarks` is a breaking change for custom
+  implementations of `ReadableBookmarksConnection` on Android.
+
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
 Use the template below to make assigning a version number during the release cutting process easier.

--- a/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
@@ -253,6 +253,20 @@ interface ReadableBookmarksConnection : InterruptibleConnection {
      * has its `interrupt()` method called on another thread.
      */
     fun getRecentBookmarks(limit: Int): List<BookmarkItem>
+
+    /**
+     * Returns the list of most recently added or updated bookmarks.
+     *
+     * The result list be in order of time of addition or update, descending (more recent
+     * additions/updates first), and will contain no folder or separator nodes.
+     *
+     * @param limit The maximum number of items to return.
+     * @return A list of recently added/updated bookmarks.
+     *
+     * @throws OperationInterrupted if this database implements [InterruptibleConnection] and
+     * has its `interrupt()` method called on another thread.
+     */
+    fun getRecentlyUpdatedBookmarks(limit: Int): List<BookmarkItem>
 }
 
 /**

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -293,6 +293,12 @@ internal interface LibPlacesFFI : Library {
         error: RustError.ByReference
     ): RustBuffer.ByValue
 
+    fun bookmarks_get_recently_updated(
+        handle: PlacesConnectionHandle,
+        limit: Int,
+        error: RustError.ByReference
+    ): RustBuffer.ByValue
+
     // Returns newly inserted guid
     fun bookmarks_insert(
         handle: PlacesConnectionHandle,

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -796,6 +796,20 @@ pub extern "C" fn bookmarks_get_recent(
     })
 }
 
+#[no_mangle]
+pub extern "C" fn bookmarks_get_recently_updated(
+    handle: u64,
+    limit: i32,
+    error: &mut ExternError,
+) -> ByteBuffer {
+    log::debug!("bookmarks_get_recently_updated");
+    CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
+        Ok(BookmarkNodeList::from(
+            bookmarks::public_node::recently_updated_bookmarks(conn, limit as u32)?,
+        ))
+    })
+}
+
 define_string_destructor!(places_destroy_string);
 define_bytebuffer_destructor!(places_destroy_bytebuffer);
 define_handle_map_deleter!(APIS, places_api_destroy);

--- a/components/places/src/storage/bookmarks/public_node.rs
+++ b/components/places/src/storage/bookmarks/public_node.rs
@@ -256,7 +256,6 @@ pub fn recent_bookmarks(db: &PlacesDb, limit: u32) -> Result<Vec<PublicNode>> {
         .collect())
 }
 
-
 pub fn recently_updated_bookmarks(db: &PlacesDb, limit: u32) -> Result<Vec<PublicNode>> {
     let scope = db.begin_interrupt_scope();
     let sql = format!(


### PR DESCRIPTION
Based on https://github.com/mozilla/application-services/commit/bd6532716c9da5bfc1474dfa15dc19d1b16225ce.
For https://github.com/mozilla-mobile/android-components/issues/10419

The intention of this is to retrieve a list of recently modified bookmark nodes. `recent_bookmarks` only retrieves bookmarks that have been Added, so this call returns a list based on `lastModified` date.

I need some help writing tests for this...

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
