### PR TITLE
merges the VisitType and VisitTransition types

### DIFF
--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -19,6 +19,7 @@ import mozilla.appservices.places.uniffi.PlacesApi as UniffiPlacesApi
 import mozilla.appservices.places.uniffi.PlacesConnection as UniffiPlacesConnection
 import mozilla.appservices.places.uniffi.placesApiNew
 import mozilla.appservices.places.uniffi.VisitObservation
+import mozilla.appservices.places.uniffi.VisitType
 import mozilla.appservices.places.uniffi.HistoryVisitInfo
 import mozilla.appservices.places.uniffi.HistoryVisitInfosWithBound
 import mozilla.appservices.places.uniffi.SearchResult
@@ -443,10 +444,25 @@ open class PlacesReaderConnection internal constructor(connHandle: Long, conn: U
     }
 }
 
+internal fun VisitType.typeValue(): Int {
+    return when (this) {
+        VisitType.UPDATE_PLACE -> -1
+        VisitType.LINK -> 1
+        VisitType.TYPED -> 2
+        VisitType.BOOKMARK -> 3
+        VisitType.EMBED -> 4
+        VisitType.REDIRECT_PERMANENT -> 5
+        VisitType.REDIRECT_TEMPORARY -> 6
+        VisitType.DOWNLOAD -> 7
+        VisitType.FRAMED_LINK -> 8
+        VisitType.RELOAD -> 9
+    }
+}
+
 fun visitTransitionSet(l: List<VisitType>): Int {
     var res = 0
     for (ty in l) {
-        res = res or (1 shl ty.type)
+        res = res or (1 shl ty.typeValue())
     }
     return res
 }
