### PR TITLE
Make sure limit param is of the correct type at FFI boundary

### DIFF
--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -542,10 +542,10 @@ pub extern "C" fn places_get_history_metadata_since(
 pub extern "C" fn places_query_history_metadata(
     handle: u64,
     query: FfiStr<'_>,
-    limit: i64,
+    limit: i32,
     error: &mut ExternError,
 ) -> ByteBuffer {
-    log::debug!("places_get_history_metadata_since");
+    log::debug!("places_query_history_metadata");
     CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
         storage::history_metadata::query(conn, query.as_str(), limit)
     })

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -246,7 +246,7 @@ pub fn get_since(db: &PlacesDb, start: i64) -> Result<HistoryMetadataList> {
     Ok(HistoryMetadataList { metadata })
 }
 
-pub fn query(db: &PlacesDb, query: &str, limit: i64) -> Result<HistoryMetadataList> {
+pub fn query(db: &PlacesDb, query: &str, limit: i32) -> Result<HistoryMetadataList> {
     let metadata = db.query_rows_and_then_named_cached(
         QUERY_SQL.as_str(),
         rusqlite::named_params! {


### PR DESCRIPTION
As a result of data type mismatch (Kt header file specifies Int, ffi/lib.rs specifies i64), this function was crashing on x86 emulators - but not on arm64 devices!

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
