### PR TITLE
 Evolve enrollment error handling sdk-294

### DIFF
--- a/components/nimbus/src/dbcache.rs
+++ b/components/nimbus/src/dbcache.rs
@@ -58,10 +58,12 @@ impl DatabaseCache {
             branches_by_experiment.insert(e.slug, e.branch_slug.clone());
         }
 
+        log::debug!("collecting... ");
         let enrollments: Vec<ExperimentEnrollment> =
             db.get_store(StoreId::Enrollments).collect_all(&writer)?;
         let experiments: Vec<Experiment> =
             db.get_store(StoreId::Experiments).collect_all(&writer)?;
+        log::debug!("...finished");
 
         let features_by_feature_id = map_features_by_feature_id(&enrollments, &experiments);
 

--- a/components/nimbus/src/dbcache.rs
+++ b/components/nimbus/src/dbcache.rs
@@ -58,12 +58,10 @@ impl DatabaseCache {
             branches_by_experiment.insert(e.slug, e.branch_slug.clone());
         }
 
-        log::debug!("collecting... ");
         let enrollments: Vec<ExperimentEnrollment> =
             db.get_store(StoreId::Enrollments).collect_all(&writer)?;
         let experiments: Vec<Experiment> =
             db.get_store(StoreId::Experiments).collect_all(&writer)?;
-        log::debug!("...finished");
 
         let features_by_feature_id = map_features_by_feature_id(&enrollments, &experiments);
 

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -643,6 +643,8 @@ impl<'a> EnrollmentsEvolver<'a> {
             }
             let slug = &prev_enrollment.slug;
 
