### PR TITLE
Removes enabled and probeSets fields from DTO

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -25,3 +25,7 @@ Use the template below to make assigning a version number during the release cut
 
 - Clients engine now checks for tombstones and any deserialisation errors when receiving a client record, and ignores
   it if either are present ([#4504](https://github.com/mozilla/application-services/pull/4504))
+
+## Nimbus
+### What's changed
+- The DTO changed to remove the `probeSets` and `enabled` fields that were previously unused. ([#4482](https://github.com/mozilla/application-services/pull/4482))

--- a/components/nimbus/src/client/http_client.rs
+++ b/components/nimbus/src/client/http_client.rs
@@ -312,7 +312,6 @@ mod tests {
                 proposed_duration: None,
                 proposed_enrollment: 7,
                 reference_branch: Some("control".to_string()),
-                probe_sets: vec![],
                 feature_ids: vec!["first_switch".to_string()],
                 branches: vec![
                     Branch {
@@ -320,7 +319,6 @@ mod tests {
                         ratio: 1,
                         feature: Some(FeatureConfig {
                             feature_id: "first_switch".to_string(),
-                            enabled: false,
                             value: Default::default(),
                         }),
                         features: None,
@@ -330,7 +328,6 @@ mod tests {
                         ratio: 1,
                         feature: Some(FeatureConfig {
                             feature_id: "first_switch".to_string(),
-                            enabled: true,
                             value: Default::default(),
                         }),
                         features: None,


### PR DESCRIPTION
Follow up after #4452 

Removes the `enabled` and `probeSets` fields from the DTO and adds tests for the removal. For context, this to align fully with the proposal https://github.com/mozilla/nimbus-shared/pull/172 

The multi-feature related part of the proposal was implemented in #4452.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
