### PR TITLE
Verify desktop build environment when verifying for mobile.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
       - carthage-bootstrap
       - run:
           name: Verify the build environment
-          command: ./libs/verify-ios-environment.sh
+          command: ./libs/verify-ios-ci-environment.sh
       - run:
           name: Run XCode tests
           command: ./automation/tests.py ios-tests

--- a/libs/verify-android-ci-environment.sh
+++ b/libs/verify-android-ci-environment.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2148
+# Ensure the build toolchains are set up correctly for android builds.
+#
+# This is intended for use in CI, so it verifies only the minimum that is needed
+# to build in CI. For local development use `verify-android-environment.sh`.
+#
+# This file should be used via `./libs/verify-android-ci-environment.sh`.
+
+set -e
+
+RUST_TARGETS=("aarch64-linux-android" "armv7-linux-androideabi" "i686-linux-android" "x86_64-linux-android")
+
+if [[ ! -f "$(pwd)/libs/build-all.sh" ]]; then
+  echo "ERROR: verify-android-ci-environment.sh should be run from the root directory of the repo"
+  exit 1
+fi
+
+"$(pwd)/libs/verify-common.sh"
+
+# If you add a dependency below, mention it in building.md in the Android section!
+
+if [[ -z "${ANDROID_HOME}" ]]; then
+  echo "Could not find Android SDK:"
+  echo 'Please install the Android SDK and then set ANDROID_HOME.'
+  exit 1
+fi
+
+rustup target add "${RUST_TARGETS[@]}"
+
+# Determine the Java command to use to start the JVM.
+# Same implementation as gradlew
+if [[ -n "$JAVA_HOME" ]] ; then
+    if [[ -x "$JAVA_HOME/jre/sh/java" ]] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="$JAVA_HOME/bin/java"
+    fi
+    if [[ ! -x "$JAVACMD" ]] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    command -v $JAVACMD >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+JAVA_VERSION=$("$JAVACMD" -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-2)
+if [[ "${JAVA_VERSION}" != "1.8" ]]; then
+  echo "Incompatible java version: ${JAVA_VERSION}. JDK 8 must be installed."
+  echo "Try switching versions and re-running. Using sdkman: sdk install java 8.0.282+8.hs-adpt || sdk use java 8.0.282+8.hs-adpt"
+  exit 1
+fi
+
+# NDK ez-install
+"$ANDROID_HOME/tools/bin/sdkmanager" "ndk;$(./gradlew -q printNdkVersion | tail -1)"
+
+# CI just downloads these libs anyway.
+if [[ -z "${CI}" ]]; then
+  if [[ ! -d "${PWD}/libs/android/arm64-v8a/nss" ]] || [[ ! -d "${PWD}/libs/android/arm64-v8a/sqlcipher" ]]; then
+    pushd libs || exit 1
+    ./build-all.sh android
+    popd || exit 1
+  fi
+fi

--- a/libs/verify-android-environment.sh
+++ b/libs/verify-android-environment.sh
@@ -5,67 +5,15 @@
 #
 # This file should be used via `./libs/verify-android-environment.sh`.
 
-set -e
-
-RUST_TARGETS=("aarch64-linux-android" "armv7-linux-androideabi" "i686-linux-android" "x86_64-linux-android")
-
 if [[ ! -f "$(pwd)/libs/build-all.sh" ]]; then
   echo "ERROR: verify-android-environment.sh should be run from the root directory of the repo"
   exit 1
 fi
 
-"$(pwd)/libs/verify-common.sh"
+# Android consumers are likely to also want to be able to run a quick
+# `cargo build` for their desktop env, so verify that as well.
+"$(pwd)/libs/verify-desktop-environment.sh"
 
