### PR TITLE
fixes github actions failure

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -34,6 +34,11 @@ jobs:
           ./libs/verify-desktop-environment.sh
       
       - name: Build mdbook
+        env: 
+          SQLCIPHER_LIB_DIR: ${{ github.workspace }}/libs/desktop/linux-x86-64/sqlcipher/lib
+          SQLCIPHER_INCLUDE_DIR: ${{ github.workspace }}/libs/desktop/linux-x86-64/sqlcipher/include
+          NSS_DIR: ${{ github.workspace }}/libs/desktop/linux-x86-64/nss
+          NSS_STATIC: 1 
         run: |
           cargo install mdbook mdbook-mermaid mdbook-open-on-gh
           ./tools/build-book.sh


### PR DESCRIPTION
Since I moved the `cargo doc` to the `build-book.sh` script, on #4340  which is a different CD step, it expects that the `NSS` environment variables are set correctly, otherwise `cargo doc` will fail. (as is seen in https://github.com/mozilla/application-services/actions/runs/1047252137)

This basically just sets the correct env variables on the `Build mdbook` step so cargo doc doesn't fail
