### PR TITLE
Guard against invalid view time observations

### DIFF
--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -77,6 +77,9 @@ pub enum ErrorKind {
 
     #[error("Error opening database: {0}")]
     OpenDatabaseError(#[from] sql_support::open_database::Error),
+
+    #[error("Invalid metadata observation: {0}")]
+    InvalidMetadataObservation(InvalidMetadataObservation),
 }
 
 error_support::define_error! {
@@ -93,6 +96,7 @@ error_support::define_error! {
         (InterruptedError, Interrupted),
         (Utf8Error, std::str::Utf8Error),
         (OpenDatabaseError, sql_support::open_database::Error),
+        (InvalidMetadataObservation, InvalidMetadataObservation),
     }
 }
 
@@ -152,4 +156,10 @@ pub enum Corruption {
 
     #[error("Bookmark '{0}' has no parent but is not the bookmarks root")]
     NonRootWithoutParent(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidMetadataObservation {
+    #[error("Observed view time is invalid (too long)")]
+    ViewTimeTooLong,
 }


### PR DESCRIPTION
Certain client bugs lead to us making view_time observations that lead
to an i32 overflow (our return type for total_view_time is i32, but due
to in-sql incrementing, it's possible to encounter a value that's larger
than i32 in the database).

This patch does two things:
- on the way in, it guards against abnormally high view time
  observations, reporting an error to the client
- on the way out, it guards against overflowing total_view_time values
  in the database, capping at them i32::MAX

Since metadata naturally expires and is deleted, it's assumed that any
incorrect values won't survive for too long on actual devices, and so we
don't bother dealing with bad data in other places where it is used (for
ranking/sorting, for example).

Reporting errors to clients allows them to detect that something's wrong
with their logic.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
