### PR TITLE
[push] refactors uaid and auth into same enum variant

### DIFF
--- a/components/push/android/src/main/java/mozilla/appservices/push/RustError.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/RustError.kt
@@ -30,6 +30,7 @@ open class GeneralError(msg: String) : PushError(msg)
 open class JSONDeserializeError(msg: String) : PushError(msg)
 open class UAIDNotRecognizedError(msg: String) : PushError(msg)
 open class RequestError(msg: String) : PushError(msg)
+open class ReconnectError : PushError("Client needs to reconnect to the server")
 
 /**
  * This should be considered private, but it needs to be public for JNA.

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -175,8 +175,7 @@ pub extern "C" fn push_decrypt(
         let r_encoding = encoding.as_str();
         let r_salt: Option<&str> = salt.as_opt_str();
         let r_dh: Option<&str> = dh.as_opt_str();
-        let uaid = mgr.conn.uaid.clone().unwrap();
-        mgr.decrypt(&uaid, r_chid, r_body, r_encoding, r_salt, r_dh)
+        mgr.decrypt(r_chid, r_body, r_encoding, r_salt, r_dh)
     })
 }
 

--- a/components/push/src/error.rs
+++ b/components/push/src/error.rs
@@ -70,6 +70,10 @@ pub enum ErrorKind {
     /// Was unable to send request to server
     #[error("Unable to send request to server: {0}")]
     RequestError(#[from] viaduct::Error),
+
+    /// Client needs to reconnect to the server
+    #[error("Client needs to reconnect to the server")]
+    ReconnectError,
 }
 
 // Note, be sure to duplicate errors in the Kotlin side
@@ -91,6 +95,7 @@ impl ErrorKind {
             ErrorKind::JSONDeserializeError(_) => 34,
             ErrorKind::UAIDNotRecognizedError(_) => 35,
             ErrorKind::RequestError(_) => 36,
+            ErrorKind::ReconnectError => 37,
         };
         ffi_support::ErrorCode::new(code)
     }

--- a/examples/push-livetest/src/livetest.rs
+++ b/examples/push-livetest/src/livetest.rs
@@ -49,7 +49,7 @@ fn test_live_server() -> Result<()> {
     println!("\n == Subscribing channels");
     let sub1 = pm.subscribe(&channel1, "", None).expect("subscribe failed");
     // These are normally opaque values, displayed here for debug.
-    println!("Connection info: {:?}", (&pm.conn.uaid, &pm.conn.auth));
+    println!("Connection info: {:?}", &pm.conn.state);
     println!("## Subscription 1: {:?}", sub1);
     println!("## Info: {:?}", pm.get_record_by_chid(&channel1));
     let sub2 = pm.subscribe(&channel2, "", None)?;


### PR DESCRIPTION
a part of #4372 

Refactors the `uaid` and `auth` `Option`s into an enum that guides the state of the component. This is a bit more involved as a refactor, and before I take this out of draft, I would very much like to build fenix using this and see if it works (well "works" as well as what we already have :'( )... with all the `uniffi` 0.14.0 breaking changes this might have to wait a little, but wanted to open it up for visibility


(Note: this is a breaking change since it adds errors,  something I completely missed with #4347 :( ) - I'll add the change log

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
