### PR TITLE
Removes old StateV1 schema from fxa-client

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,4 +18,12 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-- `./libs/build-all.sh` now displays a more helpful error message when a file fails checksum integrity test.
+
+## fxa-client
+### ⚠️ Breaking Changes ⚠️
+  - The old StateV1 persisted state schema is now removed. ([#4218](https://github.com/mozilla/application-services/pull/4218))
+    Users on very old versions of this component will no longer be able to cleanly update to this version. Instead, the consumer code
+    will recieve an error indicating that the schema was not correctly formated.
+
+## Other
+  - `./libs/build-all.sh` now displays a more helpful error message when a file fails checksum integrity test.

--- a/components/fxa-client/src/internal/config.rs
+++ b/components/fxa-client/src/internal/config.rs
@@ -90,46 +90,6 @@ impl Config {
         self
     }
 
-    // FIXME
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn init(
-        content_url: String,
-        auth_url: String,
-        oauth_url: String,
-        profile_url: String,
-        token_server_endpoint_url: String,
-        authorization_endpoint: String,
-        issuer: String,
-        jwks_uri: String,
-        token_endpoint: String,
-        userinfo_endpoint: String,
-        introspection_endpoint: String,
-        client_id: String,
-        redirect_uri: String,
-        token_server_url_override: Option<String>,
-    ) -> Self {
-        let remote_config = RemoteConfig {
-            auth_url,
-            oauth_url,
-            profile_url,
-            token_server_endpoint_url,
-            authorization_endpoint,
-            issuer,
-            jwks_uri,
-            token_endpoint,
-            userinfo_endpoint,
-            introspection_endpoint,
-        };
-
-        Config {
-            content_url,
-            remote_config: RefCell::new(Some(Arc::new(remote_config))),
-            client_id,
-            redirect_uri,
-            token_server_url_override,
-        }
-    }
-
     fn remote_config(&self) -> Result<Arc<RemoteConfig>> {
         if let Some(remote_config) = self.remote_config.borrow().clone() {
             return Ok(remote_config);

--- a/components/fxa-client/src/internal/state_persistence.rs
+++ b/components/fxa-client/src/internal/state_persistence.rs
@@ -26,6 +26,8 @@
 //! For backwards-incompatible changes to the data (such as removing or significantly refactoring
 //! fields) we define a new `StateV{X+1}` struct, and use the `From` trait to define how to update
 //! from older struct versions.
+//! For an example how the conversion works, [we can look at `StateV1` which was deliberately removed](https://github.com/mozilla/application-services/issues/3912)
+//! The code that was deleted demonstrates how we can implement the migration
 
 use serde_derive::*;
 use std::collections::{HashMap, HashSet};
@@ -60,7 +62,6 @@ pub(crate) fn state_to_json(state: &State) -> Result<String> {
 
 fn upgrade_state(in_state: PersistedState) -> Result<State> {
     match in_state {
-        PersistedState::V1(state) => state.into(),
         PersistedState::V2(state) => Ok(state),
     }
 }
@@ -72,8 +73,6 @@ fn upgrade_state(in_state: PersistedState) -> Result<State> {
 #[serde(tag = "schema_version")]
 #[allow(clippy::large_enum_variant)]
 enum PersistedState {
-    #[serde(skip_serializing)]
-    V1(StateV1),
     V2(StateV2),
 }
 
@@ -135,154 +134,16 @@ impl StateV2 {
     }
 }
 
-/// Migration from `StateV1` to `StateV2`.
-/// There was a lot of changing of structs and renaming of fields,
-/// but the key change is that we went from supporting multiple active
-/// refresh_tokens to only supporting a single one.
-///
-impl From<StateV1> for Result<StateV2> {
-    fn from(state: StateV1) -> Self {
-        let mut all_refresh_tokens: Vec<V1AuthInfo> = vec![];
-        let mut all_scoped_keys = HashMap::new();
-        for access_token in state.oauth_cache.values() {
-            if access_token.refresh_token.is_some() {
-                all_refresh_tokens.push(access_token.clone());
-            }
-            if let Some(ref scoped_keys) = access_token.keys {
-                let scoped_keys: serde_json::Map<String, serde_json::Value> =
-                    serde_json::from_str(scoped_keys)?;
-                for (scope, key) in scoped_keys {
-                    let scoped_key: ScopedKey = serde_json::from_value(key)?;
-                    all_scoped_keys.insert(scope, scoped_key);
-                }
-            }
-        }
-        // In StateV2 we hold one and only one refresh token.
-        // Obviously this means a loss of information.
-        // Heuristic: We keep the most recent token.
-        let refresh_token = all_refresh_tokens
-            .iter()
-            .max_by(|a, b| a.expires_at.cmp(&b.expires_at))
-            .map(|token| RefreshToken {
-                token: token.refresh_token.clone().expect(
-                    "all_refresh_tokens should only contain access tokens with refresh tokens",
-                ),
-                scopes: token.scopes.iter().map(ToString::to_string).collect(),
-            });
-        let introspection_endpoint = format!("{}/v1/introspect", &state.config.oauth_url);
-        Ok(StateV2 {
-            config: Config::init(
-                state.config.content_url,
-                state.config.auth_url,
-                state.config.oauth_url,
-                state.config.profile_url,
-                state.config.token_server_endpoint_url,
-                state.config.authorization_endpoint,
-                state.config.issuer,
-                state.config.jwks_uri,
-                state.config.token_endpoint,
-                state.config.userinfo_endpoint,
-                introspection_endpoint,
-                state.client_id,
-                state.redirect_uri,
-                None,
-            ),
-            refresh_token,
-            scoped_keys: all_scoped_keys,
-            last_handled_command: None,
-            commands_data: HashMap::new(),
-            device_capabilities: HashSet::new(),
-            session_token: None,
-            current_device_id: None,
-            last_seen_profile: None,
-            in_flight_migration: None,
-            access_token_cache: HashMap::new(),
-        })
-    }
-}
-
-/// `StateV1` was a previous state schema.
-///
-/// The below is sufficient to read existing state data serialized in this form, but should not
-/// be used to create new data using that schema, so it is deliberately private and deliberately
-/// does not derive(Serialize).
-///
-/// If you find yourself modifying this code, you're almost certainly creating a potential data-migration
-/// problem and should reconsider.
-///
-#[derive(Deserialize)]
-struct StateV1 {
-    client_id: String,
-    redirect_uri: String,
-    config: V1Config,
-    oauth_cache: HashMap<String, V1AuthInfo>,
-}
-
-#[derive(Deserialize)]
-struct V1Config {
-    content_url: String,
-    auth_url: String,
-    oauth_url: String,
-    profile_url: String,
-    token_server_endpoint_url: String,
-    authorization_endpoint: String,
-    issuer: String,
-    jwks_uri: String,
-    token_endpoint: String,
-    userinfo_endpoint: String,
-}
-
-#[derive(Deserialize, Clone)]
-struct V1AuthInfo {
-    pub access_token: String,
-    pub keys: Option<String>,
-    pub refresh_token: Option<String>,
-    pub expires_at: u64, // seconds since epoch
-    pub scopes: Vec<String>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_migration_from_v1() {
-        // This is a snapshot of what some persisted StateV1 data would look like in practice.
-        // It's very important that you don't modify this string, which would defeat the point of the test!
+    fn test_invalid_schema_version() {
         let state_v1_json = "{\"schema_version\":\"V1\",\"client_id\":\"98adfa37698f255b\",\"redirect_uri\":\"https://lockbox.firefox.com/fxa/ios-redirect.html\",\"config\":{\"content_url\":\"https://accounts.firefox.com\",\"auth_url\":\"https://api.accounts.firefox.com/\",\"oauth_url\":\"https://oauth.accounts.firefox.com/\",\"profile_url\":\"https://profile.accounts.firefox.com/\",\"token_server_endpoint_url\":\"https://token.services.mozilla.com/1.0/sync/1.5\",\"authorization_endpoint\":\"https://accounts.firefox.com/authorization\",\"issuer\":\"https://accounts.firefox.com\",\"jwks_uri\":\"https://oauth.accounts.firefox.com/v1/jwks\",\"token_endpoint\":\"https://oauth.accounts.firefox.com/v1/token\",\"userinfo_endpoint\":\"https://profile.accounts.firefox.com/v1/profile\"},\"oauth_cache\":{\"https://identity.mozilla.com/apps/oldsync https://identity.mozilla.com/apps/lockbox profile\":{\"access_token\":\"bef37ec0340783356bcac67a86c4efa23a56f2ddd0c7a6251d19988bab7bdc99\",\"keys\":\"{\\\"https://identity.mozilla.com/apps/oldsync\\\":{\\\"kty\\\":\\\"oct\\\",\\\"scope\\\":\\\"https://identity.mozilla.com/apps/oldsync\\\",\\\"k\\\":\\\"kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg\\\",\\\"kid\\\":\\\"1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ\\\"},\\\"https://identity.mozilla.com/apps/lockbox\\\":{\\\"kty\\\":\\\"oct\\\",\\\"scope\\\":\\\"https://identity.mozilla.com/apps/lockbox\\\",\\\"k\\\":\\\"Qk4K4xF2PgQ6XvBXW8X7B7AWwWgW2bHQov9NHNd4v-k\\\",\\\"kid\\\":\\\"1231014287-KDVj0DFaO3wGpPJD8oPwVg\\\"}}\",\"refresh_token\":\"bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188\",\"expires_at\":1543474657,\"scopes\":[\"https://identity.mozilla.com/apps/oldsync\",\"https://identity.mozilla.com/apps/lockbox\",\"profile\"]}}}";
-        let state = state_from_json(state_v1_json).unwrap();
-        assert!(state.refresh_token.is_some());
-        let refresh_token = state.refresh_token.unwrap();
-        assert_eq!(
-            refresh_token.token,
-            "bed5532f4fea7e39c5c4f609f53603ee7518fd1c103cc4034da3618f786ed188"
-        );
-        assert_eq!(refresh_token.scopes.len(), 3);
-        assert!(refresh_token.scopes.contains("profile"));
-        assert!(refresh_token
-            .scopes
-            .contains("https://identity.mozilla.com/apps/oldsync"));
-        assert!(refresh_token
-            .scopes
-            .contains("https://identity.mozilla.com/apps/lockbox"));
-        assert_eq!(state.scoped_keys.len(), 2);
-        let oldsync_key = &state.scoped_keys["https://identity.mozilla.com/apps/oldsync"];
-        assert_eq!(oldsync_key.kid, "1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ");
-        assert_eq!(oldsync_key.k, "kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg");
-        assert_eq!(oldsync_key.kty, "oct");
-        assert_eq!(
-            oldsync_key.scope,
-            "https://identity.mozilla.com/apps/oldsync"
-        );
-        let lockbox_key = &state.scoped_keys["https://identity.mozilla.com/apps/lockbox"];
-
-        assert_eq!(lockbox_key.kid, "1231014287-KDVj0DFaO3wGpPJD8oPwVg");
-        assert_eq!(lockbox_key.k, "Qk4K4xF2PgQ6XvBXW8X7B7AWwWgW2bHQov9NHNd4v-k");
-        assert_eq!(lockbox_key.kty, "oct");
-        assert_eq!(
-            lockbox_key.scope,
-            "https://identity.mozilla.com/apps/lockbox"
-        );
+        if state_from_json(state_v1_json).is_ok() {
+            panic!("Invalid schema passed the conversion from json")
+        }
     }
 
     #[test]


### PR DESCRIPTION
fixes #3912 

Removes the old StateV1 from the fxa-client.

Still not 100% sure of the implication of this, but based on the issue it seems more or less harmless.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
