### PR TITLE
Cleanups before uniffication

### DIFF
--- a/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
+++ b/components/push/android/src/main/java/mozilla/appservices/push/PushManager.kt
@@ -75,9 +75,6 @@ class PushManager(
     }
 
     override fun unsubscribe(channelID: String): Boolean {
-        if (channelID == "") {
-            return false
-        }
         return rustCall { error ->
             LibPushFFI.INSTANCE.push_unsubscribe(
                 this.handle.get(), channelID, error)
@@ -123,6 +120,9 @@ class PushManager(
         LibPushFFI.INSTANCE.push_decrypt(
             this.handle.get(), channelID, body, encoding, salt, dh, error
         ) }
+        // TODO(teshaq): The logic here will be removed when uniffing the component
+        // for now, keeping this since Vec<u8> doesn't implement IntoFFI on the rust
+        // side, so we send a String
         val jarray = JSONArray(result)
         val retarray = ByteArray(jarray.length())
         // `for` is inclusive.


### PR DESCRIPTION
fixes #4423 

Point of the PR is to do as many incremental cleanups as possible without chucking everything into a big "uniffi" pr, or introducing too much temporary code.

The main goal I tried to do here is move as much logic as possible away from the ffi crate / and into the library crate..

There is still some logic I couldn't move, mainly whenever the return type I wanted to return didn't implement `ffi_support::IntoFfi` and adding a temporary Impl is not worth it (For example the `decrypt` still returns a string)
