### PR TITLE
Updates docs to specify relative path for application services in fenix

### DIFF
--- a/docs/howtos/locally-published-components-in-fenix.md
+++ b/docs/howtos/locally-published-components-in-fenix.md
@@ -18,8 +18,10 @@ in their build. The workflow is:
 1. Edit (or create) the file `local.properties` *in the consuming project* and tell it where to
    find your local checkout of application-services, by adding a line like:
 
-   `autoPublish.application-services.dir=path/to/your/checkout/of/application-services`
+   `autoPublish.application-services.dir=relative/path/to/your/checkout/of/application-services`
 
+   Note that the path should be relative from the root of the consumer's directory. For example, if `application-services`
+   and `fenix` are at the same level, the relative path would be `../application-services`
 1. Build the consuming project following its usual build procedure, e.g. via `./gradlew assembleDebug` or `./gradlew
    test`.
 


### PR DESCRIPTION
This bit me a little, https://github.com/mozilla-mobile/fenix/blob/master/app/build.gradle#L718 expects it to be a relative path

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
  

