### PR TITLE
SDK-278 Remove app_id matching from `is_experiment_available`

### DIFF
--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -1577,7 +1577,7 @@ mod tests {
     fn test_evolver_experiment_update_enrolled_then_targeting_changed() -> Result<()> {
         let exp = get_test_experiments()[0].clone();
         let (nimbus_id, mut app_ctx, aru) = local_ctx();
-        app_ctx.app_id = "foobar".to_owned(); // Make the experiment targeting fail.
+        app_ctx.app_name = "foobar".to_owned(); // Make the experiment targeting fail.
         let evolver = enrollment_evolver(&nimbus_id, &app_ctx, &aru);
         let mut events = vec![];
         let enrollment_id = Uuid::new_v4();

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -464,11 +464,10 @@ mod tests {
             ..Default::default()
         };
 
-        // Application context for matching the above experiment.  If any of the `app_name`, `app_id`,
-        // or `channel` doesn't match the experiment, then the client won't be enrolled.
+        // Application context for matching the above experiment.  If the `app_name` or
+        // `channel` doesn't match the experiment, then the client won't be enrolled.
         let mut context = AppContext {
             app_name: "NimbusTest".to_string(),
-            app_id: "org.example.app".to_string(),
             channel: "nightly".to_string(),
             ..Default::default()
         };
@@ -607,12 +606,11 @@ mod tests {
 
         let id = uuid::Uuid::new_v4();
 
-        // If any of the `app_name`, `app_id`, or `channel` doesn't match the experiment,
+        // If the `app_name` or `channel` doesn't match the experiment,
         // then the client won't be enrolled.
         // Start with a context that does't match the app_name:
         let mut context = AppContext {
             app_name: "Wrong!".to_string(),
-            app_id: "org.example.app".to_string(),
             channel: "nightly".to_string(),
             ..Default::default()
         };
@@ -627,23 +625,8 @@ mod tests {
             }
         ));
 
-        // Change the app_name back and change the app_id to test when it doesn't match:
+        // Change the app_name back and change the channel to test when it doesn't match:
         context.app_name = "NimbusTest".to_string();
-        context.app_id = "Wrong".to_string();
-
-        // Now we won't be enrolled in the experiment because we don't have the right app_id, but with the same
-        // `NotTargeted` reason
-        let enrollment =
-            evaluate_enrollment(&id, &Default::default(), &context, &experiment).unwrap();
-        assert!(matches!(
-            enrollment.status,
-            EnrollmentStatus::NotEnrolled {
-                reason: NotEnrolledReason::NotTargeted
-            }
-        ));
-
-        // Change the app_id back and change the channel to test when it doesn't match:
-        context.app_id = "org.example.app".to_string();
         context.channel = "Wrong".to_string();
 
         // Now we won't be enrolled in the experiment because we don't have the right channel, but with the same

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -28,13 +28,15 @@ impl Bucket {
 /// Determine the enrolment status for an experiment.
 ///
 /// # Arguments:
-///
 /// - `nimbus_id` The auto-generated nimbus_id
-/// - `available_randomization_units`: The app provded available randomization units
-/// - `experiment` - The experiment.
+/// - `available_randomization_units` The app provded available randomization units
+/// - `app_context` The application parameters to use for evaluating targeting
+/// - `exp` The `Experiment` to evaluate.
 ///
+/// # Returns:
 /// An `ExperimentEnrollment` -  you need to inspect the EnrollmentStatus to
 /// determine if the user is actually enrolled.
+///
 /// # Errors:
 ///
 /// The function can return errors in one of the following cases (but not limited to):
@@ -109,9 +111,15 @@ pub fn evaluate_enrollment(
 
 /// Check if an experiment is available for this app defined by this `AppContext`.
 ///
-/// `is_release` supports two modes:
-/// if `true`, available means available for enrollment: i.e. does the `app_name`, `app_id` and `channel` match.
-/// if `false`, available means available for testing: i.e. does only the `app_name` match.
+/// # Arguments:
+/// - `app_context` The application parameters to use for targeting purposes
+/// - `exp` The `Experiment` to evaluate
+/// - `is_release` Supports two modes:
+///     if `true`, available means available for enrollment: i.e. does the `app_name` and `channel` match.
+///     if `false`, available means available for testing: i.e. does only the `app_name` match.
+///
+/// # Returns:
+/// Returns `true` if the experiment matches the targeting
 pub fn is_experiment_available(
     app_context: &AppContext,
     exp: &Experiment,
@@ -132,16 +140,6 @@ pub fn is_experiment_available(
         return true;
     }
 
-    // Verify the app_id matches the application being targeted
-    // by the experiment.
-    match &exp.app_id {
-        Some(app_id) => {
-            if !app_id.eq(&app_context.app_id) {
-                return false;
-            }
-        }
-        None => log::debug!("Experiment missing app_id, skipping it as a targeting parameter"),
-    }
     // Verify the channel matches the application being targeted
     // by the experiment.  Note, we are intentionally comparing in a case-insensitive way.
     // See https://jira.mozilla.com/browse/SDK-246 for more info.

--- a/components/nimbus/src/matcher.rs
+++ b/components/nimbus/src/matcher.rs
@@ -33,9 +33,9 @@ pub struct Matcher {
 
 /// The `AppContext` object represents the parameters and characteristics of the
 /// consuming application that we are interested in for targeting purposes. The
-/// `app_name`, `app_id`, and `channel` fields are not optional as they are expected
-/// to be provided by all consuming applications as they are used in the first
-/// pieces of targeting that help to ensure that an experiment is only processed
+/// `app_name` and `channel` fields are not optional as they are expected
+/// to be provided by all consuming applications as they are used in the top-level
+/// targeting that help to ensure that an experiment is only processed
 /// by the correct application.
 ///
 /// Definitions of the fields are as follows:


### PR DESCRIPTION
This removes the app_id matching from `is_experiment_available` so we no longer need to fake the app_id while testing and debugging.  The top-level targeting only considers the `app_name` and `channel` now.