### PR TITLE
Move to `parking_lot::Mutex` in logins, places and sync_manager

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -22,3 +22,8 @@ Use the template below to make assigning a version number during the release cut
 ## Logins
 ### What's changed
   - The `update()` and `add_or_update()` methods will log rather than return an error when trying to update a duplicate login (#4648)
+
+## Logins, Places, SyncManager
+### What's Changed
+  - These packages all use `parking_lot::Mutex` instead of `std::Mutex`, meaning we should no
+    longer see errors about mutexes being poisoned.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,6 +1606,7 @@ dependencies = [
  "lazy_static",
  "log",
  "more-asserts",
+ "parking_lot",
  "rusqlite",
  "serde",
  "serde_derive",
@@ -1636,6 +1637,12 @@ name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "megazord"
@@ -2085,6 +2092,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "owning_ref"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d05f1349491390b1730afba60bb20d55761bef489a954546b58b4b34e1e2ac"
+dependencies = [
+ "owning_ref",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+ "smallvec 0.6.14",
+ "winapi",
+]
+
+[[package]]
 name = "paste"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2206,7 @@ dependencies = [
  "lazy_static",
  "log",
  "memchr",
+ "parking_lot",
  "percent-encoding",
  "pretty_assertions",
  "prost",
@@ -2193,6 +2232,7 @@ name = "places-bench"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "parking_lot",
  "places",
  "serde_json",
  "sql-support",
@@ -2228,6 +2268,7 @@ version = "0.1.0"
 dependencies = [
  "dogear",
  "env_logger 0.7.1",
+ "parking_lot",
  "places",
  "rusqlite",
  "serde_json",
@@ -2785,7 +2826,7 @@ dependencies = [
  "libsqlite3-sys",
  "memchr",
  "serde_json",
- "smallvec",
+ "smallvec 1.6.1",
 ]
 
 [[package]]
@@ -3040,6 +3081,15 @@ checksum = "75ce4f9dc4a41b4c3476cc925f1efb11b66df373a8fde5d4b8915fa91b5d995e"
 
 [[package]]
 name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
+
+[[package]]
+name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
@@ -3074,6 +3124,12 @@ dependencies = [
  "tempfile",
  "thiserror",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -3180,6 +3236,7 @@ dependencies = [
  "lazy_static",
  "log",
  "logins",
+ "parking_lot",
  "places",
  "serde",
  "serde_derive",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -29,6 +29,7 @@ the details of which are reproduced below.
 * [MIT License: openssl-sys](#mit-license-openssl-sys)
 * [MIT License: ordered-float](#mit-license-ordered-float)
 * [MIT License: oslog](#mit-license-oslog)
+* [MIT License: owning_ref](#mit-license-owning_ref)
 * [MIT License: radium](#mit-license-radium)
 * [MIT License: rusqlite](#mit-license-rusqlite)
 * [MIT License: schannel](#mit-license-schannel)
@@ -513,6 +514,7 @@ The following text applies to code linked from these dependencies:
 [lmdb-rkv-sys](https://github.com/mozilla/lmdb-rs.git),
 [lmdb-rkv](https://github.com/mozilla/lmdb-rs.git),
 [log](https://github.com/rust-lang/log),
+[maybe-uninit](https://github.com/est31/maybe-uninit),
 [mime](https://github.com/hyperium/mime),
 [miow](https://github.com/yoshuawuyts/miow),
 [native-tls](https://github.com/sfackler/rust-native-tls),
@@ -525,6 +527,8 @@ The following text applies to code linked from these dependencies:
 [openssl-probe](https://github.com/alexcrichton/openssl-probe),
 [openssl-src](https://github.com/alexcrichton/openssl-src-rs),
 [openssl](https://github.com/sfackler/rust-openssl),
+[parking_lot](https://github.com/Amanieu/parking_lot),
+[parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste-impl](https://github.com/dtolnay/paste),
 [paste](https://github.com/dtolnay/paste),
 [percent-encoding](https://github.com/servo/rust-url/),
@@ -538,6 +542,7 @@ The following text applies to code linked from these dependencies:
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
 [quote](https://github.com/dtolnay/quote),
+[rand](https://github.com/rust-lang-nursery/rand),
 [rand](https://github.com/rust-random/rand),
 [rand_chacha](https://github.com/rust-random/rand),
 [rand_core](https://github.com/rust-random/rand),
@@ -559,6 +564,7 @@ The following text applies to code linked from these dependencies:
 [smallbitvec](https://github.com/servo/smallbitvec),
 [smallvec](https://github.com/servo/rust-smallvec),
 [socket2](https://github.com/rust-lang/socket2),
+[stable_deref_trait](https://github.com/storyyeller/stable_deref_trait),
 [static_assertions](https://github.com/nvzqz/static-assertions-rs),
 [swift-protobuf](https://github.com/apple/swift-protobuf),
 [syn](https://github.com/dtolnay/syn),
@@ -1479,6 +1485,36 @@ The following text applies to code linked from these dependencies:
 MIT License
 
 Copyright (c) 2020 Steven Joruk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: owning_ref
+
+The following text applies to code linked from these dependencies:
+[owning_ref](https://github.com/Kimundi/owning-ref-rs)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Marvin Löbel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -15,6 +15,7 @@ sync15 = { path = "../sync15" }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+parking_lot = "0.5"
 log = "0.4"
 lazy_static = "1.4"
 url = "2.2"

--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -452,7 +452,7 @@ fn insert_logins(
     let mut num_failed_insert: u64 = 0;
     let mut insert_errors: Vec<String> = Vec::new();
 
-    let new_db = store.db.lock().unwrap();
+    let new_db = store.db.lock();
     let conn = new_db.conn();
     let tx = conn.unchecked_transaction()?;
 
@@ -706,7 +706,7 @@ fn get_login_from_row(row: &Row<'_>) -> Result<Login> {
 }
 
 fn migrate_sync_metadata(cipher_conn: &Connection, store: &LoginStore) -> Result<MigrationMetrics> {
-    let new_db = store.db.lock().unwrap();
+    let new_db = store.db.lock();
     let conn = new_db.conn();
     let import_start = Instant::now();
 

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -15,6 +15,7 @@ sync15 = { path = "../sync15" }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+parking_lot = "0.5"
 log = "0.4"
 lazy_static = "1.4"
 url = { version = "2.1", features = ["serde"] }

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -11,6 +11,7 @@ use crate::storage::{
 };
 use crate::util::normalize_path;
 use lazy_static::lazy_static;
+use parking_lot::Mutex;
 use rusqlite::OpenFlags;
 use sql_support::{SqlInterruptHandle, SqlInterruptScope};
 use std::cell::Cell;
@@ -19,7 +20,7 @@ use std::mem;
 use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
-    Arc, Mutex, Weak,
+    Arc, Weak,
 };
 use sync15::{sync_multiple, telemetry, MemoryCachedState, SyncEngine, SyncResult};
 
@@ -42,7 +43,7 @@ lazy_static::lazy_static! {
 // Called by the sync manager to get a sync engine via the PlacesApi previously
 // registered with the sync manager.
 pub fn get_registered_sync_engine(name: &str) -> Option<Box<dyn SyncEngine>> {
-    match PLACES_API_FOR_SYNC_MANAGER.lock().unwrap().upgrade() {
+    match PLACES_API_FOR_SYNC_MANAGER.lock().upgrade() {
         None => {
             log::error!("get_registered_sync_engine: no PlacesApi registered");
             None
@@ -172,7 +173,7 @@ impl PlacesApi {
     }
 
     fn new_or_existing(db_name: PathBuf) -> Result<Arc<Self>> {
-        let mut guard = APIS.lock().unwrap();
+        let mut guard = APIS.lock();
         Self::new_or_existing_into(&mut guard, db_name)
     }
 
@@ -190,7 +191,7 @@ impl PlacesApi {
             }
             ConnectionType::ReadWrite => {
                 // We only allow one of these.
-                let mut guard = self.write_connection.lock().unwrap();
+                let mut guard = self.write_connection.lock();
                 match mem::replace(&mut *guard, None) {
                     None => Err(ErrorKind::ConnectionAlreadyOpen.into()),
                     Some(db) => Ok(db),
@@ -211,7 +212,7 @@ impl PlacesApi {
     //     get_sync_connection() will reuse it.
     pub fn get_sync_connection(&self) -> Result<Arc<Mutex<PlacesDb>>> {
         // First step: lock the outer mutex
-        let mut conn = self.sync_connection.lock().unwrap();
+        let mut conn = self.sync_connection.lock();
         match conn.upgrade() {
             // If our Weak is still alive, then re-use that
             Some(db) => Ok(db),
@@ -238,7 +239,7 @@ impl PlacesApi {
         }
         if connection.conn_type() == ConnectionType::ReadWrite {
             // We only allow one of these.
-            let mut guard = self.write_connection.lock().unwrap();
+            let mut guard = self.write_connection.lock();
             assert!((*guard).is_none());
             *guard = Some(connection);
         }
@@ -262,7 +263,7 @@ impl PlacesApi {
     // `register_with_sync_manager()` is logically what's happening so that's
     // the name it gets.
     pub fn register_with_sync_manager(self: Arc<Self>) {
-        *PLACES_API_FOR_SYNC_MANAGER.lock().unwrap() = Arc::downgrade(&self);
+        *PLACES_API_FOR_SYNC_MANAGER.lock() = Arc::downgrade(&self);
     }
 
     // NOTE: These should be deprecated as soon as possible - that will be once
@@ -324,12 +325,12 @@ impl PlacesApi {
     where
         F: FnOnce(Arc<Mutex<PlacesDb>>, &mut MemoryCachedState, &mut Option<String>) -> SyncResult,
     {
-        let mut guard = self.sync_state.lock().unwrap();
+        let mut guard = self.sync_state.lock();
         let conn = self.get_sync_connection()?;
         if guard.is_none() {
             *guard = Some(SyncState {
                 mem_cached_state: Cell::default(),
-                disk_cached_state: Cell::new(self.get_disk_persisted_state(&conn.lock().unwrap())?),
+                disk_cached_state: Cell::new(self.get_disk_persisted_state(&conn.lock())?),
             });
         }
 
@@ -340,7 +341,7 @@ impl PlacesApi {
         let mut result = syncer(conn.clone(), &mut mem_cached_state, &mut disk_cached_state);
         // even on failure we set the persisted state - sync itself takes care
         // to ensure this has been None'd out if necessary.
-        self.set_disk_persisted_state(&conn.lock().unwrap(), &disk_cached_state)?;
+        self.set_disk_persisted_state(&conn.lock(), &disk_cached_state)?;
         sync_state.mem_cached_state.replace(mem_cached_state);
         sync_state.disk_cached_state.replace(disk_cached_state);
 
@@ -367,12 +368,12 @@ impl PlacesApi {
         client_init: &sync15::Sync15StorageClientInit,
         key_bundle: &sync15::KeyBundle,
     ) -> Result<SyncResult> {
-        let mut guard = self.sync_state.lock().unwrap();
+        let mut guard = self.sync_state.lock();
         let conn = self.get_sync_connection()?;
         if guard.is_none() {
             *guard = Some(SyncState {
                 mem_cached_state: Cell::default(),
-                disk_cached_state: Cell::new(self.get_disk_persisted_state(&conn.lock().unwrap())?),
+                disk_cached_state: Cell::new(self.get_disk_persisted_state(&conn.lock())?),
             });
         }
 
@@ -397,7 +398,7 @@ impl PlacesApi {
         );
         // even on failure we set the persisted state - sync itself takes care
         // to ensure this has been None'd out if necessary.
-        if let Err(e) = self.set_disk_persisted_state(&conn.lock().unwrap(), &disk_cached_state) {
+        if let Err(e) = self.set_disk_persisted_state(&conn.lock(), &disk_cached_state) {
             log::error!("Failed to persist the sync state: {:?}", e);
         }
         sync_state.mem_cached_state.replace(mem_cached_state);
@@ -408,43 +409,37 @@ impl PlacesApi {
 
     pub fn wipe_bookmarks(&self) -> Result<()> {
         // Take the lock to prevent syncing while we're doing this.
-        let _guard = self.sync_state.lock().unwrap();
+        let _guard = self.sync_state.lock();
         let conn = self.get_sync_connection()?;
 
-        storage::bookmarks::delete_everything(&conn.lock().unwrap())?;
+        storage::bookmarks::delete_everything(&conn.lock())?;
         Ok(())
     }
 
     pub fn reset_bookmarks(&self) -> Result<()> {
         // Take the lock to prevent syncing while we're doing this.
-        let _guard = self.sync_state.lock().unwrap();
+        let _guard = self.sync_state.lock();
         let conn = self.get_sync_connection()?;
 
-        bookmark_sync::reset(
-            &conn.lock().unwrap(),
-            &sync15::EngineSyncAssociation::Disconnected,
-        )?;
+        bookmark_sync::reset(&conn.lock(), &sync15::EngineSyncAssociation::Disconnected)?;
         Ok(())
     }
 
     pub fn wipe_history(&self) -> Result<()> {
         // Take the lock to prevent syncing while we're doing this.
-        let _guard = self.sync_state.lock().unwrap();
+        let _guard = self.sync_state.lock();
         let conn = self.get_sync_connection()?;
 
-        storage::history::delete_everything(&conn.lock().unwrap())?;
+        storage::history::delete_everything(&conn.lock())?;
         Ok(())
     }
 
     pub fn reset_history(&self) -> Result<()> {
         // Take the lock to prevent syncing while we're doing this.
-        let _guard = self.sync_state.lock().unwrap();
+        let _guard = self.sync_state.lock();
         let conn = self.get_sync_connection()?;
 
-        history_sync::reset(
-            &conn.lock().unwrap(),
-            &sync15::EngineSyncAssociation::Disconnected,
-        )?;
+        history_sync::reset(&conn.lock(), &sync15::EngineSyncAssociation::Disconnected)?;
         Ok(())
     }
 
@@ -468,9 +463,9 @@ impl PlacesApi {
     pub fn new_sync_conn_interrupt_handle(&self) -> Result<SqlInterruptHandle> {
         // Probably not necessary to lock here, since this should only get
         // called in startup.
-        let _guard = self.sync_state.lock().unwrap();
+        let _guard = self.sync_state.lock();
         let conn = self.get_sync_connection()?;
-        let db = conn.lock().unwrap();
+        let db = conn.lock();
         Ok(db.new_interrupt_handle())
     }
 }

--- a/components/places/src/bookmark_sync/incoming.rs
+++ b/components/places/src/bookmark_sync/incoming.rs
@@ -597,7 +597,7 @@ mod tests {
 
     fn apply_incoming(api: &PlacesApi, records_json: Value) {
         let db = api.get_sync_connection().expect("should get a db mutex");
-        let conn = db.lock().unwrap();
+        let conn = db.lock();
 
         let server_timestamp = ServerTimestamp(0);
         let applicator = IncomingApplicator::new(&conn);
@@ -628,12 +628,9 @@ mod tests {
             .to_string();
         let api = new_mem_api();
         apply_incoming(&api, record_json);
-        let got = SyncedBookmarkItem::get(
-            &api.get_sync_connection().unwrap().lock().unwrap(),
-            &guid.into(),
-        )
-        .expect("should work")
-        .expect("item should exist");
+        let got = SyncedBookmarkItem::get(&api.get_sync_connection().unwrap().lock(), &guid.into())
+            .expect("should work")
+            .expect("item should exist");
         assert_eq!(*expected, got);
     }
 
@@ -897,7 +894,7 @@ mod tests {
     fn test_apply_unknown() {
         let api = new_mem_api();
         let db = api.get_sync_connection().expect("should get a db mutex");
-        let conn = db.lock().unwrap();
+        let conn = db.lock();
         let applicator = IncomingApplicator::new(&conn);
 
         let record = json!({

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -6,6 +6,7 @@ use super::schema;
 use crate::api::places_api::ConnectionType;
 use crate::error::*;
 use lazy_static::lazy_static;
+use parking_lot::Mutex;
 use rusqlite::{self, Connection, Transaction};
 use sql_support::{
     open_database::{self, open_database_with_flags, ConnectionInitializer},
@@ -17,7 +18,7 @@ use std::path::Path;
 
 use std::sync::{
     atomic::{AtomicI64, AtomicUsize, Ordering},
-    Arc, Mutex, RwLock,
+    Arc, RwLock,
 };
 
 pub const MAX_VARIABLE_NUMBER: usize = 999;

--- a/components/places/src/import/fennec/bookmarks.rs
+++ b/components/places/src/import/fennec/bookmarks.rs
@@ -55,7 +55,7 @@ pub fn import_pinned_sites(
 
 fn do_import(places_api: &PlacesApi, fennec_db_file_url: Url) -> Result<BookmarksMigrationResult> {
     let conn_mutex = places_api.get_sync_connection()?;
-    let conn = conn_mutex.lock().unwrap();
+    let conn = conn_mutex.lock();
 
     let scope = conn.begin_interrupt_scope();
 
@@ -161,7 +161,7 @@ fn do_pinned_sites_import(
     fennec_db_file_url: Url,
 ) -> Result<Vec<PublicNode>> {
     let conn_mutex = places_api.get_sync_connection()?;
-    let conn = conn_mutex.lock().unwrap();
+    let conn = conn_mutex.lock();
     let scope = conn.begin_interrupt_scope();
 
     sql_fns::define_functions(&conn)?;

--- a/components/places/src/import/fennec/history.rs
+++ b/components/places/src/import/fennec/history.rs
@@ -41,7 +41,7 @@ pub fn select_count(conn: &PlacesDb, stmt: &str) -> u32 {
 
 fn do_import(places_api: &PlacesApi, android_db_file_url: Url) -> Result<HistoryMigrationResult> {
     let conn_mutex = places_api.get_sync_connection()?;
-    let conn = conn_mutex.lock().unwrap();
+    let conn = conn_mutex.lock();
 
     let scope = conn.begin_interrupt_scope();
 

--- a/components/places/src/import/ios_bookmarks.rs
+++ b/components/places/src/import/ios_bookmarks.rs
@@ -85,7 +85,7 @@ pub fn import_ios_bookmarks(
 
 fn do_import_ios_bookmarks(places_api: &PlacesApi, ios_db_file_url: Url) -> Result<()> {
     let conn_mutex = places_api.get_sync_connection()?;
-    let conn = conn_mutex.lock().unwrap();
+    let conn = conn_mutex.lock();
 
     let scope = conn.begin_interrupt_scope();
 

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -21,6 +21,7 @@ url = "2.2"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
+parking_lot = "0.5"
 interrupt-support = { path = "../support/interrupt" }
 uniffi = "^0.14"
 uniffi_macros = "^0.14"

--- a/components/sync_manager/src/lib.rs
+++ b/components/sync_manager/src/lib.rs
@@ -14,34 +14,34 @@ use sync15::clients::DeviceType;
 pub use types::*;
 
 use manager::SyncManager;
-use std::sync::Mutex;
+use parking_lot::Mutex;
 
 lazy_static::lazy_static! {
     static ref MANAGER: Mutex<SyncManager> = Mutex::new(SyncManager::new());
 }
 
 pub fn disconnect() {
-    let manager = MANAGER.lock().unwrap();
+    let manager = MANAGER.lock();
     manager.disconnect();
 }
 
 pub fn wipe(engine: &str) -> Result<()> {
-    let manager = MANAGER.lock().unwrap();
+    let manager = MANAGER.lock();
     manager.wipe(engine)
 }
 
 pub fn reset(engine: &str) -> Result<()> {
-    let manager = MANAGER.lock().unwrap();
+    let manager = MANAGER.lock();
     manager.reset(engine)
 }
 
 pub fn reset_all() -> Result<()> {
-    let manager = MANAGER.lock().unwrap();
+    let manager = MANAGER.lock();
     manager.reset_all()
 }
 
 pub fn sync(params: SyncParams) -> Result<SyncResult> {
-    let manager = MANAGER.lock().unwrap();
+    let manager = MANAGER.lock();
     manager.sync(params)
 }
 

--- a/components/sync_manager/src/manager.rs
+++ b/components/sync_manager/src/manager.rs
@@ -5,8 +5,9 @@
 use crate::error::*;
 use crate::types::{ServiceStatus, SyncEngineSelection, SyncParams, SyncReason, SyncResult};
 use crate::{reset, reset_all, wipe};
+use parking_lot::Mutex;
 use std::collections::{HashMap, HashSet};
-use std::sync::{atomic::AtomicUsize, Arc, Mutex};
+use std::sync::{atomic::AtomicUsize, Arc};
 use std::time::SystemTime;
 use sync15::{
     self,
@@ -173,7 +174,7 @@ impl SyncManager {
 
     /// Perform a sync.  See [SyncParams] and [SyncResult] for details on how this works
     pub fn sync(&self, params: SyncParams) -> Result<SyncResult> {
-        let mut state = self.mem_cached_state.lock().unwrap();
+        let mut state = self.mem_cached_state.lock();
         let mut have_engines = vec![];
         let bookmarks = Self::places_engine("bookmarks");
         let history = Self::places_engine("history");

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -342,7 +342,6 @@ fn get_encryption_key(store: &LoginStore) -> Option<String> {
     store
         .db
         .lock()
-        .unwrap()
         .query_row(
             "SELECT value FROM loginsSyncMeta WHERE key = 'sync-pass-key'",
             NO_PARAMS,
@@ -356,7 +355,6 @@ fn set_encryption_key(store: &LoginStore, key: &str) -> rusqlite::Result<()> {
     store
         .db
         .lock()
-        .unwrap()
         .execute(
             "
         INSERT INTO  loginsSyncMeta (key, value)
@@ -550,7 +548,7 @@ fn main() -> Result<()> {
             'x' | 'X' => {
                 log::info!("Running arbitrary SQL, there's no way this could go wrong!");
                 if let Some(sql) = prompt_string("SQL (one line only, press enter when done):\n") {
-                    let db = store.db.lock().unwrap();
+                    let db = store.db.lock();
                     if let Err(e) = show_sql(&db, &sql) {
                         log::warn!("Failed to run sql query: {}", e);
                     }

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -19,6 +19,7 @@ the details of which are reproduced below.
 * [MIT License: matches](#mit-license-matches)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
+* [MIT License: owning_ref](#mit-license-owning_ref)
 * [MIT License: radium](#mit-license-radium)
 * [MIT License: rusqlite](#mit-license-rusqlite)
 * [MIT License: tap](#mit-license-tap)
@@ -467,10 +468,13 @@ The following text applies to code linked from these dependencies:
 [lmdb-rkv-sys](https://github.com/mozilla/lmdb-rs.git),
 [lmdb-rkv](https://github.com/mozilla/lmdb-rs.git),
 [log](https://github.com/rust-lang/log),
+[maybe-uninit](https://github.com/est31/maybe-uninit),
 [num-integer](https://github.com/rust-num/num-integer),
 [num-traits](https://github.com/rust-num/num-traits),
 [once_cell](https://github.com/matklad/once_cell),
 [opaque-debug](https://github.com/RustCrypto/utils),
+[parking_lot](https://github.com/Amanieu/parking_lot),
+[parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste-impl](https://github.com/dtolnay/paste),
 [paste](https://github.com/dtolnay/paste),
 [percent-encoding](https://github.com/servo/rust-url/),
@@ -482,6 +486,7 @@ The following text applies to code linked from these dependencies:
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
 [quote](https://github.com/dtolnay/quote),
+[rand](https://github.com/rust-lang-nursery/rand),
 [rand](https://github.com/rust-random/rand),
 [rand_chacha](https://github.com/rust-random/rand),
 [rand_core](https://github.com/rust-random/rand),
@@ -498,6 +503,7 @@ The following text applies to code linked from these dependencies:
 [sha2](https://github.com/RustCrypto/hashes),
 [smallbitvec](https://github.com/servo/smallbitvec),
 [smallvec](https://github.com/servo/rust-smallvec),
+[stable_deref_trait](https://github.com/storyyeller/stable_deref_trait),
 [static_assertions](https://github.com/nvzqz/static-assertions-rs),
 [syn](https://github.com/dtolnay/syn),
 [tempfile](https://github.com/Stebalien/tempfile),
@@ -1126,6 +1132,36 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: owning_ref
+
+The following text applies to code linked from these dependencies:
+[owning_ref](https://github.com/Kimundi/owning-ref-rs)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Marvin Löbel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ```
 -------------

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -225,6 +225,10 @@ the details of which are reproduced below.
     <url>https://github.com/rust-lang/log/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: maybe-uninit</name>
+    <url>https://github.com/est31/maybe-uninit/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: num-integer</name>
     <url>https://github.com/rust-num/num-integer/blob/master/LICENSE-APACHE</url>
   </license>
@@ -239,6 +243,14 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: opaque-debug</name>
     <url>https://github.com/RustCrypto/utils/blob/master/opaque-debug/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: parking_lot</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: parking_lot_core</name>
+    <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: paste</name>
@@ -287,6 +299,10 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: quote</name>
     <url>https://github.com/dtolnay/quote/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: rand</name>
+    <url>https://github.com/rust-lang-nursery/rand/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: rand</name>
@@ -363,6 +379,14 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: smallvec</name>
     <url>https://github.com/servo/rust-smallvec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: smallvec</name>
+    <url>https://github.com/servo/rust-smallvec/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: stable_deref_trait</name>
+    <url>https://github.com/storyyeller/stable_deref_trait/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: static_assertions</name>
@@ -515,6 +539,10 @@ the details of which are reproduced below.
   <license>
     <name>MIT License: ordered-float</name>
     <url>https://github.com/reem/rust-ordered-float/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: owning_ref</name>
+    <url>https://github.com/Kimundi/owning-ref-rs/blob/master/LICENSE</url>
   </license>
   <license>
     <name>MIT License: radium</name>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -24,6 +24,7 @@ the details of which are reproduced below.
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
+* [MIT License: owning_ref](#mit-license-owning_ref)
 * [MIT License: radium](#mit-license-radium)
 * [MIT License: rusqlite](#mit-license-rusqlite)
 * [MIT License: slab](#mit-license-slab)
@@ -492,6 +493,7 @@ The following text applies to code linked from these dependencies:
 [lmdb-rkv-sys](https://github.com/mozilla/lmdb-rs.git),
 [lmdb-rkv](https://github.com/mozilla/lmdb-rs.git),
 [log](https://github.com/rust-lang/log),
+[maybe-uninit](https://github.com/est31/maybe-uninit),
 [mime](https://github.com/hyperium/mime),
 [native-tls](https://github.com/sfackler/rust-native-tls),
 [num-integer](https://github.com/rust-num/num-integer),
@@ -499,6 +501,8 @@ The following text applies to code linked from these dependencies:
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
 [opaque-debug](https://github.com/RustCrypto/utils),
+[parking_lot](https://github.com/Amanieu/parking_lot),
+[parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste-impl](https://github.com/dtolnay/paste),
 [paste](https://github.com/dtolnay/paste),
 [percent-encoding](https://github.com/servo/rust-url/),
@@ -512,6 +516,7 @@ The following text applies to code linked from these dependencies:
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
 [quote](https://github.com/dtolnay/quote),
+[rand](https://github.com/rust-lang-nursery/rand),
 [rand](https://github.com/rust-random/rand),
 [rand_chacha](https://github.com/rust-random/rand),
 [rand_core](https://github.com/rust-random/rand),
@@ -533,6 +538,7 @@ The following text applies to code linked from these dependencies:
 [smallbitvec](https://github.com/servo/smallbitvec),
 [smallvec](https://github.com/servo/rust-smallvec),
 [socket2](https://github.com/rust-lang/socket2),
+[stable_deref_trait](https://github.com/storyyeller/stable_deref_trait),
 [static_assertions](https://github.com/nvzqz/static-assertions-rs),
 [swift-protobuf](https://github.com/apple/swift-protobuf),
 [syn](https://github.com/dtolnay/syn),
@@ -1315,6 +1321,36 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: owning_ref
+
+The following text applies to code linked from these dependencies:
+[owning_ref](https://github.com/Kimundi/owning-ref-rs)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Marvin Löbel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ```
 -------------

--- a/megazords/ios/DEPENDENCIES.md
+++ b/megazords/ios/DEPENDENCIES.md
@@ -28,6 +28,7 @@ the details of which are reproduced below.
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
 * [MIT License: oslog](#mit-license-oslog)
+* [MIT License: owning_ref](#mit-license-owning_ref)
 * [MIT License: radium](#mit-license-radium)
 * [MIT License: rusqlite](#mit-license-rusqlite)
 * [MIT License: slab](#mit-license-slab)
@@ -502,6 +503,7 @@ The following text applies to code linked from these dependencies:
 [lmdb-rkv-sys](https://github.com/mozilla/lmdb-rs.git),
 [lmdb-rkv](https://github.com/mozilla/lmdb-rs.git),
 [log](https://github.com/rust-lang/log),
+[maybe-uninit](https://github.com/est31/maybe-uninit),
 [mime](https://github.com/hyperium/mime),
 [native-tls](https://github.com/sfackler/rust-native-tls),
 [num-integer](https://github.com/rust-num/num-integer),
@@ -509,6 +511,8 @@ The following text applies to code linked from these dependencies:
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
 [opaque-debug](https://github.com/RustCrypto/utils),
+[parking_lot](https://github.com/Amanieu/parking_lot),
+[parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste-impl](https://github.com/dtolnay/paste),
 [paste](https://github.com/dtolnay/paste),
 [percent-encoding](https://github.com/servo/rust-url/),
@@ -522,6 +526,7 @@ The following text applies to code linked from these dependencies:
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
 [quote](https://github.com/dtolnay/quote),
+[rand](https://github.com/rust-lang-nursery/rand),
 [rand](https://github.com/rust-random/rand),
 [rand_chacha](https://github.com/rust-random/rand),
 [rand_core](https://github.com/rust-random/rand),
@@ -543,6 +548,7 @@ The following text applies to code linked from these dependencies:
 [smallbitvec](https://github.com/servo/smallbitvec),
 [smallvec](https://github.com/servo/rust-smallvec),
 [socket2](https://github.com/rust-lang/socket2),
+[stable_deref_trait](https://github.com/storyyeller/stable_deref_trait),
 [static_assertions](https://github.com/nvzqz/static-assertions-rs),
 [swift-protobuf](https://github.com/apple/swift-protobuf),
 [syn](https://github.com/dtolnay/syn),
@@ -1427,6 +1433,36 @@ The following text applies to code linked from these dependencies:
 MIT License
 
 Copyright (c) 2020 Steven Joruk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: owning_ref
+
+The following text applies to code linked from these dependencies:
+[owning_ref](https://github.com/Kimundi/owning-ref-rs)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Marvin Löbel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/testing/separated/places-bench/Cargo.toml
+++ b/testing/separated/places-bench/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/bench.rs"
 [dependencies]
 criterion = "0.3"
 tempdir = "0.3"
+parking_lot = "0.5"
 places = { path = "../../../components/places" }
 sql-support = { path = "../../../components/support/sql" }
 types = { path = "../../../components/support/types" }

--- a/testing/separated/places-bench/src/database.rs
+++ b/testing/separated/places-bench/src/database.rs
@@ -59,14 +59,14 @@ pub struct TestDb {
 
 impl TestDb {
     pub fn new() -> Rc<Self> {
-        use std::sync::{Arc, Mutex};
+        use std::sync::Arc;
         let dir = TempDir::new("placesbench").unwrap();
         let file = dir.path().join("places.sqlite");
         let mut db = PlacesDb::open(
             &file,
             ConnectionType::ReadWrite,
             0,
-            Arc::new(Mutex::new(())),
+            Arc::new(parking_lot::Mutex::new(())),
         )
         .unwrap();
         println!("Populating test database...");

--- a/testing/separated/places-tests/Cargo.toml
+++ b/testing/separated/places-tests/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/tests.rs"
 name = "places-integration-tests"
 
 [dev-dependencies]
+parking_lot = "0.5"
 sql-support = { path = "../../../components/support/sql" }
 sync-guid = { path = "../../../components/support/guid" }
 types = { path = "../../../components/support/types" }

--- a/testing/separated/places-tests/src/check_coop_tx.rs
+++ b/testing/separated/places-tests/src/check_coop_tx.rs
@@ -7,7 +7,7 @@ use places::{PlacesDb, Result};
 use rusqlite::NO_PARAMS;
 use std::fs::remove_file;
 use std::sync::mpsc::sync_channel;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread;
 
 fn update(t: &PlacesDb, n: u32) -> Result<()> {
@@ -29,7 +29,7 @@ fn test_coop_tx() {
     let _ = remove_file(path); // ignore error
     let _ = env_logger::try_init();
 
-    let coop_tx_lock = Arc::new(Mutex::new(()));
+    let coop_tx_lock = Arc::new(parking_lot::Mutex::new(()));
 
     let dbmain = PlacesDb::open(path, ConnectionType::ReadWrite, 0, coop_tx_lock.clone()).unwrap();
     let (tx, rx) = sync_channel(0);

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -380,6 +380,19 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "https://raw.githubusercontent.com/Frommi/miniz_oxide/master/miniz_oxide/LICENSE-MIT.md",
         }
     },
+    "parking_lot_core": {
+        "repository": {
+            "check": "https://github.com/Amanieu/parking_lot",
+        },
+        "licence": {
+            "check": None,
+            "fixup": "Apache-2.0",
+        },
+        "license_file": {
+            "check": None,
+            "fixup": "https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE",
+        },
+    },
     "phf": {
         "repository": {
             "check": "https://github.com/sfackler/rust-phf",


### PR DESCRIPTION
Avoiding panics in all cases, like #4661 and #4662, is going to be whack-a-mole, and when one happens, we pollute sentry with many many ```Caught a panic calling rust code: "called `Result::unwrap()` on an `Err` value: PoisonError { .. }"``` errors.

I don't think we rely on the poisoning strategy for correctness, so we should consider moving to parking_lot.

(Not requesting review yet - I think we should discuss a little - so thoughts welcome!)