### PR TITLE
Fixup checksum and default/defaults alias in FML

### DIFF
--- a/components/support/nimbus-fml/fixtures/fe/default_merging.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/default_merging.yaml
@@ -30,7 +30,7 @@ features:
           "child": {},
           "adult": {}
         }
-    default:
+    defaults:
       - channel: release
         value: {
           "positive": {

--- a/components/support/nimbus-fml/scripts/build-dist.sh
+++ b/components/support/nimbus-fml/scripts/build-dist.sh
@@ -64,7 +64,7 @@ done
 # Finish up by executing the zip command.
 echo
 echo "## Preparing dist archive"
-checksum="shasum -a 256 $zipfile"
+checksum="shasum -a 256 $dist_file"
 if [[ $dry_run != "true" ]] ; then
     (cd "$target_dir" && $zip_cmd )
     $checksum > "$filename.sha256"

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -52,6 +52,7 @@ pub(crate) struct Types {
 pub(crate) struct FeatureBody {
     description: String,
     variables: HashMap<String, FieldBody>,
+    #[serde(alias = "defaults")]
     default: Option<serde_json::Value>,
 }
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -291,7 +292,7 @@ fn collect_channel_defaults(
 ///      "positive": {
 ///        "alt-text": "Go Ahead!"
 ///      }
-/// }   
+/// }
 /// ```
 ///
 /// The result of the algorithm would be a default that looks like:
@@ -304,7 +305,7 @@ fn collect_channel_defaults(
 ///         "color": "green",
 ///         "alt-text": "Go Ahead!"
 ///     }
-///         
+///
 /// ```
 ///
 /// - The `label` comes from the original field level default


### PR DESCRIPTION
This PR fixes up nits which have come up when demoing the FML.

* the checksum was being run on an absolute path. This made it harder to run the checksum check.
* The `defaults` section of the FML manifest was spelled as a singular. This now supports both singular and plural versions.

These should be landed before the next release.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
