### PR TITLE
Use correct name for espresso-core dependency

### DIFF
--- a/build-scripts/component-common.gradle
+++ b/build-scripts/component-common.gradle
@@ -70,5 +70,5 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$mockito_core_version"
 
     androidTestImplementation "androidx.test:runner:$androidx_test_runner_version"
-    androidTestImplementation "androidx.test.espresso:expresso-core:$espresso_core_version"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_core_version"
 }


### PR DESCRIPTION
So ... uhm ... I just ran `./gradlew nimbus:build` in a checkout and it failed.
Then it took me 10 minutes to figure out the typo and now it builds again.

I don't know how this worked before? Is that code not exercised in CI?