### PR TITLE
Consolidate types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3594,9 +3594,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uniffi"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e39922a6e95a3933017766cceebdc071891d43257cae272c55028842da724a"
+checksum = "472b6bbce3490a55f4f889e382a64803693929fea11e05c1057c0363af8fe019"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3609,9 +3609,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0b1d54aee6bf6ab8e13d322cd9438c559e768790d356ecb54cf73f587afadc"
+checksum = "87e8e61e7f6d03d3bf70fe16c956061b7b5a5ef571171bb7bec160c86b5a5779"
 dependencies = [
  "anyhow",
  "askama",
@@ -3626,9 +3626,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eef7d21f7e302fedef7e52f0dd4a5b1a636c99d4afea9f23a762106676f4960"
+checksum = "9e41292abe9503cfdc682f53566b785f322548ca728e5b3b6183b0f2694b4225"
 dependencies = [
  "anyhow",
  "uniffi_bindgen",
@@ -3636,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16590eef444dcdd49dfbaa08f5931469375756fac5d3f831a287df65ba1d8cc8"
+checksum = "58ce535e537d6a3004d503b405bde5971a0c0952a836a4c756af23bf09acd823"
 dependencies = [
  "glob",
  "proc-macro2",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -23,7 +23,7 @@ sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.15"
+uniffi = "^0.16"
 url = { version = "2.2", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -36,4 +36,4 @@ libsqlite3-sys = "0.20.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.15", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.16", features = [ "builtin-bindgen" ]}

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,8 +9,8 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = "^0.15"
-uniffi_macros = "^0.15"
+uniffi = "^0.16"
+uniffi_macros = "^0.16"
 
 [build-dependencies]
-uniffi_build = { version = "^0.15", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,11 +24,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.15"
-uniffi_macros = "^0.15"
+uniffi = "^0.16"
+uniffi_macros = "^0.16"
 
 [build-dependencies]
-uniffi_build = { version = "^0.15", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -26,15 +26,15 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.15"
-uniffi_macros = "^0.15"
+uniffi = "^0.16"
+uniffi_macros = "^0.16"
 
 [dependencies.rusqlite]
 version = "0.24.2"
 features = ["sqlcipher", "limits", "unlock_notify"]
 
 [build-dependencies]
-uniffi_build = { version = "^0.15", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 more-asserts = "0.2"

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -33,11 +33,11 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "^0.15", optional = true }
+uniffi = { version = "^0.16", optional = true }
 chrono = { version = "0.4", features = ["serde"]}
 
 [build-dependencies]
-uniffi_build = { version = "^0.15", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.16", features = [ "builtin-bindgen" ], optional = true }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -39,8 +39,8 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.15"
-uniffi_macros = "^0.15"
+uniffi = "^0.16"
+uniffi_macros = "^0.16"
 
 [dependencies.rusqlite]
 version = "0.24.2"
@@ -52,4 +52,4 @@ tempfile = "3.1"
 env_logger = {version = "0.7", default-features = false}
 
 [build-dependencies]
-uniffi_build = { version = "^0.15", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }

--- a/components/places/ffi/Cargo.toml
+++ b/components/places/ffi/Cargo.toml
@@ -24,8 +24,8 @@ interrupt-support = { path = "../../support/interrupt" }
 sql-support = { path = "../../support/sql" }
 sync-guid = { path = "../../support/guid" }
 types = { path = "../../support/types" }
-uniffi = "^0.15"
-uniffi_macros = "^0.15"
+uniffi = "^0.16"
+uniffi_macros = "^0.16"
 
 [dependencies.sync15]
 path = "../../sync15"

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -381,7 +381,7 @@ pub struct HistoryVisitInfo {
     pub url: Url,
     pub title: Option<String>,
     pub timestamp: Timestamp,
-    pub visit_type: i32,
+    pub visit_type: VisitTransition,
     pub is_hidden: bool,
     pub preview_image_url: Option<Url>,
 }

--- a/components/places/src/observation.rs
+++ b/components/places/src/observation.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::types::*;
-use serde_derive::*;
 use types::Timestamp;
 use url::Url;
 
@@ -20,56 +19,27 @@ use url::Url;
 /// It exposes a "builder api", but for convenience, that API allows Options too.
 /// So, eg, `.with_title(None)` or `with_is_error(None)` is allowed but records
 /// no observation.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 pub struct VisitObservation {
     /// Ideally, we'd use url::Url here with `serde_url`, but we really would
     /// like to expose these errors over the FFI as UrlParseErrors and not json
     /// errors, and we also would like to do so without parsing strings.
-    pub url: String,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    pub url: Url,
     pub title: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub visit_type: Option<VisitTransition>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub is_error: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub is_redirect_source: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub is_permanent_redirect_source: Option<bool>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
     pub at: Option<Timestamp>,
-
-    /// Semantically also a url::Url, See the comment about the `url` property.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
-    pub referrer: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
+    pub referrer: Option<Url>,
     pub is_remote: Option<bool>,
-
-    /// Semantically also a url::Url, See the comment about the `url` property.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(default)]
-    pub preview_image_url: Option<String>,
+    pub preview_image_url: Option<Url>,
 }
 
 impl VisitObservation {
     pub fn new(url: Url) -> Self {
         VisitObservation {
-            url: url.into(),
+            url: url,
             title: None,
             visit_type: None,
             is_error: None,
@@ -125,8 +95,7 @@ impl VisitObservation {
         self
     }
 
-    // v is a String instead of a Url to allow testing invalid urls as input.
-    pub fn with_preview_image_url(mut self, v: impl Into<Option<String>>) -> Self {
+    pub fn with_preview_image_url(mut self, v: impl Into<Option<Url>>) -> Self {
         self.preview_image_url = v.into();
         self
     }

--- a/components/places/src/observation.rs
+++ b/components/places/src/observation.rs
@@ -21,9 +21,6 @@ use url::Url;
 /// no observation.
 #[derive(Debug)]
 pub struct VisitObservation {
-    /// Ideally, we'd use url::Url here with `serde_url`, but we really would
-    /// like to expose these errors over the FFI as UrlParseErrors and not json
-    /// errors, and we also would like to do so without parsing strings.
     pub url: Url,
     pub title: Option<String>,
     pub visit_type: Option<VisitTransition>,

--- a/components/places/src/observation.rs
+++ b/components/places/src/observation.rs
@@ -39,7 +39,7 @@ pub struct VisitObservation {
 impl VisitObservation {
     pub fn new(url: Url) -> Self {
         VisitObservation {
-            url: url,
+            url,
             title: None,
             visit_type: None,
             is_error: None,

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -228,7 +228,7 @@ dictionary HistoryVisitInfo {
     string? title;
     Timestamp timestamp;
     // XXX - This should use the VisitType enum when it gets uniffied
-    i32 visit_type;
+    VisitTransition visit_type;
     boolean is_hidden;
     Url? preview_image_url;
 };

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -244,16 +244,16 @@ dictionary HistoryVisitInfosWithBound {
  * or both. Use [VisitType.UPDATE_PLACE] to differentiate an update from a visit.
  */
 dictionary VisitObservation {
-    string url;
+    Url url;
     string? title = null;
     VisitTransition? visit_type;
     boolean? is_error = null;
     boolean? is_redirect_source = null;
     boolean? is_permanent_redirect_source = null;
     Timestamp? at = null;
-    string? referrer = null;
+    Url? referrer = null;
     boolean? is_remote = null;
-    string? preview_image_url = null;
+    Url? preview_image_url = null;
 };
 
 // Exists just to convince uniffi to generate `liftSequence*` helpers!

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -227,7 +227,6 @@ dictionary HistoryVisitInfo {
     Url url;
     string? title;
     Timestamp timestamp;
-    // XXX - This should use the VisitType enum when it gets uniffied
     VisitTransition visit_type;
     boolean is_hidden;
     Url? preview_image_url;

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -1849,8 +1849,9 @@ mod tests {
         // An observation with just a preview_image_url should not update it.
         apply_observation(
             &conn,
-            VisitObservation::new(pi.url.clone())
-                .with_preview_image_url(Some(Url::parse("https://www.example.com/preview.png").unwrap())),
+            VisitObservation::new(pi.url.clone()).with_preview_image_url(Some(
+                Url::parse("https://www.example.com/preview.png").unwrap(),
+            )),
         )?;
         pi = fetch_page_info(&conn, &pi.url)?
             .expect("page should exist")
@@ -2762,8 +2763,9 @@ mod tests {
         // Can observe preview url without an associated visit.
         assert!(apply_observation(
             &conn,
-            VisitObservation::new(url1.clone())
-                .with_preview_image_url(Some(Url::parse("https://www.example.com/image.png").unwrap()))
+            VisitObservation::new(url1.clone()).with_preview_image_url(Some(
+                Url::parse("https://www.example.com/image.png").unwrap()
+            ))
         )
         .unwrap()
         .is_none());
@@ -2807,7 +2809,9 @@ mod tests {
         let another_visit_id = apply_observation(
             &conn,
             VisitObservation::new(Url::parse("https://www.example.com/another/").unwrap())
-                .with_preview_image_url(Some(Url::parse("https://www.example.com/funky/image.png").unwrap()))
+                .with_preview_image_url(Some(
+                    Url::parse("https://www.example.com/funky/image.png").unwrap(),
+                ))
                 .with_visit_type(VisitTransition::Link),
         )
         .unwrap();

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -1323,7 +1323,7 @@ mod tests {
         let observation1 = VisitObservation::new(Url::parse("https://www.cbc.ca/news/politics/federal-budget-2021-freeland-zimonjic-1.5991021").unwrap())
                 .with_at(now)
                 .with_title(Some(String::from("Budget vows to build &#x27;for the long term&#x27; as it promises child care cash, projects massive deficits | CBC News")))
-                .with_preview_image_url(Some(String::from("https://i.cbc.ca/1.5993583.1618861792!/cpImage/httpImage/image.jpg_gen/derivatives/16x9_620/fedbudget-20210419.jpg")))
+                .with_preview_image_url(Some(Url::parse("https://i.cbc.ca/1.5993583.1618861792!/cpImage/httpImage/image.jpg_gen/derivatives/16x9_620/fedbudget-20210419.jpg").unwrap()))
                 .with_is_remote(false)
                 .with_visit_type(VisitTransition::Link);
         apply_observation(&conn, observation1).unwrap();

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -197,7 +197,7 @@ impl HistoryVisitInfo {
             url: Url::parse(&url)?,
             title: row.get("title")?,
             timestamp: visit_date,
-            visit_type: visit_type as i32,
+            visit_type,
             is_hidden: row.get("hidden")?,
             preview_image_url: match preview_image_url {
                 Some(s) => Some(Url::parse(&s)?),

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -23,11 +23,11 @@ viaduct = { path = "../viaduct" }
 sql-support = { path = "../support/sql" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }
 thiserror = "1.0"
-uniffi = "^0.15"
-uniffi_macros = "^0.15"
+uniffi = "^0.16"
+uniffi_macros = "^0.16"
 
 [build-dependencies]
-uniffi_build = { version = "^0.15", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }
 
 
 [dev-dependencies]

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -23,8 +23,8 @@ serde_derive = "1"
 serde_json = "1"
 parking_lot = "0.5"
 interrupt-support = { path = "../support/interrupt" }
-uniffi = "^0.15"
-uniffi_macros = "^0.15"
+uniffi = "^0.16"
+uniffi_macros = "^0.16"
 
 [build-dependencies]
-uniffi_build = { version = "^0.15", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -22,8 +22,8 @@ interrupt-support = { path = "../support/interrupt" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.15"
-uniffi_macros = "^0.15"
+uniffi = "^0.16"
+uniffi_macros = "^0.16"
 
 [build-dependencies]
-uniffi_build = { version = "^0.15", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.16", features = [ "builtin-bindgen" ]}

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.15"
+uniffi_bindgen = "^0.16"


### PR DESCRIPTION
a part of #4713 

Uses URLs for the `VisitObservation` type and the `VisitTransition` for the `HistoryVisitInfo` type.

Note that our tests will fail, because we still haven't upgraded to a version of uniffi that fixed the whole wrapped types panic if they error out

this as-is also fails to compile AC, but I'll make sure to update that before this lands

I also tried to fix the `VisitTransition` and `VisitType` confusion, but since that's a bigger change I have it as its own PR on top of this PR
