### PR TITLE
Cleaning up Sync Manager code

### DIFF
--- a/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
+++ b/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
@@ -241,9 +241,9 @@ class DatabaseLoginsStorageTest {
         val store = createTestStore()
         val syncManager = SyncManager()
 
-        assertFalse(syncManager.getAvailableEngines().contains("logins"))
+        assertFalse(syncManager.getAvailableEngines().contains("passwords"))
 
         store.registerWithSyncManager()
-        assertTrue(syncManager.getAvailableEngines().contains("logins"))
+        assertTrue(syncManager.getAvailableEngines().contains("passwords"))
     }
 }

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -9,7 +9,7 @@ use crate::LoginsSyncEngine;
 use parking_lot::Mutex;
 use std::path::Path;
 use std::sync::{Arc, Weak};
-use sync15::{sync_multiple, EngineSyncAssociation, MemoryCachedState, SyncEngine};
+use sync15::{sync_multiple, EngineSyncAssociation, MemoryCachedState, SyncEngine, SyncEngineId};
 
 // Our "sync manager" will use whatever is stashed here.
 lazy_static::lazy_static! {
@@ -20,15 +20,15 @@ lazy_static::lazy_static! {
 
 /// Called by the sync manager to get a sync engine via the store previously
 /// registered with the sync manager.
-pub fn get_registered_sync_engine(name: &str) -> Option<Box<dyn SyncEngine>> {
+pub fn get_registered_sync_engine(engine_id: &SyncEngineId) -> Option<Box<dyn SyncEngine>> {
     let weak = STORE_FOR_MANAGER.lock();
     match weak.upgrade() {
         None => None,
-        Some(store) => match name {
-            "logins" => Some(Box::new(LoginsSyncEngine::new(Arc::clone(&store)))),
+        Some(store) => match engine_id {
+            SyncEngineId::Passwords => Some(Box::new(LoginsSyncEngine::new(Arc::clone(&store)))),
             // panicing here seems reasonable - it's a static error if this
             // it hit, not something that runtime conditions can influence.
-            _ => unreachable!("can't provide unknown engine: {}", name),
+            _ => unreachable!("can't provide unknown engine: {}", engine_id),
         },
     }
 }

--- a/components/support/sync15-traits/src/engine.rs
+++ b/components/support/sync15-traits/src/engine.rs
@@ -7,6 +7,7 @@ use crate::{
     ServerTimestamp,
 };
 use anyhow::Result;
+use std::{convert::TryFrom, fmt};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct CollSyncIds {
@@ -26,6 +27,66 @@ pub enum EngineSyncAssociation {
     Disconnected,
     /// Sync is connected, and has the following sync IDs.
     Connected(CollSyncIds),
+}
+
+/// The concrete `SyncEngine` implementations
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SyncEngineId {
+    Passwords,
+    History,
+    Bookmarks,
+    Tabs,
+    Addresses,
+    CreditCards,
+}
+
+impl SyncEngineId {
+    // Iterate over all possible engines
+    pub fn iter() -> impl Iterator<Item = SyncEngineId> {
+        // Once we switch to the 2021 edition, this can just be [ ... ].into_iter()
+        std::array::IntoIter::new([
+            Self::Passwords,
+            Self::History,
+            Self::Bookmarks,
+            Self::Tabs,
+            Self::Addresses,
+            Self::CreditCards,
+        ])
+    }
+
+    // Get the string identifier for this engine.  This must match the strings in SyncEngineSelection.
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::Passwords => "passwords",
+            Self::History => "history",
+            Self::Bookmarks => "bookmarks",
+            Self::Tabs => "tabs",
+            Self::Addresses => "addresses",
+            Self::CreditCards => "creditcards",
+        }
+    }
+}
+
+impl fmt::Display for SyncEngineId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl TryFrom<&str> for SyncEngineId {
+    type Error = String;
+
+    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+        match value {
+            "passwords" => Ok(Self::Passwords),
+            "history" => Ok(Self::History),
+            "bookmarks" => Ok(Self::Bookmarks),
+            "tabs" => Ok(Self::Tabs),
+            "addresses" => Ok(Self::Addresses),
+            "creditcards" => Ok(Self::CreditCards),
+            _ => Err(value.into()),
+        }
+    }
 }
 
 /// A "sync engine" is a thing that knows how to sync. It's often implemented

--- a/components/support/sync15-traits/src/lib.rs
+++ b/components/support/sync15-traits/src/lib.rs
@@ -25,7 +25,7 @@ pub mod telemetry;
 
 pub use bridged_engine::{ApplyResults, BridgedEngine, IncomingEnvelope, OutgoingEnvelope};
 pub use changeset::{IncomingChangeset, OutgoingChangeset, RecordChangeset};
-pub use engine::{CollSyncIds, EngineSyncAssociation, SyncEngine};
+pub use engine::{CollSyncIds, EngineSyncAssociation, SyncEngine, SyncEngineId};
 pub use payload::Payload;
 pub use request::{CollectionRequest, RequestOrder};
 pub use server_timestamp::ServerTimestamp;

--- a/components/sync15/src/lib.rs
+++ b/components/sync15/src/lib.rs
@@ -43,3 +43,4 @@ pub use crate::sync_multiple::{
     sync_multiple, sync_multiple_with_command_processor, MemoryCachedState, SyncRequestInfo,
 };
 pub use crate::util::ServerTimestamp;
+pub use sync15_traits::SyncEngineId;

--- a/components/tabs/src/sync/store.rs
+++ b/components/tabs/src/sync/store.rs
@@ -10,6 +10,7 @@ use std::cell::RefCell;
 use std::sync::{Arc, Mutex, Weak};
 use sync15::{
     sync_multiple, telemetry, KeyBundle, MemoryCachedState, Sync15StorageClientInit, SyncEngine,
+    SyncEngineId,
 };
 
 // Our "sync manager" will use whatever is stashed here.
@@ -20,15 +21,15 @@ lazy_static::lazy_static! {
 
 /// Called by the sync manager to get a sync engine via the store previously
 /// registered with the sync manager.
-pub fn get_registered_sync_engine(name: &str) -> Option<Box<dyn SyncEngine>> {
+pub fn get_registered_sync_engine(engine_id: &SyncEngineId) -> Option<Box<dyn SyncEngine>> {
     let weak = STORE_FOR_MANAGER.lock().unwrap();
     match weak.upgrade() {
         None => None,
-        Some(store) => match name {
-            "tabs" => Some(Box::new(TabsEngine::new(Arc::clone(&store)))),
+        Some(store) => match engine_id {
+            SyncEngineId::Tabs => Some(Box::new(TabsEngine::new(Arc::clone(&store)))),
             // panicing here seems reasonable - it's a static error if this
             // it hit, not something that runtime conditions can influence.
-            _ => unreachable!("can't provide unknown engine: {}", name),
+            _ => unreachable!("can't provide unknown engine: {}", engine_id),
         },
     }
 }


### PR DESCRIPTION
Added an enum that contains all possible sync engines and a method to
iterate over registered sync engines.  Used that, plus the existing
`get_engine()` method to remove a lot of redundant code.

I wanted to add tests for this, but I couldn't figure out a good way.  I think it's possible to create mock `dyn SyncEngine`s, then test if they had the correct methods called on them.  But this seems like a lot of work for the amount it's testing.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
