### PR TITLE
Update android dependencies [ci full]

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -13,3 +13,11 @@ style:
     active: false
   ProtectedMemberInFinalClass:
     active: false
+  UnusedPrivateMember:
+    active: false
+
+exceptions:
+  RethrowCaughtException:
+    active: false
+  SwallowedException:
+    active: false

--- a/build-scripts/component-common.gradle
+++ b/build-scripts/component-common.gradle
@@ -69,6 +69,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:$roboelectric_core_version"
     testImplementation "org.mockito:mockito-core:$mockito_core_version"
 
-    androidTestImplementation "com.android.support.test:runner:$android_test_runner_version"
-    androidTestImplementation "com.android.support.test.espresso:$espresso_core_version"
+    androidTestImplementation "androidx.test:runner:$androidx_test_runner_version"
+    androidTestImplementation "androidx.test.espresso:expresso-core:$espresso_core_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,22 +3,27 @@
 buildscript {
 
     ext {
-        kotlin_version = '1.3.71'
-        kotlin_coroutines_version = '1.4.2'
-        jna_version = '5.6.0'
-        android_gradle_plugin_version = '4.0.1'
-        android_components_version = '75.0.0'
+        kotlin_version = '1.5.20'
+        kotlin_coroutines_version = '1.5.0'
+        jna_version = '5.8.0'
+        android_gradle_plugin_version = '4.2.2'
+        android_components_version = '91.0.3'
         androidx_annotation_version = '1.2.0'
         androidx_core_version = '1.3.2'
         androidx_test_core_version = '1.3.0'
         androidx_test_junit_version = '1.1.2'
         androidx_work_testing_version = '2.5.0'
+        androidx_test_runner_version = '1.3.0'
+        detekt_version = '1.17.1'
+        gradle_download_task_version = '3.4.3'
         junit_version = '4.13'
+        maven_publish_version = '3.6.2'
         mockito_core_version = '2.24.5'
         roboelectric_core_version = '4.3.1'
-        android_test_runner_version = '1.0.2'
-        espresso_core_version = '3.0.2'
+        rust_android_gradle_version = '0.8.3'
+        espresso_core_version = '3.3.0'
         protobuf_version = '3.11.4'
+        gradle_protobuf_version = '0.8.14'
     }
 
     ext.build = [
@@ -49,20 +54,21 @@ buildscript {
 
     dependencies {
         classpath "com.android.tools.build:gradle:$android_gradle_plugin_version"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // Publish.
-        classpath 'digital.wup:android-maven-publish:3.6.2'
+        classpath "digital.wup:android-maven-publish:$maven_publish_version"
 
-        classpath 'gradle.plugin.org.mozilla.rust-android-gradle:plugin:0.8.3'
+        classpath "gradle.plugin.org.mozilla.rust-android-gradle:plugin:$rust_android_gradle_version"
 
         // Yes, this is unusual.  We want to access some host-specific
         // computation at build time.
         classpath "net.java.dev.jna:jna:$jna_version"
 
         // Downloading libs/ archives from Taskcluster.
-        classpath 'de.undercouch:gradle-download-task:3.4.3'
+        classpath "de.undercouch:gradle-download-task:$gradle_download_task_version"
 
-        classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.14'
+        classpath "com.google.protobuf:protobuf-gradle-plugin:$gradle_protobuf_version"
 
         // Since the Glean version depends on the Android components version,
         // it is very important to use a modern version of Glean and, ideally,
@@ -75,7 +81,7 @@ buildscript {
 }
 
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "1.7.4"
+    id "io.gitlab.arturbosch.detekt" version "$detekt_version"
 }
 
 apply plugin: 'de.undercouch.download'
@@ -138,6 +144,7 @@ if (useDownloadedLibs) {
         src {
             switch (DefaultPlatform.RESOURCE_PREFIX) {
                 case 'darwin':
+                case 'darwin-x86-64':
                     return "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.desktop.macos.${rootProject.ext.libsGitSha}/artifacts/public/build/macos.tar.gz"
                 case 'linux-x86-64':
                     return "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.application-services.build.libs.desktop.linux.${rootProject.ext.libsGitSha}/artifacts/public/build/linux.tar.gz"
@@ -154,6 +161,7 @@ if (useDownloadedLibs) {
         dest {
             switch (DefaultPlatform.RESOURCE_PREFIX) {
                 case 'darwin':
+                case 'darwin-x86-64':
                     return new File(buildDir, "libs.desktop.macos.${rootProject.ext.libsGitSha}.tar.gz")
                 case 'linux-x86-64':
                     return new File(buildDir, "libs.desktop.linux.${rootProject.ext.libsGitSha}.tar.gz")
@@ -220,6 +228,7 @@ ext.rustTargets = [
 // Generate libs for our current platform so we can run unit tests.
 switch (DefaultPlatform.RESOURCE_PREFIX) {
     case 'darwin':
+    case 'darwin-x86-64':
         ext.nativeRustTarget = 'darwin'
         break
     case 'linux-x86-64':
@@ -277,7 +286,7 @@ ext.cargoExecWithSQLCipher = { spec, toolchain ->
 }
 
 detekt {
-    toolVersion = "1.7.4"
+    toolVersion = "$detekt_version"
     input = files(
         fileTree(dir: "${projectDir}/components", excludes: ["external", "**/generated"]),
         "${projectDir}/gradle-plugin",

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeatureVariables.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeatureVariables.kt
@@ -126,7 +126,7 @@ interface VariablesWithContext : Variables {
     // defaults from manifest information.
     fun asText(res: Int) = context.getString(res)
     fun asDrawable(res: Int) = context.getDrawable(res)
-    fun asText(string: String) = asStringResource(string)?.let(this::asText) ?: string
+    fun asText(string: String): String? = asStringResource(string)?.let(this::asText) ?: string
     fun asStringResource(string: String) = context.getResource(string, "string")
     fun asDrawableResource(string: String) = context.getResource(string, "drawable")
 }

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -540,24 +540,24 @@ open class Nimbus(
         enrollmentChangeEvents.forEach { event ->
             when (event.change) {
                 EnrollmentChangeEventType.ENROLLMENT -> {
-                    NimbusEvents.enrollment.record(mapOf(
-                        NimbusEvents.enrollmentKeys.experiment to event.experimentSlug,
-                        NimbusEvents.enrollmentKeys.branch to event.branchSlug,
-                        NimbusEvents.enrollmentKeys.enrollmentId to event.enrollmentId
+                    NimbusEvents.enrollment.record(NimbusEvents.EnrollmentExtra(
+                        experiment = event.experimentSlug,
+                        branch = event.branchSlug,
+                        enrollmentId = event.enrollmentId
                     ))
                 }
                 EnrollmentChangeEventType.DISQUALIFICATION -> {
-                    NimbusEvents.disqualification.record(mapOf(
-                        NimbusEvents.disqualificationKeys.experiment to event.experimentSlug,
-                        NimbusEvents.disqualificationKeys.branch to event.branchSlug,
-                        NimbusEvents.disqualificationKeys.enrollmentId to event.enrollmentId
+                    NimbusEvents.disqualification.record(NimbusEvents.DisqualificationExtra(
+                        experiment = event.experimentSlug,
+                        branch = event.branchSlug,
+                        enrollmentId = event.enrollmentId
                     ))
                 }
                 EnrollmentChangeEventType.UNENROLLMENT -> {
-                    NimbusEvents.unenrollment.record(mapOf(
-                        NimbusEvents.unenrollmentKeys.experiment to event.experimentSlug,
-                        NimbusEvents.unenrollmentKeys.branch to event.branchSlug,
-                        NimbusEvents.unenrollmentKeys.enrollmentId to event.enrollmentId
+                    NimbusEvents.unenrollment.record(NimbusEvents.UnenrollmentExtra(
+                        experiment = event.experimentSlug,
+                        branch = event.branchSlug,
+                        enrollmentId = event.enrollmentId
                     ))
                 }
             }
@@ -578,10 +578,10 @@ open class Nimbus(
     internal fun recordExposureOnThisThread(featureId: String) = withCatchAll {
         val activeExperiments = getActiveExperiments()
         activeExperiments.find { it.featureIds.contains(featureId) }?.also { experiment ->
-            NimbusEvents.exposure.record(mapOf(
-                NimbusEvents.exposureKeys.experiment to experiment.slug,
-                NimbusEvents.exposureKeys.branch to experiment.branchSlug,
-                NimbusEvents.exposureKeys.enrollmentId to experiment.enrollmentId
+            NimbusEvents.exposure.record(NimbusEvents.ExposureExtra(
+                experiment = experiment.slug,
+                branch = experiment.branchSlug,
+                enrollmentId = experiment.enrollmentId
             ))
         }
     }

--- a/components/nimbus/metrics.yaml
+++ b/components/nimbus/metrics.yaml
@@ -19,10 +19,13 @@ nimbus_events:
       per user.
     extra_keys:
       experiment:
+        type: string
         description: The slug/unique identifier of the experiment
       branch:
+        type: string
         description: The branch slug/identifier that was randomly chosen
       enrollment_id:
+        type: string
         description: A unique identifier generated at enrollment time
     bugs:
       - https://jira.mozilla.com/browse/SDK-61
@@ -42,10 +45,13 @@ nimbus_events:
       Remote Settings collection)
     extra_keys:
       experiment:
+        type: string
         description: The slug/unique identifier of the experiment
       branch:
+        type: string
         description: The branch slug/identifier that was randomly chosen
       enrollment_id:
+        type: string
         description: A unique identifier generated at enrollment time
     bugs:
       - https://jira.mozilla.com/browse/SDK-126
@@ -66,10 +72,13 @@ nimbus_events:
       experiment.
     extra_keys:
       experiment:
+        type: string
         description: The slug/unique identifier of the experiment
       branch:
+        type: string
         description: The branch slug/identifier that was randomly chosen
       enrollment_id:
+        type: string
         description: A unique identifier generated at enrollment time
     bugs:
       - https://jira.mozilla.com/browse/SDK-126
@@ -89,10 +98,13 @@ nimbus_events:
       branch that would have shown one.
     extra_keys:
       experiment:
+        type: string
         description: The slug/unique identifier of the experiment
       branch:
+        type: string
         description: The branch slug/identifier that was randomly chosen
       enrollment_id:
+        type: string
         description: A unique identifier generated at enrollment time
     bugs:
       - https://jira.mozilla.com/browse/SDK-65

--- a/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
@@ -185,7 +185,7 @@ class PushManager(
 enum class BridgeType {
     FCM, ADM, APNS, TEST;
 
-    override fun toString() = name.toLowerCase(Locale.US)
+    override fun toString() = name.lowercase(Locale.US)
 }
 
 /**

--- a/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
+++ b/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
@@ -74,7 +74,7 @@ data class SyncTelemetryPing(
     }
 
     fun toJSON(): JSONObject {
-        var result = JSONObject()
+        val result = JSONObject()
         result.put("version", version)
         result.put("uid", uid)
         if (!events.isEmpty()) {
@@ -131,7 +131,7 @@ data class SyncInfo(
     }
 
     fun toJSON(): JSONObject {
-        var result = JSONObject()
+        val result = JSONObject()
         result.put("when", at)
         if (took > 0) {
             result.put("took", took)
@@ -322,7 +322,7 @@ data class ValidationInfo(
     }
 
     fun toJSON(): JSONObject {
-        var result = JSONObject()
+        val result = JSONObject()
         result.put("version", version)
         if (!problems.isEmpty()) {
             result.put("problems", JSONArray().apply {
@@ -406,7 +406,7 @@ data class FailureReason(
     }
 
     fun toJSON(): JSONObject {
-        var result = JSONObject()
+        val result = JSONObject()
         when (name) {
             FailureName.Shutdown -> {
                 result.put("name", "shutdownerror")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/publish.gradle
+++ b/publish.gradle
@@ -89,7 +89,7 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
         publications {
             aar(MavenPublication) {
                 project.afterEvaluate {
-                    from components.findByName("androidRelease")
+                    from components.release
                 }
                 artifact sourcesJar
                 // Can't publish Javadoc yet: fxaclient isn't well behaved.


### PR DESCRIPTION
This uses the new, cleaner factoring of our Android config from #4194
as an excuse to update some of our Android dependencies to bring them
inline with what's used in current android-components. It was much
easier than it has been in the past!

I'm getting some weird test failures locally that look transient, let's
see what CI has to say about them...
