### PR TITLE
Exit verify-ios-env immediately on error

### DIFF
--- a/libs/verify-ios-environment.sh
+++ b/libs/verify-ios-environment.sh
@@ -4,6 +4,8 @@
 #
 # This file should be used via `./libs/verify-ios-environment.sh`.
 
+set -e
+
 if [[ ! -f "$(pwd)/libs/build-all.sh" ]]; then
   echo "ERROR: verify-ios-environment.sh should be run from the root directory of the repo"
   exit 1


### PR DESCRIPTION
If one of the called scripts fails, e.g. because some tooling is missing,
it would still print the "Looks good" message, which is confusing.
Now it just error-exits if one of the called scripts error-exits (which
btw prints an error message and if that's the last thing printed its
more noticable)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
