### PR TITLE
Uniffi Search result and match url

### DIFF
--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -63,13 +63,6 @@ internal interface LibPlacesFFI : Library {
         out_err: RustError.ByReference
     )
 
-    /** Returns a URL, or null if no match was found. */
-    fun places_match_url(
-        handle: PlacesConnectionHandle,
-        search: String,
-        out_err: RustError.ByReference
-    ): Pointer?
-
     fun places_new_interrupt_handle(
         conn: PlacesConnectionHandle,
         out_err: RustError.ByReference

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -63,14 +63,6 @@ internal interface LibPlacesFFI : Library {
         out_err: RustError.ByReference
     )
 
-    /** Returns JSON string, which you need to free with places_destroy_string */
-    fun places_query_autocomplete(
-        handle: PlacesConnectionHandle,
-        search: String,
-        limit: Int,
-        out_err: RustError.ByReference
-    ): RustBuffer.ByValue
-
     /** Returns a URL, or null if no match was found. */
     fun places_match_url(
         handle: PlacesConnectionHandle,

--- a/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/LibPlacesFFI.kt
@@ -174,13 +174,6 @@ internal interface LibPlacesFFI : Library {
     fun places_interrupt_handle_destroy(obj: RawPlacesInterruptHandle)
 
     fun places_destroy_bytebuffer(bb: RustBuffer.ByValue)
-
-    fun places_accept_result(
-        handle: PlacesConnectionHandle,
-        search_string: String,
-        url: String,
-        out_err: RustError.ByReference
-    )
 }
 
 internal typealias PlacesConnectionHandle = Long

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -285,9 +285,7 @@ open class PlacesReaderConnection internal constructor(connHandle: Long, conn: U
     }
 
     override fun matchUrl(query: String): String? {
-        return rustCallForOptString { error ->
-            LibPlacesFFI.INSTANCE.places_match_url(this.handle.get(), query, error)
-        }
+        return this.conn.matchUrl(query)
     }
 
     override fun getTopFrecentSiteInfos(numItems: Int, frecencyThreshold: FrecencyThresholdOption): List<TopFrecentSiteInfo> {

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -630,11 +630,7 @@ class PlacesWriterConnection internal constructor(connHandle: Long, conn: Uniffi
     }
 
     override fun acceptResult(searchString: String, url: String) {
-        rustCall { error ->
-            LibPlacesFFI.INSTANCE.places_accept_result(
-                this.handle.get(), searchString, url, error
-            )
-        }
+        return this.conn.acceptResult(searchString, url)
     }
 
     @Synchronized

--- a/components/places/ffi/src/lib.rs
+++ b/components/places/ffi/src/lib.rs
@@ -21,7 +21,7 @@ use sql_support::SqlInterruptHandle;
 use std::os::raw::c_char;
 use sync_guid::Guid as SyncGuid;
 
-use places::api::matcher::{self, match_url};
+use places::api::matcher;
 
 // indirection to help `?` figure out the target error type
 fn parse_url(url: &str) -> places::Result<url::Url> {
@@ -160,18 +160,6 @@ pub extern "C" fn places_new_interrupt_handle(
 #[no_mangle]
 pub extern "C" fn places_interrupt(handle: &SqlInterruptHandle, error: &mut ExternError) {
     ffi_support::call_with_output(error, || handle.interrupt())
-}
-
-/// Execute a query, returning a URL string or null. Returned string must be freed
-/// using `places_destroy_string`. Returns null if no match is found.
-#[no_mangle]
-pub extern "C" fn places_match_url(
-    handle: u64,
-    search: FfiStr<'_>,
-    error: &mut ExternError,
-) -> *mut c_char {
-    log::debug!("places_match_url");
-    CONNECTIONS.call_with_result(error, handle, |conn| match_url(conn, search.as_str()))
 }
 
 #[no_mangle]

--- a/components/places/ios/Places/RustPlacesAPI.h
+++ b/components/places/ios/Places/RustPlacesAPI.h
@@ -60,11 +60,6 @@ void places_note_observation(PlacesConnectionHandle handle,
                              const char *_Nonnull observation_json,
                              PlacesRustError *_Nonnull out_err);
 
-char *_Nullable places_query_autocomplete(PlacesConnectionHandle handle,
-                                          const char *_Nonnull search,
-                                          int32_t limit,
-                                          PlacesRustError *_Nonnull out_err);
-
 char *_Nullable places_match_url(PlacesConnectionHandle handle,
                                  const char *_Nonnull search,
                                  PlacesRustError *_Nonnull out_err);

--- a/components/places/ios/Places/RustPlacesAPI.h
+++ b/components/places/ios/Places/RustPlacesAPI.h
@@ -60,10 +60,6 @@ void places_note_observation(PlacesConnectionHandle handle,
                              const char *_Nonnull observation_json,
                              PlacesRustError *_Nonnull out_err);
 
-char *_Nullable places_match_url(PlacesConnectionHandle handle,
-                                 const char *_Nonnull search,
-                                 PlacesRustError *_Nonnull out_err);
-
 void places_bookmarks_import_from_ios(PlacesAPIHandle handle,
                                       const char *_Nonnull db_path,
                                       PlacesRustError *_Nonnull out_err);

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -4,8 +4,8 @@
 
 use crate::db::PlacesDb;
 use crate::error::Result;
+use crate::ffi::{MatchReason as FfiMatchReason, SearchResult as FfiSearchResult};
 pub use crate::match_impl::{MatchBehavior, SearchBehavior};
-use crate::ffi::{SearchResult as FfiSearchResult, MatchReason as FfiMatchReason};
 use rusqlite::{types::ToSql, Row};
 use serde_derive::*;
 use sql_support::{maybe_log_plan, ConnExt};
@@ -345,11 +345,7 @@ impl From<SearchResult> for FfiSearchResult {
             url: res.url.into(),
             title: res.title,
             frecency: res.frecency,
-            reasons: res
-                .reasons
-                .into_iter()
-                .map(Into::into)
-                .collect::<Vec<_>>(),
+            reasons: res.reasons.into_iter().map(Into::into).collect::<Vec<_>>(),
         }
     }
 }

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -4,7 +4,7 @@
 
 // This module implement the traits that make the FFI code easier to manage.
 
-use crate::api::matcher::{search_frecent, SearchParams};
+use crate::api::matcher::{self, search_frecent, SearchParams};
 use crate::api::places_api::places_api_new;
 use crate::error::{Error, ErrorKind, InvalidPlaceInfo, PlacesError};
 use crate::storage::history_metadata::{
@@ -349,6 +349,10 @@ impl PlacesConnection {
             search_string: search,
             limit: limit as u32,
         }).map(|search_results| search_results.into_iter().map(Into::into).collect()))
+    }
+
+    fn accept_result(&self, search_string: String, url: Url) -> Result<()> {
+        self.with_conn(|conn| matcher::accept_result(conn, &search_string, &url))
     }
 }
 

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -354,6 +354,10 @@ impl PlacesConnection {
     fn accept_result(&self, search_string: String, url: Url) -> Result<()> {
         self.with_conn(|conn| matcher::accept_result(conn, &search_string, &url))
     }
+
+    fn match_url(&self, query: String) -> Result<Option<Url>> {
+        self.with_conn(|conn| matcher::match_url(conn, query))
+    }
 }
 
 #[derive(Clone, PartialEq)]

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -4,6 +4,7 @@
 
 // This module implement the traits that make the FFI code easier to manage.
 
