### PR TITLE
Allow multiple features per experiment (without DTO change)

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -25,5 +25,9 @@ Use the template below to make assigning a version number during the release cut
     Users on very old versions of this component will no longer be able to cleanly update to this version. Instead, the consumer code
     will recieve an error indicating that the schema was not correctly formated.
 
+## Nimbus
+### What's Changed
+  - Nimbus SDK now supports different branches having different Feature Configs ([#4213](https://github.com/mozilla/application-services/pull/4213))
+
 ## Other
   - `./libs/build-all.sh` now displays a more helpful error message when a file fails checksum integrity test.

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -517,7 +517,7 @@ pub fn get_enrollments<'r>(
                 .get::<Experiment, _>(reader, &enrollment.slug)?
             {
                 result.push(EnrolledExperiment {
-                    feature_ids: vec![],
+                    feature_ids: experiment.get_feature_ids(),
                     slug: experiment.slug,
                     user_facing_name: experiment.user_facing_name,
                     user_facing_description: experiment.user_facing_description,

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -434,10 +434,6 @@ pub enum EnrollmentStatus {
         enrollment_id: Uuid, // Random ID used for telemetry events correlation.
         reason: EnrolledReason,
         branch: String,
-        // The `feature_id` field was added later. To avoid a db migration we
-        // default it to "" for persisted enrollments where it is missing.
-        // #[serde(default)]
-        // feature_id: String,
     },
     NotEnrolled {
         reason: NotEnrolledReason,

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2481,7 +2481,6 @@ mod tests {
                 enrollment_id: Uuid::new_v4(),
                 branch: "hello".to_owned(), // XXX this OK?
                 reason: EnrolledReason::Qualified,
-                feature_id: "some_control".to_owned(),
             },
         }];
 

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -85,7 +85,6 @@ pub fn evaluate_enrollment(
                         EnrollmentStatus::new_enrolled(
                             EnrolledReason::Qualified,
                             &choose_branch(&exp.slug, &exp.branches, &id)?.clone().slug,
-                            &exp.get_first_feature_id(),
                         )
                     } else {
                         EnrollmentStatus::NotEnrolled {

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -502,7 +502,6 @@ mod tests {
         let mock_client_id = "client-1".to_string();
         let mock_exp_slug = "exp-1".to_string();
         let mock_exp_branch = "branch-1".to_string();
-        let mock_feature_id = "feature-1".to_string();
 
         let tmp_dir = TempDir::new("test_telemetry_reset")?;
         let client = NimbusClient::new(
@@ -541,11 +540,7 @@ mod tests {
             &mock_exp_slug,
             &ExperimentEnrollment {
                 slug: mock_exp_slug.clone(),
-                status: EnrollmentStatus::new_enrolled(
-                    EnrolledReason::Qualified,
-                    &mock_exp_branch,
-                    &mock_feature_id,
-                ),
+                status: EnrollmentStatus::new_enrolled(EnrolledReason::Qualified, &mock_exp_branch),
             },
         )?;
         writer.commit()?;

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -36,6 +36,7 @@ use once_cell::sync::OnceCell;
 use persistence::{Database, StoreId, Writer};
 use serde_derive::*;
 use serde_json::{Map, Value};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use updating::{read_and_remove_pending_experiments, write_pending_experiments};
@@ -367,7 +368,18 @@ impl Experiment {
     }
 
     fn get_feature_ids(&self) -> Vec<String> {
-        self.feature_ids.clone()
+        let branches = &self.branches;
+        let feature_ids = branches
+            .iter()
+            .flat_map(|b| {
+                b.get_feature_configs()
+                    .iter()
+                    .map(|f| f.to_owned().feature_id)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<HashSet<_>>();
+
+        feature_ids.into_iter().collect()
     }
 }
 

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -369,6 +369,10 @@ impl Experiment {
             self.feature_ids[0].clone()
         }
     }
+
+    fn get_feature_ids(&self) -> Vec<String> {
+        self.feature_ids.clone()
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
@@ -624,7 +628,7 @@ mod test_schema_bw_compat {
             "last_modified":1_602_197_324_372i64
         }))
         .unwrap();
-        assert_eq!(exp.get_first_feature_id(), "");
+        assert!(exp.get_feature_ids().is_empty());
     }
 
     // In #96 we added a `featureIds` field to the Experiment schema.
@@ -674,7 +678,7 @@ mod test_schema_bw_compat {
             "last_modified":1_602_197_324_372i64
         }))
         .unwrap();
-        assert_eq!(exp.get_first_feature_id(), "some_control");
+        assert_eq!(exp.get_feature_ids(), vec!["some_control"]);
     }
 
     // In #97 we deprecated `application` and added `app_name`, `app_id`,

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -362,12 +362,8 @@ impl Experiment {
             .any(|branch| branch.slug == branch_slug)
     }
 
-    fn get_first_feature_id(&self) -> String {
-        if self.feature_ids.is_empty() {
-            "".to_string()
-        } else {
-            self.feature_ids[0].clone()
-        }
+    fn get_branch(&self, branch_slug: &str) -> Option<&Branch> {
+        self.branches.iter().find(|b| b.slug == branch_slug)
     }
 
     fn get_feature_ids(&self) -> Vec<String> {
@@ -394,6 +390,19 @@ pub struct Branch {
     pub slug: String,
     pub ratio: i32,
     pub feature: Option<FeatureConfig>,
+}
+
+impl Branch {
+    /// We want to be able to support multiple features per branch.
+    /// The schema does not support this yet, but we can still write the
+    // enrollment code as it does.
+    fn get_feature_configs(&self) -> Vec<FeatureConfig> {
+        if let Some(feature) = &self.feature {
+            vec![feature.clone()]
+        } else {
+            Default::default()
+        }
+    }
 }
 
 fn default_buckets() -> u32 {

--- a/components/nimbus/src/persistence.rs
+++ b/components/nimbus/src/persistence.rs
@@ -1152,10 +1152,8 @@ mod tests {
 
         let enrollments = db.collect_all::<ExperimentEnrollment>(StoreId::Enrollments)?;
 
-        // XXX hoist into build_map function
         let db_enrollments: Vec<String> = enrollments.iter().map(|e| e.slug.clone()).collect();
 
-        // XXX hoist into build_map function
         let orig_enrollments: Vec<String> = db_v1_enrollments_with_non_empty_features
             .iter()
             .map(|e_ref| e_ref.get("slug").unwrap().as_str().unwrap().to_string())

--- a/components/nimbus/src/persistence.rs
+++ b/components/nimbus/src/persistence.rs
@@ -10,7 +10,7 @@ use crate::error::{NimbusError, Result};
 // it must be noted that the rkv documentation explicitly says "To use rkv in
 // production/release environments at Mozilla, you may do so with the "SafeMode"
 // backend", so we really should get more guidance here.)
-use crate::enrollment::{EnrollmentStatus, ExperimentEnrollment};
+use crate::enrollment::ExperimentEnrollment;
 use crate::Experiment;
 use core::iter::Iterator;
 use rkv::{StoreError, StoreOptions};
@@ -352,18 +352,18 @@ impl Database {
 
         // figure out which enrollments have records that need to be dropped
         // and log that we're going to drop them and why
-        let slugs_without_enrollment_feature_ids: HashSet<String> = enrollments
-            .iter()
-            .filter_map(
-                    |e| {
-                if matches!(e.status, EnrollmentStatus::Enrolled {ref feature_id, ..} if feature_id.is_empty()) {
-                    log::warn!("Enrollment for {:?} missing feature_ids; experiment & enrollment will be discarded", &e.slug);
-                    Some(e.slug.to_owned())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        // let slugs_without_enrollment_feature_ids: HashSet<String> = enrollments
+        //     .iter()
+        //     .filter_map(
+        //             |e| {
+        //         if matches!(e.status, EnrollmentStatus::Enrolled {ref feature_id, ..} if feature_id.is_empty()) {
+        //             log::warn!("Enrollment for {:?} missing feature_ids; experiment & enrollment will be discarded", &e.slug);
+        //             Some(e.slug.to_owned())
+        //         } else {
+        //             None
+        //         }
+        //     })
+        //     .collect();
 
         // figure out which experiments have records that need to be dropped
         // and log that we're going to drop them and why
@@ -385,9 +385,7 @@ impl Database {
                 }
             })
             .collect();
-        let slugs_to_discard: HashSet<_> = slugs_without_enrollment_feature_ids
-            .union(&slugs_with_experiment_issues)
-            .collect();
+        let slugs_to_discard: HashSet<_> = slugs_with_experiment_issues;
 
         // filter out experiments to be dropped
         let updated_experiments: Vec<Experiment> = experiments
@@ -1040,36 +1038,6 @@ mod tests {
         ]
     }
 
-    fn get_v1_enrollments_with_missing_feature_ids() -> Vec<serde_json::Value> {
-        vec![
-            json!({
-                "slug": "feature-id-missing",
-                "status":
-                    {
-                        "Enrolled":
-                            {
-                                "enrollment_id": "801ee64b-0b1b-47a7-be47-5f1b5c189084",
-                                "reason": "Qualified",
-                                "branch": "control",
-                            }
-                    }
-            }),
-            json!({
-                "slug": "feature-id-empty",
-                "status":
-                    {
-                        "Enrolled":
-                            {
-                                "enrollment_id": "801ee64b-0b1b-44a7-be47-5f1b5c189086",
-                                "reason": "Qualified",
-                                "branch": "control",
-                                "feature_id": ""
-                            }
-                        }
-            }),
-        ]
-    }
-
     /// Create a database with an old database version number, and
     /// populate it with the given experiments and enrollments.
     fn create_old_database(
@@ -1116,33 +1084,33 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    /// Migrating db v1 to db v2 involves finding enrollments that
-    /// don't contain all the feature stuff they should and discarding.
-    /// It will also discard other experiments/enrollments with required
-    /// headers that are missing.
-    fn test_migrate_db_v1_to_db_v2_enrollment_discarding() -> Result<()> {
-        let _ = env_logger::try_init();
-        let tmp_dir = TempDir::new("migrate_db_v1_to_db_v2")?;
+    // #[test]
+    // /// Migrating db v1 to db v2 involves finding enrollments that
+    // /// don't contain all the feature stuff they should and discarding.
+    // /// It will also discard other experiments/enrollments with required
+    // /// headers that are missing.
+    // fn test_migrate_db_v1_to_db_v2_enrollment_discarding() -> Result<()> {
+    //     let _ = env_logger::try_init();
+    //     let tmp_dir = TempDir::new("migrate_db_v1_to_db_v2")?;
 
-        // write invalid enrollments
-        let db_v1_enrollments_with_missing_feature_ids =
-            &get_v1_enrollments_with_missing_feature_ids();
+    //     // write invalid enrollments
+    //     let db_v1_enrollments_with_missing_feature_ids =
+    //         &get_v1_enrollments_with_missing_feature_ids();
 
-        create_old_database(&tmp_dir, 1, &[], db_v1_enrollments_with_missing_feature_ids)?;
-        let db = Database::new(&tmp_dir)?;
+    //     create_old_database(&tmp_dir, 1, &[], db_v1_enrollments_with_missing_feature_ids)?;
+    //     let db = Database::new(&tmp_dir)?;
 
-        // The enrollments with invalid feature_ids should have been discarded
-        // during migration; leaving us with none.
-        let enrollments = db
-            .collect_all::<ExperimentEnrollment>(StoreId::Enrollments)
-            .unwrap();
-        //log::debug!("enrollments = {:?}", enrollments);
+    //     // The enrollments with invalid feature_ids should have been discarded
+    //     // during migration; leaving us with none.
+    //     let enrollments = db
+    //         .collect_all::<ExperimentEnrollment>(StoreId::Enrollments)
+    //         .unwrap();
+    //     //log::debug!("enrollments = {:?}", enrollments);
 
-        assert_eq!(enrollments.len(), 0);
+    //     assert_eq!(enrollments.len(), 2);
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     /// Migrating v1 to v2 involves finding experiments that
     /// don't contain all the feature stuff they should and discarding.
@@ -1228,27 +1196,13 @@ mod tests {
         let enrollments = db.collect_all::<ExperimentEnrollment>(StoreId::Enrollments)?;
 
         // XXX hoist into build_map function
-        let db_enrollments: HashMap<String, serde_json::Value> = enrollments
-            .into_iter()
-            .map(|e| {
-                let e_json = serde_json::to_value::<ExperimentEnrollment>(e).unwrap();
-                let mut e_slug: String = String::new();
-                e_slug.push_str(e_json.get("slug").unwrap().as_str().unwrap());
-                (e_slug, e_json)
-            })
-            .collect();
+        let db_enrollments: Vec<String> = enrollments.iter().map(|e| e.slug.clone()).collect();
 
         // XXX hoist into build_map function
-        let orig_enrollments: HashMap<String, serde_json::Value> =
-            db_v1_enrollments_with_non_empty_features
-                .iter()
-                .map(|e_ref| {
-                    let e = e_ref.clone();
-                    let mut e_slug: String = String::new();
-                    e_slug.push_str(e.get("slug").unwrap().as_str().unwrap());
-                    (e_slug, e)
-                })
-                .collect();
+        let orig_enrollments: Vec<String> = db_v1_enrollments_with_non_empty_features
+            .iter()
+            .map(|e_ref| e_ref.get("slug").unwrap().as_str().unwrap().to_string())
+            .collect();
 
         // The original json should be the same as data that's gone through
         // migration, put into the rust structs again, and pulled back out.

--- a/components/nimbus/src/persistence.rs
+++ b/components/nimbus/src/persistence.rs
@@ -350,21 +350,6 @@ impl Database {
             self.enrollment_store.try_collect_all(&reader)?;
         let experiments: Vec<Experiment> = self.experiment_store.try_collect_all(&reader)?;
 
-        // figure out which enrollments have records that need to be dropped
-        // and log that we're going to drop them and why
-        // let slugs_without_enrollment_feature_ids: HashSet<String> = enrollments
-        //     .iter()
-        //     .filter_map(
-        //             |e| {
-        //         if matches!(e.status, EnrollmentStatus::Enrolled {ref feature_id, ..} if feature_id.is_empty()) {
-        //             log::warn!("Enrollment for {:?} missing feature_ids; experiment & enrollment will be discarded", &e.slug);
-        //             Some(e.slug.to_owned())
-        //         } else {
-        //             None
-        //         }
-        //     })
-        //     .collect();
-
         // figure out which experiments have records that need to be dropped
         // and log that we're going to drop them and why
         let empty_string = "".to_string();
@@ -1083,34 +1068,6 @@ mod tests {
 
         Ok(())
     }
-
-    // #[test]
-    // /// Migrating db v1 to db v2 involves finding enrollments that
-    // /// don't contain all the feature stuff they should and discarding.
-    // /// It will also discard other experiments/enrollments with required
-    // /// headers that are missing.
-    // fn test_migrate_db_v1_to_db_v2_enrollment_discarding() -> Result<()> {
-    //     let _ = env_logger::try_init();
-    //     let tmp_dir = TempDir::new("migrate_db_v1_to_db_v2")?;
-
-    //     // write invalid enrollments
-    //     let db_v1_enrollments_with_missing_feature_ids =
-    //         &get_v1_enrollments_with_missing_feature_ids();
-
-    //     create_old_database(&tmp_dir, 1, &[], db_v1_enrollments_with_missing_feature_ids)?;
-    //     let db = Database::new(&tmp_dir)?;
-
-    //     // The enrollments with invalid feature_ids should have been discarded
-    //     // during migration; leaving us with none.
-    //     let enrollments = db
-    //         .collect_all::<ExperimentEnrollment>(StoreId::Enrollments)
-    //         .unwrap();
-    //     //log::debug!("enrollments = {:?}", enrollments);
-
-    //     assert_eq!(enrollments.len(), 2);
-
-    //     Ok(())
-    // }
 
     /// Migrating v1 to v2 involves finding experiments that
     /// don't contain all the feature stuff they should and discarding.

--- a/components/nimbus/src/persistence.rs
+++ b/components/nimbus/src/persistence.rs
@@ -293,7 +293,7 @@ impl Database {
                 };
             }
             None => {
-                log::error!("maybe_upgrade: no version number; wiping most stores");
+                log::info!("maybe_upgrade: no version number; wiping most stores");
                 // The "first" version of the database (= no version number) had un-migratable data
                 // for experiments and enrollments, start anew.
                 // XXX: We can most likely remove this behaviour once enough time has passed,


### PR DESCRIPTION
Fixes [SDK-298](https://jira.mozilla.com/browse/SDK-298).

This PR performs quite a bit of cleanup from the Feature API work.

 * Remove `feature_id` from enrollments, to break the 1-1 link between experiment and enrollment.
 * Changes `get_feature_config()` to `get_enrolled_features()`, and to return a *list* of features configs, not just one.
 * Change `evolve_enrollments()` to iterate over a list of feature configs per experiment, instead of one (i.e. remove `get_first_feature_id()`))
 * All access to the feature in `Branch` is now done via `get_feature_configs()`.
 * Derive the `feature_ids` from the `Branch`es themselves, not from the top level property of `Experiment`. This can be removed from the DTO if needed.
 * Fixed up tests to make sure the `Branch` feature_configs are correctly formed.
 * Added new tests to show multifeature experiment collisions that prevent enrollment.

Without further changes to the DTO (i.e. migrating from a single `feature` to a list of `features`), this is allows for each branch having a different feature.

The feature that doesn't get specified by a given branch is given a default (i.e. enrollment exclusion happens, but a default is given to the application).

In order to take advantage of this:

1. Experimenter needs to be able unlock the branches' feature id.
2. Change the DTO to allow `features` instead of `feature`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.