### PR TITLE
Cut release v86.0.1

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 86.0.0
+libraryVersion: 86.0.1
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v86.0.1 (_2021-10-28_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v86.0.0...v86.0.1)
+## Logins
+### What's Changed
+- Downgraded the log level of some logs, so now they should not show up in Sentry.
+
+
 # v86.0.0 (_2021-10-13_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v85.4.1...v86.0.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v86.0.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v86.0.1...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 


### PR DESCRIPTION
Cuts release v86.0.1, based on branch `release-v86.0`