### PR TITLE
Updating libs/scripts to require Java 11

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -74,8 +74,8 @@ The instructions here assume that you are building for Fenix in order test your 
 1. Install Android SDK, JAVA, NDK and set required env vars
    1. Clone the [Fenix](https://github.com/mozilla-mobile/fenix/) repository (not in a-s)
    1. Clone the [android-components](https://github.com/mozilla-mobile/android-components/) repository (not in a-s)
-   1. Install [Java **8**] for your system
-   1. Set `JAVA_HOME` to point to the JDK 8 installation directory.
+   1. Install [Java **11**] for your system
+   1. Set `JAVA_HOME` to point to the JDK 11 installation directory.
    1. Download and install [Android Studio](https://developer.android.com/studio/#downloads)
    1. Set `ANDROID_SDK_ROOT` and `ANDROID_HOME` to the Android Studio sdk location and add it to your rc file.
    1. Configure the required versions of NDK

--- a/libs/verify-android-ci-environment.sh
+++ b/libs/verify-android-ci-environment.sh
@@ -53,14 +53,14 @@ location of your Java installation."
 fi
 
 JAVA_VERSION=$("$JAVACMD" -version 2>&1 | grep -i version | cut -d'"' -f2 | cut -d'.' -f1-2)
-if [[ "${JAVA_VERSION}" != "1.8" ]]; then
-  echo "Incompatible java version: ${JAVA_VERSION}. JDK 8 must be installed."
-  echo "Try switching versions and re-running. Using sdkman: sdk install java 8.0.282+8.hs-adpt || sdk use java 8.0.282+8.hs-adpt"
+if [[ "${JAVA_VERSION}" != "11.0" ]]; then
+  echo "Incompatible java version: ${JAVA_VERSION}. JDK 11 must be installed."
+  echo "Try switching versions and re-running. Using sdkman: sdk install java 11.0.3.hs-adpt || sdk use 11.0.3.hs-adpt"
   exit 1
 fi
 
 # NDK ez-install
-"$ANDROID_HOME/tools/bin/sdkmanager" "ndk;$(./gradlew -q printNdkVersion | tail -1)"
+"$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "ndk;$(./gradlew -q printNdkVersion | tail -1)"
 
 # CI just downloads these libs anyway.
 if [[ -z "${CI}" ]]; then

--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -20,9 +20,9 @@ WORKDIR /builds/worker/
 
 # Configuration
 
-ENV ANDROID_BUILD_TOOLS "28.0.3"
-ENV ANDROID_SDK_VERSION "3859397"
-ENV ANDROID_PLATFORM_VERSION "28"
+ENV ANDROID_BUILD_TOOLS "30.0.3"
+ENV ANDROID_PLATFORM_VERSION "30"
+ENV ANDROID_NDK_VERSION "21.3.6528147"
 
 # Set up the language variables to avoid problems (we run locale-gen later).
 ENV LANG en_US.UTF-8
@@ -51,7 +51,7 @@ RUN apt-get update -qq \
         # If you add anything below, please update building.md.
         ####################
         # Android builds
-        openjdk-8-jdk \
+        openjdk-11-jdk \
         # Required by gyp but also CI scripts.
         python3 \
         # libs/ source patching.
@@ -110,10 +110,14 @@ WORKDIR /builds/worker
 
 ENV ANDROID_HOME /builds/worker/android-sdk
 ENV ANDROID_SDK_HOME /builds/worker/android-sdk
-ENV PATH ${PATH}:${ANDROID_SDK_HOME}/tools:${ANDROID_SDK_HOME}/tools/bin:${ANDROID_SDK_HOME}/platform-tools:/opt/tools:${ANDROID_SDK_HOME}/build-tools/${ANDROID_BUILD_TOOLS}
+ENV PATH ${PATH}:${ANDROID_SDK_HOME}/cmdline-tools/latest/bin:${ANDROID_SDK_HOME}/platform-tools:/opt/tools:${ANDROID_SDK_HOME}/build-tools/${ANDROID_BUILD_TOOLS}
 
-RUN curl -sfSL --retry 5 --retry-delay 10 https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_VERSION}.zip > sdk.zip \
-    && unzip -q sdk.zip -d ${ANDROID_SDK_HOME} \
+# Download the Android SDK tools, unzip them to ${ANDROID_SDK_HOME}/cmdline-tools/latest/, accept all licenses
+# The download link comes from https://developer.android.com/studio/#downloads
+RUN curl -sfSL --retry 5 --retry-delay 10 https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip > sdk.zip \
+    && unzip -q sdk.zip \
+    && mkdir $ANDROID_SDK_HOME/cmdline-tools \
+    && mv cmdline-tools $ANDROID_HOME/cmdline-tools/latest \
     && rm sdk.zip \
     && mkdir -p /builds/worker/android-sdk/.android/ \
     && touch /builds/worker/android-sdk/.android/repositories.cfg \


### PR DESCRIPTION
I saw an email from Grisha indicating Java 11 is needed to build fenix.  That's what I saw too when trying to build yesterday, so I updated some scripts and documentation.

Looks like the taskcluster config also needs to be updated, but I'm not sure how to do that.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
