### PR TITLE
Change places bookmark APIs to use Uint

### DIFF
--- a/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
@@ -163,7 +163,7 @@ interface WritableBookmarksConnection : ReadableBookmarksConnection {
     fun createFolder(
         parentGUID: Guid,
         title: String,
-        position: Int? = null
+        position: UInt? = null
     ): Guid
 
     /**
@@ -182,7 +182,7 @@ interface WritableBookmarksConnection : ReadableBookmarksConnection {
      */
     fun createSeparator(
         parentGUID: Guid,
-        position: Int? = null
+        position: UInt? = null
     ): Guid
 
     /**
@@ -207,7 +207,7 @@ interface WritableBookmarksConnection : ReadableBookmarksConnection {
         parentGUID: Guid,
         url: Url,
         title: String,
-        position: Int? = null
+        position: UInt? = null
     ): Guid
 
     /**
@@ -228,5 +228,5 @@ interface WritableBookmarksConnection : ReadableBookmarksConnection {
      * @throws InvalidParent If `info.parentGUID` is specified, but does not refer to a
      * folder node.
      */
-    fun updateBookmark(guid: Guid, parentGuid: Guid?, position: Int?, title: String?, url: Url?)
+    fun updateBookmark(guid: Guid, parentGuid: Guid?, position: UInt?, title: String?, url: Url?)
 }

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -518,7 +518,7 @@ class PlacesWriterConnection internal constructor(connHandle: Long, conn: Uniffi
         }
     }
 
-    override fun createFolder(parentGUID: Guid, title: String, position: Int?): Guid {
+    override fun createFolder(parentGUID: Guid, title: String, position: UInt?): Guid {
         val p = if (position == null) {
             BookmarkPosition.Append
         } else {
@@ -528,7 +528,7 @@ class PlacesWriterConnection internal constructor(connHandle: Long, conn: Uniffi
         return this.doInsert(InsertableBookmarkItem.Folder(folder))
     }
 
-    override fun createSeparator(parentGUID: Guid, position: Int?): Guid {
+    override fun createSeparator(parentGUID: Guid, position: UInt?): Guid {
         val p = if (position == null) {
             BookmarkPosition.Append
         } else {
@@ -538,7 +538,7 @@ class PlacesWriterConnection internal constructor(connHandle: Long, conn: Uniffi
         return this.doInsert(InsertableBookmarkItem.Separator(sep))
     }
 
-    override fun createBookmarkItem(parentGUID: Guid, url: Url, title: String, position: Int?): Guid {
+    override fun createBookmarkItem(parentGUID: Guid, url: Url, title: String, position: UInt?): Guid {
         val p = if (position == null) {
             BookmarkPosition.Append
         } else {
@@ -548,7 +548,7 @@ class PlacesWriterConnection internal constructor(connHandle: Long, conn: Uniffi
         return this.doInsert(InsertableBookmarkItem.Bookmark(bm))
     }
 
-    override fun updateBookmark(guid: Guid, parentGuid: Guid?, position: Int?, title: String?, url: Url?) {
+    override fun updateBookmark(guid: Guid, parentGuid: Guid?, position: UInt?, title: String?, url: Url?) {
         val p: UInt? = if (position == null) {
             null
         } else {

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -352,7 +352,7 @@ class PlacesConnectionTest {
 
         val sepGUID = db.createSeparator(
             parentGUID = BookmarkRoot.Unfiled.id,
-            position = 0
+            position = 0u
         )
 
         val folderGUID = db.createFolder(


### PR DESCRIPTION
This will keep it consistent with our internal rust structs and wrapper values. The amount of changes on the consumer side is also minimal. However keeping this as a Draft as we may not want to do down this route.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
