### PR TITLE
Fix Fenix smoketest script.

### DIFF
--- a/automation/smoke-test-fenix.py
+++ b/automation/smoke-test-fenix.py
@@ -83,7 +83,7 @@ elif action == "run-tests" or action is None:
     # It's not useful to us to run them all, so just pick the one that sounds like it's
     # least likely to be broken for unrelated reasons.
     step_msg("Running fenix tests")
-    run_cmd_checked(["./gradlew", "app:testGeckoBetaDebugUnitTest"], cwd=repo_path)
+    run_cmd_checked(["./gradlew", "app:testNightlyUnitTest"], cwd=repo_path)
     # XXX TODO: I would also like to run the sync integration tests described here:
     #   https://docs.google.com/document/d/1dhxlbGQBA6aJi2Xz-CsJZuGJPRReoL7nfm9cYu4HcZI/
     # However they do not currently pass reliably on my machine.


### PR DESCRIPTION
The Fenix gradle task that we were relying on for our smoketest
scripts has been removed. This updates our script to use a different
test target.
