### PR TITLE
Have Nimbus optionally import Glean as an external Swift module.

### DIFF
--- a/automation/tests.py
+++ b/automation/tests.py
@@ -286,7 +286,8 @@ def swift_format():
     if on_darwin():
         run_command([
             'swiftformat', 'megazords', 'components/*/ios',
-            '--exclude', '**/Generated', '--lint', '--swiftversion', '4',
+            '--exclude', '**/Generated', '--exclude', 'components/nimbus/ios/Nimbus/Utils',
+            '--lint', '--swiftversion', '4',
         ])
     else:
         print("WARNING: skipping swiftformat on non-Darwin host")

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -4,6 +4,17 @@
 
 import Foundation
 
+// Depending on build setup, we may be importing Glean as a Swift module
+// or we may be compiled together with it. This detects whether Glean is
+// an external module and makes it available to our entire package if so.
+//
+// Note that the files under `./Utils` are copies of internal files from
+// Glean, and it's very important they they be excluded from any build
+// that is compiling us together with Glean.
+#if canImport(Glean)
+    @_exported import Glean
+#endif
+
 public class Nimbus: NimbusApi {
     private let nimbusClient: NimbusClientProtocol
 

--- a/components/nimbus/ios/Nimbus/Utils/Logger.swift
+++ b/components/nimbus/ios/Nimbus/Utils/Logger.swift
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import os.log
+
+class Logger {
+    private let log: OSLog
+
+    /// Creates a new logger instance with the specified tag value
+    ///
+    /// - parameters:
+    ///     * tag: `String` value used to tag log messages
+    init(tag: String) {
+        self.log = OSLog(
+            subsystem: Bundle.main.bundleIdentifier!,
+            category: tag
+        )
+    }
+
+    /// Output a debug log message
+    ///
+    /// - parameters:
+    ///     * message: The message to log
+    func debug(_ message: String) {
+        log(message, type: .debug)
+    }
+
+    /// Output an info log message
+    ///
+    /// - parameters:
+    ///     * message: The message to log
+    func info(_ message: String) {
+        log(message, type: .info)
+    }
+
+    /// Output an error log message
+    ///
+    /// - parameters:
+    ///     * message: The message to log
+    func error(_ message: String) {
+        log(message, type: .error)
+    }
+
+    /// Private function that calls os_log with the proper parameters
+    ///
+    /// - parameters:
+    ///     * message: The message to log
+    ///     * level: The `LogLevel` at which to output the message
+    private func log(_ message: String, type: OSLogType) {
+        os_log("%@", log: self.log, type: type, message)
+    }
+}

--- a/components/nimbus/ios/Nimbus/Utils/Sysctl.swift
+++ b/components/nimbus/ios/Nimbus/Utils/Sysctl.swift
@@ -1,0 +1,162 @@
+// swiftlint:disable line_length
+// REASON: URLs and doc strings
+
+// Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved.
+//
+// Original: https://github.com/mattgallagher/CwlUtils/blob/0e08b0194bf95861e5aac27e8857a972983315d7/Sources/CwlUtils/CwlSysctl.swift
+// Modified:
+//   * iOS only
+//   * removed unused functions
+//   * reformatted
+//
+// ISC License
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+// SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+// IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+import Foundation
+
+// swiftlint:disable force_try
+// REASON: Used on infallible operations
+
+/// A "static"-only namespace around a series of functions that operate on buffers returned from the `Darwin.sysctl` function
+struct Sysctl {
+    /// Possible errors.
+    enum Error: Swift.Error {
+        case unknown
+        case malformedUTF8
+        case invalidSize
+        case posixError(POSIXErrorCode)
+    }
+
+    /// Access the raw data for an array of sysctl identifiers.
+    public static func data(for keys: [Int32]) throws -> [Int8] {
+        return try keys.withUnsafeBufferPointer { keysPointer throws -> [Int8] in
+            // Preflight the request to get the required data size
+            var requiredSize = 0
+            let preFlightResult = Darwin.sysctl(
+                UnsafeMutablePointer<Int32>(mutating: keysPointer.baseAddress),
+                UInt32(keys.count),
+                nil,
+                &requiredSize,
+                nil,
+                0
+            )
+            if preFlightResult != 0 {
+                throw POSIXErrorCode(rawValue: errno).map {
+                    print($0.rawValue)
+                    return Error.posixError($0)
+                } ?? Error.unknown
+            }
+
+            // Run the actual request with an appropriately sized array buffer
+            let data = [Int8](repeating: 0, count: requiredSize)
+            let result = data.withUnsafeBufferPointer { dataBuffer -> Int32 in
+                Darwin.sysctl(
+                    UnsafeMutablePointer<Int32>(mutating: keysPointer.baseAddress),
+                    UInt32(keys.count),
+                    UnsafeMutableRawPointer(mutating: dataBuffer.baseAddress),
+                    &requiredSize,
+                    nil,
+                    0
+                )
+            }
+            if result != 0 {
+                throw POSIXErrorCode(rawValue: errno).map { Error.posixError($0) } ?? Error.unknown
+            }
+
+            return data
+        }
+    }
+
+    /// Convert a sysctl name string like "hw.memsize" to the array of `sysctl` identifiers (e.g. [CTL_HW, HW_MEMSIZE])
+    public static func keys(for name: String) throws -> [Int32] {
+        var keysBufferSize = Int(CTL_MAXNAME)
+        var keysBuffer = [Int32](repeating: 0, count: keysBufferSize)
+        try keysBuffer.withUnsafeMutableBufferPointer { (lbp: inout UnsafeMutableBufferPointer<Int32>) throws in
+            try name.withCString { (nbp: UnsafePointer<Int8>) throws in
+                guard sysctlnametomib(nbp, lbp.baseAddress, &keysBufferSize) == 0 else {
+                    throw POSIXErrorCode(rawValue: errno).map { Error.posixError($0) } ?? Error.unknown
+                }
+            }
+        }
+        if keysBuffer.count > keysBufferSize {
+            keysBuffer.removeSubrange(keysBufferSize ..< keysBuffer.count)
+        }
+        return keysBuffer
+    }
+
+    /// Invoke `sysctl` with an array of identifers, interpreting the returned buffer as the specified type.
+    /// This function will throw `Error.invalidSize` if the size of buffer returned from `sysctl` fails to match the size of `T`.
+    public static func value<T>(ofType _: T.Type, forKeys keys: [Int32]) throws -> T {
+        let buffer = try data(for: keys)
+        if buffer.count != MemoryLayout<T>.size {
+            throw Error.invalidSize
+        }
+        return try buffer.withUnsafeBufferPointer { bufferPtr throws -> T in
+            guard let baseAddress = bufferPtr.baseAddress else { throw Error.unknown }
+            return baseAddress.withMemoryRebound(to: T.self, capacity: 1) { $0.pointee }
+        }
+    }
+
+    /// Invoke `sysctl` with an array of identifers, interpreting the returned buffer as the specified type.
+    /// This function will throw `Error.invalidSize` if the size of buffer returned from `sysctl` fails to match the size of `T`.
+    public static func value<T>(ofType type: T.Type, forKeys keys: Int32...) throws -> T {
+        return try value(ofType: type, forKeys: keys)
+    }
+
+    /// Invoke `sysctl` with the specified name, interpreting the returned buffer as the specified type.
+    /// This function will throw `Error.invalidSize` if the size of buffer returned from `sysctl` fails to match the size of `T`.
+    public static func value<T>(ofType type: T.Type, forName name: String) throws -> T {
+        return try value(ofType: type, forKeys: keys(for: name))
+    }
+
+    /// Invoke `sysctl` with an array of identifers, interpreting the returned buffer as a `String`.
+    /// This function will throw `Error.malformedUTF8` if the buffer returned from `sysctl` cannot be interpreted as a UTF8 buffer.
+    public static func string(for keys: [Int32]) throws -> String {
+        let optionalString = try data(for: keys).withUnsafeBufferPointer { dataPointer -> String? in
+            dataPointer.baseAddress.flatMap { String(validatingUTF8: $0) }
+        }
+        guard let s = optionalString else {
+            throw Error.malformedUTF8
+        }
+        return s
+    }
+
+    /// Invoke `sysctl` with an array of identifers, interpreting the returned buffer as a `String`.
+    /// This function will throw `Error.malformedUTF8` if the buffer returned from `sysctl` cannot be interpreted as a UTF8 buffer.
+    public static func string(for keys: Int32...) throws -> String {
+        return try string(for: keys)
+    }
+
+    /// Invoke `sysctl` with the specified name, interpreting the returned buffer as a `String`.
+    /// This function will throw `Error.malformedUTF8` if the buffer returned from `sysctl` cannot be interpreted as a UTF8 buffer.
+    public static func string(for name: String) throws -> String {
+        return try string(for: keys(for: name))
+    }
+
+    /// Always the same on Apple hardware
+    public static var manufacturer: String = "Apple"
+
+    /// e.g. "N71mAP"
+    public static var machine: String {
+        return try! Sysctl.string(for: [CTL_HW, HW_MODEL])
+    }
+
+    /// e.g. "iPhone8,1"
+    public static var model: String {
+        return try! Sysctl.string(for: [CTL_HW, HW_MACHINE])
+    }
+
+    /// e.g. "15D21" or "13D20"
+    public static var osVersion: String { return try! Sysctl.string(for: [CTL_KERN, KERN_OSVERSION]) }
+}

--- a/components/nimbus/ios/Nimbus/Utils/Unreachable.swift
+++ b/components/nimbus/ios/Nimbus/Utils/Unreachable.swift
@@ -1,0 +1,56 @@
+//  Unreachable.swift
+//  Unreachable
+//  Original: https://github.com/nvzqz/Unreachable
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2017 Nikolai Vazquez
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+/// An unreachable code path.
+///
+/// This can be used for whenever the compiler can't determine that a
+/// path is unreachable, such as dynamically terminating an iterator.
+@inline(__always)
+func unreachable() -> Never {
+    return unsafeBitCast((), to: Never.self)
+}
+
+/// Asserts that the code path is unreachable.
+///
+/// Calls `assertionFailure(_:file:line:)` in unoptimized builds and `unreachable()` otherwise.
+///
+/// - parameter message: The message to print. The default is "Encountered unreachable path".
+/// - parameter file: The file name to print with the message. The default is the file where this function is called.
+/// - parameter line: The line number to print with the message. The default is the line where this function is called.
+@inline(__always)
+func assertUnreachable(_ message: @autoclosure () -> String = "Encountered unreachable path",
+                       file: StaticString = #file,
+                       line: UInt = #line) -> Never {
+    var isDebug = false
+    assert({ isDebug = true; return true }())
+
+    if isDebug {
+        fatalError(message(), file: file, line: line)
+    } else {
+        unreachable()
+    }
+}

--- a/components/nimbus/ios/Nimbus/Utils/Utils.swift
+++ b/components/nimbus/ios/Nimbus/Utils/Utils.swift
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+extension Bool {
+    /// Convert a bool to its byte equivalent.
+    func toByte() -> UInt8 {
+        return self ? 1 : 0
+    }
+}
+
+extension UInt8 {
+    /// Convert a byte to its Bool equivalen.
+    func toBool() -> Bool {
+        return self != 0
+    }
+}
+
+// swiftlint:enable function_parameter_count
+
+/// Create a temporary array of C-compatible (null-terminated) strings to pass over FFI.
+///
+/// The strings are deallocated after the closure returns.
+///
+/// - parameters:
+///     * args: The array of strings to use.
+//              If `nil` no output array will be allocated and `nil` will be passed to `body`.
+///     * body: The closure that gets an array of C-compatible strings
+func withArrayOfCStrings<R>(
+    _ args: [String]?,
+    _ body: ([UnsafePointer<CChar>?]?) -> R
+) -> R {
+    if let args = args {
+        let cStrings = args.map { UnsafePointer(strdup($0)) }
+        defer {
+            cStrings.forEach { free(UnsafeMutableRawPointer(mutating: $0)) }
+        }
+        return body(cStrings)
+    } else {
+        return body(nil)
+    }
+}
+
+/// This struct creates a Boolean with atomic or synchronized access.
+///
+/// This makes use of synchronization tools from Grand Central Dispatch (GCD)
+/// in order to synchronize access.
+struct AtomicBoolean {
+    private var semaphore = DispatchSemaphore(value: 1)
+    private var val: Bool
+    var value: Bool {
+        get {
+            semaphore.wait()
+            let tmp = val
+            semaphore.signal()
+            return tmp
+        }
+        set {
+            semaphore.wait()
+            val = newValue
+            semaphore.signal()
+        }
+    }
+
+    init(_ initialValue: Bool = false) {
+        val = initialValue
+    }
+}
+
+/// Get a timestamp in nanos.
+///
+/// This is a monotonic clock.
+func timestampNanos() -> UInt64 {
+    var info = mach_timebase_info()
+    guard mach_timebase_info(&info) == KERN_SUCCESS else { return 0 }
+    let currentTime = mach_absolute_time()
+    let nanos = currentTime * UInt64(info.numer) / UInt64(info.denom)
+    return nanos
+}
+
+/// Gets a gecko-compatible locale string (e.g. "es-ES")
+// If the locale can't be determined on the system, the value is "und",
+// to indicate "undetermined".
+///
+/// - returns: a locale string that supports custom injected locale/languages.
+func getLocaleTag() -> String {
+    if NSLocale.current.languageCode == nil {
+        return "und"
+    } else {
+        if NSLocale.current.regionCode == nil {
+            return NSLocale.current.languageCode!
+        } else {
+            return "\(NSLocale.current.languageCode!)-\(NSLocale.current.regionCode!)"
+        }
+    }
+}
+
+/// Gather information about the running application
+struct AppInfo {
+    /// The application's identifier name
+    public static var name: String {
+        return Bundle.main.bundleIdentifier!
+    }
+
+    /// The application's display version string
+    public static var displayVersion: String {
+        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+    }
+
+    /// The application's build ID
+    public static var buildId: String {
+        return Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+    }
+}


### PR DESCRIPTION
Currently on iOS, Nimbus and Glean are always compiled together as
part of the same Swift module in the iOS megazord. This means that
Nimbus can see and use many of Glean's internal helper functions,
which in fact it does.

When we switch to distributing via Swift packages, we'll need to
be more careful about inter-module hygiene. I think ideally the
Nimbus Swift code would consume Glean as an ordinary Swift dependency
via `import Glean`.

To make that work while also preserving the current behaviour for
current consumers, I have:

* Added a conditional import of Glean, which gets ignored in the
  existing megazord but makes Glean available in a Swift package build.
* Copied the internal helper modules that we were using from Glean
  into the `nimbus/ios` directory, so that this directory can be
  compiled as a standalone Swift module using only public Glean
  APIs.

Importantly, I have *not* included the copied utility files in the
iOS megazord Xcode project. That build already uses the ones from
Glean and would error out if we included duplicates.

All in all, this doesn't seem like a sustainable setup, but perhaps
it can be the first step towards something cleaner. Maybe we could
make a shared utility module that both Glean and Nimbus can depend
on? Maybe Glean could commit to making these utilities part of its
public API surface?

Suggestions welcome! What I know is that this helps unblock the work
on publishing as a Swift package in the meantime. Fixes #4308.