@@ -1083,25 +1099,6 @@ interface WritableHistoryConnection : ReadableHistoryConnection {
      * @param url The chosen URL string
      */
     fun acceptResult(searchString: String, url: String)
-}
-
-enum class VisitType(val type: Int) {
-    /** This isn't a visit, but a request to update meta data about a page */
-    UPDATE_PLACE(-1),
-    /** This transition type means the user followed a link. */
-    LINK(1),
-    /** This transition type means that the user typed the page's URL in the
-     *  URL bar or selected it from UI (URL bar autocomplete results, etc).
-     */
-    TYPED(2),
-    // TODO: rest of docs
-    BOOKMARK(3),
-    EMBED(4),
-    REDIRECT_PERMANENT(5),
-    REDIRECT_TEMPORARY(6),
-    DOWNLOAD(7),
-    FRAMED_LINK(8),
-    RELOAD(9)
 }
 
 /**

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.runBlocking
 import mozilla.appservices.Megazord
 import mozilla.appservices.places.uniffi.DocumentType
 import mozilla.appservices.places.uniffi.VisitObservation
-import mozilla.appservices.places.uniffi.VisitTransition
+import mozilla.appservices.places.uniffi.VisitType
 import mozilla.appservices.places.uniffi.FrecencyThresholdOption
 import mozilla.appservices.syncmanager.SyncManager
 import mozilla.appservices.places.uniffi.PlacesException
@@ -79,7 +79,7 @@ class PlacesConnectionTest {
         )
 
         for (url in toAdd) {
-            db.noteObservation(VisitObservation(url = url, visitType = VisitTransition.LINK))
+            db.noteObservation(VisitObservation(url = url, visitType = VisitType.LINK))
         }
 
         val toSearch = listOf(
@@ -128,7 +128,7 @@ class PlacesConnectionTest {
     @Test
     fun testNoteObservationBadUrl() {
         try {
-            db.noteObservation(VisitObservation(url = "http://www.[].com", visitType = VisitTransition.LINK))
+            db.noteObservation(VisitObservation(url = "http://www.[].com", visitType = VisitType.LINK))
         } catch (e: PlacesException) {
             assert(e is PlacesException.UrlParseFailed)
         }
@@ -150,7 +150,7 @@ class PlacesConnectionTest {
         )
 
         for (url in toAdd) {
-            db.noteObservation(VisitObservation(url = url, visitType = VisitTransition.LINK))
+            db.noteObservation(VisitObservation(url = url, visitType = VisitType.LINK))
         }
         // Should use the origin search
         assertEquals("https://www.example.com/", db.matchUrl("example.com"))
@@ -188,25 +188,25 @@ class PlacesConnectionTest {
     fun testObservingPreviewImage() {
         db.noteObservation(VisitObservation(
             url = "https://www.example.com/0",
-            visitType = VisitTransition.LINK)
+            visitType = VisitType.LINK)
         )
 
         db.noteObservation(VisitObservation(
             url = "https://www.example.com/1",
-            visitType = VisitTransition.LINK)
+            visitType = VisitType.LINK)
         )
 
         // Can change preview image.
         db.noteObservation(VisitObservation(
             url = "https://www.example.com/1",
-            visitType = VisitTransition.LINK,
+            visitType = VisitType.LINK,
             previewImageUrl = "https://www.example.com/1/previewImage.png")
         )
 
         // Can make an initial observation with the preview image.
         db.noteObservation(VisitObservation(
             url = "https://www.example.com/2",
-            visitType = VisitTransition.LINK,
+            visitType = VisitType.LINK,
             previewImageUrl = "https://www.example.com/2/previewImage.png")
         )
 
@@ -220,12 +220,12 @@ class PlacesConnectionTest {
 
     @Test
     fun testGetTopFrecentSiteInfos() {
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.DOWNLOAD))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.EMBED))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.REDIRECT_PERMANENT))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.REDIRECT_TEMPORARY))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.FRAMED_LINK))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.RELOAD))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.DOWNLOAD))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.EMBED))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.REDIRECT_PERMANENT))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.REDIRECT_TEMPORARY))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.FRAMED_LINK))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.RELOAD))
 
         val toAdd = listOf(
             "https://www.example.com/123",
@@ -239,7 +239,7 @@ class PlacesConnectionTest {
         )
 
         for (url in toAdd) {
-            db.noteObservation(VisitObservation(url = url, visitType = VisitTransition.LINK))
+            db.noteObservation(VisitObservation(url = url, visitType = VisitType.LINK))
         }
 
         var infos = db.getTopFrecentSiteInfos(numItems = 0, frecencyThreshold = FrecencyThresholdOption.NONE)
@@ -283,11 +283,11 @@ class PlacesConnectionTest {
     // as well as the handling of invalid urls.
     @Test
     fun testGetVisitInfos() {
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.LINK, at = 100000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2a", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 130000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2b", visitType = VisitTransition.LINK, at = 150000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/3", visitType = VisitTransition.LINK, at = 200000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/4", visitType = VisitTransition.LINK, at = 250000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.LINK, at = 100000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2a", visitType = VisitType.REDIRECT_TEMPORARY, at = 130000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2b", visitType = VisitType.LINK, at = 150000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/3", visitType = VisitType.LINK, at = 200000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/4", visitType = VisitType.LINK, at = 250000))
         var infos = db.getVisitInfos(125000, 225000, excludeTypes = listOf(VisitType.REDIRECT_TEMPORARY))
         assertEquals(2, infos.size)
         assertEquals("https://www.example.com/2b", infos[0].url)
@@ -301,15 +301,15 @@ class PlacesConnectionTest {
 
     @Test
     fun testGetVisitPage() {
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.LINK, at = 100000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2", visitType = VisitTransition.LINK, at = 110000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/3a", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 120000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/3b", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 130000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/4", visitType = VisitTransition.LINK, at = 140000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/5", visitType = VisitTransition.LINK, at = 150000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/6", visitType = VisitTransition.LINK, at = 160000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/7", visitType = VisitTransition.LINK, at = 170000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/8", visitType = VisitTransition.LINK, at = 180000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.LINK, at = 100000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2", visitType = VisitType.LINK, at = 110000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/3a", visitType = VisitType.REDIRECT_TEMPORARY, at = 120000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/3b", visitType = VisitType.REDIRECT_TEMPORARY, at = 130000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/4", visitType = VisitType.LINK, at = 140000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/5", visitType = VisitType.LINK, at = 150000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/6", visitType = VisitType.LINK, at = 160000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/7", visitType = VisitType.LINK, at = 170000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/8", visitType = VisitType.LINK, at = 180000))
 
         assertEquals(9, db.getVisitCount())
         assertEquals(7, db.getVisitCount(excludeTypes = listOf(VisitType.REDIRECT_TEMPORARY)))
@@ -385,15 +385,15 @@ class PlacesConnectionTest {
         assert(!PlacesManagerMetrics.writeQueryCount.testHasValue())
         assert(!PlacesManagerMetrics.writeQueryErrorCount["url_parse_failed"].testHasValue())
 
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2a", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 130000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2b", visitType = VisitTransition.LINK, at = 150000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/3", visitType = VisitTransition.LINK, at = 200000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2a", visitType = VisitType.REDIRECT_TEMPORARY, at = 130000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2b", visitType = VisitType.LINK, at = 150000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/3", visitType = VisitType.LINK, at = 200000))
 
         assertEquals(3, PlacesManagerMetrics.writeQueryCount.testGetValue())
         assert(!PlacesManagerMetrics.writeQueryErrorCount["__other__"].testHasValue())
 
         try {
-            db.noteObservation(VisitObservation(url = "4", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 160000))
+            db.noteObservation(VisitObservation(url = "4", visitType = VisitType.REDIRECT_TEMPORARY, at = 160000))
             fail("Should have thrown")
         } catch (e: PlacesException.UrlParseFailed) {
             // nothing to do here
@@ -494,7 +494,7 @@ class PlacesConnectionTest {
                 url = "https://www.ifixit.com/News/35377/which-wireless-earbuds-are-the-least-evil",
                 title = "Are All Wireless Earbuds As Evil As AirPods?",
                 previewImageUrl = "https://valkyrie.cdn.ifixit.com/media/2020/02/03121341/bose_soundsport_13.jpg",
-                visitType = VisitTransition.LINK
+                visitType = VisitType.LINK
             )
         )
 

--- a/components/places/src/api/history.rs
+++ b/components/places/src/api/history.rs
@@ -34,7 +34,7 @@ pub struct AddablePlaceInfo {
 #[derive(Debug)]
 pub struct AddableVisit {
     pub date: Timestamp,
-    pub transition: VisitTransition,
+    pub transition: VisitType,
     pub referrer: Option<Url>,
     pub is_local: bool,
 }
@@ -68,7 +68,7 @@ mod tests {
         let date = Timestamp::now();
         let visits = vec![AddableVisit {
             date,
-            transition: VisitTransition::Link,
+            transition: VisitType::Link,
             referrer: None,
             is_local: true,
         }];
@@ -154,7 +154,7 @@ pub fn visit_uri(
     // To be more honest, this would *not* take a VisitTransition,
     // but instead other "internal" nsIHistory flags, from which
     // it would deduce the VisitTransition.
-    transition: VisitTransition,
+    transition: VisitType,
     redirect_source: Option<RedirectSourceType>,
     is_error_page: bool,
 ) -> Result<()> {
@@ -186,7 +186,7 @@ pub fn visit_uri(
 
     // EMBED visits are session-persistent and should not go through the database.
     // They exist only to keep track of isVisited status during the session.
-    if transition == VisitTransition::Embed {
+    if transition == VisitType::Embed {
         log::warn!("Embed visit, but in-memory storage of these isn't done yet");
         return Ok(());
     }

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -611,7 +611,7 @@ mod tests {
     use crate::api::places_api::test::new_mem_connection;
     use crate::observation::VisitObservation;
     use crate::storage::history::apply_observation;
-    use crate::types::VisitTransition;
+    use crate::types::VisitType;
     use types::Timestamp;
 
     #[test]
@@ -666,7 +666,7 @@ mod tests {
         let url = Url::parse("http://example.com/123").unwrap();
         let visit = VisitObservation::new(url.clone())
             .with_title("Example page 123".to_string())
-            .with_visit_type(VisitTransition::Typed)
+            .with_visit_type(VisitType::Typed)
             .with_at(Timestamp::now());
 
         apply_observation(&conn, visit).expect("Should apply visit");
@@ -757,7 +757,7 @@ mod tests {
         let url = Url::parse("http://exämple.com/123").unwrap();
         let visit = VisitObservation::new(url)
             .with_title("Example page 123".to_string())
-            .with_visit_type(VisitTransition::Typed)
+            .with_visit_type(VisitType::Typed)
             .with_at(Timestamp::now());
 
         apply_observation(&conn, visit).expect("Should apply visit");

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -15,7 +15,7 @@ use crate::storage::{history, history_metadata};
 use crate::types::VisitTransitionSet;
 use crate::ConnectionType;
 use crate::VisitObservation;
-use crate::VisitTransition;
+use crate::VisitType;
 use crate::{msg_types, storage};
 use crate::{PlacesApi, PlacesDb};
 use ffi_support::{
@@ -381,7 +381,7 @@ pub struct HistoryVisitInfo {
     pub url: Url,
     pub title: Option<String>,
     pub timestamp: Timestamp,
-    pub visit_type: VisitTransition,
+    pub visit_type: VisitType,
     pub is_hidden: bool,
     pub preview_image_url: Option<Url>,
 }

--- a/components/places/src/history_sync/plan.rs
+++ b/components/places/src/history_sync/plan.rs
@@ -14,7 +14,7 @@ use crate::storage::{
         fetch_visits, finish_outgoing, FetchedVisit, FetchedVisitPage, OutgoingInfo,
     },
 };
-use crate::types::VisitTransition;
+use crate::types::VisitType;
 use interrupt_support::Interruptee;
 use std::collections::HashSet;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -102,7 +102,7 @@ fn plan_incoming_record(conn: &PlacesDb, record: HistoryRecord, max_visits: usiz
         None => false,
     };
 
-    let mut cur_visit_map: HashSet<(VisitTransition, Timestamp)> =
+    let mut cur_visit_map: HashSet<(VisitType, Timestamp)> =
         HashSet::with_capacity(existing_visits.len());
     for visit in &existing_visits {
         // it should be impossible for us to have invalid visits locally, but...
@@ -134,7 +134,7 @@ fn plan_incoming_record(conn: &PlacesDb, record: HistoryRecord, max_visits: usiz
     // work out which of the incoming visits we should apply.
     let mut to_apply = Vec::with_capacity(record.visits.len());
     for incoming_visit in record.visits {
-        let transition = match VisitTransition::from_primitive(incoming_visit.transition) {
+        let transition = match VisitType::from_primitive(incoming_visit.transition) {
             Some(v) => v,
             None => continue,
         };
@@ -420,7 +420,7 @@ mod tests {
         let url = Url::parse("https://example.com").expect("is valid");
         // add it locally
         let obs = VisitObservation::new(url.clone())
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(now.into()));
         apply_observation(&conn, obs).expect("should apply");
         // should be New with a change counter.
@@ -456,7 +456,7 @@ mod tests {
         let url = Url::parse("https://example.com").expect("is valid");
         // add it locally
         let obs = VisitObservation::new(url.clone())
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(now.into()));
         apply_observation(&conn, obs).expect("should apply");
 
@@ -557,7 +557,7 @@ mod tests {
 
         let ts_local: Timestamp = (SystemTime::now() - Duration::new(10, 0)).into();
         let obs = VisitObservation::new(url.clone())
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(ts_local));
         apply_observation(&db, obs)?;
 
@@ -619,7 +619,7 @@ mod tests {
 
         let ts_local: Timestamp = (SystemTime::now() - Duration::new(10, 0)).into();
         let obs = VisitObservation::new(url.clone())
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(ts_local));
         apply_observation(&db, obs)?;
 
@@ -806,7 +806,7 @@ mod tests {
         let url = Url::parse("https://example.com")?;
         let now = SystemTime::now();
         let obs = VisitObservation::new(url)
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(now.into()));
         apply_observation(&db, obs)?;
 
@@ -831,7 +831,7 @@ mod tests {
 
         // First add a local visit with the timestamp.
         let obs = VisitObservation::new(url.clone())
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(ts));
         apply_observation(&db, obs)?;
         // Sync status should be "new" and have a change recorded.
@@ -879,7 +879,7 @@ mod tests {
 
         // First add a local visit with ts1.
         let obs = VisitObservation::new(url.clone())
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(ts1));
         apply_observation(&db, obs)?;
 
@@ -935,7 +935,7 @@ mod tests {
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let url = Url::parse("https://example.com")?;
         let obs = VisitObservation::new(url.clone())
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(SystemTime::now().into()));
         apply_observation(&db, obs)?;
         assert_eq!(get_sync(&db, &url), (SyncStatus::New, 1));
@@ -969,7 +969,7 @@ mod tests {
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let url = Url::parse("https://example.com")?;
         let obs = VisitObservation::new(url.clone())
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(SystemTime::now().into()));
         apply_observation(&db, obs)?;
         let guid = get_existing_guid(&db, &url);
@@ -1010,7 +1010,7 @@ mod tests {
         let db = PlacesDb::open_in_memory(ConnectionType::Sync)?;
         let url = Url::parse("https://example.com")?;
         let obs = VisitObservation::new(url.clone())
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Some(SystemTime::now().into()));
         apply_observation(&db, obs)?;
         let guid = get_existing_guid(&db, &url);

--- a/components/places/src/observation.rs
+++ b/components/places/src/observation.rs
@@ -26,7 +26,7 @@ pub struct VisitObservation {
     /// errors, and we also would like to do so without parsing strings.
     pub url: Url,
     pub title: Option<String>,
-    pub visit_type: Option<VisitTransition>,
+    pub visit_type: Option<VisitType>,
     pub is_error: Option<bool>,
     pub is_redirect_source: Option<bool>,
     pub is_permanent_redirect_source: Option<bool>,
@@ -60,7 +60,7 @@ impl VisitObservation {
         self
     }
 
-    pub fn with_visit_type(mut self, t: impl Into<Option<VisitTransition>>) -> Self {
+    pub fn with_visit_type(mut self, t: impl Into<Option<VisitType>>) -> Self {
         self.visit_type = t.into();
         self
     }
@@ -104,7 +104,7 @@ impl VisitObservation {
     pub fn get_redirect_frecency_boost(&self) -> bool {
         self.is_redirect_source.is_some()
             && match self.visit_type {
-                Some(t) => t != VisitTransition::Typed,
+                Some(t) => t != VisitType::Typed,
                 _ => true,
             }
     }
@@ -114,8 +114,8 @@ impl VisitObservation {
         match self.visit_type {
             Some(visit_type) => {
                 self.is_redirect_source.is_some()
-                    || visit_type == VisitTransition::FramedLink
-                    || visit_type == VisitTransition::Embed
+                    || visit_type == VisitType::FramedLink
+                    || visit_type == VisitType::Embed
             }
             None => false,
         }

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -172,7 +172,9 @@ enum DocumentType {
     "Media",
 };
 
-enum VisitTransition {
+enum VisitType {
+    // This isn't a visit, but a request to update meta data about a page
+    "UpdatePlace",
     // This transition type means the user followed a link.
     "Link",
     // This transition type means that the user typed the page's URL in the
@@ -227,8 +229,7 @@ dictionary HistoryVisitInfo {
     Url url;
     string? title;
     Timestamp timestamp;
-    // XXX - This should use the VisitType enum when it gets uniffied
-    VisitTransition visit_type;
+    VisitType visit_type;
     boolean is_hidden;
     Url? preview_image_url;
 };
@@ -246,7 +247,7 @@ dictionary HistoryVisitInfosWithBound {
 dictionary VisitObservation {
     Url url;
     string? title = null;
-    VisitTransition? visit_type;
+    VisitType? visit_type;
     boolean? is_error = null;
     boolean? is_redirect_source = null;
     boolean? is_permanent_redirect_source = null;

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -1314,7 +1314,7 @@ mod tests {
     fn test_query() {
         use crate::observation::VisitObservation;
         use crate::storage::history::apply_observation;
-        use crate::types::VisitTransition;
+        use crate::types::VisitType;
 
         let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
         let now = Timestamp::now();
@@ -1325,7 +1325,7 @@ mod tests {
                 .with_title(Some(String::from("Budget vows to build &#x27;for the long term&#x27; as it promises child care cash, projects massive deficits | CBC News")))
                 .with_preview_image_url(Some(Url::parse("https://i.cbc.ca/1.5993583.1618861792!/cpImage/httpImage/image.jpg_gen/derivatives/16x9_620/fedbudget-20210419.jpg").unwrap()))
                 .with_is_remote(false)
-                .with_visit_type(VisitTransition::Link);
+                .with_visit_type(VisitType::Link);
         apply_observation(&conn, observation1).unwrap();
 
         note_observation!(
@@ -1641,7 +1641,7 @@ mod tests {
         // The cleanup functionality lives as a TRIGGER in `create_shared_triggers`.
         use crate::observation::VisitObservation;
         use crate::storage::history::{apply_observation, wipe_local};
-        use crate::types::VisitTransition;
+        use crate::types::VisitType;
 
         let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
 
@@ -1655,13 +1655,13 @@ mod tests {
             .with_at(now)
             .with_title(Some(String::from("Test page 0")))
             .with_is_remote(false)
-            .with_visit_type(VisitTransition::Link);
+            .with_visit_type(VisitType::Link);
 
         let observation2 = VisitObservation::new(parent_url.clone())
             .with_at(now)
             .with_title(Some(String::from("Test page 1")))
             .with_is_remote(false)
-            .with_visit_type(VisitTransition::Link);
+            .with_visit_type(VisitType::Link);
 
         apply_observation(&conn, observation1).expect("Should apply visit");
         apply_observation(&conn, observation2).expect("Should apply visit");
@@ -1725,7 +1725,7 @@ mod tests {
         // The cleanup functionality lives as a TRIGGER in `create_shared_triggers`.
         use crate::observation::VisitObservation;
         use crate::storage::history::{apply_observation, delete_visits_between, wipe_local};
-        use crate::types::VisitTransition;
+        use crate::types::VisitType;
 
         let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
 
@@ -1734,19 +1734,19 @@ mod tests {
             .with_at(now)
             .with_title(Some(String::from("Test page 1")))
             .with_is_remote(false)
-            .with_visit_type(VisitTransition::Link);
+            .with_visit_type(VisitType::Link);
         let observation2 =
             VisitObservation::new(Url::parse("https://www.mozilla.org/another/").unwrap())
                 .with_at(Timestamp((now.as_millis() + 10000) as u64))
                 .with_title(Some(String::from("Test page 3")))
                 .with_is_remote(false)
-                .with_visit_type(VisitTransition::Link);
+                .with_visit_type(VisitType::Link);
         let observation3 =
             VisitObservation::new(Url::parse("https://www.mozilla.org/first/").unwrap())
                 .with_at(Timestamp((now.as_millis() - 10000) as u64))
                 .with_title(Some(String::from("Test page 0")))
                 .with_is_remote(true)
-                .with_visit_type(VisitTransition::Link);
+                .with_visit_type(VisitType::Link);
         apply_observation(&conn, observation1).expect("Should apply visit");
         apply_observation(&conn, observation2).expect("Should apply visit");
         apply_observation(&conn, observation3).expect("Should apply visit");

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -14,7 +14,7 @@ use crate::db::PlacesDb;
 use crate::error::{ErrorKind, InvalidPlaceInfo, Result};
 use crate::ffi::HistoryVisitInfo;
 use crate::ffi::TopFrecentSiteInfo;
-use crate::types::{SyncStatus, VisitTransition};
+use crate::types::{SyncStatus, VisitType};
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::Result as RusqliteResult;
 use rusqlite::Row;
@@ -185,11 +185,11 @@ fn new_page_info(db: &PlacesDb, url: &Url, new_guid: Option<SyncGuid>) -> Result
 
 impl HistoryVisitInfo {
     pub(crate) fn from_row(row: &rusqlite::Row<'_>) -> Result<Self> {
-        let visit_type = VisitTransition::from_primitive(row.get::<_, u8>("visit_type")?)
+        let visit_type = VisitType::from_primitive(row.get::<_, u8>("visit_type")?)
             // Do we have an existing error we use for this? For now they
             // probably don't care too much about VisitTransition, so this
             // is fine.
-            .unwrap_or(VisitTransition::Link);
+            .unwrap_or(VisitType::Link);
         let visit_date: Timestamp = row.get("visit_date")?;
         let url: String = row.get("url")?;
         let preview_image_url: Option<String> = row.get("preview_image_url")?;

--- a/examples/places-autocomplete/src/autocomplete.rs
+++ b/examples/places-autocomplete/src/autocomplete.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Result;
 use clap::value_t;
-use places::{PlacesDb, VisitObservation, VisitTransition};
+use places::{PlacesDb, VisitObservation, VisitType};
 use rusqlite::NO_PARAMS;
 use sql_support::ConnExt;
 use std::io::prelude::*;
@@ -70,9 +70,7 @@ impl LegacyPlace {
         let url = Url::parse(&self.url)?;
         for v in self.visits {
             let obs = VisitObservation::new(url.clone())
-                .with_visit_type(
-                    VisitTransition::from_primitive(v.visit_type).unwrap_or(VisitTransition::Link),
-                )
+                .with_visit_type(VisitType::from_primitive(v.visit_type).unwrap_or(VisitType::Link))
                 .with_at(types::Timestamp((v.date / 1000) as u64))
                 .with_title(self.title.clone())
                 .with_is_remote(rand::random::<f64>() < options.remote_probability);

--- a/testing/separated/places-bench/src/database.rs
+++ b/testing/separated/places-bench/src/database.rs
@@ -40,7 +40,7 @@ fn init_db(db: &mut PlacesDb) -> places::Result<()> {
             let obs = places::VisitObservation::new(url.clone())
                 .with_title(entry.title.clone())
                 .with_is_remote(i < 10)
-                .with_visit_type(places::VisitTransition::Link)
+                .with_visit_type(places::VisitType::Link)
                 .with_at(Timestamp(now.0 - day_ms * (1 + i)));
             places::storage::history::apply_observation_direct(db, obs)?;
         }

--- a/testing/separated/places-tests/src/fennec_history.rs
+++ b/testing/separated/places-tests/src/fennec_history.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use places::import::fennec::history::HistoryMigrationResult;
-use places::{api::places_api::PlacesApi, types::VisitTransition, ErrorKind, Result};
+use places::{api::places_api::PlacesApi, types::VisitType, ErrorKind, Result};
 use rusqlite::{Connection, NO_PARAMS};
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -61,7 +61,7 @@ impl FennecHistory {
 #[derive(Clone, Debug)]
 struct FennecVisit<'a> {
     history: &'a FennecHistory,
-    visit_type: VisitTransition,
+    visit_type: VisitType,
     date: Timestamp,
     is_local: bool,
 }
@@ -210,55 +210,55 @@ fn test_import() -> Result<()> {
     let visits = [
         FennecVisit {
             history: &history[0],
-            visit_type: VisitTransition::Typed,
+            visit_type: VisitType::Typed,
             date: Timestamp::from(1_565_117_389_897),
             is_local: true,
         },
         FennecVisit {
             history: &history[0],
-            visit_type: VisitTransition::Link,
+            visit_type: VisitType::Link,
             date: Timestamp::from(1_565_117_389_898),
             is_local: false,
         },
         FennecVisit {
             history: &history[1],
-            visit_type: VisitTransition::Link,
+            visit_type: VisitType::Link,
             date: Timestamp::from(1), // Invalid timestamp should get corrected!
             is_local: false,
         },
         FennecVisit {
             history: &history[1],
-            visit_type: VisitTransition::Link,
+            visit_type: VisitType::Link,
             date: Timestamp::from(1_565_117_123_123_123), // Microsecond timestamp should be imported.
             is_local: false,
         },
         FennecVisit {
             history: &history[3],
-            visit_type: VisitTransition::Link,
+            visit_type: VisitType::Link,
             date: Timestamp::from(1_565_117_389_898),
             is_local: true,
         },
         FennecVisit {
             history: &history[4],
-            visit_type: VisitTransition::Link,
+            visit_type: VisitType::Link,
             date: Timestamp::from(1_565_117_389_898),
             is_local: true,
         },
         FennecVisit {
             history: &history[5],
-            visit_type: VisitTransition::Link,
+            visit_type: VisitType::Link,
             date: Timestamp::from(1_565_117_389_898),
             is_local: true,
         },
         FennecVisit {
             history: &history[7],
-            visit_type: VisitTransition::Link,
+            visit_type: VisitType::Link,
             date: Timestamp::from(1_565_117_389_898),
             is_local: true,
         },
         FennecVisit {
             history: &history[8],
-            visit_type: VisitTransition::Link,
+            visit_type: VisitType::Link,
             date: Timestamp::from(1_565_117_389_898),
             is_local: false,
         },


### PR DESCRIPTION
a part of #4713 

I'm not 100% sure we should do this, which is why it's its own PR on top of the other one

But, I don't know why we have two type for this, AC only has one `VisitType` and it seems to me like we should have the same...

That said, I'm happy to dump this and just work with #4736 if this ends up being controversial or adds any type of complexity