### PR TITLE
Fixes broken ci link and missing metrics docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Get in touch with other community members on Matrix, or through issues here on G
 ### Building the Rust Components
 1. Clone or Download the repository:
 ```shell
-  $ git clone https://github.com/mozilla/application-services (or use the ssh link)
+  $ git clone https://github.com/mozilla/application-services # (or use the ssh link)
   $ cd application-services
   $ git submodule init
   $ git submodule update --recursive

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,7 +20,5 @@
   - [How we distribute the application-services library](design/megazords.md)
   - [CI Publishing tools and flow](build-and-publish-pipeline.md)
   - [How to upgrade NSS](howtos/upgrading-nss-guide.md)
-- [Metrics - (Glean Telemetry)](metrics/README.md)
-  - [Logins](metrics/logins/metrics.md)
-  - [Places](metrics/places/metrics.md)
+- [Metrics - (Glean Telemetry)](metrics.md)
 - [Adding to these documents](adding-docs.md)

--- a/docs/building.md
+++ b/docs/building.md
@@ -14,10 +14,16 @@ a number of hours to complete.
 ## Building the Rust Components
 
 *Complete this section before moving to the android/iOS build instructions.*
-
-1. Install Rust: install [via rustup](https://www.rust-lang.org/tools/install)
-1. Install your system dependencies: - install via the instructions below for [Linux](building.md#linux), [MacOS](building.md#macos) or [Windows](building.md#windows)
-1. Check dependencies, environment variables and test
+1. Make sure you cloned the repository:
+  ```shell
+    $ git clone https://github.com/mozilla/application-services # (or use the ssh link)
+    $ cd application-services
+    $ git submodule init
+    $ git submodule update --recursive
+  ```
+2. Install Rust: install [via rustup](https://www.rust-lang.org/tools/install)
+3. Install your system dependencies: - install via the instructions below for [Linux](building.md#linux), [MacOS](building.md#macos) or [Windows](building.md#windows)
+4. Check dependencies, environment variables and test
    1. Run: `./libs/verify-desktop-environment.sh`
    1. Run: `cargo test`
 
@@ -35,7 +41,7 @@ Once you have successfully run `./libs/verify-desktop-environment.sh` and `cargo
 
 
 #### MacOS
-1. Install Xcode: check the [ci config](../.circleci/config) for the correct
+1. Install Xcode: check the [ci config](../.circleci/config.yml) for the correct
 version.
 1. Install Xcode tools: `xcode-select --install`
 1. Install homebrew: [via homebrew](https://brew.sh/) (its what we use for ci)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,13 +1,7 @@
 ## Metrics collected by Application Services components
 
 Some application-services components collect telemetry using the [Glean SDK](https://mozilla.github.io/glean/).
-This directory contains auto-generated documentation for all such metrics.
 
 Products that send telemetry via Glean *must request* a data-review following
 [the Firefox Data Collection process](https://wiki.mozilla.org/Firefox/Data_Collection)
 before integrating any of the components listed below.
-
-### Components that collect telemetry
-
-* [logins](./logins/metrics.md)
-* [places](./places/metrics.md)


### PR DESCRIPTION
Removes the links to removed autogenerated metrics docs (ref: #4098) and fixes a broken link to the CI config.


Also adds the `git clone` step to the build doc, since someone only reading the mdbook, and not the github README.md won't see the git clone instructions

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
