### PR TITLE
Allow getDBSaltForKey error to propagate for fxiOS

### DIFF
--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -64,7 +64,7 @@ open class LoginsStorage {
             if self.store != nil {
                 throw LoginsStoreError.MismatchedLock(message: "Mismatched Lock")
             }
-            return try! openAndGetSalt(path: self.dbPath, encryptionKey: key)
+            return try openAndGetSalt(path: self.dbPath, encryptionKey: key)
         }
     }
 

--- a/megazords/ios/MozillaAppServicesTests/LoginsTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/LoginsTests.swift
@@ -10,9 +10,8 @@ class LoginsTests: XCTestCase {
     var encryptionKey: String!
     var salt: String!
 
-    //This tests setup mimics closer to what fxiOS is doing
+    // This test setup mimics as close as we can to how fxiOS consumes our API
     override func setUp() {
-
         let directory = NSTemporaryDirectory()
         let filename = "testdb-\(UUID().uuidString).db"
         let fileURL = URL(fileURLWithPath: directory).appendingPathComponent(filename)
@@ -23,30 +22,28 @@ class LoginsTests: XCTestCase {
         encryptionKey = "uyvuyvuvWSRYRWYRW47654754hdxjkinouhi"
         salt = setupPlaintextHeaderAndGetSalt(databasePath: databasePath, encryptionKey: encryptionKey)
         storage = LoginsStorage(databasePath: fileURL.absoluteString)
-            
-       
     }
 
     override func tearDown() {
         // This method is called after the invocation of each test method in the class.
     }
-    
+
     // Migrate and return the salt, or create a new salt
     // Also, in the event of an error, returns a new salt.
     public func setupPlaintextHeaderAndGetSalt(databasePath: String, encryptionKey: String) -> String {
         do {
             if FileManager.default.fileExists(atPath: databasePath) {
-               let db = LoginsStorage(databasePath: databasePath)
-               let salt = try db.getDbSaltForKey(key: encryptionKey)
-               try db.migrateToPlaintextHeader(key: encryptionKey, salt: salt)
-               return salt
-           }
-       } catch {
-           print("could not sucessfully migrate plaintext")
-       }
-       let saltOf32Chars = UUID().uuidString.replacingOccurrences(of: "-", with: "")
-       return saltOf32Chars
-   }
+                let db = LoginsStorage(databasePath: databasePath)
+                let salt = try db.getDbSaltForKey(key: encryptionKey)
+                try db.migrateToPlaintextHeader(key: encryptionKey, salt: salt)
+                return salt
+            }
+        } catch {
+            print("could not sucessfully migrate plaintext")
+        }
+        let saltOf32Chars = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        return saltOf32Chars
+    }
 
     func testBadEncryptionKey() {
         var dbOpened = true
@@ -113,7 +110,7 @@ class LoginsTests: XCTestCase {
     func testLoginEnsureValid() {
         try! storage.unlockWithKeyAndSalt(key: encryptionKey, salt: salt)
 
-        let _ = try! storage.add(login: Login(
+        _ = try! storage.add(login: Login(
             id: "",
             hostname: "https://www.example5.com",
             password: "hunter5",
@@ -161,7 +158,7 @@ class LoginsTests: XCTestCase {
         XCTAssertThrowsError(try storage.ensureValid(login: dupeLogin))
         XCTAssertThrowsError(try storage.ensureValid(login: nullValueLogin))
     }
-    
+
     func addLogin() -> String {
         let login = Login(
             id: "",
@@ -179,15 +176,15 @@ class LoginsTests: XCTestCase {
         )
         return try! storage.add(login: login)
     }
-    
+
     func testListLogins() {
         try! storage.unlockWithKeyAndSalt(key: encryptionKey, salt: salt)
-        
+
         let listResult1 = try! storage.list()
         XCTAssertEqual(listResult1.count, 0)
-        
-       let _ = addLogin()
-        
+
+        _ = addLogin()
+
         let listResult2 = try! storage.list()
         XCTAssertEqual(listResult2.count, 1)
     }

--- a/megazords/ios/MozillaAppServicesTests/LoginsTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/LoginsTests.swift
@@ -6,28 +6,52 @@ import XCTest
 @testable import MozillaAppServices
 
 class LoginsTests: XCTestCase {
-    func getTestStorage() -> LoginsStorage {
+    var storage: LoginsStorage!
+    var encryptionKey: String!
+    var salt: String!
+
+    //This tests setup mimics closer to what fxiOS is doing
+    override func setUp() {
+
         let directory = NSTemporaryDirectory()
         let filename = "testdb-\(UUID().uuidString).db"
         let fileURL = URL(fileURLWithPath: directory).appendingPathComponent(filename)
+        let databasePath = URL(fileURLWithPath: fileURL.absoluteString).absoluteString
+
         // Note: SQLite supports using file: urls, so this works. (Maybe we should allow
         // passing in a URL argument too?)
-        return LoginsStorage(databasePath: fileURL.absoluteString)
-    }
-
-    override func setUp() {
-        // This method is called before the invocation of each test method in the class.
+        encryptionKey = "uyvuyvuvWSRYRWYRW47654754hdxjkinouhi"
+        salt = setupPlaintextHeaderAndGetSalt(databasePath: databasePath, encryptionKey: encryptionKey)
+        storage = LoginsStorage(databasePath: fileURL.absoluteString)
+            
+       
     }
 
     override func tearDown() {
         // This method is called after the invocation of each test method in the class.
     }
+    
+    // Migrate and return the salt, or create a new salt
+    // Also, in the event of an error, returns a new salt.
+    public func setupPlaintextHeaderAndGetSalt(databasePath: String, encryptionKey: String) -> String {
+        do {
+            if FileManager.default.fileExists(atPath: databasePath) {
+               let db = LoginsStorage(databasePath: databasePath)
+               let salt = try db.getDbSaltForKey(key: encryptionKey)
+               try db.migrateToPlaintextHeader(key: encryptionKey, salt: salt)
+               return salt
+           }
+       } catch {
+           print("could not sucessfully migrate plaintext")
+       }
+       let saltOf32Chars = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+       return saltOf32Chars
+   }
 
     func testBadEncryptionKey() {
-        let storage = getTestStorage()
         var dbOpened = true
         do {
-            try storage.unlock(withEncryptionKey: "foofoofoo")
+            try storage.unlockWithKeyAndSalt(key: encryptionKey, salt: salt)
         } catch {
             XCTFail("Failed to setup db")
         }
@@ -35,7 +59,7 @@ class LoginsTests: XCTestCase {
         try! storage.lock()
 
         do {
-            try storage.unlock(withEncryptionKey: "zebra")
+            try storage.unlockWithKeyAndSalt(key: "zebra", salt: salt)
         } catch {
             dbOpened = false
         }
@@ -44,8 +68,7 @@ class LoginsTests: XCTestCase {
     }
 
     func testLoginNil() {
-        let storage = getTestStorage()
-        try! storage.unlock(withEncryptionKey: "test123")
+        try! storage.unlockWithKeyAndSalt(key: encryptionKey, salt: salt)
         let id0 = try! storage.add(login: Login(
             id: "",
             hostname: "https://www.example.com",
@@ -88,10 +111,9 @@ class LoginsTests: XCTestCase {
     }
 
     func testLoginEnsureValid() {
-        let storage = getTestStorage()
-        try! storage.unlock(withEncryptionKey: "test123")
+        try! storage.unlockWithKeyAndSalt(key: encryptionKey, salt: salt)
 
-        let id0 = try! storage.add(login: Login(
+        let _ = try! storage.add(login: Login(
             id: "",
             hostname: "https://www.example5.com",
             password: "hunter5",
@@ -138,5 +160,35 @@ class LoginsTests: XCTestCase {
 
         XCTAssertThrowsError(try storage.ensureValid(login: dupeLogin))
         XCTAssertThrowsError(try storage.ensureValid(login: nullValueLogin))
+    }
+    
+    func addLogin() -> String {
+        let login = Login(
+            id: "",
+            hostname: "https://www.example5.com",
+            password: "hunter3",
+            username: "cooluser55",
+            httpRealm: nil,
+            formSubmitUrl: "https://www.example5.com",
+            usernameField: "users_name",
+            passwordField: "users_password",
+            timesUsed: 0,
+            timeCreated: 0,
+            timeLastUsed: 0,
+            timePasswordChanged: 0
+        )
+        return try! storage.add(login: login)
+    }
+    
+    func testListLogins() {
+        try! storage.unlockWithKeyAndSalt(key: encryptionKey, salt: salt)
+        
+        let listResult1 = try! storage.list()
+        XCTAssertEqual(listResult1.count, 0)
+        
+       let _ = addLogin()
+        
+        let listResult2 = try! storage.list()
+        XCTAssertEqual(listResult2.count, 1)
     }
 }


### PR DESCRIPTION
The way iOS uses getDBSaltForKey, they have a do/catch wrapper if there is no salt and generate a new one [Here](https://github.com/mozilla-mobile/firefox-ios/blob/041c85483b1aa4a4e357d8bd9419550e4f20347a/Storage/Rust/RustLogins.swift#L108). The uniffi logins effort added a `try!` which hard fails and causes error propagation to be disabled.

I have also updated the iOS testing on the a-s side to better mimic what fxiOS is doing and testy the APIs the way they are using it.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
