### PR TITLE
Cut release v82.3.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 82.2.0
+libraryVersion: 82.3.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v82.3.0 (_2021-08-30_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v82.2.0...v82.3.0)
+
+### What's New
+  - Changed how shared libraries are loaded to avoid an issue when both uniffi
+    and `Helpers.kt` wants to load the same library ([#4412](https://github.com/mozilla/application-services/pull/4412))
+
+
 # v82.2.0 (_2021-08-19_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v82.1.0...v82.2.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,13 +2,9 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v82.2.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v82.3.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
-
-### What's New
-  - Changed how shared libraries are loaded to avoid an issue when both uniffi
-    and `Helpers.kt` wants to load the same library ([#4412](https://github.com/mozilla/application-services/pull/4412))
 
 Use the template below to make assigning a version number during the release cutting process easier.
 


### PR DESCRIPTION
Runs the cut release script for 82.3.0

~~For some reason the changelogs were not copied over correctly, I'll do that manually~~

Had to copy over the changelogs manually, but otherwise this should be ready to land - we can cut the release right after

(note that we'll get failures on check-dependencies CI, but that's okay, to clarify, they're security vulnerability errors in **test only** code that's fixed anyways in main)
