### PR TITLE
Implement register_with_sync_manager for places (fixes #4617)

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,8 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Places
+
+### ⚠️ Breaking Changes ⚠️
+  - Switched sync manager integration to use `registerWithSyncManager()` like the other components ([#4627](https://github.com/mozilla/application-services/pull/4627))

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -38,6 +38,11 @@ internal interface LibPlacesFFI : Library {
         out_err: RustError.ByReference
     ): PlacesConnectionHandle
 
+    fun places_api_register_with_sync_manager(
+        handle: PlacesApiHandle,
+        out_err: RustError.ByReference
+    )
+
     // Returns a JSON string containing bookmark import metrics
     fun places_bookmarks_import_from_fennec(
         handle: PlacesApiHandle,

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -58,13 +58,10 @@ class PlacesApi(path: String) : PlacesManager, AutoCloseable {
         private const val READ_WRITE: Int = 2
     }
 
-    /**
-     * Return the raw handle used to reference this PlacesApi.
-     *
-     * Generally should only be used to pass the handle into `SyncManager.setPlaces`
-     */
-    fun getHandle(): Long {
-        return this.handle.get()
+    override fun registerWithSyncManager() {
+        rustCall(this) { error ->
+            LibPlacesFFI.INSTANCE.places_api_register_with_sync_manager(handle.get(), error)
+        }
     }
 
     override fun openReader(): PlacesReaderConnection {
@@ -822,6 +819,13 @@ class SyncAuthInfo(
  * functionality.
  */
 interface PlacesManager {
+    /**
+     * Registers with the sync manager.
+     *
+     * Call this to enable bookmarks/history syncing functionality
+     */
+    fun registerWithSyncManager()
+
     /**
      * Open a reader connection.
      */

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -486,6 +486,14 @@ pub extern "C" fn places_accept_result(
 }
 
 #[no_mangle]
+pub extern "C" fn places_api_register_with_sync_manager(handle: u64, error: &mut ExternError) {
+    log::debug!("register_with_sync_manager");
+    APIS.call_with_output(error, handle, |api| {
+        api.clone().register_with_sync_manager()
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn places_reset(handle: u64, error: &mut ExternError) {
     log::debug!("places_reset");
     APIS.call_with_result(error, handle, |api| -> places::Result<_> {

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -283,6 +283,8 @@ impl PlacesApi {
                     mem_cached_state,
                     client_init,
                     key_bundle,
+                    // The interrupt system is not currently working (#1684), but we need to pass
+                    // in something, so let's use the engine scope.
                     &engine.scope,
                     None,
                 )
@@ -305,6 +307,8 @@ impl PlacesApi {
                     mem_cached_state,
                     client_init,
                     key_bundle,
+                    // The interrupt system is not currently working (#1684), but we need to pass
+                    // in something, so let's use the engine scope.
                     &engine.scope,
                     None,
                 )
@@ -386,6 +390,8 @@ impl PlacesApi {
             &mut mem_cached_state,
             client_init,
             key_bundle,
+            // The interrupt system is not currently working (#1684), but we need to pass
+            // in something, so let's use the engine scope.
             &bm_engine.scope,
             None,
         );

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -2,10 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bookmark_sync::engine::BookmarksEngine;
+use crate::bookmark_sync::BookmarksSyncEngine;
 use crate::db::db::PlacesDb;
 use crate::error::*;
-use crate::history_sync::engine::HistoryEngine;
+use crate::history_sync::HistorySyncEngine;
 use crate::storage::{
     self, bookmarks::bookmark_sync, delete_meta, get_meta, history::history_sync, put_meta,
 };
@@ -18,10 +18,10 @@ use std::collections::HashMap;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::{
-    atomic::{AtomicBool, AtomicUsize, Ordering},
+    atomic::{AtomicUsize, Ordering},
     Arc, Mutex, Weak,
 };
-use sync15::{sync_multiple, telemetry, MemoryCachedState, SyncResult};
+use sync15::{sync_multiple, telemetry, MemoryCachedState, SyncEngine, SyncResult};
 
 // Not clear if this should be here, but this is the "global sync state"
 // which is persisted to disk and reused for all engines.
@@ -29,6 +29,37 @@ use sync15::{sync_multiple, telemetry, MemoryCachedState, SyncResult};
 // by a store or collection, so it's safe to storage globally rather than
 // per collection.
 pub const GLOBAL_STATE_META_KEY: &str = "global_sync_state_v2";
+
+// Our "sync manager" will use whatever is stashed here.
+lazy_static::lazy_static! {
+    // Mutex: just taken long enough to update the contents - needed to wrap
+    //        the Weak as it isn't `Sync`
+    // [Arc/Weak]: Stores the places api used to create the connection for
+    //             BookmarksSyncEngine/HistorySyncEngine
+    static ref PLACES_API_FOR_SYNC_MANAGER: Mutex<Weak<PlacesApi>> = Mutex::new(Weak::new());
+}
+
+// Called by the sync manager to get a sync engine via the PlacesApi previously
+// registered with the sync manager.
+pub fn get_registered_sync_engine(name: &str) -> Option<Box<dyn SyncEngine>> {
+    match PLACES_API_FOR_SYNC_MANAGER.lock().unwrap().upgrade() {
+        None => {
+            log::error!("get_registered_sync_engine: no PlacesApi registered");
+            None
+        }
+        Some(places_api) => match places_api.get_sync_connection() {
+            Ok(db) => match name {
+                "bookmarks" => Some(Box::new(BookmarksSyncEngine::new(db))),
+                "history" => Some(Box::new(HistorySyncEngine::new(db))),
+                _ => unreachable!("can't provide unknown engine: {}", name),
+            },
+            Err(e) => {
+                log::error!("get_registered_sync_engine: {}", e);
+                None
+            }
+        },
+    }
+}
 
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -82,10 +113,18 @@ pub struct PlacesApi {
     write_connection: Mutex<Option<PlacesDb>>,
     sync_state: Mutex<Option<SyncState>>,
     coop_tx_lock: Arc<Mutex<()>>,
-    sync_conn_active: AtomicBool,
-    sync_interrupt_counter: Arc<AtomicUsize>,
+    // Used for get_sync_connection()
+    // - The inner mutux synchronizes sync operation (for example one of the [SyncEngine] methods).
+    //   This avoids issues like #867
+    // - The weak facilitates connection sharing.  When `get_sync_connection()` returns an Arc, we
+    //   keep a weak reference to it.  If the Arc is still alive when `get_sync_connection()` is
+    //   called again, we reuse it.
+    // - The outer mutex synchronizes the `get_sync_connection()` operation.  If multiple threads
+    //   ran that at the same time there would be issues.
+    sync_connection: Mutex<Weak<Mutex<PlacesDb>>>,
     id: usize,
 }
+
 impl PlacesApi {
     /// Create a new, or fetch an already open, PlacesApi backed by a file on disk.
     pub fn new(db_name: impl AsRef<Path>) -> Result<Arc<Self>> {
@@ -121,8 +160,7 @@ impl PlacesApi {
                     db_name: db_name.clone(),
                     write_connection: Mutex::new(Some(connection)),
                     sync_state: Mutex::new(None),
-                    sync_conn_active: AtomicBool::new(false),
-                    sync_interrupt_counter: Arc::new(AtomicUsize::new(0)),
+                    sync_connection: Mutex::new(Weak::new()),
                     id,
                     coop_tx_lock,
                 };
@@ -159,25 +197,37 @@ impl PlacesApi {
                 }
             }
             ConnectionType::Sync => {
-                panic!("Use `open_sync_connection` to open a sync connection");
+                panic!("Use `get_sync_connection` to open a sync connection");
             }
         }
     }
 
-    pub fn open_sync_connection(&self) -> Result<SyncConn<'_>> {
-        self.sync_conn_active
-            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-            .map_err(|_| ErrorKind::ConnectionAlreadyOpen)?;
-        let db = PlacesDb::open(
-            self.db_name.clone(),
-            ConnectionType::Sync,
-            self.id,
-            self.coop_tx_lock.clone(),
-        )?;
-        Ok(SyncConn {
-            db,
-            flag: &self.sync_conn_active,
-        })
+    // Get a database connection to sync with
+    //
+    // This function provides a couple features to facilitate sharing the connection between
+    // different sync engines:
+    //   - Each connection is wrapped in a `Mutex<>` to synchronize access.
+    //   - The mutex is then wrapped in an Arc<>.  If the last Arc<> returned is still alive, then
+    //     get_sync_connection() will reuse it.
+    pub fn get_sync_connection(&self) -> Result<Arc<Mutex<PlacesDb>>> {
+        // First step: lock the outer mutex
+        let mut conn = self.sync_connection.lock().unwrap();
+        match conn.upgrade() {
+            // If our Weak is still alive, then re-use that
+            Some(db) => Ok(db),
+            // If not, create a new connection
+            None => {
+                let db = Arc::new(Mutex::new(PlacesDb::open(
+                    self.db_name.clone(),
+                    ConnectionType::Sync,
+                    self.id,
+                    self.coop_tx_lock.clone(),
+                )?));
+                // Store a weakref for next time
+                *conn = Arc::downgrade(&db);
+                Ok(db)
+            }
+        }
     }
 
     /// Close a connection to the database. If the connection is the write
@@ -206,6 +256,15 @@ impl PlacesApi {
         }
     }
 
+    // This allows the embedding app to say "make this instance available to
+    // the sync manager". The implementation is more like "offer to sync mgr"
+    // (thereby avoiding us needing to link with the sync manager) but
+    // `register_with_sync_manager()` is logically what's happening so that's
+    // the name it gets.
+    pub fn register_with_sync_manager(self: Arc<Self>) {
+        *PLACES_API_FOR_SYNC_MANAGER.lock().unwrap() = Arc::downgrade(&self);
+    }
+
     // NOTE: These should be deprecated as soon as possible - that will be once
     // all consumers have been updated to use the .sync() method below, and/or
     // we have implemented the sync manager and migrated consumers to that.
@@ -217,15 +276,14 @@ impl PlacesApi {
         self.do_sync_one(
             "history",
             move |conn, mem_cached_state, disk_cached_state| {
-                let interruptee = self.begin_sync_interrupt_scope();
-                let engine = HistoryEngine::new(conn, &interruptee);
+                let engine = HistorySyncEngine::new(conn);
                 sync_multiple(
                     &[&engine],
                     disk_cached_state,
                     mem_cached_state,
                     client_init,
                     key_bundle,
-                    &interruptee,
+                    &engine.scope,
                     None,
                 )
             },
@@ -240,15 +298,14 @@ impl PlacesApi {
         self.do_sync_one(
             "bookmarks",
             move |conn, mem_cached_state, disk_cached_state| {
-                let interruptee = self.begin_sync_interrupt_scope();
-                let engine = BookmarksEngine::new(conn, &interruptee);
+                let engine = BookmarksSyncEngine::new(conn);
                 sync_multiple(
                     &[&engine],
                     disk_cached_state,
                     mem_cached_state,
                     client_init,
                     key_bundle,
-                    &interruptee,
+                    &engine.scope,
                     None,
                 )
             },
@@ -261,14 +318,14 @@ impl PlacesApi {
         syncer: F,
     ) -> Result<telemetry::SyncTelemetryPing>
     where
-        F: FnOnce(&SyncConn<'_>, &mut MemoryCachedState, &mut Option<String>) -> SyncResult,
+        F: FnOnce(Arc<Mutex<PlacesDb>>, &mut MemoryCachedState, &mut Option<String>) -> SyncResult,
     {
         let mut guard = self.sync_state.lock().unwrap();
-        let conn = self.open_sync_connection()?;
+        let conn = self.get_sync_connection()?;
         if guard.is_none() {
             *guard = Some(SyncState {
                 mem_cached_state: Cell::default(),
-                disk_cached_state: Cell::new(self.get_disk_persisted_state(&conn)?),
+                disk_cached_state: Cell::new(self.get_disk_persisted_state(&conn.lock().unwrap())?),
             });
         }
 
@@ -276,10 +333,10 @@ impl PlacesApi {
 
         let mut mem_cached_state = sync_state.mem_cached_state.take();
         let mut disk_cached_state = sync_state.disk_cached_state.take();
-        let mut result = syncer(&conn, &mut mem_cached_state, &mut disk_cached_state);
+        let mut result = syncer(conn.clone(), &mut mem_cached_state, &mut disk_cached_state);
         // even on failure we set the persisted state - sync itself takes care
         // to ensure this has been None'd out if necessary.
-        self.set_disk_persisted_state(&conn, &disk_cached_state)?;
+        self.set_disk_persisted_state(&conn.lock().unwrap(), &disk_cached_state)?;
         sync_state.mem_cached_state.replace(mem_cached_state);
         sync_state.disk_cached_state.replace(disk_cached_state);
 
@@ -307,19 +364,18 @@ impl PlacesApi {
         key_bundle: &sync15::KeyBundle,
     ) -> Result<SyncResult> {
         let mut guard = self.sync_state.lock().unwrap();
-        let conn = self.open_sync_connection()?;
+        let conn = self.get_sync_connection()?;
         if guard.is_none() {
             *guard = Some(SyncState {
                 mem_cached_state: Cell::default(),
-                disk_cached_state: Cell::new(self.get_disk_persisted_state(&conn)?),
+                disk_cached_state: Cell::new(self.get_disk_persisted_state(&conn.lock().unwrap())?),
             });
         }
 
         let sync_state = guard.as_ref().unwrap();
 
-        let interruptee = self.begin_sync_interrupt_scope();
-        let bm_engine = BookmarksEngine::new(&conn, &interruptee);
-        let history_engine = HistoryEngine::new(&conn, &interruptee);
+        let bm_engine = BookmarksSyncEngine::new(conn.clone());
+        let history_engine = HistorySyncEngine::new(conn.clone());
         let mut mem_cached_state = sync_state.mem_cached_state.take();
         let mut disk_cached_state = sync_state.disk_cached_state.take();
 
@@ -330,12 +386,12 @@ impl PlacesApi {
             &mut mem_cached_state,
             client_init,
             key_bundle,
-            &interruptee,
+            &bm_engine.scope,
             None,
         );
         // even on failure we set the persisted state - sync itself takes care
         // to ensure this has been None'd out if necessary.
-        if let Err(e) = self.set_disk_persisted_state(&conn, &disk_cached_state) {
+        if let Err(e) = self.set_disk_persisted_state(&conn.lock().unwrap(), &disk_cached_state) {
             log::error!("Failed to persist the sync state: {:?}", e);
         }
         sync_state.mem_cached_state.replace(mem_cached_state);
@@ -347,50 +403,52 @@ impl PlacesApi {
     pub fn wipe_bookmarks(&self) -> Result<()> {
         // Take the lock to prevent syncing while we're doing this.
         let _guard = self.sync_state.lock().unwrap();
-        let conn = self.open_sync_connection()?;
+        let conn = self.get_sync_connection()?;
 
-        storage::bookmarks::delete_everything(&conn)?;
+        storage::bookmarks::delete_everything(&conn.lock().unwrap())?;
         Ok(())
     }
 
     pub fn reset_bookmarks(&self) -> Result<()> {
         // Take the lock to prevent syncing while we're doing this.
         let _guard = self.sync_state.lock().unwrap();
-        let conn = self.open_sync_connection()?;
+        let conn = self.get_sync_connection()?;
 
-        bookmark_sync::reset(&conn, &sync15::EngineSyncAssociation::Disconnected)?;
+        bookmark_sync::reset(
+            &conn.lock().unwrap(),
+            &sync15::EngineSyncAssociation::Disconnected,
+        )?;
         Ok(())
     }
 
     pub fn wipe_history(&self) -> Result<()> {
         // Take the lock to prevent syncing while we're doing this.
         let _guard = self.sync_state.lock().unwrap();
-        let conn = self.open_sync_connection()?;
+        let conn = self.get_sync_connection()?;
 
-        storage::history::delete_everything(&conn)?;
+        storage::history::delete_everything(&conn.lock().unwrap())?;
         Ok(())
     }
 
     pub fn reset_history(&self) -> Result<()> {
         // Take the lock to prevent syncing while we're doing this.
         let _guard = self.sync_state.lock().unwrap();
-        let conn = self.open_sync_connection()?;
+        let conn = self.get_sync_connection()?;
 
-        history_sync::reset(&conn, &sync15::EngineSyncAssociation::Disconnected)?;
+        history_sync::reset(
+            &conn.lock().unwrap(),
+            &sync15::EngineSyncAssociation::Disconnected,
+        )?;
         Ok(())
     }
 
-    /// Create a new SqlInterruptScope for syncing
+    /// Create a new SqlInterruptScope for the syncing code
     ///
-    /// Call this at the begining of a sync operation.  Then if interrupt_sync() is called, we will
-    /// interrupt the current DB query and return `InterruptedError`
-    pub fn begin_sync_interrupt_scope(&self) -> SqlInterruptScope {
-        SqlInterruptScope::new(self.sync_interrupt_counter.clone())
-    }
-
-    /// Interrupt the current sync operation if one is in progress
-    pub fn interrupt_sync(&self) {
-        // TODO: update the sync connection code so we can implement this method.  This will fix #1684.
+    /// The syncing code expects a SqlInterruptScope, but it's never been actually hooked up to
+    /// anything.  This method returns something to make the compiler happy, but we should replace
+    /// this with working code as part of #1684.
+    pub fn dummy_sync_interrupt_scope(&self) -> SqlInterruptScope {
+        SqlInterruptScope::new(Arc::new(AtomicUsize::new(0)))
     }
 
     // Deprecated/Broken interrupt handler method, let's try to replace it with the above methods
@@ -405,28 +463,9 @@ impl PlacesApi {
         // Probably not necessary to lock here, since this should only get
         // called in startup.
         let _guard = self.sync_state.lock().unwrap();
-        let conn = self.open_sync_connection()?;
-        Ok(conn.new_interrupt_handle())
-    }
-}
-
-/// Wrapper around PlacesDb that automatically sets a flag (`sync_conn_active`)
-/// to false when finished
-pub struct SyncConn<'api> {
-    db: PlacesDb,
-    flag: &'api AtomicBool,
-}
-
-impl<'a> Drop for SyncConn<'a> {
-    fn drop(&mut self) {
-        self.flag.store(false, Ordering::SeqCst)
-    }
-}
-
-impl<'a> std::ops::Deref for SyncConn<'a> {
-    type Target = PlacesDb;
-    fn deref(&self) -> &PlacesDb {
-        &self.db
+        let conn = self.get_sync_connection()?;
+        let db = conn.lock().unwrap();
+        Ok(db.new_interrupt_handle())
     }
 }
 

--- a/components/places/src/bookmark_sync/mod.rs
+++ b/components/places/src/bookmark_sync/mod.rs
@@ -10,6 +10,7 @@ pub mod record;
 mod tests;
 
 use crate::error::*;
+pub use engine::BookmarksSyncEngine;
 use rusqlite::types::{ToSql, ToSqlOutput};
 use rusqlite::Result as RusqliteResult;
 

--- a/components/places/src/history_sync/mod.rs
+++ b/components/places/src/history_sync/mod.rs
@@ -11,6 +11,8 @@ pub mod engine;
 mod plan;
 pub mod record;
 
+pub use engine::HistorySyncEngine;
+
 const MAX_INCOMING_PLACES: usize = 5000;
 const MAX_OUTGOING_PLACES: usize = 5000;
 const MAX_VISITS: usize = 20;

--- a/components/places/src/import/common.rs
+++ b/components/places/src/import/common.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::api::places_api::SyncConn;
+use crate::db::PlacesDb;
 use crate::error::*;
 use rusqlite::named_params;
 use types::Timestamp;
@@ -80,7 +80,7 @@ pub mod sql_fns {
 }
 
 pub fn attached_database<'a>(
-    conn: &'a SyncConn<'a>,
+    conn: &'a PlacesDb,
     path: &Url,
     db_alias: &'static str,
 ) -> Result<ExecuteOnDrop<'a>> {
@@ -104,12 +104,12 @@ pub fn attached_database<'a>(
 /// automatically, as we can't report errors beyond logging when running
 /// Drop.
 pub struct ExecuteOnDrop<'a> {
-    conn: &'a SyncConn<'a>,
+    conn: &'a PlacesDb,
     sql: String,
 }
 
 impl<'a> ExecuteOnDrop<'a> {
-    pub fn new(conn: &'a SyncConn<'a>, sql: String) -> Self {
+    pub fn new(conn: &'a PlacesDb, sql: String) -> Self {
         Self { conn, sql }
     }
 

--- a/components/places/src/import/fennec/bookmarks.rs
+++ b/components/places/src/import/fennec/bookmarks.rs
@@ -54,7 +54,8 @@ pub fn import_pinned_sites(
 }
 
 fn do_import(places_api: &PlacesApi, fennec_db_file_url: Url) -> Result<BookmarksMigrationResult> {
-    let conn = places_api.open_sync_connection()?;
+    let conn_mutex = places_api.get_sync_connection()?;
+    let conn = conn_mutex.lock().unwrap();
 
     let scope = conn.begin_interrupt_scope();
 
@@ -159,7 +160,8 @@ fn do_pinned_sites_import(
     places_api: &PlacesApi,
     fennec_db_file_url: Url,
 ) -> Result<Vec<PublicNode>> {
-    let conn = places_api.open_sync_connection()?;
+    let conn_mutex = places_api.get_sync_connection()?;
+    let conn = conn_mutex.lock().unwrap();
     let scope = conn.begin_interrupt_scope();
 
     sql_fns::define_functions(&conn)?;

--- a/components/places/src/import/fennec/history.rs
+++ b/components/places/src/import/fennec/history.rs
@@ -40,7 +40,8 @@ pub fn select_count(conn: &PlacesDb, stmt: &str) -> u32 {
 }
 
 fn do_import(places_api: &PlacesApi, android_db_file_url: Url) -> Result<HistoryMigrationResult> {
-    let conn = places_api.open_sync_connection()?;
+    let conn_mutex = places_api.get_sync_connection()?;
+    let conn = conn_mutex.lock().unwrap();
 
     let scope = conn.begin_interrupt_scope();
 

--- a/components/places/src/import/ios_bookmarks.rs
+++ b/components/places/src/import/ios_bookmarks.rs
@@ -84,7 +84,8 @@ pub fn import_ios_bookmarks(
 }
 
 fn do_import_ios_bookmarks(places_api: &PlacesApi, ios_db_file_url: Url) -> Result<()> {
-    let conn = places_api.open_sync_connection()?;
+    let conn_mutex = places_api.get_sync_connection()?;
+    let conn = conn_mutex.lock().unwrap();
 
     let scope = conn.begin_interrupt_scope();
 

--- a/components/places/src/lib.rs
+++ b/components/places/src/lib.rs
@@ -31,7 +31,7 @@ pub mod msg_types {
 pub use crate::api::apply_observation;
 #[cfg(test)]
 pub use crate::api::places_api::test;
-pub use crate::api::places_api::{ConnectionType, PlacesApi};
+pub use crate::api::places_api::{get_registered_sync_engine, ConnectionType, PlacesApi};
 
 pub use crate::db::PlacesDb;
 pub use crate::error::*;

--- a/components/sync_manager/ffi/src/lib.rs
+++ b/components/sync_manager/ffi/src/lib.rs
@@ -8,21 +8,7 @@
 // the closure is small.
 #![allow(clippy::redundant_closure)]
 
-use ffi_support::{ExternError, HandleError};
-use sync_manager::Result as MgrResult;
-
-#[no_mangle]
-pub extern "C" fn sync_manager_set_places(_places_api_handle: u64, error: &mut ExternError) {
-    ffi_support::call_with_result(error, || -> MgrResult<()> {
-        log::debug!("sync_manager_set_places");
-        let api = places_ffi::APIS
-            .get_u64(_places_api_handle, |api| -> Result<_, HandleError> {
-                Ok(std::sync::Arc::clone(api))
-            })?;
-        sync_manager::set_places(api);
-        Ok(())
-    })
-}
+use ffi_support::ExternError;
 
 #[no_mangle]
 pub extern "C" fn sync_manager_disconnect(error: &mut ExternError) {

--- a/components/sync_manager/src/lib.rs
+++ b/components/sync_manager/src/lib.rs
@@ -16,17 +16,10 @@ pub mod msg_types {
 }
 
 use manager::SyncManager;
-use places::PlacesApi;
-use std::sync::Arc;
 use std::sync::Mutex;
 
 lazy_static::lazy_static! {
     static ref MANAGER: Mutex<SyncManager> = Mutex::new(SyncManager::new());
-}
-
-pub fn set_places(places: Arc<PlacesApi>) {
-    let mut manager = MANAGER.lock().unwrap();
-    manager.set_places(places);
 }
 
 pub fn disconnect() {

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -5,8 +5,6 @@
 #![warn(rust_2018_idioms)]
 
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
-use places::bookmark_sync::engine::BookmarksEngine;
-use places::history_sync::engine::HistoryEngine;
 use places::storage::bookmarks::{
     fetch_tree, insert_tree, BookmarkNode, BookmarkRootGuid, BookmarkTreeNode, FetchDepth,
     FolderNode, SeparatorNode,
@@ -171,17 +169,6 @@ fn sync(
     wait: u64,
 ) -> Result<()> {
     use_reqwest_backend();
-    let conn = api.open_sync_connection()?;
-
-    // interrupts are per-connection, so we need to set that up here.
-    let interrupt_handle = conn.new_interrupt_handle();
-
-    ctrlc::set_handler(move || {
-        println!("received Ctrl+C!");
-        interrupt_handle.interrupt();
-    })
-    .expect("Error setting Ctrl-C handler");
-    let interruptee = conn.begin_interrupt_scope();
 
     let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file)?;
 
@@ -197,21 +184,15 @@ fn sync(
     let mut global_state: Option<String> = None;
     let engines: Vec<Box<dyn SyncEngine>> = if engine_names.is_empty() {
         vec![
-            Box::new(BookmarksEngine::new(&conn, &interruptee)),
-            Box::new(HistoryEngine::new(&conn, &interruptee)),
+            places::get_registered_sync_engine("bookmarks").unwrap(),
+            places::get_registered_sync_engine("history").unwrap(),
         ]
     } else {
         engine_names.sort();
         engine_names.dedup();
         engine_names
             .into_iter()
-            .map(|name| -> Box<dyn SyncEngine> {
-                match name.as_str() {
-                    "bookmarks" => Box::new(BookmarksEngine::new(&conn, &interruptee)),
-                    "history" => Box::new(HistoryEngine::new(&conn, &interruptee)),
-                    _ => unimplemented!("Can't sync unsupported engine {}", name),
-                }
-            })
+            .map(|name| places::get_registered_sync_engine(&name).unwrap())
             .collect()
     };
     for engine in &engines {
@@ -239,7 +220,7 @@ fn sync(
             &mut mem_cached_state,
             &cli_fxa.client_init.clone(),
             &cli_fxa.root_sync_key,
-            &interruptee,
+            &api.dummy_sync_interrupt_scope(),
             None,
         );
 
@@ -379,6 +360,8 @@ fn main() -> Result<()> {
     let db_path = opts.database_path;
     let api = PlacesApi::new(&db_path)?;
     let db = api.open_connection(ConnectionType::ReadWrite)?;
+    // Needed to make the get_registered_sync_engine() calls work.
+    api.clone().register_with_sync_manager();
 
     match opts.cmd {
         Command::Sync {

--- a/testing/separated/places-tests/src/fennec_bookmarks.rs
+++ b/testing/separated/places-tests/src/fennec_bookmarks.rs
@@ -733,7 +733,7 @@ enum TimestampTestType {
 
 fn do_test_sync_after_migrate(test_type: TimestampTestType) -> Result<()> {
     use places::api::places_api::ConnectionType;
-    use places::bookmark_sync::engine::BookmarksEngine;
+    use places::bookmark_sync::engine::BookmarksSyncEngine;
     use places::storage::bookmarks::bookmarks_get_url_for_keyword;
     use places::storage::tags;
     use serde_json::json;
@@ -803,7 +803,6 @@ fn do_test_sync_after_migrate(test_type: TimestampTestType) -> Result<()> {
     assert_eq!(metrics.num_failed, 0);
 
     let writer = places_api.open_connection(ConnectionType::ReadWrite)?;
-    let syncer = places_api.open_sync_connection()?;
 
     // Should be no bookmark with keyword 'a' yet.
     assert_eq!(bookmarks_get_url_for_keyword(&writer, "a")?, None);
@@ -844,8 +843,7 @@ fn do_test_sync_after_migrate(test_type: TimestampTestType) -> Result<()> {
         }),
     ];
 
-    let interrupt_scope = syncer.begin_interrupt_scope();
-    let engine = BookmarksEngine::new(&syncer, &interrupt_scope);
+    let engine = BookmarksSyncEngine::new(places_api.get_sync_connection().unwrap());
 
     let mut incoming =
         IncomingChangeset::new(engine.collection_name().to_string(), server_timestamp);


### PR DESCRIPTION
This one replaces the entire bookmarks/history sync engines with new ones that use `Arc<Mutex<PlacesDb>>`.  `PlacesApi` and the importer code have been updated to use the new system.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
