### PR TITLE
Fix for fetch_login_data() (#4667)

### DIFF
--- a/components/logins/src/sync/engine.rs
+++ b/components/logins/src/sync/engine.rs
@@ -151,9 +151,11 @@ impl LoginsSyncEngine {
         }
         scope.err_if_interrupted()?;
 
-        sql_support::each_chunk_mapped(
-            records,
-            |r| r.0.id.as_str(),
+        sql_support::each_chunk(
+            &sync_data
+                .iter()
+                .map(|s| s.guid.as_str().to_string())
+                .collect::<Vec<String>>(),
             |chunk, offset| -> Result<()> {
                 // pairs the bound parameter for the guid with an integer index.
                 let values_with_idx = sql_support::repeat_display(chunk.len(), ",", |i, f| {
@@ -667,6 +669,9 @@ mod tests {
     #[test]
     fn test_bad_record() {
         let store = LoginStore::new_in_memory().unwrap();
+        for id in ["dummy_000001", "dummy_000002", "dummy_000003"] {
+            insert_login(&store.db.lock(), id, Some("password"), Some("password"));
+        }
         let (res, telem) = run_fetch_login_data(
             store,
             &[


### PR DESCRIPTION
Added a test that caused the wrong guid issue.  I'm pretty sure this is
what's causing the sentry issues -- at least some of them.

The issue was that we were calling `each_chunk_mapped()` with the
expectation that the `records` and `sync_data` vecs matched up
(`records[i].0.id == sync_data[i].guid`).  However, we only push items
to `sync_data` if `from_payload()` returns `Ok`.  If it returns an error
for any item then this fails.

Some more details:
  - [Here we're assuming that the correct SyncData item for a DB row is `sync_data[guid_idx]` 
](https://github.com/mozilla/application-services/blob/main/components/logins/src/sync/engine.rs#L206-L209)
  - [`guid_idx` comes from `records` ](https://github.com/mozilla/application-services/blob/main/components/logins/src/sync/engine.rs#L154-L161)
  - [However, if `from_payload` fails, then sync_data and records won't align correctly](https://github.com/mozilla/application-services/blob/main/components/logins/src/sync/engine.rs#L141-L148)

I think this system could use a rework, but this should fix the error
for now.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
