### PR TITLE
Run all android tests at once when cutting a release [ci full]

### DIFF
--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -16,10 +16,10 @@ kind-dependencies:
 jobs:
   pr:
     attributes:
-      run-on-pr-type: normal-ci
+      run-on-pr-type: all
       resource-monitor: true
     needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
-    run-on-tasks-for: [github-pull-request]
+    run-on-tasks-for: [github-pull-request, github-release]
     description: Build and test (Android - linux-x86-64)
     scopes:
       - project:releng:services/tooltool/api/download/internal

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -42,7 +42,6 @@ job-defaults:
       # add `win32-x86-64-gnu` back in to the list of targets here.
       - [bash, '-c', 'echo "rust.targets=arm,arm64,x86_64,x86,darwin,linux-x86-64\n" > local.properties']
     gradlew:
-      - ':{module_name}:testDebug'
       - ':{module_name}:assembleRelease'
       - ':{module_name}:publish'
       - ':{module_name}:checkMavenArtifacts'


### PR DESCRIPTION
Prior to the commit, the Taskcluster job for each individual component
would execute `./gradlew component:test` and would thus need to build
the Rust code for the megazord.

With this commit, each of those tasks now depend on the existing
`android-build` task which knows how to run all the tests in a single
build. This should reduce the number of times we have to build the
megazord from once-per-components to just once. (Plus the independent
builds we do for actually publishin the megazord).

This is separate from #4188 because I'm not sure if it'll work, and I didn't
want to hold up the already-substantial improvements in that PR.

Fixes #3389.
