### PR TITLE
Adds a targeting specific struct for targeting

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,8 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+## Nimbus
+
+### What's new
+
+- Nimbus can now target on `is_already_enrolled`. Which is true only if the user is already enrolled in experiment. ([#4490](https://github.com/mozilla/application-services/pull/4490))

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -4,6 +4,7 @@
 
 use clap::{App, Arg, SubCommand};
 use env_logger::Env;
+use nimbus::TargetingAttributes;
 use nimbus::{
     error::Result, AppContext, AvailableRandomizationUnits, EnrollmentStatus, NimbusClient,
     RemoteSettingsConfig,
@@ -282,8 +283,12 @@ fn main() -> Result<()> {
             'outer: loop {
                 let uuid = uuid::Uuid::new_v4();
                 let mut num_of_experiments_enrolled = 0;
+                let targeting_attributes = TargetingAttributes {
+                    app_context: context.clone(),
+                    ..Default::default()
+                };
                 for exp in &all_experiments {
-                    let enr = nimbus::evaluate_enrollment(&uuid, &aru, &context.clone(), exp)?;
+                    let enr = nimbus::evaluate_enrollment(&uuid, &aru, &targeting_attributes, exp)?;
                     if enr.status.is_enrolled() {
                         num_of_experiments_enrolled += 1;
                         if num_of_experiments_enrolled >= num {
@@ -337,7 +342,12 @@ fn main() -> Result<()> {
                 // options.
                 let uuid = uuid::Uuid::new_v4();
                 let aru = AvailableRandomizationUnits::with_client_id(&client_id);
-                let enrollment = nimbus::evaluate_enrollment(&uuid, &aru, &context.clone(), &exp)?;
+                let targeting_attributes = TargetingAttributes {
+                    app_context: context.clone(),
+                    ..Default::default()
+                };
+                let enrollment =
+                    nimbus::evaluate_enrollment(&uuid, &aru, &targeting_attributes, &exp)?;
                 let key = match enrollment.status.clone() {
                     EnrollmentStatus::Enrolled { .. } => "Enrolled",
                     EnrollmentStatus::NotEnrolled { .. } => "NotEnrolled",

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -280,13 +280,13 @@ fn main() -> Result<()> {
 
             let mut num_tries = 0;
             let aru = AvailableRandomizationUnits::with_client_id(&client_id);
+            let targeting_attributes = TargetingAttributes {
+                app_context: context,
+                ..Default::default()
+            };
             'outer: loop {
                 let uuid = uuid::Uuid::new_v4();
                 let mut num_of_experiments_enrolled = 0;
-                let targeting_attributes = TargetingAttributes {
-                    app_context: context.clone(),
-                    ..Default::default()
-                };
                 for exp in &all_experiments {
                     let enr = nimbus::evaluate_enrollment(&uuid, &aru, &targeting_attributes, exp)?;
                     if enr.status.is_enrolled() {

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -25,12 +25,19 @@ impl Bucket {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct TargetingAttributes {
+    #[serde(flatten)]
+    pub app_context: AppContext,
+    pub is_already_enrolled: bool,
+}
+
 /// Determine the enrolment status for an experiment.
 ///
 /// # Arguments:
 /// - `nimbus_id` The auto-generated nimbus_id
 /// - `available_randomization_units` The app provded available randomization units
-/// - `app_context` The application parameters to use for evaluating targeting
+/// - `targeting_attributes` The attributes to use when evaluating targeting
 /// - `exp` The `Experiment` to evaluate.
 ///
 /// # Returns:
@@ -46,10 +53,10 @@ impl Bucket {
 pub fn evaluate_enrollment(
     nimbus_id: &Uuid,
     available_randomization_units: &AvailableRandomizationUnits,
-    app_context: &AppContext,
+    targeting_attributes: &TargetingAttributes,
     exp: &Experiment,
 ) -> Result<ExperimentEnrollment> {
-    if !is_experiment_available(app_context, exp, true) {
+    if !is_experiment_available(&targeting_attributes.app_context, exp, true) {
         return Ok(ExperimentEnrollment {
             slug: exp.slug.clone(),
             status: EnrollmentStatus::NotEnrolled {
@@ -61,7 +68,7 @@ pub fn evaluate_enrollment(
     // Get targeting out of the way - "if let chains" are experimental,
     // otherwise we could improve this.
     if let Some(expr) = &exp.targeting {
-        if let Some(status) = targeting(expr, app_context) {
+        if let Some(status) = targeting(expr, targeting_attributes) {
             return Ok(ExperimentEnrollment {
                 slug: exp.slug.clone(),
                 status,
@@ -194,7 +201,7 @@ fn choose_branch<'a>(slug: &str, branches: &'a [Branch], id: &str) -> Result<&'a
 ///
 /// # Arguments
 /// - `expression_statement`: The JEXL statement provided by the server
-/// - `ctx`: The application context provided by the client
+/// - `targeting_attributes`: The client attributes to target against
 ///
 /// If this app can not be targeted, returns an EnrollmentStatus to indicate
 /// why. Returns None if we should continue to evaluate the enrollment status.
@@ -206,8 +213,11 @@ fn choose_branch<'a>(slug: &str, branches: &'a [Branch], id: &str) -> Result<&'a
 /// - The `expression_statement` expects fields that do not exist in the AppContext definition
 /// - The result of evaluating the statement against the context is not a boolean
 /// - jexl-rs returned an error
-fn targeting(expression_statement: &str, ctx: &AppContext) -> Option<EnrollmentStatus> {
-    match Evaluator::new().eval_in_context(expression_statement, ctx.clone()) {
+fn targeting(
+    expression_statement: &str,
+    targeting_attributes: &TargetingAttributes,
+) -> Option<EnrollmentStatus> {
+    match Evaluator::new().eval_in_context(expression_statement, targeting_attributes) {
         Ok(res) => match res.as_bool() {
             Some(true) => None,
             Some(false) => Some(EnrollmentStatus::NotEnrolled {
@@ -228,6 +238,14 @@ mod tests {
     use super::*;
     use crate::{BucketConfig, Experiment, RandomizationUnit};
 
+    impl From<AppContext> for TargetingAttributes {
+        fn from(app_context: AppContext) -> Self {
+            Self {
+                app_context,
+                ..Default::default()
+            }
+        }
+    }
     #[test]
     fn test_targeting() {
         // Here's our valid jexl statement
@@ -235,7 +253,7 @@ mod tests {
             "app_id == '1010' && (app_version == '4.4' || locale == \"en-US\")";
 
         // A matching context testing the logical AND + OR of the expression
-        let ctx = AppContext {
+        let targeting_attributes = AppContext {
             app_name: "nimbus_test".to_string(),
             app_id: "1010".to_string(),
             channel: "test".to_string(),
@@ -250,11 +268,12 @@ mod tests {
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
             custom_targeting_attributes: None,
-        };
-        assert_eq!(targeting(expression_statement, &ctx), None);
+        }
+        .into();
+        assert_eq!(targeting(expression_statement, &targeting_attributes), None);
 
         // A matching context testing the logical OR of the expression
-        let ctx = AppContext {
+        let targeting_attributes = AppContext {
             app_name: "nimbus_test".to_string(),
             app_id: "1010".to_string(),
             channel: "test".to_string(),
@@ -269,11 +288,12 @@ mod tests {
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
             custom_targeting_attributes: None,
-        };
-        assert_eq!(targeting(expression_statement, &ctx), None);
+        }
+        .into();
+        assert_eq!(targeting(expression_statement, &targeting_attributes), None);
 
         // A non-matching context testing the logical AND of the expression
-        let non_matching_ctx = AppContext {
+        let non_matching_targeting = AppContext {
             app_name: "not_nimbus_test".to_string(),
             app_id: "org.example.app".to_string(),
             channel: "test".to_string(),
@@ -288,16 +308,17 @@ mod tests {
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
             custom_targeting_attributes: None,
-        };
+        }
+        .into();
         assert!(matches!(
-            targeting(expression_statement, &non_matching_ctx),
+            targeting(expression_statement, &non_matching_targeting),
             Some(EnrollmentStatus::NotEnrolled {
                 reason: NotEnrolledReason::NotTargeted
             })
         ));
 
         // A non-matching context testing the logical OR of the expression
-        let non_matching_ctx = AppContext {
+        let non_matching_targeting = AppContext {
             app_name: "not_nimbus_test".to_string(),
             app_id: "org.example.app".to_string(),
             channel: "test".to_string(),
@@ -312,9 +333,10 @@ mod tests {
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
             custom_targeting_attributes: None,
-        };
+        }
+        .into();
         assert!(matches!(
-            targeting(expression_statement, &non_matching_ctx),
+            targeting(expression_statement, &non_matching_targeting),
             Some(EnrollmentStatus::NotEnrolled {
                 reason: NotEnrolledReason::NotTargeted
             })
@@ -332,7 +354,7 @@ mod tests {
         custom_targeting_attributes.insert("is_first_run".into(), "true".into());
         custom_targeting_attributes.insert("ios_version".into(), "8.8".into());
         // A matching context that includes the appropriate specific context
-        let ctx = AppContext {
+        let targeting_attributes = AppContext {
             app_name: "nimbus_test".to_string(),
             app_id: "1010".to_string(),
             channel: "test".to_string(),
@@ -347,11 +369,12 @@ mod tests {
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
             custom_targeting_attributes: Some(custom_targeting_attributes),
-        };
-        assert_eq!(targeting(expression_statement, &ctx), None);
+        }
+        .into();
+        assert_eq!(targeting(expression_statement, &targeting_attributes), None);
 
         // A matching context without the specific context
-        let ctx = AppContext {
+        let targeting_attributes = AppContext {
             app_name: "nimbus_test".to_string(),
             app_id: "1010".to_string(),
             channel: "test".to_string(),
@@ -366,11 +389,49 @@ mod tests {
             android_sdk_version: Some("29".to_string()),
             debug_tag: None,
             custom_targeting_attributes: None,
-        };
+        }
+        .into();
         assert!(matches!(
-            targeting(expression_statement, &ctx),
+            targeting(expression_statement, &targeting_attributes),
             Some(EnrollmentStatus::Error { .. })
         ));
+    }
+
+    #[test]
+    fn test_targeting_is_already_enrolled() {
+        // Here's our valid jexl statement
+        let expression_statement = "is_already_enrolled";
+        // A matching context that includes the appropriate specific context
+        let mut targeting_attributes: TargetingAttributes = AppContext {
+            app_name: "nimbus_test".to_string(),
+            app_id: "1010".to_string(),
+            channel: "test".to_string(),
+            app_version: Some("4.4".to_string()),
+            app_build: Some("1234".to_string()),
+            architecture: Some("x86_64".to_string()),
+            device_manufacturer: Some("Samsung".to_string()),
+            device_model: Some("Galaxy S10".to_string()),
+            locale: Some("en-US".to_string()),
+            os: Some("Android".to_string()),
+            os_version: Some("10".to_string()),
+            android_sdk_version: Some("29".to_string()),
+            debug_tag: None,
+            custom_targeting_attributes: None,
+        }
+        .into();
+        targeting_attributes.is_already_enrolled = true;
+
+        // The targeting should pass!
+        assert_eq!(targeting(expression_statement, &targeting_attributes), None);
+
+        // We make the is_already_enrolled false and try again
+        targeting_attributes.is_already_enrolled = false;
+        assert_eq!(
+            targeting(expression_statement, &targeting_attributes),
+            Some(EnrollmentStatus::NotEnrolled {
+                reason: NotEnrolledReason::NotTargeted
+            })
+        );
     }
 
     #[test]
@@ -527,16 +588,18 @@ mod tests {
 
         // Application context for matching the above experiment.  If the `app_name` or
         // `channel` doesn't match the experiment, then the client won't be enrolled.
-        let mut context = AppContext {
+        let mut targeting_attributes = AppContext {
             app_name: "NimbusTest".to_string(),
             channel: "nightly".to_string(),
             ..Default::default()
-        };
+        }
+        .into();
 
         let id = uuid::Uuid::new_v4();
 
         let enrollment =
-            evaluate_enrollment(&id, &Default::default(), &context, &experiment).unwrap();
+            evaluate_enrollment(&id, &Default::default(), &targeting_attributes, &experiment)
+                .unwrap();
         println!("Uh oh!  {:#?}", enrollment.status);
         assert!(matches!(
             enrollment.status,
@@ -548,11 +611,12 @@ mod tests {
 
         // Change the channel to test when it has a different case than expected
         // (See SDK-246: https://jira.mozilla.com/browse/SDK-246 )
-        context.channel = "Nightly".to_string();
+        targeting_attributes.app_context.channel = "Nightly".to_string();
 
         // Now we will be enrolled in the experiment because we have the right channel, but with different capitalization
         let enrollment =
-            evaluate_enrollment(&id, &Default::default(), &context, &experiment).unwrap();
+            evaluate_enrollment(&id, &Default::default(), &targeting_attributes, &experiment)
+                .unwrap();
         assert!(matches!(
             enrollment.status,
             EnrollmentStatus::Enrolled {
@@ -599,12 +663,13 @@ mod tests {
 
         // Application context for matching the above experiment.  If any of the `app_name`, `app_id`,
         // or `channel` doesn't match the experiment, then the client won't be enrolled.
-        let context = AppContext {
+        let targeting_attributes = AppContext {
             app_name: "NimbusTest".to_string(),
             app_id: "org.example.app".to_string(),
             channel: "nightly".to_string(),
             ..Default::default()
-        };
+        }
+        .into();
 
         // We won't be enrolled in the experiment because we don't have the right randomization units since the
         // experiment is requesting the `ClientId` and the `Default::default()` here will just have the
@@ -612,7 +677,7 @@ mod tests {
         let enrollment = evaluate_enrollment(
             &uuid::Uuid::new_v4(),
             &Default::default(),
-            &context,
+            &targeting_attributes,
             &experiment,
         )
         .unwrap();
@@ -622,9 +687,13 @@ mod tests {
         // Fits because of the client_id.
         let available_randomization_units = AvailableRandomizationUnits::with_client_id("bobo");
         let id = uuid::Uuid::parse_str("542213c0-9aef-47eb-bc6b-3b8529736ba2").unwrap();
-        let enrollment =
-            evaluate_enrollment(&id, &available_randomization_units, &context, &experiment)
-                .unwrap();
+        let enrollment = evaluate_enrollment(
+            &id,
+            &available_randomization_units,
+            &targeting_attributes,
+            &experiment,
+        )
+        .unwrap();
         assert!(matches!(
             enrollment.status,
             EnrollmentStatus::Enrolled {
@@ -674,15 +743,17 @@ mod tests {
         // If the `app_name` or `channel` doesn't match the experiment,
         // then the client won't be enrolled.
         // Start with a context that does't match the app_name:
-        let mut context = AppContext {
+        let mut targeting_attributes = AppContext {
             app_name: "Wrong!".to_string(),
             channel: "nightly".to_string(),
             ..Default::default()
-        };
+        }
+        .into();
 
         // We won't be enrolled in the experiment because we don't have the right app_name
         let enrollment =
-            evaluate_enrollment(&id, &Default::default(), &context, &experiment).unwrap();
+            evaluate_enrollment(&id, &Default::default(), &targeting_attributes, &experiment)
+                .unwrap();
         assert!(matches!(
             enrollment.status,
             EnrollmentStatus::NotEnrolled {
@@ -691,13 +762,14 @@ mod tests {
         ));
 
         // Change the app_name back and change the channel to test when it doesn't match:
-        context.app_name = "NimbusTest".to_string();
-        context.channel = "Wrong".to_string();
+        targeting_attributes.app_context.app_name = "NimbusTest".to_string();
+        targeting_attributes.app_context.channel = "Wrong".to_string();
 
         // Now we won't be enrolled in the experiment because we don't have the right channel, but with the same
         // `NotTargeted` reason
         let enrollment =
-            evaluate_enrollment(&id, &Default::default(), &context, &experiment).unwrap();
+            evaluate_enrollment(&id, &Default::default(), &targeting_attributes, &experiment)
+                .unwrap();
         assert!(matches!(
             enrollment.status,
             EnrollmentStatus::NotEnrolled {
@@ -735,15 +807,20 @@ mod tests {
         // Tested against the desktop implementation
         let id = uuid::Uuid::parse_str("299eed1e-be6d-457d-9e53-da7b1a03f10d").unwrap();
         // Application context for matching exp3
-        let context = AppContext {
+        let targeting_attributes = AppContext {
             app_id: "org.example.app".to_string(),
             channel: "nightly".to_string(),
             ..Default::default()
-        };
+        }
+        .into();
 
-        let enrollment =
-            evaluate_enrollment(&id, &available_randomization_units, &context, &experiment)
-                .unwrap();
+        let enrollment = evaluate_enrollment(
+            &id,
+            &available_randomization_units,
+            &targeting_attributes,
+            &experiment,
+        )
+        .unwrap();
         assert!(matches!(
             enrollment.status,
             EnrollmentStatus::Enrolled {

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -26,6 +26,9 @@ use enrollment::{
 };
 use evaluator::is_experiment_available;
 
+// Exposed for Example only
+pub use evaluator::TargetingAttributes;
+
 // We only use this in a test, and with --no-default-features, we don't use it
 // at all
 #[allow(unused_imports)]


### PR DESCRIPTION
A part of https://mozilla-hub.atlassian.net/browse/SDK-384

### What's in this
- Uses a different struct `TargetingAttributes` to do the actual targeting, the struct is not persisted, and only created before targeting is done. This creates flexibility for the SDK to define targeting attributes without worrying about the app having to add them
- Adds a new targeting attribute: `is_already_enrolled` which is only true if the user was already enrolled in the experiment
- A bunch of tests for both the targeting change, and the general "make sure the `is_already_enrolled` works correctly"


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