+use crate::api::matcher::{search_frecent, SearchParams};
 use crate::api::places_api::places_api_new;
 use crate::error::{Error, ErrorKind, InvalidPlaceInfo, PlacesError};
 use crate::storage::history_metadata::{
@@ -342,6 +343,13 @@ impl PlacesConnection {
     fn run_maintenance(&self) -> Result<()> {
         self.with_conn(|conn| storage::run_maintenance(conn))
     }
+
+    fn query_autocomplete(&self, search: String, limit: i32) -> Result<Vec<SearchResult>> {
+        self.with_conn(|conn| search_frecent(conn, SearchParams {
+            search_string: search,
+            limit: limit as u32,
+        }).map(|search_results| search_results.into_iter().map(Into::into).collect()))
+    }
 }
 
 #[derive(Clone, PartialEq)]
@@ -379,6 +387,27 @@ impl FrecencyThresholdOption {
     }
 }
 
+// We define those types to cross the FFI
+// a better approach would be to:
+// - Rename the `Url` in the internal MatchReason to have a different name
+// - Fix the mismatch between the consumers and the rust layer with the Tags
+//     variant in the internal MatchReason, the rust layer uses a 
+//     variant with associated data, the kotlin layers assumes a flat enum.
+pub struct SearchResult {
+    pub url: Url,
+    pub title: String,
+    pub frecency: i64,
+    pub reasons: Vec<MatchReason>,
+}
+
+pub enum MatchReason {
+    Keyword,
+    Origin,
+    UrlMatch,
+    PreviousUse,
+    Bookmark,
+    Tags,
+}
 pub mod error_codes {
     // Note: 0 (success) and -1 (panic) are reserved by ffi_support
 
@@ -509,7 +538,6 @@ impl From<Error> for ExternError {
     }
 }
 
