### PR TITLE
Cut release v81.0.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 80.0.1
+libraryVersion: 81.0.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+# v81.0.0 (_2021-07-13_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v80.0.1...v81.0.0)
+
+## Tabs
+### ⚠️ Breaking Changes ⚠️
+ - Tabs has been Uniffi-ed! ([#4192](https://github.com/mozilla/application-services/pull/4192))
+    - Manual calling of sync() is removed
+    - registerWithSyncManager() should be used instead
+    - Tab struct member lastUsed is now a U64
+## Nimbus
+### What's changed
+  - Fixed a bug where opt-in enrollments in experiments were not preserved when the application is restarted ([#4324](https://github.com/mozilla/application-services/pull/4324))
+  - The nimbus component now specifies the version of the server's api - currently V1. That was done to avoid redirects. ([#4319](https://github.com/mozilla/application-services/pull/4319))
+
+## Push
+### What's changed
+  - Fixed a bug where we don't delete a client's UAID locally when it's deleted on the server ([#4325](https://github.com/mozilla/application-services/pull/4325))
+
+
 # v80.0.1 (_2021-07-06_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v80.0.0...v80.0.1)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v80.0.1...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v81.0.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,15 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-## Nimbus
-### What's changed
-  - Fixed a bug where opt-in enrollments in experiments were not preserved when the application is restarted ([#4324](https://github.com/mozilla/application-services/pull/4324))
-  - The nimbus component now specifies the version of the server's api - currently V1. That was done to avoid redirects. ([#4319](https://github.com/mozilla/application-services/pull/4319))
-
-## Push
-### What's changed
-  - Fixed a bug where we don't delete a client's UAID locally when it's deleted on the server ([#4325](https://github.com/mozilla/application-services/pull/4325))
-
-## Tabs
-### ⚠️ Breaking Changes ⚠️
- - Tabs has been Uniffi-ed! ([#4192](https://github.com/mozilla/application-services/pull/4192))


### PR DESCRIPTION
Cutting release 81.0.0, changelog:
# v81.0.0 (_2021-07-13_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v80.0.1...v81.0.0)

## Tabs
### ⚠️ Breaking Changes ⚠️
 - Tabs has been Uniffi-ed! ([#4192](https://github.com/mozilla/application-services/pull/4192))
    - Manual calling of sync() is removed
    - registerWithSyncManager() should be used instead
    - Tab struct member lastUsed is now a U64
## Nimbus
### What's changed
  - Fixed a bug where opt-in enrollments in experiments were not preserved when the application is restarted ([#4324](https://github.com/mozilla/application-services/pull/4324))
  - The nimbus component now specifies the version of the server's api - currently V1. That was done to avoid redirects. ([#4319](https://github.com/mozilla/application-services/pull/4319))

## Push
### What's changed
  - Fixed a bug where we don't delete a client's UAID locally when it's deleted on the server ([#4325](https://github.com/mozilla/application-services/pull/4325))

 
