### PR TITLE
nimbus attempt re-enroll if errored out

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -29,3 +29,4 @@ Use the template below to make assigning a version number during the release cut
 ## Nimbus
 ### What's changed
 - The DTO changed to remove the `probeSets` and `enabled` fields that were previously unused. ([#4482](https://github.com/mozilla/application-services/pull/4482))
+- Nimbus will retry enrollment if it previously errored out on a previous enrollment.

--- a/components/rc_log/ios/RustLog.swift
+++ b/components/rc_log/ios/RustLog.swift
@@ -225,7 +225,7 @@ private class RustLogState {
     }
 
     func disable() {
-        guard let adapter = self.adapter else {
+        guard let adapter = adapter else {
             return
         }
         self.adapter = nil


### PR DESCRIPTION
If enrollment errors out on one run, we try again on the next. This is needed because if a user is on an old version of nimbus, and they see new targeting attributes, they would error. Then, when they update the app, we don't try to re-enroll, thus they would never be enrolled.

Note the change in the swift file is to pass swiftformat CI, which started failing on a new upgrade of swiftformat

I'll cut a release for this and we'll need to uplift it