### PR TITLE
Build iOS Rust code as an XCFramework.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ commands:
             cargo metadata --locked > /dev/null
             python3 ./tools/dependency_summary.py --check ./DEPENDENCIES.md
             python3 ./tools/dependency_summary.py --all-ios-targets --package megazord_ios --check megazords/ios/DEPENDENCIES.md
+            python3 ./tools/dependency_summary.py --all-ios-targets --package ios_rust --check megazords/ios-rust/DEPENDENCIES.md
             python3 ./tools/dependency_summary.py --all-android-targets --package megazord --check megazords/full/DEPENDENCIES.md
             python3 ./tools/dependency_summary.py --all-android-targets --package megazord --format pom --check megazords/full/android/dependency-licenses.xml
   bench-all:
@@ -380,6 +381,21 @@ jobs:
       - store_artifacts:
           path: raw_xcodebuild.log
           destination: logs/raw_xcodebuild.log
+      - run:
+          name: Build XCFramework archive
+          command: |
+            # For now we need the nightly toolchain to build for the M1 simulator.
+            rustup install nightly
+            # For now we need to build the Rust stdlib from source for the M1 simulator.
+            rustup component add rust-src --toolchain nightly-x86_64-apple-darwin
+            if [ -z "${CIRCLE_TAG}" ]; then
+              # XCode tests build in Debug configuration, save us a full
+              # Rust rebuild in Release mode by forcing Debug mode on
+              # non-release builds.
+              bash megazords/ios-rust/build-xcframework.sh --build-profile debug
+            else
+              bash megazords/ios-rust/build-xcframework.sh --build-profile release
+            fi
       - save_cache:
           name: Save sccache cache
           key: sccache-cache-macos-{{ arch }}-{{ epoch }}
@@ -392,21 +408,33 @@ jobs:
             ZIP_URL=https://circleci.com/api/v1.1/project/github/mozilla/application-services/$CIRCLE_BUILD_NUM/artifacts/0/dist/MozillaAppServices.framework.zip
             echo "{\"0.0.1\":\"$ZIP_URL\"}" > mozilla.app-services.json
       - store_artifacts:
+          name: Store Carthage framework in workspace
           path: MozillaAppServices.framework.zip
           destination: dist/MozillaAppServices.framework.zip
       - store_artifacts:
+          name: Store Carthage bin-only project specification in workspace
           path: mozilla.app-services.json
           destination: dist/mozilla.app-services.json
+      - store_artifacts:
+          name: Store XCFramework bundle in workspace
+          path: megazords/ios-rust/MozillaRustComponents.xcframework.zip
+          destination: dist/MozillaRustComponents.xcframework.zip
       - run:
           name: "Carthage binary snapshot URL"
           command: |
             JSON_URL=https://circleci.com/api/v1.1/project/github/mozilla/application-services/$CIRCLE_BUILD_NUM/artifacts/0/dist/mozilla.app-services.json
             echo "Add the following line to your Cartfile:"
             echo "binary \"$JSON_URL\" ~> 0.0.1-snapshot # mozilla/application-services@$CIRCLE_SHA1"
+      - run:
+          name: "XCFramework bundle checksum"
+          command: |
+            shasum -a 256 ./megazords/ios-rust/MozillaRustComponents.xcframework.zip
+            echo "Use the above checksum to depend on MozillaRustComponents.xcframework.zip as a Swift Package binary target"
       - persist_to_workspace:
           root: .
           paths:
             - MozillaAppServices.framework.zip
+            - megazords/ios-rust/MozillaRustComponents.xcframework.zip
   Carthage release:
     executor: macos
     steps:
@@ -422,6 +450,21 @@ jobs:
             echo "${GHR_SHA256} *${GHR}.zip" | shasum -a 256 -c -
             unzip "${GHR}.zip"
             ./${GHR}/ghr -replace "${CIRCLE_TAG}" MozillaAppServices.framework.zip
+  XCFramework release:
+    executor: macos
+    steps:
+      - full-checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Release XCFramework archive on GitHub
+          command: |
+            GHR=ghr_v0.12.0_darwin_amd64
+            GHR_SHA256=c868ef9fc5dd8c8a397b74d84051d83693c42dd59041cb17b66f90f563477249
+            curl -sfSL --retry 5 --retry-delay 10 -O "https://github.com/tcnksm/ghr/releases/download/v0.12.0/${GHR}.zip"
+            echo "${GHR_SHA256} *${GHR}.zip" | shasum -a 256 -c -
+            unzip "${GHR}.zip"
+            ./${GHR}/ghr -replace "${CIRCLE_TAG}" megazords/ios-rust/MozillaRustComponents.xcframework.zip
 
 workflows:
   version: 2
@@ -473,13 +516,21 @@ workflows:
   coverage:
     jobs:
       - Generate code coverage
-  carthage-framework:
+  ios-artifacts:
     jobs:
       - iOS build and test:
           filters: # required since `Release` has tag filters AND requires `Build`
             tags:
               only: /.*/
       - Carthage release:
+          requires:
+            - iOS build and test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - XCFramework release:
           requires:
             - iOS build and test
           filters:

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ components/**/ios/Generated
 # Glean generated artifacts
 megazords/ios/MozillaAppServices/Generated/Metrics.swift
 megazords/ios/.venv
+megazords/ios-rust/MozillaRustComponents.xcframework*
 
 # Carthage generated artifacts
 Carthage
@@ -50,3 +51,4 @@ docs/book
 
 # Generated rustdocs
 docs/rust-docs
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,18 +292,18 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "camino"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4648c6d00a709aa069a236adcaae4f605a6241c72bf5bee79331a4b625921a9"
+checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
  "serde",
 ]
@@ -504,16 +504,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
+checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
  "atty",
  "cast",
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.10.1",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -530,12 +530,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
  "cast",
