### PR TITLE
Only test all-features if features exist

### DIFF
--- a/automation/tests.py
+++ b/automation/tests.py
@@ -131,6 +131,9 @@ class RustPackage:
     def has_default_features(self):
         return bool(self.cargo_metadata.get('features').get('default'))
 
+    def has_features(self):
+        return bool(self.cargo_metadata.get('features'))
+
     def has_changes(self, branch_changes):
         return any(path_is_relative_to(p, self.directory)
                    for p in branch_changes.paths)
@@ -173,6 +176,7 @@ def calc_rust_items(branch_changes=None, default_features_only=False):
     ]))
 
     packages = [RustPackage(p) for p in json_data['packages']]
+
     if branch_changes:
         packages = [p for p in packages if p.has_changes(branch_changes)]
 
@@ -183,7 +187,8 @@ def calc_rust_items(branch_changes=None, default_features_only=False):
         return
 
     for p in packages:
-        yield p, RustFeatures.ALL
+        if p.has_features():
+            yield p, RustFeatures.ALL
     for p in packages:
         if p.has_default_features():
             yield p, RustFeatures.NONE

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -6,9 +6,6 @@ authors = ["jrconlin <me+crypt@jrconlin.com>", "Phil Jenvey <pjenvey@underboss.o
 license = "MPL-2.0"
 exclude = ["/android", "/ios"]
 
-[features]
-default = []
-
 [dependencies]
 serde = "1"
 serde_derive = "1"

--- a/components/support/viaduct-reqwest/Cargo.toml
+++ b/components/support/viaduct-reqwest/Cargo.toml
@@ -8,9 +8,6 @@ license = "MPL-2.0"
 [lib]
 crate-type = ["lib"]
 
-[features]
-default = []
-
 [dependencies]
 viaduct = { path = "../../viaduct" }
 reqwest = { version = "0.11", features = ["blocking", "native-tls-vendored"] }

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -6,9 +6,6 @@ authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 license = "MPL-2.0"
 exclude = ["/android", "/ios"]
 
-[features]
-default = []
-
 [dependencies]
 base64 = "0.12"
 ffi-support = "0.4"

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -6,9 +6,6 @@ authors = ["application-services@mozilla.com"]
 license = "MPL-2.0"
 exclude = ["/android", "/ios"]
 
-[features]
-default = []
-
 [dependencies]
 sync15 = { path = "../sync15" }
 serde = "1"

--- a/components/viaduct/Cargo.toml
+++ b/components/viaduct/Cargo.toml
@@ -9,9 +9,6 @@ exclude = ["/android", "/ios"]
 [lib]
 crate-type = ["lib"]
 
-[features]
-default = []
-
 [dependencies]
 url = "2.2"
 log = "0.4"


### PR DESCRIPTION
This should give us significant savings in testing/clippy times in both CI and locally through the `automation/tests.py` script

Most of our components don't have features at all, so it doesn't make sense to re-reun their tests with `--all-features`.