### PR TITLE
Ignore clap yaml-rust advisory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,11 @@ commands:
             #                       fix this: https://github.com/chronotope/chrono/pull/578
             #                       note that both the Nimbus-SDK and glean use chrono, so if we would like to move away from it, both projects
             #                       need to do that before we can remove the ignores (assuming `chrono` doesn't release a fixed version)
-            cargo audit --ignore RUSTSEC-2021-0019 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071
+            #  * RUSTSEC-2018-0006: Uncontrolled recursion in `yaml-rust`, which is included by `clap` v2. `clap` itself already updated to a safe
+            #                       version of `yaml-rust`, which will be released in `v3` and additionally, 
+            #                       reading https://github.com/rustsec/advisory-db/issues/288, this is a false
+            #                       positive for clap and based on our dependency tree, we only use `yaml-rust` in `clap`.
+            cargo audit --ignore RUSTSEC-2021-0019 --ignore RUSTSEC-2020-0159 --ignore RUSTSEC-2020-0071 --ignore RUSTSEC-2018-0006
       - run:
           name: Check for any unrecorded changes in our dependency trees
           command: |

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -506,11 +506,11 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>MIT License: nom</name>
-    <url>https://github.com/Geal/nom/blob/master/LICENSE</url>
+    <url>https://github.com/Geal/nom/blob/main/LICENSE</url>
   </license>
   <license>
     <name>MIT License: nom</name>
-    <url>https://github.com/Geal/nom/blob/master/LICENSE</url>
+    <url>https://github.com/Geal/nom/blob/main/LICENSE</url>
   </license>
   <license>
     <name>MIT License: ordered-float</name>

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -102,7 +102,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: cc</name>
-    <url>https://github.com/alexcrichton/cc-rs/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/alexcrichton/cc-rs/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: cfg-if</name>


### PR DESCRIPTION
Our dependency advisory CI is failing again... I'm starting to question how useful of a check this is in practice, as opposed to a different advisory checking strategy..

An alternative I'm thinking of:
- When an advisory is detected (we can run a chron job for this, github actions maybe?) that we are impacted by, it creates an issue for it. If one is already created, it's ignored
- When anyone adds a new dependency, the normal "check-dependencies" job runs, we can probably add filters or something to circle CI to only run that job if `Cargo.toml`s are changed

Anyhoo, I'll create an issue for that, in the meantime:
https://github.com/mozilla/application-services/pull/4604 added a `yaml` feature for clap, clap `2.33` uses a version of `yaml-rust` that has an advisory out. Based on https://github.com/clap-rs/clap/issues/1569 it's a false positive for clap and can be safely ignored. Once clap v3 is out, we can upgrade and we'll get the new version of `yaml-rust` for free, and thus we can remove the ignore