### PR TITLE
Build iOS Rust code as an XCFramework.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,7 @@ commands:
             cargo metadata --locked > /dev/null
             python3 ./tools/dependency_summary.py --check ./DEPENDENCIES.md
             python3 ./tools/dependency_summary.py --all-ios-targets --package megazord_ios --check megazords/ios/DEPENDENCIES.md
+            python3 ./tools/dependency_summary.py --all-ios-targets --package ios_rust --check megazords/ios-rust/DEPENDENCIES.md
             python3 ./tools/dependency_summary.py --all-android-targets --package megazord --check megazords/full/DEPENDENCIES.md
             python3 ./tools/dependency_summary.py --all-android-targets --package megazord --format pom --check megazords/full/android/dependency-licenses.xml
   bench-all:
@@ -380,6 +381,21 @@ jobs:
       - store_artifacts:
           path: raw_xcodebuild.log
           destination: logs/raw_xcodebuild.log
+      - run:
+          name: Build XCFramework archive
+          command: |
+            # For now we need the nightly toolchain to build for the M1 simulator.
+            rustup install nightly
+            # For now we need to build the Rust stdlib from source for the M1 simulator.
+            rustup component add rust-src --toolchain nightly-x86_64-apple-darwin
+            if [ -z "${CIRCLE_TAG}" ]; then
+              # XCode tests build in Debug configuration, save us a full
+              # Rust rebuild in Release mode by forcing Debug mode on
+              # non-release builds.
+              bash megazords/ios-rust/build-xcframework.sh --build-profile debug
+            else
+              bash megazords/ios-rust/build-xcframework.sh --build-profile release
+            fi
       - save_cache:
           name: Save sccache cache
           key: sccache-cache-macos-{{ arch }}-{{ epoch }}
@@ -392,21 +408,33 @@ jobs:
             ZIP_URL=https://circleci.com/api/v1.1/project/github/mozilla/application-services/$CIRCLE_BUILD_NUM/artifacts/0/dist/MozillaAppServices.framework.zip
             echo "{\"0.0.1\":\"$ZIP_URL\"}" > mozilla.app-services.json
       - store_artifacts:
+          name: Store Carthage framework in workspace
           path: MozillaAppServices.framework.zip
           destination: dist/MozillaAppServices.framework.zip
       - store_artifacts:
+          name: Store Carthage bin-only project specification in workspace
           path: mozilla.app-services.json
           destination: dist/mozilla.app-services.json
+      - store_artifacts:
+          name: Store XCFramework bundle in workspace
+          path: megazords/ios-rust/MozillaRustComponents.xcframework.zip
+          destination: dist/MozillaRustComponents.xcframework.zip
       - run:
           name: "Carthage binary snapshot URL"
           command: |
             JSON_URL=https://circleci.com/api/v1.1/project/github/mozilla/application-services/$CIRCLE_BUILD_NUM/artifacts/0/dist/mozilla.app-services.json
             echo "Add the following line to your Cartfile:"
             echo "binary \"$JSON_URL\" ~> 0.0.1-snapshot # mozilla/application-services@$CIRCLE_SHA1"
+      - run:
+          name: "XCFramework bundle checksum"
+          command: |
+            shasum -a 256 ./megazords/ios-rust/MozillaRustComponents.xcframework.zip
+            echo "Use the above checksum to depend on MozillaRustComponents.xcframework.zip as a Swift Package binary target"
       - persist_to_workspace:
           root: .
           paths:
             - MozillaAppServices.framework.zip
+            - megazords/ios-rust/MozillaRustComponents.xcframework.zip
   Carthage release:
     executor: macos
     steps:
@@ -422,6 +450,21 @@ jobs:
             echo "${GHR_SHA256} *${GHR}.zip" | shasum -a 256 -c -
             unzip "${GHR}.zip"
             ./${GHR}/ghr -replace "${CIRCLE_TAG}" MozillaAppServices.framework.zip
+  XCFramework release:
+    executor: macos
+    steps:
+      - full-checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Release XCFramework archive on GitHub
+          command: |
+            GHR=ghr_v0.12.0_darwin_amd64
+            GHR_SHA256=c868ef9fc5dd8c8a397b74d84051d83693c42dd59041cb17b66f90f563477249
+            curl -sfSL --retry 5 --retry-delay 10 -O "https://github.com/tcnksm/ghr/releases/download/v0.12.0/${GHR}.zip"
+            echo "${GHR_SHA256} *${GHR}.zip" | shasum -a 256 -c -
+            unzip "${GHR}.zip"
+            ./${GHR}/ghr -replace "${CIRCLE_TAG}" megazords/ios-rust/MozillaRustComponents.xcframework.zip
 
 workflows:
   version: 2
@@ -473,13 +516,21 @@ workflows:
   coverage:
     jobs:
       - Generate code coverage
-  carthage-framework:
+  ios-artifacts:
     jobs:
       - iOS build and test:
           filters: # required since `Release` has tag filters AND requires `Build`
             tags:
               only: /.*/
       - Carthage release:
+          requires:
+            - iOS build and test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+      - XCFramework release:
           requires:
             - iOS build and test
           filters:

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ components/**/ios/Generated
 # Glean generated artifacts
 megazords/ios/MozillaAppServices/Generated/Metrics.swift
 megazords/ios/.venv
+megazords/ios-rust/MozillaRustComponents.xcframework*
 
 # Carthage generated artifacts
 Carthage
@@ -50,3 +51,4 @@ docs/book
 
 # Generated rustdocs
 docs/rust-docs
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,6 +1401,17 @@ name = "interrupt-support"
 version = "0.1.0"
 
 [[package]]
