### PR TITLE
Cut release v85.4.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 85.3.0
+libraryVersion: 85.4.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v85.4.0 (_2021-10-05_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v85.3.0...v85.4.0)
+
+## Sync
+
+### What's Changed
+
+- Clients engine now checks for tombstones and any deserialisation errors when receiving a client record, and ignores
+  it if either are present ([#4504](https://github.com/mozilla/application-services/pull/4504))
+
+## Nimbus
+### What's changed
+- The DTO changed to remove the `probeSets` and `enabled` fields that were previously unused. ([#4482](https://github.com/mozilla/application-services/pull/4482))
+- Nimbus will retry enrollment if it previously errored out on a previous enrollment.
+
 # v85.3.0 (_2021-09-30_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v85.2.0...v85.3.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v85.3.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v85.4.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,15 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-
-## Sync
-
-### What's Changed
-
-- Clients engine now checks for tombstones and any deserialisation errors when receiving a client record, and ignores
-  it if either are present ([#4504](https://github.com/mozilla/application-services/pull/4504))
-
-## Nimbus
-### What's changed
-- The DTO changed to remove the `probeSets` and `enabled` fields that were previously unused. ([#4482](https://github.com/mozilla/application-services/pull/4482))
-- Nimbus will retry enrollment if it previously errored out on a previous enrollment.


### PR DESCRIPTION
Cutting 85.4.0 - we need this to be in 94, so it'll be uplifted (if the betas are cut already) Mostly for a change in how nimbus reacts when it errors out on enrollment, it should attempt to retry enrollment on the next run