### PR TITLE
Only run dependency CI on schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,9 +490,6 @@ workflows:
   check-protobuf-uptodate:
     jobs:
       - Check Protobuf files are up-to-date
-  check-dependencies:
-    jobs:
-      - Check Rust dependencies
   bash-lint:
     jobs:
       - Lint Bash scripts


### PR DESCRIPTION
Fixes #4623 

We already have dependency CI running on a schedule, and in-practice, the fact that we have it running on PRs isn't really helping because people are more often than not getting red ci when they didn't change anything related to dependencies.

The demo I had also ran CI when a PR changed any `Cargo.toml` or the `Cargo.lock`, I'll file a follow up to implement that - I could have switched us to use GitHub actions for this (which would have made it super simple to implement the followup), but wasn't sure if it was worth the switch (and the added complexity of dealing with two different types of CI runners) 
