### PR TITLE
Gh 4551

### DIFF
--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -139,10 +139,6 @@ interface LoginStore {
     [Throws=LoginsStorageError]
     Login? find_login_to_update(LoginEntry look, [ByRef]string encryption_key);
 
-    // XXX - Can we kill this, and just fix the semantics of add/update?
-    [Throws=LoginsStorageError]
-    sequence<EncryptedLogin> potential_dupes_ignoring_username([ByRef]string id, LoginEntry login);
-
     [Throws=LoginsStorageError]
     EncryptedLogin? get([ByRef] string id);
 

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -9,7 +9,6 @@ use crate::LoginsSyncEngine;
 use std::path::Path;
 use std::sync::{Arc, Mutex, Weak};
 use sync15::{sync_multiple, EngineSyncAssociation, MemoryCachedState, SyncEngine};
-use sync_guid::Guid;
 
 // Our "sync manager" will use whatever is stashed here.
 lazy_static::lazy_static! {
@@ -63,17 +62,6 @@ impl LoginStore {
     pub fn find_login_to_update(&self, entry: LoginEntry, enc_key: &str) -> Result<Option<Login>> {
         let encdec = EncryptorDecryptor::new(enc_key)?;
         self.db.lock().unwrap().find_login_to_update(entry, &encdec)
-    }
-
-    pub fn potential_dupes_ignoring_username(
-        &self,
-        id: &str,
-        entry: LoginEntry,
-    ) -> Result<Vec<EncryptedLogin>> {
-        self.db
-            .lock()
-            .unwrap()
-            .potential_dupes_ignoring_username(&Guid::new(id), &entry.fields)
     }
 
     pub fn touch(&self, id: &str) -> Result<()> {


### PR DESCRIPTION
Removes the 2 methods annotated with "XXX: Can we kill this?" in logins.udl.  `check_valid_with_no_dupes()` was easy, `potential_dupes_ignoring_username()` was a bit harder.  Check the commit message for details there.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
