### PR TITLE
Logins per field encryption

### DIFF
--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -583,6 +583,8 @@ impl LoginDb {
         entry: LoginEntry,
         encdec: &EncryptorDecryptor,
     ) -> Result<EncryptedLogin> {
+        // Make sure to fixup the entry first, in case that changes the username
+        let entry = entry.fixup()?;
         let logins: Result<Vec<Login>> = self
             .get_by_base_domain(&entry.fields.origin)?
             .into_iter()

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -26,8 +26,8 @@ pub use crate::login::*;
 pub use crate::store::*;
 pub use crate::sync::LoginsSyncEngine;
 
-// Public encryption functions.  We create need to publish these as top-level functions to expose
-// them across UniFFI
+// Public encryption functions.  We publish these as top-level functions to expose them across
+// UniFFI
 fn encrypt_login(login: Login, enc_key: &str) -> Result<EncryptedLogin> {
     let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
     login.encrypt(&encdec)
@@ -36,4 +36,14 @@ fn encrypt_login(login: Login, enc_key: &str) -> Result<EncryptedLogin> {
 fn decrypt_login(login: EncryptedLogin, enc_key: &str) -> Result<Login> {
     let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
     login.decrypt(&encdec)
+}
+
+fn encrypt_fields(sec_fields: SecureLoginFields, enc_key: &str) -> Result<String> {
+    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+    sec_fields.encrypt(&encdec)
+}
+
+fn decrypt_fields(sec_fields: String, enc_key: &str) -> Result<SecureLoginFields> {
+    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+    encdec.decrypt_struct(&sec_fields)
 }

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -17,6 +17,14 @@ namespace logins {
     [Throws=LoginsStorageError]
     EncryptedLogin encrypt_login(Login login, [ByRef]string encryption_key);
 
+    // Decrypt an encrypted `string` to `SecureLoginFields`
+    [Throws=LoginsStorageError]
+    SecureLoginFields decrypt_fields(string sec_fields, [ByRef]string encryption_key);
+
+    // Encrypt `SecureLoginFields` to an encrypted `string`
+    [Throws=LoginsStorageError]
+    string encrypt_fields(SecureLoginFields sec_fields, [ByRef]string encryption_key);
+
     Login? find_login_to_update([ByRef]LoginEntry look, [ByRef]sequence<Login> logins);
 
     // XXX - we still need some way to have a "canary" for the encryption_key - eg, to ensure


### PR DESCRIPTION
Pretty simple change. Right now it doesn't actually change any behavior, because the only username validation throws rather than tries to fixup the data. But maybe in the future we will have a different one.

This also makes it so we fixup the data twice in this path since we do it again in add() or update(), whichever is called. That seems fine to me, but we could consider splitting up those functions to avoid this.

I also added a commit to add encryption functions for secure_login_data.  It seems like people were also good with this change.