### PR TITLE
[push] create a communications.rs unsubscribe_all call

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -30,3 +30,8 @@ Use the template below to make assigning a version number during the release cut
 
 ### ⚠️ Breaking Changes ⚠️
   - The `Error` enum is now called `AutofillError` (`AutofillException` in Kotlin) to avoid conflicts with builtin names.
+
+## Push
+### What's Changed
+ - The push `unsubscribe` API will no longer accept a null `channel_id` value, a valid `channel_id` must be presented, otherwise rust will panic and an error will be thrown to android.
+  note that this is not a breaking change, since our hand-written Kotlin code already ensures that the function can only be called with a valid, non-empty, non-nullable string.

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -112,7 +112,7 @@ pub extern "C" fn push_unsubscribe(
 ) -> u8 {
     log::debug!("push_unsubscribe");
     MANAGER.call_with_result_mut(error, handle, |mgr| -> Result<bool> {
-        let channel = channel_id.as_opt_str();
+        let channel = channel_id.as_str();
         mgr.unsubscribe(channel)
     })
 }

--- a/examples/push-livetest/src/livetest.rs
+++ b/examples/push-livetest/src/livetest.rs
@@ -62,7 +62,7 @@ fn test_live_server() -> Result<()> {
     println!("Server Known channels: {:?}", ll);
 
     println!("\n == Unsubscribing single channel");
-    pm.unsubscribe(Some(&channel1)).expect("chid unsub failed");
+    pm.unsubscribe(&channel1).expect("chid unsub failed");
     println!("\n == Fetching channel list 2");
     let ll = pm.conn.channel_list().expect("channel list failed");
     println!("Server Known channels: {:?}", ll);
@@ -77,7 +77,7 @@ fn test_live_server() -> Result<()> {
 
     println!("\n == Unsubscribing all.");
     // Unsubscribe all channels.
-    pm.unsubscribe(None)?;
+    pm.unsubscribe_all()?;
 
     println!("Done");
     Ok(())


### PR DESCRIPTION
a part of #4372

Separates the logic in `communications.rs`'s `unsubscribe` call into:
- `unsubscribe` for a single channel, and this function now accepts a `&str` and not an `Option`
- `unsubscribe_all` for unsubscribing from all channels.

The separation works well for a couple of reasons:
- It aligns better with the API calls (and that the `unsubscribe_all` wipes the `uaid` and `auth` values)
- It aligns better with the `PushManager` API, which already defines two functions with the same names.
- It prevents us from using an `Option` as a flag to dictate which API call should run


Additionally, this PR makes the FFI contract on `unsubscribe` stricter. Previously, if the Kotlin caller passes a `null` value for the `channel_id`, our `PushManager.unsubscribe` would simply do nothing and return `false` which is a little misleading. That said, this change is safe because [our handwritten Kotlin wrapper for the FFI](https://github.com/mozilla/application-services/blob/main/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt#L77) accepts a `String` (and not a `String?`) therefore it was impossible in the first place to call this API with a null value

I'll have another PR addressing the rest of #4372 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
