### PR TITLE
Refactors ios CI into multiple jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,28 @@ commands:
       - store_artifacts:
           path: /tmp/sccache.log
           destination: logs/sccache.log
+  setup-ios-environment:
+    steps:
+      - run:
+          name: Toggle brew auto-updates
+          command: |
+            if [ -z "${CIRCLE_TAG}" ]; then
+              # On non-release builds do not update brew (takes ages).
+              echo 'export HOMEBREW_NO_AUTO_UPDATE=1' >> $BASH_ENV
+            fi
+      - build-ios-libs
+      - run:
+          name: Set up the build environment
+          command: |
+            # See #4163 - brew will fail because this six.py already exists.
+            # This is clearly unsatisfactory, but works, so :shrug
+            rm /usr/local/lib/python3.9/site-packages/six.py
+
+            brew install swift-protobuf --force
+      - carthage-bootstrap
+      - run:
+          name: Verify the build environment
+          command: ./libs/verify-ios-ci-environment.sh
 
 executors:
   # Where possible we want to run jobs using docker, because it's cheaper.
@@ -308,47 +330,15 @@ jobs:
       - run: rustup override set beta
       - run-tests
       - save-sccache-cache
-  iOS build and test:
+  iOS build carthage:
     executor: macos
     steps:
       - full-checkout
       - restore-sccache-cache
       - install-rust
       - setup-rust-target-version
-      - run:
-          name: Toggle brew auto-updates
-          command: |
-            if [ -z "${CIRCLE_TAG}" ]; then
-              # On non-release builds do not update brew (takes ages).
-              echo 'export HOMEBREW_NO_AUTO_UPDATE=1' >> $BASH_ENV
-            fi
       - setup-sccache
-      - build-ios-libs
-      - run:
-          name: Set up the build environment
-          command: |
-            # See #4163 - brew will fail because this six.py already exists.
-            # This is clearly unsatisfactory, but works, so :shrug
-            rm /usr/local/lib/python3.9/site-packages/six.py
-
-            brew install swift-protobuf --force
-      - carthage-bootstrap
-      - run:
-          name: Verify the build environment
-          command: ./libs/verify-ios-ci-environment.sh
-      - run:
-          name: Run XCode tests
-          command: ./automation/tests.py ios-tests
-      - store_artifacts:
-          path: raw_xcodetest.log
-          destination: logs/raw_xcodetest.log
-      - run:
-          name: (Optional) Run firefox-ios tests
-          command: |
-            # Only run these on PRs.
-            if [ -n "${CIRCLE_PULL_REQUEST}" ]; then
-              ./automation/maybe_run_fxios_tests.py << pipeline.git.base_revision >>
-            fi
+      - setup-ios-environment
       - run:
           name: Build Carthage archive
           no_output_timeout: 20m
@@ -365,16 +355,12 @@ jobs:
           path: raw_xcodebuild.log
           destination: logs/raw_xcodebuild.log
       - run:
-          name: Build XCFramework archive
-          command: |
-            bash megazords/ios-rust/build-xcframework.sh --build-profile release
-      - save-sccache-cache:
-          path: "~/Library/Caches/Mozilla.sccache"
-      - run:
           name: "Create Carthage bin-only project specification"
           command: |
             ZIP_URL=https://circleci.com/api/v1.1/project/github/mozilla/application-services/$CIRCLE_BUILD_NUM/artifacts/0/dist/MozillaAppServices.framework.zip
             echo "{\"0.0.1\":\"$ZIP_URL\"}" > mozilla.app-services.json
+      - save-sccache-cache:
+          path: "~/Library/Caches/Mozilla.sccache"
       - store_artifacts:
           name: Store Carthage framework in workspace
           path: MozillaAppServices.framework.zip
@@ -383,16 +369,46 @@ jobs:
           name: Store Carthage bin-only project specification in workspace
           path: mozilla.app-services.json
           destination: dist/mozilla.app-services.json
-      - store_artifacts:
-          name: Store XCFramework bundle in workspace
-          path: megazords/ios-rust/MozillaRustComponents.xcframework.zip
-          destination: dist/MozillaRustComponents.xcframework.zip
       - run:
           name: "Carthage binary snapshot URL"
           command: |
             JSON_URL=https://circleci.com/api/v1.1/project/github/mozilla/application-services/$CIRCLE_BUILD_NUM/artifacts/0/dist/mozilla.app-services.json
             echo "Add the following line to your Cartfile:"
             echo "binary \"$JSON_URL\" ~> 0.0.1-snapshot # mozilla/application-services@$CIRCLE_SHA1"
+      - persist_to_workspace:
+          root: .
+          paths:
+            - MozillaAppServices.framework.zip
+        
+  iOS build xcframework:
+    executor: macos
+    steps:
+      - full-checkout
+      - restore-sccache-cache
+      - install-rust
+      - setup-rust-target-version
+      - setup-sccache
+      - setup-ios-environment
+      # XX: this will be removed when upgrading to rust 1.56+
+      - run:
+          name: Install Rust Nightly
+          command: |
+            # For now we need the nightly toolchain to build for the M1 simulator.
+            rustup install nightly
+            # For now we need to build the Rust stdlib from source for the M1 simulator.
+            rustup component add rust-src --toolchain nightly-x86_64-apple-darwin
+            rustup toolchain add nightly --profile minimal
+            rustup target add aarch64-apple-ios-sim --toolchain nightly
+      - run:
+          name: Build XCFramework archive
+          command: |
+            bash megazords/ios-rust/build-xcframework.sh --build-profile release
+      - save-sccache-cache:
+          path: "~/Library/Caches/Mozilla.sccache"
+      - store_artifacts:
+          name: Store XCFramework bundle in workspace
+          path: megazords/ios-rust/MozillaRustComponents.xcframework.zip
+          destination: dist/MozillaRustComponents.xcframework.zip
       - run:
           name: "XCFramework bundle checksum"
           command: |
