### PR TITLE
Lower invalid login log level

### DIFF
--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -222,7 +222,7 @@ impl From<Error> for LoginsStorageError {
                 LoginsStorageError::NoSuchRecord(label)
             }
             ErrorKind::InvalidLogin(desc) => {
-                log::error!("Invalid login: {}", desc);
+                log::warn!("Invalid login: {}", desc);
                 match desc {
                     InvalidLogin::EmptyOrigin => {
                         LoginsStorageError::InvalidRecord(label, InvalidLoginReason::EmptyOrigin)


### PR DESCRIPTION
Cherry picks the lower invalid log level for login into release v86.0

note that typically, this would be merging into a release branch called `release-v86`, but we already cut `v86.1.0`, so it wouldn't make sense to put this on top of that - since v86.1.0 already has this change. This is not a normal setup, and I can't imagine we've hit this before.

I improvised and created a branch called `release-v86.0` to base the v86.0.1 release of off. But happy to take suggestions if that doesn't make sense!

I'll add some docs to https://mozilla.github.io/application-services/book/howtos/cut-a-new-release.html#make-a-new-point-release-from-an-existing-release-that-is-behind-latest-main that this could happen (i.e you cut a patch release **after** a minor release, and what to do if that happens)
