### PR TITLE
Remove incorrect serde implementation for one copy of the DeviceType …

### DIFF
--- a/components/fxa-client/src/internal/http_client.rs
+++ b/components/fxa-client/src/internal/http_client.rs
@@ -794,6 +794,53 @@ pub enum DeviceType {
     Unknown,
 }
 
+#[cfg(test)]
+mod device_type_tests {
+    use super::*;
+
+    #[test]
+    fn test_serde_ser() {
+        assert_eq!(
+            serde_json::to_string(&DeviceType::Desktop).unwrap(),
+            "\"desktop\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DeviceType::Mobile).unwrap(),
+            "\"mobile\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DeviceType::Tablet).unwrap(),
+            "\"tablet\""
+        );
+        assert_eq!(serde_json::to_string(&DeviceType::VR).unwrap(), "\"vr\"");
+        assert_eq!(serde_json::to_string(&DeviceType::TV).unwrap(), "\"tv\"");
+    }
+
+    #[test]
+    fn test_serde_de() {
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"desktop\"").unwrap(),
+            DeviceType::Desktop
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"mobile\"").unwrap(),
+            DeviceType::Mobile
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"tablet\"").unwrap(),
+            DeviceType::Tablet
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"vr\"").unwrap(),
+            DeviceType::VR
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"tv\"").unwrap(),
+            DeviceType::TV
+        ));
+    }
+}
+
 #[allow(clippy::option_option)]
 pub struct DeviceUpdateRequestBuilder<'a> {
     device_type: Option<Option<&'a DeviceType>>,

--- a/components/support/sync15-traits/src/client.rs
+++ b/components/support/sync15-traits/src/client.rs
@@ -25,7 +25,9 @@ pub struct RemoteClient {
 
 /// The type of a client. Please keep these variants in sync with the device
 /// types in the FxA client and sync manager.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
+// In particular, ensure the to and from string values (either explicitly as
+// below, or via serde as done by fxa-client) match.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum DeviceType {
     Desktop,
     Mobile,

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -18,7 +18,7 @@ pub struct RemoteTab {
     pub last_used: u64, // In ms.
 }
 
-#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug)]
 pub struct ClientRemoteTabs {
     pub client_id: String, // Corresponds to the `clients` collection ID of the client.
     pub client_name: String,


### PR DESCRIPTION
Due to [this uniffi issue](https://github.com/mozilla/uniffi-rs/issues/478) we have a few duplicates of the `DeviceType` enum, and one of them has incorrect serde serialize and deserialize implementations. Fortunately it turns out they are unused. While I was there I added tests for the one in fxa-client which does implement it correctly.
