### PR TITLE
Run fixup() before the add_or_update test (#4457)

### DIFF
--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -583,6 +583,8 @@ impl LoginDb {
         entry: LoginEntry,
         encdec: &EncryptorDecryptor,
     ) -> Result<EncryptedLogin> {
+        // Make sure to fixup the entry first, in case that changes the username
+        let entry = entry.fixup()?;
         let logins: Result<Vec<Login>> = self
             .get_by_base_domain(&entry.fields.origin)?
             .into_iter()


### PR DESCRIPTION
Very simple change.  Right now it doesn't actually change any behavior, because the only username validation throws rather than tries to fixup the data.  But maybe in the future we will have a different one.

This also makes it so we fixup the data twice in this path since we do it again in `add()` or `update()`, whichever is called.  That seems fine to me, but we could consider splitting up those functions to avoid this.