### PR TITLE
Rewrite Nimbus.kt and FxaClient in terms of a decorator

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/PersistedFirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/PersistedFirefoxAccount.kt
@@ -7,6 +7,58 @@ package mozilla.appservices.fxaclient
 import android.util.Log
 import org.json.JSONObject
 
+class PersistedFxADecorator(
+    private var persistCallback: PersistedFirefoxAccount.PersistCallback?
+) :  FxADecorator<FirefoxAccount>, FxAPersistCallbackHolder {
+    override fun <ReturnType> thenPersistsState(obj: FirefoxAccount, thunk: () -> ReturnType) =
+        try {
+            thunk()
+        } finally {
+            tryPersistState(obj)
+        }
+
+    override fun tryPersistState(obj: FirefoxAccountInterface) {
+        this.persistCallback?.let {
+            val json: String
+            try {
+                json = obj.toJson()
+            } catch (e: FxaException) {
+                Log.e("FirefoxAccount", "Error serializing the FirefoxAccount state.")
+                return
+            }
+            it.persist(json)
+        }
+    }
+
+    override fun registerPersistCallback(persistCallback: PersistedFirefoxAccount.PersistCallback) {
+        this.persistCallback = persistCallback
+    }
+
+    override fun unregisterPersistCallback() {
+        this.persistCallback = null
+    }
+}
+
+interface FxAPersistCallbackHolder {
+    /**
+     * Registers a PersistCallback that will be called every time the
+     * FirefoxAccount internal state has mutated.
+     * The FirefoxAccount instance can be later restored using the
+     * `fromJSONString` class method.
+     * It is the responsibility of the consumer to ensure the persisted data
+     * is saved in a secure location, as it can contain Sync Keys and
+     * OAuth tokens.
+     */
+    fun registerPersistCallback(persistCallback: PersistedFirefoxAccount.PersistCallback)
+
+    /**
+     * Unregisters any previously registered PersistCallback.
+     */
+    fun unregisterPersistCallback()
+
+    fun tryPersistState(obj: FirefoxAccountInterface)
+}
+
 /**
  * PersistedFirefoxAccount represents the authentication state of a client.
  *
@@ -18,9 +70,11 @@ import org.json.JSONObject
  * once UniFFI's support for callback interfaces is a little more battle-tested.
  *
  */
-class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCallback?) : AutoCloseable {
-    private var inner: FirefoxAccount = inner
-    private var persistCallback: PersistCallback? = persistCallback
+class PersistedFirefoxAccount
+    private constructor(private val inner: FirefoxAccount) : AutoCloseable,
+        FirefoxAccountInterface by inner,
+        FxAPersistCallbackHolder by (inner.fxADecorator as PersistedFxADecorator)
+    {
 
     /**
      * Create a PersistedFirefoxAccount using the given config.
@@ -29,6 +83,7 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      *
      */
     constructor(config: Config, persistCallback: PersistCallback? = null) : this(FirefoxAccount(
+        PersistedFxADecorator(persistCallback),
         // This is kind of dumb - we take a Config object on the Kotlin side, destructure it into its fields
         // to pass over the FFI, then the Rust side turns it back into its own variant of a Config object!
         // That made sense when we had to write the FFI layer by hand, but we should see whether we can nicely
@@ -38,9 +93,9 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
         config.clientId,
         config.redirectUri,
         config.tokenServerUrlOverride
-    ), persistCallback) {
+    )) {
         // Persist the newly created instance state.
-        this.tryPersistState()
+        tryPersistState(this)
     }
 
     companion object {
@@ -53,7 +108,7 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
          * @return [PersistedFirefoxAccount] representing the authentication state
          */
         fun fromJSONString(json: String, persistCallback: PersistCallback? = null): PersistedFirefoxAccount {
-            return PersistedFirefoxAccount(FirefoxAccount.fromJson(json), persistCallback)
+            return PersistedFirefoxAccount(FirefoxAccount.fromJson(PersistedFxADecorator(persistCallback), json))
         }
     }
 
@@ -61,38 +116,6 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
         fun persist(data: String)
     }
 
