### PR TITLE
Update rust according to moz-central updates [ci full]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ commands:
   # Our minimum supported rust version is specified here.
   setup-rust-min-version:
     steps:
-      # Technically should be on 1.47 here, but that boat sailed - 1.50 has been our effective min for some time now.
+      # https://searchfox.org/mozilla-central/source/python/mozboot/mozboot/util.py#20
       - run: rustup override set 1.53.0
 
   full-checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
   setup-rust-min-version:
     steps:
       # Technically should be on 1.47 here, but that boat sailed - 1.50 has been our effective min for some time now.
-      - run: rustup override set 1.50.0
+      - run: rustup override set 1.53.0
 
   full-checkout:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,7 +215,7 @@ executors:
   # Unfortunately some of our jobs can only run successfully on macos.
   docker:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.53.0
   macos:
     macos:
       xcode: 12.5.1

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,9 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## General
+
+### What's Changed
+
+- Rust toolchain has been bumped to 1.55 and minimum version bumped to 1.53 to comply with our [Rust Policy](https://github.com/mozilla/application-services/blob/main/docs/rust-versions.md#application-services-rust-version-policy)

--- a/components/autofill/src/db/schema.rs
+++ b/components/autofill/src/db/schema.rs
@@ -81,7 +81,7 @@ impl ConnectionInitializer for AutofillConnectionInitializer {
     const END_VERSION: u32 = 2;
 
     fn prepare(&self, conn: &Connection) -> Result<()> {
-        define_functions(&conn)?;
+        define_functions(conn)?;
         conn.set_prepared_statement_cache_capacity(128);
         Ok(())
     }

--- a/components/autofill/src/encryption.rs
+++ b/components/autofill/src/encryption.rs
@@ -63,7 +63,7 @@ impl EncryptorDecryptor {
 
     pub fn decrypt(&self, ciphertext: &str) -> Result<String> {
         Ok(jwcrypto::decrypt_jwe(
-            &ciphertext,
+            ciphertext,
             jwcrypto::DecryptionParameters::Direct {
                 jwk: self.jwk.clone(),
             },

--- a/components/autofill/src/sync/address/incoming.rs
+++ b/components/autofill/src/sync/address/incoming.rs
@@ -190,7 +190,7 @@ impl ProcessIncomingRecordImpl for IncomingAddressesImpl {
         };
 
         let result = tx.query_row_named(&sql, params, |row| {
-            Ok(Self::Record::from_row(&row).expect("wtf? '?' doesn't work :("))
+            Ok(Self::Record::from_row(row).expect("wtf? '?' doesn't work :("))
         });
 
         match result {

--- a/components/autofill/src/sync/address/outgoing.rs
+++ b/components/autofill/src/sync/address/outgoing.rs
@@ -49,9 +49,9 @@ impl ProcessOutgoingRecordImpl for OutgoingAddressesImpl {
 
         // save outgoing records to the mirror table
         let staging_records = common_get_outgoing_staging_records(
-            &tx,
+            tx,
             &data_sql,
-            &tombstones_sql,
+            tombstones_sql,
             payload_from_data_row,
         )?
         .into_iter()
@@ -63,11 +63,11 @@ impl ProcessOutgoingRecordImpl for OutgoingAddressesImpl {
             )
         })
         .collect::<Vec<(SyncGuid, String, i64)>>();
-        common_save_outgoing_records(&tx, STAGING_TABLE_NAME, staging_records)?;
+        common_save_outgoing_records(tx, STAGING_TABLE_NAME, staging_records)?;
 
         // return outgoing changes
         let outgoing_records: Vec<(Payload, i64)> =
-            common_get_outgoing_records(&tx, &data_sql, &tombstones_sql, payload_from_data_row)?;
+            common_get_outgoing_records(tx, &data_sql, tombstones_sql, payload_from_data_row)?;
 
         outgoing.changes = outgoing_records
             .into_iter()
@@ -82,7 +82,7 @@ impl ProcessOutgoingRecordImpl for OutgoingAddressesImpl {
         records_synced: Vec<SyncGuid>,
     ) -> anyhow::Result<()> {
         common_finish_synced_items(
-            &tx,
+            tx,
             DATA_TABLE_NAME,
             MIRROR_TABLE_NAME,
             STAGING_TABLE_NAME,

--- a/components/autofill/src/sync/common.rs
+++ b/components/autofill/src/sync/common.rs
@@ -495,23 +495,23 @@ pub(super) mod tests {
         // call fetch outgoing records
         assert!(ro
             .fetch_outgoing_records(
-                &tx,
+                tx,
                 collection_name.to_string(),
                 ServerTimestamp::from_millis(0)
             )
             .is_ok());
 
         // check that the record is in the outgoing table
-        exists_in_table(&tx, &format!("temp.{}", staging_table_name), guid);
+        exists_in_table(tx, &format!("temp.{}", staging_table_name), guid);
 
         // call push synced items
-        assert!(ro.finish_synced_items(&tx, vec![guid.clone()]).is_ok());
+        assert!(ro.finish_synced_items(tx, vec![guid.clone()]).is_ok());
 
         // check that the sync change counter
-        exists_with_counter_value_in_table(&tx, data_table_name, guid, 0);
+        exists_with_counter_value_in_table(tx, data_table_name, guid, 0);
 
         // check that the outgoing record is in the mirror
-        exists_in_table(&tx, mirror_table_name, guid);
+        exists_in_table(tx, mirror_table_name, guid);
     }
 
     pub(in crate::sync) fn do_test_outgoing_tombstone<T: SyncRecord + std::fmt::Debug + Clone>(
@@ -526,17 +526,17 @@ pub(super) mod tests {
         // call fetch outgoing records
         assert!(ro
             .fetch_outgoing_records(
-                &tx,
+                tx,
                 collection_name.to_string(),
                 ServerTimestamp::from_millis(0),
             )
             .is_ok());
 
         // check that the record is in the outgoing table
-        exists_in_table(&tx, &format!("temp.{}", staging_table_name), guid);
+        exists_in_table(tx, &format!("temp.{}", staging_table_name), guid);
 
         // call push synced items
-        assert!(ro.finish_synced_items(&tx, vec![guid.clone()]).is_ok());
+        assert!(ro.finish_synced_items(tx, vec![guid.clone()]).is_ok());
 
         // check that the record wasn't copied to the data table
         let sql = format!(
@@ -549,7 +549,7 @@ pub(super) mod tests {
         assert_eq!(num_rows, 0);
 
         // check that the outgoing record is in the mirror
-        exists_in_table(&tx, mirror_table_name, guid);
+        exists_in_table(tx, mirror_table_name, guid);
     }
 
     pub(in crate::sync) fn do_test_outgoing_synced_with_local_change<
@@ -566,23 +566,23 @@ pub(super) mod tests {
         // call fetch outgoing records
         assert!(ro
             .fetch_outgoing_records(
-                &tx,
+                tx,
                 collection_name.to_string(),
                 ServerTimestamp::from_millis(0),
             )
             .is_ok());
 
         // check that the record is in the outgoing table
-        exists_in_table(&tx, &format!("temp.{}", staging_table_name), guid);
+        exists_in_table(tx, &format!("temp.{}", staging_table_name), guid);
 
         // call push synced items
-        assert!(ro.finish_synced_items(&tx, vec![guid.clone()]).is_ok());
+        assert!(ro.finish_synced_items(tx, vec![guid.clone()]).is_ok());
 
         // check that the sync change counter
-        exists_with_counter_value_in_table(&tx, data_table_name, guid, 0);
+        exists_with_counter_value_in_table(tx, data_table_name, guid, 0);
 
         // check that the outgoing record is in the mirror
-        exists_in_table(&tx, mirror_table_name, guid);
+        exists_in_table(tx, mirror_table_name, guid);
     }
 
     pub(in crate::sync) fn do_test_outgoing_synced_with_no_change<
@@ -598,7 +598,7 @@ pub(super) mod tests {
         // call fetch outgoing records
         assert!(ro
             .fetch_outgoing_records(
-                &tx,
+                tx,
                 collection_name.to_string(),
                 ServerTimestamp::from_millis(0),
             )
@@ -616,9 +616,9 @@ pub(super) mod tests {
         assert_eq!(num_rows, 0);
 
         // call push synced items
-        assert!(ro.finish_synced_items(&tx, Vec::<Guid>::new()).is_ok());
+        assert!(ro.finish_synced_items(tx, Vec::<Guid>::new()).is_ok());
 
         // check that the sync change counter is unchanged
-        exists_with_counter_value_in_table(&tx, data_table_name, guid, 0);
+        exists_with_counter_value_in_table(tx, data_table_name, guid, 0);
     }
 }

--- a/components/autofill/src/sync/credit_card/incoming.rs
+++ b/components/autofill/src/sync/credit_card/incoming.rs
@@ -184,7 +184,7 @@ impl ProcessIncomingRecordImpl for IncomingCreditCardsImpl {
         // rows and decrypt the numbers here.
         let records =
             tx.query_rows_and_then_named(&sql, params, |row| -> Result<Self::Record> {
-                Ok(Self::Record::from_row(&row)?)
+                Ok(Self::Record::from_row(row)?)
             })?;
 
         let incoming_cc_number = self.encdec.decrypt(&incoming.cc_number_enc)?;

--- a/components/autofill/src/sync/credit_card/outgoing.rs
+++ b/components/autofill/src/sync/credit_card/outgoing.rs
@@ -54,9 +54,9 @@ impl ProcessOutgoingRecordImpl for OutgoingCreditCardsImpl {
 
         // save outgoing records to the mirror table
         let cleartext_staging_records = common_get_outgoing_staging_records(
-            &tx,
+            tx,
             &data_sql,
-            &tombstones_sql,
+            tombstones_sql,
             payload_from_data_row,
         )?;
         // Turn the payloads into encrypted reprs to save in the mirror.
@@ -65,11 +65,11 @@ impl ProcessOutgoingRecordImpl for OutgoingCreditCardsImpl {
             let pp = PersistablePayload::from_cc_payload(payload, &self.encdec)?;
             staging_records.push((pp.guid, pp.payload, sync_change_counter));
         }
-        common_save_outgoing_records(&tx, STAGING_TABLE_NAME, staging_records)?;
+        common_save_outgoing_records(tx, STAGING_TABLE_NAME, staging_records)?;
 
         // return outgoing changes
         let outgoing_records: Vec<(Payload, i64)> =
-            common_get_outgoing_records(&tx, &data_sql, &tombstones_sql, payload_from_data_row)?;
+            common_get_outgoing_records(tx, &data_sql, tombstones_sql, payload_from_data_row)?;
 
         outgoing.changes = outgoing_records
             .into_iter()
@@ -84,7 +84,7 @@ impl ProcessOutgoingRecordImpl for OutgoingCreditCardsImpl {
         records_synced: Vec<SyncGuid>,
     ) -> anyhow::Result<()> {
         common_finish_synced_items(
-            &tx,
+            tx,
             DATA_TABLE_NAME,
             MIRROR_TABLE_NAME,
             STAGING_TABLE_NAME,

--- a/components/autofill/src/sync/mod.rs
+++ b/components/autofill/src/sync/mod.rs
@@ -294,7 +294,7 @@ fn plan_incoming<T: std::fmt::Debug + SyncRecord>(
                     //     metadata changes.
                     let metadata = incoming_record.metadata_mut();
                     metadata.merge(
-                        &local_record.metadata(),
+                        local_record.metadata(),
                         mirror.as_ref().map(|m| m.metadata()),
                     );
                     // a micro-optimization here would be to `::DoNothing` if
@@ -338,7 +338,7 @@ fn plan_incoming<T: std::fmt::Debug + SyncRecord>(
                             // we still merge that metadata.
                             let metadata = incoming_record.metadata_mut();
                             metadata.merge(
-                                &local_dupe.metadata(),
+                                local_dupe.metadata(),
                                 mirror.as_ref().map(|m| m.metadata()),
                             );
                             IncomingAction::UpdateLocalGuid {

--- a/components/fxa-client/src/internal/auth.rs
+++ b/components/fxa-client/src/internal/auth.rs
@@ -87,7 +87,7 @@ pub fn get_scoped_keys(
                 .ok_or_else(|| anyhow::Error::msg("Key data not an object"))?
                 .get(key)
                 .ok_or_else(|| anyhow::Error::msg("Key does not exist"))?;
-            scoped_keys.insert(key.clone(), get_key_for_scope(&key, val, acct_keys)?);
+            scoped_keys.insert(key.clone(), get_key_for_scope(key, val, acct_keys)?);
             Ok(())
         })?;
     Ok(scoped_keys)
@@ -207,7 +207,7 @@ fn get_account_keys(config: &Config, key_fetch_token: &str) -> Result<Vec<u8>> {
     let more_creds = derive_hkdf_sha256_key(key_request_key, &[0u8; 0], &kw("account/keys"), 96)?;
     let _resp_hmac_key = &more_creds[0..32];
     let resp_xor_key = &more_creds[32..96];
-    let bundle = http_client::get_keys_bundle(&config, &creds.out)?;
+    let bundle = http_client::get_keys_bundle(config, &creds.out)?;
     // Missing MAC matching since this is only for tests
     xored(resp_xor_key, &bundle[0..64])
 }

--- a/components/fxa-client/src/internal/config.rs
+++ b/components/fxa-client/src/internal/config.rs
@@ -192,7 +192,7 @@ impl Config {
 
     pub fn token_server_endpoint_url(&self) -> Result<Url> {
         if let Some(token_server_url_override) = &self.token_server_url_override {
-            return Ok(Url::parse(&token_server_url_override)?);
+            return Ok(Url::parse(token_server_url_override)?);
         }
         Ok(Url::parse(
             &self.remote_config()?.token_server_endpoint_url,

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -45,9 +45,7 @@ impl FirefoxAccount {
         }
 
         let refresh_token = self.get_refresh_token()?;
-        let response = self
-            .client
-            .get_devices(&self.state.config, refresh_token)?;
+        let response = self.client.get_devices(&self.state.config, refresh_token)?;
 
         self.devices_cache = Some(CachedResponse {
             response: response.clone(),

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -47,7 +47,7 @@ impl FirefoxAccount {
         let refresh_token = self.get_refresh_token()?;
         let response = self
             .client
-            .get_devices(&self.state.config, &refresh_token)?;
+            .get_devices(&self.state.config, refresh_token)?;
 
         self.devices_cache = Some(CachedResponse {
             response: response.clone(),
@@ -103,7 +103,7 @@ impl FirefoxAccount {
         device_type: Type,
         capabilities: &[Capability],
     ) -> Result<()> {
-        let commands = self.register_capabilities(&capabilities)?;
+        let commands = self.register_capabilities(capabilities)?;
         let update = DeviceUpdateRequestBuilder::new()
             .display_name(name)
             .device_type(&device_type)
@@ -133,7 +133,7 @@ impl FirefoxAccount {
         {
             return Ok(());
         }
-        let commands = self.register_capabilities(&capabilities)?;
+        let commands = self.register_capabilities(capabilities)?;
         let update = DeviceUpdateRequestBuilder::new()
             .available_commands(&commands)
             .build();
@@ -161,7 +161,7 @@ impl FirefoxAccount {
         let refresh_token = self.get_refresh_token()?;
         self.client.invoke_command(
             &self.state.config,
-            &refresh_token,
+            refresh_token,
             command,
             &target.id,
             payload,

--- a/components/fxa-client/src/internal/http_client.rs
+++ b/components/fxa-client/src/internal/http_client.rs
@@ -209,7 +209,7 @@ impl FxAClient for Client {
         scopes: &[&str],
     ) -> Result<OAuthTokenResponse> {
         let url = config.token_endpoint()?;
-        let key = derive_auth_key_from_session_token(&session_token)?;
+        let key = derive_auth_key_from_session_token(session_token)?;
         let body = json!({
             "client_id": config.client_id,
             "scope": scopes.join(" "),
@@ -294,7 +294,7 @@ impl FxAClient for Client {
         session_token: &str,
     ) -> Result<DuplicateTokenResponse> {
         let url = config.auth_url_path("v1/session/duplicate")?;
-        let key = derive_auth_key_from_session_token(&session_token)?;
+        let key = derive_auth_key_from_session_token(session_token)?;
         let duplicate_body = json!({
             "reason": "migration"
         });

--- a/components/fxa-client/src/internal/oauth.rs
+++ b/components/fxa-client/src/internal/oauth.rs
@@ -65,7 +65,7 @@ impl FirefoxAccount {
             None => match self.state.session_token {
                 Some(ref session_token) => self.client.create_access_token_using_session_token(
                     &self.state.config,
-                    &session_token,
+                    session_token,
                     &[scope],
                 )?,
                 None => return Err(ErrorKind::NoCachedToken(scope.to_string()).into()),
@@ -270,7 +270,7 @@ impl FirefoxAccount {
         self.clear_access_token_cache();
         let state = util::random_base64_url_string(16)?;
         let code_verifier = util::random_base64_url_string(43)?;
-        let code_challenge = digest::digest(&digest::SHA256, &code_verifier.as_bytes())?;
+        let code_challenge = digest::digest(&digest::SHA256, code_verifier.as_bytes())?;
         let code_challenge = base64::encode_config(&code_challenge, base64::URL_SAFE_NO_PAD);
         let scoped_keys_flow = ScopedKeysFlow::with_random_key()?;
         let jwk = scoped_keys_flow.get_public_key_jwk()?;
@@ -419,7 +419,7 @@ impl FirefoxAccount {
         let scopes: Vec<&str> = old_refresh_token.scopes.iter().map(AsRef::as_ref).collect();
         let resp = self.client.create_refresh_token_using_session_token(
             &self.state.config,
-            &session_token,
+            session_token,
             &scopes,
         )?;
         let new_refresh_token = resp
@@ -721,7 +721,7 @@ mod tests {
         );
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_oauth_flow(&SCOPES, "test_webchannel_context_url", None)
+            .begin_oauth_flow(SCOPES, "test_webchannel_context_url", None)
             .unwrap();
         let url = Url::parse(&url).unwrap();
         let query_params: HashMap<_, _> = url.query_pairs().into_owned().collect();
@@ -743,8 +743,8 @@ mod tests {
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
             .begin_pairing_flow(
-                &PAIRING_URL,
-                &SCOPES,
+                PAIRING_URL,
+                SCOPES,
                 "test_webchannel_pairing_context_url",
                 None,
             )
@@ -774,8 +774,8 @@ mod tests {
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
             .begin_pairing_flow(
-                &PAIRING_URL,
-                &SCOPES,
+                PAIRING_URL,
+                SCOPES,
                 "test_pairing_flow_url",
                 Some(metrics_params),
             )
@@ -848,7 +848,7 @@ mod tests {
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa.begin_pairing_flow(
-            &PAIRING_URL,
+            PAIRING_URL,
             &["https://identity.mozilla.com/apps/oldsync"],
             "test_pairiong_flow_origin_mismatch",
             None,

--- a/components/fxa-client/src/internal/push.rs
+++ b/components/fxa-client/src/internal/push.rs
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn test_deserialize_send_tab_command() {
         let json = "{\"version\":1,\"command\":\"fxaccounts:command_received\",\"data\":{\"command\":\"send-tab-recv\",\"index\":1,\"sender\":\"bobo\",\"url\":\"https://mozilla.org\"}}";
-        let _: PushPayload = serde_json::from_str(&json).unwrap();
+        let _: PushPayload = serde_json::from_str(json).unwrap();
     }
 
     #[test]

--- a/components/fxa-client/src/internal/send_tab.rs
+++ b/components/fxa-client/src/internal/send_tab.rs
@@ -23,7 +23,7 @@ impl FirefoxAccount {
         let own_keys = self.load_or_generate_keys()?;
         let public_keys: PublicSendTabKeys = own_keys.into();
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
-        public_keys.as_command_data(&oldsync_key)
+        public_keys.as_command_data(oldsync_key)
     }
 
     fn load_or_generate_keys(&mut self) -> Result<PrivateSendTabKeys> {
@@ -59,7 +59,7 @@ impl FirefoxAccount {
             .ok_or_else(|| ErrorKind::UnknownTargetDevice(target_device_id.to_owned()))?;
         let (payload, sent_telemetry) = SendTabPayload::single_tab(title, url);
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
-        let command_payload = send_tab::build_send_command(&oldsync_key, target, &payload)?;
+        let command_payload = send_tab::build_send_command(oldsync_key, target, &payload)?;
         self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)?;
         self.telemetry.borrow_mut().record_tab_sent(sent_telemetry);
         Ok(())

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -246,7 +246,7 @@ impl LoginDb {
         let form_submit_host_port = l
             .form_submit_url
             .as_ref()
-            .and_then(|s| util::url_host_port(&s));
+            .and_then(|s| util::url_host_port(s));
         let args = named_params! {
             ":hostname": l.hostname,
             ":http_realm": l.http_realm,
@@ -514,7 +514,7 @@ impl LoginDb {
             let maybe_fixed_login = login.maybe_fixup().and_then(|fixed| {
                 match &fixed {
                     None => self.check_for_dupes(login)?,
-                    Some(l) => self.check_for_dupes(&l)?,
+                    Some(l) => self.check_for_dupes(l)?,
                 };
                 Ok(fixed)
             });
@@ -662,7 +662,7 @@ impl LoginDb {
 
     pub fn check_valid_with_no_dupes(&self, login: &Login) -> Result<()> {
         login.check_valid()?;
-        self.check_for_dupes(&login)
+        self.check_for_dupes(login)
     }
 
     pub fn fixup_and_check_for_dupes(&self, login: Login) -> Result<Login> {
@@ -672,7 +672,7 @@ impl LoginDb {
     }
 
     pub fn check_for_dupes(&self, login: &Login) -> Result<()> {
-        if self.dupe_exists(&login)? {
+        if self.dupe_exists(login)? {
             throw!(InvalidLogin::DuplicateLogin);
         }
         Ok(())

--- a/components/logins/src/engine.rs
+++ b/components/logins/src/engine.rs
@@ -129,7 +129,7 @@ impl LoginsSyncEngine {
         scope.err_if_interrupted()?;
 
         sql_support::each_chunk_mapped(
-            &records,
+            records,
             |r| r.0.id.as_str(),
             |chunk, offset| -> Result<()> {
                 // pairs the bound parameter for the guid with an integer index.

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -335,7 +335,7 @@ impl Login {
     /// a string.
     fn validate_and_fixup_origin(origin: &str) -> Result<Option<String>> {
         // Check we can parse the origin, then use the normalized version of it.
-        match Url::parse(&origin) {
+        match Url::parse(origin) {
             Ok(mut u) => {
                 // Presumably this is a faster path than always setting?
                 if u.path() != "/"
@@ -501,7 +501,7 @@ impl Login {
                             .form_submit_url = Some("".into());
                     }
                 } else if !href.is_empty() && href != "javascript:" {
-                    if let Some(fixed) = Login::validate_and_fixup_origin(&href)? {
+                    if let Some(fixed) = Login::validate_and_fixup_origin(href)? {
                         get_fixed_or_throw!(InvalidLogin::IllegalFieldValue {
                             field_info: "formActionOrigin is not normalized".into()
                         })?
@@ -665,7 +665,7 @@ pub(crate) struct SyncLoginData {
 impl SyncLoginData {
     #[inline]
     pub fn guid_str(&self) -> &str {
-        &self.guid.as_str()
+        self.guid.as_str()
     }
 
     #[inline]

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -135,7 +135,7 @@ impl LoginStore {
     }
 
     pub fn check_valid_with_no_dupes(&self, login: &Login) -> Result<()> {
-        self.db.lock().unwrap().check_valid_with_no_dupes(&login)
+        self.db.lock().unwrap().check_valid_with_no_dupes(login)
     }
 
     /// A convenience wrapper around sync_multiple.

--- a/components/logins/src/update_plan.rs
+++ b/components/logins/src/update_plan.rs
@@ -179,7 +179,7 @@ impl UpdatePlan {
 
                 :guid
             )";
-        let mut stmt = conn.prepare_cached(&sql)?;
+        let mut stmt = conn.prepare_cached(sql)?;
 
         for (login, timestamp, is_overridden) in &self.mirror_inserts {
             log::trace!("Inserting mirror {:?}", login.guid_str());

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -184,7 +184,7 @@ fn main() -> Result<()> {
         .value_of("db-path")
         .unwrap_or_else(|| match config.get("db_path") {
             Some(v) => v.as_str().unwrap(),
-            _ => &db_path_default,
+            _ => db_path_default,
         });
     log::info!("Database directory is {}", db_path);
 
@@ -283,7 +283,7 @@ fn main() -> Result<()> {
                 let uuid = uuid::Uuid::new_v4();
                 let mut num_of_experiments_enrolled = 0;
                 for exp in &all_experiments {
-                    let enr = nimbus::evaluate_enrollment(&uuid, &aru, &context.clone(), &exp)?;
+                    let enr = nimbus::evaluate_enrollment(&uuid, &aru, &context.clone(), exp)?;
                     if enr.status.is_enrolled() {
                         num_of_experiments_enrolled += 1;
                         if num_of_experiments_enrolled >= num {

--- a/components/nimbus/src/dbcache.rs
+++ b/components/nimbus/src/dbcache.rs
@@ -44,7 +44,7 @@ impl DatabaseCache {
     pub fn commit_and_update(&self, db: &Database, writer: Writer) -> Result<()> {
         // By passing in the active `writer` we read the state of enrollments
         // as written by the calling code, before it's committed to the db.
-        let enrollments = get_enrollments(&db, &writer)?;
+        let enrollments = get_enrollments(db, &writer)?;
 
         // Build the new hashmaps.  Note that this is somewhat temporary, is
         // likely to change when the full FeatureConfig stuff is implemented.

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -2150,17 +2150,23 @@ mod tests {
 
         // There should be one WasEnrolled; the NotEnrolled will have been
         // discarded.
-        
-        assert_eq!(1, enrollments
-            .clone()
-            .into_iter()
-            .filter(|e| matches!(e.status, EnrollmentStatus::WasEnrolled { .. })).count());
 
-        
-        assert_eq!(0, enrollments
-            .into_iter()
-            .filter(|e| matches!(e.status, EnrollmentStatus::Enrolled { .. })).count());
+        assert_eq!(
+            1,
+            enrollments
+                .clone()
+                .into_iter()
+                .filter(|e| matches!(e.status, EnrollmentStatus::WasEnrolled { .. }))
+                .count()
+        );
 
+        assert_eq!(
+            0,
+            enrollments
+                .into_iter()
+                .filter(|e| matches!(e.status, EnrollmentStatus::Enrolled { .. }))
+                .count()
+        );
         Ok(())
     }
 
@@ -3217,8 +3223,9 @@ mod tests {
         assert_eq!(events.len(), 2);
         // We should see 2 experiment enrolments, this time they're both opt outs
         assert_eq!(get_experiment_enrollments(&db, &writer)?.len(), 2);
-        
-        assert_eq!(get_experiment_enrollments(&db, &writer)?
+
+        assert_eq!(
+            get_experiment_enrollments(&db, &writer)?
                 .into_iter()
                 .filter(|enr| {
                     matches!(
@@ -3228,7 +3235,10 @@ mod tests {
                             ..
                         }
                     )
-                }).count(), 2);
+                })
+                .count(),
+            2
+        );
 
         // Opting in again and updating SHOULD NOT enroll us again (we've been disqualified).
         set_global_user_participation(&db, &mut writer, true)?;
@@ -3239,8 +3249,9 @@ mod tests {
         let enrollments = get_enrollments(&db, &writer)?;
         assert_eq!(enrollments.len(), 0);
         assert!(events.is_empty());
-        
-        assert_eq!(get_experiment_enrollments(&db, &writer)?
+
+        assert_eq!(
+            get_experiment_enrollments(&db, &writer)?
                 .into_iter()
                 .filter(|enr| {
                     matches!(
@@ -3250,7 +3261,10 @@ mod tests {
                             ..
                         }
                     )
-                }).count(), 2);
+                })
+                .count(),
+            2
+        );
 
         writer.commit()?;
         Ok(())

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -386,8 +386,8 @@ impl ExperimentEnrollment {
                 ..
             } => EnrollmentChangeEvent::new(
                 &self.slug,
-                &enrollment_id,
-                &branch,
+                enrollment_id,
+                branch,
                 None,
                 EnrollmentChangeEventType::Unenrollment,
             ),
@@ -398,8 +398,8 @@ impl ExperimentEnrollment {
                 ..
             } => EnrollmentChangeEvent::new(
                 &self.slug,
-                &enrollment_id,
-                &branch,
+                enrollment_id,
+                branch,
                 match reason {
                     DisqualifiedReason::NotTargeted => Some("targeting"),
                     DisqualifiedReason::OptOut => Some("optout"),
@@ -611,9 +611,9 @@ impl<'a> EnrollmentsEvolver<'a> {
         prev_enrollments: &[ExperimentEnrollment],
     ) -> Result<(Vec<ExperimentEnrollment>, Vec<EnrollmentChangeEvent>)> {
         let mut enrollment_events = vec![];
-        let prev_experiments = map_experiments(&prev_experiments);
-        let next_experiments = map_experiments(&next_experiments);
-        let prev_enrollments = map_enrollments(&prev_enrollments);
+        let prev_experiments = map_experiments(prev_experiments);
+        let next_experiments = map_experiments(next_experiments);
+        let prev_enrollments = map_enrollments(prev_enrollments);
 
         // Step 1. Build an initial active_features to keep track of
         // the features that are being experimented upon.
@@ -774,7 +774,7 @@ impl<'a> EnrollmentsEvolver<'a> {
             // Now we have an enrollment object!
             // If it's an enrolled enrollment, then get the FeatureConfigs
             // from the experiment and store them in the active_features map.
-            for enrolled_feature in get_enrolled_feature_configs(&enrollment, &experiments) {
+            for enrolled_feature in get_enrolled_feature_configs(&enrollment, experiments) {
                 enrolled_features.insert(enrolled_feature.feature_id.clone(), enrolled_feature);
             }
             // Also, record the enrollment for our return value
@@ -2150,18 +2150,16 @@ mod tests {
 
         // There should be one WasEnrolled; the NotEnrolled will have been
         // discarded.
-        let enrolled: Vec<ExperimentEnrollment> = enrollments
+        
+        assert_eq!(1, enrollments
             .clone()
             .into_iter()
-            .filter(|e| matches!(e.status, EnrollmentStatus::WasEnrolled { .. }))
-            .collect();
-        assert_eq!(1, enrolled.len());
+            .filter(|e| matches!(e.status, EnrollmentStatus::WasEnrolled { .. })).count());
 
-        let enrolled: Vec<ExperimentEnrollment> = enrollments
+        
+        assert_eq!(0, enrollments
             .into_iter()
-            .filter(|e| matches!(e.status, EnrollmentStatus::Enrolled { .. }))
-            .collect();
-        assert_eq!(0, enrolled.len());
+            .filter(|e| matches!(e.status, EnrollmentStatus::Enrolled { .. })).count());
 
         Ok(())
     }
@@ -3219,8 +3217,8 @@ mod tests {
         assert_eq!(events.len(), 2);
         // We should see 2 experiment enrolments, this time they're both opt outs
         assert_eq!(get_experiment_enrollments(&db, &writer)?.len(), 2);
-        let disqualified_enrollments: Vec<ExperimentEnrollment> =
-            get_experiment_enrollments(&db, &writer)?
+        
+        assert_eq!(get_experiment_enrollments(&db, &writer)?
                 .into_iter()
                 .filter(|enr| {
                     matches!(
@@ -3230,9 +3228,7 @@ mod tests {
                             ..
                         }
                     )
-                })
-                .collect();
-        assert_eq!(disqualified_enrollments.len(), 2);
+                }).count(), 2);
 
         // Opting in again and updating SHOULD NOT enroll us again (we've been disqualified).
         set_global_user_participation(&db, &mut writer, true)?;
@@ -3243,8 +3239,8 @@ mod tests {
         let enrollments = get_enrollments(&db, &writer)?;
         assert_eq!(enrollments.len(), 0);
         assert!(events.is_empty());
-        let disqualified_enrollments: Vec<ExperimentEnrollment> =
-            get_experiment_enrollments(&db, &writer)?
+        
+        assert_eq!(get_experiment_enrollments(&db, &writer)?
                 .into_iter()
                 .filter(|enr| {
                     matches!(
@@ -3254,9 +3250,7 @@ mod tests {
                             ..
                         }
                     )
-                })
-                .collect();
-        assert_eq!(disqualified_enrollments.len(), 2);
+                }).count(), 2);
 
         writer.commit()?;
         Ok(())
@@ -3362,7 +3356,7 @@ mod tests {
         } if reason == "optout"
             && *experiment_slug == mock_exp1_slug
             && *branch_slug == mock_exp1_branch
-            && ! Uuid::parse_str(&enrollment_id)?.is_nil()
+            && ! Uuid::parse_str(enrollment_id)?.is_nil()
         ));
 
         Ok(())

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -84,7 +84,7 @@ pub fn evaluate_enrollment(
                     )? {
                         EnrollmentStatus::new_enrolled(
                             EnrolledReason::Qualified,
-                            &choose_branch(&exp.slug, &exp.branches, &id)?.clone().slug,
+                            &choose_branch(&exp.slug, &exp.branches, id)?.clone().slug,
                         )
                     } else {
                         EnrollmentStatus::NotEnrolled {

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -219,8 +219,7 @@ impl NimbusClient {
                     &state.available_randomization_units,
                     &self.app_context,
                 );
-                let events =
-                    evolver.evolve_enrollments_in_db(db, &mut writer, &new_experiments)?;
+                let events = evolver.evolve_enrollments_in_db(db, &mut writer, &new_experiments)?;
                 self.database_cache.commit_and_update(db, writer)?;
                 events
             }

--- a/components/nimbus/src/persistence.rs
+++ b/components/nimbus/src/persistence.rs
@@ -191,7 +191,7 @@ impl SingleStore {
         let mut iter = self.store.iter_start(reader)?;
         while let Some(Ok((_, data))) = iter.next() {
             if let rkv::Value::Json(data) = data {
-                let unserialized = serde_json::from_str::<T>(&data);
+                let unserialized = serde_json::from_str::<T>(data);
                 match unserialized {
                     Ok(value) => result.push(value),
                     Err(e) => {
@@ -222,7 +222,7 @@ impl SingleStore {
         let mut iter = self.store.iter_start(reader)?;
         while let Some(Ok((_, data))) = iter.next() {
             if let rkv::Value::Json(data) = data {
-                result.push(serde_json::from_str::<T>(&data)?);
+                result.push(serde_json::from_str::<T>(data)?);
             }
         }
         Ok(result)
@@ -500,7 +500,7 @@ impl Database {
         let mut iter = self.get_store(store_id).store.iter_start(&reader)?;
         while let Some(Ok((_, data))) = iter.next() {
             if let rkv::Value::Json(data) = data {
-                result.push(serde_json::from_str::<T>(&data)?);
+                result.push(serde_json::from_str::<T>(data)?);
             }
         }
         Ok(result)

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -174,7 +174,7 @@ pub extern "C" fn places_note_observation(
     log::debug!("places_note_observation");
     CONNECTIONS.call_with_result_mut(error, handle, |conn| {
         let json = json_observation.as_str();
-        let visit: places::VisitObservation = serde_json::from_str(&json)?;
+        let visit: places::VisitObservation = serde_json::from_str(json)?;
         places::api::apply_observation(conn, visit)
     })
 }

--- a/components/places/src/api/history.rs
+++ b/components/places/src/api/history.rs
@@ -159,7 +159,7 @@ pub fn visit_uri(
     is_error_page: bool,
 ) -> Result<()> {
     // Silently return if URI is something we shouldn't add to DB.
-    if !can_add_url(&url)? {
+    if !can_add_url(url)? {
         return Ok(());
     };
     // Do not save a reloaded uri if we have visited the same URI recently.

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -194,13 +194,13 @@ impl PlacesApi {
     }
 
     fn get_disk_persisted_state(&self, conn: &PlacesDb) -> Result<Option<String>> {
-        get_meta::<String>(&conn, GLOBAL_STATE_META_KEY)
+        get_meta::<String>(conn, GLOBAL_STATE_META_KEY)
     }
 
     fn set_disk_persisted_state(&self, conn: &PlacesDb, state: &Option<String>) -> Result<()> {
         match state {
-            Some(ref s) => put_meta(&conn, GLOBAL_STATE_META_KEY, s),
-            None => delete_meta(&conn, GLOBAL_STATE_META_KEY),
+            Some(ref s) => put_meta(conn, GLOBAL_STATE_META_KEY, s),
+            None => delete_meta(conn, GLOBAL_STATE_META_KEY),
         }
     }
 
@@ -216,7 +216,7 @@ impl PlacesApi {
             "history",
             move |conn, mem_cached_state, disk_cached_state| {
                 let interruptee = conn.begin_interrupt_scope();
-                let engine = HistoryEngine::new(&conn, &interruptee);
+                let engine = HistoryEngine::new(conn, &interruptee);
                 sync_multiple(
                     &[&engine],
                     disk_cached_state,
@@ -239,7 +239,7 @@ impl PlacesApi {
             "bookmarks",
             move |conn, mem_cached_state, disk_cached_state| {
                 let interruptee = conn.begin_interrupt_scope();
-                let engine = BookmarksEngine::new(&conn, &interruptee);
+                let engine = BookmarksEngine::new(conn, &interruptee);
                 sync_multiple(
                     &[&engine],
                     disk_cached_state,

--- a/components/places/src/bookmark_sync/engine.rs
+++ b/components/places/src/bookmark_sync/engine.rs
@@ -80,7 +80,7 @@ impl<'a> BookmarksEngine<'a> {
         let timestamp = inbound.timestamp;
         let mut tx = self.db.begin_transaction()?;
 
-        let applicator = IncomingApplicator::new(&self.db);
+        let applicator = IncomingApplicator::new(self.db);
 
         for incoming in inbound.changes {
             applicator.apply_payload(incoming.0, incoming.1)?;
@@ -88,14 +88,14 @@ impl<'a> BookmarksEngine<'a> {
             if tx.should_commit() {
                 // Trigger frecency updates for all new origins.
                 log::debug!("Updating origins for new synced URLs since last commit");
-                delete_pending_temp_tables(&self.db)?;
+                delete_pending_temp_tables(self.db)?;
             }
             tx.maybe_commit()?;
             self.interruptee.err_if_interrupted()?;
         }
 
         log::debug!("Updating origins for new synced URLs in last chunk");
-        delete_pending_temp_tables(&self.db)?;
+        delete_pending_temp_tables(self.db)?;
 
         tx.commit()?;
         Ok(timestamp)
@@ -849,7 +849,7 @@ impl<'a> BookmarksEngine<'a> {
                 // make sure we aren't interrupted before each calculation.
                 self.interruptee.err_if_interrupted()?;
                 let frecency = calculate_frecency(
-                    &self.db,
+                    self.db,
                     &DEFAULT_FRECENCY_SETTINGS,
                     place_id,
                     Some(false),
@@ -928,7 +928,7 @@ impl<'a> SyncEngine for BookmarksEngine<'a> {
         put_meta(self.db, LAST_SYNC_META_KEY, &(timestamp.as_millis() as i64))?;
 
         // Merge.
-        let mut merger = Merger::with_telemetry(&self, timestamp, telem);
+        let mut merger = Merger::with_telemetry(self, timestamp, telem);
         merger.merge()?;
 
         // Finally, stage outgoing items.
@@ -973,7 +973,7 @@ impl<'a> SyncEngine for BookmarksEngine<'a> {
     }
 
     fn reset(&self, assoc: &EngineSyncAssociation) -> anyhow::Result<()> {
-        reset(&self.db, assoc)?;
+        reset(self.db, assoc)?;
         Ok(())
     }
 
@@ -1334,7 +1334,7 @@ impl<'a> dogear::Store for Merger<'a> {
         let mut results = stmt.query(NO_PARAMS)?;
         let mut builder = match results.next()? {
             Some(row) => {
-                let (item, _) = self.local_row_to_item(&row)?;
+                let (item, _) = self.local_row_to_item(row)?;
                 Tree::with_root(item)
             }
             None => return Err(ErrorKind::Corruption(Corruption::InvalidLocalRoots).into()),
@@ -1364,7 +1364,7 @@ impl<'a> dogear::Store for Merger<'a> {
         while let Some(row) = results.next()? {
             self.engine.interruptee.err_if_interrupted()?;
 
-            let (item, content) = self.local_row_to_item(&row)?;
+            let (item, content) = self.local_row_to_item(row)?;
 
             let parent_guid = row.get::<_, SyncGuid>("parentGuid")?;
             child_guids_by_parent_guid
@@ -1458,7 +1458,7 @@ impl<'a> dogear::Store for Merger<'a> {
                 let guid = row.get::<_, SyncGuid>("guid")?;
                 builder.deletion(guid.as_str().into());
             } else {
-                let (item, content) = self.remote_row_to_item(&row)?;
+                let (item, content) = self.remote_row_to_item(row)?;
                 let mut p = builder.item(item)?;
                 if let Some(content) = content {
                     p.content(content);
@@ -1787,7 +1787,7 @@ mod tests {
     ) -> Vec<Guid> {
         // suck records into the engine.
         let interrupt_scope = conn.begin_interrupt_scope();
-        let engine = BookmarksEngine::new(&conn, &interrupt_scope);
+        let engine = BookmarksEngine::new(conn, &interrupt_scope);
 
         let mut incoming = IncomingChangeset::new(engine.collection_name(), remote_time);
 
@@ -3460,7 +3460,7 @@ mod tests {
             .validity(SyncedBookmarkValidity::Valid)
             .kind(SyncedBookmarkKind::Bookmark)
             .url(Some("http://example.com/b"))
-            .keyword(Some(&keyword_for_b));
+            .keyword(Some(keyword_for_b));
         let mut synced_item_for_c = SyncedBookmarkItem::new();
         synced_item_for_c
             .validity(SyncedBookmarkValidity::Valid)

--- a/components/places/src/bookmark_sync/engine.rs
+++ b/components/places/src/bookmark_sync/engine.rs
@@ -848,12 +848,8 @@ impl<'a> BookmarksEngine<'a> {
                 // Frecency recalculation runs several statements, so check to
                 // make sure we aren't interrupted before each calculation.
                 self.interruptee.err_if_interrupted()?;
-                let frecency = calculate_frecency(
-                    self.db,
-                    &DEFAULT_FRECENCY_SETTINGS,
-                    place_id,
-                    Some(false),
-                )?;
+                let frecency =
+                    calculate_frecency(self.db, &DEFAULT_FRECENCY_SETTINGS, place_id, Some(false))?;
                 frecencies.push((place_id, frecency));
             }
             if frecencies.is_empty() {

--- a/components/places/src/bookmark_sync/incoming.rs
+++ b/components/places/src/bookmark_sync/incoming.rs
@@ -75,7 +75,7 @@ impl<'a> IncomingApplicator<'a> {
             let mut seen = HashSet::with_capacity(array.len());
             for v in array {
                 if let JsonValue::String(s) = v {
-                    let tag = match validate_tag(&s) {
+                    let tag = match validate_tag(s) {
                         ValidatedTag::Invalid(t) => {
                             log::trace!("Incoming bookmark has invalid tag: {:?}", t);
                             set_reupload(&mut validity);
@@ -266,7 +266,7 @@ impl<'a> IncomingApplicator<'a> {
             // Sadly we can't use `url.query_pairs()` here as the format of
             // the url is, eg, `place:type=7` - ie, the "params" are actually
             // the path portion of the URL.
-            let parse = url::form_urlencoded::parse(&url.path().as_bytes());
+            let parse = url::form_urlencoded::parse(url.path().as_bytes());
             if parse
                 .clone()
                 .any(|(k, v)| k == "type" && v == RESULTS_AS_TAG_CONTENTS)
@@ -384,7 +384,7 @@ impl<'a> IncomingApplicator<'a> {
         // livemarks don't store a reference to the place, so we validate it manually.
         fn validate_href(h: Option<&str>, guid: &SyncGuid, what: &str) -> Option<String> {
             match h {
-                Some(h) => match Url::parse(&h) {
+                Some(h) => match Url::parse(h) {
                     Ok(url) => {
                         let s = url.to_string();
                         if s.len() > URL_LENGTH_MAX {
@@ -405,8 +405,8 @@ impl<'a> IncomingApplicator<'a> {
                 }
             }
         }
-        let feed_url = validate_href(feed_url, &record_id.as_guid(), "feed");
-        let site_url = validate_href(site_url, &record_id.as_guid(), "site");
+        let feed_url = validate_href(feed_url, record_id.as_guid(), "feed");
+        let site_url = validate_href(site_url, record_id.as_guid(), "site");
 
         if feed_url.is_none() {
             set_replace(&mut validity);
@@ -511,7 +511,7 @@ fn unpack_optional_str<'a>(
 ) -> Option<&'a str> {
     let val = &data[key];
     match val {
-        JsonValue::String(s) => Some(&s),
+        JsonValue::String(s) => Some(s),
         JsonValue::Null => None,
         _ => {
             set_reupload(validity);
@@ -649,7 +649,7 @@ mod tests {
                 "tags": ["foo", "bar"],
                 "keyword": "baz",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Valid)
                 .kind(SyncedBookmarkKind::Bookmark)
                 .parent_guid(Some(&BookmarkRootGuid::Unfiled.as_guid()))
@@ -680,7 +680,7 @@ mod tests {
         .expect("Should serialize folder with children");
         assert_incoming_creates_mirror_item(
             value,
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Valid)
                 .kind(SyncedBookmarkKind::Folder)
                 .parent_guid(Some(&BookmarkRootGuid::Unfiled.as_guid()))
@@ -696,7 +696,7 @@ mod tests {
                 "id": "deadbeef____",
                 "deleted": true
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Valid)
                 .deleted(true),
         );
@@ -718,7 +718,7 @@ mod tests {
                 "title": "Some query",
                 "bmkUri": "place:tag=foo",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Valid)
                 .kind(SyncedBookmarkKind::Query)
                 .parent_guid(Some(&BookmarkRootGuid::Unfiled.as_guid()))
@@ -736,7 +736,7 @@ mod tests {
                 "bmkUri": "place:type=7",
                 "folderName": "a-folder-name",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Reupload)
                 .kind(SyncedBookmarkKind::Query)
                 .url(Some("place:tag=a-folder-name")),
@@ -752,7 +752,7 @@ mod tests {
                 "bmkUri": "place:type=7",
                 "folderName": "",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Replace)
                 .kind(SyncedBookmarkKind::Query)
                 .url(None),
@@ -767,7 +767,7 @@ mod tests {
                 "parentid": "unfiled",
                 "bmkUri": "place:folder=123",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Reupload)
                 .kind(SyncedBookmarkKind::Query)
                 .url(Some("place:folder=123&excludeItems=1")),
@@ -782,7 +782,7 @@ mod tests {
                 "parentid": "unfiled",
                 "bmkUri": "place:folder=123&excludeItems=1",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Valid)
                 .kind(SyncedBookmarkKind::Query)
                 .url(Some("place:folder=123&excludeItems=1")),
@@ -796,7 +796,7 @@ mod tests {
                 "parentid": "unfiled",
                 "bmkUri": "foo",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Replace)
                 .kind(SyncedBookmarkKind::Query)
                 .url(None),
@@ -809,7 +809,7 @@ mod tests {
                 "type": "query",
                 "parentid": "unfiled",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Replace)
                 .kind(SyncedBookmarkKind::Query)
                 .url(None),
@@ -826,7 +826,7 @@ mod tests {
                 "parentid": "unfiled",
                 "parentName": "Unfiled Bookmarks",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Valid)
                 .kind(SyncedBookmarkKind::Separator)
                 .parent_guid(Some(&BookmarkRootGuid::Unfiled.as_guid()))
@@ -844,7 +844,7 @@ mod tests {
                 "parentid": "unfiled",
                 "parentName": "Unfiled Bookmarks",
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Replace)
                 .kind(SyncedBookmarkKind::Livemark)
                 .parent_guid(Some(&BookmarkRootGuid::Unfiled.as_guid()))
@@ -863,7 +863,7 @@ mod tests {
                 "feedUri": "http://example.com",
                 "siteUri": "foo"
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Valid)
                 .kind(SyncedBookmarkKind::Livemark)
                 .parent_guid(Some(&BookmarkRootGuid::Unfiled.as_guid()))
@@ -881,7 +881,7 @@ mod tests {
                 "feedUri": "http://example.com",
                 "siteUri": "http://example.com/something"
             }),
-            &SyncedBookmarkItem::new()
+            SyncedBookmarkItem::new()
                 .validity(SyncedBookmarkValidity::Valid)
                 .kind(SyncedBookmarkKind::Livemark)
                 .parent_guid(Some(&BookmarkRootGuid::Unfiled.as_guid()))

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -346,9 +346,9 @@ pub(crate) mod sql_fns {
                 let mode = get_raw_str(ctx, "hash", 1)?;
                 if let Some(value) = value {
                     Some(match mode {
-                        "" => hash::hash_url(&value),
-                        "prefix_lo" => hash::hash_url_prefix(&value, hash::PrefixMode::Lo),
-                        "prefix_hi" => hash::hash_url_prefix(&value, hash::PrefixMode::Hi),
+                        "" => hash::hash_url(value),
+                        "prefix_lo" => hash::hash_url_prefix(value, hash::PrefixMode::Lo),
+                        "prefix_hi" => hash::hash_url_prefix(value, hash::PrefixMode::Hi),
                         arg => {
                             return Err(rusqlite::Error::UserFunctionError(format!(
                                 "`hash` second argument must be either '', 'prefix_lo', or 'prefix_hi', got {:?}.",
@@ -415,21 +415,21 @@ pub(crate) mod sql_fns {
     #[inline(never)]
     pub fn get_prefix(ctx: &Context<'_>) -> Result<String> {
         let href = get_raw_str(ctx, "get_prefix", 0)?;
-        let (prefix, _) = split_after_prefix(&href);
+        let (prefix, _) = split_after_prefix(href);
         Ok(prefix.to_owned())
     }
 
     #[inline(never)]
     pub fn get_host_and_port(ctx: &Context<'_>) -> Result<String> {
         let href = get_raw_str(ctx, "get_host_and_port", 0)?;
-        let (host_and_port, _) = split_after_host_and_port(&href);
+        let (host_and_port, _) = split_after_host_and_port(href);
         Ok(host_and_port.to_owned())
     }
 
     #[inline(never)]
     pub fn strip_prefix_and_userinfo(ctx: &Context<'_>) -> Result<String> {
         let href = get_raw_str(ctx, "strip_prefix_and_userinfo", 0)?;
-        let (host_and_port, remainder) = split_after_host_and_port(&href);
+        let (host_and_port, remainder) = split_after_host_and_port(href);
         let mut res = String::with_capacity(host_and_port.len() + remainder.len() + 1);
         res += host_and_port;
         res += remainder;

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -150,7 +150,7 @@ pub fn upgrade_from(db: &Connection, from: u32) -> rusqlite::Result<()> {
             "DROP TABLE moz_bookmarks",
             CREATE_SHARED_SCHEMA_SQL,
         ],
-        || create_bookmark_roots(&db.conn()),
+        || create_bookmark_roots(db.conn()),
     )?;
     migration(db, from, 4, &[CREATE_SHARED_SCHEMA_SQL], || Ok(()))?;
     migration(db, from, 5, &[CREATE_SHARED_SCHEMA_SQL], || Ok(()))?; // new tags tables.

--- a/components/places/src/db/tx/mod.rs
+++ b/components/places/src/db/tx/mod.rs
@@ -108,9 +108,9 @@ impl<'conn> std::ops::Deref for PlacesTransaction<'conn> {
 
     fn deref(&self) -> &Connection {
         match &self.0 {
-            PlacesTransactionRepr::ChunkedWrite(t) => &t,
-            PlacesTransactionRepr::UnchunkedWrite(t) => &t,
-            PlacesTransactionRepr::ReadOnly(t) => &t,
+            PlacesTransactionRepr::ChunkedWrite(t) => t,
+            PlacesTransactionRepr::UnchunkedWrite(t) => t,
+            PlacesTransactionRepr::ReadOnly(t) => t,
         }
     }
 }

--- a/components/places/src/history_sync/engine.rs
+++ b/components/places/src/history_sync/engine.rs
@@ -55,7 +55,7 @@ impl<'a> HistoryEngine<'a> {
         let timestamp = inbound.timestamp;
         let outgoing = {
             let mut incoming_telemetry = telemetry::EngineIncoming::new();
-            let result = apply_plan(&self.db, inbound, &mut incoming_telemetry, self.interruptee);
+            let result = apply_plan(self.db, inbound, &mut incoming_telemetry, self.interruptee);
             telem.incoming(incoming_telemetry);
             result
         }?;
@@ -74,7 +74,7 @@ impl<'a> HistoryEngine<'a> {
             "sync completed after uploading {} records",
             records_synced.len()
         );
-        finish_plan(&self.db)?;
+        finish_plan(self.db)?;
 
         // write timestamp to reflect what we just wrote.
         self.put_meta(LAST_SYNC_META_KEY, &(new_timestamp.as_millis() as i64))?;
@@ -118,7 +118,7 @@ impl<'a> Deref for HistoryEngine<'a> {
     type Target = Connection;
     #[inline]
     fn deref(&self) -> &Connection {
-        &self.db
+        self.db
     }
 }
 
@@ -175,12 +175,12 @@ impl<'a> SyncEngine for HistoryEngine<'a> {
     }
 
     fn reset(&self, assoc: &EngineSyncAssociation) -> anyhow::Result<()> {
-        reset(&self.db, assoc)?;
+        reset(self.db, assoc)?;
         Ok(())
     }
 
     fn wipe(&self) -> anyhow::Result<()> {
-        delete_everything(&self.db)?;
+        delete_everything(self.db)?;
         Ok(())
     }
 }

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -225,7 +225,7 @@ pub fn apply_plan(
             }
             IncomingPlan::Delete => {
                 log::trace!("incoming: deleting {:?}", guid);
-                apply_synced_deletion(&db, &guid)?;
+                apply_synced_deletion(db, &guid)?;
                 telem.applied(1);
             }
             IncomingPlan::Apply {
@@ -240,13 +240,13 @@ pub fn apply_plan(
                     new_title,
                     visits
                 );
-                apply_synced_visits(&db, &guid, &url, new_title, visits)?;
+                apply_synced_visits(db, &guid, url, new_title, visits)?;
                 telem.applied(1);
             }
             IncomingPlan::Reconciled => {
                 telem.reconciled(1);
                 log::trace!("incoming: reconciled {:?}", guid);
-                apply_synced_reconciliation(&db, &guid)?;
+                apply_synced_reconciliation(db, &guid)?;
             }
         };
         if tx.should_commit() {

--- a/components/places/src/import/fennec/bookmarks.rs
+++ b/components/places/src/import/fennec/bookmarks.rs
@@ -84,7 +84,7 @@ fn do_import(places_api: &PlacesApi, fennec_db_file_url: Url) -> Result<Bookmark
     // Clear the mirror now, since we're about to fill it with data from the fennec
     // connection.
     log::debug!("Clearing mirror to prepare for import");
-    conn.execute_batch(&WIPE_MIRROR)?;
+    conn.execute_batch(WIPE_MIRROR)?;
     scope.err_if_interrupted()?;
 
     log::debug!("Populating mirror with the bookmarks roots");
@@ -112,7 +112,7 @@ fn do_import(places_api: &PlacesApi, fennec_db_file_url: Url) -> Result<Bookmark
     // could turn use `PRAGMA defer_foreign_keys = true`, but since we commit
     // everything in one go, that seems harder to debug.
     log::debug!("Populating mirror structure");
-    conn.execute_batch(&POPULATE_MIRROR_STRUCTURE)?;
+    conn.execute_batch(POPULATE_MIRROR_STRUCTURE)?;
     scope.err_if_interrupted()?;
 
     let engine = BookmarksEngine::new(&conn, &scope);

--- a/components/places/src/import/ios_bookmarks.rs
+++ b/components/places/src/import/ios_bookmarks.rs
@@ -133,7 +133,7 @@ fn do_import_ios_bookmarks(places_api: &PlacesApi, ios_db_file_url: Url) -> Resu
     // could turn use `PRAGMA defer_foreign_keys = true`, but since we commit
     // everything in one go, that seems harder to debug.
     log::debug!("Populating mirror structure");
-    conn.execute_batch(&POPULATE_MIRROR_STRUCTURE)?;
+    conn.execute_batch(POPULATE_MIRROR_STRUCTURE)?;
     scope.err_if_interrupted()?;
 
     // log::debug!("Detaching iOS database");

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -1625,13 +1625,9 @@ mod tests {
     fn test_bookmark_invalid_url_for_keyword() -> Result<()> {
         let conn = new_mem_connection();
 
-        let place_id = append_invalid_bookmark(
-            &conn,
-            BookmarkRootGuid::Unfiled.guid(),
-            "invalid",
-            "badurl",
-        )
-        .place_id;
+        let place_id =
+            append_invalid_bookmark(&conn, BookmarkRootGuid::Unfiled.guid(), "invalid", "badurl")
+                .place_id;
 
         // create a bookmark with keyword 'donut' pointing at it.
         conn.execute_named_cached(

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -382,7 +382,7 @@ pub fn delete_bookmark(db: &PlacesDb, guid: &SyncGuid) -> Result<bool> {
 
 fn delete_bookmark_in_tx(db: &PlacesDb, guid: &SyncGuid) -> Result<bool> {
     // Can't delete a root.
-    if let Some(root) = BookmarkRootGuid::well_known(&guid.as_str()) {
+    if let Some(root) = BookmarkRootGuid::well_known(guid.as_str()) {
         return Err(InvalidPlaceInfo::CannotUpdateRoot(root).into());
     }
     let record = match get_raw_bookmark(db, guid)? {
@@ -509,7 +509,7 @@ fn update_bookmark_in_tx(
     raw: RawBookmark,
 ) -> Result<()> {
     // if guid is root
-    if BookmarkRootGuid::well_known(&guid.as_str()).is_some() {
+    if BookmarkRootGuid::well_known(guid.as_str()).is_some() {
         return Err(InvalidPlaceInfo::CannotUpdateRoot(BookmarkRootGuid::Root).into());
     }
     let existing_parent_guid = raw
@@ -555,7 +555,7 @@ fn update_bookmark_in_tx(
             if new_parent_guid == BookmarkRootGuid::Root {
                 return Err(InvalidPlaceInfo::CannotUpdateRoot(BookmarkRootGuid::Root).into());
             }
-            let new_parent = get_raw_bookmark(db, &new_parent_guid)?
+            let new_parent = get_raw_bookmark(db, new_parent_guid)?
                 .ok_or_else(|| InvalidPlaceInfo::NoSuchGuid(new_parent_guid.to_string()))?;
             if new_parent.bookmark_type != BookmarkType::Folder {
                 return Err(InvalidPlaceInfo::InvalidParent(new_parent_guid.to_string()).into());
@@ -574,9 +574,9 @@ fn update_bookmark_in_tx(
         UpdatableItem::Bookmark(b) => match &b.url {
             None => raw.place_id,
             Some(url) => {
-                let page_info = match fetch_page_info(db, &url)? {
+                let page_info = match fetch_page_info(db, url)? {
                     Some(info) => info.page,
-                    None => new_page_info(db, &url, None)?,
+                    None => new_page_info(db, url, None)?,
                 };
                 Some(page_info.row_id)
             }
@@ -1074,7 +1074,7 @@ fn add_subtree_infos(parent: &SyncGuid, tree: &FolderNode, insert_infos: &mut Ve
                     }
                     .into(),
                 );
-                add_subtree_infos(&my_guid, &f, insert_infos);
+                add_subtree_infos(&my_guid, f, insert_infos);
             }
         };
     }
@@ -1104,7 +1104,7 @@ pub fn insert_tree(db: &PlacesDb, tree: &FolderNode) -> Result<()> {
     };
 
     let mut insert_infos: Vec<InsertableItem> = Vec::new();
-    add_subtree_infos(&parent_guid, tree, &mut insert_infos);
+    add_subtree_infos(parent_guid, tree, &mut insert_infos);
     log::info!("insert_tree inserting {} records", insert_infos.len());
     let tx = db.begin_transaction()?;
 
@@ -1307,7 +1307,7 @@ pub fn fetch_tree(
         }
         let node = match row.node_type {
             BookmarkType::Bookmark => match &row.url {
-                Some(url_str) => match Url::parse(&url_str) {
+                Some(url_str) => match Url::parse(url_str) {
                     Ok(url) => BookmarkNode {
                         guid: Some(row.guid.clone()),
                         date_added: Some(row.date_added),
@@ -1627,7 +1627,7 @@ mod tests {
 
         let place_id = append_invalid_bookmark(
             &conn,
-            &BookmarkRootGuid::Unfiled.guid(),
+            BookmarkRootGuid::Unfiled.guid(),
             "invalid",
             "badurl",
         )

--- a/components/places/src/storage/bookmarks/public_node.rs
+++ b/components/places/src/storage/bookmarks/public_node.rs
@@ -422,7 +422,7 @@ mod test {
         );
         append_invalid_bookmark(
             &conns.write,
-            &BookmarkRootGuid::Unfiled.guid(),
+            BookmarkRootGuid::Unfiled.guid(),
             "invalid",
             "badurl",
         );
@@ -497,7 +497,7 @@ mod test {
         // valid items)
         let guid_bad = append_invalid_bookmark(
             &conns.write,
-            &BookmarkRootGuid::Mobile.guid(),
+            BookmarkRootGuid::Mobile.guid(),
             "invalid url",
             "badurl",
         )
@@ -574,7 +574,7 @@ mod test {
 
         append_invalid_bookmark(
             &conns.write,
-            &BookmarkRootGuid::Mobile.guid(),
+            BookmarkRootGuid::Mobile.guid(),
             "invalid url",
             "badurl",
         );
@@ -660,7 +660,7 @@ mod test {
 
         append_invalid_bookmark(
             &conns.write,
-            &BookmarkRootGuid::Unfiled.guid(),
+            BookmarkRootGuid::Unfiled.guid(),
             "invalid url",
             "badurl",
         );

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -142,7 +142,7 @@ pub fn apply_observation_direct(
     // This needs to happen after the other updates.
     if update_frec {
         update_frecency(
-            &db,
+            db,
             page_info.row_id,
             Some(visit_ob.get_redirect_frecency_boost()),
         )?;
@@ -453,7 +453,7 @@ pub fn delete_everything(db: &PlacesDb) -> Result<()> {
     wipe_local_in_tx(db)?;
 
     // Remove Sync metadata, too.
-    reset_in_tx(&db, &EngineSyncAssociation::Disconnected)?;
+    reset_in_tx(db, &EngineSyncAssociation::Disconnected)?;
 
     tx.commit()?;
 
@@ -806,7 +806,7 @@ pub mod history_sync {
             .collect::<Vec<_>>();
 
         let mut counter_incr = 0;
-        let page_info = match fetch_page_info(db, &url)? {
+        let page_info = match fetch_page_info(db, url)? {
             Some(mut info) => {
                 // If the existing record has not yet been synced, then we will
                 // change the GUID to the incoming one. If it has been synced
@@ -833,7 +833,7 @@ pub mod history_sync {
                 if visits.is_empty() {
                     return Ok(());
                 }
-                new_page_info(db, &url, Some(incoming_guid.clone()))?
+                new_page_info(db, url, Some(incoming_guid.clone()))?
             }
         };
 
@@ -886,7 +886,7 @@ pub mod history_sync {
         }
         // XXX - we really need a better story for frecency-boost than
         // Option<bool> - None vs Some(false) is confusing. We should use an enum.
-        update_frecency(&db, page_info.row_id, None)?;
+        update_frecency(db, page_info.row_id, None)?;
 
         // and the place itself if necessary.
         let new_title = title.as_ref().unwrap_or(&page_info.title);
@@ -1161,7 +1161,7 @@ pub fn get_visited_into(
     result: &mut [bool],
 ) -> Result<()> {
     sql_support::each_chunk_mapped(
-        &urls_idxs,
+        urls_idxs,
         |(_, url)| url.as_str(),
         |chunk, offset| -> Result<()> {
             let values_with_idx = sql_support::repeat_display(chunk.len(), ",", |i, f| {
@@ -1583,7 +1583,7 @@ mod tests {
         // this stage we don't "officially" support deletes, so this is TODO.
         let sql = "DELETE FROM moz_historyvisits WHERE id = :row_id";
         // Delete the latest local visit.
-        conn.execute_named_cached(&sql, &[(":row_id", &rid1)])?;
+        conn.execute_named_cached(sql, &[(":row_id", &rid1)])?;
         pi = fetch_page_info(&conn, &url)?.expect("should have the page");
         assert_eq!(pi.page.visit_count_local, 1);
         assert_eq!(pi.page.last_visit_date_local, early_time.into());
@@ -1591,7 +1591,7 @@ mod tests {
         assert_eq!(pi.page.last_visit_date_remote, late_time.into());
 
         // Delete the earliest remote  visit.
-        conn.execute_named_cached(&sql, &[(":row_id", &rid3)])?;
+        conn.execute_named_cached(sql, &[(":row_id", &rid3)])?;
         pi = fetch_page_info(&conn, &url)?.expect("should have the page");
         assert_eq!(pi.page.visit_count_local, 1);
         assert_eq!(pi.page.last_visit_date_local, early_time.into());
@@ -1599,8 +1599,8 @@ mod tests {
         assert_eq!(pi.page.last_visit_date_remote, late_time.into());
 
         // Delete all visits.
-        conn.execute_named_cached(&sql, &[(":row_id", &rid2)])?;
-        conn.execute_named_cached(&sql, &[(":row_id", &rid4)])?;
+        conn.execute_named_cached(sql, &[(":row_id", &rid2)])?;
+        conn.execute_named_cached(sql, &[(":row_id", &rid4)])?;
         // It may turn out that we also delete the place after deleting all
         // visits, but for now we don't - check the values are sane though.
         pi = fetch_page_info(&conn, &url)?.expect("should have the page");
@@ -1671,7 +1671,7 @@ mod tests {
 
         let urls = to_search
             .iter()
-            .map(|(url, _expect)| Url::parse(&url).unwrap())
+            .map(|(url, _expect)| Url::parse(url).unwrap())
             .collect::<Vec<_>>();
 
         let visited = get_visited(&conn, urls).unwrap();

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -397,7 +397,7 @@ pub fn delete_metadata(
     };
     let referrer_entry = match referrer_url {
         Some(referrer_url) if !referrer_url.is_empty() => {
-            Some(PlaceEntry::fetch(&referrer_url, &tx, None)?)
+            Some(PlaceEntry::fetch(referrer_url, &tx, None)?)
         }
         _ => None,
     };
@@ -410,7 +410,7 @@ pub fn delete_metadata(
     };
     let search_query_entry = match search_term {
         Some(search_term) if !search_term.is_empty() => {
-            Some(SearchQueryEntry::from(&search_term, &tx)?)
+            Some(SearchQueryEntry::from(search_term, &tx)?)
         }
         _ => None,
     };
@@ -466,13 +466,13 @@ fn apply_metadata_observation_impl(
 ) -> Result<()> {
     let referrer_entry = match observation.referrer_url {
         Some(referrer_url) if !referrer_url.is_empty() => {
-            Some(PlaceEntry::fetch(&referrer_url, &tx, None)?)
+            Some(PlaceEntry::fetch(&referrer_url, tx, None)?)
         }
         Some(_) | None => None,
     };
     let search_query_entry = match observation.search_term {
         Some(search_term) if !search_term.is_empty() => {
-            Some(SearchQueryEntry::from(&search_term, &tx)?)
+            Some(SearchQueryEntry::from(&search_term, tx)?)
         }
         Some(_) | None => None,
     };
@@ -490,7 +490,7 @@ fn apply_metadata_observation_impl(
 
     let now = Timestamp::now().as_millis() as i64;
     let newer_than = now - DEBOUNCE_WINDOW_MS;
-    let matching_metadata = compound_key.lookup(&tx, newer_than)?;
+    let matching_metadata = compound_key.lookup(tx, newer_than)?;
 
     // If a matching record exists, update it; otherwise, insert a new one.
     match matching_metadata {
@@ -538,7 +538,7 @@ fn apply_metadata_observation_impl(
             }
             Ok(())
         }
-        None => insert_metadata_in_tx(&tx, compound_key, observation),
+        None => insert_metadata_in_tx(tx, compound_key, observation),
     }
 }
 
@@ -551,17 +551,17 @@ fn insert_metadata_in_tx(
 
     let referrer_place_id = match key.referrer_entry {
         None => None,
-        Some(entry) => Some(entry.get_or_insert(&tx)?),
+        Some(entry) => Some(entry.get_or_insert(tx)?),
     };
 
     let search_query_id = match key.search_query_entry {
         None => None,
-        Some(entry) => Some(entry.get_or_insert(&tx)?),
+        Some(entry) => Some(entry.get_or_insert(tx)?),
     };
 
     // Heavy lifting around moz_places inserting (e.g. updating moz_origins, frecency, etc) is performed via triggers.
     // This lets us simply INSERT here without worrying about the rest.
-    let place_id = key.place_entry.get_or_insert(&tx)?;
+    let place_id = key.place_entry.get_or_insert(tx)?;
 
     let sql = "INSERT INTO moz_places_metadata
         (place_id, created_at, updated_at, total_view_time, search_query_id, document_type, referrer_place_id)

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -272,7 +272,7 @@ mod tests {
         put_meta(&conn, "foo", &value2).expect("should put an existing value");
         assert_eq!(get_meta(&conn, "foo").expect("should get"), Some(value2));
         delete_meta(&conn, "foo").expect("should delete");
-        assert!(get_meta::<String>(&conn, &"foo")
+        assert!(get_meta::<String>(&conn, "foo")
             .expect("should get non-existing")
             .is_none());
         delete_meta(&conn, "foo").expect("delete non-existing should work");

--- a/components/places/src/storage/tags.rs
+++ b/components/places/src/storage/tags.rs
@@ -66,7 +66,7 @@ pub fn validate_tag(tag: &str) -> ValidatedTag<'_> {
 ///
 /// There is no success return value.
 pub fn tag_url(db: &PlacesDb, url: &Url, tag: &str) -> Result<()> {
-    let tag = validate_tag(&tag).ensure_valid()?;
+    let tag = validate_tag(tag).ensure_valid()?;
     let tx = db.begin_transaction()?;
 
     // This function will not create a new place.
@@ -107,7 +107,7 @@ pub fn tag_url(db: &PlacesDb, url: &Url, tag: &str) -> Result<()> {
 /// There is no success return value - the operation is ignored if the URL
 /// does not have the tag.
 pub fn untag_url(db: &PlacesDb, url: &Url, tag: &str) -> Result<()> {
-    let tag = validate_tag(&tag).ensure_valid()?;
+    let tag = validate_tag(tag).ensure_valid()?;
     db.execute_named_cached(
         "DELETE FROM moz_tags_relation
          WHERE tag_id = (SELECT id FROM moz_tags
@@ -176,7 +176,7 @@ pub fn remove_tag(db: &PlacesDb, tag: &str) -> Result<()> {
 /// * A Vec<Url> with all URLs which have the tag, ordered by the frecency of
 /// the URLs.
 pub fn get_urls_with_tag(db: &PlacesDb, tag: &str) -> Result<Vec<Url>> {
-    let tag = validate_tag(&tag).ensure_valid()?;
+    let tag = validate_tag(tag).ensure_valid()?;
 
     let mut stmt = db.prepare(
         "SELECT p.url FROM moz_places p
@@ -232,7 +232,7 @@ mod tests {
     use crate::storage::new_page_info;
 
     fn check_tags_for_url(db: &PlacesDb, url: &Url, mut expected: Vec<String>) {
-        let mut tags = get_tags_for_url(&db, &url).expect("should work");
+        let mut tags = get_tags_for_url(db, url).expect("should work");
         tags.sort();
         expected.sort();
         assert_eq!(tags, expected);

--- a/components/places/src/tests.rs
+++ b/components/places/src/tests.rs
@@ -89,7 +89,7 @@ pub fn assert_json_tree_with_depth(
     let deser_tree: BookmarkTreeNode = serde_json::from_value(expected).unwrap();
     assert_eq!(fetched, deser_tree);
     // and while checking the tree, check positions are correct.
-    check_positions(&conn);
+    check_positions(conn);
 }
 
 // check the positions for children in a folder are "correct" in that

--- a/components/push/src/internal/communications.rs
+++ b/components/push/src/internal/communications.rs
@@ -216,7 +216,7 @@ impl Connection for ConnectHttp {
         // Add the Authorization header if we have a prior subscription.
         if let Some(uaid) = &self.uaid {
             url.push('/');
-            url.push_str(&uaid);
+            url.push_str(uaid);
             url.push_str("/subscription");
         }
         let mut body = HashMap::new();
@@ -397,7 +397,7 @@ impl Connection for ConnectHttp {
         Ok(payload
             .channel_ids
             .iter()
-            .map(|s| Store::normalize_uuid(&s))
+            .map(|s| Store::normalize_uuid(s))
             .collect())
     }
 

--- a/components/push/src/internal/communications/rate_limiter.rs
+++ b/components/push/src/internal/communications/rate_limiter.rs
@@ -83,7 +83,7 @@ impl PersistedRateLimiter {
 
     fn get_meta_integer<T: FromStr + Default>(store: &Store, key: &str) -> T {
         store
-            .get_meta(&key)
+            .get_meta(key)
             .ok()
             .flatten()
             .map(|s| s.parse())

--- a/components/push/src/internal/crypto.rs
+++ b/components/push/src/internal/crypto.rs
@@ -180,8 +180,8 @@ impl Cryptography for Crypto {
         })?;
 
         match encoding.to_lowercase().as_str() {
-            "aesgcm" => Self::decrypt_aesgcm(&key, &d_body, d_salt, d_dh),
-            "aes128gcm" => Self::decrypt_aes128gcm(&key, &d_body),
+            "aesgcm" => Self::decrypt_aesgcm(key, &d_body, d_salt, d_dh),
+            "aes128gcm" => Self::decrypt_aes128gcm(key, &d_body),
             _ => Err(error::ErrorKind::CryptoError("Unknown Content Encoding".to_string()).into()),
         }
     }
@@ -220,7 +220,7 @@ impl Cryptography for Crypto {
     }
 
     fn decrypt_aes128gcm(key: &Key, content: &[u8]) -> error::Result<Vec<u8>> {
-        ece::decrypt(key.key_pair(), key.auth_secret(), &content)
+        ece::decrypt(key.key_pair(), key.auth_secret(), content)
             .map_err(|_| error::ErrorKind::CryptoError("Decryption error".to_owned()).into())
     }
 }

--- a/components/push/src/internal/storage/db.rs
+++ b/components/push/src/internal/storage/db.rs
@@ -198,7 +198,7 @@ impl Storage for PushDb {
             &[
                 (":endpoint", &endpoint),
                 (":uaid", &uaid),
-                (":channel_id", &Self::normalize_uuid(&channel_id)),
+                (":channel_id", &Self::normalize_uuid(channel_id)),
             ],
         )?;
         Ok(affected_rows == 1)

--- a/components/push/src/internal/subscriber.rs
+++ b/components/push/src/internal/subscriber.rs
@@ -145,7 +145,7 @@ impl PushManager {
         if self.store.get_meta("uaid")?.is_none() {
             self.store.set_meta("uaid", &info.uaid)?;
             if let Some(secret) = &info.secret {
-                self.store.set_meta("auth", &secret)?;
+                self.store.set_meta("auth", secret)?;
             }
         }
         Ok((info, subscription_key).into())
@@ -182,7 +182,7 @@ impl PushManager {
         if !self.update_rate_limiter.check(&self.store) {
             return Ok(false);
         }
-        self.conn.update(&new_token)?;
+        self.conn.update(new_token)?;
         self.store
             .update_native_id(self.conn.uaid.as_ref().unwrap(), new_token)?;
         Ok(true)
@@ -231,7 +231,7 @@ impl PushManager {
         let uaid = self.conn.uaid.as_ref().unwrap();
         let val = self
             .store
-            .get_record(&uaid, chid)
+            .get_record(uaid, chid)
             .map_err(|e| ErrorKind::StorageError(format!("{:?}", e)))?
             .ok_or_else(|| ErrorKind::RecordNotFoundError(uaid.to_owned(), chid.to_owned()))?;
         let key = Key::deserialize(&val.key)?;

--- a/components/support/guid/src/lib.rs
+++ b/components/support/guid/src/lib.rs
@@ -252,7 +252,7 @@ const BASE64URL_BYTES: [u8; 256] = [
 
 impl Ord for Guid {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.as_bytes().cmp(&other.as_bytes())
+        self.as_bytes().cmp(other.as_bytes())
     }
 }
 

--- a/components/support/rc_crypto/nss/src/aes.rs
+++ b/components/support/rc_crypto/nss/src/aes.rs
@@ -86,7 +86,7 @@ pub fn common_crypt(
     // Most of the following code is inspired by the Firefox WebCrypto implementation:
     // https://searchfox.org/mozilla-central/rev/f46e2bf881d522a440b30cbf5cf8d76fc212eaf4/dom/crypto/WebCryptoTask.cpp#566
     // CKA_ENCRYPT always is fine.
-    let sym_key = import_sym_key(mech, nss_sys::CKA_ENCRYPT.into(), &key)?;
+    let sym_key = import_sym_key(mech, nss_sys::CKA_ENCRYPT.into(), key)?;
     // Initialize the output buffer (enough space for padding / a full tag).
     let result_max_len = data
         .len()

--- a/components/support/rc_crypto/src/aead.rs
+++ b/components/support/rc_crypto/src/aead.rs
@@ -293,11 +293,11 @@ mod test {
     fn test_cant_use_incorrectly_sized_key() {
         for algorithm in ALL_ALGORITHMS {
             let key_bytes = vec![0u8; algorithm.key_len() - 1];
-            let result = Key::new(&algorithm, &key_bytes);
+            let result = Key::new(algorithm, &key_bytes);
             assert!(result.is_err());
 
             let key_bytes = vec![0u8; algorithm.key_len() + 1];
-            let result = Key::new(&algorithm, &key_bytes);
+            let result = Key::new(algorithm, &key_bytes);
             assert!(result.is_err());
         }
     }
@@ -306,11 +306,11 @@ mod test {
     fn test_cant_use_incorrectly_sized_nonce() {
         for algorithm in ALL_ALGORITHMS {
             let nonce_bytes = vec![0u8; algorithm.nonce_len() - 1];
-            let result = Nonce::try_assume_unique_for_key(&algorithm, &nonce_bytes);
+            let result = Nonce::try_assume_unique_for_key(algorithm, &nonce_bytes);
             assert!(result.is_err());
 
             let nonce_bytes = vec![0u8; algorithm.nonce_len() + 1];
-            let result = Nonce::try_assume_unique_for_key(&algorithm, &nonce_bytes);
+            let result = Nonce::try_assume_unique_for_key(algorithm, &nonce_bytes);
             assert!(result.is_err());
         }
     }

--- a/components/support/rc_crypto/src/aead/aes_gcm.rs
+++ b/components/support/rc_crypto/src/aead/aes_gcm.rs
@@ -74,7 +74,7 @@ fn aes_gcm(
     Ok(aes::aes_gcm_crypt(
         &key.key_value,
         &nonce.0,
-        &aad.0,
+        aad.0,
         data,
         direction.to_nss_operation(),
     )?)

--- a/components/support/rc_crypto/src/agreement.rs
+++ b/components/support/rc_crypto/src/agreement.rs
@@ -143,7 +143,7 @@ impl<'a> UnparsedPublicKey<'a> {
     }
 
     pub fn bytes(&self) -> &'a [u8] {
-        &self.bytes
+        self.bytes
     }
 }
 

--- a/components/support/rc_crypto/src/contentsignature.rs
+++ b/components/support/rc_crypto/src/contentsignature.rs
@@ -58,7 +58,7 @@ fn split_pem(pem_content: &[u8]) -> Result<Vec<Vec<u8>>> {
             blocks.push(decoded);
             block.clear();
         } else if read {
-            block.extend_from_slice(&line.as_bytes());
+            block.extend_from_slice(line.as_bytes());
         }
     }
     if read {
@@ -86,14 +86,14 @@ pub fn verify(
     root_sha256_hash: &str,
     hostname: &str,
 ) -> Result<()> {
-    let certificates = split_pem(&pem_bytes)?;
+    let certificates = split_pem(pem_bytes)?;
 
     let mut certificates_slices: Vec<&[u8]> = vec![];
     for certificate in &certificates {
         certificates_slices.push(certificate);
     }
 
-    let root_hash_bytes = decode_root_hash(&root_sha256_hash)?;
+    let root_hash_bytes = decode_root_hash(root_sha256_hash)?;
 
     nss::pkixc::verify_code_signing_certificate_chain(
         certificates_slices,
@@ -110,7 +110,7 @@ pub fn verify(
 
     let leaf_cert = certificates.first().unwrap(); // PEM parse fails if len == 0.
 
-    let public_key_bytes = match nss::cert::extract_ec_public_key(&leaf_cert) {
+    let public_key_bytes = match nss::cert::extract_ec_public_key(leaf_cert) {
         Ok(bytes) => bytes,
         Err(err) => return Err(ErrorKind::CertificateContentError(err.to_string()).into()),
     };
@@ -143,7 +143,7 @@ pub fn verify(
     let public_key = signature::UnparsedPublicKey::new(signature_alg, &public_key_bytes);
     // Note that if the provided key type or curve is incorrect here, the signature will
     // be considered as invalid.
-    match public_key.verify(&input, &signature_bytes) {
+    match public_key.verify(input, &signature_bytes) {
         Ok(_) => Ok(()),
         Err(err) => Err(ErrorKind::SignatureMismatchError(err.to_string()).into()),
     }

--- a/components/support/rc_crypto/src/ece_crypto.rs
+++ b/components/support/rc_crypto/src/ece_crypto.rs
@@ -41,7 +41,7 @@ impl RcCryptoLocalKeyPair {
     fn agree(&self, peer: &RcCryptoRemotePublicKey) -> Result<Vec<u8>, ece::Error> {
         let peer_public_key_raw_bytes = &peer.as_raw()?;
         let peer_public_key =
-            UnparsedPublicKey::new(&agreement::ECDH_P256, &peer_public_key_raw_bytes);
+            UnparsedPublicKey::new(&agreement::ECDH_P256, peer_public_key_raw_bytes);
         self.wrapped
             .private_key()
             .agree_static(&peer_public_key)?
@@ -120,7 +120,7 @@ impl Cryptographer for RcCryptoCryptographer {
         let remote = remote_any
             .downcast_ref::<RcCryptoRemotePublicKey>()
             .unwrap();
-        local.agree(&remote)
+        local.agree(remote)
     }
 
     fn hkdf_sha256(
@@ -130,9 +130,9 @@ impl Cryptographer for RcCryptoCryptographer {
         info: &[u8],
         len: usize,
     ) -> Result<Vec<u8>, ece::Error> {
-        let salt = hmac::SigningKey::new(&digest::SHA256, &salt);
+        let salt = hmac::SigningKey::new(&digest::SHA256, salt);
         let mut out = vec![0u8; len];
-        hkdf::extract_and_expand(&salt, &secret, &info, &mut out)?;
+        hkdf::extract_and_expand(&salt, secret, info, &mut out)?;
         Ok(out)
     }
 
@@ -159,7 +159,7 @@ impl Cryptographer for RcCryptoCryptographer {
             &key,
             nonce,
             aead::Aad::empty(),
-            &ciphertext_and_tag,
+            ciphertext_and_tag,
         )?)
     }
 

--- a/components/support/rc_crypto/src/hawk_crypto.rs
+++ b/components/support/rc_crypto/src/hawk_crypto.rs
@@ -16,7 +16,7 @@ pub(crate) struct RcCryptoCryptographer;
 
 impl hc::HmacKey for crate::hmac::SigningKey {
     fn sign(&self, data: &[u8]) -> Result<Vec<u8>, hc::CryptoError> {
-        let digest = hmac::sign(&self, data)?;
+        let digest = hmac::sign(self, data)?;
         Ok(digest.as_ref().into())
     }
 }

--- a/components/support/rc_crypto/src/signature.rs
+++ b/components/support/rc_crypto/src/signature.rs
@@ -62,7 +62,7 @@ impl<'a> UnparsedPublicKey<'a> {
     }
 
     pub fn bytes(&self) -> &'a [u8] {
-        &self.bytes
+        self.bytes
     }
 }
 

--- a/components/support/sql/src/open_database.rs
+++ b/components/support/sql/src/open_database.rs
@@ -406,7 +406,7 @@ mod test {
             .query_row("SELECT col FROM my_table", NO_PARAMS, |r| r.get(0))
             .unwrap();
         assert_eq!(value, "correct-value");
-        assert_eq!(get_schema_version(&conn).unwrap(), 4);
+        assert_eq!(get_schema_version(conn).unwrap(), 4);
     }
 
     #[test]

--- a/components/support/sync15-traits/src/request.rs
+++ b/components/support/sync15-traits/src/request.rs
@@ -107,7 +107,7 @@ impl CollectionRequest {
             pairs.append_pair("ids", &buf);
         }
         if let Some(batch) = &self.batch {
-            pairs.append_pair("batch", &batch);
+            pairs.append_pair("batch", batch);
         }
         if self.commit {
             pairs.append_pair("commit", "true");

--- a/components/support/viaduct-reqwest/src/lib.rs
+++ b/components/support/viaduct-reqwest/src/lib.rs
@@ -51,7 +51,7 @@ fn into_reqwest(request: viaduct::Request) -> Result<reqwest::blocking::Request,
     for h in request.headers {
         use reqwest::header::{HeaderName, HeaderValue};
         // Unwraps should be fine, we verify these in `Header`
-        let value = HeaderValue::from_str(&h.value()).unwrap();
+        let value = HeaderValue::from_str(h.value()).unwrap();
         result
             .headers_mut()
             .insert(HeaderName::from_bytes(h.name().as_bytes()).unwrap(), value);

--- a/components/sync15/src/bso_record.rs
+++ b/components/sync15/src/bso_record.rs
@@ -239,7 +239,7 @@ impl EncryptedPayload {
     ) -> error::Result<Self> {
         let cleartext = serde_json::to_string(cleartext_payload)?;
         let (enc_base64, iv_base64, hmac_base16) =
-            key.encrypt_bytes_rand_iv(&cleartext.as_bytes())?;
+            key.encrypt_bytes_rand_iv(cleartext.as_bytes())?;
         Ok(EncryptedPayload {
             iv: iv_base64,
             hmac: hmac_base16,

--- a/components/sync15/src/clients/engine.rs
+++ b/components/sync15/src/clients/engine.rs
@@ -274,7 +274,7 @@ impl<'a> Engine<'a> {
         log::info!("Syncing collection clients");
 
         let coll_keys =
-            CollectionKeys::from_encrypted_bso(global_state.keys.clone(), &root_sync_key)?;
+            CollectionKeys::from_encrypted_bso(global_state.keys.clone(), root_sync_key)?;
         let mut coll_state = CollState {
             config: global_state.config.clone(),
             last_modified: global_state
@@ -285,7 +285,7 @@ impl<'a> Engine<'a> {
             key: coll_keys.key_for_collection(COLLECTION_NAME).clone(),
         };
 
-        let inbound = self.fetch_incoming(&storage_client, &mut coll_state)?;
+        let inbound = self.fetch_incoming(storage_client, &mut coll_state)?;
 
         let mut driver = Driver::new(
             self.command_processor,
@@ -300,7 +300,7 @@ impl<'a> Engine<'a> {
 
         self.interruptee.err_if_interrupted()?;
         let upload_info =
-            CollectionUpdate::new_from_changeset(&storage_client, &coll_state, outgoing, true)?
+            CollectionUpdate::new_from_changeset(storage_client, &coll_state, outgoing, true)?
                 .upload()?;
 
         log::info!(
@@ -324,7 +324,7 @@ impl<'a> Engine<'a> {
         let coll_request = CollectionRequest::new(COLLECTION_NAME).full();
 
         self.interruptee.err_if_interrupted()?;
-        let inbound = crate::changeset::fetch_incoming(&storage_client, coll_state, &coll_request)?;
+        let inbound = crate::changeset::fetch_incoming(storage_client, coll_state, &coll_request)?;
 
         Ok(inbound)
     }

--- a/components/sync15/src/coll_state.rs
+++ b/components/sync15/src/coll_state.rs
@@ -182,7 +182,7 @@ mod tests {
     fn get_global_state(root_key: &KeyBundle) -> GlobalState {
         let keys = CollectionKeys::new_random()
             .unwrap()
-            .to_encrypted_bso(&root_key)
+            .to_encrypted_bso(root_key)
             .unwrap();
         GlobalState {
             config: InfoConfiguration::default(),

--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -151,7 +151,7 @@ impl PersistedGlobalState {
     }
     pub(crate) fn get_declined(&self) -> &[String] {
         match self {
-            Self::V2 { declined: Some(d) } => &d,
+            Self::V2 { declined: Some(d) } => d,
             Self::V2 { declined: None } => &[],
         }
     }
@@ -558,7 +558,7 @@ impl<'a> SetupStateMachine<'a> {
                     .put_meta_global(ServerTimestamp::default(), &new_global)?;
 
                 // ...And a fresh `crypto/keys`.
-                let new_keys = CollectionKeys::new_random()?.to_encrypted_bso(&self.root_key)?;
+                let new_keys = CollectionKeys::new_random()?.to_encrypted_bso(self.root_key)?;
                 self.client
                     .put_crypto_keys(ServerTimestamp::default(), &new_keys)?;
 
@@ -590,13 +590,13 @@ impl<'a> SetupStateMachine<'a> {
                 // cycle, and should try again later. Intermediate states
                 // aren't a problem, just the initial ones.
                 FreshStartRequired { .. } | WithPreviousState { .. } | Initial => {
-                    if self.sequence.contains(&label) {
+                    if self.sequence.contains(label) {
                         // Is this really the correct error?
                         return Err(ErrorKind::SetupRace.into());
                     }
                 }
                 _ => {
-                    if !self.allowed_states.contains(&label) {
+                    if !self.allowed_states.contains(label) {
                         return Err(ErrorKind::SetupRequired.into());
                     }
                 }

--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -235,7 +235,7 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
             if let Err(e) = engine.sync(
                 &client_info.client,
                 &global_state,
-                &self.root_sync_key,
+                self.root_sync_key,
                 should_refresh,
             ) {
                 // Record telemetry with the error just in case...
@@ -314,7 +314,7 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
             let mut telem_engine = telemetry::Engine::new(&*name);
             let result = sync::synchronize_with_clients_engine(
                 &client_info.client,
-                &global_state,
+                global_state,
                 self.root_sync_key,
                 clients,
                 *engine,
@@ -327,7 +327,7 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
                 Ok(()) => log::info!("Sync of {} was successful!", name),
                 Err(ref e) => {
                     log::warn!("Sync of {} failed! {:?}", name, e);
-                    let this_status = ServiceStatus::from_err(&e);
+                    let this_status = ServiceStatus::from_err(e);
                     // The only error which forces us to discard our state is an
                     // auth error.
                     self.saw_auth_error =
@@ -361,7 +361,7 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
 
         let mut state_machine = SetupStateMachine::for_full_sync(
             &client_info.client,
-            &self.root_sync_key,
+            self.root_sync_key,
             pgs,
             self.engines_to_state_change,
             self.interruptee,
@@ -410,7 +410,7 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
         }
         for e in &changes.remote_wipes {
             log::info!("Engine {:?} just got disabled locally, wiping server", e);
-            client.wipe_remote_engine(&e)?;
+            client.wipe_remote_engine(e)?;
         }
 
         for s in self.engines {
@@ -462,7 +462,7 @@ impl<'info, 'res, 'pgs, 'mcs> SyncMultipleDriver<'info, 'res, 'pgs, 'mcs> {
         // persisted state for next time.
         match self.persisted_global_state {
             Some(persisted_string) if !persisted_string.is_empty() => {
-                match serde_json::from_str::<PersistedGlobalState>(&persisted_string) {
+                match serde_json::from_str::<PersistedGlobalState>(persisted_string) {
                     Ok(state) => {
                         log::trace!("Read persisted state: {:?}", state);
                         // Note that we don't set `result.declined` from the

--- a/components/viaduct/src/headers.rs
+++ b/components/viaduct/src/headers.rs
@@ -84,7 +84,7 @@ impl Header {
     #[inline]
     fn set_value<V: AsRef<str>>(&mut self, s: V) -> Result<(), crate::Error> {
         let value = s.as_ref();
-        if !is_valid_header_value(&value) {
+        if !is_valid_header_value(value) {
             Err(crate::Error::RequestHeaderError(self.name.clone()))
         } else {
             self.value.clear();

--- a/components/webext-storage/src/api.rs
+++ b/components/webext-storage/src/api.rs
@@ -348,7 +348,7 @@ pub fn get_bytes_in_use(conn: &Connection, ext_id: &str, keys: JsonValue) -> Res
     let mut size = 0;
     for key in keys.into_iter() {
         if let Some(v) = existing.get(key) {
-            size += get_quota_size_of(key, &v);
+            size += get_quota_size_of(key, v);
         }
     }
     Ok(size)
@@ -443,16 +443,16 @@ mod tests {
 
         // an empty store.
         for q in vec![JsonValue::Null, json!("foo"), json!(["foo"])].into_iter() {
-            assert_eq!(get(&tx, &ext_id, q)?, json!({}));
+            assert_eq!(get(&tx, ext_id, q)?, json!({}));
         }
 
         // Default values in an empty store.
         for q in vec![json!({ "foo": null }), json!({"foo": "default"})].into_iter() {
-            assert_eq!(get(&tx, &ext_id, q.clone())?, q.clone());
+            assert_eq!(get(&tx, ext_id, q.clone())?, q.clone());
         }
 
         // Single item in the store.
-        set(&tx, &ext_id, json!({"foo": "bar" }))?;
+        set(&tx, ext_id, json!({"foo": "bar" }))?;
         for q in vec![
             JsonValue::Null,
             json!("foo"),
@@ -462,7 +462,7 @@ mod tests {
         ]
         .into_iter()
         {
-            assert_eq!(get(&tx, &ext_id, q)?, json!({"foo": "bar" }));
+            assert_eq!(get(&tx, ext_id, q)?, json!({"foo": "bar" }));
         }
 
         // Default values in a non-empty store.
@@ -476,51 +476,51 @@ mod tests {
         ]
         .into_iter()
         {
-            assert_eq!(get(&tx, &ext_id, q.clone())?, q.clone());
+            assert_eq!(get(&tx, ext_id, q.clone())?, q.clone());
         }
 
         // more complex stuff, including changes checking.
         assert_eq!(
-            set(&tx, &ext_id, json!({"foo": "new", "other": "also new" }))?,
+            set(&tx, ext_id, json!({"foo": "new", "other": "also new" }))?,
             make_changes(&[
                 ("foo", Some(json!("bar")), Some(json!("new"))),
                 ("other", None, Some(json!("also new")))
             ])
         );
         assert_eq!(
-            get(&tx, &ext_id, JsonValue::Null)?,
+            get(&tx, ext_id, JsonValue::Null)?,
             json!({"foo": "new", "other": "also new"})
         );
-        assert_eq!(get(&tx, &ext_id, json!("foo"))?, json!({"foo": "new"}));
+        assert_eq!(get(&tx, ext_id, json!("foo"))?, json!({"foo": "new"}));
         assert_eq!(
-            get(&tx, &ext_id, json!(["foo", "other"]))?,
+            get(&tx, ext_id, json!(["foo", "other"]))?,
             json!({"foo": "new", "other": "also new"})
         );
         assert_eq!(
-            get(&tx, &ext_id, json!({"foo": null, "default": "yo"}))?,
+            get(&tx, ext_id, json!({"foo": null, "default": "yo"}))?,
             json!({"foo": "new", "default": "yo"})
         );
 
         assert_eq!(
-            remove(&tx, &ext_id, json!("foo"))?,
+            remove(&tx, ext_id, json!("foo"))?,
             make_changes(&[("foo", Some(json!("new")), None)]),
         );
 
         assert_eq!(
-            set(&tx, &ext_id, json!({"foo": {"sub-object": "sub-value"}}))?,
+            set(&tx, ext_id, json!({"foo": {"sub-object": "sub-value"}}))?,
             make_changes(&[("foo", None, Some(json!({"sub-object": "sub-value"}))),])
         );
 
         // XXX - other variants.
 
         assert_eq!(
-            clear(&tx, &ext_id)?,
+            clear(&tx, ext_id)?,
             make_changes(&[
                 ("foo", Some(json!({"sub-object": "sub-value"})), None),
                 ("other", Some(json!("also new")), None),
             ]),
         );
-        assert_eq!(get(&tx, &ext_id, JsonValue::Null)?, json!({}));
+        assert_eq!(get(&tx, ext_id, JsonValue::Null)?, json!({}));
 
         Ok(())
     }
@@ -538,10 +538,10 @@ mod tests {
         set(&tx, ext_id, json!({ prop: value }))?;
 
         // this is the checkGetImpl part!
-        let mut data = get(&tx, &ext_id, json!(null))?;
+        let mut data = get(&tx, ext_id, json!(null))?;
         assert_eq!(value, json!(data[prop]), "null getter worked for {}", prop);
 
-        data = get(&tx, &ext_id, json!(prop))?;
+        data = get(&tx, ext_id, json!(prop))?;
         assert_eq!(
             value,
             json!(data[prop]),
@@ -554,7 +554,7 @@ mod tests {
             "string getter should return an object with a single property"
         );
 
-        data = get(&tx, &ext_id, json!([prop]))?;
+        data = get(&tx, ext_id, json!([prop]))?;
         assert_eq!(value, json!(data[prop]), "array getter worked for {}", prop);
         assert_eq!(
             data.as_object().unwrap().len(),
@@ -564,7 +564,7 @@ mod tests {
 
         // checkGetImpl() uses `{ [prop]: undefined }` - but json!() can't do that :(
         // Hopefully it's just testing a simple object, so we use `{ prop: null }`
-        data = get(&tx, &ext_id, json!({ prop: null }))?;
+        data = get(&tx, ext_id, json!({ prop: null }))?;
         assert_eq!(
             value,
             json!(data[prop]),
@@ -588,10 +588,10 @@ mod tests {
         let tx = db.transaction()?;
         let ext_id = "xyz";
 
-        set(&tx, &ext_id, json!({"foo": "bar" }))?;
+        set(&tx, ext_id, json!({"foo": "bar" }))?;
 
         assert_eq!(
-            set(&tx, &ext_id, json!({"foo": "bar" }))?,
+            set(&tx, ext_id, json!({"foo": "bar" }))?,
             make_changes(&[("foo", Some(json!("bar")), Some(json!("bar")))]),
         );
         Ok(())
@@ -605,11 +605,11 @@ mod tests {
         for i in 1..SYNC_MAX_ITEMS + 1 {
             set(
                 &tx,
-                &ext_id,
+                ext_id,
                 json!({ format!("key-{}", i): format!("value-{}", i) }),
             )?;
         }
-        let e = set(&tx, &ext_id, json!({"another": "another"})).unwrap_err();
+        let e = set(&tx, ext_id, json!({"another": "another"})).unwrap_err();
         match e.kind() {
             ErrorKind::QuotaError(QuotaReason::MaxItems) => {}
             _ => panic!("unexpected error type"),
@@ -628,14 +628,14 @@ mod tests {
         let val = "x".repeat(SYNC_QUOTA_BYTES_PER_ITEM - 5);
 
         // Key length doesn't push it over.
-        set(&tx, &ext_id, json!({ "x": val }))?;
+        set(&tx, ext_id, json!({ "x": val }))?;
         assert_eq!(
-            get_bytes_in_use(&tx, &ext_id, json!("x"))?,
+            get_bytes_in_use(&tx, ext_id, json!("x"))?,
             SYNC_QUOTA_BYTES_PER_ITEM - 2
         );
 
         // Key length does push it over.
-        let e = set(&tx, &ext_id, json!({ "xxxx": val })).unwrap_err();
+        let e = set(&tx, ext_id, json!({ "xxxx": val })).unwrap_err();
         match e.kind() {
             ErrorKind::QuotaError(QuotaReason::ItemBytes) => {}
             _ => panic!("unexpected error type"),
@@ -658,14 +658,14 @@ mod tests {
         )?;
 
         // Adding more data fails.
-        let e = set(&tx, &ext_id, json!({ "y": "newvalue" })).unwrap_err();
+        let e = set(&tx, ext_id, json!({ "y": "newvalue" })).unwrap_err();
         match e.kind() {
             ErrorKind::QuotaError(QuotaReason::TotalBytes) => {}
             _ => panic!("unexpected error type"),
         };
 
         // Remove data does not fails.
-        remove(&tx, &ext_id, json!["x"])?;
+        remove(&tx, ext_id, json!["x"])?;
 
         // Restore the over quota data.
         save_to_db(
@@ -675,7 +675,7 @@ mod tests {
         )?;
 
         // Overwrite with less data does not fail.
-        set(&tx, &ext_id, json!({ "y": "lessdata" }))?;
+        set(&tx, ext_id, json!({ "y": "lessdata" }))?;
 
         Ok(())
     }
@@ -686,29 +686,29 @@ mod tests {
         let tx = db.transaction()?;
         let ext_id = "xyz";
 
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!(null))?, 0);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!(null))?, 0);
 
-        set(&tx, &ext_id, json!({ "a": "a" }))?; // should be 4
-        set(&tx, &ext_id, json!({ "b": "bb" }))?; // should be 5
-        set(&tx, &ext_id, json!({ "c": "ccc" }))?; // should be 6
-        set(&tx, &ext_id, json!({ "n": 999_999 }))?; // should be 7
+        set(&tx, ext_id, json!({ "a": "a" }))?; // should be 4
+        set(&tx, ext_id, json!({ "b": "bb" }))?; // should be 5
+        set(&tx, ext_id, json!({ "c": "ccc" }))?; // should be 6
+        set(&tx, ext_id, json!({ "n": 999_999 }))?; // should be 7
 
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!("x"))?, 0);
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!("a"))?, 4);
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!("b"))?, 5);
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!("c"))?, 6);
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!("n"))?, 7);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!("x"))?, 0);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!("a"))?, 4);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!("b"))?, 5);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!("c"))?, 6);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!("n"))?, 7);
 
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!(["a"]))?, 4);
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!(["a", "x"]))?, 4);
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!(["a", "b"]))?, 9);
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!(["a", "c"]))?, 10);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!(["a"]))?, 4);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!(["a", "x"]))?, 4);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!(["a", "b"]))?, 9);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!(["a", "c"]))?, 10);
 
         assert_eq!(
-            get_bytes_in_use(&tx, &ext_id, json!(["a", "b", "c", "n"]))?,
+            get_bytes_in_use(&tx, ext_id, json!(["a", "b", "c", "n"]))?,
             22
         );
-        assert_eq!(get_bytes_in_use(&tx, &ext_id, json!(null))?, 22);
+        assert_eq!(get_bytes_in_use(&tx, ext_id, json!(null))?, 22);
         Ok(())
     }
 

--- a/components/webext-storage/src/schema.rs
+++ b/components/webext-storage/src/schema.rs
@@ -28,7 +28,7 @@ impl MigrationLogic for WebExtMigrationLogin {
             PRAGMA foreign_keys = ON;
         ";
         conn.execute_batch(initial_pragmas)?;
-        define_functions(&conn)?;
+        define_functions(conn)?;
         conn.set_prepared_statement_cache_capacity(128);
         Ok(())
     }

--- a/components/webext-storage/src/sync/bridge.rs
+++ b/components/webext-storage/src/sync/bridge.rs
@@ -80,7 +80,7 @@ impl<'a> sync15_traits::BridgedEngine for BridgedEngine<'a> {
     }
 
     fn sync_started(&self) -> Result<()> {
-        schema::create_empty_sync_temp_tables(&self.db)?;
+        schema::create_empty_sync_temp_tables(self.db)?;
         Ok(())
     }
 
@@ -112,7 +112,7 @@ impl<'a> sync15_traits::BridgedEngine for BridgedEngine<'a> {
         stage_outgoing(&tx)?;
         tx.commit()?;
 
-        let outgoing = get_outgoing(&self.db, &signal)?
+        let outgoing = get_outgoing(self.db, &signal)?
             .into_iter()
             .map(OutgoingEnvelope::from)
             .collect::<Vec<_>>();
@@ -129,7 +129,7 @@ impl<'a> sync15_traits::BridgedEngine for BridgedEngine<'a> {
     }
 
     fn sync_finished(&self) -> Result<()> {
-        schema::create_empty_sync_temp_tables(&self.db)?;
+        schema::create_empty_sync_temp_tables(self.db)?;
         Ok(())
     }
 

--- a/components/webext-storage/src/sync/outgoing.rs
+++ b/components/webext-storage/src/sync/outgoing.rs
@@ -101,7 +101,7 @@ pub fn record_uploaded(
     // Updating the `was_uploaded` column fires the `record_uploaded` trigger,
     // which updates the local change counter and writes the uploaded record
     // data back to the mirror.
-    sql_support::each_chunk(&items, |chunk, _| -> Result<()> {
+    sql_support::each_chunk(items, |chunk, _| -> Result<()> {
         signal.err_if_interrupted()?;
         let sql = format!(
             "UPDATE storage_sync_outgoing_staging SET

--- a/components/webext-storage/src/sync/sync_tests.rs
+++ b/components/webext-storage/src/sync/sync_tests.rs
@@ -33,7 +33,7 @@ fn do_sync(tx: &Transaction<'_>, incoming_payloads: Vec<Payload>) -> Result<Vec<
         .map(|(item, state)| (item, plan_incoming(state)))
         .collect();
     log::debug!("do_sync applying {:?}", actions);
-    apply_actions(&tx, actions, &NeverInterrupts)?;
+    apply_actions(tx, actions, &NeverInterrupts)?;
     // So we've done incoming - do outgoing.
     stage_outgoing(tx)?;
     let outgoing = get_outgoing(tx, &NeverInterrupts)?;
@@ -54,7 +54,7 @@ fn do_sync(tx: &Transaction<'_>, incoming_payloads: Vec<Payload>) -> Result<Vec<
 
 // Check *both* the mirror and local API have ended up with the specified data.
 fn check_finished_with(conn: &Connection, ext_id: &str, val: serde_json::Value) -> Result<()> {
-    let local = get(conn, &ext_id, serde_json::Value::Null)?;
+    let local = get(conn, ext_id, serde_json::Value::Null)?;
     assert_eq!(local, val);
     let guid = get_mirror_guid(conn, ext_id)?;
     let mirror = get_mirror_data(conn, &guid);
@@ -228,7 +228,7 @@ fn test_incoming_tombstone_not_exists() -> Result<()> {
     );
     // But we still keep the tombstone in the mirror.
     assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
-    assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
+    assert_eq!(get_mirror_data(&tx, guid), DbData::NullRow);
     Ok(())
 }
 

--- a/docs/rust-versions.md
+++ b/docs/rust-versions.md
@@ -14,7 +14,7 @@ mozilla-central (aka, the main Firefox repository).
 
 It should also come as no surprise that the Rust policy for mozilla-central
 is somewhat flexible. There is an official [Rust Update Policy Document
-](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html])
+](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html)
 but everything in the future is documented as "estimated".
 
 Ultimately though, that page defines 2 Rust versions - "Uses" and "Requires",

--- a/examples/cli-support/src/fxa_creds.rs
+++ b/examples/cli-support/src/fxa_creds.rs
@@ -49,7 +49,7 @@ fn create_fxa_creds(path: &str, cfg: Config) -> Result<FirefoxAccount> {
     let mut acct = FirefoxAccount::with_config(cfg);
     let oauth_uri = acct.begin_oauth_flow(&[SYNC_SCOPE], "fxa_creds", None)?;
 
-    if webbrowser::open(&oauth_uri.as_ref()).is_err() {
+    if webbrowser::open(oauth_uri.as_ref()).is_err() {
         log::warn!("Failed to open a web browser D:");
         println!("Please visit this URL, sign in, and then copy-paste the final URL below.");
         println!("\n    {}\n", oauth_uri);

--- a/examples/fxa-client/src/devices-api.rs
+++ b/examples/fxa-client/src/devices-api.rs
@@ -51,9 +51,9 @@ fn persist_fxa_state(acct: &FirefoxAccount) {
 
 fn create_fxa_creds(cfg: Config) -> Result<FirefoxAccount> {
     let mut acct = FirefoxAccount::with_config(cfg);
-    let oauth_uri = acct.begin_oauth_flow(&SCOPES, "device_api_example", None)?;
+    let oauth_uri = acct.begin_oauth_flow(SCOPES, "device_api_example", None)?;
 
-    if webbrowser::open(&oauth_uri.as_ref()).is_err() {
+    if webbrowser::open(oauth_uri.as_ref()).is_err() {
         println!("Please visit this URL, sign in, and then copy-paste the final URL below.");
         println!("\n    {}\n", oauth_uri);
     } else {
@@ -65,7 +65,7 @@ fn create_fxa_creds(cfg: Config) -> Result<FirefoxAccount> {
     let query_params: HashMap<_, _> = redirect_uri.query_pairs().into_owned().collect();
     let code = &query_params["code"];
     let state = &query_params["state"];
-    acct.complete_oauth_flow(&code, &state).unwrap();
+    acct.complete_oauth_flow(code, state).unwrap();
     persist_fxa_state(&acct);
     Ok(acct)
 }

--- a/examples/fxa-client/src/oauth-flow.rs
+++ b/examples/fxa-client/src/oauth-flow.rs
@@ -16,7 +16,7 @@ fn main() {
     let config = Config::new(CONTENT_SERVER, CLIENT_ID, REDIRECT_URI);
     let mut fxa = FirefoxAccount::with_config(config);
     let url = fxa
-        .begin_oauth_flow(&SCOPES, "oauth_flow_example", None)
+        .begin_oauth_flow(SCOPES, "oauth_flow_example", None)
         .unwrap();
     println!("Open the following URL:");
     println!("{}", url);
@@ -25,7 +25,7 @@ fn main() {
     let query_params: HashMap<_, _> = redirect_uri.query_pairs().into_owned().collect();
     let code = &query_params["code"];
     let state = &query_params["state"];
-    fxa.complete_oauth_flow(&code, &state).unwrap();
+    fxa.complete_oauth_flow(code, state).unwrap();
     let oauth_info = fxa.get_access_token(SCOPES[0], None);
     println!("access_token: {:?}", oauth_info);
 }

--- a/examples/places-autocomplete/src/autocomplete.rs
+++ b/examples/places-autocomplete/src/autocomplete.rs
@@ -177,12 +177,12 @@ fn import_places(
                 eprintln!("warning: failed to insert: {}", e);
             }
         }
-        current_place = LegacyPlace::from_row(&row);
+        current_place = LegacyPlace::from_row(row);
         let now = Instant::now();
         if now.duration_since(timer).as_secs_f32() > secs {
             println!();
             println!(" -- deleting origin temps");
-            places::storage::delete_pending_temp_tables(&new)?;
+            places::storage::delete_pending_temp_tables(new)?;
             tx.commit()?;
 
             println!(" -- optimizing table...");
@@ -206,7 +206,7 @@ fn import_places(
     println!("Committing....");
     tx.commit()?;
     println!("running maintenance...");
-    places::storage::run_maintenance(&new)?;
+    places::storage::run_maintenance(new)?;
 
     log::info!("Finished import!");
     Ok(())

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -130,7 +130,7 @@ fn show_sql(conn: &rusqlite::Connection, sql: &str) -> Result<()> {
     let mut table = Table::new();
     table.add_row(Row::new(
         cols.iter()
-            .map(|name| Cell::new(&name).style_spec("bc"))
+            .map(|name| Cell::new(name).style_spec("bc"))
             .collect(),
     ));
 

--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
         .value_of("credential_file")
         .unwrap_or("./credentials.json");
 
-    let mut cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file)?;
+    let mut cli_fxa = get_cli_fxa(get_default_fxa_config(), cred_file)?;
     let device_id = cli_fxa.account.get_current_device_id()?;
 
     let store = Arc::new(TabsStore::new());

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -7,7 +7,7 @@
 #   supported and used in CI.
 
 [toolchain]
-channel = "1.52.1"
+channel = "1.55.0"
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -14,7 +14,6 @@ targets = [
     "i686-linux-android",
     "x86_64-linux-android",
     "aarch64-apple-ios",
-    "aarch64-apple-ios-sim",
     "x86_64-apple-ios",
 ]
 # The "rust-src" component is currently required for building for the M1 iOS simulator.

--- a/testing/separated/places-bench/src/database.rs
+++ b/testing/separated/places-bench/src/database.rs
@@ -42,12 +42,12 @@ fn init_db(db: &mut PlacesDb) -> places::Result<()> {
                 .with_is_remote(i < 10)
                 .with_visit_type(places::VisitTransition::Link)
                 .with_at(Timestamp(now.0 - day_ms * (1 + i)));
-            places::storage::history::apply_observation_direct(&db, obs)?;
+            places::storage::history::apply_observation_direct(db, obs)?;
         }
     }
-    places::storage::delete_pending_temp_tables(&db)?;
+    places::storage::delete_pending_temp_tables(db)?;
     tx.commit()?;
-    places::storage::run_maintenance(&db)?;
+    places::storage::run_maintenance(db)?;
     Ok(())
 }
 
@@ -90,7 +90,7 @@ pub fn bench_search_frecent(c: &mut Criterion) {
     let test_db = TestDb::new();
     db_bench!(c, "search_frecent string", |db: test_db| {
         search_frecent(
-            &db,
+            db,
             SearchParams {
                 search_string: "mozilla".into(),
                 limit: 10,
@@ -100,7 +100,7 @@ pub fn bench_search_frecent(c: &mut Criterion) {
     });
     db_bench!(c, "search_frecent origin", |db: test_db| {
         search_frecent(
-            &db,
+            db,
             SearchParams {
                 search_string: "blog.mozilla.org".into(),
                 limit: 10,
@@ -110,7 +110,7 @@ pub fn bench_search_frecent(c: &mut Criterion) {
     });
     db_bench!(c, "search_frecent url", |db: test_db| {
         search_frecent(
-            &db,
+            db,
             SearchParams {
                 search_string: "https://hg.mozilla.org/mozilla-central".into(),
                 limit: 10,
@@ -123,12 +123,12 @@ pub fn bench_search_frecent(c: &mut Criterion) {
 pub fn bench_match_url(c: &mut Criterion) {
     let test_db = TestDb::new();
     db_bench!(c, "match_url string", |db: test_db| {
-        match_url(&db, "mozilla").unwrap()
+        match_url(db, "mozilla").unwrap()
     });
     db_bench!(c, "match_url origin", |db: test_db| {
-        match_url(&db, "blog.mozilla.org").unwrap()
+        match_url(db, "blog.mozilla.org").unwrap()
     });
     db_bench!(c, "match_url url", |db: test_db| {
-        match_url(&db, "https://hg.mozilla.org/mozilla-central").unwrap()
+        match_url(db, "https://hg.mozilla.org/mozilla-central").unwrap()
     });
 }

--- a/testing/separated/places-tests/src/fennec_bookmarks.rs
+++ b/testing/separated/places-tests/src/fennec_bookmarks.rs
@@ -54,8 +54,7 @@ struct FennecBookmark {
 
 impl FennecBookmark {
     fn insert_into_db(&self, conn: &Connection) -> Result<()> {
-        let mut stmt = conn.prepare(&
-            "INSERT OR IGNORE INTO bookmarks(_id, title, url, type, parent, position, keyword,
+        let mut stmt = conn.prepare("INSERT OR IGNORE INTO bookmarks(_id, title, url, type, parent, position, keyword,
                                              description, tags, favicon_id, created, modified,
                                              guid, deleted, localVersion, syncVersion)
              VALUES (:_id, :title, :url, :type, :parent, :position, :keyword, :description, :tags,
@@ -361,10 +360,10 @@ fn test_import() -> Result<()> {
     assert_eq!(pinned.len(), 1);
     assert_eq!(pinned[0].title, Some("Pinned Bookmark".to_owned()));
 
-    assert!(bookmark_exists(&places_api, &"about:firefox")?);
-    assert!(bookmark_exists(&places_api, &"https://bar.foo")?);
-    assert!(bookmark_exists(&places_api, &"http://💖.com/💖")?);
-    assert!(bookmark_exists(&places_api, &"http://😍.com/😍")?);
+    assert!(bookmark_exists(&places_api, "about:firefox")?);
+    assert!(bookmark_exists(&places_api, "https://bar.foo")?);
+    assert!(bookmark_exists(&places_api, "http://💖.com/💖")?);
+    assert!(bookmark_exists(&places_api, "http://😍.com/😍")?);
     // Uncomment the following to debug with cargo test -- --nocapture.
     // println!(
     //     "Places DB Path: {}",

--- a/testing/separated/places-tests/src/fennec_history.rs
+++ b/testing/separated/places-tests/src/fennec_history.rs
@@ -35,8 +35,7 @@ struct FennecHistory {
 
 impl FennecHistory {
     fn insert_into_db(&self, conn: &Connection) -> Result<()> {
-        let mut stmt = conn.prepare(&
-            "INSERT OR IGNORE INTO history(title, url, visits, visits_local, visits_remote, date,
+        let mut stmt = conn.prepare("INSERT OR IGNORE INTO history(title, url, visits, visits_local, visits_remote, date,
                                            date_local, date_remote, created, modified, guid, deleted)
              VALUES (:title, :url, :visits, :visits_local, :visits_remote, :date,
                      :date_local, :date_remote, :created, :modified, :guid, :deleted)"
@@ -70,7 +69,7 @@ struct FennecVisit<'a> {
 impl<'a> FennecVisit<'a> {
     fn insert_into_db(&self, conn: &Connection) -> Result<()> {
         let mut stmt = conn.prepare(
-            &"INSERT OR IGNORE INTO visits(history_guid, visit_type, date, is_local)
+            "INSERT OR IGNORE INTO visits(history_guid, visit_type, date, is_local)
              VALUES (:history_guid, :visit_type, :date, :is_local)",
         )?;
         stmt.execute_named(rusqlite::named_params! {


### PR DESCRIPTION
fixes #4485,

According to our [Rust policy](https://github.com/mozilla/application-services/blob/main/docs/rust-versions.md#application-services-rust-version-policy) we should be updating our toolchain to keep up with moz-central.  

Note: Most of the changes came from running `cargo clippy --fix` and some hand-changed but almost all of them are dealing the error:

```
error: this expression borrows a reference that is immediately dereferenced by the compiler
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
