### PR TITLE
Adds v1 to the experiment server's URL

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -1,10 +1,10 @@
 **See [the release process docs](docs/howtos/cut-a-new-release.md) for the steps to take when cutting a new release.**
 
 # Unreleased Changes
-
 ## Nimbus
 ### What's changed
   - Fixed a bug where opt-in enrollments in experiments were not preserved when the application is restarted ([#4324](https://github.com/mozilla/application-services/pull/4324))
+  - The nimbus component now specifies the version of the server's api - currently V1. That was done to avoid redirects. ([#4319](https://github.com/mozilla/application-services/pull/4319))
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v80.0.1...main)
 

--- a/components/nimbus/src/client/http_client.rs
+++ b/components/nimbus/src/client/http_client.rs
@@ -109,7 +109,10 @@ impl SettingsClient for Client {
     }
 
     fn fetch_experiments(&self) -> Result<Vec<Experiment>> {
-        let path = format!("buckets/main/collections/{}/records", &self.collection_name);
+        let path = format!(
+            "v1/buckets/main/collections/{}/records",
+            &self.collection_name
+        );
         let url = self.base_url.join(&path)?;
         let req = Request::get(url);
         let resp = self.make_request(req)?;
@@ -270,7 +273,7 @@ mod tests {
         // in order to test filtering of unsupported schema versions.
         let m = mock(
             "GET",
-            "/buckets/main/collections/messaging-experiments/records",
+            "/v1/buckets/main/collections/messaging-experiments/records",
         )
         .with_body(response_body())
         .with_status(200)
@@ -341,7 +344,7 @@ mod tests {
         viaduct_reqwest::use_reqwest_backend();
         let m = mock(
             "GET",
-            "/buckets/main/collections/messaging-experiments/records",
+            "/v1/buckets/main/collections/messaging-experiments/records",
         )
         .with_body(response_body())
         .with_status(200)
@@ -364,7 +367,7 @@ mod tests {
         viaduct_reqwest::use_reqwest_backend();
         let m = mock(
             "GET",
-            "/buckets/main/collections/messaging-experiments/records",
+            "/v1/buckets/main/collections/messaging-experiments/records",
         )
         .with_body("Boom!")
         .with_status(500)
@@ -386,7 +389,7 @@ mod tests {
         viaduct_reqwest::use_reqwest_backend();
         let m = mock(
             "GET",
-            "/buckets/main/collections/messaging-experiments/records",
+            "/v1/buckets/main/collections/messaging-experiments/records",
         )
         .with_body(response_body())
         .with_status(200)


### PR DESCRIPTION
Fixes https://mozilla-hub.atlassian.net/browse/SDK-306

Added a `v1` to the URL per our discussion in Nimbus check-in. Also modified the mockito test and ran the demo using the `show-experiments` subcommand and it displayed experiments from the server.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
