### PR TITLE
[nimbus] Adds async api for features on iOS

### DIFF
--- a/components/nimbus/ios/Nimbus/NimbusApi.swift
+++ b/components/nimbus/ios/Nimbus/NimbusApi.swift
@@ -21,16 +21,24 @@ public protocol NimbusApi: AnyObject,
 public protocol NimbusFeatureConfiguration {
     /// Get the currently enrolled branch for the given experiment
     ///
-    /// - Parameter featureId The string feature id that applies to the feature under experiment.
+    /// - Parameter experimentId The string feature id that applies to the feature under experiment.
     /// - Returns A String representing the branch-id or "slug"; or `nil` if not enrolled in this experiment.
     ///
     func getExperimentBranch(experimentId: String) -> String?
+
+    /// Get the currently enrolled branch for the given experiment and execute
+    /// the callback asynchronously on the main thread
+    ///
+    /// - Parameter experimentId: The string feature id that applied to the feature under experiment.
+    /// - Parameter callback: A callback that will be executed on the main thread once the branch-id or "slug" is ready
+    ///
+    func getExperimentBranchAsync(experimentId: String, callback: @escaping (String?) -> Void)
 
     /// Get the variables needed to configure the feature given by `featureId`.
     ///
     /// - Parameters:
     ///     - featureId The string feature id that identifies to the feature under experiment.
-    ///     - recordExposureEvent Passing `true` to this parameter will record the exposure
+    ///     - sendExposureEvent Passing `true` to this parameter will record the exposure
     ///         event automatically if the client is enrolled in an experiment for the given `featureId`.
     ///         Passing `false` here indicates that the application will manually record the exposure
     ///         event by calling `recordExposureEvent`.
@@ -39,6 +47,21 @@ public protocol NimbusFeatureConfiguration {
     ///
     /// - Returns a `Variables` object used to configure the feature.
     func getVariables(featureId: String, sendExposureEvent: Bool) -> Variables
+
+    /// Get the variables needed to configure the feature given by `featureId`.
+    ///
+    /// - Parameters:
+    ///     - featureId The string feature id that identifies to the feature under experiment.
+    ///     - sendExposureEvent Passing `true` to this parameter will record the exposure
+    ///         event automatically if the client is enrolled in an experiment for the given `featureId`.
+    ///         Passing `false` here indicates that the application will manually record the exposure
+    ///         event by calling `recordExposureEvent`.
+    ///     - callback: a callback that will be executed on the main thread once the variables object is ready
+    ///
+    /// See `recordExposureEvent` for more information on manually recording the event.
+    ///
+    /// - Returns a `Variables` object used to configure the feature.
+    func getVariablesAsync(featureId: String, sendExposureEvent: Bool, callback: @escaping (Variables) -> Void)
 }
 
 public extension NimbusFeatureConfiguration {
@@ -117,6 +140,13 @@ public protocol NimbusStartup {
     /// Notifies `.nimbusExperimentsApplied` once enrollments are recalculated.
     ///
     func applyPendingExperiments()
+
+    /// Fetches experiment and calculates the enrollment. Both operations will run
+    /// sequencially.
+    ///
+    /// Both operations are performed on a background thread.
+    ///
+    func fetchAndApplyExperiments()
 
     /// Set the experiments as the passed string, just as `fetchExperiments` gets the string from
     /// the server. Like `fetchExperiments`, this requires `applyPendingExperiments` to be called


### PR DESCRIPTION
## What is this
### Background on "why now"
With the first run targeting work on mobile, we are opting to fetch and apply experiments sequentially (on the first run only, every other run will apply then fetch concurrently). This means that it will create more of a delay till the experiment information is ready **on the first run only, every other run is unaffected**.

### Consumer experience
Consumers that want to consume our API's currently will simply call our synchronous API, and if the experiments are not ready they'll get a `nil` value (and an error will be reported). 

What I'm proposing here is an asynchronous API, where the consumer has the option to pass in a `callback` that will execute **on the main thread** once the experiment data is ready. This is to support two main use cases:
- The case where a consumer is determined to get the experiment data (and a `nil` is not acceptable), without an async API, the consumer is forced to poll until the experiment data is ready
- The case where a consumer is okay "waiting" for a result (without blocking of course) to minimize the rate of failure. This is going to be especially important for experiments running on a user's first run (since there will be an expected delay). In practice, the delay isn't great in iOS, but the API is more about creating deterministic behavior if consumers want it

Another benefit to this is it creates a clear understanding of what a client receiving a `nil` means. If a client calls the async API and the callback receives a `nil` value, this can only imply that the experiment **Doesn't exist**... because if it existed, the async API will guarantee that the callback gets it. In the synchronous api, a `nil` could mean either the experiment data is not ready **or** that the experiment doesn't exist, and there is no way for the caller to determine which is it.


### How it's implemented
What I have here is **simple**, basically have everything async executing on the same **background thread**, this is not the best way to make it async (in reality there is only one dependency, the `applyExperiments`, every other call can be concurrent as long as the `apply` is done). I can explore making the asynchrony here better, but I think that's worth its own follow-up **if we decide we want to keep this**

Another note is that we might want to modify some of the Rust logic that this API calls (or define other rust APIs for this) but I haven't thought of that deeply since this seems to get the job done (I have a demo using firefox-ios that consumes this code)


(disclaimer that I'm very new to swift and I could have easily missed something here)

### TODO:
- [ ] Change log
- [ ] Tests (haven't looked at how the existing API is tested)