- "itertools 0.9.0",
+ "itertools",
 ]
 
 [[package]]
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
@@ -926,9 +926,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "ffi-support"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f476e3c4fa6d9a3e0eeabd4f7555a382025ec05194675d72fa1db347e53ae6c"
+checksum = "27838c6815cfe9de2d3aeb145ffd19e565f577414b33f3bdbf42fe040e9e0ff6"
 dependencies = [
  "lazy_static",
  "log",
@@ -1302,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+checksum = "399c583b2979440c60be0821a6199eca73bc3c8dcd9d070d75ac726e2c6186e5"
 dependencies = [
  "bytes",
  "http",
@@ -1401,19 +1401,21 @@ name = "interrupt-support"
 version = "0.1.0"
 
 [[package]]
+name = "ios_rust"
+version = "0.1.0"
+dependencies = [
+ "crashtest",
+ "nimbus-sdk",
+ "rc_log_ffi",
+ "viaduct",
+ "viaduct-reqwest",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1455,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1504,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2293,7 +2295,7 @@ checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.1",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -2310,7 +2312,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.10.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -2586,9 +2588,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -2599,7 +2601,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
- "redox_syscall 0.2.9",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -2620,7 +2622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
  "getrandom 0.2.3",
- "redox_syscall 0.2.9",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -2781,7 +2783,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.3",
+ "semver 1.0.4",
 ]
 
 [[package]]
@@ -2859,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "semver-parser"
@@ -2880,9 +2882,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
@@ -2899,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2910,9 +2912,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -2921,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd1055d1c20532080b9da5040ec8e27425f4d4573d8e29eb19ba4ff1e4b9da2d"
+checksum = "de9e52f2f83e2608a121618b6d3885b514613aac702306232c4f035ff60fdb56"
 dependencies = [
  "serde",
 ]
@@ -2967,15 +2969,15 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "smallbitvec"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797a4eaffb90d896f29698d45676f9f940a71936d7574996a7df54593ba209fa"
+checksum = "75ce4f9dc4a41b4c3476cc925f1efb11b66df373a8fde5d4b8915fa91b5d995e"
 
 [[package]]
 name = "smallvec"
@@ -2985,9 +2987,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",
@@ -3194,7 +3196,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.4",
- "redox_syscall 0.2.9",
+ "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi",
 ]
@@ -3247,7 +3249,7 @@ checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
 dependencies = [
  "libc",
  "numtoa",
- "redox_syscall 0.2.9",
+ "redox_syscall 0.2.10",
  "redox_termios",
 ]
 
@@ -3618,9 +3620,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3630,9 +3632,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3645,9 +3647,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+checksum = "16646b21c3add8e13fdb8f20172f8a28c3dbf62f45406bcff0233188226cfe0c"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3657,9 +3659,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3667,9 +3669,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3680,15 +3682,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3752,11 +3754,12 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.1.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
 dependencies = [
  "either",
+ "lazy_static",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "components/webext-storage/ffi",
     "megazords/full",
     "megazords/ios/rust",
+    "megazords/ios-rust",
 # Disabled for intermittent failures; see SDK-233 and #3909 for details.
 #    "testing/sync-test",
     "tools/protobuf-gen",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -476,7 +476,7 @@ The following text applies to code linked from these dependencies:
 [env_logger](https://github.com/sebasmagri/env_logger/),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
-[ffi-support](https://github.com/mozilla/application-services),
+[ffi-support](https://github.com/mozilla/ffi-support),
 [flate2](https://github.com/rust-lang/flate2-rs),
 [fnv](https://github.com/servo/rust-fnv),
 [foreign-types-shared](https://github.com/sfackler/foreign-types),

--- a/components/crashtest/uniffi.toml
+++ b/components/crashtest/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "mozilla.appservices.crashtest"
 cdylib_name = "megazord"
 
-[bindings.swift]
-generate_module_map = false
 
+[bindings.swift]
+ffi_module_name = "MozillaRustComponents"
+ffi_module_filename = "crashtestFFI"
+generate_module_map = false

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -4,6 +4,9 @@
 
 import Foundation
 import UIKit
+#if canImport(Sync15)
+    import Sync15
+#endif
 
 typealias LoginsStoreError = LoginsStorageError
 

--- a/components/nimbus/ios/Nimbus/FeatureVariables.swift
+++ b/components/nimbus/ios/Nimbus/FeatureVariables.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import UIKit
 
 /// `Variables` provides a type safe key-value style interface to configure application features
 ///

--- a/components/nimbus/uniffi.toml
+++ b/components/nimbus/uniffi.toml
@@ -3,4 +3,6 @@ package_name = "org.mozilla.experiments.nimbus.internal"
 cdylib = "megazord"
 
 [bindings.swift]
+ffi_module_name = "MozillaRustComponents"
+ffi_module_filename = "nimbusFFI"
 generate_module_map = false

--- a/components/rc_log/ios/RustLog.swift
+++ b/components/rc_log/ios/RustLog.swift
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+#if canImport(MozillaRustComponents)
+    import MozillaRustComponents
+#endif
 
 /// The level of a log message
 public enum LogLevel: Int32 {

--- a/components/viaduct/ios/Viaduct.swift
+++ b/components/viaduct/ios/Viaduct.swift
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+#if canImport(MozillaRustComponents)
+    import MozillaRustComponents
+#endif
 
 /// The public interface to viaduct.
 /// Right now it doesn't do any "true" viaduct things,

--- a/docs/build-and-publish-pipeline.md
+++ b/docs/build-and-publish-pipeline.md
@@ -24,7 +24,7 @@ The key points:
 * Releases are made by [manually creating a new release](./howtos/cut-a-new-release.md) via github,
   which triggers various CI jobs:
     * [CircleCI](../.circleci/config.yml) is used to build an iOS binary release on every release,
-      and publish it as a GitHub release artifact.
+      and publish it as GitHub release artifacts.
     * [TaskCluster](../automation/taskcluster/README.md) is used to:
         * Build an Android binary release.
         * Upload Android library symbols to [Socorro](https://wiki.mozilla.org/Socorro).
@@ -75,7 +75,9 @@ For iOS consumers the corresponding steps are:
     * TODO: could this step check for signed tags as an additional integrity measure?
     * TODO: can we prevent these steps from being able to see the tokens used
       for publishing in subsequent steps?
-4. CircleCI runs Carthage to assemble a zipfile of built frameworks.
+4. CircleCI builds two binary artifacts:
+    * A Carthage framework containing both Rust and Swift code compiled together, as a zipfile.
+    * An XCFramework containing just Rust code and header files, as a zipfile, for use by Swift Packags.
     * TODO: could a malicious dev dependency from step (3) influence the build environment here?
 5. CircleCI uses [dpl](https://github.com/travis-ci/dpl) to publish to GitHub as a release artifact.
     * CircleCI config contains a github token (owned by the @appsvc-moz GitHub account) with appropriate permissions to add release artifacts.

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -446,7 +446,7 @@ The following text applies to code linked from these dependencies:
 [either](https://github.com/bluss/either),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
-[ffi-support](https://github.com/mozilla/application-services),
+[ffi-support](https://github.com/mozilla/ffi-support),
 [form_urlencoded](https://github.com/servo/rust-url),
 [getrandom](https://github.com/rust-random/getrandom),
 [glob](https://github.com/rust-lang/glob),

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -86,7 +86,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: bitflags</name>
-    <url>https://github.com/bitflags/bitflags/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/bitflags/bitflags/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: block-buffer</name>

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ios_rust"
+edition = "2018"
+version = "0.1.0"
+authors = ["application-services <application-services@mozilla.com>"]
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+rc_log_ffi = { path = "../../components/rc_log" }
+viaduct = { path = "../../components/viaduct" }
+viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+nimbus-sdk = { path = "../../components/nimbus" }
+crashtest = { path = "../../components/crashtest" }
+
+# TODO: can't include fxa-client until we get NSS working on M1 simulator,
+# ref https://github.com/mozilla/application-services/issues/4352.
+#fxa-client = { path = "../../components/fxa-client" }
+# TODO: can't include logins until we get SQLCipher working on M1 simulator,
+# ref https://github.com/mozilla/application-services/issues/4352.
+# (or until we entirely get rid of SQLCipher)
+#logins = { path = "../../components/logins" }

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -7,29 +7,22 @@ the details of which are reproduced below.
 * [Mozilla Public License 2.0](#mozilla-public-license-20)
 * [Apache License 2.0](#apache-license-20)
 * [MIT License: SwiftKeychainWrapper](#mit-license-swiftkeychainwrapper)
-* [MIT License: aho-corasick, byteorder, memchr, termcolor](#mit-license-aho-corasick-byteorder-memchr-termcolor)
-* [MIT License: atty](#mit-license-atty)
+* [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bitvec, wyz](#mit-license-bitvec-wyz)
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata](#mit-license-cargo_metadata)
-* [MIT License: caseless](#mit-license-caseless)
 * [MIT License: clap](#mit-license-clap)
-* [MIT License: dashmap](#mit-license-dashmap)
 * [MIT License: funty](#mit-license-funty)
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: h2](#mit-license-h2)
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
-* [MIT License: libsqlite3-sys](#mit-license-libsqlite3-sys)
 * [MIT License: matches](#mit-license-matches)
-* [MIT License: miniz_oxide](#mit-license-miniz_oxide)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
-* [MIT License: oslog](#mit-license-oslog)
 * [MIT License: radium](#mit-license-radium)
-* [MIT License: rusqlite](#mit-license-rusqlite)
 * [MIT License: slab](#mit-license-slab)
 * [MIT License: tap](#mit-license-tap)
 * [MIT License: textwrap](#mit-license-textwrap)
@@ -39,26 +32,17 @@ the details of which are reproduced below.
 * [MIT License: try-lock](#mit-license-try-lock)
 * [MIT License: want](#mit-license-want)
 * [MIT License: weedle](#mit-license-weedle)
-* [CC0-1.0 License: base16](#cc0-10-license-base16)
-* [ISC License: ring](#isc-license-ring)
 * [BSD-2-Clause License: arrayref](#bsd-2-clause-license-arrayref)
-* [BSD-3-Clause License: sqlcipher](#bsd-3-clause-license-sqlcipher)
-* [Optional Notice: SQLite](#optional-notice-sqlite)
 -------------
 ## Mozilla Public License 2.0
 
 The following text applies to code linked from these dependencies:
-[NSPR](https://hg.mozilla.org/projects/nspr),
-[NSS](https://hg.mozilla.org/projects/nss),
-[ece](https://github.com/mozilla/rust-ece),
-[hawk](https://github.com/taskcluster/rust-hawk),
 [jexl-eval](https://github.com/mozilla/jexl-rs),
 [jexl-parser](https://github.com/mozilla/jexl-rs),
 [uniffi](https://github.com/mozilla/uniffi-rs),
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
-[uniffi_macros](https://github.com/mozilla/uniffi-rs),
-[zeitstempel](https://github.com/badboy/zeitstempel)
+[uniffi_macros](https://github.com/mozilla/uniffi-rs)
 
 ```
 Mozilla Public License Version 2.0
@@ -98,7 +82,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"
@@ -440,8 +424,6 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 ## Apache License 2.0
 
 The following text applies to code linked from these dependencies:
-[adler](https://github.com/jonas-schievink/adler.git),
-[ahash](https://github.com/tkaitchuck/ahash),
 [anyhow](https://github.com/dtolnay/anyhow),
 [arrayvec](https://github.com/bluss/arrayvec),
 [askama](https://github.com/djc/askama),
@@ -456,20 +438,13 @@ The following text applies to code linked from these dependencies:
 [cargo-platform](https://github.com/rust-lang/cargo),
 [cc](https://github.com/alexcrichton/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
-[chrono](https://github.com/chronotope/chrono),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
 [core-foundation](https://github.com/servo/core-foundation-rs),
 [cpufeatures](https://github.com/RustCrypto/utils),
-[crc32fast](https://github.com/srijs/rust-crc32fast),
 [digest](https://github.com/RustCrypto/traits),
-[dogear](https://github.com/mozilla/dogear),
 [either](https://github.com/bluss/either),
 [encoding_rs](https://github.com/hsivonen/encoding_rs),
-[env_logger](https://github.com/sebasmagri/env_logger/),
-[fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
-[fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
 [ffi-support](https://github.com/mozilla/ffi-support),
-[flate2](https://github.com/rust-lang/flate2-rs),
 [fnv](https://github.com/servo/rust-fnv),
 [form_urlencoded](https://github.com/servo/rust-url),
 [futures-channel](https://github.com/rust-lang/futures-rs),
@@ -481,13 +456,11 @@ The following text applies to code linked from these dependencies:
 [getrandom](https://github.com/rust-random/getrandom),
 [glob](https://github.com/rust-lang/glob),
 [hashbrown](https://github.com/rust-lang/hashbrown),
-[hashlink](https://github.com/kyren/hashlink),
 [heck](https://github.com/withoutboats/heck),
 [hex](https://github.com/KokaKiwi/rust-hex),
 [http](https://github.com/hyperium/http),
 [httparse](https://github.com/seanmonstar/httparse),
 [httpdate](https://github.com/pyfisch/httpdate),
-[humantime](https://github.com/tailhook/humantime),
 [hyper-tls](https://github.com/hyperium/hyper-tls),
 [id-arena](https://github.com/fitzgen/id-arena),
 [idna](https://github.com/servo/rust-url/),
@@ -504,7 +477,6 @@ The following text applies to code linked from these dependencies:
 [log](https://github.com/rust-lang/log),
 [mime](https://github.com/hyperium/mime),
 [native-tls](https://github.com/sfackler/rust-native-tls),
-[num-integer](https://github.com/rust-num/num-integer),
 [num-traits](https://github.com/rust-num/num-traits),
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
@@ -521,7 +493,6 @@ The following text applies to code linked from these dependencies:
 [proc-macro2](https://github.com/alexcrichton/proc-macro2),
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
-[quick-error](http://github.com/tailhook/quick-error),
 [quote](https://github.com/dtolnay/quote),
 [rand](https://github.com/rust-random/rand),
 [rand_chacha](https://github.com/rust-random/rand),
@@ -541,8 +512,6 @@ The following text applies to code linked from these dependencies:
 [serde_json](https://github.com/serde-rs/json),
 [serde_urlencoded](https://github.com/nox/serde_urlencoded),
 [sha2](https://github.com/RustCrypto/hashes),
-[smallbitvec](https://github.com/servo/smallbitvec),
-[smallvec](https://github.com/servo/rust-smallvec),
 [socket2](https://github.com/rust-lang/socket2),
 [static_assertions](https://github.com/nvzqz/static-assertions-rs),
 [swift-protobuf](https://github.com/apple/swift-protobuf),
@@ -550,7 +519,6 @@ The following text applies to code linked from these dependencies:
 [tempfile](https://github.com/Stebalien/tempfile),
 [thiserror-impl](https://github.com/dtolnay/thiserror),
 [thiserror](https://github.com/dtolnay/thiserror),
-[time](https://github.com/time-rs/time),
 [tinyvec](https://github.com/Lokathor/tinyvec),
 [tinyvec_macros](https://github.com/Soveu/tinyvec_macros),
 [toml](https://github.com/alexcrichton/toml-rs),
@@ -568,7 +536,7 @@ The following text applies to code linked from these dependencies:
 ```
                               Apache License
                         Version 2.0, January 2004
-                     https://www.apache.org/licenses/LICENSE-2.0
+                     http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -760,7 +728,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	https://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -801,13 +769,12 @@ SOFTWARE.
 
 ```
 -------------
-## MIT License: aho-corasick, byteorder, memchr, termcolor
+## MIT License: aho-corasick, byteorder, memchr
 
 The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
-[memchr](https://github.com/BurntSushi/rust-memchr),
-[termcolor](https://github.com/BurntSushi/termcolor)
+[memchr](https://github.com/BurntSushi/rust-memchr)
 
 ```
 The MIT License (MIT)
@@ -831,35 +798,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: atty
-
-The following text applies to code linked from these dependencies:
-[atty](https://github.com/softprops/atty)
-
-```
-Copyright (c) 2015-2019 Doug Tangren
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
@@ -990,37 +928,6 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
-## MIT License: caseless
-
-The following text applies to code linked from these dependencies:
-[caseless](https://github.com/SimonSapin/rust-caseless)
-
-```
-Copyright (c) 2017 Simon Sapin
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-```
--------------
 ## MIT License: clap
 
 The following text applies to code linked from these dependencies:
@@ -1030,36 +937,6 @@ The following text applies to code linked from these dependencies:
 The MIT License (MIT)
 
 Copyright (c) 2015-2016 Kevin B. Knapp
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
-## MIT License: dashmap
-
-The following text applies to code linked from these dependencies:
-[dashmap](https://github.com/xacrimon/dashmap)
-
-```
-MIT License
-
-Copyright (c) 2019 Acrimon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1236,34 +1113,6 @@ THE SOFTWARE.
 
 ```
 -------------
-## MIT License: libsqlite3-sys
-
-The following text applies to code linked from these dependencies:
-[libsqlite3-sys](https://github.com/rusqlite/rusqlite)
-
-```
-Copyright (c) 2014-2021 The rusqlite developers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-```
--------------
 ## MIT License: matches
 
 The following text applies to code linked from these dependencies:
@@ -1295,36 +1144,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: miniz_oxide
-
-The following text applies to code linked from these dependencies:
-[miniz_oxide](https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide)
-
-```
-MIT License
-
-Copyright (c) 2017 Frommi
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ```
 -------------
@@ -1419,36 +1238,6 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
-## MIT License: oslog
-
-The following text applies to code linked from these dependencies:
-[oslog](https://github.com/steven-joruk/oslog)
-
-```
-MIT License
-
-Copyright (c) 2020 Steven Joruk
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
 ## MIT License: radium
 
 The following text applies to code linked from these dependencies:
@@ -1476,34 +1265,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-```
--------------
-## MIT License: rusqlite
-
-The following text applies to code linked from these dependencies:
-[rusqlite](https://github.com/rusqlite/rusqlite)
-
-```
-Copyright (c) 2014-2020 The rusqlite developers
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
 ```
 -------------
@@ -1788,159 +1549,6 @@ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFT
 DEALINGS IN THE SOFTWARE.
 ```
 -------------
-## CC0-1.0 License: base16
-
-The following text applies to code linked from these dependencies:
-[base16](https://github.com/thomcc/rust-base16)
-
-```
-Creative Commons Legal Code
-
-CC0 1.0 Universal
-
-    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
-    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
-    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
-    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
-    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
-    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
-    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
-    HEREUNDER.
-
-Statement of Purpose
-
-The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator
-and subsequent owner(s) (each and all, an "owner") of an original work of
-authorship and/or a database (each, a "Work").
-
-Certain owners wish to permanently relinquish those rights to a Work for
-the purpose of contributing to a commons of creative, cultural and
-scientific works ("Commons") that the public can reliably and without fear
-of later claims of infringement build upon, modify, incorporate in other
-works, reuse and redistribute as freely as possible in any form whatsoever
-and for any purposes, including without limitation commercial purposes.
-These owners may contribute to the Commons to promote the ideal of a free
-culture and the further production of creative, cultural and scientific
-works, or to gain reputation or greater distribution for their Work in
-part through the use and efforts of others.
-
-For these and/or other purposes and motivations, and without any
-expectation of additional consideration or compensation, the person
-associating CC0 with a Work (the "Affirmer"), to the extent that he or she
-is an owner of Copyright and Related Rights in the Work, voluntarily
-elects to apply CC0 to the Work and publicly distribute the Work under its
-terms, with knowledge of his or her Copyright and Related Rights in the
-Work and the meaning and intended legal effect of CC0 on those rights.
-
-1. Copyright and Related Rights. A Work made available under CC0 may be
-protected by copyright and related or neighboring rights ("Copyright and
-Related Rights"). Copyright and Related Rights include, but are not
-limited to, the following:
-
-  i. the right to reproduce, adapt, distribute, perform, display,
-     communicate, and translate a Work;
- ii. moral rights retained by the original author(s) and/or performer(s);
-iii. publicity and privacy rights pertaining to a person's image or
-     likeness depicted in a Work;
- iv. rights protecting against unfair competition in regards to a Work,
-     subject to the limitations in paragraph 4(a), below;
-  v. rights protecting the extraction, dissemination, use and reuse of data
-     in a Work;
- vi. database rights (such as those arising under Directive 96/9/EC of the
-     European Parliament and of the Council of 11 March 1996 on the legal
-     protection of databases, and under any national implementation
-     thereof, including any amended or successor version of such
-     directive); and
-vii. other similar, equivalent or corresponding rights throughout the
-     world based on applicable law or treaty, and any national
-     implementations thereof.
-
-2. Waiver. To the greatest extent permitted by, but not in contravention
-of, applicable law, Affirmer hereby overtly, fully, permanently,
-irrevocably and unconditionally waives, abandons, and surrenders all of
-Affirmer's Copyright and Related Rights and associated claims and causes
-of action, whether now known or unknown (including existing as well as
-future claims and causes of action), in the Work (i) in all territories
-worldwide, (ii) for the maximum duration provided by applicable law or
-treaty (including future time extensions), (iii) in any current or future
-medium and for any number of copies, and (iv) for any purpose whatsoever,
-including without limitation commercial, advertising or promotional
-purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
-member of the public at large and to the detriment of Affirmer's heirs and
-successors, fully intending that such Waiver shall not be subject to
-revocation, rescission, cancellation, termination, or any other legal or
-equitable action to disrupt the quiet enjoyment of the Work by the public
-as contemplated by Affirmer's express Statement of Purpose.
-
-3. Public License Fallback. Should any part of the Waiver for any reason
-be judged legally invalid or ineffective under applicable law, then the
-Waiver shall be preserved to the maximum extent permitted taking into
-account Affirmer's express Statement of Purpose. In addition, to the
-extent the Waiver is so judged Affirmer hereby grants to each affected
-person a royalty-free, non transferable, non sublicensable, non exclusive,
-irrevocable and unconditional license to exercise Affirmer's Copyright and
-Related Rights in the Work (i) in all territories worldwide, (ii) for the
-maximum duration provided by applicable law or treaty (including future
-time extensions), (iii) in any current or future medium and for any number
-of copies, and (iv) for any purpose whatsoever, including without
-limitation commercial, advertising or promotional purposes (the
-"License"). The License shall be deemed effective as of the date CC0 was
-applied by Affirmer to the Work. Should any part of the License for any
-reason be judged legally invalid or ineffective under applicable law, such
-partial invalidity or ineffectiveness shall not invalidate the remainder
-of the License, and in such case Affirmer hereby affirms that he or she
-will not (i) exercise any of his or her remaining Copyright and Related
-Rights in the Work or (ii) assert any associated claims and causes of
-action with respect to the Work, in either case contrary to Affirmer's
-express Statement of Purpose.
-
-4. Limitations and Disclaimers.
-
- a. No trademark or patent rights held by Affirmer are waived, abandoned,
-    surrendered, licensed or otherwise affected by this document.
- b. Affirmer offers the Work as-is and makes no representations or
-    warranties of any kind concerning the Work, express, implied,
-    statutory or otherwise, including without limitation warranties of
-    title, merchantability, fitness for a particular purpose, non
-    infringement, or the absence of latent or other defects, accuracy, or
-    the present or absence of errors, whether or not discoverable, all to
-    the greatest extent permissible under applicable law.
- c. Affirmer disclaims responsibility for clearing rights of other persons
-    that may apply to the Work or any use thereof, including without
-    limitation any person's Copyright and Related Rights in the Work.
-    Further, Affirmer disclaims responsibility for obtaining any necessary
-    consents, permissions or other rights required for any use of the
-    Work.
- d. Affirmer understands and acknowledges that Creative Commons is not a
-    party to this document and has no duty or obligation with respect to
-    this CC0 or use of the Work.
-
-```
--------------
-## ISC License: ring
-
-The following text applies to code linked from these dependencies:
-[ring](https://github.com/briansmith/ring)
-
-```
-
-Copyright 2015-2016 Brian Smith.
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
-SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
-OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
-CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-```
--------------
 ## BSD-2-Clause License: arrayref
 
 The following text applies to code linked from these dependencies:
@@ -1974,47 +1582,5 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-```
--------------
-## BSD-3-Clause License: sqlcipher
-
-The following text applies to code linked from these dependencies:
-[sqlcipher](https://github.com/sqlcipher/sqlcipher)
-
-```
-Copyright (c) 2008, ZETETIC LLC
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the ZETETIC LLC nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY ZETETIC LLC ''AS IS'' AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL ZETETIC LLC BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-```
--------------
-## Optional Notice: SQLite
-
-The following text applies to code linked from these dependencies:
-[sqlite](https://www.sqlite.org/)
-
-```
-This software makes use of the 'SQLite' database engine, and we are very grateful to D. Richard Hipp and team for producing it.
 ```
 -------------

--- a/megazords/ios-rust/Info.plist
+++ b/megazords/ios-rust/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array>
+		<!-- If we want to add desktop builds in future, this is the required snippet:
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>macos-x86_64</string>
+			<key>LibraryPath</key>
+			<string>MozillaRustComponents.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>x86_64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>macos</string>
+		</dict>-->
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>MozillaRustComponents.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64_x86_64-simulator</string>
+			<key>LibraryPath</key>
+			<string>MozillaRustComponents.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+				<string>x86_64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+			<key>SupportedPlatformVariant</key>
+			<string>simulator</string>
+		</dict>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/megazords/ios-rust/MozillaRustComponents.h
+++ b/megazords/ios-rust/MozillaRustComponents.h
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This is the "umbrella header" for our combined Rust code library.
+// It needs to import all of the individual headers.
+
+#import "crashtestFFI.h"
+#import "nimbusFFI.h"
+#import "RustViaductFFI.h"
+#import "RustLogFFI.h"

--- a/megazords/ios-rust/README.md
+++ b/megazords/ios-rust/README.md
@@ -1,0 +1,113 @@
+# XCFramework build for distributing Rust code on iOS
+
+This directory contains the logic for compiling all of our Rust code into a binary
+artifact that can be easily distributed to iOS consumers. If you run the following
+script:
+
+```
+$> ./build-xcframework.sh
+```
+
+Then it should produce a file named `MozillaRustComponents.xcframework.zip` that
+contains:
+
+* The compiled Rust code for all the crates listed in `Cargo.toml`, as a static library,
+* along with their corresponding C header files and Swift module maps,
+* built for all our target iOS platforms, as an "XCFramework" bundle.
+
+The resulting `.zip` is suitable for consumption as a Swift Package binary dependency.
+
+## What's here?
+
+In this directory we have:
+
+* A Rust crate that serves as the "megazord" for our iOS distributions; it basically depends
+  on all the Rust Component crates and re-exports their public APIs.
+* Some skeleton files for building an XCFramework:
+    * `module.modulemap` is a "module map", which tells the Swift compiler how to use C-level APIs.
+    * `MozillaRustComponents.h` is an "umbrella header", used by the module map as a shortcut
+      to specify all the available header files.
+    * `Info.plist` specified metadata about the resulting XCFramework, such as the available
+      architectures and their subdirectories.
+* The `build-xcframework.sh` script which knows how to stitch things together into a full
+  XCFramework bundle.
+    * The XCFramework format is not well documented; briefly:
+        * It's a directory containing resources compiled for multiple target architectures,
+          typically distributed as `.zip` file.
+        * The top-level directory contains a subdirectory per architecture, and an `Info.plist`
+          file that says what things live in which directory.
+        * Each subdirectory contains a `.framework` directory for that architecture. There
+          are notes on the layout of an individual `.framework` in the links below.
+
+It's a little unusual that we're building the XCFramework by hand, rather than defining it
+as the build output of an Xcode project. It turns out to be simpler for our purposes, but
+does risk diverging from the expected format if Apple changes the detailts of XCFrameworks
+in future Xcode releases.
+
+## Adding crates
+
+To add a new crate to the distribution:
+
+1. Update its `uniffi.toml`, if any, to include the following settings:
+    ```
+    [bindings.swift]
+    ffi_module_name = "MozillaRustComponents"
+    ffi_module_filename = "<crate_name>FFI"
+    ```
+1. Add it as a dependency in `Cargo.toml`.
+1. Add a `pub use` declaration for it in `./src/lib.rs`.
+1. Add logic to `build-xcframework.sh` to copy or generate its header file into the build.
+1. Add a `#import` for its header file to `MozillaRustComponents.h`
+
+## Testing locally
+
+For testing out local changes in a consuming app, you can:
+
+* Take a local checkout of https://github.com/mozilla/rust-components-swift.
+* Run `./build-xcframework.sh` to build the XCFramework bundle.
+* Unzip the resulting bundle inside the root of the `rust-components-swift` checkout, and `git add` it.
+* Edit `rust-components-swift/Package.swift` and follow the comments on the `MozillaRustComponents`
+  binary target to point it at the local path.
+* Commit the result to your local checkout, and make a git tag in `MAJOR.MINOR.PATCH` format.
+* Add your local `rust-components-swift` repo as a Swift Package dependency in a consuming app,
+  by specifying `file:///path/to/rust-components-swift` as the git repo.
+    * (You'll have to remove any existing depdency on https://github.com/mozilla/rust-components-swift first)
+
+Note that the XCFramework *must* be committed to the local repo and your changes *must* be included
+in a local git tag. Swift Package Manager is very opinionated and will only pull dependencies from a
+git tag that it can parse as a semver version number.
+
+## Testing from a pre-release commit
+
+For release builds, we publish the resulting `MozillaRustComponents.xcframework.zip` as a GitHub
+release artifact, and then update https://github.com/mozilla/rust-components-swift to point to
+it via URL and hash.
+
+For testing from a PR or unreleased git commit, you can:
+
+* Find the CircleCI job named `ios-artifacts` for the commit you want to test, click through to view it on CircleCI,
+and confirm that it completed successfully.
+* In the "artifacts" list, locate `MozillaRustComponents.xcframework.zip` and note its URL.
+* In the "steps" list, find the step named `XCFramework bundle checksum`, and note the checksum in its output.
+* Take a local checkout of https://github.com/mozilla/rust-components-swift,
+and edit its `Swift.package` to use the above URL and checksum for the `MozillaRustComponents` binary target.
+* Commit the result to your local checkout, and make a git tag in `MAJOR.MINOR.PATCH` format.
+* Add your local `rust-components-swift` repo as a Swift Package dependency in a consuming app,
+  by specifying `file:///path/to/rust-components-swift` as the git repo.
+    * (You'll have to remove any existing depdency on https://github.com/mozilla/rust-components-swift first)
+
+Note that your changes *must* be included in a local git tag. Swift Package Manager is very
+opinionated and will only pull dependencies from a git tag that it can parse as a semver
+version number.
+
+## Further Reading
+
+* The Architecture Design Doc wherein we decided to distribute things this way:
+    * [0003-swift-packaging.md](../../docs/adr/0003-swift-packaging.md)
+* An introduction to the problem that XCFrameworks as designed to solve:
+    * https://blog.embrace.io/xcode-12-and-xcframework/
+* A brief primer on the contents of a Framework, which is useful when you want
+  to construct one by hand:
+    * https://bignerdranch.com/blog/it-looks-like-youre-still-trying-to-use-a-framework/
+* The documentation on Module Maps, which is how C-level code gets exposed to Swift:
+    * https://clang.llvm.org/docs/Modules.html#module-maps

--- a/megazords/ios-rust/build-xcframework.sh
+++ b/megazords/ios-rust/build-xcframework.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# This script builds the Rust crate in its directory into a staticlib XCFramework for iOS.
+
+BUILD_PROFILE="release"
+FRAMEWORK_NAME="MozillaRustComponents"
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+  --build-profile) BUILD_PROFILE="$2"; shift;shift;;
+  --framework-name) FRAMEWORK_NAME="$2"; shift;shift;;
+  *) echo "Unknown parameter: $1"; exit 1;
+esac; done
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REPO_ROOT="$( dirname "$( dirname "$THIS_DIR" )" )"
+
+MANIFEST_PATH="$THIS_DIR/Cargo.toml"
+if [[ ! -f "$MANIFEST_PATH" ]]; then
+  echo "Could not locate Cargo.toml relative to script"
+  exit 1
+fi
+
+CRATE_NAME=$(grep --max-count=1 '^name =' "$MANIFEST_PATH" | cut -d '"' -f 2)
+if [[ -z "$CRATE_NAME" ]]; then
+  echo "Could not determine crate name from $MANIFEST_PATH"
+  exit 1
+fi
+
+LIB_NAME="lib${CRATE_NAME}.a"
+
+####
+##
+## 1) Build the rust code individually for each target architecture.
+##
+####
+
+# Helper to run the cargo build command in a controlled environment.
+# It's important that we don't let environment variables from the user's default
+# desktop build environment leak into the iOS build, otherwise it might e.g.
+# link against the desktop build of NSS.
+
+CARGO="$HOME/.cargo/bin/cargo"
+LIBS_DIR="$REPO_ROOT/libs"
+
+DEFAULT_RUSTFLAGS=""
+BUILD_ARGS=(build --manifest-path "$MANIFEST_PATH" --lib)
+case $BUILD_PROFILE in
+  debug) ;;
+  release)
+    BUILD_ARGS=("${BUILD_ARGS[@]}" --release)
+    # With debuginfo, the zipped artifact quickly baloons to many
+    # hundred megabytes in size. Ideally we'd find a way to keep
+    # the debug info but in a separate artifact.
+    DEFAULT_RUSTFLAGS="-C debuginfo=0"
+    ;;
+  *) echo "Unknown build profile: $BUILD_PROFILE"; exit 1;
+esac
+
+cargo_build () {
+  TARGET=$1
+  case $TARGET in
+    x86_64*)
+      LIBS_DIR="$REPO_ROOT/libs/ios/x86_64";;
+    # TODO: when we want to include crates that depend on SQLCipher or NSS,
+    # we'll need to distinguish between hardware and simulator builds here
+    # and link the later against separately-compiled libraries.
+    # Ref https://github.com/mozilla/application-services/issues/4352.
+    aarch64*)
+      LIBS_DIR="$REPO_ROOT/libs/ios/arm64";;
+    *)
+      echo "Unexpected target architecture: $TARGET" && exit 1;;
+  esac
+  env -i \
+    NSS_STATIC=1 \
+    NSS_DIR="$LIBS_DIR/nss" \
+    SQLCIPHER_STATIC=1 \
+    SQLCIPHER_LIB_DIR="${LIBS_DIR}/sqlcipher/lib" \
+    SQLCIPHER_INCLUDE_DIR="${LIBS_DIR}/sqlcipher/include" \
+    PATH="${PATH}" \
+    RUSTC_WRAPPER="${RUSTC_WRAPPER:-}" \
+    SCCACHE_IDLE_TIMEOUT="${SCCACHE_IDLE_TIMEOUT:-}" \
+    SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-}" \
+    SCCACHE_ERROR_LOG="${SCCACHE_ERROR_LOG:-}" \
+    RUST_LOG="${RUST_LOG:-}" \
+    RUSTFLAGS="${RUSTFLAGS:-$DEFAULT_RUSTFLAGS}" \
+    "$CARGO" "${BUILD_ARGS[@]}" --target "$TARGET"
+}
+
+set -euvx
+
+# Intel iOS simulator
+# TODO: why is the env var necessary?
+CFLAGS_x86_64_apple_ios="-target x86_64-apple-ios" \
+  cargo_build x86_64-apple-ios
+
+# Hardware iOS targets
+cargo_build aarch64-apple-ios
+
+# M1 iOS simulator.
+# It's currently in Nightly only and requires to build `libstd`.
+# We hope this will be available by default in Rust 1.56.0.
+BUILD_ARGS=(+nightly "${BUILD_ARGS[@]}" -Z build-std)
+cargo_build aarch64-apple-ios-sim
+
+# TODO: would it be useful to also include desktop builds here?
+# It might make it possible to run the Swift tests via `swift test`
+# rather than through Xcode.
+
+####
+##
+## 2) Stitch the individual builds together an XCFramework bundle.
+##
+####
+
+TARGET_DIR="$REPO_ROOT/target"
+XCFRAMEWORK_ROOT="$THIS_DIR/$FRAMEWORK_NAME.xcframework"
+
+# Start from a clean slate.
+
+rm -rf "$XCFRAMEWORK_ROOT"
+
+# Build the directory structure right for an individual framework.
+# Most of this doesn't change between architectures.
+
+COMMON="$XCFRAMEWORK_ROOT/common/$FRAMEWORK_NAME.framework"
+
+mkdir -p "$COMMON/Modules"
+cp "$THIS_DIR/module.modulemap" "$COMMON/Modules/"
+
+cp "$THIS_DIR/DEPENDENCIES.md" "$COMMON/DEPENDENCIES.md"
+
+mkdir -p "$COMMON/Headers"
+cp "$THIS_DIR/MozillaRustComponents.h" "$COMMON/Headers"
+cp "$REPO_ROOT/components/rc_log/ios/RustLogFFI.h" "$COMMON/Headers"
+cp "$REPO_ROOT/components/viaduct/ios/RustViaductFFI.h" "$COMMON/Headers"
+# TODO: it would be neat if there was a single UniFFI command that would spit out
+# all of the generated headers for all UniFFIed dependencies of a given crate.
+# For now we generate the Swift bindings to get the headers as a side effect,
+# then delete the generated Swift code. Bleh.
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/crashtest/src/crashtest.udl" -l swift -o "$COMMON/Headers"
+rm -rf "$COMMON"/Headers/*.swift
+
+# Flesh out the framework for each architecture based on the common files.
+# It's a little fiddly, because we apparently need to put all the simulator targets
+# together into a single fat binary, but keep the hardware target separate.
+# (TODO: we should try harder to see if we can avoid using `lipo` here, eliminating it
+# would make the overall system simpler to understand).
+
+# iOS hardware
+mkdir -p "$XCFRAMEWORK_ROOT/ios-arm64"
+cp -r "$COMMON" "$XCFRAMEWORK_ROOT/ios-arm64/$FRAMEWORK_NAME.framework"
+cp "$TARGET_DIR/aarch64-apple-ios/$BUILD_PROFILE/$LIB_NAME" "$XCFRAMEWORK_ROOT/ios-arm64/$FRAMEWORK_NAME.framework/$FRAMEWORK_NAME"
+
+# iOS simulator, with both platforms as a fat binary for mysterious reasons
+mkdir -p "$XCFRAMEWORK_ROOT/ios-arm64_x86_64-simulator"
+cp -r "$COMMON" "$XCFRAMEWORK_ROOT/ios-arm64_x86_64-simulator/$FRAMEWORK_NAME.framework"
+lipo -create \
+  -output "$XCFRAMEWORK_ROOT/ios-arm64_x86_64-simulator/$FRAMEWORK_NAME.framework/$FRAMEWORK_NAME" \
+  "$TARGET_DIR/aarch64-apple-ios-sim/$BUILD_PROFILE/$LIB_NAME" \
+  "$TARGET_DIR/x86_64-apple-ios/$BUILD_PROFILE/$LIB_NAME"
+
+# Set up the metadata for the XCFramework as a whole.
+
+cp "$THIS_DIR/Info.plist" "$XCFRAMEWORK_ROOT/Info.plist"
+cp "$THIS_DIR/DEPENDENCIES.md" "$XCFRAMEWORK_ROOT/DEPENDENCIES.md"
+
+rm -rf "$XCFRAMEWORK_ROOT/common"
+
+# Zip it all up into a bundle for distribution.
+
+(cd "$THIS_DIR" && zip -9 -r "$FRAMEWORK_NAME.xcframework.zip" "$FRAMEWORK_NAME.xcframework")
+rm -rf "$XCFRAMEWORK_ROOT"

--- a/megazords/ios-rust/module.modulemap
+++ b/megazords/ios-rust/module.modulemap
@@ -1,0 +1,6 @@
+framework module MozillaRustComponents {
+  umbrella header "MozillaRustComponents.h"
+
+  export *
+  module * { export * }
+}

--- a/megazords/ios-rust/src/lib.rs
+++ b/megazords/ios-rust/src/lib.rs
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
+
+pub use crashtest;
+pub use nimbus;
+pub use rc_log_ffi;
+pub use viaduct_reqwest;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -14,6 +14,8 @@ targets = [
     "i686-linux-android",
     "x86_64-linux-android",
     "aarch64-apple-ios",
-    "x86_64-apple-ios"
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
 ]
-components = ["clippy", "rustfmt"]
+# The "rust-src" component is currently required for building for the M1 iOS simulator.
+components = ["clippy", "rustfmt", "rust-src"]

--- a/tools/regenerate_dependency_summaries.sh
+++ b/tools/regenerate_dependency_summaries.sh
@@ -5,6 +5,7 @@ set -euvx
 python3 ./tools/dependency_summary.py > ./DEPENDENCIES.md
 
 python3 ./tools/dependency_summary.py --all-ios-targets --package megazord_ios > megazords/ios/DEPENDENCIES.md
+python3 ./tools/dependency_summary.py --all-ios-targets --package ios_rust > megazords/ios-rust/DEPENDENCIES.md
 
 python3 ./tools/dependency_summary.py --all-android-targets --package megazord > megazords/full/DEPENDENCIES.md
 python3 ./tools/dependency_summary.py --all-android-targets --package megazord --format pom > megazords/full/android/dependency-licenses.xml


### PR DESCRIPTION
(Opening as a draft for early visibility)

This is an experiment in making our iOS build process more compatible
with M1 Mac build environments, and easier to consume via Swift Packages.

In our existing iOS build setup, we compile together all of the Rust
code and all of the wrapping Swift code into a single module named
"MozillaAppServices". This is a bit of a violation of clean package
separation, because it means that we risk name conflicts in the Swift
code between different components.

In this new setup, we don't pre-compile any of the Swift code. Instead
we build only the Rust code, package it along with its associated headers,
tell Swift to treat this as a module named "MozillaRustComponents".
Each individual Swift wrapper can then `import MozillaRustComponents`
and get access to the low-level FFI functions that it needs.

An additional benefit of this setup is that we can distribute it as
a `.xcframework` bundle for easy consumption on different platforms,
and we can build it without using XCode.