-    /**
-     * Registers a PersistCallback that will be called every time the
-     * FirefoxAccount internal state has mutated.
-     * The FirefoxAccount instance can be later restored using the
-     * `fromJSONString` class method.
-     * It is the responsibility of the consumer to ensure the persisted data
-     * is saved in a secure location, as it can contain Sync Keys and
-     * OAuth tokens.
-     */
-    fun registerPersistCallback(persistCallback: PersistCallback) {
-        this.persistCallback = persistCallback
-    }
-
-    /**
-     * Unregisters any previously registered PersistCallback.
-     */
-    fun unregisterPersistCallback() {
-        this.persistCallback = null
-    }
-
-    private fun tryPersistState() {
-        this.persistCallback?.let {
-            val json: String
-            try {
-                json = this.toJSONString()
-            } catch (e: FxaException) {
-                Log.e("FirefoxAccount", "Error serializing the FirefoxAccount state.")
-                return
-            }
-            it.persist(json)
-        }
-    }
 
     /**
      * Constructs a URL used to begin the OAuth flow for the requested scopes and keys.
@@ -105,12 +128,9 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      * @return String that resolves to the flow URL when complete
      */
     fun beginOAuthFlow(
-        scopes: Array<String>,
-        entrypoint: String,
-        metricsParams: MetricsParams = MetricsParams(mapOf())
-    ): String {
-        return this.inner.beginOauthFlow(scopes.toList(), entrypoint, metricsParams)
-    }
+        scopes: List<String>,
+        entrypoint: String
+    ) = this.beginOauthFlow(scopes.toList(), entrypoint, MetricsParams(mapOf()))
 
     /**
      * Begins the pairing flow.
@@ -126,151 +146,8 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
     fun beginPairingFlow(
         pairingUrl: String,
         scopes: Array<String>,
-        entrypoint: String,
-        metricsParams: MetricsParams = MetricsParams(mapOf())
-    ): String {
-        return this.inner.beginPairingFlow(pairingUrl, scopes.toList(), entrypoint, metricsParams)
-    }
-
-    /**
-     * Authenticates the current account using the code and state parameters fetched from the
-     * redirect URL reached after completing the sign in flow triggered by [beginOAuthFlow].
-     *
-     * Modifies the FirefoxAccount state.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     */
-    fun completeOAuthFlow(code: String, state: String) {
-        this.inner.completeOauthFlow(code, state)
-        this.tryPersistState()
-    }
-
-    /**
-     * Fetches the profile object for the current client either from the existing cached account,
-     * or from the server (requires the client to have access to the profile scope).
-     *
-     * This performs network requests, and should not be used on the main thread.
-     *
-     * @param ignoreCache Fetch the profile information directly from the server
-     * @return [Profile] representing the user's basic profile info
-     * @throws FxaException.Unauthorized We couldn't find any suitable access token to make that call.
-     * The caller should then start the OAuth Flow again with the "profile" scope.
-     */
-    fun getProfile(ignoreCache: Boolean): Profile {
-        try {
-            return this.inner.getProfile(ignoreCache)
-        } finally {
-            this.tryPersistState()
-        }
-    }
-
-    /**
-     * Convenience method to fetch the profile from a cached account by default, but fall back
-     * to retrieval from the server.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     *
-     * @return [Profile] representing the user's basic profile info
-     * @throws FxaException.Unauthorized We couldn't find any suitable access token to make that call.
-     * The caller should then start the OAuth Flow again with the "profile" scope.
-     */
-    fun getProfile(): Profile {
-        return getProfile(false)
-    }
-
-    /**
-     * Fetches the token server endpoint, for authenticating to Firefox Sync via OAuth.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     */
-    fun getTokenServerEndpointURL(): String {
-        return this.inner.getTokenServerEndpointUrl()
-    }
-
-    /**
-     * Get the pairing URL to navigate to on the Auth side (typically a computer).
-     *
-     * This does not make network requests, and can be used on the main thread.
-     */
-    fun getPairingAuthorityURL(): String {
-        return this.inner.getPairingAuthorityUrl()
-    }
-
-    /**
-     * Fetches the connection success url.
-     *
-     * This does not make network requests, and can be used on the main thread.
-     */
-    fun getConnectionSuccessURL(): String {
-        return this.inner.getConnectionSuccessUrl()
-    }
-
-    /**
-     * Fetches the user's manage-account url.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     *
-     * @throws FxaException.Unauthorized We couldn't find any suitable access token to identify the user.
-     * The caller should then start the OAuth Flow again with the "profile" scope.
-     */
-    fun getManageAccountURL(entrypoint: String): String {
-        return this.inner.getManageAccountUrl(entrypoint)
-    }
-
-    /**
-     * Fetches the user's manage-devices url.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     *
-     * @throws FxaException.Unauthorized We couldn't find any suitable access token to identify the user.
-     * The caller should then start the OAuth Flow again with the "profile" scope.
-     */
-    fun getManageDevicesURL(entrypoint: String): String {
-        return this.inner.getManageDevicesUrl(entrypoint)
-    }
-
-    /**
-     * Tries to fetch an access token for the given scope.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     * It may modify the persisted account state.
-     *
-     * @param scope Single OAuth scope (no spaces) for which the client wants access
-     * @param ttl time in seconds for which the token will be valid
-     * @return [AccessTokenInfo] that stores the token, along with its scopes and keys when complete
-     * @throws FxaException.Unauthorized We couldn't provide an access token
-     * for this scope. The caller should then start the OAuth Flow again with
-     * the desired scope.
-     */
-    fun getAccessToken(scope: String, ttl: Long? = null): AccessTokenInfo {
-        try {
-            return this.inner.getAccessToken(scope, ttl)
-        } finally {
-            this.tryPersistState()
-        }
-    }
-
-    fun checkAuthorizationStatus(): AuthorizationInfo {
-        return this.inner.checkAuthorizationStatus()
-    }
-
-    /**
-     * Tries to return a session token
-     *
-     * @throws FxaException Will send you an exception if there is no session token set
-     */
-    fun getSessionToken(): String {
-        return this.inner.getSessionToken()
-    }
-
-    /**
-     * Get the current device id
-     *
-     * @throws FxaException Will send you an exception if there is no device id set
-     */
-    fun getCurrentDeviceId(): String {
-        return this.inner.getCurrentDeviceId()
-    }
+        entrypoint: String
+    ) = this.beginPairingFlow(pairingUrl, scopes.toList(), entrypoint, MetricsParams(mapOf()))
 
     /**
      * Provisions an OAuth code using the session token from state
@@ -280,20 +157,7 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      */
     fun authorizeOAuthCode(
         authParams: AuthorizationParameters
-    ): String {
-        return this.inner.authorizeCodeUsingSessionToken(authParams)
-    }
-
-    /**
-     * This method should be called when a request made with
-     * an OAuth token failed with an authentication error.
-     * It clears the internal cache of OAuth access tokens,
-     * so the caller can try to call `getAccessToken` or `getProfile`
-     * again.
-     */
-    fun clearAccessTokenCache() {
-        this.inner.clearAccessTokenCache()
-    }
+    ) = this.authorizeCodeUsingSessionToken(authParams)
 
     /**
      * Migrate from a logged-in Firefox Account, takes ownership of the provided session token.
@@ -305,24 +169,9 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      * @return JSONObject JSON object with the result of the migration
      * This performs network requests, and should not be used on the main thread.
      */
