### PR TITLE
Enable rust logging in CI and in more places tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,7 @@ commands:
           echo 'export NSS_DIR=$(pwd)/libs/desktop/linux-x86-64/nss' >> $BASH_ENV
           echo 'export SQLCIPHER_LIB_DIR=$(pwd)/libs/desktop/linux-x86-64/sqlcipher/lib' >> $BASH_ENV
           echo 'export SQLCIPHER_INCLUDE_DIR=$(pwd)/libs/desktop/linux-x86-64/sqlcipher/include' >> $BASH_ENV
+          echo 'export RUST_LOG=trace' >> $BASH_ENV
       - run:
           name: Verify the build environment
           command: ./libs/verify-desktop-environment.sh
@@ -302,7 +303,7 @@ jobs:
       - setup-rust-min-version
       # tests.py doesn't support skipping tests, and we need to skip the systests on this rust version.
       # It's not in the default workspace members, so just `cargo test` is OK.
-      - run: cargo test
+      - run: RUST_LOG=trace cargo test
       - save-sccache-cache
   # These run periodically (driven by cron).
   Rust tests - beta:

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -443,6 +443,10 @@ pub mod test {
     static ATOMIC_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
     pub fn new_mem_api() -> Arc<PlacesApi> {
+        // A bit hacky, but because this is a test-only function that almost all tests use,
+        // it's a convenient place to initialize logging for tests.
+        let _ = env_logger::try_init();
+
         let counter = ATOMIC_COUNTER.fetch_add(1, Ordering::Relaxed);
         PlacesApi::new_memory(&format!("test-api-{}", counter)).expect("should get an API")
     }

--- a/components/places/src/bookmark_sync/engine.rs
+++ b/components/places/src/bookmark_sync/engine.rs
@@ -1852,7 +1852,6 @@ mod tests {
 
     #[test]
     fn test_fetch_remote_tree() -> Result<()> {
-        let _ = env_logger::try_init();
         let records = vec![
             json!({
                 "id": "qqVTRWhLBOu3",
@@ -3001,8 +3000,6 @@ mod tests {
 
     #[test]
     fn test_apply_tombstones() -> Result<()> {
-        let _ = env_logger::try_init();
-
         let local_modified = Timestamp::now();
         let api = new_mem_api();
         let writer = api.open_connection(ConnectionType::ReadWrite)?;
@@ -3791,8 +3788,6 @@ mod tests {
 
     #[test]
     fn test_dedupe_local_newer() -> anyhow::Result<()> {
-        let _ = env_logger::try_init();
-
         let api = new_mem_api();
         let writer = api.open_connection(ConnectionType::ReadWrite)?;
         let syncer = api.open_sync_connection()?;
@@ -3910,8 +3905,6 @@ mod tests {
 
     #[test]
     fn test_deduping_remote_newer() -> anyhow::Result<()> {
-        let _ = env_logger::try_init();
-
         let api = new_mem_api();
         let writer = api.open_connection(ConnectionType::ReadWrite)?;
         let syncer = api.open_sync_connection()?;
@@ -4147,8 +4140,6 @@ mod tests {
 
     #[test]
     fn test_reconcile_sync_metadata() -> anyhow::Result<()> {
-        let _ = env_logger::try_init();
-
         let api = new_mem_api();
         let writer = api.open_connection(ConnectionType::ReadWrite)?;
         let syncer = api.open_sync_connection()?;

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -1646,7 +1646,6 @@ mod tests {
 
     #[test]
     fn test_insert() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
         let url = Url::parse("https://www.example.com")?;
 
@@ -1689,7 +1688,6 @@ mod tests {
 
     #[test]
     fn test_insert_titles() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
         let url = Url::parse("https://www.example.com")?;
 
@@ -1723,7 +1721,6 @@ mod tests {
 
     #[test]
     fn test_delete() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
 
         let guid1 = SyncGuid::random();
@@ -1792,7 +1789,6 @@ mod tests {
 
     #[test]
     fn test_delete_roots() {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
 
         delete_bookmark(&conn, &BookmarkRootGuid::Root.into()).expect_err("can't delete root");
@@ -1802,7 +1798,6 @@ mod tests {
 
     #[test]
     fn test_insert_pos_too_large() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
         let url = Url::parse("https://www.example.com")?;
 
@@ -1826,7 +1821,6 @@ mod tests {
 
     #[test]
     fn test_update_move_same_parent() {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
         let unfiled = &BookmarkRootGuid::Unfiled.as_guid();
 
@@ -1923,7 +1917,6 @@ mod tests {
 
     #[test]
     fn test_update() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
         let unfiled = &BookmarkRootGuid::Unfiled.as_guid();
 
@@ -2071,7 +2064,6 @@ mod tests {
 
     #[test]
     fn test_update_titles() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
         let guid: SyncGuid = "bookmark1___".into();
 
@@ -2139,7 +2131,6 @@ mod tests {
 
     #[test]
     fn test_update_statuses() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
         let unfiled = &BookmarkRootGuid::Unfiled.as_guid();
 
@@ -2277,7 +2268,6 @@ mod tests {
 
     #[test]
     fn test_update_errors() {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
 
         insert_json_tree(
@@ -2348,7 +2338,6 @@ mod tests {
 
     #[test]
     fn test_fetch_root() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
 
         // Fetch the root
@@ -2365,7 +2354,6 @@ mod tests {
 
     #[test]
     fn test_insert_tree_and_fetch_level() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
 
         let tree = FolderNode {
@@ -2481,7 +2469,6 @@ mod tests {
 
     #[test]
     fn test_delete_everything() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
 
         insert_bookmark(
@@ -2548,7 +2535,6 @@ mod tests {
 
     #[test]
     fn test_sync_reset() -> Result<()> {
-        let _ = env_logger::try_init();
         let conn = new_mem_connection();
 
         // Add Sync metadata keys, to ensure they're reset.

--- a/components/places/src/storage/bookmarks/public_node.rs
+++ b/components/places/src/storage/bookmarks/public_node.rs
@@ -302,7 +302,6 @@ mod test {
     #[test]
     fn test_get_by_url() -> Result<()> {
         let conns = new_mem_connections();
-        let _ = env_logger::try_init();
         insert_json_tree(
             &conns.write,
             json!({
@@ -376,7 +375,6 @@ mod test {
     #[test]
     fn test_search() -> Result<()> {
         let conns = new_mem_connections();
-        let _ = env_logger::try_init();
         insert_json_tree(
             &conns.write,
             json!({
@@ -472,7 +470,6 @@ mod test {
     #[test]
     fn test_fetch_bookmark() -> Result<()> {
         let conns = new_mem_connections();
-        let _ = env_logger::try_init();
 
         insert_json_tree(
             &conns.write,
@@ -553,7 +550,6 @@ mod test {
     #[test]
     fn test_fetch_tree() -> Result<()> {
         let conns = new_mem_connections();
-        let _ = env_logger::try_init();
 
         insert_json_tree(
             &conns.write,
@@ -613,7 +609,6 @@ mod test {
     #[test]
     fn test_recent() -> Result<()> {
         let conns = new_mem_connections();
-        let _ = env_logger::try_init();
         let kids = [
             json!({
                 "guid": "bookmark1___",

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -1873,7 +1873,6 @@ mod tests {
     fn test_status_columns() -> Result<()> {
         let _ = env_logger::try_init();
         let mut conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite)?;
-        let _ = env_logger::try_init();
         // A page with "normal" and a change counter.
         let mut pi = get_observed_page(&mut conn, "http://example.com/1")?;
         assert_eq!(pi.sync_change_counter, 1);
@@ -2188,7 +2187,6 @@ mod tests {
 
         let _ = env_logger::try_init();
         let mut conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite)?;
-        let _ = env_logger::try_init();
 
         // Add Sync metadata keys, to ensure they're reset.
         put_meta(&conn, GLOBAL_SYNCID_META_KEY, &"syncAAAAAAAA")?;


### PR DESCRIPTION
#4502 is strange, and it's almost impossible to see what might have happened for 2 reasons:

* `RUST_LOG` isn't set in CI - so even if tests try and enable logging it would not be seen.
* Places enabled logging in a very ad-hoc way, so only some tests would log even with `RUST_LOG` set - and this test was one that did not. So I just moved the logging initialization to a test-only function that most tests use right at the start of the test.

The end result being that if we ever see that failure again, we should end up with a log.