### PR TITLE
Gh 4617

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,8 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Places
+
+### ⚠️ Breaking Changes ⚠️
+  - Switched sync manager integration to use `registerWithSyncManager()` like the other components ([#4627](https://github.com/mozilla/application-services/pull/4627))

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -38,6 +38,11 @@ internal interface LibPlacesFFI : Library {
         out_err: RustError.ByReference
     ): PlacesConnectionHandle
 
+    fun places_api_register_with_sync_manager(
+        handle: PlacesApiHandle,
+        out_err: RustError.ByReference
+    )
+
     // Returns a JSON string containing bookmark import metrics
     fun places_bookmarks_import_from_fennec(
         handle: PlacesApiHandle,

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -58,13 +58,10 @@ class PlacesApi(path: String) : PlacesManager, AutoCloseable {
         private const val READ_WRITE: Int = 2
     }
 
-    /**
-     * Return the raw handle used to reference this PlacesApi.
-     *
-     * Generally should only be used to pass the handle into `SyncManager.setPlaces`
-     */
-    fun getHandle(): Long {
-        return this.handle.get()
+    override fun registerWithSyncManager() {
+        rustCall(this) { error ->
+            LibPlacesFFI.INSTANCE.places_api_register_with_sync_manager(handle.get(), error)
+        }
     }
 
     override fun openReader(): PlacesReaderConnection {
@@ -822,6 +819,13 @@ class SyncAuthInfo(
  * functionality.
  */
 interface PlacesManager {
+    /**
+     * Registers with the sync manager.
+     *
+     * Call this to enable bookmarks/history syncing functionality
+     */
+    fun registerWithSyncManager()
+
     /**
      * Open a reader connection.
      */

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -486,6 +486,14 @@ pub extern "C" fn places_accept_result(
 }
 
 #[no_mangle]
+pub extern "C" fn places_api_register_with_sync_manager(handle: u64, error: &mut ExternError) {
+    log::debug!("register_with_sync_manager");
+    APIS.call_with_output(error, handle, |api| {
+        api.clone().register_with_sync_manager()
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn places_reset(handle: u64, error: &mut ExternError) {
     log::debug!("places_reset");
     APIS.call_with_result(error, handle, |api| -> places::Result<_> {

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -271,9 +271,6 @@ impl PlacesApi {
         }
 
         let sync_state = guard.as_ref().unwrap();
-        // Note that this *must* be called before either history or bookmarks are
-        // synced, to ensure the shared global state is correct.
-        HistoryEngine::migrate_v1_global_state(&conn)?;
 
         let mut mem_cached_state = sync_state.mem_cached_state.take();
         let mut disk_cached_state = sync_state.disk_cached_state.take();
@@ -317,9 +314,6 @@ impl PlacesApi {
         }
 
         let sync_state = guard.as_ref().unwrap();
-        // Note that counter-intuitively, this must be called before we do a
-        // bookmark sync too, to ensure the shared global state is correct.
-        HistoryEngine::migrate_v1_global_state(&conn)?;
 
         let interruptee = conn.begin_interrupt_scope();
         let bm_engine = BookmarksEngine::new(&conn, &interruptee);
@@ -353,11 +347,6 @@ impl PlacesApi {
         let _guard = self.sync_state.lock().unwrap();
         let conn = self.open_sync_connection()?;
 
-        // Somewhat ironically, we start by migrating from the legacy storage
-        // format. We *are* just going to delete it anyway, but the code is
-        // simpler if we can just reuse the existing path.
-        HistoryEngine::migrate_v1_global_state(&conn)?;
-
         storage::bookmarks::delete_everything(&conn)?;
         Ok(())
     }
@@ -366,11 +355,6 @@ impl PlacesApi {
         // Take the lock to prevent syncing while we're doing this.
         let _guard = self.sync_state.lock().unwrap();
         let conn = self.open_sync_connection()?;
-
-        // Somewhat ironically, we start by migrating from the legacy storage
-        // format. We *are* just going to delete it anyway, but the code is
-        // simpler if we can just reuse the existing path.
-        HistoryEngine::migrate_v1_global_state(&conn)?;
 
         bookmark_sync::reset(&conn, &sync15::EngineSyncAssociation::Disconnected)?;
         Ok(())
@@ -381,11 +365,6 @@ impl PlacesApi {
         let _guard = self.sync_state.lock().unwrap();
         let conn = self.open_sync_connection()?;
 
-        // Somewhat ironically, we start by migrating from the legacy storage
-        // format. We *are* just going to delete it anyway, but the code is
-        // simpler if we can just reuse the existing path.
-        HistoryEngine::migrate_v1_global_state(&conn)?;
-
         storage::history::delete_everything(&conn)?;
         Ok(())
     }
@@ -394,11 +373,6 @@ impl PlacesApi {
         // Take the lock to prevent syncing while we're doing this.
         let _guard = self.sync_state.lock().unwrap();
         let conn = self.open_sync_connection()?;
-
-        // Somewhat ironically, we start by migrating from the legacy storage
-        // format. We *are* just going to delete it anyway, but the code is
-        // simpler if we can just reuse the existing path.
-        HistoryEngine::migrate_v1_global_state(&conn)?;
 
         history_sync::reset(&conn, &sync15::EngineSyncAssociation::Disconnected)?;
         Ok(())

--- a/components/places/src/bookmark_sync/mod.rs
+++ b/components/places/src/bookmark_sync/mod.rs
@@ -10,6 +10,7 @@ pub mod record;
 mod tests;
 
 use crate::error::*;
+pub use engine::BookmarksSyncEngine;
 use rusqlite::types::{ToSql, ToSqlOutput};
 use rusqlite::Result as RusqliteResult;
 

--- a/components/places/src/history_sync/mod.rs
+++ b/components/places/src/history_sync/mod.rs
@@ -11,6 +11,8 @@ pub mod engine;
 mod plan;
 pub mod record;
 
+pub use engine::HistoryEngine;
+
 const MAX_INCOMING_PLACES: usize = 5000;
 const MAX_OUTGOING_PLACES: usize = 5000;
 const MAX_VISITS: usize = 20;

--- a/components/places/src/lib.rs
+++ b/components/places/src/lib.rs
@@ -31,7 +31,7 @@ pub mod msg_types {
 pub use crate::api::apply_observation;
 #[cfg(test)]
 pub use crate::api::places_api::test;
-pub use crate::api::places_api::{ConnectionType, PlacesApi};
+pub use crate::api::places_api::{get_registered_sync_engine, ConnectionType, PlacesApi};
 
 pub use crate::db::PlacesDb;
 pub use crate::error::*;

--- a/components/sync_manager/ffi/src/lib.rs
+++ b/components/sync_manager/ffi/src/lib.rs
@@ -8,21 +8,7 @@
 // the closure is small.
 #![allow(clippy::redundant_closure)]
 
-use ffi_support::{ExternError, HandleError};
-use sync_manager::Result as MgrResult;
-
-#[no_mangle]
-pub extern "C" fn sync_manager_set_places(_places_api_handle: u64, error: &mut ExternError) {
-    ffi_support::call_with_result(error, || -> MgrResult<()> {
-        log::debug!("sync_manager_set_places");
-        let api = places_ffi::APIS
-            .get_u64(_places_api_handle, |api| -> Result<_, HandleError> {
-                Ok(std::sync::Arc::clone(api))
-            })?;
-        sync_manager::set_places(api);
-        Ok(())
-    })
-}
+use ffi_support::ExternError;
 
 #[no_mangle]
 pub extern "C" fn sync_manager_disconnect(error: &mut ExternError) {

--- a/components/sync_manager/src/lib.rs
+++ b/components/sync_manager/src/lib.rs
@@ -16,17 +16,10 @@ pub mod msg_types {
 }
 
 use manager::SyncManager;
-use places::PlacesApi;
-use std::sync::Arc;
 use std::sync::Mutex;
 
 lazy_static::lazy_static! {
     static ref MANAGER: Mutex<SyncManager> = Mutex::new(SyncManager::new());
-}
-
-pub fn set_places(places: Arc<PlacesApi>) {
-    let mut manager = MANAGER.lock().unwrap();
-    manager.set_places(places);
 }
 
 pub fn disconnect() {


### PR DESCRIPTION
This implements `register_with_sync_manager()` for places.

This also takes the first step in a plan for migrating away from the old sync engine code.  Here's how I think it could work:
  - Implement new sync engines that work with `register_with_sync_manager()` and `get_registered_sync_engine()` (this PR)
  - Make all syncing go through `SyncManager`.  Delete the old syncing code.
  - Refactor the importer code to use the new `BookmarksSyncEngine` and `HistorySyncEngine` structs (or maybe delete it if we don't need it anymore)
  - Remove the old `BookmarksEngine` and `HistoryEngine` structs, move the code into `BookmarksSyncEngine` and `HistorySyncEngine`.
 - Remove `open_sync_connection()` and the fields in `PlacesApi` needed to support it

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
