### PR TITLE
[ci full] Nimbus using Glean Rust Bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ commands:
     steps:
       - run: sudo apt-get update
       - run: sudo apt-get install python tcl
+      - run: sudo apt-get install python3-venv
       - run:
           name: Install NSS build system dependencies
           command: sudo apt-get install ninja-build gyp zlib1g-dev

--- a/components/nimbus/build.rs
+++ b/components/nimbus/build.rs
@@ -2,7 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::{env, process::Command};
+
 pub fn main() {
     #[cfg(feature = "uniffi-bindings")]
     uniffi_build::generate_scaffolding("./src/nimbus.udl").unwrap();
+
+    // Run Glean Parser via tools/bootstrap_glean_rust.py python script
+    let out_dir = env::var("OUT_DIR").unwrap();
+    Command::new("python")
+        .args(&[
+            "../../tools/bootstrap_glean_rust.py",
+            "online",
+            "glean_parser",
+            "5.1.1",
+            "translate",
+            "-f",
+            "rust",
+            "-o",
+            out_dir.as_str(),
+            "./metrics.yaml",
+        ])
+        .status()
+        .expect("Error generating Glean Rust bindings");
+
+    println!("cargo:rerun-if-changed=./metrics.yaml");
 }

--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -91,6 +91,8 @@ RUN apt-get update -qq \
         p7zip-full \
         # Required to rsync the `libs` folder after fetch (see taskcluster/ci/android-build/kind.yml)
         rsync \
+        # Required for creating a venv for glean_parser
+        python3-venv \
     && apt-get clean
 
 RUN pip3 install --upgrade pip

--- a/tools/bootstrap_glean_rust.py
+++ b/tools/bootstrap_glean_rust.py
@@ -1,0 +1,39 @@
+#!python3
+# Python 3
+
+import importlib
+import subprocess
+import sys
+offline = sys.argv[1] == 'offline'
+module_name = sys.argv[2]
+expected_version = sys.argv[3]
+try:
+    module = importlib.import_module(module_name)
+except ImportError:
+    found_version = None
+else:
+    found_version = getattr(module, '__version__')
+if found_version != expected_version:
+    if not offline:
+        subprocess.check_call([
+            sys.executable,
+            '-m',
+            'pip',
+            'install',
+            '--upgrade',
+            f'{module_name}=={expected_version}'
+        ])
+    else:
+        print(f'Using Python environment at {sys.executable},')
+        print(f'expected glean_parser version {expected_version}, found {found_version}.')
+        sys.exit(1)
+try:
+    subprocess.check_call([
+        sys.executable,
+        '-m',
+        module_name
+    ] + sys.argv[4:])
+except:
+    # We don't need to show a traceback in this helper script.
+    # Only the output of the subprocess is interesting.
+    sys.exit(1)


### PR DESCRIPTION
Okay, this roughly follows what Glean does for an iOS build, by creating a virtual environment for glean_parser and then translating the metrics.yaml.  This can probably be improved, and the .venv moved to a higher place in the tree once other components migrate to using Glean-Rust bindings.