### PR TITLE
Ensure JNA always encodes strings as UTF-8.

### DIFF
--- a/components/support/android/src/main/java/mozilla/appservices/support/native/Helpers.kt
+++ b/components/support/android/src/main/java/mozilla/appservices/support/native/Helpers.kt
@@ -11,8 +11,14 @@ package mozilla.appservices.support.native
 import android.util.Log
 import com.google.protobuf.CodedOutputStream
 import com.google.protobuf.MessageLite
+import com.sun.jna.DefaultTypeMapper
+import com.sun.jna.FromNativeContext
 import com.sun.jna.Library
+import com.sun.jna.Memory
 import com.sun.jna.Native
+import com.sun.jna.Pointer
+import com.sun.jna.ToNativeContext
+import com.sun.jna.TypeConverter
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -169,7 +175,18 @@ inline fun <reified Lib : Library> loadIndirect(
     componentVersion: String
 ): Lib {
     val mzLibrary = findMegazordLibraryName(componentName, componentVersion)
-    return Native.load<Lib>(mzLibrary, Lib::class.java)
+    // Rust code always expects strings to be UTF-8 encoded.
+    // Unfortunately, the `STRING_ENCODING` option doesn't seem to apply
+    // to function arguments, only to return values.
+    val options: MutableMap<String, Any> = mutableMapOf(
+        Library.OPTION_STRING_ENCODING to "UTF-8"
+    )
+    // So, if the default encoding is not UTF-8, we need to use an
+    // explicit TypeMapper to ensure that strings are handled correctly.
+    if (Native.getDefaultStringEncoding() != "UTF-8") {
+        options[Library.OPTION_TYPE_MAPPER] = UTF8TypeMapper()
+    }
+    return Native.load<Lib>(mzLibrary, Lib::class.java, options)
 }
 
 // See the comment on full_megazord_get_version for background
@@ -238,4 +255,38 @@ internal fun checkFullMegazord(componentName: String, componentVersion: String):
         }
         false
     }
+}
+
+/**
+ * A JNA TypeMapper that always converts strings as UTF-8 bytes.
+ *
+ * Rust always expects strings to be in UTF-8, but JNA defaults to using the
+ * system encoding. This is *often* UTF-8, but not always. In cases where it
+ * isn't you can use this TypeMapper to ensure Strings are correctly
+ * interpreted by Rust.
+ *
+ * The logic here is essentially the same as what JNA does by default
+ * with String values, but explicitly using a fixed UTF-8 encoding.
+ *
+ */
+public class UTF8TypeMapper : DefaultTypeMapper() {
+    init {
+        addTypeConverter(String::class.java, UTF8TypeConverter())
+    }
+}
+
+internal class UTF8TypeConverter : TypeConverter {
+    override fun toNative(value: Any, context: ToNativeContext): Any {
+        val bytes = (value as String).toByteArray(Charsets.UTF_8)
+        val mem = Memory(bytes.size.toLong() + 1L)
+        mem.write(0, bytes, 0, bytes.size)
+        mem.setByte(bytes.size.toLong(), 0)
+        return mem
+    }
+
+    override fun fromNative(value: Any, context: FromNativeContext): Any {
+        return (value as Pointer).getString(0, Charsets.UTF_8.name())
+    }
+
+    override fun nativeType() = Pointer::class.java
 }

--- a/docs/howtos/when-to-use-what-in-the-ffi.md
+++ b/docs/howtos/when-to-use-what-in-the-ffi.md
@@ -81,6 +81,11 @@ good support for calling over the FFI), but it's our lowest common denominator.
 
 These we pass as nul-terminated UTF-8 C-strings.
 
+JNA automatically converts a `String` argument into a nul-terminated C-string,
+but it will use the system default encoding unless specially configured.
+*This may not be UTF-8*, in which case we use a custom TypeMapper to override
+the default behaviour.
+
 For return values, used `*mut c_char`, and for input, use
 [`ffi_support::FfiStr`](https://docs.rs/ffi-support/*/ffi_support/struct.FfiStr.html)
 


### PR DESCRIPTION
JNA defaults to encoding strings in the system default encoding,
which is usually UTF-8 but not always. Rust *always* expects strings
encoded in UTF-8, so this commit adds logic to enforce that encoding
when we detect that JNA won't do it for us for free.
    
I was able to test this locally by setting `LANG=C` in my environment
and then running the Places Kotlin tests. Prior to this commit they
fail on some Unicode test data; with this commit they succeed.
    
Luckily for us in practice, Android devices *always* use UTF-8 as
the default encoding, so this issue won't have caused any problems
for production users. Still, we shouldn't depend on that in the general
case.

Fixes #4209.
