### PR TITLE
Fixes nimbus installation date on iOS (#4597)

### DIFF
--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -67,6 +67,17 @@ public extension Nimbus {
         device: UIDevice = .current
     ) -> AppContext {
         let info = bundle.infoDictionary ?? [:]
+        var inferredDateInstalledOn: Date? {
+            guard
+                let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last,
+                let attributes = try? FileManager.default.attributesOfItem(atPath: documentsURL.path)
+            else { return nil }
+            return attributes[.creationDate] as? Date
+        }
+        let installationDateSinceEpoch = inferredDateInstalledOn.map {
+            Int64(($0.timeIntervalSince1970 * 1000).rounded())
+        }
+
         return AppContext(
             appName: appSettings.appName,
             appId: info["CFBundleIdentifier"] as? String ?? "unknown",
@@ -81,8 +92,8 @@ public extension Nimbus {
             osVersion: device.systemVersion,
             androidSdkVersion: nil,
             debugTag: "Nimbus.rs",
-            installationDate: nil,
-            homeDirectory: NSHomeDirectory(),
+            installationDate: installationDateSinceEpoch,
+            homeDirectory: nil,
             customTargetingAttributes: appSettings.customTargetingAttributes
         )
     }


### PR DESCRIPTION
Adds the fix we just merged to `main` onto the `release-v85` branch, so we can cut `v85.4.2`

Note that the `check-dependencies` will probably fail, but that should be OK the fix is already in main