-# If you add a dependency below, mention it in building.md in the Android section!
-
-if [[ -z "${ANDROID_HOME}" ]]; then
-  echo "Could not find Android SDK:"
-  echo 'Please install the Android SDK and then set ANDROID_HOME.'
-  exit 1
-fi
-
-rustup target add "${RUST_TARGETS[@]}"
-
-# Determine the Java command to use to start the JVM.
-# Same implementation as gradlew
-if [[ -n "$JAVA_HOME" ]] ; then
-    if [[ -x "$JAVA_HOME/jre/sh/java" ]] ; then
-        # IBM's JDK on AIX uses strange locations for the executables
-        JAVACMD="$JAVA_HOME/jre/sh/java"
-    else
-        JAVACMD="$JAVA_HOME/bin/java"
-    fi
-    if [[ ! -x "$JAVACMD" ]] ; then
-        die "ERROR: JAVA_HOME is set to an invalid directory: $JAVA_HOME
-
-Please set the JAVA_HOME variable in your environment to match the
-location of your Java installation."
-    fi
-else
-    JAVACMD="java"
-    command -v $JAVACMD >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-
-Please set the JAVA_HOME variable in your environment to match the
-location of your Java installation."
-fi
-
-JAVA_VERSION=$("$JAVACMD" -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-2)
-if [[ "${JAVA_VERSION}" != "1.8" ]]; then
-  echo "Incompatible java version: ${JAVA_VERSION}. JDK 8 must be installed."
-  echo "Try switching versions and re-running. Using sdkman: sdk install java 8.0.282+8.hs-adpt || sdk use java 8.0.282+8.hs-adpt"
-  exit 1
-fi
-
-# NDK ez-install
-"$ANDROID_HOME/tools/bin/sdkmanager" "ndk;$(./gradlew -q printNdkVersion | tail -1)"
-
-# CI just downloads these libs anyway.
-if [[ -z "${CI}" ]]; then
-  if [[ ! -d "${PWD}/libs/android/arm64-v8a/nss" ]] || [[ ! -d "${PWD}/libs/android/arm64-v8a/sqlcipher" ]]; then
-    pushd libs || exit 1
-    ./build-all.sh android
-    popd || exit 1
-  fi
-fi
+"$(pwd)/libs/verify-android-ci-environment.sh"
 
 echo "Looks good! Try building with ./gradlew assembleDebug"

--- a/libs/verify-ios-ci-environment.sh
+++ b/libs/verify-ios-ci-environment.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Ensure the build toolchains are set up correctly for iOS builds.
+#
+# This is intended for use in CI, so it verifies only the minimum that is needed
+# to build in CI. For local development use `verify-ios-environment.sh`.
+#
+# This file should be used via `./libs/verify-ios-ci-environment.sh`.
+
+set -e
+
+RUST_TARGETS=("aarch64-apple-ios" "x86_64-apple-ios")
+
+if [[ ! -f "$(pwd)/libs/build-all.sh" ]]; then
+  echo "ERROR: verify-ios-ci-environment.sh should be run from the root directory of the repo"
+  exit 1
+fi
+
+"$(pwd)/libs/verify-common.sh"
+
+rustup target add "${RUST_TARGETS[@]}"
+
+# If you add a dependency below, mention it in building.md in the iOS section!
+
+if ! [[ -x "$(command -v carthage)" ]]; then
+  echo 'Error: Carthage needs to be installed. See https://github.com/Carthage/Carthage#installing-carthage for install instructions.' >&2
+  exit 1
+fi
+
+if ! [[ -x "$(command -v protoc-gen-swift)" ]]; then
+  echo 'Error: swift-protobuf needs to be installed. See https://github.com/apple/swift-protobuf#alternatively-install-via-homebrew for install instructions.' >&2
+  exit 1
+fi
+
+if ! [[ -x "$(command -v xcpretty)" ]]; then
+  echo 'Error: xcpretty needs to be installed. See https://github.com/xcpretty/xcpretty#installation for install instructions.' >&2
+  exit 1
+fi
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+XCODE_XCCONFIG_FILE=$(pwd)/xcconfig/xcode-12-fix-carthage-lipo.xcconfig
+export XCODE_XCCONFIG_FILE
+
+echo "Running carthage boostrap..."
+carthage bootstrap --platform iOS --cache-builds
+
+if [[ ! -d "${PWD}/libs/ios/universal/nss" ]] || [[ ! -d "${PWD}/libs/ios/universal/sqlcipher" ]]; then
+  pushd libs || exit 1
+  ./build-all.sh ios
+  popd || exit 1
+fi