-    fun migrateFromSessionToken(sessionToken: String, kSync: String, kXCS: String): JSONObject {
-        try {
-            val res = this.inner.migrateFromSessionToken(sessionToken, kSync, kXCS, false)
-            return JSONObject(mapOf("total_duration" to res.totalDuration))
-        } finally {
-            // Even a failed migration might alter the persisted account state, if it's able to be retried.
-            // It's safe to call this unconditionally, as the underlying code will not leave partial states.
-            this.tryPersistState()
-        }
-    }
-
-    /**
-     * Migrate from a logged-in Firefox Account, takes ownership of the provided session token.
-     *
-     * @return bool Returns a boolean if we are in a migration state
-     */
-    fun isInMigrationState(): MigrationState {
-        return this.inner.isInMigrationState()
+    fun migrateFromSessionTokenToJSON(sessionToken: String, kSync: String, kXCS: String): JSONObject {
+        val res = this.migrateFromSessionToken(sessionToken, kSync, kXCS, false)
+        return JSONObject(mapOf("total_duration" to res.totalDuration))
     }
 
     /**
@@ -336,32 +185,8 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      * This performs network requests, and should not be used on the main thread.
      */
     fun copyFromSessionToken(sessionToken: String, kSync: String, kXCS: String): JSONObject {
-        try {
-            val res = this.inner.migrateFromSessionToken(sessionToken, kSync, kXCS, true)
-            return JSONObject(mapOf("total_duration" to res.totalDuration))
-        } finally {
-            // Even a failed migration might alter the persisted account state, if it's able to be retried.
-            // It's safe to call this unconditionally, as the underlying code will not leave partial states.
-            this.tryPersistState()
-        }
-    }
-
-    /**
-     * Retry migration from a logged-in Firefox Account.
-     *
-     * Modifies the FirefoxAccount state.
-     * @return JSONObject JSON object with the result of the migration
-     * This performs network requests, and should not be used on the main thread.
-     */
-    fun retryMigrateFromSessionToken(): JSONObject {
-        try {
-            val res = this.inner.retryMigrateFromSessionToken()
-            return JSONObject(mapOf("total_duration" to res.totalDuration))
-        } finally {
-            // A failure her might alter the persisted account state, if we discover a permanent migration failure.
-            // It's safe to call this unconditionally, as the underlying code will not leave partial states.
-            this.tryPersistState()
-        }
+        val res = this.migrateFromSessionToken(sessionToken, kSync, kXCS, true)
+        return JSONObject(mapOf("total_duration" to res.totalDuration))
     }
 
     /**
@@ -374,7 +199,7 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      * @return String containing the authentication details in JSON format
      */
     fun toJSONString(): String {
-        return this.inner.toJson()
+        return this.toJson()
     }
 
     /**
@@ -387,13 +212,8 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      * @param publicKey Public key used to encrypt push payloads
      * @param authKey Auth key used to encrypt push payloads
      */
-    fun setDevicePushSubscription(endpoint: String, publicKey: String, authKey: String) {
-        try {
-            return this.inner.setPushSubscription(DevicePushSubscription(endpoint, publicKey, authKey))
-        } finally {
-            this.tryPersistState()
-        }
-    }
+    fun setDevicePushSubscription(endpoint: String, publicKey: String, authKey: String) =
+        this.setPushSubscription(DevicePushSubscription(endpoint, publicKey, authKey))
 
     /**
      * Update the display name (as shown in the FxA device manager, or the Send Tab target list)
@@ -403,68 +223,7 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      *
      * @param displayName The current device display name
      */
-    fun setDeviceDisplayName(displayName: String) {
-        try {
-            return this.inner.setDeviceName(displayName)
-        } finally {
-            this.tryPersistState()
-        }
-    }
-
-    /**
-     * Retrieves the list of the connected devices in the current account, including the current one.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     */
-    fun getDevices(ignoreCache: Boolean = false): Array<Device> {
-        return this.inner.getDevices(ignoreCache).toTypedArray()
-    }
-
-    /**
-     * Disconnect from the account and optionaly destroy our device record.
-     * `beginOAuthFlow` will need to be called to reconnect.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     */
-    fun disconnect() {
-        this.inner.disconnect()
-        this.tryPersistState()
-    }
-
-    /**
-     * Retrieves any pending commands for the current device.
-     * This should be called semi-regularly as the main method of commands delivery (push)
-     * can sometimes be unreliable on mobile devices.
-     * If a persist callback is set and the host application failed to process the
-     * returned account events, they will never be seen again.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     *
-     * @return A collection of [IncomingDeviceCommand] that should be handled by the caller.
-     */
-    fun pollDeviceCommands(): Array<IncomingDeviceCommand> {
-        try {
-            return this.inner.pollDeviceCommands().toTypedArray()
-        } finally {
-            this.tryPersistState()
-        }
-    }
-
-    /**
-     * Handle any incoming push message payload coming from the Firefox Accounts
-     * servers that has been decrypted and authenticated by the Push crate.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     *
-     * @return A collection of [AccountEvent] that should be handled by the caller.
-     */
-    fun handlePushMessage(payload: String): Array<AccountEvent> {
-        try {
-            return this.inner.handlePushMessage(payload).toTypedArray()
-        } finally {
-            this.tryPersistState()
-        }
-    }
+    fun setDeviceDisplayName(displayName: String) = setDeviceName(displayName)
 
     /**
      * Ensure the current device is registered with the specified name and device type, with
@@ -473,51 +232,11 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      *
      * This performs network requests, and should not be used on the main thread.
      */
-    fun initializeDevice(name: String, deviceType: DeviceType, supportedCapabilities: Set<DeviceCapability>) {
-        this.inner.initializeDevice(name, deviceType, supportedCapabilities.toList())
-        this.tryPersistState()
-    }
-
-    /**
-     * Ensure that the supported capabilities described earlier in `initializeDevice` are A-OK.
-     * A set of capabilities to be supported by the Device must also be passed (at this time only
-     * Send Tab).
-     *
-     * As for now there's only the Send Tab capability, so we ensure the command is registered with the server.
-     * This method should be called at least every time the sync keys change (because Send Tab relies on them).
-     *
-     * This performs network requests, and should not be used on the main thread.
-     */
-    fun ensureCapabilities(supportedCapabilities: Set<DeviceCapability>) {
-        this.inner.ensureCapabilities(supportedCapabilities.toList())
-        this.tryPersistState()
-    }
-
-    /**
-     * Send a single tab to another device identified by its device ID.
-     *
-     * This performs network requests, and should not be used on the main thread.
-     *
-     * @param targetDeviceId The target Device ID
-     * @param title The document title of the tab being sent
-     * @param url The url of the tab being sent
-     */
-    fun sendSingleTab(targetDeviceId: String, title: String, url: String) {
-        this.inner.sendSingleTab(targetDeviceId, title, url)
-    }
-
-    /**
-     * Gather any telemetry which has been collected internally and return
-     * the result as a JSON string.
-     *
-     * This does not make network requests, and can be used on the main thread.
-     */
-    fun gatherTelemetry(): String {
-        return this.inner.gatherTelemetry()
-    }
+    fun initializeDevice(name: String, deviceType: DeviceType, supportedCapabilities: Set<DeviceCapability>) =
+        this.initializeDevice(name, deviceType, supportedCapabilities.toList())
 
     @Synchronized
     override fun close() {
-        this.inner.destroy()
+        inner.destroy()
     }
 }

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -85,7 +85,10 @@ enum FxaError {
   "Other",
 };
 
-
+[Decorator]
+interface FxADecorator {
+    Any then_persists_state();
+};
 
 // Object representing the signed-in state of an application.
 //
