### PR TITLE
Fix duplication logic in logins migration

### DIFF
--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -550,13 +550,9 @@ fn insert_local_login(
     let login = &local_login.login;
     let dec_login = &local_login.login.clone().decrypt(encdec)?;
 
-    match new_db.check_for_dupes(&login.guid(), &dec_login.entry(), &encdec) {
-        Ok(_) => {}
-        Err(e) => {
-            log::warn!("Duplicate {} ({}).", login.record.id, e);
-            // Should we record this as an error? or just silently ignore it
-            return Err(e.into());
-        }
+    if let Err(e) = new_db.check_for_dupes(&login.guid(), &dec_login.entry(), &encdec) {
+        log::warn!("Duplicate {} ({}).", login.record.id, e);
+        return Ok(());
     };
     match conn.execute_named_cached(
         &sql,

--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -1354,10 +1354,10 @@ mod tests {
         .unwrap();
 
         let db = LoginDb::open(testpaths.new_db).unwrap();
-        // Should only be 1 login in loginsL
+        // Should only be 2 logins in loginsL (blank username and test)
         assert_eq!(
             db.query_one::<i32>("SELECT COUNT(*) FROM loginsL").unwrap(),
-            1
+            2
         );
     }
 }


### PR DESCRIPTION
Fixes #4401 

Main focus was implementing a check for dupes before inserting into the local logins table (mirror is presumed to have dealt with this unless their sync was completely broken?)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
