### PR TITLE
[Nimbus] Fixup visibility for FeatureVariables Dictionary extensions

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -27,3 +27,9 @@ Use the template below to make assigning a version number during the release cut
 
 - Xcode has been updated to version 13
   - application-services noq uses the new build system by default
+
+## Nimbus
+
+### What's Changed
+
+- 🐞🍏 Bugfix, iOS only — Increased visibility for `Dictionary` extensions when working with `FeatureVariables` and `enums`.

--- a/components/nimbus/ios/Nimbus/FeatureVariables.swift
+++ b/components/nimbus/ios/Nimbus/FeatureVariables.swift
@@ -170,7 +170,7 @@ public extension Variables {
     }
 }
 
-extension Dictionary where Key == String {
+public extension Dictionary where Key == String {
     func compactMapKeys<T>(_ transform: (String) -> T?) -> [T: Value] {
         let pairs = keys.compactMap { (k: String) -> (T, Value)? in
             guard let value = self[k],
@@ -202,7 +202,7 @@ extension Dictionary where Key == String {
     }
 }
 
-extension Dictionary where Value == String {
+public extension Dictionary where Value == String {
     /// Convenience extension method for maps with `String` values.
     /// If a `String` value cannot be coerced into a variant of the given Enum, then the entry is
     /// omitted.


### PR DESCRIPTION
Visibility for Swift Dictionary extensions in Nimbus FeatureVariables were set to internal, and should've been public.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.