### PR TITLE
Fix parse tabs bug

### DIFF
--- a/components/tabs/src/sync/record.rs
+++ b/components/tabs/src/sync/record.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::error::*;
+use serde::de::Error;
 use serde_derive::{Deserialize, Serialize};
 use serde_json::{Map, Value as JsonValue};
 
@@ -28,41 +29,63 @@ pub struct TabsRecord {
 impl TabsRecord {
     #[inline]
     pub fn from_payload(payload: sync15::Payload) -> Result<Self> {
-        let client_name: String = payload.data["clientName"]
-            .as_str()
-            .unwrap_or_default()
-            .to_string();
-        let tabs: Vec<TabsRecordTab> = payload.data["tabs"]
+        // Note: We are hand-parsing the tabs payload so that we can provide support for
+        // older clients that may have a stringified float or integer `last_used` value.
+        let id = payload.id.to_string();
+        let client_name = parse_string_from_json(&"clientName", payload.data.get("clientName"))?;
+        let tabs: Vec<TabsRecordTab> = payload
+            .data
+            .get("tabs")
+            .ok_or_else(|| serde_json::Error::custom("missing field `tabs`"))?
             .as_array()
-            .unwrap_or(&Vec::new())
+            .ok_or_else(|| serde_json::Error::custom("invalid `tabs`, expected sequence"))?
             .iter()
-            .map(|x| {
+            .map(|x| -> Result<TabsRecordTab> {
                 let tabs_obj: Map<String, JsonValue> = x.as_object().unwrap_or(&Map::new()).clone();
-                let title: String = tabs_obj["title"].as_str().unwrap_or_default().to_string();
-                let url_history: Vec<String> = tabs_obj["urlHistory"]
+                let title: String = parse_string_from_json(&"title", tabs_obj.get("title"))?;
+                let url_history: Vec<String> = tabs_obj
+                    .get("urlHistory")
+                    .ok_or_else(|| serde_json::Error::custom("missing field `urlHistory`"))?
                     .as_array()
-                    .unwrap_or(&Vec::new())
+                    .ok_or_else(|| {
+                        serde_json::Error::custom("invalid `urlHistory`, expected sequence")
+                    })?
                     .iter()
-                    .map(|u| u.as_str().unwrap_or_default().to_string())
-                    .collect::<Vec<_>>();
-                let icon: Option<String> = tabs_obj
-                    .get("icon")
-                    .map(|i| i.as_str().unwrap_or_default().to_string());
-                let last_used = parse_last_used(&tabs_obj["lastUsed"]);
+                    .map(|u| -> Result<String> {
+                        Ok(u.as_str()
+                            .ok_or_else(|| {
+                                serde_json::Error::custom(
+                                    "invalid `urlHistory` value, expected string",
+                                )
+                            })?
+                            .to_string())
+                    })
+                    .into_iter()
+                    .collect::<Result<_>>()?;
+                let icon: Option<String> = match tabs_obj.get("icon") {
+                    Some(i) => Some(parse_string_from_json("icon", Some(i))?),
+                    None => None,
+                };
+                let last_used = parse_last_used(
+                    tabs_obj
+                        .get("lastUsed")
+                        .ok_or_else(|| serde_json::Error::custom("missing field `lastUsed`"))?,
+                )?;
 
-                TabsRecordTab {
+                Ok(TabsRecordTab {
                     title,
                     url_history,
                     icon,
                     last_used,
-                }
+                })
             })
-            .collect::<Vec<_>>();
+            .into_iter()
+            .collect::<Result<_>>()?;
 
         let ttl: u32 = payload.data["ttl"].as_u64().unwrap_or_default() as u32;
 
         Ok(TabsRecord {
-            id: payload.id.to_string(),
+            id,
             client_name,
             tabs,
             ttl,
@@ -70,26 +93,43 @@ impl TabsRecord {
     }
 }
 
-fn parse_last_used(last_used_val: &JsonValue) -> u64 {
+fn parse_last_used(last_used_val: &JsonValue) -> Result<u64> {
     // In order to support older clients, we are handling `last used` values that
     // are either floats, integers, or stringified floats or integers. We attempt to
     // represent `last used` as a float before converting it to an integer. If that
     // operation isn't successful, we try converting `last used` to an integer directly.
-    // If that isn't successful, the returned value will be zero.
+    // If that isn't successful, we return an error.
 
-    if last_used_val.is_string() {
+    let invalid_err_msg = "invalid `lastUsed`, expected u64";
+    let last_used = if last_used_val.is_string() {
         let l = last_used_val.as_str().unwrap_or_default();
 
         match l.parse::<f64>() {
             Ok(f) => f.trunc() as u64,
-            Err(_) => l.parse::<u64>().unwrap_or_default(),
+            Err(_) => l
+                .parse::<u64>()
+                .map_err(|_| serde_json::Error::custom(invalid_err_msg))?,
         }
     } else {
         match last_used_val.as_f64() {
             Some(f) => f.trunc() as u64,
-            None => last_used_val.as_u64().unwrap_or_default(),
+            None => last_used_val
+                .as_u64()
+                .ok_or_else(|| serde_json::Error::custom(invalid_err_msg))?,
         }
-    }
+    };
+
+    Ok(last_used)
+}
+
+fn parse_string_from_json(field_name: &str, val: Option<&JsonValue>) -> Result<String> {
+    Ok(val
+        .ok_or_else(|| serde_json::Error::custom(format!("missing field `{}`", field_name)))?
+        .as_str()
+        .ok_or_else(|| {
+            serde_json::Error::custom(format!("invalid `{}`, expected string", field_name))
+        })?
+        .to_string())
 }
 
 #[cfg(test)]
@@ -101,56 +141,56 @@ pub(crate) mod tests {
     #[test]
     fn test_tabs_record_from_payload() -> Result<()> {
         let guid = Guid::random();
-        let mut data = Map::new();
 
-        let tabs: JsonValue = json!([
-            {
-                "title": "Example",
-                "urlHistory": [
-                    "example.com",
-                    "example2.com"
-                ],
-                "icon": "example.png",
-                "lastUsed": 1623745123 // test with integer value
-            },
-            {
-                "title": "Test",
-                "urlHistory": [
-                    "test.com",
-                    "test2.com"
-                ],
-                "icon": "test.png",
-                "lastUsed": 1623745000.99 // test with float value
-            },
-            {
-                "title": "Example2",
-                "urlHistory": [
-                    "example2.com"
-                ],
-                "icon": "example2.png",
-                "lastUsed": "1623745144" // test with stringified integer value
-            },
-            {
-                "title": "Test2",
-                "urlHistory": [
-                    "test2.com"
-                ],
-                "icon": "test2.png",
-                "lastUsed": "1623745018.99" // test with stringified float value
-            },
-        ]);
+        let data = json!({
+            "clientName": "Nightly",
+            "tabs": [
+                {
+                    "title": "Example",
+                    "urlHistory": [
+                        "example.com",
+                        "example2.com"
+                    ],
+                    "lastUsed": 1623745123 // test with integer value
+                },
+                {
+                    "title": "Test",
+                    "urlHistory": [
+                        "test.com",
+                        "test2.com"
+                    ],
+                    "icon": "test.png",
+                    "lastUsed": 1623745000.99 // test with float value
+                },
+                {
+                    "title": "Example2",
+                    "urlHistory": [
+                        "example2.com"
+                    ],
+                    "icon": "example2.png",
+                    "lastUsed": "1623745144" // test with stringified integer value
+                },
+                {
+                    "title": "Test2",
+                    "urlHistory": [
+                        "test2.com"
+                    ],
+                    "icon": "test2.png",
+                    "lastUsed": "1623745018.99" // test with stringified float value
+                },
+            ],
+            "ttl": 0
+        })
+        .as_object()
+        .unwrap()
+        .clone();
 
-        data.insert("tabs".to_string(), tabs);
-        data.insert("clientName".to_string(), JsonValue::from("Nightly"));
-        data.insert("ttl".to_string(), JsonValue::from(0));
-
-        let payload_input = sync15::Payload {
+        let actual = TabsRecord::from_payload(sync15::Payload {
             id: guid.clone(),
             deleted: false,
             data,
-        };
+        })?;
 
-        let actual = TabsRecord::from_payload(payload_input)?;
         let expected = TabsRecord {
             id: guid.to_string(),
             client_name: "Nightly".to_string(),
@@ -158,7 +198,7 @@ pub(crate) mod tests {
                 TabsRecordTab {
                     title: "Example".to_string(),
                     url_history: vec!["example.com".to_string(), "example2.com".to_string()],
-                    icon: Some("example.png".to_string()),
+                    icon: None,
                     last_used: 1623745123,
                 },
                 TabsRecordTab {
@@ -184,6 +224,176 @@ pub(crate) mod tests {
         };
 
         assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_tabs_record_from_payload_with_invalid_data() -> Result<()> {
+        struct TestCase {
+            case_description: String,
+            data: JsonValue,
+            expected_err_msg: String,
+        }
+
+        let test_cases = vec![
+            TestCase {
+                case_description: "test missing client name".to_string(),
+                data: json!({
+                    "tabs": []
+                }),
+                expected_err_msg: "missing field `clientName`".to_string(),
+            },
+            TestCase {
+                case_description: "test invalid client name".to_string(),
+                data: json!({
+                    "clientName": 0,
+                }),
+                expected_err_msg: "invalid `clientName`, expected string".to_string(),
+            },
+            TestCase {
+                case_description: "test missing tabs".to_string(),
+                data: json!({
+                    "clientName": "",
+                }),
+                expected_err_msg: "missing field `tabs`".to_string(),
+            },
+            TestCase {
+                case_description: "test invalid tabs".to_string(),
+                data: json!({
+                    "clientName": "",
+                    "tabs": 0,
+                }),
+                expected_err_msg: "invalid `tabs`, expected sequence".to_string(),
+            },
+            TestCase {
+                case_description: "test missing title".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "urlHistory": []
+                        }
+                    ],
+                    "ttl": 0
+                }),
+                expected_err_msg: "missing field `title`".to_string(),
+            },
+            TestCase {
+                case_description: "test invalid title".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": false
+                        }
+                    ],
+                    "ttl": 0
+                }),
+                expected_err_msg: "invalid `title`, expected string".to_string(),
+            },
+            TestCase {
+                case_description: "test missing url history".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": ""
+                        }
+                    ],
+                    "ttl": 0
+                }),
+                expected_err_msg: "missing field `urlHistory`".to_string(),
+            },
+            TestCase {
+                case_description: "test invalid url history".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": "",
+                            "urlHistory": 0
+                        }
+                    ],
+                    "ttl": 0
+                }),
+                expected_err_msg: "invalid `urlHistory`, expected sequence".to_string(),
+            },
+            TestCase {
+                case_description: "test invalid url history values".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": "",
+                            "urlHistory": [0, 2, 3]
+                        }
+                    ],
+                    "ttl": 0
+                }),
+                expected_err_msg: "invalid `urlHistory` value, expected string".to_string(),
+            },
+            TestCase {
+                case_description: "test invalid icon".to_string(),
+                data: json!({
+                        "clientName": "Nightly",
+                        "tabs": [
+                            {
+                                "title": "",
+                                "urlHistory": [],
+                                "icon": [],
+                                "lastUsed": 0
+                            }
+                        ],
+                "ttl": 0
+                    }),
+                expected_err_msg: "invalid `icon`, expected string".to_string(),
+            },
+            TestCase {
+                case_description: "test missing last used".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": "",
+                            "urlHistory": [],
+                            "icon": ""
+                        }
+                    ],
+                    "ttl": 0
+                }),
+                expected_err_msg: "missing field `lastUsed`".to_string(),
+            },
+            TestCase {
+                case_description: "test invalid last used".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": "",
+                            "urlHistory": [],
+                            "lastUsed": true
+                        }
+                    ],
+                    "ttl": 0
+                }),
+                expected_err_msg: "invalid `lastUsed`, expected u64".to_string(),
+            },
+        ];
+
+        for tc in test_cases {
+            let actual = TabsRecord::from_payload(sync15::Payload {
+                id: Guid::random(),
+                deleted: false,
+                data: tc.data.as_object().unwrap().clone(),
+            });
+
+            assert!(actual.is_err(), "{}", tc.case_description);
+            assert_eq!(
+                actual.err().unwrap().to_string(),
+                format!("Error parsing JSON data: {}", tc.expected_err_msg)
+            );
+        }
 
         Ok(())
     }

