### PR TITLE
Don't provide a stdc++ on Windows

### DIFF
--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -82,7 +82,7 @@ fn link_nss_libs(kind: LinkingKind) {
     let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
     if target_os == "android" || target_os == "linux" {
         println!("cargo:rustc-link-lib=stdc++");
-    } else {
+    } else if target_os != "windows" {
         println!("cargo:rustc-link-lib=c++");
     }
 }


### PR DESCRIPTION
In the current state of things, the build will fail on Windows, because it won't find the stdlib.

The rustc docs mention (but I'm struggling to find the docs again) that, on Windows, this should not be provided.
It fixes the compilation for me, locally.

Update: while I can't find the documentation page that @badboy sent me a while back, he was kind enough to provide [this example](https://github.com/rust-lang/rust/blob/87dce6e8dfdae605c9c2a713cf0133066a52022a/compiler/rustc_llvm/build.rs#L288-L303) of how rustc skips everything when the target is msvc.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
