### PR TITLE
Surface our Rustdoc documentation

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -17,8 +17,6 @@ jobs:
           echo 'rust.targets=linux-x86-64' > local.properties
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source $HOME/.cargo/env
-          cargo install mdbook mdbook-mermaid mdbook-open-on-gh
-          ./tools/build-book.sh
  
       - name: Build Dependencies and Generate Rust Docs
         env: 
@@ -36,8 +34,13 @@ jobs:
           ./libs/verify-desktop-environment.sh
           cargo doc --no-deps
           echo '<meta http-equiv=refresh content=0;url=fxa_client>' > target/doc/index.html
-          mkdir -p build/docs/rust-docs
-          cp -rf target/doc/* build/docs/rust-docs
+          mkdir -p docs/rust-docs
+          cp -rf target/doc/* docs/rust-docs
+      
+      - name: Build mdbook
+        run: |
+          cargo install mdbook mdbook-mermaid mdbook-open-on-gh
+          ./tools/build-book.sh
           
       - name: Deploy
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ __pycache__
 # Generated mdbook documentation files
 build/docs/*
 docs/book
+
+# Generated rustdocs
+docs/rust-docs

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The [Application Services Book](https://mozilla.github.io/application-services/b
 
 ### Package docs
 
-We use rustdoc to document both the public API of the components and the various internal implementation details.  View them on [https://mozilla.github.io/application-services/rust-docs/](https://mozilla.github.io/application-services/rust-docs/).  Once you have completed the build steps, you can view the docs by running:
+We use rustdoc to document both the public API of the components and the various internal implementation details.  View them on [https://mozilla.github.io/application-services/book/rust-docs/fxa_client/index.html](https://mozilla.github.io/application-services/book/rust-docs/fxa_client/index.html).  Once you have completed the build steps, you can view the docs by running:
 
 ```shell
 cargo doc --no-deps --document-private-items --open

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -26,4 +26,5 @@
   - [How to upgrade NSS](howtos/upgrading-nss-guide.md)
 - [Sync overview](sync-overview.md)
 - [Metrics - (Glean Telemetry)](metrics.md)
+- [Rustdocs for components](rust-docs/fxa_client/index.html)
 - [Adding to these documents](adding-docs.md)


### PR DESCRIPTION
I almost went through adding them myself before I realized they already existed.

- Changed the github actions job to copy the docs directly into the `docs` directory for ease of reference from the book
- Referenced the rust-docs from both our book and our README.md

I'm crossing my fingers that everything works here, it works locally. Does anyone know if there's a "See what the docs would look like if the PR is merged" kind of feature with our docs?


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