--- a/libs/verify-ios-environment.sh
+++ b/libs/verify-ios-environment.sh
@@ -4,49 +4,16 @@
 #
 # This file should be used via `./libs/verify-ios-environment.sh`.
 
-set -e
-
-RUST_TARGETS=("aarch64-apple-ios" "x86_64-apple-ios")
-
 if [[ ! -f "$(pwd)/libs/build-all.sh" ]]; then
   echo "ERROR: verify-ios-environment.sh should be run from the root directory of the repo"
   exit 1
 fi
 
-"$(pwd)/libs/verify-common.sh"
+# iOS consumers are likely to also want to be able to run a quick
+# `cargo build` for their desktop env, so verify that as well.
+"$(pwd)/libs/verify-desktop-environment.sh"
 
-rustup target add "${RUST_TARGETS[@]}"
-
-# If you add a dependency below, mention it in building.md in the iOS section!
-
-if ! [[ -x "$(command -v carthage)" ]]; then
-  echo 'Error: Carthage needs to be installed. See https://github.com/Carthage/Carthage#installing-carthage for install instructions.' >&2
-  exit 1
-fi
-
-if ! [[ -x "$(command -v protoc-gen-swift)" ]]; then
-  echo 'Error: swift-protobuf needs to be installed. See https://github.com/apple/swift-protobuf#alternatively-install-via-homebrew for install instructions.' >&2
-  exit 1
-fi
-
-if ! [[ -x "$(command -v xcpretty)" ]]; then
-  echo 'Error: xcpretty needs to be installed. See https://github.com/xcpretty/xcpretty#installation for install instructions.' >&2
-  exit 1
-fi
-
-# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
-# the build will fail on lipo due to duplicate architectures.
-XCODE_XCCONFIG_FILE=$(pwd)/xcconfig/xcode-12-fix-carthage-lipo.xcconfig
-export XCODE_XCCONFIG_FILE
-
-echo "Running carthage boostrap..."
-carthage bootstrap --platform iOS --cache-builds
-
-if [[ ! -d "${PWD}/libs/ios/universal/nss" ]] || [[ ! -d "${PWD}/libs/ios/universal/sqlcipher" ]]; then
-  pushd libs || exit 1
-  ./build-all.sh ios
-  popd || exit 1
-fi
+"$(pwd)/libs/verify-ios-ci-environment.sh"
 
 echo ""
 echo "Looks good! You can do the following:"

--- a/taskcluster/scripts/toolchain/android.sh
+++ b/taskcluster/scripts/toolchain/android.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd src
 . ./taskcluster/scripts/toolchain/rustup-setup.sh
-./libs/verify-android-environment.sh
+./libs/verify-android-ci-environment.sh
 pushd libs
 ./build-all.sh android
 popd

--- a/taskcluster/scripts/toolchain/desktop-linux.sh
+++ b/taskcluster/scripts/toolchain/desktop-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd src
 . ./taskcluster/scripts/toolchain/rustup-setup.sh
-./libs/verify-android-environment.sh
+./libs/verify-android-ci-environment.sh
 pushd libs
 ./build-all.sh desktop
 popd


### PR DESCRIPTION
It's reasonable for mobile-focused consumers to want to be able
to do a quick `cargo build` to test their local checkout, and it's
not reasonable for us to expect them to understand how or why this
is different from building inside Xcode or Android Studio. Let's
help make this Just Work (tm) by verifying the Desktop development
environment whenever we verify a Mobile development environment.

What I've done here is essentially:

* Move the bulk of the android/ios verify logic into new scripts named `verify-[platform]-ci-environment.sh`
* Make the existing `verify-[platform]-environment.sh` scripts be wrappers around this logic that also:
    * Verify the desktop build environment
    * Print human-facing next steps

See [this slack thread](https://mozilla.slack.com/archives/CKL0LGV9B/p1627078154471100) for a situation in which doing this by default would have helped provide a smoother consumer experience.

