### PR TITLE
Fixes dependency summaries

### DIFF
--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -202,7 +202,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: lexical-core</name>
-    <url>https://github.com/Alexhuszagh/rust-lexical/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/Alexhuszagh/rust-lexical/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: libc</name>


### PR DESCRIPTION
The check dependencies CI is failing again (for an unrelated reason to before, a repo changed their default branch name to `main`
