### PR TITLE
[nimbus] adds posting a notification when fetching experiments on iOS

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -26,3 +26,7 @@ Use the template below to make assigning a version number during the release cut
     - Two other new errors were defined that were used to be reported under a generic error:
       - `JSONDeserializeError` for errors in deserialization
       - `RequestError` for errors in sending a network request
+
+## Nimbus
+### What's changed
+   - Nimbus on iOS will now post a notification when it's done fetching experiments, to match what it does when applying experiments. ([#4378](https://github.com/mozilla/application-services/pull/4378))

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -160,6 +160,7 @@ internal extension Nimbus {
 
     func fetchExperimentsOnThisThread() throws {
         try nimbusClient.fetchExperiments()
+        notifyOnExperimentsFetched()
     }
 
     func applyPendingExperimentsOnThisThread() throws {


### PR DESCRIPTION
Just came across this, so no bug filed for it, but we'll need this to do some testing around how much of a delay the consuming app expects before the experiments are fetched and applied

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
