### PR TITLE
Attempt at fixing the `database is locked` error (#4762)

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,6 +18,10 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+## Places
+### What's Changed
+- Switched to using sqlite shared-cached mode for connections to avoid "database is locked" errors ([#4764](https://github.com/mozilla/application-services/pull/4764))
+
 ## viaduct
 ### What's New
 - Add support for PATCH methods. ([#4751](https://github.com/mozilla/application-services/pull/4751))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sql-support",
  "structopt",
  "sync-guid",
  "sync15",

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -83,7 +83,10 @@ impl ConnectionType {
 
 impl ConnectionType {
     pub fn rusqlite_flags(self) -> OpenFlags {
-        let common_flags = OpenFlags::SQLITE_OPEN_NO_MUTEX | OpenFlags::SQLITE_OPEN_URI;
+        let common_flags = OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_URI
+            | OpenFlags::SQLITE_OPEN_SHARED_CACHE;
+
         match self {
             ConnectionType::ReadOnly => common_flags | OpenFlags::SQLITE_OPEN_READ_ONLY,
             ConnectionType::ReadWrite => {

--- a/examples/places-utils/Cargo.toml
+++ b/examples/places-utils/Cargo.toml
@@ -15,6 +15,7 @@ places = { path = "../../components/places" }
 sync-guid = { path = "../../components/support/guid" }
 types = { path = "../../components/support/types" }
 sync15 = { path = "../../components/sync15" }
+sql-support = { path = "../../components/support/sql" }
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
 serde = "1"
 serde_derive = "1"


### PR DESCRIPTION
The error was happening while opening the database so I added a
places-utils test to stress-test opening sync connections.  I was able
to reproduce the error and tracked down the source to the `INSERT OR
IGNORE` statements inside the `create_synced_bookmark_roots()` call.

The error happens when attempting to get a write lock for a transaction,
after the it already has a read lock.  This is causing SQL_BUSY errors
(which has a misleading "database is locked" error message).

This issue happened in two different ways:
  - When a separate thread held a write lock on the writer DB.  Note
    that the thread only held the lock for 2 seconds, which is short
    enough that other threads should just wait for the lock rather than
    timing out.

  - When multiple threads tried to open a sync connection at once.
    Because get_sync_connection uses a mutex this happened sequentially,
    but it still triggered the issue if open attempts happened
    immediately after the connection was dropped. Adding a 10ms sleep
    stopped the error.

Interestingly, if we used `BEGIN IMMEDIATE` to start the transaction,
which immediately tries to take the write lock, then the issue wouldn't
appear. The thread would just wait until the lock was available.  The
issue only happened when we took the read lock first, then tried to take
a write lock.

Fixed this by using the SQLITE_OPEN_SHARED_CACHE flag when opening the
connection.  This changes how sqlite handles locking and fixes the
problem.  It also seems good in general.  The sqlite site says it "can
significantly reduce the quantity of memory and IO required by the
system".
