### PR TITLE
Enables manual deployment of docs

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -2,6 +2,7 @@ name: Build and Deploy
 on:   
   schedule:
     - cron: '0 1 * * *'
+  workflow_dispatch:
 jobs:
   build-and-deploy-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Super minor change, in case we ever need to redeploy our **docs** manually (in case something went wrong on a previous docs deployment, or just testing)

To run the job manually (once this merges) you can go to `Actions` > on the left under `Workflows`, click `Build and Deploy` > On the right-hand side, there will be a `Run workflow` button > choose the `main` or desired branch to run the job on
