### PR TITLE
This fixes FML maps to allow for the use of user defined types

### DIFF
--- a/components/support/nimbus-fml/fixtures/fe/nimbus_features.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/nimbus_features.yaml
@@ -23,6 +23,13 @@ features:
         description: This is the background color
         type: String
         default: white
+      player-mapping:
+        description: This is the map of the player type to a button
+        type: Map<PlayerProfile, Button>
+        default: {
+          "child": {},
+          "adult": {}
+        }
     defaults:
       - channel: release
         value: {


### PR DESCRIPTION
This fixes an issue where user-defined types used in Maps defined in the features weren't working as intended, causing a parsing error.