### PR TITLE
Add test for `ttl` parsing during Tabs syncing

### DIFF
--- a/components/tabs/src/sync/record.rs
+++ b/components/tabs/src/sync/record.rs
@@ -400,4 +400,103 @@ pub(crate) mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_tabs_record_from_payload_ttl_values() -> Result<()> {
+        struct TestCase {
+            case_description: String,
+            data: JsonValue,
+            expected_ttl: u32,
+        }
+
+        let test_cases = vec![
+            TestCase {
+                case_description: "test missing ttl".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": "",
+                            "urlHistory": [],
+                            "lastUsed": 0
+                        }
+                    ],
+                }),
+                expected_ttl: 0,
+            },
+            TestCase {
+                case_description: "test null ttl".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": "",
+                            "urlHistory": [],
+                            "lastUsed": 0
+                        }
+                    ],
+                    "ttl": null,
+                }),
+                expected_ttl: 0,
+            },
+            TestCase {
+                case_description: "test sequence ttl".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": "",
+                            "urlHistory": [],
+                            "lastUsed": 0
+                        }
+                    ],
+                    "ttl": [],
+                }),
+                expected_ttl: 0,
+            },
+            TestCase {
+                case_description: "test string ttl".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": "",
+                            "urlHistory": [],
+                            "lastUsed": 0
+                        }
+                    ],
+                    "ttl": "",
+                }),
+                expected_ttl: 0,
+            },
+            TestCase {
+                case_description: "test non-zero ttl".to_string(),
+                data: json!({
+                    "clientName": "Nightly",
+                    "tabs": [
+                        {
+                            "title": "",
+                            "urlHistory": [],
+                            "lastUsed": 0
+                        }
+                    ],
+                    "ttl": 4,
+                }),
+                expected_ttl: 4,
+            },
+        ];
+
+        for tc in test_cases {
+            let actual = TabsRecord::from_payload(sync15::Payload {
+                id: Guid::random(),
+                deleted: false,
+                data: tc.data.as_object().unwrap().clone(),
+            });
+
+            assert!(actual.is_ok(), "{}", tc.case_description);
+            assert_eq!(actual?.ttl, tc.expected_ttl);
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Just adding test cases to cover the fix @tarikeshaq created in #4335 for the `ttl` population bug I introduced in the refactor of the `from_record` function. I'm stunned with all the tests I created this slipped through the cracks. 😅

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
