### PR TITLE
Merges back releases v85.4.2 and v86.0.1 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@
     See [the Glean Changelog](https://github.com/mozilla/glean/blob/v42.0.1/CHANGELOG.md) for full details.
     (Note there is a breaking change in Rust, but that doesn't impact consumers of Application Services)
 
+# v86.0.1 (_2021-10-28_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v86.0.0...v86.0.1)
+## Logins
+### What's Changed
+- Downgraded the log level of some logs, so now they should not show up in Sentry.
+
+
 # v86.0.0 (_2021-10-13_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v85.4.1...v86.0.0)


### PR DESCRIPTION
Adds back the changelog from `release-v85` and `release-v86.0`, wasn't sure if this should be up top since it's the "latest" release, or if it should be where I put it, because it's the chronological order.. this seemed a little more like it 🤷 
