### PR TITLE
Uniffi top frecent site info

### DIFF
--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -118,13 +118,6 @@ internal interface LibPlacesFFI : Library {
         out_err: RustError.ByReference
     )
 
-    fun places_get_top_frecent_site_infos(
-        handle: PlacesConnectionHandle,
-        numItems: Int,
-        frecencyThreshold: Long,
-        error: RustError.ByReference
-    ): RustBuffer.ByValue
-
     fun places_reset(
         handle: PlacesApiHandle,
         error: RustError.ByReference

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -8,6 +8,7 @@ import com.sun.jna.Native
 import com.sun.jna.Pointer
 import mozilla.appservices.places.uniffi.ConnectionType
 import mozilla.appservices.places.uniffi.DocumentType
+import mozilla.appservices.places.uniffi.FrecencyThresholdOption
 import mozilla.appservices.places.uniffi.PlacesException
 import mozilla.appservices.places.uniffi.HistoryHighlight
 import mozilla.appservices.places.uniffi.HistoryHighlightWeights
@@ -309,7 +310,7 @@ open class PlacesReaderConnection internal constructor(connHandle: Long, conn: U
     }
 
     override fun getTopFrecentSiteInfos(numItems: Int, frecencyThreshold: FrecencyThresholdOption): List<TopFrecentSiteInfo> {
-        return this.conn.getTopFrecentSiteInfos(numItems, frecencyThreshold.value)
+        return this.conn.getTopFrecentSiteInfos(numItems, frecencyThreshold)
     }
 
     override fun getVisited(urls: List<String>): List<Boolean> {
@@ -1223,18 +1224,6 @@ data class HistoryMetadataKey(
     val searchTerm: String?,
     val referrerUrl: String?
 )
-
-/**
- * Frecency threshold options for fetching top frecent sites. Requests a page that was visited
- * with a frecency score greater or equal to the [value].
- */
-enum class FrecencyThresholdOption(val value: Long) {
-    /** Returns all visited pages. */
-    NONE(0),
-
-    /** Skip visited pages that were only visited once. */
-    SKIP_ONE_TIME_PAGES(101)
-}
 
 /**
  * A helper class for gathering basic count metrics on different kinds of PlacesManager operations.

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -9,6 +9,7 @@ import mozilla.appservices.Megazord
 import mozilla.appservices.places.uniffi.DocumentType
 import mozilla.appservices.places.uniffi.VisitObservation
 import mozilla.appservices.places.uniffi.VisitTransition
+import mozilla.appservices.places.uniffi.FrecencyThresholdOption
 import mozilla.appservices.syncmanager.SyncManager
 import mozilla.appservices.places.uniffi.PlacesException
 import mozilla.components.service.glean.testing.GleanTestRule

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -228,19 +228,6 @@ pub extern "C" fn places_delete_everything(handle: u64, error: &mut ExternError)
 }
 
 #[no_mangle]
-pub extern "C" fn places_get_top_frecent_site_infos(
-    handle: u64,
-    num_items: i32,
-    frecency_threshold: i64,
-    error: &mut ExternError,
-) -> ByteBuffer {
-    log::debug!("places_get_top_frecent_site_infos");
-    CONNECTIONS.call_with_result(error, handle, |conn| -> places::Result<_> {
-        storage::history::get_top_frecent_site_infos(conn, num_items, frecency_threshold)
-    })
-}
-
-#[no_mangle]
 pub extern "C" fn places_accept_result(
     handle: u64,
     search_string: FfiStr<'_>,

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -255,6 +255,16 @@ impl PlacesConnection {
             Ok(())
         })
     }
+
+    fn get_top_frecent_site_infos(
+        &self,
+        num_items: i32,
+        frecency_threshold: i64,
+    ) -> Result<Vec<TopFrecentSiteInfo>> {
+        self.with_conn(|conn| {
+            crate::storage::history::get_top_frecent_site_infos(conn, num_items, frecency_threshold)
+        })
+    }
 }
 
 #[derive(Clone, PartialEq)]
@@ -271,6 +281,11 @@ pub struct HistoryVisitInfosWithBound {
     pub infos: Vec<HistoryVisitInfo>,
     pub bound: i64,
     pub offset: i64,
+}
+
+pub struct TopFrecentSiteInfo {
+    pub url: Url,
+    pub title: Option<String>,
 }
 
 pub mod error_codes {
@@ -404,7 +419,6 @@ impl From<Error> for ExternError {
 }
 
 implement_into_ffi_by_protobuf!(msg_types::SearchResultList);
-implement_into_ffi_by_protobuf!(msg_types::TopFrecentSiteInfos);
 implement_into_ffi_by_protobuf!(msg_types::BookmarkNode);
 implement_into_ffi_by_protobuf!(msg_types::BookmarkNodeList);
 implement_into_ffi_by_delegation!(

--- a/components/places/src/mozilla.appservices.places.protobuf.rs
+++ b/components/places/src/mozilla.appservices.places.protobuf.rs
@@ -150,18 +150,6 @@ pub struct SearchResultList {
     #[prost(message, repeated, tag="1")]
     pub results: ::prost::alloc::vec::Vec<SearchResultMessage>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TopFrecentSiteInfo {
-    #[prost(string, required, tag="1")]
-    pub url: ::prost::alloc::string::String,
-    #[prost(string, optional, tag="2")]
-    pub title: ::core::option::Option<::prost::alloc::string::String>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct TopFrecentSiteInfos {
-    #[prost(message, repeated, tag="1")]
-    pub infos: ::prost::alloc::vec::Vec<TopFrecentSiteInfo>,
-}
 /// Protobuf allows nesting these, but prost behaves weirdly if we do.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -82,7 +82,18 @@ interface PlacesConnection {
     void delete_visit(string url, Timestamp timestamp);
 
     [Throws=PlacesError]
-    sequence<TopFrecentSiteInfo> get_top_frecent_site_infos(i32 num_items, i64 frecency_threshold);
+    sequence<TopFrecentSiteInfo> get_top_frecent_site_infos(i32 num_items, FrecencyThresholdOption threshold_option);
+};
+
+/**
+ * Frecency threshold options for fetching top frecent sites. Requests a page that was visited
+ * with a frecency score greater or equal to the value associated with the enums
+ */
+enum FrecencyThresholdOption {
+// Returns all visited pages. The frecency score is 0
+  "None",
+// Skip visited pages that were only visited once. The frecency score is 101
+  "SkipOneTimePages",
 };
 
 // Some kind of namespacing for uniffi would be ideal. Multiple udl/macro defns?

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -80,6 +80,9 @@ interface PlacesConnection {
 
     [Throws=PlacesError]
     void delete_visit(string url, Timestamp timestamp);
+
+    [Throws=PlacesError]
+    sequence<TopFrecentSiteInfo> get_top_frecent_site_infos(i32 num_items, i64 frecency_threshold);
 };
 
 // Some kind of namespacing for uniffi would be ideal. Multiple udl/macro defns?
@@ -180,6 +183,12 @@ dictionary VisitObservation {
 dictionary Dummy {
     sequence<HistoryMetadata>? md;
 };
+
+dictionary TopFrecentSiteInfo {
+    Url url;
+    string? title;
+};
+
 
 [Error]
 enum PlacesError {

--- a/components/places/src/places_msg_types.proto
+++ b/components/places/src/places_msg_types.proto
@@ -178,12 +178,3 @@ message SearchResultMessage {
 message SearchResultList {
     repeated SearchResultMessage results = 1;
 }
-
-message TopFrecentSiteInfo {
-    required string url = 1;
-    optional string title = 2;
-}
-
-message TopFrecentSiteInfos {
-    repeated TopFrecentSiteInfo infos = 1;
-}

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -5,13 +5,12 @@
 use super::{fetch_page_info, new_page_info, PageInfo, RowId};
 use crate::db::PlacesDb;
 use crate::error::Result;
-use crate::ffi::{HistoryVisitInfo, HistoryVisitInfosWithBound};
+use crate::ffi::{HistoryVisitInfo, HistoryVisitInfosWithBound, TopFrecentSiteInfo};
 use crate::frecency;
 use crate::hash;
 use crate::history_sync::engine::{
     COLLECTION_SYNCID_META_KEY, GLOBAL_SYNCID_META_KEY, LAST_SYNC_META_KEY,
 };
-use crate::msg_types::{TopFrecentSiteInfo, TopFrecentSiteInfos};
 use crate::observation::VisitObservation;
 use crate::storage::{delete_meta, delete_pending_temp_tables, get_meta, put_meta};
 use crate::types::{SyncStatus, VisitTransition, VisitTransitionSet};
@@ -1221,7 +1220,7 @@ pub fn get_top_frecent_site_infos(
     db: &PlacesDb,
     num_items: i32,
     frecency_threshold: i64,
-) -> Result<TopFrecentSiteInfos> {
+) -> Result<Vec<TopFrecentSiteInfo>> {
     // Get the complement of the visit types that should be excluded.
     let allowed_types = VisitTransitionSet::for_specific(&[
         VisitTransition::Download,
@@ -1255,7 +1254,7 @@ pub fn get_top_frecent_site_infos(
         },
         TopFrecentSiteInfo::from_row,
     )?;
-    Ok(TopFrecentSiteInfos { infos })
+    Ok(infos)
 }
 
 pub fn get_visit_infos(

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -13,7 +13,7 @@ pub mod tags;
 use crate::db::PlacesDb;
 use crate::error::{ErrorKind, InvalidPlaceInfo, Result};
 use crate::ffi::HistoryVisitInfo;
-use crate::msg_types::TopFrecentSiteInfo;
+use crate::ffi::TopFrecentSiteInfo;
 use crate::types::{SyncStatus, VisitTransition};
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::Result as RusqliteResult;
@@ -209,8 +209,9 @@ impl HistoryVisitInfo {
 
 impl TopFrecentSiteInfo {
     pub(crate) fn from_row(row: &rusqlite::Row<'_>) -> Result<Self> {
+        let url: String = row.get("url")?;
         Ok(Self {
-            url: row.get("url")?,
+            url: Url::parse(&url)?,
             title: row.get("title")?,
         })
     }


### PR DESCRIPTION
fixes #4696 

Uniffies the top frecent site info types and function call

no change in behaviour it was a small mechanical change. Only thing to point out it the `url` is now represented as an actual `Url` type, and it would error out if it wasn't

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
