### PR TITLE
Fix swift warnings re non-null parentGuid

### DIFF
--- a/megazords/ios/MozillaAppServicesTests/PlacesTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/PlacesTests.swift
@@ -60,14 +60,14 @@ enum CheckChildren {
 func checkTree(_ n: BookmarkItem, _ want: [String: Any], checkChildren: CheckChildren = .full) {
     switch n {
     case let .bookmark(b):
-        XCTAssert(b.parentGuid != nil || b.guid == BookmarkRoots.RootGUID)
+        XCTAssert(b.guid != BookmarkRoots.RootGUID)
         XCTAssert(dynCmp(b.guid, want["guid"]))
         XCTAssert(dynCmp(b.url, want["url"]))
         XCTAssert(dynCmp(b.title, want["title"]))
         XCTAssertNil(want["children"])
         XCTAssertNil(want["childGUIDs"])
     case let .separator(s):
-        XCTAssert(s.parentGuid != nil || s.guid == BookmarkRoots.RootGUID)
+        XCTAssert(s.guid != BookmarkRoots.RootGUID)
         XCTAssert(dynCmp(s.guid, want["guid"]))
         XCTAssertNil(want["url"])
         XCTAssertNil(want["children"])


### PR DESCRIPTION
I think I actually caused this in 6f6c4906e1391759acb9d2b930155ceda8aad426/#4748 but CI is hiding it and it's only a warning.