### PR TITLE
Update UniFFI to v0.12.0 [ci full]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,9 +3485,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uniffi"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "657fbc531f30fefafcdd40484152a35f573af0670394c8e879e113eafddc0d60"
+checksum = "5e2749a4075e662e6ac28bed98b579f6d66bfabcfbe3fea5de6709334aaf8343"
 dependencies = [
  "anyhow",
  "bytes 1.0.1",
@@ -3501,9 +3501,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d10d1a19352133760809d06cf69742d4baa36ef756d96b67d88438713408e32"
+checksum = "59fbb8000ed428fc9da5066af68bc2c04084a2233fb67bf5d0f5727b05c236b6"
 dependencies = [
  "anyhow",
  "askama",
@@ -3517,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "015624925af99e254321a257e5a51d3c5192da4fae9887770be5841c0c9c2a4c"
+checksum = "e4a45dcfc8bad77ee7b13380f8c1e57648e126b9a5f8ff101172d543d94ec53a"
 dependencies = [
  "anyhow",
  "uniffi_bindgen",
@@ -3527,9 +3527,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbafc1d13d61d903addb3eed289510d238ba25806714f978e4a1caa45fa95b06"
+checksum = "16d30c114f99379b3ac762e2220c76c21582af80fd105a1d1ad194c89e17c12d"
 dependencies = [
  "glob",
  "proc-macro2",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -23,7 +23,7 @@ sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.11"
+uniffi = "^0.12"
 url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -36,4 +36,4 @@ libsqlite3-sys = "0.20.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.11", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.12", features = [ "builtin-bindgen" ]}

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,8 +9,8 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = "^0.11"
-uniffi_macros = "^0.11"
+uniffi = "^0.12"
+uniffi_macros = "^0.12"
 
 [build-dependencies]
-uniffi_build = { version = "^0.11", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.12", features=["builtin-bindgen"] }

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -26,11 +26,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.11"
-uniffi_macros = "^0.11"
+uniffi = "^0.12"
+uniffi_macros = "^0.12"
 
 [build-dependencies]
-uniffi_build = { version = "^0.11", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.12", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -25,15 +25,15 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.11"
-uniffi_macros = "^0.11"
+uniffi = "^0.12"
+uniffi_macros = "^0.12"
 
 [dependencies.rusqlite]
 version = "0.24.2"
 features = ["sqlcipher", "limits", "unlock_notify"]
 
 [build-dependencies]
-uniffi_build = { version = "^0.11.0", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.12.0", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 more-asserts = "0.2"

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -33,10 +33,10 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "^0.11", optional = true }
+uniffi = { version = "^0.12", optional = true }
 
 [build-dependencies]
-uniffi_build = { version = "^0.11", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.12", features = [ "builtin-bindgen" ], optional = true }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.11"
+uniffi_bindgen = "^0.12"


### PR DESCRIPTION
The latest release of UniFFI includes a significant change to the
way Object instances are managed, switching from handlemaps to
raw Arc<T> pointers. We should get this into consumers for testing
at some point early in a Nightly cycle.