### PR TITLE
update README to no longer use logins as ffi example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The application-services library primary consumers are Fenix (Firefox on Android
 
 [./components/](components) contains the source for each component, and its
   FFI bindings.
+
+> Please note that we are in the process of moving away from hand-written ffi code and instead favouring the use of the [uniffi](https://github.com/mozilla/uniffi-rs/) library.
 * See [./components/push/](components/places) for an example, where you can
     find:
   * The shared [rust code](components/places/src).

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ The application-services library primary consumers are Fenix (Firefox on Android
 
 [./components/](components) contains the source for each component, and its
   FFI bindings.
-* See [./components/logins/](components/logins) for an example, where you can
+* See [./components/push/](components/push) for an example, where you can
     find:
-  * The shared [rust code](components/logins/src).
-  * The mapping into a [C FFI](components/logins/ffi).
-  * The [Kotlin bindings](components/logins/android) for use by Android
+  * The shared [rust code](components/push/src).
+  * The mapping into a [C FFI](components/push/ffi).
+  * The [Kotlin bindings](components/push/android) for use by Android
       applications.
-  * The [Swift bindings](components/logins/ios) for use by iOS applications.
+  * The [Swift bindings](components/push/ios) for use by iOS applications.
 * See [./components/fxa-client](components/fxa-client) for an example that uses
     [uniffi](https://github.com/mozilla/uniffi-rs/) to generate API wrappers for
     multiple languages, such as Kotlin and Swift.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ The application-services library primary consumers are Fenix (Firefox on Android
 
 [./components/](components) contains the source for each component, and its
   FFI bindings.
-* See [./components/push/](components/push) for an example, where you can
+* See [./components/push/](components/places) for an example, where you can
     find:
-  * The shared [rust code](components/push/src).
-  * The mapping into a [C FFI](components/push/ffi).
-  * The [Kotlin bindings](components/push/android) for use by Android
+  * The shared [rust code](components/places/src).
+  * The mapping into a [C FFI](components/places/ffi).
+  * The [Kotlin bindings](components/places/android) for use by Android
       applications.
-  * The [Swift bindings](components/push/ios) for use by iOS applications.
+  * The [Swift bindings](components/places/ios) for use by iOS applications.
 * See [./components/fxa-client](components/fxa-client) for an example that uses
     [uniffi](https://github.com/mozilla/uniffi-rs/) to generate API wrappers for
     multiple languages, such as Kotlin and Swift.


### PR DESCRIPTION
Tiny PR to use places instead of logins as an example of the a-s README since it's now officially uniffi-ed 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
