### PR TITLE
PrivateSendTabKeys should encode commands_data as base64

### DIFF
--- a/components/fxa-client/src/internal/commands/send_tab.rs
+++ b/components/fxa-client/src/internal/commands/send_tab.rs
@@ -115,13 +115,15 @@ impl PrivateSendTabKeys {
     // `serde_json::to_string` would compile because both types derive
     // `Serialize`.
     pub(crate) fn serialize(&self) -> Result<String> {
-        Ok(serde_json::to_string(&VersionnedPrivateSendTabKeys::V1(
-            self.clone(),
-        ))?)
+        Ok(base64::encode_config(
+            serde_json::to_string(&VersionnedPrivateSendTabKeys::V1(self.clone()))?,
+            base64::URL_SAFE_NO_PAD,
+        ))
     }
 
     pub(crate) fn deserialize(s: &str) -> Result<Self> {
-        let versionned: VersionnedPrivateSendTabKeys = serde_json::from_str(s)?;
+        let decoded = base64::decode(s)?;
+        let versionned: VersionnedPrivateSendTabKeys = serde_json::from_slice(&decoded)?;
         match versionned {
             VersionnedPrivateSendTabKeys::V1(prv_key) => Ok(prv_key),
         }


### PR DESCRIPTION
fixes #3999

After looking through the code and the example, it seems like the general trend is to use base64 crate to encode/decode the keys when necessary. I took this approach and can validate and send tabs successfully so it seems to be the right thing to do? Definitely would like feedback if this is the right approach.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
