### PR TITLE
removes error-support from push

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,7 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Push
+### What's changed
+  - Push internally no longer uses the `error_support` dependency to simplify the code. It now directly defines exactly one error enum and exposes that to `uniffi`. This should have no implication to the consumer code ([#4650](https://github.com/mozilla/application-services/pull/4650))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,7 +2406,6 @@ dependencies = [
  "base64 0.12.3",
  "bincode",
  "env_logger 0.8.4",
- "error-support",
  "hex",
  "lazy_static",
  "log",

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -21,7 +21,6 @@ rusqlite = { version = "0.24.2", features = ["bundled", "unlock_notify"] }
 url = "2.2"
 viaduct = { path = "../viaduct" }
 sql-support = { path = "../support/sql" }
-error-support = { path = "../support/error" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }
 thiserror = "1.0"
 uniffi = "^0.14"

--- a/components/push/src/error.rs
+++ b/components/push/src/error.rs
@@ -2,18 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-error_support::define_error! {
-    ErrorKind {
-        (StorageSqlError, rusqlite::Error),
-        (UrlParseError, url::ParseError),
-        (JSONDeserializeError, serde_json::Error),
-        (RequestError, viaduct::Error),
-        (OpenDatabaseError, sql_support::open_database::Error),
-    }
-}
+pub type Result<T, E = PushError> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
-pub enum ErrorKind {
+pub enum PushError {
     /// An unspecified general error has occured
     #[error("General Error: {0:?}")]
     GeneralError(String),

--- a/components/push/src/internal/communications/rate_limiter.rs
+++ b/components/push/src/internal/communications/rate_limiter.rs
@@ -113,7 +113,7 @@ fn now_secs() -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::internal::error::Result;
+    use crate::error::Result;
 
     static PERIODIC_INTERVAL: u64 = 24 * 3600;
     static VERIFY_NOW_INTERVAL: u64 = PERIODIC_INTERVAL + 3600;

--- a/components/push/src/internal/mod.rs
+++ b/components/push/src/internal/mod.rs
@@ -5,7 +5,6 @@
 pub mod communications;
 pub mod config;
 pub mod crypto;
-pub mod error;
 pub mod storage;
 pub mod subscriber;
 

--- a/components/push/src/internal/storage/record.rs
+++ b/components/push/src/internal/storage/record.rs
@@ -4,8 +4,8 @@
 
 use rusqlite::Row;
 
+use crate::error::Result;
 use crate::internal::crypto::KeyV1 as Key;
-use crate::internal::error::Result;
 
 use super::types::Timestamp;
 


### PR DESCRIPTION
fixes #4592 

As noted in the issue, `error_support` is not providing the value that it promises for us, and removing it removes a bunch of redundant code. It was a very mechanical change and I faced no issues (and didn't have to change the UDL at all!)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
