### PR TITLE
Add mavenCentral repo to resolve protobuf dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ buildscript {
     ]
 
     repositories {
+        mavenCentral()
         google()
         jcenter()
         maven {


### PR DESCRIPTION
Ran into this setting up A-S on a fresh M1, being unable to resolve `com/google/protobuf/protoc/3.11.4` without this repo present.

mavenCentral ends up pointing to https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.11.4/, while before we were only looking in https://maven.google.com/web/index.html?q=protoc

protobuf docs also point to repo1: https://github.com/protocolbuffers/protobuf#protocol-compiler-installation




### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
