### PR TITLE
Refactors push to not return bools when possible

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -32,6 +32,9 @@ Use the template below to make assigning a version number during the release cut
   - The `Error` enum is now called `AutofillError` (`AutofillException` in Kotlin) to avoid conflicts with builtin names.
 
 ## Push
+### ⚠️ Breaking Changes ⚠️
+- The `unsubscribeAll` API will now return nothing as opposed to a boolean. The boolean was misleading as it only ever returned true. 
+  errors can be caught using exceptions. ([#4418](https://github.com/mozilla/application-services/pull/4418))
 ### What's Changed
  - The push `unsubscribe` API will no longer accept a null `channel_id` value, a valid `channel_id` must be presented, otherwise rust will panic and an error will be thrown to android.
-  note that this is not a breaking change, since our hand-written Kotlin code already ensures that the function can only be called with a valid, non-empty, non-nullable string.
+  note that this is not a breaking change, since our hand-written Kotlin code already ensures that the function can only be called with a valid, non-empty, non-nullable string. ([#4402](https://github.com/mozilla/application-services/pull/4402))

--- a/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/LibPushFFI.kt
@@ -52,7 +52,7 @@ internal interface LibPushFFI : Library {
     fun push_unsubscribe_all(
         mgr: PushManagerHandle,
         out_err: RustError.ByReference
-    ): Byte
+    )
 
     fun push_update(
         mgr: PushManagerHandle,

--- a/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
@@ -84,11 +84,11 @@ class PushManager(
         }.toInt() == 1
     }
 
-    override fun unsubscribeAll(): Boolean {
-        return rustCall { error ->
+    override fun unsubscribeAll() {
+        rustCall { error ->
             LibPushFFI.INSTANCE.push_unsubscribe_all(
                 this.handle.get(), error)
-        }.toInt() == 1
+        }
     }
 
     override fun update(registrationToken: String): Boolean {
@@ -360,9 +360,8 @@ interface PushAPI : AutoCloseable {
     /**
      * Unsubscribe all channels for the user.
      *
-     * @return bool
      */
-    fun unsubscribeAll(): Boolean
+    fun unsubscribeAll()
 
     /**
      * Updates the Native OS push registration ID.

--- a/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
+++ b/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
@@ -9,6 +9,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
 import java.nio.charset.Charset
 
 @RunWith(RobolectricTestRunner::class)
@@ -203,6 +204,17 @@ class PushTest {
         manager.subscribe(testChannelid, "foo", vapidPubKey)
         val result = manager.unsubscribe(testChannelid)
         assertEquals("Unsubscription check", true, result)
+    }
+
+    @Test
+    fun testUnsubscribeAll() {
+        val manager = getPushManager()
+        manager.subscribe(testChannelid, "foo", vapidPubKey)
+        try {
+            manager.unsubscribeAll()
+        } catch (e: Exception) {
+            fail("UnsubscribeAll threw an exception: ${e.message}")
+        }
     }
 
     @Test

--- a/components/push/ffi/src/lib.rs
+++ b/components/push/ffi/src/lib.rs
@@ -119,11 +119,9 @@ pub extern "C" fn push_unsubscribe(
 
 // Unsubscribe a channel
 #[no_mangle]
-pub extern "C" fn push_unsubscribe_all(handle: u64, error: &mut ExternError) -> u8 {
+pub extern "C" fn push_unsubscribe_all(handle: u64, error: &mut ExternError) {
     log::debug!("push_unsubscribe");
-    MANAGER.call_with_result_mut(error, handle, |mgr| -> Result<bool> {
-        mgr.unsubscribe_all()
-    })
+    MANAGER.call_with_result_mut(error, handle, |mgr| -> Result<()> { mgr.unsubscribe_all() })
 }
 
 // Update the OS token


### PR DESCRIPTION
a part of #4372 , some functions return bools when they shouldn't. The easiest one to look at is the `unsubscribeAll` API, where it would have only ever returned true.

We can probably extend this refactor to create another breaking change for `unsubscribe` but that API can return false in the case the underlying persisted store query didn't modify exactly one row (I think that should be an error anyways, not a boolean return value, but I could do that as a follow up if the breaking change here is OK)
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
