### PR TITLE
Cut release v82.0.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 81.0.1
+libraryVersion: 82.0.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# v82.0.0 (_2021-07-29_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v81.0.1...v82.0.0)
+
+## General
+
+### ⚠️ Breaking Changes ⚠️
+
+  - The bundled version of Glean has been updated to v39.0.4, which includes a new API
+    for recording extra event fields that have an explicit type..
+    ([#4356](https://github.com/mozilla/application-services/pull/4356))
+
+### What's New
+
+  - Added content signature and chain of trust verification features in `rc_crypto`,
+    and updated NSS to version 3.66.
+    ([#4195](https://github.com/mozilla/application-services/pull/4195))
+
+## Nimbus
+
+### What's Changed
+
+  - The Nimbus API now accepts application specific context as a part of its `appSettings`.
+    The consumers get to define this context for targeting purposes. This allows different consumers
+    to target on different fields without the SDK having to acknowledge all the fields.
+    ([#4359](https://github.com/mozilla/application-services/pull/4359))
+
 # v81.0.1 (_2021-07-19_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v81.0.0...v81.0.1)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v81.0.1...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v82.0.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,16 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-
-## General
-
-### What's Changed
-
-  - The bundled version of Glean has been updated to v39.0.4.
-
-### What's New
-
-  - Added content signature and chain of trust verification features in `rc_crypto` ([#4195](https://github.com/mozilla/application-services/pull/4195))
-## Nimbus
-### What's Changed
-  - The Nimbus API now accepts application specific context as a part of its `appSettings`. The consumers get to define this context for targeting purposes. This allows different consumers to target on different fields without the SDK having to acknowledge all the fields. ([#4359](https://github.com/mozilla/application-services/pull/4359))


### PR DESCRIPTION
The Glean version bump is a breaking change for iOS consumers, so let's get it out the door while we still have the context on how to fix the consumer APIS. Ref https://github.com/mozilla-mobile/firefox-ios/pull/8919.

We also landed an update to NSS (thanks @leplatrem!) so it'll be valuable to get that out into a release without bundling it with too many other changes.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
