### PR TITLE
Closes #4433: Allow observing previewImageUrl for visits

### DIFF
--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -16,7 +16,6 @@ import mozilla.appservices.sync15.SyncTelemetryPing
 import mozilla.components.service.glean.private.CounterMetricType
 import mozilla.components.service.glean.private.LabeledMetricType
 import org.json.JSONArray
-import org.json.JSONException
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 import java.nio.ByteBuffer
@@ -1273,7 +1272,8 @@ data class VisitObservation(
     /** Milliseconds */
     val at: Long? = null,
     val referrer: String? = null,
-    val isRemote: Boolean? = null
+    val isRemote: Boolean? = null,
+    val previewImageUrl: String? = null
 ) {
     fun toJSON(): JSONObject {
         val o = JSONObject()
@@ -1289,15 +1289,8 @@ data class VisitObservation(
         this.at?.let { o.put("at", it) }
         this.referrer?.let { o.put("referrer", it) }
         this.isRemote?.let { o.put("is_remote", it) }
+        this.previewImageUrl?.let { o.put("preview_image_url", it) }
         return o
-    }
-}
-
-fun stringOrNull(jsonObject: JSONObject, key: String): String? {
-    return try {
-        jsonObject.getString(key)
-    } catch (e: JSONException) {
-        null
     }
 }
 
@@ -1424,7 +1417,12 @@ data class VisitInfo(
      * Whether the page is hidden because it redirected to another page, or was
      * visited in a frame.
      */
-    val isHidden: Boolean
+    val isHidden: Boolean,
+
+    /**
+     * The preview image of the page that was visited, if known.
+     */
+    val previewImageUrl: String?
 ) {
     companion object {
         internal fun fromMessage(msg: MsgTypes.HistoryVisitInfos): List<VisitInfo> {
@@ -1434,7 +1432,8 @@ data class VisitInfo(
                     title = it.title,
                     visitTime = it.timestamp,
                     visitType = intToVisitType[it.visitType]!!,
-                    isHidden = it.isHidden
+                    isHidden = it.isHidden,
+                    previewImageUrl = if (it.previewImageUrl.isNullOrEmpty()) null else it.previewImageUrl
                 )
             }
         }
@@ -1454,7 +1453,8 @@ data class VisitInfosWithBound(
                     title = it.title,
                     visitTime = it.timestamp,
                     visitType = intToVisitType[it.visitType]!!,
-                    isHidden = it.isHidden
+                    isHidden = it.isHidden,
+                    previewImageUrl = it.previewImageUrl
                 )
             }
             return VisitInfosWithBound(

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -486,6 +486,7 @@ class PlacesConnectionTest {
             VisitObservation(
                 url = "https://www.ifixit.com/News/35377/which-wireless-earbuds-are-the-least-evil",
                 title = "Are All Wireless Earbuds As Evil As AirPods?",
+                previewImageUrl = "https://valkyrie.cdn.ifixit.com/media/2020/02/03121341/bose_soundsport_13.jpg",
                 visitType = VisitType.LINK
             )
         )
@@ -506,6 +507,9 @@ class PlacesConnectionTest {
             assertEquals(1, this.size)
             // view time is zero, since we didn't record it yet.
             assertEquals(0, this[0].totalViewTime)
+            // assert that we get the preview image and title
+            assertEquals("Are All Wireless Earbuds As Evil As AirPods?", this[0].title)
+            assertEquals("https://valkyrie.cdn.ifixit.com/media/2020/02/03121341/bose_soundsport_13.jpg", this[0].previewImageUrl)
         }
 
         db.noteHistoryMetadataObservationViewTime(metaKey1, 1337)

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -10,6 +10,7 @@ import mozilla.appservices.places.uniffi.DocumentType
 import mozilla.components.service.glean.testing.GleanTestRule
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
@@ -174,6 +175,40 @@ class PlacesConnectionTest {
         // Actual visit had no www
         assertEquals(null, db.matchUrl("www.mozilla.com/a1"))
         assertEquals("https://news.ycombinator.com/", db.matchUrl("news"))
+    }
+
+    @Test
+    fun testObservingPreviewImage() {
+        db.noteObservation(VisitObservation(
+            url = "https://www.example.com/0",
+            visitType = VisitType.LINK)
+        )
+
+        db.noteObservation(VisitObservation(
+            url = "https://www.example.com/1",
+            visitType = VisitType.LINK)
+        )
+
+        // Can change preview image.
+        db.noteObservation(VisitObservation(
+            url = "https://www.example.com/1",
+            visitType = VisitType.LINK,
+            previewImageUrl = "https://www.example.com/1/previewImage.png")
+        )
+
+        // Can make an initial observation with the preview image.
+        db.noteObservation(VisitObservation(
+            url = "https://www.example.com/2",
+            visitType = VisitType.LINK,
+            previewImageUrl = "https://www.example.com/2/previewImage.png")
+        )
+
+        val all = db.getVisitInfos(0)
+        assertEquals(4, all.count())
+        assertNull(all[0].previewImageUrl)
+        assertEquals("https://www.example.com/1/previewImage.png", all[1].previewImageUrl)
+        assertEquals("https://www.example.com/1/previewImage.png", all[2].previewImageUrl)
+        assertEquals("https://www.example.com/2/previewImage.png", all[3].previewImageUrl)
     }
 
     @Test

--- a/components/places/src/mozilla.appservices.places.protobuf.rs
+++ b/components/places/src/mozilla.appservices.places.protobuf.rs
@@ -10,6 +10,8 @@ pub struct HistoryVisitInfo {
     pub visit_type: i32,
     #[prost(bool, required, tag="5")]
     pub is_hidden: bool,
+    #[prost(string, optional, tag="6")]
+    pub preview_image_url: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HistoryVisitInfos {

--- a/components/places/src/observation.rs
+++ b/components/places/src/observation.rs
@@ -59,6 +59,11 @@ pub struct VisitObservation {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub is_remote: Option<bool>,
+
+    /// Semantically also a url::Url, See the comment about the `url` property.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub preview_image_url: Option<String>,
 }
 
 impl VisitObservation {
@@ -73,6 +78,7 @@ impl VisitObservation {
             at: None,
             referrer: None,
             is_remote: None,
+            preview_image_url: None,
         }
     }
 
@@ -116,6 +122,12 @@ impl VisitObservation {
 
     pub fn with_referrer(mut self, v: impl Into<Option<Url>>) -> Self {
         self.referrer = v.into().map(Url::into);
+        self
+    }
+
+    // v is a String instead of a Url to allow testing invalid urls as input.
+    pub fn with_preview_image_url(mut self, v: impl Into<Option<String>>) -> Self {
+        self.preview_image_url = v.into();
         self
     }
 

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -49,6 +49,7 @@ dictionary HistoryMetadataObservation {
 dictionary HistoryMetadata {
     string url;
     string? title;
+    string? preview_image_url;
     i64 created_at;
     i64 updated_at;
     i32 total_view_time;

--- a/components/places/src/places_msg_types.proto
+++ b/components/places/src/places_msg_types.proto
@@ -15,6 +15,7 @@ message HistoryVisitInfo {
     required int64 timestamp = 3;
     required int32 visit_type = 4;
     required bool is_hidden = 5;
+    optional string preview_image_url = 6;
 }
 
 message HistoryVisitInfos {

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -2894,7 +2894,7 @@ mod tests {
         while title.len() < crate::storage::TITLE_LENGTH_MAX + 10 {
             title += " test test";
         }
-        let maybe_row = apply_observation(
+        let maybe_visit_row = apply_observation(
             &conn,
             VisitObservation::new(Url::parse("http://www.example.com/123").unwrap())
                 .with_title(title.clone())
@@ -2903,16 +2903,16 @@ mod tests {
         )
         .unwrap();
 
-        assert!(maybe_row.is_some());
+        assert!(maybe_visit_row.is_some());
         let db_title: String = conn
             .query_row_and_then_named(
-                "SELECT title FROM moz_places WHERE id = :id",
-                &[(":id", &maybe_row.unwrap())],
+                "SELECT h.title FROM moz_places AS h JOIN moz_historyvisits AS v ON h.id = v.place_id WHERE v.id = :id",
+                &[(":id", &maybe_visit_row.unwrap())],
                 |row| row.get(0),
                 false,
             )
             .unwrap();
-        // Ensure what we get back sta
+        // Ensure what we get back the trimmed title.
         assert_eq!(db_title.len(), crate::storage::TITLE_LENGTH_MAX);
         assert!(title.starts_with(&db_title));
     }

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -2839,25 +2839,27 @@ mod tests {
         let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).unwrap();
 
         // Observing a bad preview url as part of a visit observation fails.
-        match apply_observation(
-            &conn,
-            VisitObservation::new(Url::parse("https://www.example.com/").unwrap())
-                .with_visit_type(VisitTransition::Link)
-                .with_preview_image_url(Some("not at all a url".to_string())),
-        ) {
-            Ok(_) => assert!(false, "expected bad preview url to fail an observation"),
-            Err(_) => {}
-        }
+        assert!(
+            apply_observation(
+                &conn,
+                VisitObservation::new(Url::parse("https://www.example.com/").unwrap())
+                    .with_visit_type(VisitTransition::Link)
+                    .with_preview_image_url(Some("not at all a url".to_string())),
+            )
+            .is_err(),
+            "expected bad preview url to fail an observation"
+        );
 
         // Observing a bad preview url by itself also fails.
-        match apply_observation(
-            &conn,
-            VisitObservation::new(Url::parse("https://www.example.com/").unwrap())
-                .with_preview_image_url(Some("not at all a url".to_string())),
-        ) {
-            Ok(_) => assert!(false, "expected bad preview url to fail an observation"),
-            Err(_) => {}
-        }
+        assert!(
+            apply_observation(
+                &conn,
+                VisitObservation::new(Url::parse("https://www.example.com/").unwrap())
+                    .with_preview_image_url(Some("not at all a url".to_string())),
+            )
+            .is_err(),
+            "expected bad preview url to fail an observation"
+        );
     }
 
     #[test]

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -653,10 +653,15 @@ mod tests {
             match $preview_image_url as Option<&str> {
                 Some(t) => assert_eq!(
                     String::from(t),
-                    meta.preview_image_url.expect("preview_image_url must be Some"),
+                    meta.preview_image_url
+                        .expect("preview_image_url must be Some"),
                     "preview_image_url must match"
                 ),
-                None => assert_eq!(true, meta.preview_image_url.is_none(), "preview_image_url expected to be None"),
+                None => assert_eq!(
+                    true,
+                    meta.preview_image_url.is_none(),
+                    "preview_image_url expected to be None"
+                ),
             };
         };
     }

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -54,6 +54,7 @@ pub struct HistoryMetadataObservation {
 pub struct HistoryMetadata {
     pub url: String,
     pub title: Option<String>,
+    pub preview_image_url: Option<String>,
     pub created_at: i64,
     pub updated_at: i64,
     pub total_view_time: i32,
@@ -70,6 +71,7 @@ impl HistoryMetadata {
         Ok(Self {
             url: row.get("url")?,
             title: row.get("title")?,
+            preview_image_url: row.get("preview_image_url")?,
             created_at: created_at.0 as i64,
             updated_at: updated_at.0 as i64,
             total_view_time: row.get("total_view_time")?,
@@ -277,8 +279,8 @@ const MAX_QUERY_RESULTS: i32 = 1000;
 
 const COMMON_METADATA_SELECT: &str = "
 SELECT
-    m.id as metadata_id, p.url as url, p.title as title, m.created_at as created_at,
-    m.updated_at as updated_at, m.total_view_time as total_view_time,
+    m.id as metadata_id, p.url as url, p.title as title, p.preview_image_url as preview_image_url,
+    m.created_at as created_at, m.updated_at as updated_at, m.total_view_time as total_view_time,
     m.document_type as document_type, o.url as referrer_url, s.term as search_term
 FROM moz_places_metadata m
 LEFT JOIN moz_places p ON m.place_id = p.id
@@ -609,7 +611,7 @@ mod tests {
     }
 
     macro_rules! assert_history_metadata_record {
-        ($record:expr, url $url:expr, total_time $tvt:expr, search_term $search_term:expr, document_type $document_type:expr, referrer_url $referrer_url:expr, title $title:expr) => {
+        ($record:expr, url $url:expr, total_time $tvt:expr, search_term $search_term:expr, document_type $document_type:expr, referrer_url $referrer_url:expr, title $title:expr, preview_image_url $preview_image_url:expr) => {
             assert_eq!(String::from($url), $record.url, "url must match");
             assert_eq!($tvt, $record.total_view_time, "total_view_time must match");
             assert_eq!($document_type, $record.document_type, "is_media must match");
@@ -647,6 +649,14 @@ mod tests {
                     "title must match"
                 ),
                 None => assert_eq!(true, meta.title.is_none(), "title expected to be None"),
+            };
+            match $preview_image_url as Option<&str> {
+                Some(t) => assert_eq!(
+                    String::from(t),
+                    meta.preview_image_url.expect("preview_image_url must be Some"),
+                    "preview_image_url must match"
+                ),
+                None => assert_eq!(true, meta.preview_image_url.is_none(), "preview_image_url expected to be None"),
             };
         };
     }
@@ -1031,6 +1041,7 @@ mod tests {
         let observation1 = VisitObservation::new(Url::parse("https://www.cbc.ca/news/politics/federal-budget-2021-freeland-zimonjic-1.5991021").unwrap())
                 .with_at(now)
                 .with_title(Some(String::from("Budget vows to build &#x27;for the long term&#x27; as it promises child care cash, projects massive deficits | CBC News")))
+                .with_preview_image_url(Some(String::from("https://i.cbc.ca/1.5993583.1618861792!/cpImage/httpImage/image.jpg_gen/derivatives/16x9_620/fedbudget-20210419.jpg")))
                 .with_is_remote(false)
                 .with_visit_type(VisitTransition::Link);
         apply_observation(&conn, observation1).unwrap();
@@ -1084,7 +1095,8 @@ mod tests {
             search_term Some("cbc federal budget 2021"),
             document_type DocumentType::Regular,
             referrer_url Some("https://yandex.ru/search/?text=cbc%20federal%20budget%202021&lr=21512"),
-            title Some("Budget vows to build &#x27;for the long term&#x27; as it promises child care cash, projects massive deficits | CBC News")
+            title Some("Budget vows to build &#x27;for the long term&#x27; as it promises child care cash, projects massive deficits | CBC News"),
+            preview_image_url Some("https://i.cbc.ca/1.5993583.1618861792!/cpImage/httpImage/image.jpg_gen/derivatives/16x9_620/fedbudget-20210419.jpg")
         );
 
         // query by search term
@@ -1096,7 +1108,8 @@ mod tests {
             search_term Some("rust string format"),
             document_type DocumentType::Regular,
             referrer_url Some("https://yandex.ru/search/?lr=21512&text=rust%20string%20format"),
-            title None
+            title None,
+            preview_image_url None
         );
 
         // query by url
@@ -1107,7 +1120,8 @@ mod tests {
             search_term Some("sqlite like"),
             document_type DocumentType::Regular,
             referrer_url Some("https://www.google.com/search?client=firefox-b-d&q=sqlite+like"),
-            title None
+            title None,
+            preview_image_url None
         );
 
         // by url, referrer domain is different
@@ -1118,7 +1132,8 @@ mod tests {
             search_term Some("cute cat"),
             document_type DocumentType::Media,
             referrer_url Some("https://www.youtube.com/results?search_query=cute+cat"),
-            title None
+            title None,
+            preview_image_url None
         );
     }
 


### PR DESCRIPTION
We already have this field in moz_places; this PR adds just enough
piping to allow observing preview image urls and reading them back via
VisitInfo and HistoryMetadata APIs.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
