### PR TITLE
Make `cargo uniffi-bindgen` alias work when executed from a crate.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [alias]
 regen-protobufs = ["run", "--bin", "protobuf-gen", "tools/protobuf_files.toml"]
-uniffi-bindgen = ["run", "--bin", "embedded-uniffi-bindgen"]
+uniffi-bindgen = ["run", "--package", "embedded-uniffi-bindgen", "--"]
 dev-install = ["install", "asdev"]
 verify_env = ["asdev", "verify_env"]


### PR DESCRIPTION
Previously, our special `cargo uniffi-bindgen` alias would work correctly
when executed from the workspace root directory, but would not work when
executed in the root directory of a crate (because from that location,
`cargo run` tries to run a binary from the crate you're in rather than
from the containing workspace).

This tweaks the alias to explicitly specify the package containing
the command, so it should work from any directory.

(I encountered this while working on #4216, but to be honest my
main motivation here is to see if the new mergify config will successfully
auto-land this PR).
