### PR TITLE
FxAClient as a Swift package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,7 @@ name = "ios_rust"
 version = "0.1.0"
 dependencies = [
  "crashtest",
+ "fxa-client",
  "nimbus-sdk",
  "rc_log_ffi",
  "viaduct",

--- a/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+#if canImport(MozillaRustComponents)
+    import MozillaRustComponents
+#endif
 
 /// This class inherits from the Rust `FirefoxAccount` and adds:
 /// - Automatic state persistence through `PersistCallback`.

--- a/components/fxa-client/uniffi.toml
+++ b/components/fxa-client/uniffi.toml
@@ -3,4 +3,6 @@ package_name = "mozilla.appservices.fxaclient"
 cdylib_name = "megazord"
 
 [bindings.swift]
+ffi_module_name = "MozillaRustComponents"
+ffi_module_filename = "fxaclientFFI"
 generate_module_map = false

--- a/components/fxa-client/uniffi.toml
+++ b/components/fxa-client/uniffi.toml
@@ -4,5 +4,5 @@ cdylib_name = "megazord"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"
-ffi_module_filename = "fxaclientFFI"
+ffi_module_filename = "fxa_clientFFI"
 generate_module_map = false

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -14,9 +14,6 @@ viaduct = { path = "../../components/viaduct" }
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
 nimbus-sdk = { path = "../../components/nimbus" }
 crashtest = { path = "../../components/crashtest" }
-
-# TODO: can't include fxa-client until we get NSS working on M1 simulator,
-# ref https://github.com/mozilla/application-services/issues/4352.
 fxa-client = { path = "../../components/fxa-client" }
 # TODO: can't include logins until we get SQLCipher working on M1 simulator,
 # ref https://github.com/mozilla/application-services/issues/4352.

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -17,7 +17,7 @@ crashtest = { path = "../../components/crashtest" }
 
 # TODO: can't include fxa-client until we get NSS working on M1 simulator,
 # ref https://github.com/mozilla/application-services/issues/4352.
-#fxa-client = { path = "../../components/fxa-client" }
+fxa-client = { path = "../../components/fxa-client" }
 # TODO: can't include logins until we get SQLCipher working on M1 simulator,
 # ref https://github.com/mozilla/application-services/issues/4352.
 # (or until we entirely get rid of SQLCipher)

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -18,6 +18,7 @@ the details of which are reproduced below.
 * [MIT License: h2](#mit-license-h2)
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
+* [MIT License: libsqlite3-sys](#mit-license-libsqlite3-sys)
 * [MIT License: matches](#mit-license-matches)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
@@ -32,11 +33,17 @@ the details of which are reproduced below.
 * [MIT License: try-lock](#mit-license-try-lock)
 * [MIT License: want](#mit-license-want)
 * [MIT License: weedle](#mit-license-weedle)
+* [CC0-1.0 License: base16](#cc0-10-license-base16)
+* [ISC License: ring](#isc-license-ring)
 * [BSD-2-Clause License: arrayref](#bsd-2-clause-license-arrayref)
 -------------
 ## Mozilla Public License 2.0
 
 The following text applies to code linked from these dependencies:
+[NSPR](https://hg.mozilla.org/projects/nspr),
+[NSS](https://hg.mozilla.org/projects/nss),
+[ece](https://github.com/mozilla/rust-ece),
+[hawk](https://github.com/taskcluster/rust-hawk),
 [jexl-eval](https://github.com/mozilla/jexl-rs),
 [jexl-parser](https://github.com/mozilla/jexl-rs),
 [uniffi](https://github.com/mozilla/uniffi-rs),
@@ -82,7 +89,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in
+    means a work that combines Covered Software with other material, in 
     a separate file or files, that is not Covered Software.
 
 1.8. "License"
@@ -1113,6 +1120,34 @@ THE SOFTWARE.
 
 ```
 -------------
+## MIT License: libsqlite3-sys
+
+The following text applies to code linked from these dependencies:
+[libsqlite3-sys](https://github.com/rusqlite/rusqlite)
+
+```
+Copyright (c) 2014-2021 The rusqlite developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```
+-------------
 ## MIT License: matches
 
 The following text applies to code linked from these dependencies:
@@ -1547,6 +1582,159 @@ TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONIN
 THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
 CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+```
+-------------
+## CC0-1.0 License: base16
+
+The following text applies to code linked from these dependencies:
+[base16](https://github.com/thomcc/rust-base16)
+
+```
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.
+
+```
+-------------
+## ISC License: ring
+
+The following text applies to code linked from these dependencies:
+[ring](https://github.com/briansmith/ring)
+
+```
+
+Copyright 2015-2016 Brian Smith.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHORS DISCLAIM ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
 ```
 -------------
 ## BSD-2-Clause License: arrayref

--- a/megazords/ios-rust/MozillaRustComponents.h
+++ b/megazords/ios-rust/MozillaRustComponents.h
@@ -7,6 +7,6 @@
 
 #import "crashtestFFI.h"
 #import "nimbusFFI.h"
-#import "fxaclientFFI.h"
+#import "fxa_clientFFI.h"
 #import "RustViaductFFI.h"
 #import "RustLogFFI.h"

--- a/megazords/ios-rust/MozillaRustComponents.h
+++ b/megazords/ios-rust/MozillaRustComponents.h
@@ -7,5 +7,6 @@
 
 #import "crashtestFFI.h"
 #import "nimbusFFI.h"
+#import "fxaclientFFI.h"
 #import "RustViaductFFI.h"
 #import "RustLogFFI.h"

--- a/megazords/ios-rust/README.md
+++ b/megazords/ios-rust/README.md
@@ -55,7 +55,7 @@ To add a new crate to the distribution:
     ffi_module_filename = "<crate_name>FFI"
     ```
 1. Add it as a dependency in `Cargo.toml`.
-1. Add a `pub use` declaration for it in `./src/lib.rs`.
+1. Add a `pub use` declaration for it in this `./src/lib.rs`.
 1. Add logic to `build-xcframework.sh` to copy or generate its header file into the build.
 1. Add a `#import` for its header file to `MozillaRustComponents.h`
 
@@ -64,6 +64,8 @@ To add a new crate to the distribution:
 For testing out local changes in a consuming app, you can:
 
 * Take a local checkout of https://github.com/mozilla/rust-components-swift.
+> Note: `rust-components-swift` contains a submodule of `application-services`, if you're testing any code changes you'll need
+> to push/publish your branch and update the submodule in that repo.
 * Run `./build-xcframework.sh` to build the XCFramework bundle.
 * Unzip the resulting bundle inside the root of the `rust-components-swift` checkout, and `git add` it.
 * Edit `rust-components-swift/Package.swift` and follow the comments on the `MozillaRustComponents`

--- a/megazords/ios-rust/README.md
+++ b/megazords/ios-rust/README.md
@@ -55,7 +55,7 @@ To add a new crate to the distribution:
     ffi_module_filename = "<crate_name>FFI"
     ```
 1. Add it as a dependency in `Cargo.toml`.
-1. Add a `pub use` declaration for it in this `./src/lib.rs`.
+1. Add a `pub use` declaration for it in `./src/lib.rs`.
 1. Add logic to `build-xcframework.sh` to copy or generate its header file into the build.
 1. Add a `#import` for its header file to `MozillaRustComponents.h`
 
@@ -64,8 +64,6 @@ To add a new crate to the distribution:
 For testing out local changes in a consuming app, you can:
 
 * Take a local checkout of https://github.com/mozilla/rust-components-swift.
-> Note: `rust-components-swift` contains a submodule of `application-services`, if you're testing any code changes you'll need
-> to push/publish your branch and update the submodule in that repo.
 * Run `./build-xcframework.sh` to build the XCFramework bundle.
 * Unzip the resulting bundle inside the root of the `rust-components-swift` checkout, and `git add` it.
 * Edit `rust-components-swift/Package.swift` and follow the comments on the `MozillaRustComponents`

--- a/megazords/ios-rust/build-xcframework.sh
+++ b/megazords/ios-rust/build-xcframework.sh
@@ -139,6 +139,7 @@ cp "$REPO_ROOT/components/viaduct/ios/RustViaductFFI.h" "$COMMON/Headers"
 # then delete the generated Swift code. Bleh.
 $CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l swift -o "$COMMON/Headers"
 $CARGO uniffi-bindgen generate "$REPO_ROOT/components/crashtest/src/crashtest.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/fxa-client/src/fxa_client.udl" -l swift -o "$COMMON/Headers"
 rm -rf "$COMMON"/Headers/*.swift
 
 # Flesh out the framework for each architecture based on the common files.

--- a/megazords/ios-rust/src/lib.rs
+++ b/megazords/ios-rust/src/lib.rs
@@ -6,6 +6,7 @@
 #![warn(rust_2018_idioms)]
 
 pub use crashtest;
+pub use fxa_client;
 pub use nimbus;
 pub use rc_log_ffi;
 pub use viaduct_reqwest;


### PR DESCRIPTION
This is a first (rather successful!) attempt to turn the FxA Client crate into a swift package. I was able to import FxAClient and crate a basic client in Focus iOS with my M1 without any tweaks! Pushing this PR up to test the CI resulting artifacts.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