+            log::debug!("about to call evolve_enrollment (1st call site)");
+
             let next_enrollment = self.evolve_enrollment(
                 is_user_participating,
                 prev_experiments.get(slug).copied(),
@@ -735,6 +737,8 @@ impl<'a> EnrollmentsEvolver<'a> {
                 };
 
                 if let Some(enrollment) = next_enrollment {
+                    log::debug!("inside let Some enrollment");
+
                     // We get the FeatureConfig out of the enrollment.
                     // This is copied from above. We should consider making this a function.
                     if let Some(enrolled_feature) =
@@ -2127,13 +2131,16 @@ mod tests {
         // XXX is this right?  should we be returning some sort of event for this?
         assert_eq!(events.len(), 0, "no new enrollments should have been returned");
 
+        // XXX are there any other internal errors that are worth testing in
+        // the second call site?
+
+        // XXX test various errs in first loop gets dropped and right stuff returned
+
         // Now test "New Experiment but Enrollment exists" error in 2nd loop,
         let (enrollments, events) =
            evolver.evolve_enrollments(true, &[], &test_experiments, &existing_enrollments[..])?;
 
         // XXX check that both enrollment and event were dropped
-
-        // XXX test various errs in first loop gets dropped and right stuff returned
 
         // XXX maybe test no errors returns right stuff
 

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2088,13 +2088,27 @@ mod tests {
 
     #[test]
     fn test_evolve_enrollments_error_handling() -> Result<()> {
-        // XXX test err in first loop gets dropped and right stuff returned
+        let _ = env_logger::try_init();
+        let (nimbus_id, app_ctx, aru) = local_ctx();
+        let evolver = EnrollmentsEvolver::new(&nimbus_id, &aru, &app_ctx);
 
-        // XXX test err in 2nd loop gets dropped and right stuff returned
+        // test err in 2nd loop (ie no previous enrollment) gets dropped and right stuff returned
+
+        let mut test_experiments = get_test_experiments();
+
+        // this should not return an error
+        let (enrollments, events) =
+            evolver.evolve_enrollments(true, &test_experiments, &test_experiments, &[])?;
+
+        // XXX now test "New Experiment but Enrollmnet exists" error in 2nd loop, and assert
+        // that both enrollment and experiment were dropped
+
+
+        // XXX test various errs in first loop gets dropped and right stuff returned
 
         // XXX maybe test no errors returns right stuff
 
-        OK(())
+        Ok(())
     }
 
     #[test]

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2146,12 +2146,7 @@ mod tests {
             "no new enrollments should have been returned"
         );
 
-        // XXX are there any other internal errors that are worth testing in
-        // the second call site?
-
-        // XXX test various errs in first loop gets dropped and right stuff returned
-
-        // Now test "New Experiment but Enrollment exists" error in 2nd loop,
+        // Now test "New Experiment but Enrollment exists" error in 1st loop,
         let (enrollments, events) =
             evolver.evolve_enrollments(true, &[], &test_experiments, &existing_enrollments[..])?;
 

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -656,7 +656,6 @@ impl<'a> EnrollmentsEvolver<'a> {
                 Err(e) => {
                     // XXX test that any associated enrollments,
                     // prev_experiments?, next_experiments also dropped
-                    // XXX YYY finish this logging
                     log::error!("evolve_enrollment(\n\tprev_exp: {:?}\n\t, next_exp: {:?}, \n\tprev_enrollment: {:?})\n\t returned an error: {}; dropping this record", prev_experiments.get(slug).copied(), Some(next_experiments.get(slug).copied()), prev_enrollment, e);
                     None
                 }
@@ -738,7 +737,6 @@ impl<'a> EnrollmentsEvolver<'a> {
                     Err(e) => {
                         // XXX test that any associated enrollments,
                         // prev_experiments?, next_experiments also dropped
-                        // XXX YYY finish this logging
                         log::error!("evolve_enrollment(\n\tprev_exp: {:?}\n\t, next_exp: {:?}, \n\tprev_enrollment: {:?})\n\t returned an error: {}; dropping this record", prev_experiments.get(slug).copied(), Some(next_experiment), prev_enrollment, e);
                         //return Err(NimbusError::InvalidPersistedData);
                         None
@@ -2159,21 +2157,9 @@ mod tests {
 
         // XXX check that both enrollment and event were dropped
 
-        // XXX maybe test no errors returns right stuff
-
         Ok(())
     }
 
-    #[test]
-    // fn test_evolve_enrollment_err_behaviors() -> Result<()>
-    // {
-    //     // XXX test that we drop experiments and leave the dataset consistent
-    //     // for all 8 permutations
-
-    //     Ok(())
-    // }
-
-    // XXX maybe test evolve_enrollments_in_db?
     #[test]
     fn test_evolver_experiment_update_error() -> Result<()> {
         let exp = get_test_experiments()[0].clone();

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -726,7 +726,6 @@ impl<'a> EnrollmentsEvolver<'a> {
                 };
 
                 if let Some(enrollment) = next_enrollment {
-
                     // We get the FeatureConfig out of the enrollment.
                     // This is copied from above. We should consider making this a function.
                     if let Some(enrolled_feature) =

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2100,6 +2100,16 @@ mod tests {
 
     #[test]
     fn test_evolve_enrollments_error_handling() -> Result<()> {
+        let existing_enrollments = vec![ExperimentEnrollment {
+            slug: "secure-gold".to_owned(),
+            status: EnrollmentStatus::Enrolled {
+                enrollment_id: Uuid::new_v4(),
+                branch: "hello".to_owned(), // XXX this OK?
+                reason: EnrolledReason::Qualified,
+                feature_id: "some_control".to_owned(),
+            },
+        }];
+
         let _ = env_logger::try_init();
         let (nimbus_id, app_ctx, aru) = local_ctx();
         let evolver = EnrollmentsEvolver::new(&nimbus_id, &aru, &app_ctx);
@@ -2117,9 +2127,11 @@ mod tests {
         // XXX is this right?  should we be returning some sort of event for this?
         assert_eq!(events.len(), 0, "no new enrollments should have been returned");
 
-        // XXX now test "New Experiment but Enrollmnet exists" error in 2nd loop, and assert
-        // that both enrollment and experiment were dropped
+        // Now test "New Experiment but Enrollment exists" error in 2nd loop,
+        let (enrollments, events) =
+           evolver.evolve_enrollments(true, &[], &test_experiments, &existing_enrollments[..])?;
 
+        // XXX check that both enrollment and event were dropped
 
         // XXX test various errs in first loop gets dropped and right stuff returned
 

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -618,6 +618,8 @@ impl<'a> EnrollmentsEvolver<'a> {
         let next_experiments = map_experiments(&next_experiments);
         let prev_enrollments = map_enrollments(&prev_enrollments);
 
+        log::debug!("entering evolve_enrollments");
+
         // Step 1. Build an initial active_features to keep track of
         // the features that are being experimented upon.
         let mut active_features = HashMap::with_capacity(next_experiments.len());
@@ -658,10 +660,14 @@ impl<'a> EnrollmentsEvolver<'a> {
             }
         }
 
+        log::debug!("before second loop");
+
         // Step 3. Evolve the remaining enrollments with the previous and
         // next data.
         for next_experiment in next_experiments.values() {
             let slug = &next_experiment.slug;
+
+            log::debug!("in second loop");
 
             // Check that the feature id is available.  If not, then declare
             // the enrollment as NotEnrolled; and we continue to the next
@@ -683,6 +689,7 @@ impl<'a> EnrollmentsEvolver<'a> {
                     // features that are already active. So continue to
                     // the next experiment. But…
                 }
+                log::debug!("just before continue");
                 // … perhaps we can continue here too? Because
                 // if the feature is already active,
                 //    …and the experiment it's using is this one,
@@ -690,6 +697,8 @@ impl<'a> EnrollmentsEvolver<'a> {
                 //     because we did it in step 2.
                 continue;
             }
+
+            log::debug!("past continue, feature not already active");
 
             // If we got here, then the feature is not already active.
             // But we evolved all the existing enrollments in step 2,

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2112,6 +2112,11 @@ mod tests {
         let (enrollments, events) =
             evolver.evolve_enrollments(true, &test_experiments, &test_experiments, &[])?;
 
+        assert_eq!(enrollments.len(), 0, "no new enrollments should have been returned");
+
+        // XXX is this right?  should we be returning some sort of event for this?
+        assert_eq!(events.len(), 0, "no new enrollments should have been returned");
+
         // XXX now test "New Experiment but Enrollmnet exists" error in 2nd loop, and assert
         // that both enrollment and experiment were dropped
 

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2123,13 +2123,15 @@ mod tests {
     }
 
     #[test]
-    fn test_evolve_enrollment_err_behaviors() -> Result<()>
-    {
-        // XXX test that we drop experiments and leave the dataset consistent
-        // for all 8 permutations
+    // fn test_evolve_enrollment_err_behaviors() -> Result<()>
+    // {
+    //     // XXX test that we drop experiments and leave the dataset consistent
+    //     // for all 8 permutations
 
-        OK(())
-    }
+    //     Ok(())
+    // }
+
+    // XXX maybe test evolve_enrollments_in_db?
 
     #[test]
     fn test_evolver_experiment_update_error() -> Result<()> {

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -650,6 +650,11 @@ impl<'a> EnrollmentsEvolver<'a> {
             ) {
                 Ok(enrollment) => enrollment,
                 Err(e) => {
+                    // It would be a fine thing if we had counters that
+                    // collected the number of errors here, and at the
+                    // place in this function where enrollments could be
+                    // dropped.  We could then send those errors to
+                    // telemetry so that they could be monitored (SDK-309)
                     log::error!("evolve_enrollment(\n\tprev_exp: {:?}\n\t, next_exp: {:?}, \n\tprev_enrollment: {:?})\n\t returned an error: {}; dropping this record", prev_experiments.get(slug).copied(), Some(next_experiments.get(slug).copied()), prev_enrollment, e);
                     None
                 }
@@ -720,6 +725,11 @@ impl<'a> EnrollmentsEvolver<'a> {
                 ) {
                     Ok(enrollment) => enrollment,
                     Err(e) => {
+                        // It would be a fine thing if we had counters that
+                        // collected the number of errors here, and at the
+                        // place in this function where enrollments could be
+                        // dropped.  We could then send those errors to
+                        // telemetry so that they could be monitored (SDK-309)
                         log::error!("evolve_enrollment(\n\tprev_exp: {:?}\n\t, next_exp: {:?}, \n\tprev_enrollment: {:?})\n\t returned an error: {}; dropping this record", prev_experiments.get(slug).copied(), Some(next_experiment), prev_enrollment, e);
                         None
                     }

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2119,7 +2119,6 @@ mod tests {
             "no new enrollments should have been returned"
         );
 
-        // XXX is this right?  should we be returning some sort of event for this?
         assert_eq!(
             events.len(),
             0,

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -645,13 +645,22 @@ impl<'a> EnrollmentsEvolver<'a> {
 
             log::debug!("about to call evolve_enrollment (1st call site)");
 
-            let next_enrollment = self.evolve_enrollment(
+            let next_enrollment = match self.evolve_enrollment(
                 is_user_participating,
                 prev_experiments.get(slug).copied(),
                 next_experiments.get(slug).copied(),
                 Some(prev_enrollment),
                 &mut enrollment_events,
-            )?;
+            ) {
+                Ok(enrollment) => enrollment,
+                Err(e) => {
+                    // XXX test that any associated enrollments,
+                    // prev_experiments?, next_experiments also dropped
+                    // XXX YYY finish this logging
+                    log::error!("evolve_enrollment(\n\tprev_exp: {:?}\n\t, next_exp: {:?}, \n\tprev_enrollment: {:?})\n\t returned an error: {}; dropping this record", prev_experiments.get(slug).copied(), Some(next_experiments.get(slug).copied()), prev_enrollment, e);
+                    None
+                }
+            };
 
             if let Some(enrollment) = next_enrollment {
                 // We get the FeatureConfig out of the enrollment.

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -729,6 +729,7 @@ impl<'a> EnrollmentsEvolver<'a> {
                         // prev_experiments?, next_experiments also dropped
                         // XXX YYY finish this logging
                         log::error!("evolve_enrollment(\n\tprev_exp: {:?}\n\t, next_exp: {:?}, \n\tprev_enrollment: {:?})\n\t returned an error: {}; dropping this record", prev_experiments.get(slug).copied(), Some(next_experiment), prev_enrollment, e);
+                        //return Err(NimbusError::InvalidPersistedData);
                         None
                     }
                 };

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2106,7 +2106,7 @@ mod tests {
 
         // test err in 2nd loop (ie no previous enrollment) gets dropped and right stuff returned
 
-        let mut test_experiments = get_test_experiments();
+        let test_experiments = get_test_experiments();
 
         // this should not return an error
         let (enrollments, events) =

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2078,6 +2078,26 @@ mod tests {
     }
 
     #[test]
+    fn test_evolve_enrollments_error_handling() -> Result<()> {
+        // XXX test err in first loop gets dropped and right stuff returned
+
+        // XXX test err in 2nd loop gets dropped and right stuff returned
+
+        // XXX maybe test no errors returns right stuff
+
+        OK(())
+    }
+
+    #[test]
+    fn test_evolve_enrollment_err_behaviors() -> Result<()>
+    {
+        // XXX test that we drop experiments and leave the dataset consistent
+        // for all 8 permutations
+
+        OK(())
+    }
+
+    #[test]
     fn test_evolver_experiment_update_error() -> Result<()> {
         let exp = get_test_experiments()[0].clone();
         let (nimbus_id, app_ctx, aru) = local_ctx();

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2125,8 +2125,8 @@ mod tests {
         let (nimbus_id, app_ctx, aru) = local_ctx();
         let evolver = EnrollmentsEvolver::new(&nimbus_id, &aru, &app_ctx);
 
-        // test err in 2nd loop (ie no previous enrollment) gets dropped and right stuff returned
-
+        // test that evolve_enrollments correctly handles the case where a
+        // record without a previous enrollment gets dropped
         let test_experiments = get_test_experiments();
 
         // this should not return an error
@@ -2146,11 +2146,22 @@ mod tests {
             "no new enrollments should have been returned"
         );
 
-        // Now test "New Experiment but Enrollment exists" error in 1st loop,
+        // Test that evolve_enrollments correctly handles the case where a
+        // record with a previous enrollment gets dropped
         let (enrollments, events) =
             evolver.evolve_enrollments(true, &[], &test_experiments, &existing_enrollments[..])?;
 
-        // XXX check that both enrollment and event were dropped
+        assert_eq!(
+            enrollments.len(),
+            1,
+            "only 1 of 2 enrollments should have been returned, since one caused evolve_enrollment to err"
+        );
+
+        assert_eq!(
+            events.len(),
+            1,
+            "only 1 of 2 enrollment events should have been returned, since one caused evolve_enrollment to err"
+        );
 
         Ok(())
     }

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -714,13 +714,24 @@ impl<'a> EnrollmentsEvolver<'a> {
                     }
                 )
             {
-                let next_enrollment = self.evolve_enrollment(
+                log::debug!("about to call evolve_enrollment (2nd call site)");
+
+                let next_enrollment = match self.evolve_enrollment(
                     is_user_participating,
                     prev_experiments.get(slug).copied(),
                     Some(next_experiment),
                     prev_enrollment,
                     &mut enrollment_events,
-                )?;
+                ) {
+                    Ok(enrollment) => enrollment,
+                    Err(e) => {
+                        // XXX test that any associated enrollments,
+                        // prev_experiments?, next_experiments also dropped
+                        // XXX YYY finish this logging
+                        log::error!("evolve_enrollment(\n\tprev_exp: {:?}\n\t, next_exp: {:?}, \n\tprev_enrollment: {:?})\n\t returned an error: {}; dropping this record", prev_experiments.get(slug).copied(), Some(next_experiment), prev_enrollment, e);
+                        None
+                    }
+                };
 
                 if let Some(enrollment) = next_enrollment {
                     // We get the FeatureConfig out of the enrollment.

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2135,10 +2135,18 @@ mod tests {
         let (enrollments, events) =
             evolver.evolve_enrollments(true, &test_experiments, &test_experiments, &[])?;
 
-        assert_eq!(enrollments.len(), 0, "no new enrollments should have been returned");
+        assert_eq!(
+            enrollments.len(),
+            0,
+            "no new enrollments should have been returned"
+        );
 
         // XXX is this right?  should we be returning some sort of event for this?
-        assert_eq!(events.len(), 0, "no new enrollments should have been returned");
+        assert_eq!(
+            events.len(),
+            0,
+            "no new enrollments should have been returned"
+        );
 
         // XXX are there any other internal errors that are worth testing in
         // the second call site?
@@ -2147,7 +2155,7 @@ mod tests {
 
         // Now test "New Experiment but Enrollment exists" error in 2nd loop,
         let (enrollments, events) =
-           evolver.evolve_enrollments(true, &[], &test_experiments, &existing_enrollments[..])?;
+            evolver.evolve_enrollments(true, &[], &test_experiments, &existing_enrollments[..])?;
 
         // XXX check that both enrollment and event were dropped
 
@@ -2166,7 +2174,6 @@ mod tests {
     // }
 
     // XXX maybe test evolve_enrollments_in_db?
-
     #[test]
     fn test_evolver_experiment_update_error() -> Result<()> {
         let exp = get_test_experiments()[0].clone();

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -91,6 +91,7 @@ impl NimbusClient {
     }
 
     pub fn initialize(&self) -> Result<()> {
+        log::debug!("initialize");
         let db = self.db()?;
         // We're not actually going to write, we just want to exclude concurrent writers.
         let writer = db.write()?;

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -91,7 +91,6 @@ impl NimbusClient {
     }
 
     pub fn initialize(&self) -> Result<()> {
-        log::debug!("initialize");
         let db = self.db()?;
         // We're not actually going to write, we just want to exclude concurrent writers.
         let writer = db.write()?;

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -10,7 +10,7 @@ pub use error::{NimbusError, Result};
 mod client;
 mod config;
 mod matcher;
-mod persistence;
+pub mod persistence;
 mod sampling;
 mod updating;
 #[cfg(debug_assertions)]

--- a/components/nimbus/src/persistence.rs
+++ b/components/nimbus/src/persistence.rs
@@ -428,7 +428,7 @@ impl Database {
         }
     }
 
-    fn open_rkv<P: AsRef<Path>>(path: P) -> Result<Rkv> {
+    pub fn open_rkv<P: AsRef<Path>>(path: P) -> Result<Rkv> {
         let path = std::path::Path::new(path.as_ref()).join("db");
         log::debug!("Database path: {:?}", path.display());
         fs::create_dir_all(&path)?;

--- a/components/nimbus/src/persistence.rs
+++ b/components/nimbus/src/persistence.rs
@@ -522,7 +522,7 @@ impl Database {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use serde_json::json;
     use std::collections::HashMap;
@@ -748,16 +748,11 @@ mod tests {
                 "schemaVersion": "1.0.0",
                 "slug": "branch-feature-empty-obj", // change when copy/pasting to make experiments
                 "endDate": null,
-                "featureIds": ["bbb"], // change when copy/pasting to make experiments
                 "branches":[
                     {
                         "slug": "control",
                         "ratio": 1,
-                        "feature": {
-                            "featureId": "bbb", // change when copy/pasting to make experiments
-                            "enabled": false,
-                            "value": {}
-                        }
+                        "feature": {}
                     },
                     {
                         "slug": "treatment",

--- a/components/nimbus/src/persistence.rs
+++ b/components/nimbus/src/persistence.rs
@@ -525,7 +525,7 @@ impl Database {
 }
 
 #[cfg(test)]
-pub mod tests {
+mod tests {
     use super::*;
     use serde_json::json;
     use std::collections::HashMap;

--- a/components/nimbus/tests/common/mod.rs
+++ b/components/nimbus/tests/common/mod.rs
@@ -10,16 +10,16 @@ pub fn new_test_client(identifier: &str) -> Result<NimbusClient> {
     use tempdir::TempDir;
     let tmp_dir = TempDir::new(identifier)?;
 
-    new_test_client_internal(tmp_dir)
+    new_test_client_internal(&tmp_dir)
 }
 
 #[allow(dead_code)] // not clear why this is necessary...
-pub fn new_test_client_with_db(tmp_dir: tempdir::TempDir) -> Result<NimbusClient> {
+pub fn new_test_client_with_db(tmp_dir: &tempdir::TempDir) -> Result<NimbusClient> {
     new_test_client_internal(tmp_dir)
 }
 
 fn new_test_client_internal(
-    tmp_dir: tempdir::TempDir,
+    tmp_dir: &tempdir::TempDir,
 ) -> Result<NimbusClient, nimbus::NimbusError> {
     use std::path::PathBuf;
     use url::Url;
@@ -38,6 +38,7 @@ fn new_test_client_internal(
         channel: "nightly".to_string(),
         ..Default::default()
     };
+    log::debug!("new_test_client_internal: tmp_dir.path() = {:?}", tmp_dir.path());
     NimbusClient::new(ctx, tmp_dir.path(), Some(config), aru)
 }
 
@@ -294,7 +295,8 @@ pub fn create_old_database<P: AsRef<Path>>(
     enrollments_json: &[serde_json::Value],
 ) -> Result<()> {
     let _ = env_logger::try_init();
-
+    log::debug!("create_old_database(): old_version = {:?}", old_version);
+    log::debug!("create_old_database(): path = {:?}", path.as_ref());
     let rkv = Database::open_rkv(path)?;
     let meta_store = SingleStore::new(rkv.open_single("meta", StoreOptions::create())?);
     let experiment_store =

--- a/components/nimbus/tests/common/mod.rs
+++ b/components/nimbus/tests/common/mod.rs
@@ -27,6 +27,7 @@ fn new_test_client_internal(
     let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     dir.push("tests/experiments");
     let url = Url::from_file_path(dir).expect("experiments dir should exist");
+
     let config = RemoteSettingsConfig {
         server_url: url.as_str().to_string(),
         collection_name: "doesn't matter".to_string(),
@@ -38,7 +39,6 @@ fn new_test_client_internal(
         channel: "nightly".to_string(),
         ..Default::default()
     };
-    log::debug!("new_test_client_internal: tmp_dir.path() = {:?}", tmp_dir.path());
     NimbusClient::new(ctx, tmp_dir.path(), Some(config), aru)
 }
 
@@ -328,7 +328,7 @@ pub fn create_old_database<P: AsRef<Path>>(
     }
 
     writer.commit()?;
-    log::debug!("create_old_database committed");
+    log::debug!("create_old_database: writer committed");
 
     Ok(())
 }

--- a/components/nimbus/tests/common/mod.rs
+++ b/components/nimbus/tests/common/mod.rs
@@ -5,7 +5,7 @@
 // utilities shared between tests
 use nimbus::{error::Result, AppContext, NimbusClient, RemoteSettingsConfig};
 
-#[allow(dead_code)] // not clear why this is necessary...
+#[allow(dead_code)] // work around https://github.com/rust-lang/rust/issues/46379
 pub fn new_test_client(identifier: &str) -> Result<NimbusClient> {
     use tempdir::TempDir;
     let tmp_dir = TempDir::new(identifier)?;
@@ -13,7 +13,7 @@ pub fn new_test_client(identifier: &str) -> Result<NimbusClient> {
     new_test_client_internal(&tmp_dir)
 }
 
-#[allow(dead_code)] // not clear why this is necessary...
+#[allow(dead_code)] // work around https://github.com/rust-lang/rust/issues/46379
 pub fn new_test_client_with_db(tmp_dir: &tempdir::TempDir) -> Result<NimbusClient> {
     new_test_client_internal(tmp_dir)
 }
@@ -42,7 +42,7 @@ fn new_test_client_internal(
     NimbusClient::new(ctx, tmp_dir.path(), Some(config), aru)
 }
 
-#[allow(dead_code)] // not clear why this is necessary...
+#[allow(dead_code)] //  work around https://github.com/rust-lang/rust/issues/46379
 pub fn exactly_two_experiments() -> String {
     use serde_json::json;
     json!({
@@ -141,7 +141,7 @@ pub fn exactly_two_experiments() -> String {
     .to_string()
 }
 
-#[allow(dead_code)] // not clear why this is necessary...
+#[allow(dead_code)] //  work around https://github.com/rust-lang/rust/issues/46379
 pub fn experiments_testing_feature_ids() -> String {
     use serde_json::json;
     json!({
@@ -275,7 +275,7 @@ pub fn experiments_testing_feature_ids() -> String {
     .to_string()
 }
 
-#[allow(dead_code)] // not clear why this is necessary...
+#[allow(dead_code)] // work around https://github.com/rust-lang/rust/issues/46379
 pub fn no_test_experiments() -> String {
     use serde_json::json;
     json!({
@@ -287,7 +287,7 @@ pub fn no_test_experiments() -> String {
 use nimbus::persistence::{Database, SingleStore};
 use rkv::StoreOptions;
 use std::path::Path;
-#[allow(dead_code)] // not clear why this is necessary...
+#[allow(dead_code)] //  work around https://github.com/rust-lang/rust/issues/46379
 pub fn create_old_database<P: AsRef<Path>>(
     path: P,
     old_version: u16,

--- a/components/nimbus/tests/test_updates.rs
+++ b/components/nimbus/tests/test_updates.rs
@@ -460,6 +460,8 @@ mod test {
         let db_v1_experiments_with_missing_feature_fields =
             &get_db_v1_experiments_with_missing_feature_fields();
 
+        // create a database in a way that could cause the migrator to
+        // leave some orphan records while cleaning up...
         create_old_database(
             &tmp_dir,
             1,

--- a/components/nimbus/tests/test_updates.rs
+++ b/components/nimbus/tests/test_updates.rs
@@ -481,7 +481,10 @@ mod test {
         client.apply_pending_experiments()?;
 
         let experiments = client.get_all_experiments()?;
-        log::debug!("after 2nd apply and get_all: experiments = {:?}", experiments);
+        log::debug!(
+            "after 2nd apply and get_all: experiments = {:?}",
+            experiments
+        );
 
         // Make sure that we have what we should...
         assert_eq!(experiments.len(), 1);

--- a/components/nimbus/tests/test_updates.rs
+++ b/components/nimbus/tests/test_updates.rs
@@ -412,11 +412,10 @@ mod test {
         ]
     }
 
-    #[cfg(feature = "rkv-safe-mode")]
-    #[test]
-
     /// test that even with a database with orphan records,
     /// apply_pending_experiments does not throw an error
+    #[cfg(feature = "rkv-safe-mode")]
+    #[test]
     fn test_startup_orphan_behavior() -> Result<()> {
         let _ = env_logger::try_init();
 

--- a/components/nimbus/tests/test_updates.rs
+++ b/components/nimbus/tests/test_updates.rs
@@ -414,7 +414,7 @@ mod test {
 
     #[cfg(feature = "rkv-safe-mode")]
     #[test]
-        fn test_startup_orphan_behavior() -> Result<()> {
+    fn test_startup_orphan_behavior() -> Result<()> {
         let _ = env_logger::try_init();
 
         use tempdir::TempDir;
@@ -453,7 +453,8 @@ mod test {
 
         let tmp_dir = TempDir::new("test_startup_orphan_behavior")?;
 
-        let db_v1_experiments_with_missing_feature_fields = &get_db_v1_experiments_with_missing_feature_fields();
+        let db_v1_experiments_with_missing_feature_fields =
+            &get_db_v1_experiments_with_missing_feature_fields();
 
         create_old_database(
             &tmp_dir,

--- a/components/nimbus/tests/test_updates.rs
+++ b/components/nimbus/tests/test_updates.rs
@@ -11,7 +11,10 @@ mod common;
 #[cfg(feature = "rkv-safe-mode")]
 #[cfg(test)]
 mod test {
-    use super::common::{exactly_two_experiments, new_test_client, no_test_experiments};
+    use super::common::{
+        create_old_database, exactly_two_experiments, new_test_client, new_test_client_with_db,
+        no_test_experiments,
+    };
     #[cfg(feature = "rkv-safe-mode")]
     use nimbus::{error::Result, NimbusClient};
 
@@ -105,6 +108,383 @@ mod test {
         let experiments = client.get_all_experiments()?;
         assert_eq!(experiments.len(), 1);
         assert_eq!(experiments[0].slug, "secure-gold");
+
+        Ok(())
+    }
+
+    use serde_json::json;
+
+    // forked from persistence.rs; need to be merged in a separated test-utils
+    // module usable both by unit and integration tests (nimbus/test-utils?)
+    #[cfg(feature = "rkv-safe-mode")]
+    pub fn get_db_v1_experiments_with_missing_feature_fields() -> Vec<serde_json::Value> {
+        vec![
+            json!({
+                "schemaVersion": "1.0.0",
+                "slug": "branch-feature-empty-obj", // change when copy/pasting to make experiments
+                "endDate": null,
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                        "feature": {}
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio":1,
+                        "feature": {}
+                    }
+                ],
+                "channel": "nightly",
+                "probeSets":[],
+                "startDate":null,
+                "appName": "fenix",
+                "appId": "org.mozilla.fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"branch-feature-empty-obj", // change when copy/pasting to make experiments
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+            }),
+            json!({
+                "schemaVersion": "1.0.0",
+                "slug": "missing-branch-feature-clause", // change when copy/pasting to make experiments
+                "endDate": null,
+                "featureIds": ["aaa"], // change when copy/pasting to make experiments
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio":1,
+                        "feature": {
+                            "featureId": "aaa", // change when copy/pasting to make experiments
+                            "enabled": true,
+                            "value": {},
+                        }
+                    }
+                ],
+                "channel": "nightly",
+                "probeSets":[],
+                "startDate":null,
+                "appName": "fenix",
+                "appId": "org.mozilla.fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"empty-branch-feature-clause", // change when copy/pasting to make experiments
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+            }),
+            json!({
+                "schemaVersion": "1.0.0",
+                "slug": "branch-feature-feature-id-missing", // change when copy/pasting to make experiments
+                "endDate": null,
+                "featureIds": ["ccc"], // change when copy/pasting to make experiments
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                        "feature": {
+                            "featureId": "ccc", // change when copy/pasting to make experiments
+                            "enabled": false,
+                            "value": {}
+                        }
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio":1,
+                        "feature": {
+                            "enabled": true,
+                            "value": {}
+                        }
+                    }
+                ],
+                "channel": "nightly",
+                "probeSets":[],
+                "startDate":null,
+                "appName": "fenix",
+                "appId": "org.mozilla.fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"branch-feature-feature-id-missing", // change when copy/pasting to make experiments
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+            }),
+            json!({
+                "schemaVersion": "1.0.0",
+                "slug": "feature-ids-array-has-empty_string", // change when copy/pasting to make experiments
+                "endDate": null,
+                "featureIds": [""], // change when copy/pasting to make experiments
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                        "feature": {
+                            "featureId": "def", // change when copy/pasting to make experiments
+                            "enabled": false,
+                            "value": {},
+                        }
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio":1,
+                        "feature": {
+                            "featureId": "def", // change when copy/pasting to make experiments
+                            "enabled": true,
+                            "value": {}
+                        }
+                    }
+                ],
+                "channel": "nightly",
+                "probeSets":[],
+                "startDate":null,
+                "appName": "fenix",
+                "appId": "org.mozilla.fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"feature-ids-array-has-empty-string", // change when copy/pasting to make experiments
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+            }),
+            json!({
+                "schemaVersion": "1.0.0",
+                "slug": "missing-feature-ids-in-branch",
+                "endDate": null,
+                "featureIds": ["abc"],
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                        "feature": {
+                            "enabled": true,
+                            "value": {}
+                        }
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio": 1,
+                        "feature": {
+                            "enabled": true,
+                            "value": {}
+                        }
+                    }
+                ],
+                "probeSets":[],
+                "startDate":null,
+                "appName":"fenix",
+                "appId":"org.mozilla.fenix",
+                "channel":"nightly",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"no-feature-ids-at-all",
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+            }),
+            json!({
+                "schemaVersion": "1.0.0",
+                "slug": "missing-featureids-array", // change when copy/pasting to make experiments
+                "endDate": null,
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                        "feature": {
+                            "featureId": "about_welcome", // change when copy/pasting to make experiments
+                            "enabled": false,
+                            "value": {}
+                        }
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio":1,
+                        "feature": {
+                            "featureId": "about_welcome", // change when copy/pasting to make experiments
+                            "enabled": true,
+                            "value": {}
+                        }
+                    }
+                ],
+                "channel": "nightly",
+                "probeSets":[],
+                "startDate":null,
+                "appName": "fenix",
+                "appId": "org.mozilla.fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"valid-feature-experiment", // change when copy/pasting to make experiments
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+            }),
+            json!({
+                "schemaVersion": "1.0.0",
+                "slug": "branch-feature-feature-id-empty", // change when copy/pasting to make experiments
+                "endDate": null,
+                "featureIds": [""], // change when copy/pasting to make experiments
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                        "feature": {
+                            "featureId": "", // change when copy/pasting to make experiments
+                            "enabled": false,
+                            "value": {},
+                        }
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio":1,
+                        "feature": {
+                            "featureId": "", // change when copy/pasting to make experiments
+                            "enabled": true,
+                            "value": {},
+                        }
+                    }
+                ],
+                "channel": "nightly",
+                "probeSets":[],
+                "startDate":null,
+                "appName": "fenix",
+                "appId": "org.mozilla.fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"branch-feature-feature-id-empty", // change when copy/pasting to make experiments
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+            }),
+        ]
+    }
+
+    #[cfg(feature = "rkv-safe-mode")]
+    #[test]
+        fn test_startup_orphan_behavior() -> Result<()> {
+        let _ = env_logger::try_init();
+
+        use tempdir::TempDir;
+        let enrollments_for_missing_feature_id = vec![
+            json!(
+            {
+                "slug": "missing-feature-ids-in-branch",
+                "status":
+                    {
+                        "Enrolled":
+                            {
+                                "enrollment_id": "801ee64b-0b1b-44a7-be47-5f1b5c189084",
+                                "reason": "Qualified",
+                                "branch": "control",
+                                "feature_id": ""
+                            }
+                    }
+                }
+            ),
+            json!(
+            {
+                "slug": "branch-feature-empty-obj",
+                "status":
+                    {
+                        "Enrolled":
+                            {
+                                "enrollment_id": "801ee64b-0b1b-44a7-be47-5f1b5c18984",
+                                "reason": "Qualified",
+                                "branch": "control",
+                                //"feature_id": ""
+                            }
+                    }
+                }
+            ),
+        ];
+
+        let tmp_dir = TempDir::new("test_startup_orphan_behavior")?;
+
+        let db_v1_experiments_with_missing_feature_fields = &get_db_v1_experiments_with_missing_feature_fields();
+
+        create_old_database(
+            &tmp_dir,
+            1,
+            &db_v1_experiments_with_missing_feature_fields,
+            &enrollments_for_missing_feature_id,
+        )?;
+
+        let client = new_test_client_with_db(tmp_dir)?;
+
+        client.apply_pending_experiments()?;
+        client.fetch_experiments()?; // get new stuff from test dir
+                                     // startup(&client, false)?;
+
+        let experiments = client.get_all_experiments()?;
+        log::debug!("experiments = {:?}", experiments);
+        // assert_eq!(experiments.len(), 2);
+        // assert_eq!(experiments[0].slug, "secure-gold");
+        // assert_eq!(experiments[1].slug, "startup-gold");
+
+        // The app is at a safe place to change all the experiments.
+        client.apply_pending_experiments()?; // apply new stuff
+                                             // let experiments = client.get_all_experiments()?;
+                                             // assert_eq!(experiments.len(), 1);
+                                             // assert_eq!(experiments[0].slug, "secure-gold");
+
+        // // Next time we start the app.
+        // startup(&client, false)?;
+        // let experiments = client.get_all_experiments()?;
+        // assert_eq!(experiments.len(), 1);
+        // assert_eq!(experiments[0].slug, "secure-gold");
 
         Ok(())
     }


### PR DESCRIPTION
This changes the evolve_enrollments error handling to discard invalid records, rather than simplying blowing up and letting the error propagate up the stack.

It has an integration test for apply_updates.  I thought about writing one for set_global_opt_out, but I'm not convinced it provides much additional information, at least as relevant to this patch.  Which is to say that there shouldn't be errors that such a test would catch that this patch fixes and wouldn't already be caught by the apply_updates integration test. 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
  - /No breaking changes/
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
  - /No new dependencies/