### PR TITLE
Fixes panic when indexing hashmap in tabs

### DIFF
--- a/components/tabs/src/sync/record.rs
+++ b/components/tabs/src/sync/record.rs
@@ -82,7 +82,10 @@ impl TabsRecord {
             .into_iter()
             .collect::<Result<_>>()?;
 
-        let ttl: u32 = payload.data["ttl"].as_u64().unwrap_or_default() as u32;
+        let ttl: u32 = match payload.data.get("ttl") {
+            Some(v) => v.as_u64().unwrap_or_default() as u32,
+            None => u32::default(),
+        };
 
         Ok(TabsRecord {
             id,


### PR DESCRIPTION
Fixes a problem that I got locally where sync manager panics when syncing tabs and poisons the mutex for future syncs

I think we should also have two todos beyond this PR:
- Figure out _why_ I had a payload without a `ttl`, there could be a very intuitive answer to this
- Figure out if there is an easy way to test stuff like this, it seems **very** hard to do so though 😞 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