-implement_into_ffi_by_protobuf!(msg_types::SearchResultList);
 implement_into_ffi_by_protobuf!(msg_types::BookmarkNode);
 implement_into_ffi_by_protobuf!(msg_types::BookmarkNodeList);
 implement_into_ffi_by_delegation!(

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -345,10 +345,16 @@ impl PlacesConnection {
     }
 
     fn query_autocomplete(&self, search: String, limit: i32) -> Result<Vec<SearchResult>> {
-        self.with_conn(|conn| search_frecent(conn, SearchParams {
-            search_string: search,
-            limit: limit as u32,
-        }).map(|search_results| search_results.into_iter().map(Into::into).collect()))
+        self.with_conn(|conn| {
+            search_frecent(
+                conn,
+                SearchParams {
+                    search_string: search,
+                    limit: limit as u32,
+                },
+            )
+            .map(|search_results| search_results.into_iter().map(Into::into).collect())
+        })
     }
 
     fn accept_result(&self, search_string: String, url: Url) -> Result<()> {
@@ -399,7 +405,7 @@ impl FrecencyThresholdOption {
 // a better approach would be to:
 // - Rename the `Url` in the internal MatchReason to have a different name
 // - Fix the mismatch between the consumers and the rust layer with the Tags
-//     variant in the internal MatchReason, the rust layer uses a 
+//     variant in the internal MatchReason, the rust layer uses a
 //     variant with associated data, the kotlin layers assumes a flat enum.
 pub struct SearchResult {
     pub url: Url,

--- a/components/places/src/mozilla.appservices.places.protobuf.rs
+++ b/components/places/src/mozilla.appservices.places.protobuf.rs
@@ -134,33 +134,3 @@ pub struct BookmarkNodeList {
     #[prost(message, repeated, tag="1")]
     pub nodes: ::prost::alloc::vec::Vec<BookmarkNode>,
 }
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SearchResultMessage {
-    #[prost(string, required, tag="1")]
-    pub url: ::prost::alloc::string::String,
-    #[prost(string, required, tag="2")]
-    pub title: ::prost::alloc::string::String,
-    #[prost(int64, required, tag="3")]
-    pub frecency: i64,
-    #[prost(enumeration="SearchResultReason", repeated, tag="4")]
-    pub reasons: ::prost::alloc::vec::Vec<i32>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SearchResultList {
-    #[prost(message, repeated, tag="1")]
-    pub results: ::prost::alloc::vec::Vec<SearchResultMessage>,
-}
-/// Protobuf allows nesting these, but prost behaves weirdly if we do.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
-#[repr(i32)]
-pub enum SearchResultReason {
-    /// Never used in practice. Maybe remove this from here and from the rust enum?
-    Keyword = 1,
-    Origin = 2,
-    Url = 3,
-    PreviousUse = 4,
-    Bookmark = 5,
-    /// If we get real tag support, just add `optional string tags` to SearchResult below, but
-    /// for now expose that it was because of tags.
-    Tag = 6,
-}

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -49,6 +49,9 @@ interface PlacesConnection {
     sequence<HistoryMetadata> get_history_metadata_since(Timestamp since);
 
     [Throws=PlacesError]
+    sequence<SearchResult> query_autocomplete(string search, i32 limit);
+
+    [Throws=PlacesError]
     sequence<HistoryMetadata> query_history_metadata(string query, i32 limit);
 
     [Throws=PlacesError]
@@ -124,6 +127,22 @@ enum FrecencyThresholdOption {
   "None",
 // Skip visited pages that were only visited once. The frecency score is 101
   "SkipOneTimePages",
+};
+
+dictionary SearchResult {
+    Url url;
+    string title;
+    i64 frecency;
+    sequence<MatchReason> reasons;
+};
+
+enum MatchReason {
+  "Keyword",
+  "Origin",
+  "UrlMatch",
+  "PreviousUse",
+  "Bookmark",
+  "Tags"
 };
 
 // Some kind of namespacing for uniffi would be ideal. Multiple udl/macro defns?

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -52,6 +52,9 @@ interface PlacesConnection {
     sequence<SearchResult> query_autocomplete(string search, i32 limit);
 
     [Throws=PlacesError]
+    void accept_result(string search_string, Url url);
+
+    [Throws=PlacesError]
     sequence<HistoryMetadata> query_history_metadata(string query, i32 limit);
 
     [Throws=PlacesError]

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -55,6 +55,9 @@ interface PlacesConnection {
     void accept_result(string search_string, Url url);
 
     [Throws=PlacesError]
+    Url? match_url(string query);
+
+    [Throws=PlacesError]
     sequence<HistoryMetadata> query_history_metadata(string query, i32 limit);
 
     [Throws=PlacesError]

--- a/components/places/src/places_msg_types.proto
+++ b/components/places/src/places_msg_types.proto
@@ -155,26 +155,3 @@ message BookmarkNodeList {
     repeated BookmarkNode nodes = 1;
 }
 
-// Protobuf allows nesting these, but prost behaves weirdly if we do.
-enum SearchResultReason {
-    // Never used in practice. Maybe remove this from here and from the rust enum?
-    KEYWORD = 1;
-    ORIGIN = 2;
-    URL = 3;
-    PREVIOUS_USE = 4;
-    BOOKMARK = 5;
-    // If we get real tag support, just add `optional string tags` to SearchResult below, but
-    // for now expose that it was because of tags.
-    TAG = 6;
-}
-
-message SearchResultMessage {
-    required string url = 1;
-    required string title = 2;
-    required int64 frecency = 3;
-    repeated SearchResultReason reasons = 4 [packed = true];
-}
-
-message SearchResultList {
-    repeated SearchResultMessage results = 1;
-}


### PR DESCRIPTION
fixes #4703 

This was a little quicker than expected. Android components builds and tests pass without any changes on that side

One thing to point out is the dance I do with the `SearchResult` and the `MatchResult`... basically duping the type for:
- AC only needs a subset of the fields for `SearchResult` that we use internally
- MatchResult has a variant `Url` which `uniffi` rejects since it shadows the wrapped type `Url`
- MatchResult has a `Tag` variant with associated data, AC doesn't use that data and we used to pass it as a flat enum across the FFI