@@ -401,8 +417,30 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - MozillaAppServices.framework.zip
             - megazords/ios-rust/MozillaRustComponents.xcframework.zip
+
+  iOS test:
+    executor: macos
+    steps:
+      - full-checkout
+      - restore-sccache-cache
+      - install-rust
+      - setup-rust-target-version
+      - setup-ios-environment
+      - setup-sccache
+      - run:
+          name: Run XCode tests
+          command: ./automation/tests.py ios-tests
+      - store_artifacts:
+          path: raw_xcodetest.log
+          destination: logs/raw_xcodetest.log
+      - run:
+          name: (Optional) Run firefox-ios tests
+          command: |
+            # Only run these on PRs.
+            if [ -n "${CIRCLE_PULL_REQUEST}" ]; then
+              ./automation/maybe_run_fxios_tests.py << pipeline.git.base_revision >>
+            fi
   Carthage release:
     executor: macos
     steps:
@@ -499,13 +537,18 @@ workflows:
       - Generate code coverage
   ios-artifacts:
     jobs:
-      - iOS build and test:
-          filters: # required since `Release` has tag filters AND requires `Build`
-            tags:
-              only: /.*/
+      - iOS test
+      - iOS build carthage:
+        filters: # required since `Release` has tag filters AND requires `Build`
+          tags:
+            only: /.*/
+      - iOS build xcframework:
+        filters: # required since `Release` has tag filters AND requires `Build`
+          tags:
+            only: /.*/
       - Carthage release:
           requires:
-            - iOS build and test
+            - iOS build carthage
           filters:
             branches:
               ignore: /.*/
@@ -513,7 +556,7 @@ workflows:
               only: /^v.*/
       - XCFramework release:
           requires:
-            - iOS build and test
+            - iOS build xcframework
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,16 +389,6 @@ jobs:
       - setup-rust-target-version
       - setup-sccache
       - setup-ios-environment
-      # XX: this will be removed when upgrading to rust 1.56+
-      - run:
-          name: Install Rust Nightly
-          command: |
-            # For now we need the nightly toolchain to build for the M1 simulator.
-            rustup install nightly
-            # For now we need to build the Rust stdlib from source for the M1 simulator.
-            rustup component add rust-src --toolchain nightly-x86_64-apple-darwin
-            rustup toolchain add nightly --profile minimal
-            rustup target add aarch64-apple-ios-sim --toolchain nightly
       - run:
           name: Build XCFramework archive
           command: |
@@ -441,6 +431,8 @@ jobs:
             if [ -n "${CIRCLE_PULL_REQUEST}" ]; then
               ./automation/maybe_run_fxios_tests.py << pipeline.git.base_revision >>
             fi
+      - save-sccache-cache:
+          path: "~/Library/Caches/Mozilla.sccache"
   Carthage release:
     executor: macos
     steps:
@@ -539,17 +531,13 @@ workflows:
     jobs:
       - iOS test
       - iOS build carthage:
-          filters: # required since `Carthage release` has tag filters AND requires this job
-            branches:
-              ignore: /.*/
+          filters: # required since `Carthage Release` has tag filters AND requires this job
             tags:
-              only: /^v.*/
+              only: /.*/
       - iOS build xcframework:
           filters: # required since `XCFramework release` has tag filters AND requires this job
-            branches:
-              ignore: /.*/
             tags:
-              only: /^v.*/
+              only: /.*/
       - Carthage release:
           requires:
             - iOS build carthage
@@ -569,7 +557,7 @@ workflows:
   nimbus-artifacts:
     jobs:
       - build-nimbus-fml:
-          filters: # required since `Release` has tag filters AND requires `Build`
+          filters: # required since `release-nimbus-fml` has tag filters AND requires this job
             tags:
               only: /.*/
       - release-nimbus-fml:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,17 +535,21 @@ workflows:
   coverage:
     jobs:
       - Generate code coverage
-  ios-artifacts:
+  ios-test-and-artifacts:
     jobs:
       - iOS test
       - iOS build carthage:
-        filters: # required since `Release` has tag filters AND requires `Build`
-          tags:
-            only: /.*/
+          filters: # required since `Carthage release` has tag filters AND requires this job
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
       - iOS build xcframework:
-        filters: # required since `Release` has tag filters AND requires `Build`
-          tags:
-            only: /.*/
+          filters: # required since `XCFramework release` has tag filters AND requires this job
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
       - Carthage release:
           requires:
             - iOS build carthage


### PR DESCRIPTION
This gives us significant time savings on our ios-artifacts jobs (cutting by more than half) by allowing three different jobs to run in parallel, the jobs are:
- the ios tests
- building the carthage framework
- building the xcframework

This is also nice for two other reasons:
1. Once we get rid of carthage (hopefully soon?) we can just trash the whole job since this decouples it
2. If we want to change the frequency of how often we build the frameworks (like, we really shouldn't be building those artifacts every CI run...) this makes it really easy to change, while keeping the `ios tests` running on every CI

One reason **not** to take this: now the jobs run in parallel... meaning we use more `macos` resources so costs go up (although even then it's not by much 🤷)... UNLESS, we do what point `2` above says, then it's a win/win...
