### PR TITLE
Rewrite logins migration

### DIFF
--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -115,12 +115,16 @@ mod tests {
             ALTER TABLE loginsL RENAME passwordEnc to password;
             ALTER TABLE loginsM RENAME usernameEnc to username;
             ALTER TABLE loginsM RENAME passwordEnc to password;
-            INSERT INTO loginsL(guid, username, password, origin,
-            httpRealm, formActionOrigin, usernameField, passwordField, timeCreated, timeLastUsed,
+            ALTER TABLE loginsL RENAME origin to hostname;
+            ALTER TABLE loginsL RENAME formActionOrigin to formSubmitURL;
+            ALTER TABLE loginsM RENAME origin to hostname;
+            ALTER TABLE loginsM RENAME formActionOrigin to formSubmitURL;
+            INSERT INTO loginsL(guid, username, password, hostname,
+            httpRealm, formSubmitURL, usernameField, passwordField, timeCreated, timeLastUsed,
             timePasswordChanged, timesUsed, local_modified, is_deleted, sync_status)
             VALUES ('a', 'test', 'password', 'https://www.example.com', NULL, 'https://www.example.com',
             'username', 'password', 1000, 1000, 1, 10, 1000, 0, 2);
-            INSERT INTO loginsM(guid, username, password, origin, httpRealm, formActionOrigin,
+            INSERT INTO loginsM(guid, username, password, hostname, httpRealm, formSubmitURL,
             usernameField, passwordField, timeCreated, timeLastUsed, timePasswordChanged, timesUsed,
             is_overridden, server_modified)
             VALUES ('b', 'test', 'password', 'https://www.example.com', 'Test Realm', NULL,

--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -10,7 +10,7 @@ use crate::error::*;
 use crate::Login;
 use crate::LoginStore;
 use lazy_static::lazy_static;
-use rusqlite::{Connection, NO_PARAMS};
+use rusqlite::{Connection, Row, NO_PARAMS};
 use sql_support::ConnExt;
 use std::path::Path;
 use std::time::Instant;
@@ -32,7 +32,9 @@ pub const SQL_CIPHER_COLS: &str = "
 ";
 
 lazy_static! {
-    pub static ref GET_BY_GUID_SQL: String = format!(
+    // pub static ref GET_JOINED_LOGINS_SQL: String =
+    //     format!("SELECT * FROM loginsL LEFT JOIN loginsM ON loginsL.guid = loginsM.guid");
+    pub static ref GET_ALL_SQL: String = format!(
         "SELECT {common_cols}
          FROM loginsL
          WHERE is_deleted = 0
@@ -111,56 +113,23 @@ pub fn migrate_from_sqlcipher_db(
 
     // Select From both LoginsL and LoginsM with a union to ensure we're covering our
     // migration cases (one table has but not the other, etc)
-    let mut select_stmt = cipher_conn.prepare(&GET_BY_GUID_SQL)?;
+    let mut select_stmt = cipher_conn.prepare(&GET_ALL_SQL)?;
+
+    // encrypt the username/password data
+    let encryptor = EncryptorDecryptor::new(encryption_key)?;
 
     // Use raw rows to avoid extra copying since we're looping over an entire table
     let mut rows = select_stmt.query(NO_PARAMS)?;
     while let Some(row) = rows.next()? {
         metrics.num_processed += 1;
-        let guid: String = row.get("guid")?;
-        let username: String = row.get("username").unwrap_or_default();
-        let password: String = row.get("password")?;
-        // migrating hostname to the new column origin
-        let origin: String = row.get("hostname")?;
-        let http_realm: Option<String> = row.get("httpRealm")?;
-        // migrating formSubmitURL to the new column action origin
-        let form_action_origin: Option<String> = row.get("formSubmitURL")?;
-        let username_field: Option<String> = row.get("usernameField")?;
-        let password_field: Option<String> = row.get("passwordField")?;
-        let time_created: i64 = row.get("timeCreated")?;
-        let time_last_used: i64 = row.get("timeLastUsed").unwrap_or_default();
-        let time_password_changed: i64 = row.get("timePasswordChanged")?;
-        let times_used: i64 = row.get("timesUsed")?;
-
-        // TODO: Discuss
-        // Need to handle in loginsL: local_modified, is_deleted
-        // Feels like we potentially shouldn't migrate these fields?
-
-        // Need to handle in loginsM: is_overridden, server_modified
-        // Similar to the other: I only see server_modified potentially being needed
-
-        // encrypt the username/password data
-        let encryptor = EncryptorDecryptor::new(encryption_key)?;
-        let login: Login = Login {
-            id: guid.to_string(),
-            username_enc: encryptor.encrypt(&username)?,
-            password_enc: encryptor.encrypt(&password)?,
-            origin,
-            http_realm,
-            form_action_origin,
-            username_field: username_field.unwrap_or_default(),
-            password_field: password_field.unwrap_or_default(),
-            // TO_DO: Do we need to convert from microsecond timestamps to milliseconds??
-            time_created,
-            time_last_used,
-            time_password_changed,
-            times_used,
-        };
-
-        // Leveraging the add_or_update to get free fixup
-        match new_db_store.add_or_update(login) {
-            Ok(_) => {
+        match get_login_from_row(row, &encryptor) {
+            Ok(login) => {
                 metrics.num_succeeded += 1;
+                // TODO: Discuss
+                // Need to handle in loginsL: local_modified, is_deleted
+                // Need to handle in loginsM: is_overridden, server_modified
+                // Could create a LocalLogin/Mirror Login but sql probably easier
+                new_db_store.add_or_update(login)?;
             }
             Err(e) => {
                 metrics.num_failed += 1;
@@ -171,6 +140,49 @@ pub fn migrate_from_sqlcipher_db(
 
     metrics.total_duration = start_time.elapsed().as_millis() as u64;
     Ok(metrics)
+}
+
+// Convert rows from old schema to match new fields in the Login struct
+fn get_login_from_row(row: &Row<'_>, encryptor: &EncryptorDecryptor) -> Result<Login> {
+    // We want to grab the "old" schema
+    let guid: String = row.get("guid")?;
+    let username: String = row.get("username").unwrap_or_default();
+    let password: String = row.get("password")?;
+    // migrating hostname to the new column origin
+    let origin: String = row.get("hostname")?;
+    let http_realm: Option<String> = row.get("httpRealm")?;
+    // migrating formSubmitURL to the new column action origin
+    let form_action_origin: Option<String> = row.get("formSubmitURL")?;
+    let username_field: Option<String> = row.get("usernameField")?;
+    let password_field: Option<String> = row.get("passwordField")?;
+    let time_created: i64 = row.get("timeCreated")?;
+    let time_last_used: i64 = row.get("timeLastUsed").unwrap_or_default();
+    let time_password_changed: i64 = row.get("timePasswordChanged")?;
+    let times_used: i64 = row.get("timesUsed")?;
+
+    let login: Login = Login {
+        id: guid.to_string(),
+        username_enc: encryptor.encrypt(&username)?,
+        password_enc: encryptor.encrypt(&password)?,
+        origin,
+        http_realm,
+        form_action_origin,
+        username_field: username_field.unwrap_or_default(),
+        password_field: password_field.unwrap_or_default(),
+        // TO_DO: Do we need to convert from microsecond timestamps to milliseconds??
+        time_created,
+        time_last_used,
+        time_password_changed,
+        times_used,
+    };
+
+    match login.fixup() {
+        Ok(fixed_login) => {
+            return Ok(fixed_login);
+        }
+        // We want to skip any invalid logins
+        Err(e) => return Err(e),
+    }
 }
 
 #[cfg(test)]
@@ -209,12 +221,20 @@ mod tests {
             INSERT INTO loginsL(guid, username, password, hostname,
             httpRealm, formSubmitURL, usernameField, passwordField, timeCreated, timeLastUsed,
             timePasswordChanged, timesUsed, local_modified, is_deleted, sync_status)
-            VALUES ('a', 'test', 'password', 'https://www.example.com', NULL, 'https://www.example.com',
+            VALUES
+            ('a', 'test', 'password', 'https://www.example.com', NULL, 'https://www.example.com',
+            'username', 'password', 1000, 1000, 1, 10, 1000, 0, 2),
+            ('b', 'test', 'password', 'https://www.example.com', 'https://www.example.com', 'https://www.example.com',
             'username', 'password', 1000, 1000, 1, 10, 1000, 0, 2);
             INSERT INTO loginsM(guid, username, password, hostname, httpRealm, formSubmitURL,
             usernameField, passwordField, timeCreated, timeLastUsed, timePasswordChanged, timesUsed,
             is_overridden, server_modified)
-            VALUES ('b', 'test', 'password', 'https://www.example.com', 'Test Realm', NULL,
+            VALUES
+            ('b', 'test', 'password', 'https://www.example.com', 'Test Realm', NULL,
+            '', '', 1000, 1000, 1, 10, 0, 1000),
+            ('c', 'test', 'password', 'http://example.com:1234/', 'Test Realm', NULL,
+            '', '', 1000, 1000, 1, 10, 0, 1000),
+            ('d', 'test', 'password', 'http://example.com/foo?query=bbq#bar', 'Test Realm', NULL,
             '', '', 1000, 1000, 1, 10, 0, 1000);
             PRAGMA user_version = 4;
             ",
@@ -358,11 +378,11 @@ mod tests {
         let db = LoginDb::open(testpaths.new_db).unwrap();
         assert_eq!(
             db.query_one::<i32>("SELECT COUNT(*) FROM loginsL").unwrap(),
-            1
+            2
         );
         assert_eq!(
             db.query_one::<i32>("SELECT COUNT(*) FROM loginsM").unwrap(),
-            0
+            2
         );
 
         // Check metrics

--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -202,16 +202,12 @@ mod tests {
             ALTER TABLE loginsL RENAME passwordEnc to password;
             ALTER TABLE loginsM RENAME usernameEnc to username;
             ALTER TABLE loginsM RENAME passwordEnc to password;
-            ALTER TABLE loginsL RENAME origin to hostname;
-            ALTER TABLE loginsL RENAME formActionOrigin to formSubmitURL;
-            ALTER TABLE loginsM RENAME origin to hostname;
-            ALTER TABLE loginsM RENAME formActionOrigin to formSubmitURL;
-            INSERT INTO loginsL(guid, username, password, hostname,
-            httpRealm, formSubmitURL, usernameField, passwordField, timeCreated, timeLastUsed,
+            INSERT INTO loginsL(guid, username, password, origin,
+            httpRealm, formActionOrigin, usernameField, passwordField, timeCreated, timeLastUsed,
             timePasswordChanged, timesUsed, local_modified, is_deleted, sync_status)
             VALUES ('a', 'test', 'password', 'https://www.example.com', NULL, 'https://www.example.com',
             'username', 'password', 1000, 1000, 1, 10, 1000, 0, 2);
-            INSERT INTO loginsM(guid, username, password, hostname, httpRealm, formSubmitURL,
+            INSERT INTO loginsM(guid, username, password, origin, httpRealm, formActionOrigin,
             usernameField, passwordField, timeCreated, timeLastUsed, timePasswordChanged, timesUsed,
             is_overridden, server_modified)
             VALUES ('b', 'test', 'password', 'https://www.example.com', 'Test Realm', NULL,

--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -115,16 +115,12 @@ mod tests {
             ALTER TABLE loginsL RENAME passwordEnc to password;
             ALTER TABLE loginsM RENAME usernameEnc to username;
             ALTER TABLE loginsM RENAME passwordEnc to password;
-            ALTER TABLE loginsL RENAME origin to hostname;
-            ALTER TABLE loginsL RENAME formActionOrigin to formSubmitURL;
-            ALTER TABLE loginsM RENAME origin to hostname;
-            ALTER TABLE loginsM RENAME formActionOrigin to formSubmitURL;
-            INSERT INTO loginsL(guid, username, password, hostname,
-            httpRealm, formSubmitURL, usernameField, passwordField, timeCreated, timeLastUsed,
+            INSERT INTO loginsL(guid, username, password, origin,
+            httpRealm, formActionOrigin, usernameField, passwordField, timeCreated, timeLastUsed,
             timePasswordChanged, timesUsed, local_modified, is_deleted, sync_status)
             VALUES ('a', 'test', 'password', 'https://www.example.com', NULL, 'https://www.example.com',
             'username', 'password', 1000, 1000, 1, 10, 1000, 0, 2);
-            INSERT INTO loginsM(guid, username, password, hostname, httpRealm, formSubmitURL,
+            INSERT INTO loginsM(guid, username, password, origin, httpRealm, formActionOrigin,
             usernameField, passwordField, timeCreated, timeLastUsed, timePasswordChanged, timesUsed,
             is_overridden, server_modified)
             VALUES ('b', 'test', 'password', 'https://www.example.com', 'Test Realm', NULL,

--- a/components/logins/src/schema.rs
+++ b/components/logins/src/schema.rs
@@ -88,18 +88,13 @@
 //!    JSON.
 //!
 
-use crate::db::MigrationMetrics;
-use crate::encryption::EncryptorDecryptor;
 use crate::error::*;
 use lazy_static::lazy_static;
-use rusqlite::{Connection, NO_PARAMS};
+use rusqlite::Connection;
 use sql_support::ConnExt;
-use std::time::Instant;
 
 /// The current schema version is 1.  We reset it after the SQLCipher -> plaintext migration.
 const VERSION: i64 = 1;
-/// Version where we switched from sqlcipher to a plaintext database.
-const SQLCIPHER_SWITCHOVER_VERSION: i64 = 5;
 
 /// Every column shared by both tables except for `id`
 ///
@@ -131,6 +126,21 @@ pub const COMMON_COLS: &str = "
     timeLastUsed,
     timePasswordChanged,
     timesUsed
+";
+
+pub const COMMON_VALS: &str = "
+    :guid,
+    :usernameEnc,
+    :passwordEnc,
+    :origin,
+    :httpRealm,
+    :formActionOrigin,
+    :usernameField,
+    :passwordField,
+    :timeCreated,
+    :timeLastUsed,
+    :timePasswordChanged,
+    :timesUsed
 ";
 
 const COMMON_SQL: &str = "
@@ -183,16 +193,6 @@ const CREATE_META_TABLE_SQL: &str = "
     )
 ";
 
-const CREATE_OVERRIDE_HOSTNAME_INDEX_SQL: &str = "
-    CREATE INDEX IF NOT EXISTS idx_loginsM_is_overridden_hostname
-    ON loginsM (is_overridden, hostname)
-";
-
-const CREATE_DELETED_HOSTNAME_INDEX_SQL: &str = "
-    CREATE INDEX IF NOT EXISTS idx_loginsL_is_deleted_hostname
-    ON loginsL (is_deleted, hostname)
-";
-
 const CREATE_OVERRIDE_ORIGIN_INDEX_SQL: &str = "
     CREATE INDEX IF NOT EXISTS idx_loginsM_is_overridden_origin
     ON loginsM (is_overridden, origin)
@@ -201,54 +201,6 @@ const CREATE_OVERRIDE_ORIGIN_INDEX_SQL: &str = "
 const CREATE_DELETED_ORIGIN_INDEX_SQL: &str = "
     CREATE INDEX IF NOT EXISTS idx_loginsL_is_deleted_origin
     ON loginsL (is_deleted, origin)
-";
-
-// As noted above, we use these when updating from schema v3 (firefox-ios's
-// last schema) to convert from microsecond timestamps to milliseconds.
-const UPDATE_LOCAL_TIMESTAMPS_TO_MILLIS_SQL: &str = "
-    UPDATE loginsL
-    SET timeCreated = timeCreated / 1000,
-        timeLastUsed = timeLastUsed / 1000,
-        timePasswordChanged = timePasswordChanged / 1000
-";
-
-const UPDATE_MIRROR_TIMESTAMPS_TO_MILLIS_SQL: &str = "
-    UPDATE loginsM
-    SET timeCreated = timeCreated / 1000,
-        timeLastUsed = timeLastUsed / 1000,
-        timePasswordChanged = timePasswordChanged / 1000
-";
-
-const RENAME_LOCAL_USERNAME: &str = "
-    ALTER TABLE loginsL RENAME username to usernameEnc
-";
-
-const RENAME_LOCAL_PASSWORD: &str = "
-    ALTER TABLE loginsL RENAME password to passwordEnc
-";
-
-const RENAME_MIRROR_USERNAME: &str = "
-    ALTER TABLE loginsM RENAME username to usernameEnc
-";
-
-const RENAME_MIRROR_PASSWORD: &str = "
-    ALTER TABLE loginsM RENAME password to passwordEnc
-";
-
-const RENAME_LOCAL_HOSTNAME: &str = "
-    ALTER TABLE loginsL RENAME COLUMN hostname TO origin
-";
-
-const RENAME_LOCAL_SUBMIT_URL: &str = "
-    ALTER TABLE loginsL RENAME COLUMN formSubmitURL TO formActionOrigin
-";
-
-const RENAME_MIRROR_HOSTNAME: &str = "
-    ALTER TABLE loginsM RENAME COLUMN hostname TO origin
-";
-
-const RENAME_MIRROR_SUBMIT_URL: &str = "
-    ALTER TABLE loginsM RENAME COLUMN formSubmitURL TO formActionOrigin
 ";
 
 pub(crate) static LAST_SYNC_META_KEY: &str = "last_sync_time";
@@ -304,144 +256,4 @@ pub(crate) fn create(db: &Connection) -> Result<()> {
         &*SET_VERSION_SQL,
     ])?;
     Ok(())
-}
-
-// Run schema upgrades for a SQLCipher database.  This will bring the database up to version 5
-// which is required before migrating it to a plaintext database.
-pub fn upgrade_sqlcipher_db(db: &mut Connection, encryption_key: &str) -> Result<MigrationMetrics> {
-    let user_version = db.query_one::<i64>("PRAGMA user_version")?;
-
-    if user_version == 0 {
-        // This logic is largely taken from firefox-ios. AFAICT at some point
-        // they went from having schema versions tracked using a table named
-        // `tableList` to using `PRAGMA user_version`. This leads to the
-        // following logic:
-        //
-        // - If `tableList` exists, we're hopelessly far in the past
-        //
-        // - If `tableList` doesn't exist and `PRAGMA user_version` is 0, it's
-        //   the first time through
-        //
-        // In either case, we're not going to be able to migrate any data.  Return an error which
-        // signals to the calling code that we can't migrate and therefore we should just delete
-        // the sqlcipher db and start fresh.
-        return Err(ErrorKind::InvalidDatabaseFile(
-            "can't migrate to plaintext when user_version is 0".into(),
-        )
-        .into());
-    }
-    log::debug!(
-        "Upgrading schema from {} to {} to prep for plaintext migration",
-        user_version,
-        SQLCIPHER_SWITCHOVER_VERSION
-    );
-    if user_version >= SQLCIPHER_SWITCHOVER_VERSION {
-        // This is a weird case that shouldn't happen in practice, since as soon as we upgrade the
-        // schema we immediately export it to plaintext then delete the sqlcipher file.  But if we
-        // somehow get here, it seems reasonable to try to continue on with the process, in theory
-        // we should be able to export to plaintext.
-        return Ok(MigrationMetrics::default());
-    }
-    let start_time = Instant::now();
-    let mut num_processed = 0;
-    let mut num_succeeded = 0;
-    let mut num_failed = 0;
-    let mut errors = Vec::new();
-    let tx = db.transaction()?;
-    if user_version < 3 {
-        // These indices were added in v3 (apparently)
-        tx.execute_all(&[
-            CREATE_OVERRIDE_HOSTNAME_INDEX_SQL,
-            CREATE_DELETED_HOSTNAME_INDEX_SQL,
-        ])?;
-    }
-    if user_version < 4 {
-        // This is the update from the firefox-ios schema to our schema.
-        // The `loginsSyncMeta` table was added in v4, and we moved
-        // from using microseconds to milliseconds for `timeCreated`,
-        // `timeLastUsed`, and `timePasswordChanged`.
-        tx.execute_all(&[
-            CREATE_META_TABLE_SQL,
-            UPDATE_LOCAL_TIMESTAMPS_TO_MILLIS_SQL,
-            UPDATE_MIRROR_TIMESTAMPS_TO_MILLIS_SQL,
-        ])?;
-    }
-    if user_version < 5 {
-        // encrypt the username/password data
-        let encryptor = EncryptorDecryptor::new(encryption_key)?;
-        let mut encrypt_username_and_password = |table_name: &str| -> Result<()> {
-            // Encrypt the username and password field for all rows.
-            let mut select_stmt = tx.prepare(&format!(
-                "SELECT guid, username, password FROM {}",
-                table_name
-            ))?;
-            let mut update_stmt = tx.prepare(&format!(
-                "UPDATE {} SET username=?, password=? WHERE guid=?",
-                table_name
-            ))?;
-            let mut delete_stmt =
-                tx.prepare(&format!("DELETE FROM {} WHERE guid=?", table_name))?;
-
-            let mut update_single_row = |guid: &str, row: &rusqlite::Row<'_>| -> Result<()> {
-                let username: String = row.get(1)?;
-                let password: String = row.get(2)?;
-                update_stmt.execute(rusqlite::params![
-                    encryptor.encrypt(&username)?,
-                    encryptor.encrypt(&password)?,
-                    &guid,
-                ])?;
-                Ok(())
-            };
-
-            // Use raw rows to avoid extra copying since we're looping over an entire table
-            let mut rows = select_stmt.query(NO_PARAMS)?;
-            while let Some(row) = rows.next()? {
-                let guid: String = row.get(0)?;
-                num_processed += 1;
-                match update_single_row(&guid, &row) {
-                    Ok(_) => {
-                        num_succeeded += 1;
-                    }
-                    Err(e) => {
-                        delete_stmt.execute(&[&guid])?;
-                        num_failed += 1;
-                        errors.push(e.to_string());
-                    }
-                }
-            }
-            Ok(())
-        };
-
-        encrypt_username_and_password("loginsL")?;
-        encrypt_username_and_password("loginsM")?;
-
-        // rename the fields
-        tx.execute_all(&[
-            RENAME_LOCAL_USERNAME,
-            RENAME_LOCAL_PASSWORD,
-            RENAME_MIRROR_USERNAME,
-            RENAME_MIRROR_PASSWORD,
-            RENAME_LOCAL_HOSTNAME,
-            RENAME_LOCAL_SUBMIT_URL,
-            RENAME_MIRROR_HOSTNAME,
-            RENAME_MIRROR_SUBMIT_URL,
-        ])?;
-    }
-    tx.execute(
-        &format!(
-            "PRAGMA user_version = {version}",
-            version = SQLCIPHER_SWITCHOVER_VERSION
-        ),
-        NO_PARAMS,
-    )?;
-    tx.commit()?;
-
-    Ok(MigrationMetrics {
-        num_processed,
-        num_succeeded,
-        num_failed,
-        total_duration: start_time.elapsed().as_millis() as u64,
-        errors,
-        ..MigrationMetrics::default()
-    })
 }

--- a/components/logins/src/schema.rs
+++ b/components/logins/src/schema.rs
@@ -183,14 +183,14 @@ const CREATE_META_TABLE_SQL: &str = "
     )
 ";
 
-const CREATE_OVERRIDE_HOSTNAME_INDEX_SQL: &str = "
-    CREATE INDEX IF NOT EXISTS idx_loginsM_is_overridden_hostname
-    ON loginsM (is_overridden, hostname)
+const CREATE_OVERRIDE_ORIGIN_INDEX_SQL: &str = "
+    CREATE INDEX IF NOT EXISTS idx_loginsM_is_overridden_origin
+    ON loginsM (is_overridden, origin)
 ";
 
-const CREATE_DELETED_HOSTNAME_INDEX_SQL: &str = "
-    CREATE INDEX IF NOT EXISTS idx_loginsL_is_deleted_hostname
-    ON loginsL (is_deleted, hostname)
+const CREATE_DELETED_ORIGIN_INDEX_SQL: &str = "
+    CREATE INDEX IF NOT EXISTS idx_loginsL_is_deleted_origin
+    ON loginsL (is_deleted, origin)
 ";
 
 const CREATE_OVERRIDE_ORIGIN_INDEX_SQL: &str = "
@@ -351,8 +351,8 @@ pub fn upgrade_sqlcipher_db(db: &mut Connection, encryption_key: &str) -> Result
     if user_version < 3 {
         // These indices were added in v3 (apparently)
         tx.execute_all(&[
-            CREATE_OVERRIDE_HOSTNAME_INDEX_SQL,
-            CREATE_DELETED_HOSTNAME_INDEX_SQL,
+            CREATE_OVERRIDE_ORIGIN_INDEX_SQL,
+            CREATE_DELETED_ORIGIN_INDEX_SQL,
         ])?;
     }
     if user_version < 4 {

--- a/components/logins/src/schema.rs
+++ b/components/logins/src/schema.rs
@@ -128,21 +128,6 @@ pub const COMMON_COLS: &str = "
     timesUsed
 ";
 
-pub const COMMON_VALS: &str = "
-    :guid,
-    :usernameEnc,
-    :passwordEnc,
-    :origin,
-    :httpRealm,
-    :formActionOrigin,
-    :usernameField,
-    :passwordField,
-    :timeCreated,
-    :timeLastUsed,
-    :timePasswordChanged,
-    :timesUsed
-";
-
 const COMMON_SQL: &str = "
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     origin              TEXT NOT NULL,

--- a/components/logins/src/schema.rs
+++ b/components/logins/src/schema.rs
@@ -298,8 +298,8 @@ pub(crate) fn create(db: &Connection) -> Result<()> {
     db.execute_all(&[
         &*CREATE_LOCAL_TABLE_SQL,
         &*CREATE_MIRROR_TABLE_SQL,
-        CREATE_OVERRIDE_HOSTNAME_INDEX_SQL,
-        CREATE_DELETED_HOSTNAME_INDEX_SQL,
+        CREATE_OVERRIDE_ORIGIN_INDEX_SQL,
+        CREATE_DELETED_ORIGIN_INDEX_SQL,
         CREATE_META_TABLE_SQL,
         &*SET_VERSION_SQL,
     ])?;

--- a/components/logins/src/schema.rs
+++ b/components/logins/src/schema.rs
@@ -183,14 +183,14 @@ const CREATE_META_TABLE_SQL: &str = "
     )
 ";
 
-const CREATE_OVERRIDE_ORIGIN_INDEX_SQL: &str = "
-    CREATE INDEX IF NOT EXISTS idx_loginsM_is_overridden_origin
-    ON loginsM (is_overridden, origin)
+const CREATE_OVERRIDE_HOSTNAME_INDEX_SQL: &str = "
+    CREATE INDEX IF NOT EXISTS idx_loginsM_is_overridden_hostname
+    ON loginsM (is_overridden, hostname)
 ";
 
-const CREATE_DELETED_ORIGIN_INDEX_SQL: &str = "
-    CREATE INDEX IF NOT EXISTS idx_loginsL_is_deleted_origin
-    ON loginsL (is_deleted, origin)
+const CREATE_DELETED_HOSTNAME_INDEX_SQL: &str = "
+    CREATE INDEX IF NOT EXISTS idx_loginsL_is_deleted_hostname
+    ON loginsL (is_deleted, hostname)
 ";
 
 const CREATE_OVERRIDE_ORIGIN_INDEX_SQL: &str = "
@@ -298,8 +298,8 @@ pub(crate) fn create(db: &Connection) -> Result<()> {
     db.execute_all(&[
         &*CREATE_LOCAL_TABLE_SQL,
         &*CREATE_MIRROR_TABLE_SQL,
-        CREATE_OVERRIDE_ORIGIN_INDEX_SQL,
-        CREATE_DELETED_ORIGIN_INDEX_SQL,
+        CREATE_OVERRIDE_HOSTNAME_INDEX_SQL,
+        CREATE_DELETED_HOSTNAME_INDEX_SQL,
         CREATE_META_TABLE_SQL,
         &*SET_VERSION_SQL,
     ])?;
@@ -351,8 +351,8 @@ pub fn upgrade_sqlcipher_db(db: &mut Connection, encryption_key: &str) -> Result
     if user_version < 3 {
         // These indices were added in v3 (apparently)
         tx.execute_all(&[
-            CREATE_OVERRIDE_ORIGIN_INDEX_SQL,
-            CREATE_DELETED_ORIGIN_INDEX_SQL,
+            CREATE_OVERRIDE_HOSTNAME_INDEX_SQL,
+            CREATE_DELETED_HOSTNAME_INDEX_SQL,
         ])?;
     }
     if user_version < 4 {

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -120,6 +120,20 @@ impl LoginStore {
         self.db.lock().unwrap().update(login)
     }
 
+    // TODO: STUB FOR THE NEW API THAT WILL BE USED AND WILL BE CHANGED
+    pub fn add_or_update(&self, login: Login) -> Result<()> {
+        match login.fixup() {
+            Ok(l) => {
+                println!("successfully added and fixed up");
+                self.add(l)?;
+            }
+            Err(e) => {
+                println!("Error fixing up {:?}", e);
+            }
+        }
+        Ok(())
+    }
+
     pub fn add(&self, login: Login) -> Result<String> {
         // Just return the record's ID (which we may have generated).
         self.db

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -124,7 +124,6 @@ impl LoginStore {
     pub fn add_or_update(&self, login: Login) -> Result<()> {
         match login.fixup() {
             Ok(l) => {
-                println!("successfully added and fixed up");
                 self.add(l)?;
             }
             Err(e) => {


### PR DESCRIPTION
Initial draft of rewriting the logins migration to a manual approach rather than using export

Most of the new functionality is in `migrate_from_sqlcipher_db`


Still left to discuss:
(1) needing to convert timestamps to millis?
(2) Using raw SQL vs exposed APIs


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
