### PR TITLE
Attempt at fixing the `database is locked` error (#4762)

### DIFF
--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -73,6 +73,7 @@ pub fn init(conn: &Connection) -> rusqlite::Result<()> {
     log::debug!("Initializing schema");
     conn.execute_batch(CREATE_SHARED_SCHEMA_SQL)?;
     create_bookmark_roots(conn)?;
+    create_synced_bookmark_roots(conn)?;
     Ok(())
 }
 
@@ -99,7 +100,6 @@ pub fn finish(db: &Connection, conn_type: ConnectionType) -> rusqlite::Result<()
             db.execute_batch(&CREATE_SHARED_TRIGGERS_SQL)?;
             db.execute_batch(CREATE_SYNC_TEMP_TABLES_SQL)?;
             db.execute_batch(CREATE_SYNC_TRIGGERS_SQL)?;
-            create_synced_bookmark_roots(db)?;
         }
     }
     Ok(())

--- a/components/support/sql/src/open_database.rs
+++ b/components/support/sql/src/open_database.rs
@@ -109,7 +109,7 @@ fn do_open_database_with_flags<CI: ConnectionInitializer, P: AsRef<Path>>(
     log::debug!("{}: checking if initialization is necessary", CI::NAME);
     let run_init = should_init(&conn)?;
 
-    log::debug!("{}: preparing", CI::NAME);
+    log::debug!("{}: preparing (should_init: {})", CI::NAME, run_init);
     connection_initializer.prepare(&conn)?;
 
     if open_flags.contains(OpenFlags::SQLITE_OPEN_READ_WRITE) {
@@ -135,7 +135,9 @@ fn do_open_database_with_flags<CI: ConnectionInitializer, P: AsRef<Path>>(
         log::debug!("{}: finishing writable database open", CI::NAME);
         connection_initializer.finish(&tx)?;
         set_schema_version(&tx, CI::END_VERSION)?;
+        log::debug!("{}: commiting", CI::NAME);
         tx.commit()?;
+        log::debug!("{}: done", CI::NAME);
     } else {
         // There's an implied requirement that the first connection to a DB is
         // writable, so read-only connections do much less, but panic if stuff is wrong


### PR DESCRIPTION
Added a places-utils test that opens sync connections in threads.  All
this needed to error out was:
  - The database was already created
  - 2 threads tried to open a sync connection. The Mutex in PlacesApi
    ensures that this happens sequentially, but if the second thread
    tried to immediately open the connection after the first one, then I
    would see an error.  Adding a 10ms delay in-between seemed to fix
    things.

After some investigation I narrowed it down to the `INSERT OR IGNORE`
statements inside the `create_synced_bookmark_roots()` call.  I think
the fact that that query is both a read and write causes some extra
locking to happen. I'm not sure exactly what's going on here.  Maybe the
disk needs to be flushed after the first connection closes the DB, but
`PRAGMA database.wal_checkpoint` didn't work.

In any case, it seems like we could create the roots when we are first
initializing the schema with the read/write connection so I just moved
the call there and it seemed to fix things for me.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
