### PR TITLE
Allows nimbus to accept context defined in the consumer

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -28,3 +28,6 @@ Use the template below to make assigning a version number during the release cut
 ### What's New
 
   - Added content signature and chain of trust verification features in `rc_crypto` ([#4195](https://github.com/mozilla/application-services/pull/4195))
+## Nimbus
+### What's Changed
+  - The Nimbus API now accepts application specific context as a part of its `appSettings`. The consumers get to define this context for targeting purposes. This allows different consumers to target on different fields without the SDK having to acknowledge all the fields. ([#4359](https://github.com/mozilla/application-services/pull/4359))

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -261,7 +261,13 @@ data class NimbusAppInfo(
      *
      * Examples: "nightly", "beta", "release"
      */
-    val channel: String
+    val channel: String,
+    /**
+     * Application derived attributes measured by the application, but useful for targeting of experiments.
+     *
+     * Example: mapOf("userType": "casual", "isFirstTime": "true")
+     */
+    val customTargetingAttributes: Map<String, String> = mapOf()
 )
 
 /**
@@ -609,6 +615,7 @@ open class Nimbus(
             deviceModel = Build.MODEL,
             locale = deviceInfo.localeTag,
             os = "Android",
-            osVersion = Build.VERSION.RELEASE)
+            osVersion = Build.VERSION.RELEASE,
+            customTargetingAttributes = appInfo.customTargetingAttributes)
     }
 }

--- a/components/nimbus/ios/Nimbus/NimbusApi.swift
+++ b/components/nimbus/ios/Nimbus/NimbusApi.swift
@@ -202,16 +202,19 @@ public struct NimbusServerSettings {
 
 public let remoteSettingsCollection = "nimbus-mobile-experiments"
 
-/// Name and channel of the app, which should agree with what is specified in Experimenter.
+/// Name, channel and specific context of the app which should agree with what is specified in Experimenter.
+/// The specifc context is there to capture any context that the SDK doesn't need to be explictly aware of.
 ///
 public struct NimbusAppSettings {
-    public init(appName: String, channel: String) {
+    public init(appName: String, channel: String, customTargetingAttributes: [String: String] = [String: String]()) {
         self.appName = appName
         self.channel = channel
+        self.customTargetingAttributes = customTargetingAttributes
     }
 
     public let appName: String
     public let channel: String
+    public let customTargetingAttributes: [String: String]
 }
 
 /// This error reporter is passed to `Nimbus` and any errors that are caught are reported via this type.

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -80,7 +80,8 @@ public extension Nimbus {
             os: device.systemName,
             osVersion: device.systemVersion,
             androidSdkVersion: nil,
-            debugTag: "Nimbus.rs"
+            debugTag: "Nimbus.rs",
+            customTargetingAttributes: appSettings.customTargetingAttributes
         )
     }
 }

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -249,6 +249,7 @@ mod tests {
             os_version: Some("10".to_string()),
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
+            custom_targeting_attributes: None,
         };
         assert_eq!(targeting(expression_statement, &ctx), None);
 
@@ -267,6 +268,7 @@ mod tests {
             os_version: Some("10".to_string()),
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
+            custom_targeting_attributes: None,
         };
         assert_eq!(targeting(expression_statement, &ctx), None);
 
@@ -285,6 +287,7 @@ mod tests {
             os_version: Some("10".to_string()),
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
+            custom_targeting_attributes: None,
         };
         assert!(matches!(
             targeting(expression_statement, &non_matching_ctx),
@@ -308,12 +311,65 @@ mod tests {
             os_version: Some("10".to_string()),
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
+            custom_targeting_attributes: None,
         };
         assert!(matches!(
             targeting(expression_statement, &non_matching_ctx),
             Some(EnrollmentStatus::NotEnrolled {
                 reason: NotEnrolledReason::NotTargeted
             })
+        ));
+    }
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_targeting_custom_targeting_attributes() {
+        // Here's our valid jexl statement
+        let expression_statement =
+            "app_id == '1010' && (app_version == '4.4' || locale == \"en-US\") && is_first_run == 'true' && ios_version == '8.8'";
+
+        let mut custom_targeting_attributes = HashMap::new();
+        custom_targeting_attributes.insert("is_first_run".into(), "true".into());
+        custom_targeting_attributes.insert("ios_version".into(), "8.8".into());
+        // A matching context that includes the appropriate specific context
+        let ctx = AppContext {
+            app_name: "nimbus_test".to_string(),
+            app_id: "1010".to_string(),
+            channel: "test".to_string(),
+            app_version: Some("4.4".to_string()),
+            app_build: Some("1234".to_string()),
+            architecture: Some("x86_64".to_string()),
+            device_manufacturer: Some("Samsung".to_string()),
+            device_model: Some("Galaxy S10".to_string()),
+            locale: Some("en-US".to_string()),
+            os: Some("Android".to_string()),
+            os_version: Some("10".to_string()),
+            android_sdk_version: Some("29".to_string()),
+            debug_tag: None,
+            custom_targeting_attributes: Some(custom_targeting_attributes),
+        };
+        assert_eq!(targeting(expression_statement, &ctx), None);
+
+        // A matching context without the specific context
+        let ctx = AppContext {
+            app_name: "nimbus_test".to_string(),
+            app_id: "1010".to_string(),
+            channel: "test".to_string(),
+            app_version: Some("4.4".to_string()),
+            app_build: Some("1234".to_string()),
+            architecture: Some("x86_64".to_string()),
+            device_manufacturer: Some("Samsung".to_string()),
+            device_model: Some("Galaxy S10".to_string()),
+            locale: Some("en-US".to_string()),
+            os: Some("Android".to_string()),
+            os_version: Some("10".to_string()),
+            android_sdk_version: Some("29".to_string()),
+            debug_tag: None,
+            custom_targeting_attributes: None,
+        };
+        assert!(matches!(
+            targeting(expression_statement, &ctx),
+            Some(EnrollmentStatus::Error { .. })
         ));
     }
 

--- a/components/nimbus/src/matcher.rs
+++ b/components/nimbus/src/matcher.rs
@@ -9,6 +9,7 @@
 //! provided by the consuming client.
 //!
 use serde_derive::*;
+use std::collections::HashMap;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct Matcher {
@@ -52,6 +53,7 @@ pub struct Matcher {
 /// - `os_version`: The user-visible version of the operating system (e.g. "1.2.3")
 /// - `android_sdk_version`: Android specific for targeting specific sdk versions
 /// - `debug_tag`: Used for debug purposes as a way to match only developer builds, etc.
+/// - `custom_targeting_attributes`: Contains attributes specific to the application, derived by the application
 #[derive(Deserialize, Serialize, Debug, Clone, Default)]
 pub struct AppContext {
     pub app_name: String,
@@ -67,4 +69,6 @@ pub struct AppContext {
     pub os_version: Option<String>,
     pub android_sdk_version: Option<String>,
     pub debug_tag: Option<String>,
+    #[serde(flatten)]
+    pub custom_targeting_attributes: Option<HashMap<String, String>>,
 }

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -13,6 +13,7 @@ dictionary AppContext {
     string? os_version;
     string? android_sdk_version;
     string? debug_tag;
+    record<DOMString, string>? custom_targeting_attributes;
 };
 
 dictionary EnrolledExperiment {


### PR DESCRIPTION
I'll need to add more thorough testing, but this is an initial stab at the problem to see if we wanna go through this route.

fixes https://mozilla-hub.atlassian.net/browse/SDK-345

A couple of thoughts about this, and I'm not sure if this warrants an ADR...

Pros:
  - Consumers can now define their own `targeting` fields, and as long as those align with what the settings server sends us, then the nimbus SDK will be able to evaluate it correctly, without the SDK needing to know about the specific fields. This saves us developer time of having to go on and add more fields to the `AppContext` struct.
  - As non-browser consumers (or consumers who simply don't have some of the fields other consumers have, I'm looking at you `android_sdk_version`) it wouldn't make sense for the SDK to include those fields. 

Cons:
  - Biggest con I can think of is that there's less type checking. The consumers would have to be extra careful to get their fields right, when right now the uniffi-generated struct make it impossible to get wrong.
  - Minor con is that if we want to access the `AppContext.specific_context` fields for non-targeting-related reasons, we'll probably need to be a bit more careful on the Rust side to add error handling

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
