### PR TITLE
Fix push for subsequent subscriptions

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -27,3 +27,7 @@ Use the template below to make assigning a version number during the release cut
 ### What's Changed
   - These packages all use `parking_lot::Mutex` instead of `std::Mutex`, meaning we should no
     longer see errors about mutexes being poisoned.
+
+## Push
+### What's fixed
+  - Fixes a bug where the subscriptions would fail because the server didn't return the `uaid`, this seems to happen only when the client sends request that include the `uaid`.([#4697](https://github.com/mozilla/application-services/pull/4697))


### PR DESCRIPTION
fixes #4691 

Uses the client cached `uaid` when the server doesn't return one. If we didn't have a `uaid`, we error out, because we cannot return the subscription back to our consumer.

From the logs, it seems like we are hitting this only on subsequent subscriptions (i.e not the first one where we got the `uaid`)

I'll need to cut a release once this merges

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
