### PR TITLE
Logins struct rework

### DIFF
--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -26,14 +26,14 @@ pub use crate::login::*;
 pub use crate::store::*;
 pub use crate::sync::LoginsSyncEngine;
 
-// public encryption functions - not in encryption.rs as theoretically that file doesn't need to
-// know about any of our structs.
-fn encrypt_fields(fields: &SecureLoginFields, enc_key: &str) -> Result<String> {
+// Public encryption functions.  We create need to publish these as top-level functions to expose
+// them across UniFFI
+fn encrypt_login(login: Login, enc_key: &str) -> Result<EncryptedLogin> {
     let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-    encdec.encrypt_struct(fields)
+    login.encrypt(&encdec)
 }
 
-fn decrypt_fields(ciphertext: &str, enc_key: &str) -> Result<SecureLoginFields> {
+fn decrypt_login(login: EncryptedLogin, enc_key: &str) -> Result<Login> {
     let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-    encdec.decrypt_struct(ciphertext)
+    login.decrypt(&encdec)
 }

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -38,8 +38,9 @@
 //!         login, updating an existing login, filling in a blank username, etc.
 //!       - Allows the user to tweak the username, in case we failed to detect the form field
 //!         correctly.  This may affect which header should be shown.
-//!    - Here we use `find_existing()` which has the signature `(LoginEntry, &[Login]) -> Login`
-//!      because it's matching a new login entry against a list of existing login records.
+//!    - Here we use `find_login_to_update()` which has the signature
+//!      `(LoginEntry, &[Login]) -> Login` because it's matching a new login entry against a list
+//!      of existing login records.
 //!
 //! # Login
 //! This has the complete set of data about a login. Very closely related is the
@@ -686,6 +687,31 @@ impl ValidateAndFixup for LoginEntry {
     }
 }
 
+// Find an existing `LoginEntry` from a list of `Logins`
+//
+// This is used when there is new login data to save.  The UI needs this to distinguish between 3 cases:
+//
+//  - User adding a new login
+//  - User updating an existing login with the same username
+//  - User updating an login with the blank username
+//
+// `find_login_to_update()` uses a `Vec<Login>` rather than hitting the database Vbecause Fenix
+// shows a username field and runs it on every keypress, so it needs to be fast.
+pub fn find_login_to_update(look: &LoginEntry, search: &[Login]) -> Option<Login> {
+    // Try to match the username
+    search
+        .iter()
+        .find(|login| login.sec_fields.username == look.sec_fields.username)
+        // Fall back on a blank username
+        .or_else(|| {
+            search
+                .iter()
+                .find(|login| login.sec_fields.username.is_empty())
+        })
+        // Clone the login to avoid ref issues when returning across the FFI
+        .cloned()
+}
+
 #[cfg(test)]
 pub mod test_utils {
     use super::*;
@@ -1295,5 +1321,104 @@ mod tests {
             password: "p".into(),
         };
         assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn test_find_login_to_update() {
+        let entry = LoginEntry {
+            fields: LoginFields {
+                origin: "https://www.example.com".into(),
+                http_realm: Some("the website".into()),
+                ..Default::default()
+            },
+            sec_fields: SecureLoginFields {
+                username: "user1".into(),
+                password: "password1".into(),
+            },
+        };
+        let login = Login {
+            record: RecordFields {
+                id: "A".into(),
+                ..Default::default()
+            },
+            fields: entry.fields.clone(),
+            sec_fields: entry.sec_fields.clone(),
+        };
+        assert_eq!(
+            find_login_to_update(&entry, &vec![login.clone()]),
+            Some(login.clone()),
+        );
+
+        // different username
+        assert_eq!(
+            find_login_to_update(
+                &LoginEntry {
+                    sec_fields: SecureLoginFields {
+                        username: "user2".into(),
+                        ..entry.sec_fields.clone()
+                    },
+                    ..entry.clone()
+                },
+                &vec![login.clone()],
+            ),
+            None
+        );
+
+        // different password (which should still match)
+        assert_eq!(
+            find_login_to_update(
+                &LoginEntry {
+                    sec_fields: SecureLoginFields {
+                        password: "password2".into(),
+                        ..entry.sec_fields.clone()
+                    },
+                    ..entry.clone()
+                },
+                &vec![login.clone()],
+            ),
+            Some(login.clone()),
+        );
+
+        // A blank username should match as well
+        let blank_username_login = Login {
+            record: RecordFields {
+                id: "B".into(),
+                ..Default::default()
+            },
+            fields: entry.fields.clone(),
+            sec_fields: SecureLoginFields {
+                username: "".into(),
+                ..entry.sec_fields.clone()
+            },
+        };
+
+        assert_eq!(
+            find_login_to_update(
+                &LoginEntry {
+                    sec_fields: SecureLoginFields {
+                        password: "password2".into(),
+                        ..entry.sec_fields.clone()
+                    },
+                    ..entry.clone()
+                },
+                &vec![blank_username_login.clone()],
+            ),
+            Some(blank_username_login.clone()),
+        );
+
+        // But a username match should be preferred to a blank username
+        assert_eq!(
+            find_login_to_update(
+                &LoginEntry {
+                    sec_fields: SecureLoginFields {
+                        password: "password2".into(),
+                        ..entry.sec_fields.clone()
+                    },
+                    ..entry
+                },
+                &vec![blank_username_login, login.clone()],
+            ),
+            Some(login),
+        );
     }
 }

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -37,6 +37,12 @@ dictionary LoginFields {
     string password_field;
 };
 
+// Fields available only while the encryption key is known.
+dictionary SecureLoginFields {
+    string password;
+    string username;
+};
+
 // What you can add or update. You must pass the cleartext of encrypted fields
 // and the add/update APIs can encrypt (they need to know the key anyway)
 dictionary LoginEntry {
@@ -54,12 +60,6 @@ dictionary Login {
     i64 time_created;
     i64 time_last_used;
     i64 time_password_changed;
-};
-
-// Fields available only while the encryption key is known.
-dictionary SecureLoginFields {
-    string password;
-    string username;
 };
 
 [Error]

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -43,6 +43,15 @@ dictionary SecureLoginFields {
     string username;
 };
 
+// Fields specific to database records
+dictionary RecordFields {
+    string id;
+    i64 times_used;
+    i64 time_created;
+    i64 time_last_used;
+    i64 time_password_changed;
+};
+
 // What you can add or update. You must pass the cleartext of encrypted fields
 // and the add/update APIs can encrypt (they need to know the key anyway)
 dictionary LoginEntry {
@@ -52,14 +61,10 @@ dictionary LoginEntry {
 
 // What we return for all the "read" APIs - we never return the cleartext
 // of encrypted fields.
-dictionary Login {
-    string id;
+dictionary EncryptedLogin {
+    RecordFields record;
     LoginFields fields;
     string sec_fields; // ciphertext of a SecureLoginFields
-    i64 times_used;
-    i64 time_created;
-    i64 time_last_used;
-    i64 time_password_changed;
 };
 
 [Error]
@@ -84,13 +89,13 @@ interface LoginStore {
     void check_valid_with_no_dupes([ByRef] string id, [ByRef] LoginEntry login, [ByRef] string encryption_key);
 
     [Throws=LoginsStorageError]
-    Login add(LoginEntry login, [ByRef]string encryption_key);
+    EncryptedLogin add(LoginEntry login, [ByRef]string encryption_key);
 
     [Throws=LoginsStorageError]
-    Login update([ByRef] string id, LoginEntry login, [ByRef]string encryption_key);
+    EncryptedLogin update([ByRef] string id, LoginEntry login, [ByRef]string encryption_key);
 
     [Throws=LoginsStorageError]
-    Login add_or_update(LoginEntry login, [ByRef]string encryption_key);
+    EncryptedLogin add_or_update(LoginEntry login, [ByRef]string encryption_key);
 
     [Throws=LoginsStorageError]
     boolean delete([ByRef] string id);
@@ -108,23 +113,23 @@ interface LoginStore {
     void touch([ByRef] string id);
 
     [Throws=LoginsStorageError]
-    sequence<Login> list();
+    sequence<EncryptedLogin> list();
 
     [Throws=LoginsStorageError]
-    sequence<Login> get_by_base_domain([ByRef] string base_domain);
+    sequence<EncryptedLogin> get_by_base_domain([ByRef] string base_domain);
 
     [Throws=LoginsStorageError]
     string? find_existing(LoginEntry look, [ByRef]string encryption_key);
 
     // XXX - Can we kill this, and just fix the semantics of add/update?
     [Throws=LoginsStorageError]
-    sequence<Login> potential_dupes_ignoring_username([ByRef]string id, LoginEntry login);
+    sequence<EncryptedLogin> potential_dupes_ignoring_username([ByRef]string id, LoginEntry login);
 
     [Throws=LoginsStorageError]
-    Login? get([ByRef] string id);
+    EncryptedLogin? get([ByRef] string id);
 
     [Throws=LoginsStorageError]
-    string import_multiple(sequence<Login> login, [ByRef]string encryption_key);
+    string import_multiple(sequence<EncryptedLogin> login, [ByRef]string encryption_key);
 
     [Self=ByArc]
     void register_with_sync_manager();

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -17,6 +17,8 @@ namespace logins {
     [Throws=LoginsStorageError]
     EncryptedLogin encrypt_login(Login login, [ByRef]string encryption_key);
 
+    Login? find_login_to_update([ByRef]LoginEntry look, [ByRef]sequence<Login> logins);
+
     // XXX - we still need some way to have a "canary" for the encryption_key - eg, to ensure
     // a given key is the correct key for the DB. `autofill` consumers do this by just encrypting
     // some arbitrary string and storing the ciphertext, and as the app starts and the ciphertext
@@ -122,9 +124,6 @@ interface LoginStore {
 
     [Throws=LoginsStorageError]
     sequence<EncryptedLogin> get_by_base_domain([ByRef] string base_domain);
-
-    [Throws=LoginsStorageError]
-    string? find_existing(LoginEntry look, [ByRef]string encryption_key);
 
     // XXX - Can we kill this, and just fix the semantics of add/update?
     [Throws=LoginsStorageError]

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -9,15 +9,13 @@ namespace logins {
     [Throws=LoginsStorageError]
     string create_key();
 
-    // Decrypt a string into an SecureLoginFields struct. This will be used to get the credentials
-    // from a `Login` dict.
+    // Decrypt an `EncryptedLogin` to a `Login`
     [Throws=LoginsStorageError]
-    SecureLoginFields decrypt_fields([ByRef]string ciphertext, [ByRef]string encryption_key);
+    Login decrypt_login(EncryptedLogin login, [ByRef]string encryption_key);
 
-    // Encrypt an SecureLoginFields struct into a string. This will be used only rarely, eg, when
-    // putting together `Login` dicts to pass to `import_multiple`.
+    // Encrypt a `Login` to an `EncryptedLogin`
     [Throws=LoginsStorageError]
-    string encrypt_fields([ByRef]SecureLoginFields fields, [ByRef]string encryption_key);
+    EncryptedLogin encrypt_login(Login login, [ByRef]string encryption_key);
 
     // XXX - we still need some way to have a "canary" for the encryption_key - eg, to ensure
     // a given key is the correct key for the DB. `autofill` consumers do this by just encrypting
@@ -52,15 +50,22 @@ dictionary RecordFields {
     i64 time_password_changed;
 };
 
-// What you can add or update. You must pass the cleartext of encrypted fields
-// and the add/update APIs can encrypt (they need to know the key anyway)
+// A login entry from the user, not linked to any database record.
+// The add/update APIs input these, alongside an encryption key.
 dictionary LoginEntry {
     LoginFields fields;
     SecureLoginFields sec_fields;
 };
 
-// What we return for all the "read" APIs - we never return the cleartext
-// of encrypted fields.
+// A login stored in the database
+dictionary Login {
+    RecordFields record;
+    LoginFields fields;
+    SecureLoginFields sec_fields;
+};
+
+// An encrypted version of [Login].  This is what we return for all the "read"
+// APIs - we never return the cleartext of encrypted fields.
 dictionary EncryptedLogin {
     RecordFields record;
     LoginFields fields;
@@ -129,7 +134,7 @@ interface LoginStore {
     EncryptedLogin? get([ByRef] string id);
 
     [Throws=LoginsStorageError]
-    string import_multiple(sequence<EncryptedLogin> login, [ByRef]string encryption_key);
+    string import_multiple(sequence<Login> login, [ByRef]string encryption_key);
 
     [Self=ByArc]
     void register_with_sync_manager();

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -85,12 +85,12 @@ impl LoginStore {
     pub fn potential_dupes_ignoring_username(
         &self,
         id: &str,
-        login: LoginEntry,
+        entry: LoginEntry,
     ) -> Result<Vec<Login>> {
         self.db
             .lock()
             .unwrap()
-            .potential_dupes_ignoring_username(&Guid::new(id), &login.fields)
+            .potential_dupes_ignoring_username(&Guid::new(id), &entry.fields)
     }
 
     pub fn touch(&self, id: &str) -> Result<()> {
@@ -127,22 +127,22 @@ impl LoginStore {
         Ok(())
     }
 
-    pub fn update(&self, id: &str, login: LoginEntry, enc_key: &str) -> Result<Login> {
+    pub fn update(&self, id: &str, entry: LoginEntry, enc_key: &str) -> Result<Login> {
         let encdec = EncryptorDecryptor::new(&enc_key)?;
-        self.db.lock().unwrap().update(id, login, &encdec)
+        self.db.lock().unwrap().update(id, entry, &encdec)
     }
 
-    pub fn add(&self, login: LoginEntry, enc_key: &str) -> Result<Login> {
+    pub fn add(&self, entry: LoginEntry, enc_key: &str) -> Result<Login> {
         let encdec = EncryptorDecryptor::new(&enc_key)?;
-        self.db.lock().unwrap().add(login, &encdec)
+        self.db.lock().unwrap().add(entry, &encdec)
     }
 
-    pub fn add_or_update(&self, login: LoginEntry, enc_key: &str) -> Result<Login> {
+    pub fn add_or_update(&self, entry: LoginEntry, enc_key: &str) -> Result<Login> {
         let encdec = EncryptorDecryptor::new(&enc_key)?;
         let db = self.db.lock().unwrap();
-        match db.find_existing(&login, &encdec)? {
-            Some(id) => db.update(&id, login, &encdec),
-            None => db.add(login, &encdec),
+        match db.find_existing(&entry, &encdec)? {
+            Some(id) => db.update(&id, entry, &encdec),
+            None => db.add(entry, &encdec),
         }
     }
 
@@ -155,14 +155,14 @@ impl LoginStore {
     pub fn check_valid_with_no_dupes(
         &self,
         id: &str,
-        login: &LoginEntry,
+        entry: &LoginEntry,
         enc_key: &str,
     ) -> Result<()> {
         let encdec = crate::encryption::EncryptorDecryptor::new(enc_key)?;
         self.db.lock().unwrap().check_valid_with_no_dupes(
             &Guid::new(id),
-            &login.fields,
-            &login.sec_fields,
+            &entry.fields,
+            &entry.sec_fields,
             &encdec,
         )
     }

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -77,11 +77,6 @@ impl LoginStore {
         self.db.lock().unwrap().get_by_base_domain(base_domain)
     }
 
-    pub fn find_existing(&self, look: LoginEntry, enc_key: &str) -> Result<Option<String>> {
-        let encdec = EncryptorDecryptor::new(&enc_key)?;
-        self.db.lock().unwrap().find_existing(&look, &encdec)
-    }
-
     pub fn potential_dupes_ignoring_username(
         &self,
         id: &str,
@@ -139,11 +134,7 @@ impl LoginStore {
 
     pub fn add_or_update(&self, entry: LoginEntry, enc_key: &str) -> Result<EncryptedLogin> {
         let encdec = EncryptorDecryptor::new(&enc_key)?;
-        let db = self.db.lock().unwrap();
-        match db.find_existing(&entry, &encdec)? {
-            Some(id) => db.update(&id, entry, &encdec),
-            None => db.add(entry, &encdec),
-        }
+        self.db.lock().unwrap().add_or_update(entry, &encdec)
     }
 
     pub fn import_multiple(&self, logins: Vec<Login>, enc_key: &str) -> Result<String> {


### PR DESCRIPTION
Reworks some of the login structs to better support the `android-components` code.

The main motivation is to fix some issues with `find_existing()`:
   - The android dialog code needs both a GUID and a decrypted username field.  We currently don't have a struct that includes both.  To address this, I renamed `Login` -> `EncryptedLogin` and added a `Login` struct which has the secure fields in cleartext. 
   - Android will potentially run this function frequently, since displays a username field which the user can edit.  If the user does edit that field, then we need to run it on every keypress.  `android-components` currently has code to avoid hitting the DB each time and it seems right to continue to support this.  To address this I made the function operate on a `Login` list rather than hit the DB.  This also simplifies the coded, since we don't need to duplicate the logic from `get_by_base_domain()`.  After the changes, I thought the name `find_login_to_update()` made more sense.

Once I added the `Login` struct, I refactored some code to use that when it seemed to make sense.

My first pass also nested `LoginEntry` inside `Login` (i.e. replacing `fields` and `sec_fields` with `entry`).  For symmetry, it also nested an `EncryptedLoginEntry` inside `EncryptedLogin`.  Maybe this is a good idea, but I realized it's not really needed yet, so I kept that out of this PR.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
