### PR TITLE
This makes the `test_targeting` test better

### DIFF
--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -308,7 +308,7 @@ mod tests {
     fn test_targeting() {
         // Here's our valid jexl statement
         let expression_statement =
-            "app_id == '1010' && (app_version == '4.4' || locale == \"en-US\")";
+            "app_id == '1010' && (app_version|minimum_version('4.0') || locale == \"en-US\")";
 
         // A matching context testing the logical AND + OR of the expression
         let targeting_attributes = AppContext {
@@ -352,6 +352,27 @@ mod tests {
         .into();
         assert_eq!(targeting(expression_statement, &targeting_attributes), None);
 
+        // A matching context testing the other branch of the logical OR
+        let targeting_attributes = AppContext {
+            app_name: "nimbus_test".to_string(),
+            app_id: "1010".to_string(),
+            channel: "test".to_string(),
+            app_version: Some("3.4".to_string()),
+            app_build: Some("1234".to_string()),
+            architecture: Some("x86_64".to_string()),
+            device_manufacturer: Some("Samsung".to_string()),
+            device_model: Some("Galaxy S10".to_string()),
+            locale: Some("en-US".to_string()),
+            os: Some("Android".to_string()),
+            os_version: Some("10".to_string()),
+            android_sdk_version: Some("29".to_string()),
+            debug_tag: None,
+            custom_targeting_attributes: None,
+            ..Default::default()
+        }
+        .into();
+        assert_eq!(targeting(expression_statement, &targeting_attributes), None);
+
         // A non-matching context testing the logical AND of the expression
         let non_matching_targeting = AppContext {
             app_name: "not_nimbus_test".to_string(),
@@ -381,9 +402,9 @@ mod tests {
         // A non-matching context testing the logical OR of the expression
         let non_matching_targeting = AppContext {
             app_name: "not_nimbus_test".to_string(),
-            app_id: "org.example.app".to_string(),
+            app_id: "1010".to_string(),
             channel: "test".to_string(),
-            app_version: Some("4.5".to_string()),
+            app_version: Some("3.5".to_string()),
             app_build: Some("1234".to_string()),
             architecture: Some("x86_64".to_string()),
             device_manufacturer: Some("Samsung".to_string()),


### PR DESCRIPTION
Just a couple of tweaks to the `test_targeting` test to incorporate testing of the minimum version and add a little better coverage of the logical OR testing.