### PR TITLE
Cut release v86.1.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 86.0.0
+libraryVersion: 86.1.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# v86.1.0 (_2021-10-27_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v86.0.0...v86.1.0)
+
+## ⛅️🔬🔭 Nimbus
+
+### What's New
+
+  - Rollouts: allows winning branch promotion and targeting rollouts of features. [#4567](https://github.com/mozilla/application-services/pull/4567).
+    - for both Android and iOS.
+
+### What's fixed
+  - Fixed a bug in iOS where the installation date would be set to start of EPOCH ([#4597](https://github.com/mozilla/application-services/pull/4597))
+  - Fixed a bug in Android where we were missing disqualification events after a global opt-out ([#4606](https://github.com/mozilla/application-services/pull/4606))
+
+## Push
+
+  - We've changed how the push database is opened, which should mean we now automatically handle
+    some kinds of database corruption.
+
+## General
+### What's changed
+  - The bundled version of Glean has been updated to v42.0.1.
+    See [the Glean Changelog](https://github.com/mozilla/glean/blob/v42.0.1/CHANGELOG.md) for full details.
+    (Note there is a breaking change in Rust, but that doesn't impact consumers of Application Services)
+
 # v86.0.0 (_2021-10-13_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v85.4.1...v86.0.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v86.0.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v86.1.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,21 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-
-## ⛅️🔬🔭 Nimbus
-
-### What's New
-
-  - Rollouts: allows winning branch promotion and targeting rollouts of features. [#4567](https://github.com/mozilla/application-services/pull/4567).
-    - for both Android and iOS.
-
-## Push
-
-  - We've changed how the push database is opened, which should mean we now automatically handle
-    some kinds of database corruption.
-
-## General
-### ⚠️ Breaking Changes ⚠️
-
-  - The bundled version of Glean has been updated to v42.0.1.
-    See [the Glean Changelog](https://github.com/mozilla/glean/blob/v42.0.1/CHANGELOG.md) for full details.


### PR DESCRIPTION
Cuts v86.1.0

Changelog rendered:
# v86.1.0 (_2021-10-27_)

[Full Changelog](https://github.com/mozilla/application-services/compare/v86.0.0...v86.1.0)

## ⛅️🔬🔭 Nimbus

### What's New

  - Rollouts: allows winning branch promotion and targeting rollouts of features. [#4567](https://github.com/mozilla/application-services/pull/4567).
    - for both Android and iOS.

### What's fixed
  - Fixed a bug in iOS where the installation date would be set to start of EPOCH ([#4597](https://github.com/mozilla/application-services/pull/4597))
  - Fixed a bug in Android where we were missing disqualification events after a global opt-out ([#4606](https://github.com/mozilla/application-services/pull/4606))

## Push

  - We've changed how the push database is opened, which should mean we now automatically handle
    some kinds of database corruption.