### PR TITLE
Merges defaults that are under the same release

### DIFF
--- a/components/support/nimbus-fml/fixtures/fe/nimbus_features.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/nimbus_features.yaml
@@ -30,7 +30,7 @@ features:
           "child": {},
           "adult": {}
         }
-    defaults:
+    default:
       - channel: release
         value: {
           "positive": {

--- a/components/support/nimbus-fml/src/cli.yaml
+++ b/components/support/nimbus-fml/src/cli.yaml
@@ -49,3 +49,5 @@ subcommands:
                 global: true
     - experimenter:
         about: Generate code for Experimenter
+    - intermediate-repr:
+        about: Generate the intermediate representation json

--- a/components/support/nimbus-fml/src/main.rs
+++ b/components/support/nimbus-fml/src/main.rs
@@ -65,6 +65,14 @@ fn main() -> Result<()> {
                 load_from_ir: matches.is_present("ir"),
             },
         )?,
+        ("intermediate-repr", _) => workflows::generate_ir(
+            config,
+            GenerateIRCmd {
+                manifest: file_path("INPUT", &matches, &cwd)?,
+                output: file_path("output", &matches, &cwd)?,
+                load_from_ir: matches.is_present("ir"),
+            },
+        )?,
         (word, _) => unimplemented!("Command {} not implemented", word),
     };
 
@@ -97,6 +105,12 @@ pub struct GenerateStructCmd {
 }
 
 pub struct GenerateExperimenterManifestCmd {
+    manifest: PathBuf,
+    output: PathBuf,
+    load_from_ir: bool,
+}
+
+pub struct GenerateIRCmd {
     manifest: PathBuf,
     output: PathBuf,
     load_from_ir: bool,

--- a/components/support/nimbus-fml/src/workflows.rs
+++ b/components/support/nimbus-fml/src/workflows.rs
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{backends, GenerateExperimenterManifestCmd, TargetLanguage};
+use crate::{backends, GenerateExperimenterManifestCmd, GenerateIRCmd, TargetLanguage};
 
 use crate::error::Result;
 use crate::intermediate_representation::FeatureManifest;
@@ -32,6 +32,12 @@ pub(crate) fn generate_experimenter_manifest(
 ) -> Result<()> {
     let ir = load_feature_manifest(&cmd.manifest, cmd.load_from_ir)?;
     backends::experimenter_manifest::generate_manifest(ir, config, cmd)?;
+    Ok(())
+}
+
+pub(crate) fn generate_ir(_: Config, cmd: GenerateIRCmd) -> Result<()> {
+    let ir = load_feature_manifest(&cmd.manifest, cmd.load_from_ir)?;
+    std::fs::write(cmd.output, serde_json::to_string_pretty(&ir)?)?;
     Ok(())
 }
 


### PR DESCRIPTION
fixes https://mozilla-hub.atlassian.net/browse/SDK-436
Adds:
- Cli to generate intermediate representation, which was really useful for testing
- Merging of the defaults at the feature level **if** they are under the same channel


Before this is ready to land:
- [ ] Add tests with a variety of defaults
- [ ] filter out the defaults with `targeting` at this time

This is still a draft to get initial feedback, it needs some more testing