@@ -94,6 +97,7 @@ enum FxaError {
 // user's Firefox Account, and provides methods for inspecting the state of the
 // account and accessing other services on behalf of the user.
 //
+[Decorator=FxADecorator]
 interface FirefoxAccount {
 
   // Create a new [`FirefoxAccount`] instance, not connected to any account.
@@ -228,7 +232,7 @@ interface FirefoxAccount {
   //   - `code` - the OAuth authorization code obtained from the redirect URI.
   //   - `state` - the OAuth state parameter obtained from the redirect URI.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   void complete_oauth_flow([ByRef] string code, [ByRef] string state );
   
 
@@ -257,6 +261,7 @@ interface FirefoxAccount {
   // the user to reconnnect to their account. If reconnecting to the same account
   // is not desired then the application should discard the persisted account state.
   //
+  [CallsWith=then_persists_state]
   void disconnect();
   
 
@@ -281,8 +286,8 @@ interface FirefoxAccount {
   //    - If there is no signed-in user, this method will throw an
   //      [`Authentication`](FxaError::Authentication) error.
   //
-  [Throws=FxaError]
-  Profile get_profile( boolean ignore_cache );
+  [Throws=FxaError, CallsWith=then_persists_state]
+  Profile get_profile(optional boolean ignore_cache = false);
   
 
   // Create a new device record for this application.
@@ -309,7 +314,7 @@ interface FirefoxAccount {
   //    - Device registration is only available to applications that have been
   //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   void initialize_device([ByRef] string name,  DeviceType device_type,  sequence<DeviceCapability> supported_capabilities );
   
 
@@ -345,8 +350,8 @@ interface FirefoxAccount {
   //    - Device metadata is only visible to applications that have been
   //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
   //
-  [Throws=FxaError]
-  sequence<Device> get_devices( boolean ignore_cache );
+  [Throws=FxaError, CallsWith=then_persists_state]
+  sequence<Device> get_devices( optional boolean ignore_cache = false);
   
 
   // Get the list of all client applications attached to the user's account.
@@ -384,7 +389,7 @@ interface FirefoxAccount {
   //    - Device registration is only available to applications that have been
   //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   void set_device_name([ByRef] string display_name );
   
 
@@ -427,7 +432,7 @@ interface FirefoxAccount {
   //    - Device registration is only available to applications that have been
   //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   void ensure_capabilities( sequence<DeviceCapability> supported_capabilities );
   
 
@@ -450,7 +455,7 @@ interface FirefoxAccount {
   //    - Device registration is only available to applications that have been
   //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   void set_push_subscription( DevicePushSubscription subscription );
   
 
@@ -465,7 +470,7 @@ interface FirefoxAccount {
   // accordingly and return a list of [`AccountEvent`] structs describing the events, which the application
   // may use for further processing.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   sequence<AccountEvent> handle_push_message([ByRef] string payload );
   
 
@@ -485,7 +490,7 @@ interface FirefoxAccount {
   //    - Device commands functionality is only available to applications that have been
   //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   sequence<IncomingDeviceCommand> poll_device_commands();
   
 
@@ -589,7 +594,7 @@ interface FirefoxAccount {
   //      token, it should call [`clear_access_token_cache`](FirefoxAccount::clear_access_token_cache)
   //      before requesting a fresh token.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   AccessTokenInfo get_access_token([ByRef] string scope,  i64? ttl );
   
 
@@ -626,7 +631,7 @@ interface FirefoxAccount {
   //
   //    - `session_token` - the new session token value provided from web content.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   void handle_session_token_change([ByRef] string session_token );
   
 
@@ -696,7 +701,7 @@ interface FirefoxAccount {
   //    - Use [is_in_migration_state](FirefoxAccount::is_in_migration_state) to check whether the
   //      persisted account state includes a a pending migration that can be retried.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   FxAMigrationResult migrate_from_session_token([ByRef] string session_token, [ByRef] string k_sync, [ByRef] string k_xcs,  boolean copy_session_token );
   
 
@@ -708,7 +713,7 @@ interface FirefoxAccount {
   // failed, it may have stored the provided state for retrying at a later time. Call this method
   // in order to execute such a retry.
   //
-  [Throws=FxaError]
+  [Throws=FxaError, CallsWith=then_persists_state]
   FxAMigrationResult retry_migrate_from_session_token();
   
 

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -12,9 +12,7 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import androidx.annotation.AnyThread
-import androidx.annotation.RawRes
 import androidx.annotation.VisibleForTesting
-import androidx.annotation.WorkerThread
 import androidx.core.content.pm.PackageInfoCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -28,9 +26,10 @@ import org.mozilla.experiments.nimbus.internal.EnrolledExperiment
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEvent
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEventType
 import org.mozilla.experiments.nimbus.internal.ExperimentBranch
-import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.mozilla.experiments.nimbus.internal.NimbusClient
+import org.mozilla.experiments.nimbus.internal.NimbusClientDecorator
 import org.mozilla.experiments.nimbus.internal.NimbusClientInterface
+import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.mozilla.experiments.nimbus.internal.RemoteSettingsConfig
 import java.io.File
 
@@ -46,165 +45,10 @@ typealias EnrolledExperiment = EnrolledExperiment
  * This is the main experiments API, which is exposed through the global [Nimbus] object.
  */
 interface NimbusInterface {
-    /**
-     * Get the list of currently enrolled experiments
-     *
-     * @return A list of [EnrolledExperiment]s
-     */
-    fun getActiveExperiments(): List<EnrolledExperiment> = listOf()
+    fun getVariables(featureId: String, recordExposureEvent: Boolean = true): Variables =
+        NullVariables.instance
 
-    /**
-     * Get the list of available experiments
-     *
-     * @return A list of [AvailableExperiment]s
-     */
-    fun getAvailableExperiments(): List<AvailableExperiment> = listOf()
-
-    /**
-     * Get the currently enrolled branch for the given experiment
-     *
-     * @param experimentId The string experiment-id or "slug" for which to retrieve the branch
-     *
-     * @return A String representing the branch-id or "slug"
-     */
-    @AnyThread
-    fun getExperimentBranch(experimentId: String): String? = null
-
-    /**
-     * Get the list of experiment branches for the given experiment
-     *
-     * @param experimentId The string experiment-id or "slug" for which to retrieve the branch
-     *
-     * @return A list of [Branch]s
-     */
-    fun getExperimentBranches(experimentId: String): List<Branch>? = listOf()
-
-    /**
-     * Get the variables needed to configure the feature given by `featureId`.
-     *
-     * @param featureId The string feature id that identifies to the feature under experiment.
-     *
-     * @param recordExposureEvent Passing `true` to this parameter will record the exposure event
-     *      automatically if the client is enrolled in an experiment for the given [featureId].
-     *      Passing `false` here indicates that the application will manually record the exposure
-     *      event by calling the `recordExposureEvent` function at the time of the exposure to the
-     *      feature.
-     *
-     * See [recordExposureEvent] for more information on manually recording the event.
-     *
-     * @return a [Variables] object used to configure the feature.
-     */
-    @AnyThread
-    fun getVariables(featureId: String, recordExposureEvent: Boolean = true): Variables = NullVariables.instance
-
-    /**
-     * Open the database and populate the SDK so as make it usable by feature developers.
-     *
-     * This performs the minimum amount of I/O needed to ensure `getExperimentBranch()` is usable.
-     *
-     * It will not take in to consideration previously fetched experiments: `applyPendingExperiments()`
-     * is more suitable for that use case.
-     *
-     * This method uses the single threaded worker scope, so callers can safely sequence calls to
-     * `initialize` and `setExperimentsLocally`, `applyPendingExperiments`.
-     */
-    fun initialize() = Unit
-
-    /**
-     * Fetches experiments from the RemoteSettings server.
-     *
-     * This is performed on a background thread.
-     *
-     * Notifies `onExperimentsFetched` to observers once the experiments has been fetched from the
-     * server.
-     *
-     * Notes:
-     * * this does not affect experiment enrolment, until `applyPendingExperiments` is called.
-     * * this will overwrite pending experiments previously fetched with this method, or set with
-     *   `setExperimentsLocally`.
-     */
-    fun fetchExperiments() = Unit
-
-    /**
-     * Calculates the experiment enrolment from experiments from the last `fetchExperiments` or
-     * `setExperimentsLocally`, and then informs Glean of new experiment enrolment.
-     *
-     * Notifies `onUpdatesApplied` once enrolments are recalculated.
-     */
-    fun applyPendingExperiments() = Unit
-
-    /**
-     * Set the experiments as the passed string, just as `fetchExperiments` gets the string from
-     * the server. Like `fetchExperiments`, this requires `applyPendingExperiments` to be called
-     * before enrolments are affected.
-     *
-     * The string should be in the same JSON format that is delivered from the server.
-     *
-     * This is performed on a background thread.
-     */
-    fun setExperimentsLocally(payload: String) = Unit
-
-    /**
-     * A utility method to load a file from resources and pass it to `setExperimentsLocally(String)`.
-     */
-    fun setExperimentsLocally(@RawRes file: Int) = Unit
-
-    /**
-     * Opt into a specific branch for the given experiment.
-     *
-     * @param experimentId The string experiment-id or "slug" for which to opt into
-     * @param branch The string branch slug for which to opt into
-     */
-    fun optInWithBranch(experimentId: String, branch: String) = Unit
-
-    /**
-     * Opt out of a specific experiment
-     *
-     * @param experimentId The string experiment-id or "slug" for which to opt out of
-     */
-    fun optOut(experimentId: String) = Unit
-
-    /**
-     *  Reset internal state in response to application-level telemetry reset.
-     *  Consumers should call this method when the user resets the telemetry state of the
-     *  consuming application, such as by opting out of (or in to) submitting telemetry.
-     */
-    fun resetTelemetryIdentifiers() = Unit
-
-    /**
-     * Records the `exposure` event in telemetry.
-     *
-     * This is a manual function to accomplish the same purpose as passing `true` as the
-     * `recordExposureEvent` property of the [getVariables] function. It is intended to be used
-     * when requesting feature variables must occur at a different time than the actual user's
-     * exposure to the feature within the app.
-     *
-     * Examples:
-     * * If the [Variables] are needed at a different time than when the exposure to the feature
-     *   actually happens, such as constructing a menu happening at a different time than the user
-     *   seeing the menu.
-     * * If [getVariables] is required to be called multiple times for the same feature and it is
-     *   desired to only record the exposure once, such as if [getVariables] were called with every
-     *   keystroke.
-     *
-     * In the case where the use of this function is required, then the [getVariables] function
-     * should be called with `false` so that the exposure event is not recorded when the variables
-     * are fetched.
-     *
-     * This function is safe to call even when there is no active experiment for the feature. The SDK
-     * will ensure that an event is only recorded for active experiments.
-     *
-     * @param featureId string representing the id of the feature for which to record the exposure
-     *     event.
-     */
     fun recordExposureEvent(featureId: String) = Unit
-
-    /**
-     * Control the opt out for all experiments at once. This is likely a user action.
-     */
-    var globalUserParticipation: Boolean
-        get() = false
-        set(_) = Unit
 
     /**
      * Interface to be implemented by classes that want to observe experiment updates
@@ -287,248 +131,88 @@ class NimbusDelegate(
     val logger: LoggerFunction
 )
 
-/**
- * A implementation of the [NimbusInterface] interface backed by the Nimbus SDK.
- */
-@Suppress("LargeClass", "LongParameterList")
-open class Nimbus(
-    private val context: Context,
-    appInfo: NimbusAppInfo,
-    server: NimbusServerSettings?,
-    deviceInfo: NimbusDeviceInfo,
-    private val observer: NimbusInterface.Observer? = null,
-    delegate: NimbusDelegate
-) : NimbusInterface {
-    // An I/O scope is used for reading or writing from the Nimbus's RKV database.
-    private val dbScope: CoroutineScope = delegate.dbScope
-
-    // An I/O scope is used for getting experiments from the network.
-    private val fetchScope: CoroutineScope = delegate.fetchScope
-
-    private val errorReporter = delegate.errorReporter
-
-    private val logger = delegate.logger
-
-    private val nimbusClient: NimbusClientInterface
-
-    override var globalUserParticipation: Boolean
-        get() = nimbusClient.getGlobalUserParticipation()
-        set(active) {
-            dbScope.launch {
-                setGlobalUserParticipationOnThisThread(active)
+class NimbusDecorator(
+    private val delegate: NimbusDelegate,
+    private val observer: NimbusInterface.Observer? = null
+) : NimbusClientDecorator<NimbusClient> {
+    override fun <ReturnType> withCatchAll(obj: NimbusClient, thunk: () -> ReturnType) = try {
+        thunk()
+    } catch (e: Throwable) {
+        if (e !is NimbusException.DatabaseNotReady) {
+            try {
+                delegate.errorReporter("Error in Nimbus Rust", e)
+            } catch (e1: Throwable) {
+                delegate.logger("Exception calling rust: $e")
+                delegate.logger("Exception reporting the exception: $e1")
             }
         }
-
-    init {
-        // Set the name of the native library so that we use
-        // the appservices megazord for compiled code.
-        System.setProperty(
-            "uniffi.component.nimbus.libraryOverride",
-            System.getProperty("mozilla.appservices.megazord.library", "megazord")
-        )
-        // Build a File object to represent the data directory for Nimbus data
-        val dataDir = File(context.applicationInfo.dataDir, NIMBUS_DATA_DIR)
-
-        // Build Nimbus AppContext object to pass into initialize
-        val experimentContext = buildExperimentContext(context, appInfo, deviceInfo)
-
-        // Initialize Nimbus
-        val remoteSettingsConfig = server?.let {
-            RemoteSettingsConfig(
-                serverUrl = it.url.toString(),
-                collectionName = it.collection
-            )
-        }
-
-        nimbusClient = NimbusClient(
-            experimentContext,
-            dataDir.path,
-            remoteSettingsConfig,
-            // The "dummy" field here is required for obscure reasons when generating code on desktop,
-            // so we just automatically set it to a dummy value.
-            AvailableRandomizationUnits(clientId = null, dummy = 0)
-        )
+        null
     }
 
-    // This is currently not available from the main thread.
-    // see https://jira.mozilla.com/browse/SDK-191
-    @WorkerThread
-    override fun getActiveExperiments(): List<EnrolledExperiment> = withCatchAll {
-        nimbusClient.getActiveExperiments()
-    } ?: emptyList()
-
-    @WorkerThread
-    override fun getAvailableExperiments(): List<AvailableExperiment> = withCatchAll {
-        nimbusClient.getAvailableExperiments()
-    } ?: emptyList()
-
-    @AnyThread
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun getFeatureConfigVariablesJson(featureId: String) =
-        withCatchAll {
-            nimbusClient.getFeatureConfigVariables(featureId)?.let { JSONObject(it) }
-        }
-
-    override fun getExperimentBranch(experimentId: String): String? = withCatchAll {
-        nimbusClient.getExperimentBranch(experimentId)
-    }
-
-    override fun getVariables(featureId: String, recordExposureEvent: Boolean): Variables =
-        getFeatureConfigVariablesJson(featureId)?.let { json ->
-            if (recordExposureEvent) {
-                recordExposure(featureId)
-            }
-            JSONVariables(context, json)
-        }
-        ?: NullVariables.instance
-
-    @WorkerThread
-    override fun getExperimentBranches(experimentId: String): List<Branch>? = withCatchAll {
-        nimbusClient.getExperimentBranches(experimentId)
-    }
-
-    // Method and apparatus to catch any uncaught exceptions
-    @SuppressWarnings("TooGenericExceptionCaught")
-    private fun <R> withCatchAll(thunk: () -> R) =
-        try {
-            thunk()
-        } catch (e: Throwable) {
-            if (e !is NimbusException.DatabaseNotReady) {
-                try {
-                    errorReporter("Error in Nimbus Rust", e)
-                } catch (e1: Throwable) {
-                    logger("Exception calling rust: $e")
-                    logger("Exception reporting the exception: $e1")
-                }
-            }
-            null
-        }
-
-    override fun initialize() {
-        dbScope.launch {
-            initializeOnThisThread()
-        }
-    }
-
-    @WorkerThread
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun initializeOnThisThread() = withCatchAll {
-        nimbusClient.initialize()
-    }
-
-    override fun fetchExperiments() {
-        fetchScope.launch {
-            fetchExperimentsOnThisThread()
-        }
-    }
-
-    @WorkerThread
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun fetchExperimentsOnThisThread() = withCatchAll {
-        try {
-            nimbusClient.fetchExperiments()
+    override fun <ReturnType> onNetworkThread(obj: NimbusClient, thunk: () -> ReturnType) {
+        delegate.fetchScope.launch {
+            withCatchAll(obj, thunk)
             observer?.onExperimentsFetched()
-        } catch (e: NimbusException.RequestException) {
-            errorReporter("Error fetching experiments from endpoint", e)
-        } catch (e: NimbusException.ResponseException) {
-            errorReporter("Error fetching experiments from endpoint", e)
         }
     }
 
-    override fun applyPendingExperiments() {
-        dbScope.launch {
-            applyPendingExperimentsOnThisThread()
+    override fun <ReturnType> onDbThread(obj: NimbusClient, thunk: () -> ReturnType) {
+        delegate.dbScope.launch {
+            withCatchAll(obj, thunk)
         }
     }
 
-    @WorkerThread
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun applyPendingExperimentsOnThisThread() = withCatchAll {
-        try {
-            nimbusClient.applyPendingExperiments().also(::recordExperimentTelemetryEvents)
-            // Get the experiments to record in telemetry
-            postEnrolmentCalculation()
-        } catch (e: NimbusException.InvalidExperimentFormat) {
-            errorReporter("Invalid experiment format", e)
-        }
-    }
-
-    @WorkerThread
-    private fun postEnrolmentCalculation() {
-        nimbusClient.getActiveExperiments().let {
-            recordExperimentTelemetry(it)
-            observer?.onUpdatesApplied(it)
-        }
-    }
-
-    override fun setExperimentsLocally(@RawRes file: Int) {
-        dbScope.launch {
-            withCatchAll {
-                context.resources.openRawResource(file).use {
-                    it.bufferedReader().readText()
+    override fun <ReturnType> onEnrollmentChanges(obj: NimbusClient, thunk: () -> ReturnType) {
+        onDbThread(obj) {
+            withCatchAll(obj) {
+                val result = thunk()
+                if (result is List<*>) {
+                    val events = result.filterIsInstance<EnrollmentChangeEvent>()
+                    recordExperimentTelemetryEvents(events)
                 }
-            }?.let { payload ->
-                setExperimentsLocallyOnThisThread(payload)
-            }
-        }
-    }
-
-    override fun setExperimentsLocally(payload: String) {
-        dbScope.launch {
-            setExperimentsLocallyOnThisThread(payload)
-        }
-    }
-
-    @WorkerThread
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun setExperimentsLocallyOnThisThread(payload: String) = withCatchAll {
-        nimbusClient.setExperimentsLocally(payload)
-    }
-
-    @WorkerThread
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun setGlobalUserParticipationOnThisThread(active: Boolean) = withCatchAll {
-        val enrolmentChanges = nimbusClient.setGlobalUserParticipation(active)
-        if (enrolmentChanges.isNotEmpty()) {
-            postEnrolmentCalculation()
-        }
-    }
-
-    override fun optOut(experimentId: String) {
-        dbScope.launch {
-            withCatchAll {
-                nimbusClient.optOut(experimentId).also(::recordExperimentTelemetryEvents)
-            }
-        }
-    }
-
-    override fun resetTelemetryIdentifiers() {
-        // The "dummy" field here is required for obscure reasons when generating code on desktop,
-        // so we just automatically set it to a dummy value.
-        val aru = AvailableRandomizationUnits(clientId = null, dummy = 0)
-        dbScope.launch {
-            withCatchAll {
-                nimbusClient.resetTelemetryIdentifiers(aru).also { enrollmentChangeEvents ->
-                    recordExperimentTelemetryEvents(enrollmentChangeEvents)
+                obj.getActiveExperiments()?.let {
+                    recordExperimentTelemetry(it)
+                    observer?.onUpdatesApplied(it)
                 }
             }
         }
     }
 
-    override fun optInWithBranch(experimentId: String, branch: String) {
-        dbScope.launch {
-            withCatchAll {
-                nimbusClient.optInWithBranch(experimentId, branch).also(::recordExperimentTelemetryEvents)
+    fun recordExperimentTelemetryEvents(enrollmentChangeEvents: List<EnrollmentChangeEvent>) {
+        enrollmentChangeEvents.forEach { event ->
+            when (event.change) {
+                EnrollmentChangeEventType.ENROLLMENT -> {
+                    NimbusEvents.enrollment.record(
+                        NimbusEvents.EnrollmentExtra(
+                            experiment = event.experimentSlug,
+                            branch = event.branchSlug,
+                            enrollmentId = event.enrollmentId
+                        )
+                    )
+                }
+                EnrollmentChangeEventType.DISQUALIFICATION -> {
+                    NimbusEvents.disqualification.record(
+                        NimbusEvents.DisqualificationExtra(
+                            experiment = event.experimentSlug,
+                            branch = event.branchSlug,
+                            enrollmentId = event.enrollmentId
+                        )
+                    )
+                }
+                EnrollmentChangeEventType.UNENROLLMENT -> {
+                    NimbusEvents.unenrollment.record(
+                        NimbusEvents.UnenrollmentExtra(
+                            experiment = event.experimentSlug,
+                            branch = event.branchSlug,
+                            enrollmentId = event.enrollmentId
+                        )
+                    )
+                }
             }
         }
     }
 
-    override fun recordExposureEvent(featureId: String) {
-        recordExposure(featureId)
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun recordExperimentTelemetry(experiments: List<EnrolledExperiment>) {
+    fun recordExperimentTelemetry(experiments: List<EnrolledExperiment>) {
         // Call Glean.setExperimentActive() for each active experiment.
         experiments.forEach { experiment ->
             // For now, we will just record the experiment id and the branch id. Once we can call
@@ -540,84 +224,116 @@ open class Nimbus(
             )
         }
     }
+}
 
+/**
+ * A implementation of the [NimbusInterface] interface backed by the Nimbus SDK.
+ */
+class Nimbus private constructor(private val context: Context, nimbusClient: NimbusClient) :
+    NimbusInterface, NimbusClientInterface by nimbusClient {
+    constructor(
+        context: Context,
+        decorator: NimbusClientDecorator<NimbusClient>,
+        appInfo: NimbusAppInfo,
+        server: NimbusServerSettings?,
+        deviceInfo: NimbusDeviceInfo
+    ) : this(
+        context,
+        NimbusClient(
+            nimbusClientDecorator = decorator,
+            appCtx = buildExperimentContext(context, appInfo, deviceInfo),
+            dbpath = File(context.applicationInfo.dataDir, NIMBUS_DATA_DIR).path,
+            remoteSettingsConfig = server?.let {
+                RemoteSettingsConfig(
+                    serverUrl = it.url.toString(),
+                    collectionName = it.collection
+                )
+            },
+            availableRandomizationUnits = AvailableRandomizationUnits(clientId = null, dummy = 0)
+        )
+    )
+
+    constructor(
+        context: Context,
+        appInfo: NimbusAppInfo,
+        server: NimbusServerSettings?,
+        deviceInfo: NimbusDeviceInfo,
+        observer: NimbusInterface.Observer? = null,
+        delegate: NimbusDelegate
+    ) : this(
+        context,
+        NimbusDecorator(delegate, observer),
+        appInfo,
+        server,
+        deviceInfo
+    )
+
+    @AnyThread
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun recordExperimentTelemetryEvents(enrollmentChangeEvents: List<EnrollmentChangeEvent>) {
-        enrollmentChangeEvents.forEach { event ->
-            when (event.change) {
-                EnrollmentChangeEventType.ENROLLMENT -> {
-                    NimbusEvents.enrollment.record(NimbusEvents.EnrollmentExtra(
-                        experiment = event.experimentSlug,
-                        branch = event.branchSlug,
-                        enrollmentId = event.enrollmentId
-                    ))
-                }
-                EnrollmentChangeEventType.DISQUALIFICATION -> {
-                    NimbusEvents.disqualification.record(NimbusEvents.DisqualificationExtra(
-                        experiment = event.experimentSlug,
-                        branch = event.branchSlug,
-                        enrollmentId = event.enrollmentId
-                    ))
-                }
-                EnrollmentChangeEventType.UNENROLLMENT -> {
-                    NimbusEvents.unenrollment.record(NimbusEvents.UnenrollmentExtra(
-                        experiment = event.experimentSlug,
-                        branch = event.branchSlug,
-                        enrollmentId = event.enrollmentId
-                    ))
-                }
+    internal fun getFeatureConfigVariablesJson(featureId: String) =
+        getFeatureConfigVariables(featureId)?.let { JSONObject(it) }
+
+    override fun getVariables(featureId: String, recordExposureEvent: Boolean): Variables =
+        getFeatureConfigVariablesJson(featureId)?.let { json ->
+            if (recordExposureEvent) {
+                recordExposureEvent(featureId)
             }
+            JSONVariables(context, json)
         }
-    }
+            ?: NullVariables.instance
 
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun recordExposure(featureId: String) {
-        dbScope.launch {
-            recordExposureOnThisThread(featureId)
-        }
-    }
-
-    // The exposure event should be recorded when the expected treatment (or no-treatment, such as
-    // for a "control" branch) is applied or shown to the user.
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    @WorkerThread
-    internal fun recordExposureOnThisThread(featureId: String) = withCatchAll {
+    override fun recordExposureEvent(featureId: String) {
         val activeExperiments = getActiveExperiments()
-        activeExperiments.find { it.featureIds.contains(featureId) }?.also { experiment ->
-            NimbusEvents.exposure.record(NimbusEvents.ExposureExtra(
-                experiment = experiment.slug,
-                branch = experiment.branchSlug,
-                enrollmentId = experiment.enrollmentId
-            ))
+        activeExperiments?.find { it.featureIds.contains(featureId) }?.also { experiment ->
+            NimbusEvents.exposure.record(
+                NimbusEvents.ExposureExtra(
+                    experiment = experiment.slug,
+                    branch = experiment.branchSlug,
+                    enrollmentId = experiment.enrollmentId
+                )
+            )
         }
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun buildExperimentContext(context: Context, appInfo: NimbusAppInfo, deviceInfo: NimbusDeviceInfo): AppContext {
-        val packageInfo: PackageInfo? = try {
-            context.packageManager.getPackageInfo(
-                context.packageName, 0
+    companion object {
+        init {
+            System.setProperty(
+                "uniffi.component.nimbus.libraryOverride",
+                System.getProperty("mozilla.appservices.megazord.library", "megazord")
             )
-        } catch (e: PackageManager.NameNotFoundException) {
-            null
         }
 
-        return AppContext(
-            appId = context.packageName,
-            appName = appInfo.appName,
-            channel = appInfo.channel,
-            androidSdkVersion = Build.VERSION.SDK_INT.toString(),
-            appBuild = packageInfo?.let { PackageInfoCompat.getLongVersionCode(it).toString() },
-            appVersion = packageInfo?.versionName,
-            architecture = Build.SUPPORTED_ABIS[0],
-            debugTag = null,
-            deviceManufacturer = Build.MANUFACTURER,
-            deviceModel = Build.MODEL,
-            locale = deviceInfo.localeTag,
-            os = "Android",
-            osVersion = Build.VERSION.RELEASE,
-            installationDate = packageInfo?.firstInstallTime,
-            homeDirectory = context.applicationInfo?.dataDir,
-            customTargetingAttributes = appInfo.customTargetingAttributes)
+        internal fun buildExperimentContext(
+            context: Context,
+            appInfo: NimbusAppInfo,
+            deviceInfo: NimbusDeviceInfo
+        ): AppContext {
+            val packageInfo: PackageInfo? = try {
+                context.packageManager.getPackageInfo(
+                    context.packageName, 0
+                )
+            } catch (e: PackageManager.NameNotFoundException) {
+                null
+            }
+
+            return AppContext(
+                appId = context.packageName,
+                appName = appInfo.appName,
+                channel = appInfo.channel,
+                androidSdkVersion = Build.VERSION.SDK_INT.toString(),
+                appBuild = packageInfo?.let { PackageInfoCompat.getLongVersionCode(it).toString() },
+                appVersion = packageInfo?.versionName,
+                architecture = Build.SUPPORTED_ABIS[0],
+                debugTag = null,
+                deviceManufacturer = Build.MANUFACTURER,
+                deviceModel = Build.MODEL,
+                locale = deviceInfo.localeTag,
+                os = "Android",
+                osVersion = Build.VERSION.RELEASE,
+                installationDate = packageInfo?.firstInstallTime,
+                homeDirectory = context.applicationInfo?.dataDir,
+                customTargetingAttributes = appInfo.customTargetingAttributes
+            )
+        }
     }
 }

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -13,7 +13,7 @@ dictionary AppContext {
     string? os_version;
     string? android_sdk_version;
     string? debug_tag;
-    // Note that installation date is 
+    // Note that installation date is
     // the unix time, which is milliseconds since epoch
     i64? installation_date;
     string? home_directory;
@@ -79,6 +79,25 @@ enum NimbusError {
     "DatabaseNotReady",
 };
 
+[Decorator]
+interface NimbusClientDecorator {
+    // Calls the passed method, swallowing any errors. If an error
+    // is detected, nil is returned.
+    Any? with_catch_all();
+    // Calls the passed method on a thread used for accessing the network.
+    // on_experiments_fetched observers will be notified.
+    void on_network_thread();
+    // Calls the passed method on a thread for accessing the database.
+    // Any access to the database should be done via this method.
+    void on_db_thread();
+    // Calls the passed method and then processes the resulting changes,
+    // if the return value is sequence<EnrollmentChangeEvent>.
+    // This should be done on the db thread.
+    // on_experiments_applied observers will be notified.
+    void on_enrollment_changes();
+};
+
+[Decorator=NimbusClientDecorator]
 interface NimbusClient {
     [Throws=NimbusError]
     constructor(
@@ -96,7 +115,7 @@ interface NimbusClient {
     // so that the consuming application can have confidence the non-blocking
     // functions will return data instead of returning an error, and will do
     // the minimum amount of work to achieve that.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=on_db_thread]
     void initialize();
 
     // Returns the branch allocated for a given feature_id or experiment_slug.
@@ -104,23 +123,23 @@ interface NimbusClient {
     // the first hit. If the user is enrolled neither in an experiment with id
     // as the feature_id nor with id as the experiment_slug for the feature,
     // null is returned.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=with_catch_all]
     string? get_experiment_branch(string id);
 
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=with_catch_all]
     string? get_feature_config_variables(string feature_id);
 
     // Returns a list of experiment branches for a given experiment ID.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=with_catch_all]
     sequence<ExperimentBranch> get_experiment_branches(string experiment_slug);
 
     // Returns a list of experiments this user is enrolled in.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=with_catch_all]
     sequence<EnrolledExperiment> get_active_experiments();
 
     // Returns a list of experiments for this `app_name`, as specified in the `AppContext`.
     // It is not intended to be used to be used for user facing applications.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=with_catch_all]
     sequence<AvailableExperiment> get_available_experiments();
 
     // Getter and setter for user's participation in all experiments.
@@ -130,32 +149,32 @@ interface NimbusClient {
     [Throws=NimbusError]
     boolean get_global_user_participation();
 
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=on_enrollment_changes]
     sequence<EnrollmentChangeEvent> set_global_user_participation(boolean opt_in);
 
     // Updates the list of experiments from the server.
     // This method is deprecated, in favour of calling `fetch_experiments()` and then
     // `apply_pending_updates()`.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=on_enrollment_changes]
     sequence<EnrollmentChangeEvent> update_experiments();
 
     // Fetches the list of experiments from the server. This does not affect the list
     // of active experiments or experiment enrolment.
     // Fetched experiments are not applied until `apply_pending_updates()` is called.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=on_network_thread]
     void fetch_experiments();
 
     // Apply the updated experiments from the last fetch.
     // After calling this, the list of active experiments might change
     // (there might be new experiments, or old experiments might have expired).
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=on_enrollment_changes]
     sequence<EnrollmentChangeEvent> apply_pending_experiments();
 
     // A convenience method for apps to set the experiments from a local source
     // for either testing, or before the first fetch has finished.
-    // 
+    //
     // Experiments set with this method are not applied until `apply_pending_updates()` is called.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=on_db_thread]
     void set_experiments_locally(string experiments_json);
 
     // These are test-only functions and should never be exposed to production
@@ -163,11 +182,11 @@ interface NimbusClient {
 
     // Opt in to a specific branch on a specific experiment. Useful for
     // developers to test their app's interaction with the experiment.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=on_enrollment_changes]
     sequence<EnrollmentChangeEvent> opt_in_with_branch(string experiment_slug, string branch);
 
     // Opt out of a specific experiment.
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=on_enrollment_changes]
     sequence<EnrollmentChangeEvent> opt_out(string experiment_slug);
 
     // Reset internal state in response to application-level telemetry reset.
@@ -184,6 +203,6 @@ interface NimbusClient {
     //    * disqualifying this client out of any active experiments, to avoid submitting
     //      misleading incomplete data.
     //
-    [Throws=NimbusError]
+    [Throws=NimbusError, CallsWith=on_enrollment_changes]
     sequence<EnrollmentChangeEvent> reset_telemetry_identifiers(AvailableRandomizationUnits new_randomization_units);
 };


### PR DESCRIPTION
Draft.

This is an implementation of Nimbus.kt with the [proposed Uniffi decorators][1].

Many `Nimbus` method calls go through the `NimbusClientDecorator`, and almost all the methods which were forwarding to the `NimbusClient` have now disappeared.

It is for illustrative and exploratory purposes only at this time.

I will self-review to highlight what I learned in the process of doing it.

[1]: https://github.com/mozilla/uniffi-rs/pull/1051



### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.