### PR TITLE
Added features to support application-services branch builds

### DIFF
--- a/build-scripts/substitute-local-appservices.gradle
+++ b/build-scripts/substitute-local-appservices.gradle
@@ -5,7 +5,21 @@
 // There is a companion gradle command `autoPublishForLocalDevelopment` that can be used to publish
 // the local development versions that are targetted by this script.
 
-logger.lifecycle("[local-appservices] adjusting ${project} to use locally published application-services modules")
+def version = null
+if (gradle.hasProperty("localProperties.autoPublish.application-services.dir")) {
+    //  We're doing local development using the autoPublish system.  This automatically rebuilds and
+    //  publishes application-services packages whenever the source changes.
+    // This version string will selected the latest build package
+    version = '0.0.1-SNAPSHOT-+'
+
+} else if (gradle.hasProperty("localProperties.branchBuild.application-services.dir")) {
+    //  We're running a branch build.  Here the version is set to the git commit id in
+    //  local.properties
+    version = gradle.getProperty("localProperties.branchBuild.application-services.version")
+} else {
+    throw new Exception("substitute-local-appservices.gradle called from unexpected context")
+}
+logger.lifecycle("[local-appservices] adjusting ${project} to use locally published application-services modules (${version})")
 
 // Inject mavenLocal repository. This is where we're expected to publish modules.
 repositories {
@@ -22,13 +36,10 @@ configurations.all { config ->
                         return
                     }
 
-                    // For every org.mozilla.appservices.* module, substitute its version for one
-                    // formatted like `0.0.1-SNAPSHOT-*`. This syntax will pick the latest such version
-                    // published locally by the `autoPublishForLocalDevelopment` command.
                     def group = dependency.requested.group
                     if (group == 'org.mozilla.appservices') {
                         def name = dependency.requested.module
-                        dependency.useTarget([group: group, name: name, version: '0.0.1-SNAPSHOT-+'])
+                        dependency.useTarget([group: group, name: name, version: version])
                     }
                 }
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,6 +46,18 @@ buildconfig.projects.each { project ->
     setupProject(project.key, project.value)
 }
 
+def calcVersion(buildconfig) {
+    def versionName = gradle.rootProject.findProperty("versionName")
+    def local = gradle.rootProject.findProperty("local")
+    if (versionName) {
+        return versionName
+    } else if(local) {
+        return '0.0.1-SNAPSHOT'
+    } else {
+        return buildconfig.libraryVersion
+    }
+}
+
 gradle.projectsLoaded { ->
     // Wait until root project is "loaded" before we set "config"
     // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
@@ -55,7 +67,7 @@ gradle.projectsLoaded { ->
         // It makes a fake version number that's smaller than any published version,
         // which can be depended on specifically by the ./build-scripts/substitute-local-appservices.gradle
         // but which is unlikely to be depended on by accident otherwise.
-        version: gradle.rootProject.hasProperty('local') ? '0.0.1-SNAPSHOT' : buildconfig.libraryVersion,
+        version: calcVersion(buildconfig),
         groupId: buildconfig.groupId,
     ]
 }


### PR DESCRIPTION
This is part of the application-services branch builds project, described in https://github.com/mozilla/application-services/issues/4615.  The basic idea is to add support for a CI building/testing Fenix using in-progress branches from application-services, android-components, and/or fenix.

I'm making PRs on a-s, a-c, and fenix for this.  They all work together to allow us to:

 - Locally building/publishing application-services and android-components using the git commit ID as the version name
 - Use gradle dependency substitution to select the packages from the last step.  This is similar to the autoPublish system, but has some subtle differences.

I think this code is decent and not too bad, but there's probably a better way.  I'm open to discussing different mechanisms for doing this.  

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
