### PR TITLE
Eliminate outdated UAID's from push component

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -1,10 +1,6 @@
 **See [the release process docs](docs/howtos/cut-a-new-release.md) for the steps to take when cutting a new release.**
 
 # Unreleased Changes
-## Nimbus
-### What's changed
-  - Fixed a bug where opt-in enrollments in experiments were not preserved when the application is restarted ([#4324](https://github.com/mozilla/application-services/pull/4324))
-  - The nimbus component now specifies the version of the server's api - currently V1. That was done to avoid redirects. ([#4319](https://github.com/mozilla/application-services/pull/4319))
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v80.0.1...main)
 
@@ -22,7 +18,15 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+## Nimbus
+### What's changed
+  - Fixed a bug where opt-in enrollments in experiments were not preserved when the application is restarted ([#4324](https://github.com/mozilla/application-services/pull/4324))
+  - The nimbus component now specifies the version of the server's api - currently V1. That was done to avoid redirects. ([#4319](https://github.com/mozilla/application-services/pull/4319))
+
+## Push
+### What's changed
+  - Fixed a bug where we don't delete a client's UAID locally when it's deleted on the server ([#4325](https://github.com/mozilla/application-services/pull/4325))
 
 ## Tabs
-
-Tabs has been Uniffi-ed!
+### ⚠️ Breaking Changes ⚠️
+ - Tabs has been Uniffi-ed! ([#4192](https://github.com/mozilla/application-services/pull/4192))


### PR DESCRIPTION
Relates to #3695 

For context: https://github.com/mozilla/application-services/issues/3695#issuecomment-876639532

Basically, whenever we unsubscribe from **all** channels, we also want to make sure we dump the UAID on the component and all associated records, the server does that anyways. The theory behind the problem we were getting is that we keep an invalid `UAID` in memory, then send it over to the server, the server rightfully so complains because we already told it that the UAID is invalid.

This change will hopefully force us to re-generate a new UAID on the next subscribe instead of using a stale one.

Keeping as a draft until I add a quick test in the component and give it a quick run to make sure nothing big broke

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
