### PR TITLE
Refactor the command line interface for use with gradle

### DIFF
--- a/components/support/nimbus-fml/fixtures/fe/nimbus_features.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/nimbus_features.yaml
@@ -63,6 +63,7 @@ types:
         label:
           description: This is the label for the button
           type: String
+          default: REQUIRED FIELD
           required: true
         color:
           description: This is the color of the button

--- a/components/support/nimbus-fml/src/backends/kotlin/mod.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/mod.rs
@@ -12,10 +12,9 @@ mod gen_structs;
 
 pub(crate) fn generate_struct(
     manifest: FeatureManifest,
-    config: Option<Config>,
+    config: Config,
     cmd: GenerateStructCmd,
 ) -> Result<()> {
-    let config = config.unwrap_or_default();
     let kt = gen_structs::FeatureManifestDeclaration::new(config, &manifest);
 
     let path = cmd.output;

--- a/components/support/nimbus-fml/src/cli.yaml
+++ b/components/support/nimbus-fml/src/cli.yaml
@@ -13,25 +13,39 @@ args:
         short: v
         multiple: true
         help: Sets the level of verbosity
+    - INPUT:
+        help: Sets the input file to use
+        required: true
+        index: 1
+    - ir:
+        help: The input file is intermediate representation. Useful for debugging FML.
+        long: ir
+        global: true
+    - output:
+        help: The file where generated code is created
+        short: o
+        long: output
+        value_name: FILE
+        global: true
 subcommands:
-    - struct:
-        about: Generate the app code for configuring features
+    - android:
+        about: Generate code for Android
+        subcommands:
+            - features:
+                about: Generate feature structs against the Feature Variables API.
+                args:
+                    - channel:
+                        help: The channel which the default will use. Unimplemented.
         args:
-            - language:
-                short: l
-                long: language
-                value_name: LANGUAGE
-                possible_values: [ kotlin, swift, ir ]
-            - INPUT:
-                help: Sets the input file to use
-                required: true
-                index: 1
-            - ir:
-                help: The input file is intermediate representation. Useful for debugging FML.
-                long: ir
-            - output:
-                help: The output file
-                short: o
-                long: output
-                value_name: FILE
-                required: true
+            - package:
+                help: The package name where the features class will live
+                long: package
+                value_name: PACKAGE
+                global: true
+            - class_name:
+                help: The name of the class as it will be known by the app developer
+                long: classname
+                value_name: CLASSNAME
+                global: true
+    - experimenter:
+        about: Generate code for Experimenter

--- a/components/support/nimbus-fml/src/main.rs
+++ b/components/support/nimbus-fml/src/main.rs
@@ -47,7 +47,6 @@ fn main() -> Result<()> {
                         .value_of("package")
                         .map(str::to_string)
                         .or(config.package_name),
-                    ..config
                 },
                 GenerateStructCmd {
                     language: TargetLanguage::Kotlin,

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -316,7 +316,7 @@ mod unit_tests {
             name: "label".to_string(),
             doc: "This is the label for the button".to_string(),
             typ: TypeRef::String,
-            default: serde_json::Value::Null,
+            default: serde_json::Value::String("REQUIRED FIELD".to_string()),
         }));
         assert!(obj_def.props.contains(&PropDef {
             name: "color".to_string(),

--- a/components/support/nimbus-fml/src/util/mod.rs
+++ b/components/support/nimbus-fml/src/util/mod.rs
@@ -40,3 +40,11 @@ pub(crate) fn build_dir() -> String {
 pub(crate) fn generated_src_dir() -> String {
     join(build_dir(), "generated")
 }
+
+use crate::error::Result;
+use crate::Config;
+
+pub(crate) fn slurp_config(path: &std::path::Path) -> Result<Config> {
+    let string = std::fs::read_to_string(path)?;
+    Ok(serde_yaml::from_str::<crate::Config>(&string)?)
+}

--- a/components/support/nimbus-fml/src/workflows.rs
+++ b/components/support/nimbus-fml/src/workflows.rs
@@ -8,17 +8,11 @@ use crate::error::Result;
 use crate::intermediate_representation::FeatureManifest;
 use crate::parser::Parser;
 use crate::Config;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::GenerateStructCmd;
 
-pub(crate) fn generate_struct(config: Option<PathBuf>, cmd: GenerateStructCmd) -> Result<()> {
-    let config = if let Some(path) = config {
-        Some(slurp_config(&path)?)
-    } else {
-        None
-    };
-
+pub(crate) fn generate_struct(config: Config, cmd: GenerateStructCmd) -> Result<()> {
     let ir = if !cmd.load_from_ir {
         let parser: Parser = Parser::new(&cmd.manifest)?;
         parser.get_intermediate_representation()?
@@ -39,20 +33,15 @@ pub(crate) fn generate_struct(config: Option<PathBuf>, cmd: GenerateStructCmd) -
     Ok(())
 }
 
-fn slurp_config(path: &Path) -> Result<Config> {
-    let string = std::fs::read_to_string(path)?;
-    Ok(serde_yaml::from_str::<Config>(&string)?)
-}
-
 fn slurp_file(path: &Path) -> Result<String> {
     Ok(std::fs::read_to_string(path)?)
 }
 
 #[cfg(test)]
 mod test {
-
     use std::convert::TryInto;
     use std::fs;
+    use std::path::PathBuf;
 
     use anyhow::anyhow;
 
@@ -93,7 +82,7 @@ mod test {
             load_from_ir: is_ir,
             language,
         };
-        generate_struct(None, cmd)?;
+        generate_struct(Default::default(), cmd)?;
         run_script_with_generated_code(language, manifest_kt, &test_script)?;
         Ok(())
     }


### PR DESCRIPTION
This rejigs the CLI so as to expose the classname and package name to the command line.

It moves the platform to a subcommand (rather than a language) to better reflect how the backends will be structured.

This is unlikely to be FML command line's final form.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.