### PR TITLE
Fix test failure because we no longer delete source database

### DIFF
--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -1415,8 +1415,5 @@ mod tests {
         assert!(login.is_deleted);
         assert_eq!(util::system_time_ms_i64(login.local_modified), 2000);
         assert_eq!(login.sync_status, SyncStatus::Changed);
-
-        // we unconditionally delete the sqlcipher database.
-        assert!(!testpaths.old_db.as_path().exists());
     }
 }


### PR DESCRIPTION
Commit d8e33479cd7e7330bc80dd066a45c4b5442d0aa1reverted the fact we delete the DB after migration, but this test was left behind.