--- a/components/tabs/src/sync/record.rs
+++ b/components/tabs/src/sync/record.rs
@@ -4,6 +4,7 @@
 
 use crate::error::*;
 use serde_derive::{Deserialize, Serialize};
+use serde_json::{Map, Value as JsonValue};
 
 #[derive(Debug, Clone, Hash, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -27,7 +28,123 @@ pub struct TabsRecord {
 impl TabsRecord {
     #[inline]
     pub fn from_payload(payload: sync15::Payload) -> Result<Self> {
-        let record: TabsRecord = payload.into_record()?;
-        Ok(record)
+        let client_name: String = payload.data["clientName"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string();
+        let tabs: Vec<TabsRecordTab> = payload.data["tabs"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .map(|x| {
+                let tabs_obj: Map<String, JsonValue> = x.as_object().unwrap_or(&Map::new()).clone();
+                let title: String = tabs_obj["title"].as_str().unwrap_or_default().to_string();
+                let url_history: Vec<String> = tabs_obj["urlHistory"]
+                    .as_array()
+                    .unwrap_or(&Vec::new())
+                    .iter()
+                    .map(|u| u.as_str().unwrap_or_default().to_string())
+                    .collect::<Vec<_>>();
+                let icon: Option<String> = if let Some(i) = tabs_obj.get("icon") {
+                    Some(i.as_str().unwrap_or_default().to_string())
+                } else {
+                    None
+                };
+
+                let last_used: u64 = if let Some(l) = tabs_obj.get("lastUsed") {
+                    if l.is_f64() {
+                        l.as_f64().unwrap_or_default().trunc() as u64
+                    } else {
+                        l.as_u64().unwrap_or_default()
+                    }
+                } else {
+                    0
+                };
+
+                TabsRecordTab {
+                    title,
+                    url_history,
+                    icon,
+                    last_used,
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let ttl: u32 = payload.data["ttl"].as_u64().unwrap_or_default() as u32;
+
+        Ok(TabsRecord {
+            id: payload.id.to_string(),
+            client_name,
+            tabs,
+            ttl,
+        })
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+    use serde_json::json;
+    use sync_guid::Guid;
+
+    #[test]
+    fn test_tabs_record_from_payload() -> Result<()> {
+        let guid = Guid::random();
+        let mut data = Map::new();
+
+        let tabs: JsonValue = json!([
+            {
+                "title": "Example",
+                "urlHistory": [
+                    "example.com",
+                    "example2.com"
+                ],
+                "icon": "example.png",
+                "lastUsed": 1623745123 // test with integer value
+            },
+            {
+                "title": "Test",
+                "urlHistory": [
+                    "test.com",
+                    "test2.com"
+                ],
+                "icon": "test.png",
+                "lastUsed": 1623745000.99 // test with float value
+            }
+        ]);
+
+        data.insert("clientName".to_string(), JsonValue::from("Nightly"));
+        data.insert("tabs".to_string(), tabs);
+
+        let payload_input = sync15::Payload {
+            id: guid.clone(),
+            deleted: false,
+            data,
+        };
+
+        let actual = TabsRecord::from_payload(payload_input)?;
+        let expected = TabsRecord {
+            id: guid.to_string(),
+            client_name: "Nightly".to_string(),
+            tabs: vec![
+                TabsRecordTab {
+                    title: "Example".to_string(),
+                    url_history: vec!["example.com".to_string(), "example2.com".to_string()],
+                    icon: Some("example.png".to_string()),
+                    last_used: 1623745123,
+                },
+                TabsRecordTab {
+                    title: "Test".to_string(),
+                    url_history: vec!["test.com".to_string(), "test2.com".to_string()],
+                    icon: Some("test.png".to_string()),
+                    last_used: 1623745000,
+                },
+            ],
+            ttl: 0,
+        };
+
+        assert_eq!(actual, expected);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Fixes #3892. This is also related to the firefox iOS bug [#8272](https://github.com/mozilla-mobile/firefox-ios/pull/8727), which updates the tab sync code converting the `lastUsed` type from a stringified float to an integer. The docs have also been updated [here](https://github.com/mozilla-services/docs/pull/92).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
