### PR TITLE
Fix uniffi logins crash when there is no DB

### DIFF
--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -81,7 +81,7 @@ open class LoginsStorage {
             if self.store != nil {
                 throw LoginsStoreError.MismatchedLock(message: "Mismatched Lock")
             }
-            try! openAndMigrateToPlaintextHeader(path: self.dbPath, encryptionKey: key, salt: salt)
+            try openAndMigrateToPlaintextHeader(path: self.dbPath, encryptionKey: key, salt: salt)
         }
     }
 


### PR DESCRIPTION
This is related to the uniffi effort for the logins crate

fxiOS currently crashes when testing locally on https://github.com/mozilla-mobile/firefox-ios/pull/8602 due to creating a new DB and trying to migrate https://github.com/mozilla-mobile/firefox-ios/blob/041c85483b1aa4a4e357d8bd9419550e4f20347a/Storage/Rust/RustLogins.swift#L113

**Note: This will require a package update to be able to use in the PR above**


---

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