+name = "ios_rust"
+version = "0.1.0"
+dependencies = [
+ "crashtest",
+ "nimbus-sdk",
+ "rc_log_ffi",
+ "viaduct",
+ "viaduct-reqwest",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
     "components/webext-storage/ffi",
     "megazords/full",
     "megazords/ios/rust",
+    "megazords/ios-rust",
 # Disabled for intermittent failures; see SDK-233 and #3909 for details.
 #    "testing/sync-test",
     "tools/protobuf-gen",

--- a/components/crashtest/uniffi.toml
+++ b/components/crashtest/uniffi.toml
@@ -2,6 +2,8 @@
 package_name = "mozilla.appservices.crashtest"
 cdylib_name = "megazord"
 
-[bindings.swift]
-generate_module_map = false
 
+[bindings.swift]
+ffi_module_name = "MozillaRustComponents"
+ffi_module_filename = "crashtestFFI"
+generate_module_map = false

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -4,6 +4,9 @@
 
 import Foundation
 import UIKit
+#if canImport(Sync15)
+    import Sync15
+#endif
 
 typealias LoginsStoreError = LoginsStorageError
 

--- a/components/nimbus/ios/Nimbus/FeatureVariables.swift
+++ b/components/nimbus/ios/Nimbus/FeatureVariables.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import UIKit
 
 /// `Variables` provides a type safe key-value style interface to configure application features
 ///

--- a/components/nimbus/uniffi.toml
+++ b/components/nimbus/uniffi.toml
@@ -3,4 +3,6 @@ package_name = "org.mozilla.experiments.nimbus.internal"
 cdylib = "megazord"
 
 [bindings.swift]
+ffi_module_name = "MozillaRustComponents"
+ffi_module_filename = "nimbusFFI"
 generate_module_map = false

--- a/components/rc_log/ios/RustLog.swift
+++ b/components/rc_log/ios/RustLog.swift
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+#if canImport(MozillaRustComponents)
+    import MozillaRustComponents
+#endif
 
 /// The level of a log message
 public enum LogLevel: Int32 {

--- a/components/viaduct/ios/Viaduct.swift
+++ b/components/viaduct/ios/Viaduct.swift
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+#if canImport(MozillaRustComponents)
+    import MozillaRustComponents
+#endif
 
 /// The public interface to viaduct.
 /// Right now it doesn't do any "true" viaduct things,

--- a/docs/build-and-publish-pipeline.md
+++ b/docs/build-and-publish-pipeline.md
@@ -24,7 +24,7 @@ The key points:
 * Releases are made by [manually creating a new release](./howtos/cut-a-new-release.md) via github,
   which triggers various CI jobs:
     * [CircleCI](../.circleci/config.yml) is used to build an iOS binary release on every release,
-      and publish it as a GitHub release artifact.
+      and publish it as GitHub release artifacts.
     * [TaskCluster](../automation/taskcluster/README.md) is used to:
         * Build an Android binary release.
         * Upload Android library symbols to [Socorro](https://wiki.mozilla.org/Socorro).
@@ -75,7 +75,9 @@ For iOS consumers the corresponding steps are:
     * TODO: could this step check for signed tags as an additional integrity measure?
     * TODO: can we prevent these steps from being able to see the tokens used
       for publishing in subsequent steps?
-4. CircleCI runs Carthage to assemble a zipfile of built frameworks.
+4. CircleCI builds two binary artifacts:
+    * A Carthage framework containing both Rust and Swift code compiled together, as a zipfile.
+    * An XCFramework containing just Rust code and header files, as a zipfile, for use by Swift Packags.
     * TODO: could a malicious dev dependency from step (3) influence the build environment here?
 5. CircleCI uses [dpl](https://github.com/travis-ci/dpl) to publish to GitHub as a release artifact.
     * CircleCI config contains a github token (owned by the @appsvc-moz GitHub account) with appropriate permissions to add release artifacts.

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ios_rust"
+edition = "2018"
+version = "0.1.0"
+authors = ["application-services <application-services@mozilla.com>"]
+license = "MPL-2.0"
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+rc_log_ffi = { path = "../../components/rc_log" }
+viaduct = { path = "../../components/viaduct" }
+viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+nimbus-sdk = { path = "../../components/nimbus" }
+crashtest = { path = "../../components/crashtest" }
+
+# TODO: can't include fxa-client until we get NSS working on M1 simulator,
+# ref https://github.com/mozilla/application-services/issues/4352.
+#fxa-client = { path = "../../components/fxa-client" }
+# TODO: can't include logins until we get SQLCipher working on M1 simulator,
+# ref https://github.com/mozilla/application-services/issues/4352.
+# (or until we entirely get rid of SQLCipher)
+#logins = { path = "../../components/logins" }

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -774,7 +774,7 @@ SOFTWARE.
 The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
-[memchr](https://github.com/BurntSushi/rust-memchr)
+[memchr](https://github.com/BurntSushi/memchr)
 
 ```
 The MIT License (MIT)

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -1,0 +1,1586 @@
+# Licenses for Third-Party Dependencies
+
+Binary distributions of this software incorporate code from a number of third-party dependencies.
+These dependencies are available under a variety of free and open source licenses,
+the details of which are reproduced below.
+
+* [Mozilla Public License 2.0](#mozilla-public-license-20)
+* [Apache License 2.0](#apache-license-20)
+* [MIT License: SwiftKeychainWrapper](#mit-license-swiftkeychainwrapper)
+* [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
+* [MIT License: bincode](#mit-license-bincode)
+* [MIT License: bitvec, wyz](#mit-license-bitvec-wyz)
+* [MIT License: bytes](#mit-license-bytes)
+* [MIT License: cargo_metadata](#mit-license-cargo_metadata)
+* [MIT License: clap](#mit-license-clap)
+* [MIT License: funty](#mit-license-funty)
+* [MIT License: generic-array](#mit-license-generic-array)
+* [MIT License: h2](#mit-license-h2)
+* [MIT License: http-body](#mit-license-http-body)
+* [MIT License: hyper](#mit-license-hyper)
+* [MIT License: matches](#mit-license-matches)
+* [MIT License: mio](#mit-license-mio)
+* [MIT License: nom](#mit-license-nom)
+* [MIT License: ordered-float](#mit-license-ordered-float)
+* [MIT License: radium](#mit-license-radium)
+* [MIT License: slab](#mit-license-slab)
+* [MIT License: tap](#mit-license-tap)
+* [MIT License: textwrap](#mit-license-textwrap)
+* [MIT License: tokio, tokio-util](#mit-license-tokio-tokio-util)
+* [MIT License: tokio-native-tls, tracing, tracing-core](#mit-license-tokio-native-tls-tracing-tracing-core)
+* [MIT License: tower-service](#mit-license-tower-service)
+* [MIT License: try-lock](#mit-license-try-lock)
+* [MIT License: want](#mit-license-want)
+* [MIT License: weedle](#mit-license-weedle)
+* [BSD-2-Clause License: arrayref](#bsd-2-clause-license-arrayref)
+-------------
+## Mozilla Public License 2.0
+
+The following text applies to code linked from these dependencies:
+[jexl-eval](https://github.com/mozilla/jexl-rs),
+[jexl-parser](https://github.com/mozilla/jexl-rs),
+[uniffi](https://github.com/mozilla/uniffi-rs),
+[uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
+[uniffi_build](https://github.com/mozilla/uniffi-rs),
+[uniffi_macros](https://github.com/mozilla/uniffi-rs)
+
+```
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.
+
+```
+-------------
+## Apache License 2.0
+
+The following text applies to code linked from these dependencies:
+[anyhow](https://github.com/dtolnay/anyhow),
+[arrayvec](https://github.com/bluss/arrayvec),
+[askama](https://github.com/djc/askama),
+[askama_derive](https://github.com/djc/askama),
+[askama_escape](https://github.com/djc/askama),
+[askama_shared](https://github.com/djc/askama),
+[autocfg](https://github.com/cuviper/autocfg),
+[base64](https://github.com/marshallpierce/rust-base64),
+[bitflags](https://github.com/bitflags/bitflags),
+[block-buffer](https://github.com/RustCrypto/utils),
+[camino](https://github.com/withoutboats/camino),
+[cargo-platform](https://github.com/rust-lang/cargo),
+[cc](https://github.com/alexcrichton/cc-rs),
+[cfg-if](https://github.com/alexcrichton/cfg-if),
+[core-foundation-sys](https://github.com/servo/core-foundation-rs),
+[core-foundation](https://github.com/servo/core-foundation-rs),
+[cpufeatures](https://github.com/RustCrypto/utils),
+[digest](https://github.com/RustCrypto/traits),
+[either](https://github.com/bluss/either),
+[encoding_rs](https://github.com/hsivonen/encoding_rs),
+[ffi-support](https://github.com/mozilla/ffi-support),
+[fnv](https://github.com/servo/rust-fnv),
+[form_urlencoded](https://github.com/servo/rust-url),
+[futures-channel](https://github.com/rust-lang/futures-rs),
+[futures-core](https://github.com/rust-lang/futures-rs),
+[futures-io](https://github.com/rust-lang/futures-rs),
+[futures-sink](https://github.com/rust-lang/futures-rs),
+[futures-task](https://github.com/rust-lang/futures-rs),
+[futures-util](https://github.com/rust-lang/futures-rs),
+[getrandom](https://github.com/rust-random/getrandom),
+[glob](https://github.com/rust-lang/glob),
+[hashbrown](https://github.com/rust-lang/hashbrown),
+[heck](https://github.com/withoutboats/heck),
+[hex](https://github.com/KokaKiwi/rust-hex),
+[http](https://github.com/hyperium/http),
+[httparse](https://github.com/seanmonstar/httparse),
+[httpdate](https://github.com/pyfisch/httpdate),
+[hyper-tls](https://github.com/hyperium/hyper-tls),
+[id-arena](https://github.com/fitzgen/id-arena),
+[idna](https://github.com/servo/rust-url/),
+[indexmap](https://github.com/bluss/indexmap),
+[ipnet](https://github.com/krisprice/ipnet),
+[itertools](https://github.com/rust-itertools/itertools),
+[itoa](https://github.com/dtolnay/itoa),
+[lalrpop-util](https://github.com/lalrpop/lalrpop),
+[lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
+[lexical-core](https://github.com/Alexhuszagh/rust-lexical/tree/master/lexical-core),
+[libc](https://github.com/rust-lang/libc),
+[lmdb-rkv-sys](https://github.com/mozilla/lmdb-rs.git),
+[lmdb-rkv](https://github.com/mozilla/lmdb-rs.git),
+[log](https://github.com/rust-lang/log),
+[mime](https://github.com/hyperium/mime),
+[native-tls](https://github.com/sfackler/rust-native-tls),
+[num-traits](https://github.com/rust-num/num-traits),
+[num_cpus](https://github.com/seanmonstar/num_cpus),
+[once_cell](https://github.com/matklad/once_cell),
+[opaque-debug](https://github.com/RustCrypto/utils),
+[paste-impl](https://github.com/dtolnay/paste),
+[paste](https://github.com/dtolnay/paste),
+[percent-encoding](https://github.com/servo/rust-url/),
+[pest](https://github.com/pest-parser/pest),
+[pin-project-lite](https://github.com/taiki-e/pin-project-lite),
+[pin-utils](https://github.com/rust-lang-nursery/pin-utils),
+[pkg-config](https://github.com/rust-lang/pkg-config-rs),
+[ppv-lite86](https://github.com/cryptocorrosion/cryptocorrosion),
+[proc-macro-hack](https://github.com/dtolnay/proc-macro-hack),
+[proc-macro2](https://github.com/alexcrichton/proc-macro2),
+[prost-derive](https://github.com/tokio-rs/prost),
+[prost](https://github.com/tokio-rs/prost),
+[quote](https://github.com/dtolnay/quote),
+[rand](https://github.com/rust-random/rand),
+[rand_chacha](https://github.com/rust-random/rand),
+[rand_core](https://github.com/rust-random/rand),
+[regex-syntax](https://github.com/rust-lang/regex),
+[regex](https://github.com/rust-lang/regex),
+[remove_dir_all](https://github.com/XAMPPRocky/remove_dir_all.git),
+[reqwest](https://github.com/seanmonstar/reqwest),
+[rkv](https://github.com/mozilla/rkv),
+[ryu](https://github.com/dtolnay/ryu),
+[security-framework-sys](https://github.com/kornelski/rust-security-framework),
+[security-framework](https://github.com/kornelski/rust-security-framework),
+[semver-parser](https://github.com/steveklabnik/semver-parser),
+[semver](https://github.com/steveklabnik/semver),
+[serde](https://github.com/serde-rs/serde),
+[serde_derive](https://github.com/serde-rs/serde),
+[serde_json](https://github.com/serde-rs/json),
+[serde_urlencoded](https://github.com/nox/serde_urlencoded),
+[sha2](https://github.com/RustCrypto/hashes),
+[socket2](https://github.com/rust-lang/socket2),
+[static_assertions](https://github.com/nvzqz/static-assertions-rs),
+[swift-protobuf](https://github.com/apple/swift-protobuf),
+[syn](https://github.com/dtolnay/syn),
+[tempfile](https://github.com/Stebalien/tempfile),
+[thiserror-impl](https://github.com/dtolnay/thiserror),
+[thiserror](https://github.com/dtolnay/thiserror),
+[tinyvec](https://github.com/Lokathor/tinyvec),
+[tinyvec_macros](https://github.com/Soveu/tinyvec_macros),
+[toml](https://github.com/alexcrichton/toml-rs),
+[typenum](https://github.com/paholg/typenum),
+[ucd-trie](https://github.com/BurntSushi/ucd-generate),
+[unicode-bidi](https://github.com/servo/unicode-bidi),
+[unicode-normalization](https://github.com/unicode-rs/unicode-normalization),
+[unicode-segmentation](https://github.com/unicode-rs/unicode-segmentation),
+[unicode-width](https://github.com/unicode-rs/unicode-width),
+[unicode-xid](https://github.com/unicode-rs/unicode-xid),
+[url](https://github.com/servo/rust-url),
+[uuid](https://github.com/uuid-rs/uuid),
+[version_check](https://github.com/SergioBenitez/version_check)
+
+```
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+```
+-------------
+## MIT License: SwiftKeychainWrapper
+
+The following text applies to code linked from these dependencies:
+[SwiftKeychainWrapper](https://github.com/jrendel/SwiftKeychainWrapper)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2014 Jason Rendel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+```
+-------------
+## MIT License: aho-corasick, byteorder, memchr
+
+The following text applies to code linked from these dependencies:
+[aho-corasick](https://github.com/BurntSushi/aho-corasick),
+[byteorder](https://github.com/BurntSushi/byteorder),
+[memchr](https://github.com/BurntSushi/rust-memchr)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Andrew Gallant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+-------------
+## MIT License: bincode
+
+The following text applies to code linked from these dependencies:
+[bincode](https://github.com/servo/bincode)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2014 Ty Overby
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: bitvec, wyz
+
+The following text applies to code linked from these dependencies:
+[bitvec](https://github.com/myrrlyn/bitvec),
+[wyz](https://github.com/myrrlyn/wyz)
+
+```
+MIT License
+
+Copyright (c) 2018 myrrlyn (Alexander Payne)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: bytes
+
+The following text applies to code linked from these dependencies:
+[bytes](https://github.com/tokio-rs/bytes)
+
+```
+Copyright (c) 2018 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: cargo_metadata
+
+The following text applies to code linked from these dependencies:
+[cargo_metadata](https://github.com/oli-obk/cargo_metadata)
+
+```
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: clap
+
+The following text applies to code linked from these dependencies:
+[clap](https://github.com/clap-rs/clap)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015-2016 Kevin B. Knapp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: funty
+
+The following text applies to code linked from these dependencies:
+[funty](https://github.com/myrrlyn/funty)
+
+```
+MIT License
+
+Copyright (c) 2020 myrrlyn (Alexander Payne)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: generic-array
+
+The following text applies to code linked from these dependencies:
+[generic-array](https://github.com/fizyk20/generic-array.git)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Bartłomiej Kamiński
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+-------------
+## MIT License: h2
+
+The following text applies to code linked from these dependencies:
+[h2](https://github.com/hyperium/h2)
+
+```
+Copyright (c) 2017 h2 authors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: http-body
+
+The following text applies to code linked from these dependencies:
+[http-body](https://github.com/hyperium/http-body)
+
+```
+Copyright (c) 2019 Hyper Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: hyper
+
+The following text applies to code linked from these dependencies:
+[hyper](https://github.com/hyperium/hyper)
+
+```
+Copyright (c) 2014-2021 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+-------------
+## MIT License: matches
+
+The following text applies to code linked from these dependencies:
+[matches](https://github.com/SimonSapin/rust-std-candidates)
+
+```
+Copyright (c) 2014-2016 Simon Sapin
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: mio
+
+The following text applies to code linked from these dependencies:
+[mio](https://github.com/tokio-rs/mio)
+
+```
+Copyright (c) 2014 Carl Lerche and other MIO contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+-------------
+## MIT License: nom
+
+The following text applies to code linked from these dependencies:
+[nom](https://github.com/Geal/nom)
+
+```
+Copyright (c) 2014-2019 Geoffroy Couprie
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: ordered-float
+
+The following text applies to code linked from these dependencies:
+[ordered-float](https://github.com/reem/rust-ordered-float)
+
+```
+Copyright (c) 2015 Jonathan Reem
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: radium
+
+The following text applies to code linked from these dependencies:
+[radium](https://github.com/mystor/radium)
+
+```
+MIT License
+
+Copyright (c) 2019 kneecaw (Nika Layzell)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: slab
+
+The following text applies to code linked from these dependencies:
+[slab](https://github.com/tokio-rs/slab)
+
+```
+Copyright (c) 2019 Carl Lerche
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: tap
+
+The following text applies to code linked from these dependencies:
+[tap](https://github.com/myrrlyn/tap)
+
+```
+MIT License
+
+Copyright (c) 2017 Elliot Linder <darfink@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: textwrap
+
+The following text applies to code linked from these dependencies:
+[textwrap](https://github.com/mgeisler/textwrap)
+
+```
+MIT License
+
+Copyright (c) 2016 Martin Geisler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: tokio, tokio-util
+
+The following text applies to code linked from these dependencies:
+[tokio-util](https://github.com/tokio-rs/tokio),
+[tokio](https://github.com/tokio-rs/tokio)
+
+```
+Copyright (c) 2021 Tokio Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: tokio-native-tls, tracing, tracing-core
+
+The following text applies to code linked from these dependencies:
+[tokio-native-tls](https://github.com/tokio-rs/tls),
+[tracing-core](https://github.com/tokio-rs/tracing),
+[tracing](https://github.com/tokio-rs/tracing)
+
+```
+Copyright (c) 2019 Tokio Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: tower-service
+
+The following text applies to code linked from these dependencies:
+[tower-service](https://github.com/tower-rs/tower)
+
+```
+Copyright (c) 2019 Tower Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: try-lock
+
+The following text applies to code linked from these dependencies:
+[try-lock](https://github.com/seanmonstar/try-lock)
+
+```
+Copyright (c) 2018 Sean McArthur
+Copyright (c) 2016 Alex Crichton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+```
+-------------
+## MIT License: want
+
+The following text applies to code linked from these dependencies:
+[want](https://github.com/seanmonstar/want)
+
+```
+Copyright (c) 2018-2019 Sean McArthur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+```
+-------------
+## MIT License: weedle
+
+The following text applies to code linked from these dependencies:
+[weedle](https://github.com/rustwasm/weedle)
+
+```
+Copyright 2018-Present Sharad Chand
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+```
+-------------
+## BSD-2-Clause License: arrayref
+
+The following text applies to code linked from these dependencies:
+[arrayref](https://github.com/droundy/arrayref)
+
+```
+Copyright (c) 2015 David Roundy <roundyd@physics.oregonstate.edu>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the
+   distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+```
+-------------

--- a/megazords/ios-rust/Info.plist
+++ b/megazords/ios-rust/Info.plist
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AvailableLibraries</key>
+	<array>
+		<!-- If we want to add desktop builds in future, this is the required snippet:
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>macos-x86_64</string>
+			<key>LibraryPath</key>
+			<string>MozillaRustComponents.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>x86_64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>macos</string>
+		</dict>-->
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64</string>
+			<key>LibraryPath</key>
+			<string>MozillaRustComponents.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+		</dict>
+		<dict>
+			<key>LibraryIdentifier</key>
+			<string>ios-arm64_x86_64-simulator</string>
+			<key>LibraryPath</key>
+			<string>MozillaRustComponents.framework</string>
+			<key>SupportedArchitectures</key>
+			<array>
+				<string>arm64</string>
+				<string>x86_64</string>
+			</array>
+			<key>SupportedPlatform</key>
+			<string>ios</string>
+			<key>SupportedPlatformVariant</key>
+			<string>simulator</string>
+		</dict>
+	</array>
+	<key>CFBundlePackageType</key>
+	<string>XFWK</string>
+	<key>XCFrameworkFormatVersion</key>
+	<string>1.0</string>
+</dict>
+</plist>

--- a/megazords/ios-rust/MozillaRustComponents.h
+++ b/megazords/ios-rust/MozillaRustComponents.h
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This is the "umbrella header" for our combined Rust code library.
+// It needs to import all of the individual headers.
+
+#import "crashtestFFI.h"
+#import "nimbusFFI.h"
+#import "RustViaductFFI.h"
+#import "RustLogFFI.h"

--- a/megazords/ios-rust/README.md
+++ b/megazords/ios-rust/README.md
@@ -1,0 +1,113 @@
+# XCFramework build for distributing Rust code on iOS
+
+This directory contains the logic for compiling all of our Rust code into a binary
+artifact that can be easily distributed to iOS consumers. If you run the following
+script:
+
+```
+$> ./build-xcframework.sh
+```
+
+Then it should produce a file named `MozillaRustComponents.xcframework.zip` that
+contains:
+
+* The compiled Rust code for all the crates listed in `Cargo.toml`, as a static library,
+* along with their corresponding C header files and Swift module maps,
+* built for all our target iOS platforms, as an "XCFramework" bundle.
+
+The resulting `.zip` is suitable for consumption as a Swift Package binary dependency.
+
+## What's here?
+
+In this directory we have:
+
+* A Rust crate that serves as the "megazord" for our iOS distributions; it basically depends
+  on all the Rust Component crates and re-exports their public APIs.
+* Some skeleton files for building an XCFramework:
+    * `module.modulemap` is a "module map", which tells the Swift compiler how to use C-level APIs.
+    * `MozillaRustComponents.h` is an "umbrella header", used by the module map as a shortcut
+      to specify all the available header files.
+    * `Info.plist` specified metadata about the resulting XCFramework, such as the available
+      architectures and their subdirectories.
+* The `build-xcframework.sh` script which knows how to stitch things together into a full
+  XCFramework bundle.
+    * The XCFramework format is not well documented; briefly:
+        * It's a directory containing resources compiled for multiple target architectures,
+          typically distributed as `.zip` file.
+        * The top-level directory contains a subdirectory per architecture, and an `Info.plist`
+          file that says what things live in which directory.
+        * Each subdirectory contains a `.framework` directory for that architecture. There
+          are notes on the layout of an individual `.framework` in the links below.
+
+It's a little unusual that we're building the XCFramework by hand, rather than defining it
+as the build output of an Xcode project. It turns out to be simpler for our purposes, but
+does risk diverging from the expected format if Apple changes the detailts of XCFrameworks
+in future Xcode releases.
+
+## Adding crates
+
+To add a new crate to the distribution:
+
+1. Update its `uniffi.toml`, if any, to include the following settings:
+    ```
+    [bindings.swift]
+    ffi_module_name = "MozillaRustComponents"
+    ffi_module_filename = "<crate_name>FFI"
+    ```
+1. Add it as a dependency in `Cargo.toml`.
+1. Add a `pub use` declaration for it in `./src/lib.rs`.
+1. Add logic to `build-xcframework.sh` to copy or generate its header file into the build.
+1. Add a `#import` for its header file to `MozillaRustComponents.h`
+
+## Testing locally
+
+For testing out local changes in a consuming app, you can:
+
+* Take a local checkout of https://github.com/mozilla/rust-components-swift.
+* Run `./build-xcframework.sh` to build the XCFramework bundle.
+* Unzip the resulting bundle inside the root of the `rust-components-swift` checkout, and `git add` it.
+* Edit `rust-components-swift/Package.swift` and follow the comments on the `MozillaRustComponents`
+  binary target to point it at the local path.
+* Commit the result to your local checkout, and make a git tag in `MAJOR.MINOR.PATCH` format.
+* Add your local `rust-components-swift` repo as a Swift Package dependency in a consuming app,
+  by specifying `file:///path/to/rust-components-swift` as the git repo.
+    * (You'll have to remove any existing depdency on https://github.com/mozilla/rust-components-swift first)
+
+Note that the XCFramework *must* be committed to the local repo and your changes *must* be included
+in a local git tag. Swift Package Manager is very opinionated and will only pull dependencies from a
+git tag that it can parse as a semver version number.
+
+## Testing from a pre-release commit
+
+For release builds, we publish the resulting `MozillaRustComponents.xcframework.zip` as a GitHub
+release artifact, and then update https://github.com/mozilla/rust-components-swift to point to
+it via URL and hash.
+
+For testing from a PR or unreleased git commit, you can:
+
+* Find the CircleCI job named `ios-artifacts` for the commit you want to test, click through to view it on CircleCI,
+and confirm that it completed successfully.
+* In the "artifacts" list, locate `MozillaRustComponents.xcframework.zip` and note its URL.
+* In the "steps" list, find the step named `XCFramework bundle checksum`, and note the checksum in its output.
+* Take a local checkout of https://github.com/mozilla/rust-components-swift,
+and edit its `Swift.package` to use the above URL and checksum for the `MozillaRustComponents` binary target.
+* Commit the result to your local checkout, and make a git tag in `MAJOR.MINOR.PATCH` format.
+* Add your local `rust-components-swift` repo as a Swift Package dependency in a consuming app,
+  by specifying `file:///path/to/rust-components-swift` as the git repo.
+    * (You'll have to remove any existing depdency on https://github.com/mozilla/rust-components-swift first)
+
+Note that your changes *must* be included in a local git tag. Swift Package Manager is very
+opinionated and will only pull dependencies from a git tag that it can parse as a semver
+version number.
+
+## Further Reading
+
+* The Architecture Design Doc wherein we decided to distribute things this way:
+    * [0003-swift-packaging.md](../../docs/adr/0003-swift-packaging.md)
+* An introduction to the problem that XCFrameworks as designed to solve:
+    * https://blog.embrace.io/xcode-12-and-xcframework/
+* A brief primer on the contents of a Framework, which is useful when you want
+  to construct one by hand:
+    * https://bignerdranch.com/blog/it-looks-like-youre-still-trying-to-use-a-framework/
+* The documentation on Module Maps, which is how C-level code gets exposed to Swift:
+    * https://clang.llvm.org/docs/Modules.html#module-maps

--- a/megazords/ios-rust/build-xcframework.sh
+++ b/megazords/ios-rust/build-xcframework.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# This script builds the Rust crate in its directory into a staticlib XCFramework for iOS.
+
+BUILD_PROFILE="release"
+FRAMEWORK_NAME="MozillaRustComponents"
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+  --build-profile) BUILD_PROFILE="$2"; shift;shift;;
+  --framework-name) FRAMEWORK_NAME="$2"; shift;shift;;
+  *) echo "Unknown parameter: $1"; exit 1;
+esac; done
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REPO_ROOT="$( dirname "$( dirname "$THIS_DIR" )" )"
+
+MANIFEST_PATH="$THIS_DIR/Cargo.toml"
+if [[ ! -f "$MANIFEST_PATH" ]]; then
+  echo "Could not locate Cargo.toml relative to script"
+  exit 1
+fi
+
+CRATE_NAME=$(grep --max-count=1 '^name =' "$MANIFEST_PATH" | cut -d '"' -f 2)
+if [[ -z "$CRATE_NAME" ]]; then
+  echo "Could not determine crate name from $MANIFEST_PATH"
+  exit 1
+fi
+
+LIB_NAME="lib${CRATE_NAME}.a"
+
+####
+##
+## 1) Build the rust code individually for each target architecture.
+##
+####
+
+# Helper to run the cargo build command in a controlled environment.
+# It's important that we don't let environment variables from the user's default
+# desktop build environment leak into the iOS build, otherwise it might e.g.
+# link against the desktop build of NSS.
+
+CARGO="$HOME/.cargo/bin/cargo"
+LIBS_DIR="$REPO_ROOT/libs"
+
+DEFAULT_RUSTFLAGS=""
+BUILD_ARGS=(build --manifest-path "$MANIFEST_PATH" --lib)
+case $BUILD_PROFILE in
+  debug) ;;
+  release)
+    BUILD_ARGS=("${BUILD_ARGS[@]}" --release)
+    # With debuginfo, the zipped artifact quickly baloons to many
+    # hundred megabytes in size. Ideally we'd find a way to keep
+    # the debug info but in a separate artifact.
+    DEFAULT_RUSTFLAGS="-C debuginfo=0"
+    ;;
+  *) echo "Unknown build profile: $BUILD_PROFILE"; exit 1;
+esac
+
+cargo_build () {
+  TARGET=$1
+  case $TARGET in
+    x86_64*)
+      LIBS_DIR="$REPO_ROOT/libs/ios/x86_64";;
+    # TODO: when we want to include crates that depend on SQLCipher or NSS,
+    # we'll need to distinguish between hardware and simulator builds here
+    # and link the later against separately-compiled libraries.
+    # Ref https://github.com/mozilla/application-services/issues/4352.
+    aarch64*)
+      LIBS_DIR="$REPO_ROOT/libs/ios/arm64";;
+    *)
+      echo "Unexpected target architecture: $TARGET" && exit 1;;
+  esac
+  env -i \
+    NSS_STATIC=1 \
+    NSS_DIR="$LIBS_DIR/nss" \
+    SQLCIPHER_STATIC=1 \
+    SQLCIPHER_LIB_DIR="${LIBS_DIR}/sqlcipher/lib" \
+    SQLCIPHER_INCLUDE_DIR="${LIBS_DIR}/sqlcipher/include" \
+    PATH="${PATH}" \
+    RUSTC_WRAPPER="${RUSTC_WRAPPER:-}" \
+    SCCACHE_IDLE_TIMEOUT="${SCCACHE_IDLE_TIMEOUT:-}" \
+    SCCACHE_CACHE_SIZE="${SCCACHE_CACHE_SIZE:-}" \
+    SCCACHE_ERROR_LOG="${SCCACHE_ERROR_LOG:-}" \
+    RUST_LOG="${RUST_LOG:-}" \
+    RUSTFLAGS="${RUSTFLAGS:-$DEFAULT_RUSTFLAGS}" \
+    "$CARGO" "${BUILD_ARGS[@]}" --target "$TARGET"
+}
+
+set -euvx
+
+# Intel iOS simulator
+# TODO: why is the env var necessary?
+CFLAGS_x86_64_apple_ios="-target x86_64-apple-ios" \
+  cargo_build x86_64-apple-ios
+
+# Hardware iOS targets
+cargo_build aarch64-apple-ios
+
+# M1 iOS simulator.
+# It's currently in Nightly only and requires to build `libstd`.
+# We hope this will be available by default in Rust 1.56.0.
+BUILD_ARGS=(+nightly "${BUILD_ARGS[@]}" -Z build-std)
+cargo_build aarch64-apple-ios-sim
+
+# TODO: would it be useful to also include desktop builds here?
+# It might make it possible to run the Swift tests via `swift test`
+# rather than through Xcode.
+
+####
+##
+## 2) Stitch the individual builds together an XCFramework bundle.
+##
+####
+
+TARGET_DIR="$REPO_ROOT/target"
+XCFRAMEWORK_ROOT="$THIS_DIR/$FRAMEWORK_NAME.xcframework"
+
+# Start from a clean slate.
+
+rm -rf "$XCFRAMEWORK_ROOT"
+
+# Build the directory structure right for an individual framework.
+# Most of this doesn't change between architectures.
+
+COMMON="$XCFRAMEWORK_ROOT/common/$FRAMEWORK_NAME.framework"
+
+mkdir -p "$COMMON/Modules"
+cp "$THIS_DIR/module.modulemap" "$COMMON/Modules/"
+
+cp "$THIS_DIR/DEPENDENCIES.md" "$COMMON/DEPENDENCIES.md"
+
+mkdir -p "$COMMON/Headers"
+cp "$THIS_DIR/MozillaRustComponents.h" "$COMMON/Headers"
+cp "$REPO_ROOT/components/rc_log/ios/RustLogFFI.h" "$COMMON/Headers"
+cp "$REPO_ROOT/components/viaduct/ios/RustViaductFFI.h" "$COMMON/Headers"
+# TODO: it would be neat if there was a single UniFFI command that would spit out
+# all of the generated headers for all UniFFIed dependencies of a given crate.
+# For now we generate the Swift bindings to get the headers as a side effect,
+# then delete the generated Swift code. Bleh.
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/crashtest/src/crashtest.udl" -l swift -o "$COMMON/Headers"
+rm -rf "$COMMON"/Headers/*.swift
+
+# Flesh out the framework for each architecture based on the common files.
+# It's a little fiddly, because we apparently need to put all the simulator targets
+# together into a single fat binary, but keep the hardware target separate.
+# (TODO: we should try harder to see if we can avoid using `lipo` here, eliminating it
+# would make the overall system simpler to understand).
+
+# iOS hardware
+mkdir -p "$XCFRAMEWORK_ROOT/ios-arm64"
+cp -r "$COMMON" "$XCFRAMEWORK_ROOT/ios-arm64/$FRAMEWORK_NAME.framework"
+cp "$TARGET_DIR/aarch64-apple-ios/$BUILD_PROFILE/$LIB_NAME" "$XCFRAMEWORK_ROOT/ios-arm64/$FRAMEWORK_NAME.framework/$FRAMEWORK_NAME"
+
+# iOS simulator, with both platforms as a fat binary for mysterious reasons
+mkdir -p "$XCFRAMEWORK_ROOT/ios-arm64_x86_64-simulator"
+cp -r "$COMMON" "$XCFRAMEWORK_ROOT/ios-arm64_x86_64-simulator/$FRAMEWORK_NAME.framework"
+lipo -create \
+  -output "$XCFRAMEWORK_ROOT/ios-arm64_x86_64-simulator/$FRAMEWORK_NAME.framework/$FRAMEWORK_NAME" \
+  "$TARGET_DIR/aarch64-apple-ios-sim/$BUILD_PROFILE/$LIB_NAME" \
+  "$TARGET_DIR/x86_64-apple-ios/$BUILD_PROFILE/$LIB_NAME"
+
+# Set up the metadata for the XCFramework as a whole.
+
+cp "$THIS_DIR/Info.plist" "$XCFRAMEWORK_ROOT/Info.plist"
+cp "$THIS_DIR/DEPENDENCIES.md" "$XCFRAMEWORK_ROOT/DEPENDENCIES.md"
+
+rm -rf "$XCFRAMEWORK_ROOT/common"
+
+# Zip it all up into a bundle for distribution.
+
+(cd "$THIS_DIR" && zip -9 -r "$FRAMEWORK_NAME.xcframework.zip" "$FRAMEWORK_NAME.xcframework")
+rm -rf "$XCFRAMEWORK_ROOT"

--- a/megazords/ios-rust/module.modulemap
+++ b/megazords/ios-rust/module.modulemap
@@ -1,0 +1,6 @@
+framework module MozillaRustComponents {
+  umbrella header "MozillaRustComponents.h"
+
+  export *
+  module * { export * }
+}

--- a/megazords/ios-rust/src/lib.rs
+++ b/megazords/ios-rust/src/lib.rs
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
+
+pub use crashtest;
+pub use nimbus;
+pub use rc_log_ffi;
+pub use viaduct_reqwest;

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -14,6 +14,8 @@ targets = [
     "i686-linux-android",
     "x86_64-linux-android",
     "aarch64-apple-ios",
-    "x86_64-apple-ios"
+    "aarch64-apple-ios-sim",
+    "x86_64-apple-ios",
 ]
-components = ["clippy", "rustfmt"]
+# The "rust-src" component is currently required for building for the M1 iOS simulator.
+components = ["clippy", "rustfmt", "rust-src"]

--- a/tools/regenerate_dependency_summaries.sh
+++ b/tools/regenerate_dependency_summaries.sh
@@ -5,6 +5,7 @@ set -euvx
 python3 ./tools/dependency_summary.py > ./DEPENDENCIES.md
 
 python3 ./tools/dependency_summary.py --all-ios-targets --package megazord_ios > megazords/ios/DEPENDENCIES.md
+python3 ./tools/dependency_summary.py --all-ios-targets --package ios_rust > megazords/ios-rust/DEPENDENCIES.md
 
 python3 ./tools/dependency_summary.py --all-android-targets --package megazord > megazords/full/DEPENDENCIES.md
 python3 ./tools/dependency_summary.py --all-android-targets --package megazord --format pom > megazords/full/android/dependency-licenses.xml


### PR DESCRIPTION
Continuation of #4225 -- but this time merging into main.

This is an attempt to make our iOS build process more compatible with
M1 Mac build environments, and easier to consume via Swift Packages.

In our existing iOS build setup, we compile together all of the Rust
code and all of the wrapping Swift code into a single module named
"MozillaAppServices". This is a bit of a violation of clean package
separation, because it means that we risk name conflicts in the Swift
code between different components.

In this new setup, we don't pre-compile any of the Swift code. Instead
we build only the Rust code, package it up along with its associated headers,
and tell Swift to treat this as a module named "MozillaRustComponents".
Each individual Swift wrapper can then `import MozillaRustComponents`
and get access to the low-level FFI functions that it needs.

An additional benefit of this setup is that we can distribute it as
a `.xcframework` bundle for easy consumption on different platforms,
and we can build it without using Xcode.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
