### PR TITLE
Fix CI for building M1 simulator binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,14 +401,7 @@ jobs:
       - run:
           name: Build XCFramework archive
           command: |
-            if [ -z "${CIRCLE_TAG}" ]; then
-              # TODO: Figure out Release vs Debug
-              # For whatever reason, Debug builds does not build the
-              # arm64 binaries correctly
-              bash megazords/ios-rust/build-xcframework.sh --build-profile release
-            else
-              bash megazords/ios-rust/build-xcframework.sh --build-profile release
-            fi
+            bash megazords/ios-rust/build-xcframework.sh --build-profile release
       - save_cache:
           name: Save sccache cache
           key: sccache-cache-macos-{{ arch }}-{{ epoch }}


### PR DESCRIPTION
Fixes #4585 

Building swift packages locally works but not in CI. This was due to using debug instead of release -- reasons currently unknown and will be investigated and tracked in another task .




### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
