### PR TITLE
Fix swiftformat

### DIFF
--- a/automation/tests.py
+++ b/automation/tests.py
@@ -287,7 +287,7 @@ def swift_format():
         run_command([
             'swiftformat', 'megazords', 'components/*/ios',
             '--exclude', '**/Generated', '--exclude', 'components/nimbus/ios/Nimbus/Utils',
-            '--lint', '--swiftversion', '4',
+            '--lint', '--swiftversion', '5',
         ])
     else:
         print("WARNING: skipping swiftformat on non-Darwin host")

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -52,9 +52,7 @@ open class FxAccountManager {
         setupInternalListeners()
     }
 
-    private lazy var statePersistenceCallback: FxAStatePersistenceCallback = {
-        FxAStatePersistenceCallback(manager: self)
-    }()
+    private lazy var statePersistenceCallback: FxAStatePersistenceCallback = .init(manager: self)
 
     /// Starts the FxA account manager and advances the state machine.
     /// It is required to call this method before doing anything else with the manager.


### PR DESCRIPTION
Fixes a swiftformat ci failure from the latest swiftformat release

Also realized that our `tests.py` still uses `--swiftversion 4`, when we are now using swift version 5 after the `Xcode` upgrade to 13