### PR TITLE
Cut release v82.2.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 82.1.0
+libraryVersion: 82.2.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v82.2.0 (_2021-08-19_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v82.1.0...v82.2.0)
+
+## Push
+### What's changed
+  - The push component will now attempt to auto-recover from the server losing its UAID ([#4347](https://github.com/mozilla/application-services/pull/4347))
+    - The push component will return a new kotlin Error `UAIDNotRecognizedError` in cases where auto-recovering isn't possible (when subscribing)
+    - Two other new errors were defined that were used to be reported under a generic error:
+      - `JSONDeserializeError` for errors in deserialization
+      - `RequestError` for errors in sending a network request
+
+## Nimbus
+### What's changed
+   - Nimbus on iOS will now post a notification when it's done fetching experiments, to match what it does when applying experiments. ([#4378](https://github.com/mozilla/application-services/pull/4378))
+
 # v82.1.0 (_2021-07-30_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v82.0.0...v82.1.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v82.1.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v82.2.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,15 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-
-## Push
-### What's changed
-  - The push component will now attempt to auto-recover from the server losing its UAID ([#4347](https://github.com/mozilla/application-services/pull/4347))
-    - The push component will return a new kotlin Error `UAIDNotRecognizedError` in cases where auto-recovering isn't possible (when subscribing)
-    - Two other new errors were defined that were used to be reported under a generic error:
-      - `JSONDeserializeError` for errors in deserialization
-      - `RequestError` for errors in sending a network request
-
-## Nimbus
-### What's changed
-   - Nimbus on iOS will now post a notification when it's done fetching experiments, to match what it does when applying experiments. ([#4378](https://github.com/mozilla/application-services/pull/4378))


### PR DESCRIPTION
Cutting a release for the nimbus changes that we'll need to make iOS work with first run
