### PR TITLE
Cut release v87.1.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 87.0.0
+libraryVersion: 87.1.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# v87.1.0 (_2021-12-02_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v87.0.0...v87.1.0)
+
+## Logins
+### What's changed
+  - The `update()` and `add_or_update()` methods will log rather than return an error when trying to update a duplicate login (#4648)
+
+## Logins, Places, SyncManager
+### What's Changed
+  - These packages all use `parking_lot::Mutex` instead of `std::Mutex`, meaning we should no
+    longer see errors about mutexes being poisoned.
+
+## Push
+### What's fixed
+  - Fixes a bug where the subscriptions would fail because the server didn't return the `uaid`, this seems to happen only when the client sends request that include the `uaid`.([#4697](https://github.com/mozilla/application-services/pull/4697))
+
+# General
+
+- We now use xcode 13.1 to generate our iOS build artifacts. ([#4692](https://github.com/mozilla/application-services/pull/4692))
+
 # v87.0.0 (_2021-11-17_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v86.2.0...v87.0.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v87.0.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v87.1.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,16 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-
-## Logins
-### What's changed
-  - The `update()` and `add_or_update()` methods will log rather than return an error when trying to update a duplicate login (#4648)
-
-## Logins, Places, SyncManager
-### What's Changed
-  - These packages all use `parking_lot::Mutex` instead of `std::Mutex`, meaning we should no
-    longer see errors about mutexes being poisoned.
-
-## Push
-### What's fixed
-  - Fixes a bug where the subscriptions would fail because the server didn't return the `uaid`, this seems to happen only when the client sends request that include the `uaid`.([#4697](https://github.com/mozilla/application-services/pull/4697))


### PR DESCRIPTION
Cuts v87.1.0

This is the release that will eventually be merged into AC in https://github.com/mozilla-mobile/android-components/pull/11256 and it has the Xcode upgrade to 13.1 for iOS
