### PR TITLE
Reduce gradle task dependencies on megazord build [ci full].

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,15 +215,16 @@ ext.rustTargets = [
 // Generate libs for our current platform so we can run unit tests.
 switch (DefaultPlatform.RESOURCE_PREFIX) {
     case 'darwin':
-        ext.rustTargets += 'darwin'
+        ext.nativeRustTarget = 'darwin'
         break
     case 'linux-x86-64':
-        ext.rustTargets += 'linux-x86-64'
+        ext.nativeRustTarget = 'linux-x86-64'
         break
     case 'win32-x86-64':
-        ext.rustTargets += 'win32-x86-64-gnu'
+        ext.nativeRustTarget = 'win32-x86-64-gnu'
         break
 }
+ext.rustTargets += ext.nativeRustTarget
 
 ext.libsRootDir = useDownloadedLibs ? rootProject.buildDir : rootProject.rootDir
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -251,7 +251,6 @@ ext.dependsOnTheMegazord = {
     // has their own build dir)
     android {
         sourceSets {
-            test.resources.srcDirs += "$buildDir/rustJniLibs/desktop"
             test.resources.srcDirs += "${project(':full-megazord').buildDir}/rustJniLibs/desktop"
         }
     }
@@ -271,8 +270,8 @@ ext.dependsOnTheMegazord = {
         // avoiding other configurations from being resolved.  Tricky!
         testImplementation files(configurations.jnaForTest.copyRecursive().files)
     }
-    // For running local tests, depend on a local `cargo build` of the megazord.
-    // Unfortunately the `cargoBuild` task isn't available until after evaluation.
+    // For running local tests, depend on a local native `cargo build` of the megazord.
+    // Unfortunately the `cargoBuild` tasks aren't available until after evaluation.
     evaluationDependsOn(":full-megazord")
     afterEvaluate {
         android.libraryVariants.all { variant ->
@@ -281,10 +280,8 @@ ext.dependsOnTheMegazord = {
                 productFlavor += "${it.name.capitalize()}"
             }
             def buildType = "${variant.buildType.name.capitalize()}"
-            tasks["generate${productFlavor}${buildType}Assets"].dependsOn(project(':full-megazord').tasks["cargoBuild"])
-
-            // For unit tests.
-            tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(project(':full-megazord').tasks["cargoBuild"])
+            def nativeCargoBuildTask = "cargoBuild${rootProject.ext.nativeRustTarget.capitalize()}"
+            tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(project(':full-megazord').tasks[nativeCargoBuildTask])
         }
     }
 }

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -37,7 +37,7 @@ jobs:
         - [source, taskcluster/scripts/toolchain/rustup-setup.sh]
         - [source, taskcluster/scripts/toolchain/cross-compile-setup.sh]
         - [rsync, '-a', /builds/worker/fetches/libs/, /builds/worker/checkouts/src/libs/]
-        - [bash, '-c', 'echo "rust.targets=linux-x86-64,x86_64\n" > local.properties']
+        - [bash, '-c', 'echo "rust.targets=linux-x86-64\n" > local.properties']
       gradlew:
         - 'clean'
         - 'assembleDebug'
@@ -49,5 +49,3 @@ jobs:
       toolchain:
         - android-libs
         - desktop-linux-libs
-        - desktop-macos-libs
-        - desktop-win32-x86-64-libs


### PR DESCRIPTION
Connects to #3389 (and is hopefully a big step in the right direction,
but not a full fix).

Prior to this commit, the gradle tasks for building and for testing
each component would depend on the "cargoBuild" gradle task of the
megazord, which means they would built it for all configured targets.
In TaskCluster we configure *seven* targets, so each `module-build-X`
TaskCluster job will build the full megazord seven times.

This commit makes two changes:

* Building the gradle package of a component no longer depends on
  building the megazord at all. We doesn't actually need to the
  Rust code built in order to package up the Kotlin files, and I
  think this dependency was a hangover from when each component
  used to build its own individual Rust library.
* Running the gradle tests of a component now depends only on
  building the megazord for the native host platform, since that's
  the only one that is actually needed for running the tests.

Given that we have 11 components that depend on the megazord,
each of which will now avoid building 6 useless copies of it
for non-native platforms, I expect this will save a total of
66 expensive `cargo build` invocations in a full TaskCluster run.

I've also included a few other tweaks to do less unnecessary
work in TaskCluster, so let's see how it works out in practice...