### PR TITLE
Handled URL parse errors bookmarks_get_all_with_url and accept_result…

### DIFF
--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -79,7 +79,7 @@ interface PlacesConnection {
     sequence<SearchResult> query_autocomplete(string search, i32 limit);
 
     [Throws=PlacesError]
-    void accept_result(string search_string, Url url);
+    void accept_result(string search_string, string url);
 
     [Throws=PlacesError]
     Url? match_url(string query);
@@ -157,7 +157,7 @@ interface PlacesConnection {
 
     // XXX - should return BookmarkData
     [Throws=PlacesError]
-    sequence<BookmarkItem> bookmarks_get_all_with_url(Url url);
+    sequence<BookmarkItem> bookmarks_get_all_with_url(string url);
 
     // XXX - should return BookmarkData
     [Throws=PlacesError]


### PR DESCRIPTION
Prior to the places uniffication work, the [places_accept_result](https://github.com/mozilla/application-services/blob/36ae51e12e519918946f88d1444454fc92543f2d/components/places/ffi/src/lib.rs#L468) and [bookmarks_get_all_with_url](https://github.com/mozilla/application-services/blob/36ae51e12e519918946f88d1444454fc92543f2d/components/places/ffi/src/lib.rs#L656) functions logged warnings when invalid URLs were passed in instead of returning a URL parse error. This PR is adding that functionality back.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
