### PR TITLE
Fixes dependency licenses branch rename

### DIFF
--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -86,7 +86,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: bitflags</name>
-    <url>https://github.com/bitflags/bitflags/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/bitflags/bitflags/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: block-buffer</name>
@@ -422,7 +422,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: uuid</name>
-    <url>https://github.com/uuid-rs/uuid/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/uuid-rs/uuid/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: version_check</name>


### PR DESCRIPTION
Looks like a couple of projects renamed their base branch to `main` and our dependency check ci failed (ref: https://app.circleci.com/pipelines/github/mozilla/application-services/27930/workflows/2583d700-f463-40a8-9012-c3d1c12f211e/jobs/112074)

I basically just ran `./tools/regenerate_dependency_summaries.sh` and it made those changes for me