### PR TITLE
Fixes #4370 - History metadata enums and struct access

### DIFF
--- a/components/places/ios/Places/HistoryMetadata.swift
+++ b/components/places/ios/Places/HistoryMetadata.swift
@@ -11,7 +11,7 @@ public enum DocumentType: Int32 {
     case regular = 0
     case media = 1
     case unknown = -1
-    
+
     public init(rawValue: Int32) {
         switch rawValue {
         case 0: self = .regular
@@ -28,7 +28,7 @@ public struct HistoryMetadataKey {
     public let url: String
     public let searchTerm: String?
     public let referrerUrl: String?
-    
+
     public init(url: String, searchTerm: String?, referrerUrl: String?) {
         self.url = url
         self.searchTerm = searchTerm
@@ -44,7 +44,7 @@ public enum HistoryMetadataObservation {
     case viewTimeObservation(Int32)
     case documentTypeObservation(DocumentType)
     case unknown
-    
+
     public init(value: Any) {
         switch value {
         case let title as String: self = .titleObservation(title)

--- a/components/places/ios/Places/HistoryMetadata.swift
+++ b/components/places/ios/Places/HistoryMetadata.swift
@@ -10,6 +10,15 @@ import Foundation
 public enum DocumentType: Int32 {
     case regular = 0
     case media = 1
+    case unknown = -1
+    
+    public init(rawValue: Int32) {
+        switch rawValue {
+        case 0: self = .regular
+        case 1: self = .media
+        default: self = .unknown
+        }
+    }
 }
 
 /**
@@ -19,6 +28,12 @@ public struct HistoryMetadataKey {
     public let url: String
     public let searchTerm: String?
     public let referrerUrl: String?
+    
+    public init(url: String, searchTerm: String?, referrerUrl: String?) {
+        self.url = url
+        self.searchTerm = searchTerm
+        self.referrerUrl = referrerUrl
+    }
 }
 
 /**
@@ -28,6 +43,16 @@ public enum HistoryMetadataObservation {
     case titleObservation(String)
     case viewTimeObservation(Int32)
     case documentTypeObservation(DocumentType)
+    case unknown
+    
+    public init(value: Any) {
+        switch value {
+        case let title as String: self = .titleObservation(title)
+        case let time as Int32: self = .viewTimeObservation(time)
+        case let document as DocumentType: self = .documentTypeObservation(document)
+        default: self = .unknown
+        }
+    }
 }
 
 /**

--- a/components/places/ios/Places/HistoryMetadata.swift
+++ b/components/places/ios/Places/HistoryMetadata.swift
@@ -10,21 +10,16 @@ import Foundation
 public enum DocumentType: Int32 {
     case regular = 0
     case media = 1
-    case unknown = -1
 
-    public init(rawValue: Int32) {
-        switch rawValue {
-        case 0: self = .regular
-        case 1: self = .media
-        default: self = .unknown
-        }
+    public init?(value: Int32) {
+        self.init(rawValue: value)
     }
 }
 
 /**
  Represents a set of properties which uniquely identify a history metadata. In database terms this is a compound key.
  */
-public struct HistoryMetadataKey {
+public struct HistoryMetadataKey: Codable {
     public let url: String
     public let searchTerm: String?
     public let referrerUrl: String?
@@ -39,19 +34,15 @@ public struct HistoryMetadataKey {
 /**
  Represents an observation about a `HistoryMetadataKey`.
  */
-public enum HistoryMetadataObservation {
-    case titleObservation(String)
-    case viewTimeObservation(Int32)
-    case documentTypeObservation(DocumentType)
-    case unknown
-
-    public init(value: Any) {
-        switch value {
-        case let title as String: self = .titleObservation(title)
-        case let time as Int32: self = .viewTimeObservation(time)
-        case let document as DocumentType: self = .documentTypeObservation(document)
-        default: self = .unknown
-        }
+public struct HistoryMetadataObservation {
+    var titleObservation: String? = nil
+    var viewTimeObservation: Int32? = nil
+    var documentTypeObservation: DocumentType? = nil
+    
+    public init(titleObservation: String?, viewTimeObservation: Int32?, documentTypeObservation: DocumentType?) {
+        self.titleObservation = titleObservation
+        self.viewTimeObservation = viewTimeObservation
+        self.documentTypeObservation = documentTypeObservation
     }
 }
 

--- a/components/places/ios/Places/HistoryMetadata.swift
+++ b/components/places/ios/Places/HistoryMetadata.swift
@@ -7,7 +7,7 @@ import Foundation
 /**
  Represents a document type of a page.
  */
-public enum DocumentType: Int32 {
+public enum DocumentType: Int32, Codable {
     case regular = 0
     case media = 1
 
@@ -34,7 +34,7 @@ public struct HistoryMetadataKey: Codable {
 /**
  Represents an observation about a `HistoryMetadataKey`.
  */
-public struct HistoryMetadataObservation {
+public struct HistoryMetadataObservation: Codable {
     var titleObservation: String? = nil
     var viewTimeObservation: Int32? = nil
     var documentTypeObservation: DocumentType? = nil

--- a/components/places/ios/Places/HistoryMetadata.swift
+++ b/components/places/ios/Places/HistoryMetadata.swift
@@ -35,10 +35,10 @@ public struct HistoryMetadataKey: Codable {
  Represents an observation about a `HistoryMetadataKey`.
  */
 public struct HistoryMetadataObservation: Codable {
-    var titleObservation: String? = nil
-    var viewTimeObservation: Int32? = nil
-    var documentTypeObservation: DocumentType? = nil
-    
+    var titleObservation: String?
+    var viewTimeObservation: Int32?
+    var documentTypeObservation: DocumentType?
+
     public init(titleObservation: String?, viewTimeObservation: Int32?, documentTypeObservation: DocumentType?) {
         self.titleObservation = titleObservation
         self.viewTimeObservation = viewTimeObservation

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -903,9 +903,13 @@ public class PlacesWriteConnection: PlacesReadConnection {
                 msg.searchTerm = s
             }
 
-            msg.documentType = observation.documentTypeObservation?.rawValue ?? 0
-            msg.title = observation.titleObservation ?? ""
-            msg.viewTime = observation.viewTimeObservation ?? 0
+            if let observation = observation.documentTypeObservation?.rawValue {
+                msg.documentType = observation
+            } else if let title = observation.titleObservation {
+                msg.title = title
+            } else if let viewTime = observation.viewTimeObservation {
+                msg.viewTime = viewTime
+            }
 
             let data = try! msg.serializedData()
             let size = Int32(data.count)

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -903,16 +903,9 @@ public class PlacesWriteConnection: PlacesReadConnection {
                 msg.searchTerm = s
             }
 
-            switch observation {
-            case let .viewTimeObservation(viewTime):
-                msg.viewTime = viewTime
-            case let .documentTypeObservation(documentType):
-                msg.documentType = documentType.rawValue
-            case let .titleObservation(title):
-                msg.title = title
-            case .unknown:
-                break
-            }
+            msg.documentType = observation.documentTypeObservation?.rawValue ?? 0
+            msg.title = observation.titleObservation ?? ""
+            msg.viewTime = observation.viewTimeObservation ?? 0
 
             let data = try! msg.serializedData()
             let size = Int32(data.count)

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -887,7 +887,7 @@ public class PlacesWriteConnection: PlacesReadConnection {
 
     // MARK: History Metadata
 
-    open func noteHistoryMetadataObservation (
+    open func noteHistoryMetadataObservation(
         key: HistoryMetadataKey,
         observation: HistoryMetadataObservation
     ) throws {

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -887,7 +887,7 @@ public class PlacesWriteConnection: PlacesReadConnection {
 
     // MARK: History Metadata
 
-    open func noteHistoryMetadataObservation(
+    open func noteHistoryMetadataObservation (
         key: HistoryMetadataKey,
         observation: HistoryMetadataObservation
     ) throws {
@@ -910,6 +910,8 @@ public class PlacesWriteConnection: PlacesReadConnection {
                 msg.documentType = documentType.rawValue
             case let .titleObservation(title):
                 msg.title = title
+            case .unknown:
+                break
             }
 
             let data = try! msg.serializedData()

--- a/megazords/ios/MozillaAppServicesTests/PlacesTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/PlacesTests.swift
@@ -268,7 +268,7 @@ class PlacesTests: XCTestCase {
             searchTerm: nil,
             referrerUrl: nil
         )
-        _ = try! db.noteHistoryMetadataObservation(key: metaKey1, observation: HistoryMetadataObservation.documentTypeObservation(DocumentType.media))
+        _ = try! db.noteHistoryMetadataObservation(key: metaKey1, observation: HistoryMetadataObservation(titleObservation: nil, viewTimeObservation: nil, documentTypeObservation: .media))
 
         XCTAssertEqual(1, try! db.getHistoryMetadataSince(since: beginning).count)
 
@@ -282,8 +282,7 @@ class PlacesTests: XCTestCase {
         XCTAssertEqual(0, dbMeta!.totalViewTime)
 
         XCTAssertEqual(1, try! db.getHistoryMetadataSince(since: beginning).count)
-
-        _ = try! db.noteHistoryMetadataObservation(key: metaKey1, observation: HistoryMetadataObservation.viewTimeObservation(1337))
+        _ = try! db.noteHistoryMetadataObservation(key: metaKey1, observation: HistoryMetadataObservation(titleObservation: nil, viewTimeObservation: 1337, documentTypeObservation: nil))
         dbMeta = try! db.getLatestHistoryMetadataForUrl(url: "http://www.mozilla.org")
         XCTAssertNotNil(dbMeta)
         XCTAssertEqual("http://www.mozilla.org/", dbMeta!.key.url)
@@ -295,7 +294,7 @@ class PlacesTests: XCTestCase {
 
         XCTAssertEqual(1, try! db.getHistoryMetadataSince(since: beginning).count)
 
-        _ = try! db.noteHistoryMetadataObservation(key: metaKey1, observation: HistoryMetadataObservation.viewTimeObservation(3))
+        _ = try! db.noteHistoryMetadataObservation(key: metaKey1, observation: HistoryMetadataObservation(titleObservation: nil, viewTimeObservation: 1337, documentTypeObservation: nil))
         dbMeta = try! db.getLatestHistoryMetadataForUrl(url: "http://www.mozilla.org")
         XCTAssertEqual(1340, dbMeta!.totalViewTime)
 
@@ -307,7 +306,7 @@ class PlacesTests: XCTestCase {
             searchTerm: "another firefox",
             referrerUrl: "https://www.google.com/search?client=firefox-b-d&q=another+firefox"
         )
-        _ = try! db.noteHistoryMetadataObservation(key: metaKey2, observation: HistoryMetadataObservation.titleObservation("some title"))
+        _ = try! db.noteHistoryMetadataObservation(key: metaKey2, observation: HistoryMetadataObservation(titleObservation: "some title", viewTimeObservation: nil, documentTypeObservation: nil))
 
         XCTAssertEqual(1, try! db.getHistoryMetadataSince(since: afterLastMeta1Update).count)
         XCTAssertEqual(2, try! db.getHistoryMetadataSince(since: beginning).count)
@@ -321,9 +320,9 @@ class PlacesTests: XCTestCase {
         XCTAssertEqual(DocumentType.regular, dbMeta2!.documentType)
         XCTAssertEqual(0, dbMeta2!.totalViewTime)
 
-        _ = try! db.noteHistoryMetadataObservation(key: metaKey2, observation: HistoryMetadataObservation.documentTypeObservation(DocumentType.regular))
-        _ = try! db.noteHistoryMetadataObservation(key: metaKey2, observation: HistoryMetadataObservation.titleObservation("Some Title"))
-        _ = try! db.noteHistoryMetadataObservation(key: metaKey2, observation: HistoryMetadataObservation.viewTimeObservation(52345))
+        _ = try! db.noteHistoryMetadataObservation(key: metaKey2, observation: HistoryMetadataObservation(titleObservation: nil, viewTimeObservation: nil, documentTypeObservation: .regular))
+        _ = try! db.noteHistoryMetadataObservation(key: metaKey2, observation: HistoryMetadataObservation(titleObservation: "some title", viewTimeObservation: nil, documentTypeObservation: nil))
+        _ = try! db.noteHistoryMetadataObservation(key: metaKey2, observation: HistoryMetadataObservation(titleObservation: nil, viewTimeObservation: 52345, documentTypeObservation: nil))
         dbMeta2 = try! db.getLatestHistoryMetadataForUrl(url: "http://www.mozilla.org/another/")
         XCTAssertNotNil(dbMeta2)
         XCTAssertEqual("http://www.mozilla.org/another/", dbMeta2!.key.url)

--- a/megazords/ios/MozillaAppServicesTests/PlacesTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/PlacesTests.swift
@@ -294,7 +294,7 @@ class PlacesTests: XCTestCase {
 
         XCTAssertEqual(1, try! db.getHistoryMetadataSince(since: beginning).count)
 
-        _ = try! db.noteHistoryMetadataObservation(key: metaKey1, observation: HistoryMetadataObservation(titleObservation: nil, viewTimeObservation: 1337, documentTypeObservation: nil))
+        _ = try! db.noteHistoryMetadataObservation(key: metaKey1, observation: HistoryMetadataObservation(titleObservation: nil, viewTimeObservation: 3, documentTypeObservation: nil))
         dbMeta = try! db.getLatestHistoryMetadataForUrl(url: "http://www.mozilla.org")
         XCTAssertEqual(1340, dbMeta!.totalViewTime)
 


### PR DESCRIPTION
Enums and Structs inside a library don't have accessible initializer and require public inits

