### PR TITLE
[WIP] For EXP-2012: Move tests for lib into their own test files

### DIFF
--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -3,13 +3,13 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod dbcache;
-mod enrollment;
+pub mod enrollment;
 pub mod error;
 mod evaluator;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use defaults::Defaults;
 pub use error::{NimbusError, Result};
-mod client;
+pub mod client;
 mod config;
 mod defaults;
 mod matcher;
@@ -68,10 +68,10 @@ impl From<AppContext> for TargetingAttributes {
 // struct to contain the bits that do actually need to be mutable, so they can be
 // protected by a Mutex.
 #[derive(Default)]
-struct InternalMutableState {
-    available_randomization_units: AvailableRandomizationUnits,
+pub struct InternalMutableState {
+    pub available_randomization_units: AvailableRandomizationUnits,
     // Application level targeting attributes
-    targeting_attributes: TargetingAttributes,
+    pub targeting_attributes: TargetingAttributes,
 }
 
 /// Nimbus is the main struct representing the experiments state
@@ -79,7 +79,7 @@ struct InternalMutableState {
 /// experimentation status
 pub struct NimbusClient {
     settings_client: Mutex<Box<dyn SettingsClient + Send>>,
-    mutable_state: Mutex<InternalMutableState>,
+    pub mutable_state: Mutex<InternalMutableState>,
     app_context: AppContext,
     db: OnceCell<Database>,
     // Manages an in-memory cache so that we can answer certain requests
@@ -113,13 +113,11 @@ impl NimbusClient {
         })
     }
 
-    #[cfg(test)]
     pub fn with_targeting_attributes(&mut self, targeting_attributes: TargetingAttributes) {
         let mut state = self.mutable_state.lock().unwrap();
         state.targeting_attributes = targeting_attributes;
     }
 
-    #[cfg(test)]
     pub fn get_targeting_attributes(&self) -> TargetingAttributes {
         let state = self.mutable_state.lock().unwrap();
         state.targeting_attributes.clone()
@@ -455,7 +453,7 @@ impl NimbusClient {
         Ok(())
     }
 
-    fn db(&self) -> Result<&Database> {
+    pub fn db(&self) -> Result<&Database> {
         self.db.get_or_try_init(|| Database::new(&self.db_path))
     }
 }
@@ -518,7 +516,7 @@ impl Experiment {
         self.branches.iter().find(|b| b.slug == branch_slug)
     }
 
-    fn get_feature_ids(&self) -> Vec<String> {
+    pub fn get_feature_ids(&self) -> Vec<String> {
         let branches = &self.branches;
         let feature_ids = branches
             .iter()
@@ -582,7 +580,7 @@ pub struct Branch {
 }
 
 impl Branch {
-    fn get_feature_configs(&self) -> Vec<FeatureConfig> {
+    pub fn get_feature_configs(&self) -> Vec<FeatureConfig> {
         // Some versions of desktop need both, but features should be prioritized
         // (https://mozilla-hub.atlassian.net/browse/SDK-440).
         match (&self.features, &self.feature) {
@@ -676,7 +674,7 @@ impl Default for RandomizationUnit {
 pub struct AvailableRandomizationUnits {
     pub client_id: Option<String>,
     #[allow(dead_code)]
-    dummy: i8, // See comments in nimbus.udl for why this hacky item exists.
+    pub dummy: i8, // See comments in nimbus.udl for why this hacky item exists.
 }
 
 impl AvailableRandomizationUnits {
@@ -704,1278 +702,143 @@ impl AvailableRandomizationUnits {
 #[cfg(feature = "uniffi-bindings")]
 include!(concat!(env!("OUT_DIR"), "/nimbus.uniffi.rs"));
 
-#[cfg(test)]
-mod tests {
-    use std::io::Write;
-
-    use super::*;
-    use chrono::Duration;
-    use enrollment::{EnrolledReason, EnrollmentStatus, ExperimentEnrollment};
-    use serde_json::json;
-    use tempdir::TempDir;
-
-    #[test]
-    fn test_telemetry_reset() -> Result<()> {
-        let mock_client_id = "client-1".to_string();
-        let mock_exp_slug = "exp-1".to_string();
-        let mock_exp_branch = "branch-1".to_string();
-
-        let tmp_dir = TempDir::new("test_telemetry_reset")?;
-        let client = NimbusClient::new(
-            AppContext::default(),
-            tmp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id.clone()),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-
-        let get_client_id = || {
-            client
-                .mutable_state
-                .lock()
-                .unwrap()
-                .available_randomization_units
-                .client_id
-                .clone()
-        };
-
-        // Mock being enrolled in a single experiment.
-        let db = client.db()?;
-        let mut writer = db.write()?;
-        db.get_store(StoreId::Experiments).put(
-            &mut writer,
-            &mock_exp_slug,
-            &Experiment {
-                slug: mock_exp_slug.clone(),
-                ..Experiment::default()
-            },
-        )?;
-        db.get_store(StoreId::Enrollments).put(
-            &mut writer,
-            &mock_exp_slug,
-            &ExperimentEnrollment {
-                slug: mock_exp_slug.clone(),
-                status: EnrollmentStatus::new_enrolled(EnrolledReason::Qualified, &mock_exp_branch),
-            },
-        )?;
-        writer.commit()?;
-
-        client.initialize()?;
-
-        // Check expected state before resetting telemetry.
-        let orig_nimbus_id = client.nimbus_id()?;
-        assert_eq!(get_client_id(), Some(mock_client_id));
-
-        let events = client.reset_telemetry_identifiers(AvailableRandomizationUnits::default())?;
-
-        // We should have reset our nimbus_id.
-        assert_ne!(orig_nimbus_id, client.nimbus_id()?);
-
-        // We should have updated the randomization units.
-        assert_eq!(get_client_id(), None);
-
-        // We should have been disqualified from the enrolled experiment.
-        assert_eq!(client.get_experiment_branch(mock_exp_slug)?, None);
-
-        // We should have returned a single event.
-        assert_eq!(events.len(), 1);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_installation_date() -> Result<()> {
-        let mock_client_id = "client-1".to_string();
-        let tmp_dir = TempDir::new("test_installation_date")?;
-        // Step 1: We first test that the SDK will default to using the
-        // value in the app context if it exists
-        let three_days_ago = Utc::now() - Duration::days(3);
-        let time_stamp = three_days_ago.timestamp_millis();
-        let mut app_context = AppContext {
-            installation_date: Some(time_stamp),
-            home_directory: Some(tmp_dir.path().to_str().unwrap().to_string()),
-            ..Default::default()
-        };
-        let client = NimbusClient::new(
-            app_context.clone(),
-            tmp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id.clone()),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-
-        client.initialize()?;
-        client.apply_pending_experiments()?;
-
-        // We verify that it's three days, ago. Because that's the date
-        // passed into the context
-        let targeting_attributes = client.get_targeting_attributes();
-        assert!(matches!(targeting_attributes.days_since_install, Some(3)));
-
-        // We now clear the persisted storage
-        // to make sure we start from a clear state
-        let db = client.db()?;
-        let mut writer = db.write()?;
-        let store = db.get_store(StoreId::Meta);
-
-        store.clear(&mut writer)?;
-        writer.commit()?;
-
-        // Step 2: We test that we will fallback to the
-        // filesystem, and if that fails we
-        // set Today's date.
-
-        // We recreate our client to make sure
-        // we wipe any non-persistent memory
-        // this time, with a context that does not
-        // include the timestamp
-        app_context.installation_date = None;
-        let client = NimbusClient::new(
-            app_context.clone(),
-            tmp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id.clone()),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        delete_test_creation_date(tmp_dir.path()).ok();
-        // When we check the filesystem, we will fail. We haven't `set_test_creation_date`
-        // yet.
-        client.initialize()?;
-        client.apply_pending_experiments()?;
-        // We verify that it's today.
-        let targeting_attributes = client.get_targeting_attributes();
-        assert!(matches!(targeting_attributes.days_since_install, Some(0)));
-
-        // Step 3: We test that persisted storage takes precedence over
-        // checking the filesystem
-
-        // We recreate our client to make sure
-        // we wipe any non-persistent memory
-        let client = NimbusClient::new(
-            app_context.clone(),
-            tmp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id.clone()),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        client.initialize()?;
-        // We now store a date for days ago in our file system
-        // this shouldn't change the installation date for the nimbus client
-        // since client already persisted the date seen earlier.
-        let four_days_ago = Utc::now() - Duration::days(4);
-        set_test_creation_date(four_days_ago, tmp_dir.path())?;
-        client.apply_pending_experiments()?;
-        let targeting_attributes = client.get_targeting_attributes();
-        // We will **STILL** get a 0 `days_since_install` since we persisted the value
-        // we got on the previous run, therefore we did not check the file system.
-        assert!(matches!(targeting_attributes.days_since_install, Some(0)));
-
-        // We now clear the persisted storage
-        // to make sure we start from a clear state
-        let db = client.db()?;
-        let mut writer = db.write()?;
-        let store = db.get_store(StoreId::Meta);
-
-        store.clear(&mut writer)?;
-        writer.commit()?;
-
-        // Step 4: We test that if the storage is clear, we will fallback to the
-        let client = NimbusClient::new(
-            app_context,
-            tmp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        client.initialize()?;
-        // now that the store is clear, we will fallback again to the
-        // file system, and retrieve the four_days_ago number we stored earlier
-        client.apply_pending_experiments()?;
-        let targeting_attributes = client.get_targeting_attributes();
-        assert!(matches!(targeting_attributes.days_since_install, Some(4)));
-        Ok(())
-    }
-
-    #[test]
-    fn test_days_since_update_changes_with_context() -> Result<()> {
-        let mock_client_id = "client-1".to_string();
-        let tmp_dir = TempDir::new("test_days_since_update")?;
-        let client = NimbusClient::new(
-            AppContext::default(),
-            tmp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id.clone()),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        client.initialize()?;
-
-        // Step 1: Test what happens if we have no persisted app version,
-        // but we got a new version in our app_context.
-        // We should set our update date to today.
-
-        // We re-create the client, with an app context that includes
-        // a version
-        let mut app_context = AppContext {
-            app_version: Some("v94.0.0".into()),
-            ..Default::default()
-        };
-        let client = NimbusClient::new(
-            app_context.clone(),
-            tmp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id.clone()),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        client.initialize()?;
-        client.apply_pending_experiments()?;
-        let targeting_attributes = client.get_targeting_attributes();
-        // The days_since_update should be zero
-        assert!(matches!(targeting_attributes.days_since_update, Some(0)));
-        let db = client.db()?;
-        let reader = db.read()?;
-        let store = db.get_store(StoreId::Meta);
-        let app_version: String = store.get(&reader, DB_KEY_APP_VERSION)?.unwrap();
-        // we make sure we persisted the version we saw
-        assert_eq!(app_version, "v94.0.0");
-        let update_date: DateTime<Utc> = store.get(&reader, DB_KEY_UPDATE_DATE)?.unwrap();
-        let diff_with_today = Utc::now() - update_date;
-        // we make sure the persisted date, is today
-        assert_eq!(diff_with_today.num_days(), 0);
-
-        // Step 2: Test what happens if there is already a persisted date
-        // but we get a new one in our context that is the **same**
-        // the update_date should not change
-        let client = NimbusClient::new(
-            app_context.clone(),
-            tmp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id.clone()),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        client.initialize()?;
-        client.apply_pending_experiments()?;
-
-        // We repeat the same tests we did above first
-        let targeting_attributes = client.get_targeting_attributes();
-        // The days_since_update should still be zero
-        assert!(matches!(targeting_attributes.days_since_update, Some(0)));
-        let db = client.db()?;
-        let reader = db.read()?;
-        let store = db.get_store(StoreId::Meta);
-        let app_version: String = store.get(&reader, DB_KEY_APP_VERSION)?.unwrap();
-        // we make sure we persisted the version we saw
-        assert_eq!(app_version, "v94.0.0");
-        let new_update_date: DateTime<Utc> = store.get(&reader, DB_KEY_UPDATE_DATE)?.unwrap();
-        // we make sure the persisted date, is **EXACTLY** the same
-        // one we persisted earler, not that the `DateTime` object here
-        // includes time to the nanoseconds, so this is a valid way
-        // to ensure the objects are the same
-        assert_eq!(new_update_date, update_date);
-
-        // Step 3: Test what happens if there is a persisted date,
-        // but the app_context includes a newer date, the update_date
-        // should be updated
-
-        app_context.app_version = Some("v94.0.1".into()); // A different version
-        let client = NimbusClient::new(
-            app_context,
-            tmp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        client.initialize()?;
-        client.apply_pending_experiments()?;
-
-        // We repeat some of the same tests we did above first
-        let targeting_attributes = client.get_targeting_attributes();
-        // The days_since_update should still be zero
-        assert!(matches!(targeting_attributes.days_since_update, Some(0)));
-        let db = client.db()?;
-        let reader = db.read()?;
-        let store = db.get_store(StoreId::Meta);
-        let app_version: String = store.get(&reader, DB_KEY_APP_VERSION)?.unwrap();
-        // we make sure we persisted the **NEW** version we saw
-        assert_eq!(app_version, "v94.0.1");
-        let new_update_date: DateTime<Utc> = store.get(&reader, DB_KEY_UPDATE_DATE)?.unwrap();
-        // we make sure the persisted date is newer and different
-        // than the old one. This helps us ensure that there was indeed
-        // an update to the date
-        assert!(new_update_date > update_date);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_days_since_install() -> Result<()> {
-        let mock_client_id = "client-1".to_string();
-
-        let temp_dir = TempDir::new("test_days_since_install_failed")?;
-        let app_context = AppContext {
-            app_name: "fenix".to_string(),
-            app_id: "org.mozilla.fenix".to_string(),
-            channel: "nightly".to_string(),
-            ..Default::default()
-        };
-        let mut client = NimbusClient::new(
-            app_context.clone(),
-            temp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        let targeting_attributes = TargetingAttributes {
-            app_context,
-            days_since_install: Some(10),
-            days_since_update: None,
-            is_already_enrolled: false,
-        };
-        client.with_targeting_attributes(targeting_attributes);
-        client.initialize()?;
-        let experiment_json = serde_json::to_string(&json!({
-            "data": [{
-                "schemaVersion": "1.0.0",
-                "slug": "secure-gold",
-                "endDate": null,
-                "featureIds": ["some-feature"],
-                "branches": [
-                    {
-                    "slug": "control",
-                    "ratio": 1
-                    },
-                    {
-                    "slug": "treatment",
-                    "ratio": 1
-                    }
-                ],
-                "channel": "nightly",
-                "probeSets": [],
-                "startDate": null,
-                "appName": "fenix",
-                "appId": "org.mozilla.fenix",
-                "bucketConfig": {
-                    "count": 10000,
-                    "start": 0,
-                    "total": 10000,
-                    "namespace": "secure-gold",
-                    "randomizationUnit": "nimbus_id"
-                },
-                "targeting": "days_since_install == 10",
-                "userFacingName": "test experiment",
-                "referenceBranch": "control",
-                "isEnrollmentPaused": false,
-                "proposedEnrollment": 7,
-                "userFacingDescription": "This is a test experiment for testing purposes.",
-                "id": "secure-copper",
-                "last_modified": 1_602_197_324_372i64,
-            }
-        ]}))?;
-        client.set_experiments_locally(experiment_json)?;
-        client.apply_pending_experiments()?;
-
-        // The targeting targeted days_since_install == 10, which is true in the client
-        // so we should be enrolled in that experiment
-        let active_experiments = client.get_active_experiments()?;
-        assert_eq!(active_experiments.len(), 1);
-        assert_eq!(active_experiments[0].slug, "secure-gold");
-        Ok(())
-    }
-
-    #[test]
-    fn test_days_since_install_failed_targeting() -> Result<()> {
-        let mock_client_id = "client-1".to_string();
-
-        let temp_dir = TempDir::new("test_days_since_install_failed")?;
-        let app_context = AppContext {
-            app_name: "fenix".to_string(),
-            app_id: "org.mozilla.fenix".to_string(),
-            channel: "nightly".to_string(),
-            ..Default::default()
-        };
-        let mut client = NimbusClient::new(
-            app_context.clone(),
-            temp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        let targeting_attributes = TargetingAttributes {
-            app_context,
-            days_since_install: Some(10),
-            days_since_update: None,
-            is_already_enrolled: false,
-        };
-        client.with_targeting_attributes(targeting_attributes);
-        client.initialize()?;
-        let experiment_json = serde_json::to_string(&json!({
-            "data": [{
-                "schemaVersion": "1.0.0",
-                "slug": "secure-gold",
-                "endDate": null,
-                "featureIds": ["some-feature"],
-                "branches": [
-                    {
-                    "slug": "control",
-                    "ratio": 1
-                    },
-                    {
-                    "slug": "treatment",
-                    "ratio": 1
-                    }
-                ],
-                "channel": "nightly",
-                "probeSets": [],
-                "startDate": null,
-                "appName": "fenix",
-                "appId": "org.mozilla.fenix",
-                "bucketConfig": {
-                    "count": 10000,
-                    "start": 0,
-                    "total": 10000,
-                    "namespace": "secure-gold",
-                    "randomizationUnit": "nimbus_id"
-                },
-                "targeting": "days_since_install < 10",
-                "userFacingName": "test experiment",
-                "referenceBranch": "control",
-                "isEnrollmentPaused": false,
-                "proposedEnrollment": 7,
-                "userFacingDescription": "This is a test experiment for testing purposes.",
-                "id": "secure-copper",
-                "last_modified": 1_602_197_324_372i64,
-            }
-        ]}))?;
-        client.set_experiments_locally(experiment_json)?;
-        client.apply_pending_experiments()?;
-
-        // The targeting targeted days_since_install < 10, which is false in the client
-        // so we should be enrolled in that experiment
-        let active_experiments = client.get_active_experiments()?;
-        assert_eq!(active_experiments.len(), 0);
-        Ok(())
-    }
-
-    #[test]
-    fn test_days_since_update() -> Result<()> {
-        let mock_client_id = "client-1".to_string();
-
-        let temp_dir = TempDir::new("test_days_since_update")?;
-        let app_context = AppContext {
-            app_name: "fenix".to_string(),
-            app_id: "org.mozilla.fenix".to_string(),
-            channel: "nightly".to_string(),
-            ..Default::default()
-        };
-        let mut client = NimbusClient::new(
-            app_context.clone(),
-            temp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        let targeting_attributes = TargetingAttributes {
-            app_context,
-            days_since_install: None,
-            days_since_update: Some(10),
-            is_already_enrolled: false,
-        };
-        client.with_targeting_attributes(targeting_attributes);
-        client.initialize()?;
-        let experiment_json = serde_json::to_string(&json!({
-            "data": [{
-                "schemaVersion": "1.0.0",
-                "slug": "secure-gold",
-                "endDate": null,
-                "featureIds": ["some-feature"],
-                "branches": [
-                    {
-                    "slug": "control",
-                    "ratio": 1
-                    },
-                    {
-                    "slug": "treatment",
-                    "ratio": 1
-                    }
-                ],
-                "channel": "nightly",
-                "probeSets": [],
-                "startDate": null,
-                "appName": "fenix",
-                "appId": "org.mozilla.fenix",
-                "bucketConfig": {
-                    "count": 10000,
-                    "start": 0,
-                    "total": 10000,
-                    "namespace": "secure-gold",
-                    "randomizationUnit": "nimbus_id"
-                },
-                "targeting": "days_since_update == 10",
-                "userFacingName": "test experiment",
-                "referenceBranch": "control",
-                "isEnrollmentPaused": false,
-                "proposedEnrollment": 7,
-                "userFacingDescription": "This is a test experiment for testing purposes.",
-                "id": "secure-copper",
-                "last_modified": 1_602_197_324_372i64,
-            }
-        ]}))?;
-        client.set_experiments_locally(experiment_json)?;
-        client.apply_pending_experiments()?;
-
-        // The targeting targeted days_since_update == 10, which is true in the client
-        // so we should be enrolled in that experiment
-        let active_experiments = client.get_active_experiments()?;
-        assert_eq!(active_experiments.len(), 1);
-        assert_eq!(active_experiments[0].slug, "secure-gold");
-        Ok(())
-    }
-
-    #[test]
-    fn test_days_since_update_failed_targeting() -> Result<()> {
-        let mock_client_id = "client-1".to_string();
-
-        let temp_dir = TempDir::new("test_days_since_update_failed")?;
-        let app_context = AppContext {
-            app_name: "fenix".to_string(),
-            app_id: "org.mozilla.fenix".to_string(),
-            channel: "nightly".to_string(),
-            ..Default::default()
-        };
-        let mut client = NimbusClient::new(
-            app_context.clone(),
-            temp_dir.path(),
-            None,
-            AvailableRandomizationUnits {
-                client_id: Some(mock_client_id),
-                ..AvailableRandomizationUnits::default()
-            },
-        )?;
-        let targeting_attributes = TargetingAttributes {
-            app_context,
-            days_since_install: None,
-            days_since_update: Some(10),
-            is_already_enrolled: false,
-        };
-        client.with_targeting_attributes(targeting_attributes);
-        client.initialize()?;
-        let experiment_json = serde_json::to_string(&json!({
-            "data": [{
-                "schemaVersion": "1.0.0",
-                "slug": "secure-gold",
-                "endDate": null,
-                "featureIds": ["some-feature"],
-                "branches": [
-                    {
-                    "slug": "control",
-                    "ratio": 1
-                    },
-                    {
-                    "slug": "treatment",
-                    "ratio": 1
-                    }
-                ],
-                "channel": "nightly",
-                "probeSets": [],
-                "startDate": null,
-                "appName": "fenix",
-                "appId": "org.mozilla.fenix",
-                "bucketConfig": {
-                    "count": 10000,
-                    "start": 0,
-                    "total": 10000,
-                    "namespace": "secure-gold",
-                    "randomizationUnit": "nimbus_id"
-                },
-                "targeting": "days_since_update < 10",
-                "userFacingName": "test experiment",
-                "referenceBranch": "control",
-                "isEnrollmentPaused": false,
-                "proposedEnrollment": 7,
-                "userFacingDescription": "This is a test experiment for testing purposes.",
-                "id": "secure-copper",
-                "last_modified": 1_602_197_324_372i64,
-            }
-        ]}))?;
-        client.set_experiments_locally(experiment_json)?;
-        client.apply_pending_experiments()?;
-
-        // The targeting targeted days_since_update < 10, which is false in the client
-        // so we should be enrolled in that experiment
-        let active_experiments = client.get_active_experiments()?;
-        assert_eq!(active_experiments.len(), 0);
-        Ok(())
-    }
-
-    fn set_test_creation_date<P: AsRef<Path>>(date: DateTime<Utc>, path: P) -> Result<()> {
-        use std::fs::OpenOptions;
-        let test_path = path.as_ref().with_file_name("test.json");
-        let mut file = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(test_path)
-            .unwrap();
-        file.write_all(serde_json::to_string(&date).unwrap().as_bytes())?;
-        Ok(())
-    }
-
-    fn delete_test_creation_date<P: AsRef<Path>>(path: P) -> Result<()> {
-        let test_path = path.as_ref().with_file_name("test.json");
-        std::fs::remove_file(test_path)?;
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-/// A suite of tests for b/w compat of data storage schema.
-///
-/// We use the `Serialize/`Deserialize` impls on various structs in order to persist them
-/// into rkv, and it's important that we be able to read previously-persisted data even
-/// if the struct definitions change over time.
-///
-/// This is a suite of tests specifically to check for backward compatibility with data
-/// that may have been written to disk by previous versions of the library.
-///
-/// ⚠️ Warning : Do not change the JSON data used by these tests. ⚠️
-/// ⚠️ The whole point of the tests is to check things work with that data. ⚠️
-///
-mod test_schema_bw_compat {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_without_probe_sets_and_enabled() {
-        // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
-        // this is an experiment following the schema after the removal
-        // of the `enabled` and `probe_sets` fields which were removed
-        // together in the same proposal
-        serde_json::from_value::<Experiment>(json!({
-            "schemaVersion": "1.0.0",
-            "slug": "secure-gold",
-            "appName": "fenix",
-            "appId": "bobo",
-            "channel": "nightly",
-            "endDate": null,
-            "branches":[
-                {
-                    "slug": "control",
-                    "ratio": 1,
-                    "features": [{
-                        "featureId": "feature1",
-                        "value": {
-                            "key": "value1"
-                        }
-                    },
-                    {
-                        "featureId": "feature2",
-                        "value": {
-                            "key": "value2"
-                        }
-                    }]
-                },
-                {
-                    "slug": "treatment",
-                    "ratio":1,
-                    "features": [{
-                        "featureId": "feature3",
-                        "value": {
-                            "key": "value3"
-                        }
-                    },
-                    {
-                        "featureId": "feature4",
-                        "value": {
-                            "key": "value4"
-                        }
-                    }]
-                }
-            ],
-            "startDate":null,
-            "application":"fenix",
-            "bucketConfig":{
-                "count":10_000,
-                "start":0,
-                "total":10_000,
-                "namespace":"secure-gold",
-                "randomizationUnit":"nimbus_id"
-            },
-            "userFacingName":"Diagnostic test experiment",
-            "referenceBranch":"control",
-            "isEnrollmentPaused":false,
-            "proposedEnrollment":7,
-            "userFacingDescription":"This is a test experiment for diagnostic purposes.",
-            "id":"secure-gold",
-            "last_modified":1_602_197_324_372i64
-        }))
-        .unwrap();
-    }
-
-    #[test]
-    fn test_multifeature_branch_schema() {
-        // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
-        // this is an experiment following the schema after the addition
-        // of multiple features per branch
-        let exp: Experiment = serde_json::from_value(json!({
-            "schemaVersion": "1.0.0",
-            "slug": "secure-gold",
-            "appName": "fenix",
-            "appId": "bobo",
-            "channel": "nightly",
-            "endDate": null,
-            "branches":[
-                {
-                    "slug": "control",
-                    "ratio": 1,
-                    "features": [{
-                        "featureId": "feature1",
-                        "enabled": true,
-                        "value": {
-                            "key": "value1"
-                        }
-                    },
-                    {
-                        "featureId": "feature2",
-                        "enabled": false,
-                        "value": {
-                            "key": "value2"
-                        }
-                    }]
-                },
-                {
-                    "slug": "treatment",
-                    "ratio":1,
-                    "features": [{
-                        "featureId": "feature3",
-                        "enabled": true,
-                        "value": {
-                            "key": "value3"
-                        }
-                    },
-                    {
-                        "featureId": "feature4",
-                        "enabled": false,
-                        "value": {
-                            "key": "value4"
-                        }
-                    }]
-                }
-            ],
-            "probeSets":[],
-            "startDate":null,
-            "application":"fenix",
-            "bucketConfig":{
-                "count":10_000,
-                "start":0,
-                "total":10_000,
-                "namespace":"secure-gold",
-                "randomizationUnit":"nimbus_id"
-            },
-            "userFacingName":"Diagnostic test experiment",
-            "referenceBranch":"control",
-            "isEnrollmentPaused":false,
-            "proposedEnrollment":7,
-            "userFacingDescription":"This is a test experiment for diagnostic purposes.",
-            "id":"secure-gold",
-            "last_modified":1_602_197_324_372i64
-        }))
-        .unwrap();
-        assert_eq!(
-            exp.branches[0].get_feature_configs(),
-            vec![
-                FeatureConfig {
-                    feature_id: "feature1".to_string(),
-                    value: vec![("key".to_string(), json!("value1"))]
-                        .into_iter()
-                        .collect()
-                },
-                FeatureConfig {
-                    feature_id: "feature2".to_string(),
-                    value: vec![("key".to_string(), json!("value2"))]
-                        .into_iter()
-                        .collect()
-                }
-            ]
-        );
-        assert_eq!(
-            exp.branches[1].get_feature_configs(),
-            vec![
-                FeatureConfig {
-                    feature_id: "feature3".to_string(),
-                    value: vec![("key".to_string(), json!("value3"))]
-                        .into_iter()
-                        .collect()
-                },
-                FeatureConfig {
-                    feature_id: "feature4".to_string(),
-                    value: vec![("key".to_string(), json!("value4"))]
-                        .into_iter()
-                        .collect()
-                }
-            ]
-        );
-        assert!(exp.branches[0].feature.is_none());
-        assert!(exp.branches[1].feature.is_none());
-    }
-
-    #[test]
-    fn test_only_one_feature_branch_schema() {
-        // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
-        // this is an experiment following the schema before the addition
-        // of multiple features per branch
-        let exp: Experiment = serde_json::from_value(json!({
-            "schemaVersion": "1.0.0",
-            "slug": "secure-gold",
-            "appName": "fenix",
-            "appId": "bobo",
-            "channel": "nightly",
-            "endDate": null,
-            "branches":[
-                {
-                    "slug": "control",
-                    "ratio": 1,
-                    "feature": {
-                        "featureId": "feature1",
-                        "enabled": true,
-                        "value": {
-                            "key": "value"
-                        }
-                    }
-                },
-                {
-                    "slug": "treatment",
-                    "ratio":1,
-                    "feature": {
-                        "featureId": "feature2",
-                        "enabled": true,
-                        "value": {
-                            "key": "value2"
-                        }
-                    }
-                }
-            ],
-            "probeSets":[],
-            "startDate":null,
-            "application":"fenix",
-            "bucketConfig":{
-                "count":10_000,
-                "start":0,
-                "total":10_000,
-                "namespace":"secure-gold",
-                "randomizationUnit":"nimbus_id"
-            },
-            "userFacingName":"Diagnostic test experiment",
-            "referenceBranch":"control",
-            "isEnrollmentPaused":false,
-            "proposedEnrollment":7,
-            "userFacingDescription":"This is a test experiment for diagnostic purposes.",
-            "id":"secure-gold",
-            "last_modified":1_602_197_324_372i64
-        }))
-        .unwrap();
-        assert_eq!(
-            exp.branches[0].get_feature_configs(),
-            vec![FeatureConfig {
-                feature_id: "feature1".to_string(),
-                value: vec![("key".to_string(), json!("value"))]
-                    .into_iter()
-                    .collect()
-            }]
-        );
-        assert_eq!(
-            exp.branches[1].get_feature_configs(),
-            vec![FeatureConfig {
-                feature_id: "feature2".to_string(),
-                value: vec![("key".to_string(), json!("value2"))]
-                    .into_iter()
-                    .collect()
-            }]
-        );
-        assert!(exp.branches[0].features.is_none());
-        assert!(exp.branches[1].features.is_none());
-    }
-
-    #[test]
-    fn test_feature_and_features_in_one_branch() {
-        // Single feature, no features
-        let branch: Branch = serde_json::from_value(json!(
-            {
-                "slug": "control",
-                "ratio": 1,
-                "feature": {
-                    "featureId": "feature1",
-                    "value": {
-                        "key": "value"
-                    }
-                }
-            }
-        ))
-        .unwrap();
-
-        let configs = branch.get_feature_configs();
-
-        assert_eq!(
-            configs,
-            vec![FeatureConfig {
-                feature_id: "feature1".to_string(),
-                value: json!({"key": "value"}).as_object().unwrap().clone()
-            }]
-        );
-
-        // No feature, multiple features
-        let branch: Branch = serde_json::from_value(json!(
-            {
-                "slug": "control",
-                "ratio": 1,
-                "features": [{
-                    "featureId": "feature1",
-                    "value": {
-                        "key": "value"
-                    }
-                },
-                {
-                    "featureId": "feature2",
-                    "value": {
-                        "key": "value"
-                    }
-                }]
-            }
-        ))
-        .unwrap();
-
-        let configs = branch.get_feature_configs();
-
-        assert_eq!(
-            configs,
-            vec![
-                FeatureConfig {
-                    feature_id: "feature1".to_string(),
-                    value: json!({"key": "value"}).as_object().unwrap().clone()
-                },
-                FeatureConfig {
-                    feature_id: "feature2".to_string(),
-                    value: json!({"key": "value"}).as_object().unwrap().clone()
-                }
-            ]
-        );
-
-        // Both feature AND features
-        // Some versions of desktop need both, but features are prioritized (https://mozilla-hub.atlassian.net/browse/SDK-440)
-        let branch: Branch = serde_json::from_value(json!(
-            {
-                "slug": "control",
-                "ratio": 1,
-                "feature": {
-                    "featureId": "wrong",
-                    "value": {
-                        "key": "value"
-                    }
-                },
-                "features": [{
-                    "featureId": "feature1",
-                    "value": {
-                        "key": "value"
-                    }
-                },
-                {
-                    "featureId": "feature2",
-                    "value": {
-                        "key": "value"
-                    }
-                }]
-            }
-        ))
-        .unwrap();
-
-        let configs = branch.get_feature_configs();
-
-        assert_eq!(
-            configs,
-            vec![
-                FeatureConfig {
-                    feature_id: "feature1".to_string(),
-                    value: json!({"key": "value"}).as_object().unwrap().clone()
-                },
-                FeatureConfig {
-                    feature_id: "feature2".to_string(),
-                    value: json!({"key": "value"}).as_object().unwrap().clone()
-                }
-            ]
-        );
-    }
-
-    #[test]
-    // This was the `Experiment` object schema as it originally shipped to Fenix Nightly.
-    // It was missing some fields that have since been added.
-    fn test_experiment_schema_initial_release() {
-        // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
-        let exp: Experiment = serde_json::from_value(json!({
-            "schemaVersion": "1.0.0",
-            "slug": "secure-gold",
-            "endDate": null,
-            "branches":[
-                {
-                    "slug": "control",
-                    "ratio": 1,
-                },
-                {
-                    "slug": "treatment",
-                    "ratio":1,
-                }
-            ],
-            "probeSets":[],
-            "startDate":null,
-            "application":"fenix",
-            "bucketConfig":{
-                "count":10_000,
-                "start":0,
-                "total":10_000,
-                "namespace":"secure-gold",
-                "randomizationUnit":"nimbus_id"
-            },
-            "userFacingName":"Diagnostic test experiment",
-            "referenceBranch":"control",
-            "isEnrollmentPaused":false,
-            "proposedEnrollment":7,
-            "userFacingDescription":"This is a test experiment for diagnostic purposes.",
-            "id":"secure-gold",
-            "last_modified":1_602_197_324_372i64
-        }))
-        .unwrap();
-        assert!(exp.get_feature_ids().is_empty());
-    }
-
-    // In #96 we added a `featureIds` field to the Experiment schema.
-    // This tests the data as it was after that change.
-    #[test]
-    fn test_experiment_schema_with_feature_ids() {
-        // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
-        let exp: Experiment = serde_json::from_value(json!({
-            "schemaVersion": "1.0.0",
-            "slug": "secure-gold",
-            "endDate": null,
-            "featureIds": ["some_control"],
-            "branches":[
-                {
-                    "slug": "control",
-                    "ratio": 1,
-                    "feature": {
-                        "featureId": "some_control",
-                        "enabled": false
-                    }
-                },
-                {
-                    "slug": "treatment",
-                    "ratio":1,
-                    "feature": {
-                        "featureId": "some_control",
-                        "enabled": true
-                    }
-                }
-            ],
-            "probeSets":[],
-            "startDate":null,
-            "application":"fenix",
-            "bucketConfig":{
-                "count":10_000,
-                "start":0,
-                "total":10_000,
-                "namespace":"secure-gold",
-                "randomizationUnit":"nimbus_id"
-            },
-            "userFacingName":"Diagnostic test experiment",
-            "referenceBranch":"control",
-            "isEnrollmentPaused":false,
-            "proposedEnrollment":7,
-            "userFacingDescription":"This is a test experiment for diagnostic purposes.",
-            "id":"secure-gold",
-            "last_modified":1_602_197_324_372i64
-        }))
-        .unwrap();
-        assert_eq!(exp.get_feature_ids(), vec!["some_control"]);
-    }
-
-    // In #97 we deprecated `application` and added `app_name`, `app_id`,
-    // and `channel`.  This tests the ability to deserialize both variants.
-    #[test]
-    fn test_experiment_schema_with_adr0004_changes() {
-        // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
-
-        // First, test deserializing an `application` format experiment
-        // to ensure the presence of `application` doesn't fail.
-        let exp: Experiment = serde_json::from_value(json!({
-            "schemaVersion": "1.0.0",
-            "slug": "secure-gold",
-            "endDate": null,
-            "featureIds": ["some_control"],
-            "branches":[
-                {
-                    "slug": "control",
-                    "ratio": 1,
-                    "feature": {
-                        "featureId": "some_control",
-                        "enabled": false
-                    }
-                },
-                {
-                    "slug": "treatment",
-                    "ratio":1,
-                    "feature": {
-                        "featureId": "some_control",
-                        "enabled": true
-                    }
-                }
-            ],
-            "probeSets":[],
-            "startDate":null,
-            "application":"fenix",
-            "bucketConfig":{
-                "count":10_000,
-                "start":0,
-                "total":10_000,
-                "namespace":"secure-gold",
-                "randomizationUnit":"nimbus_id"
-            },
-            "userFacingName":"Diagnostic test experiment",
-            "referenceBranch":"control",
-            "isEnrollmentPaused":false,
-            "proposedEnrollment":7,
-            "userFacingDescription":"This is a test experiment for diagnostic purposes.",
-            "id":"secure-gold",
-            "last_modified":1_602_197_324_372i64
-        }))
-        .unwrap();
-        // Without the fields in the experiment, the resulting fields in the struct
-        // should be `None`
-        assert_eq!(exp.app_name, None);
-        assert_eq!(exp.app_id, None);
-        assert_eq!(exp.channel, None);
-
-        // Next, test deserializing an experiment with `app_name`, `app_id`,
-        // and `channel`.
-        let exp: Experiment = serde_json::from_value(json!({
-            "schemaVersion": "1.0.0",
-            "slug": "secure-gold",
-            "endDate": null,
-            "featureIds": ["some_control"],
-            "branches":[
-                {
-                    "slug": "control",
-                    "ratio": 1,
-                    "feature": {
-                        "featureId": "some_control",
-                        "enabled": false
-                    }
-                },
-                {
-                    "slug": "treatment",
-                    "ratio":1,
-                    "feature": {
-                        "featureId": "some_control",
-                        "enabled": true
-                    }
-                }
-            ],
-            "probeSets":[],
-            "startDate":null,
-            "appName":"fenix",
-            "appId":"org.mozilla.fenix",
-            "channel":"nightly",
-            "bucketConfig":{
-                "count":10_000,
-                "start":0,
-                "total":10_000,
-                "namespace":"secure-gold",
-                "randomizationUnit":"nimbus_id"
-            },
-            "userFacingName":"Diagnostic test experiment",
-            "referenceBranch":"control",
-            "isEnrollmentPaused":false,
-            "proposedEnrollment":7,
-            "userFacingDescription":"This is a test experiment for diagnostic purposes.",
-            "id":"secure-gold",
-            "last_modified":1_602_197_324_372i64
-        }))
-        .unwrap();
-        assert_eq!(exp.app_name, Some("fenix".to_string()));
-        assert_eq!(exp.app_id, Some("org.mozilla.fenix".to_string()));
-        assert_eq!(exp.channel, Some("nightly".to_string()));
-
-        // Finally, test deserializing an experiment with `app_name`, `app_id`,
-        // `channel` AND `application` to ensure nothing fails.
-        let exp: Experiment = serde_json::from_value(json!({
-            "schemaVersion": "1.0.0",
-            "slug": "secure-gold",
-            "endDate": null,
-            "featureIds": ["some_control"],
-            "branches":[
-                {
-                    "slug": "control",
-                    "ratio": 1,
-                    "feature": {
-                        "featureId": "some_control",
-                        "enabled": false
-                    }
-                },
-                {
-                    "slug": "treatment",
-                    "ratio":1,
-                    "feature": {
-                        "featureId": "some_control",
-                        "enabled": true
-                    }
-                }
-            ],
-            "probeSets":[],
-            "startDate":null,
-            "application":"org.mozilla.fenix",
-            "appName":"fenix",
-            "appId":"org.mozilla.fenix",
-            "channel":"nightly",
-            "bucketConfig":{
-                "count":10_000,
-                "start":0,
-                "total":10_000,
-                "namespace":"secure-gold",
-                "randomizationUnit":"nimbus_id"
-            },
-            "userFacingName":"Diagnostic test experiment",
-            "referenceBranch":"control",
-            "isEnrollmentPaused":false,
-            "proposedEnrollment":7,
-            "userFacingDescription":"This is a test experiment for diagnostic purposes.",
-            "id":"secure-gold",
-            "last_modified":1_602_197_324_372i64
-        }))
-        .unwrap();
-        assert_eq!(exp.app_name, Some("fenix".to_string()));
-        assert_eq!(exp.app_id, Some("org.mozilla.fenix".to_string()));
-        assert_eq!(exp.channel, Some("nightly".to_string()));
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use std::io::Write;
+
+//     use super::*;
+//     use chrono::Duration;
+//     use enrollment::{EnrolledReason, EnrollmentStatus, ExperimentEnrollment};
+//     use serde_json::json;
+//     use tempdir::TempDir;
+
+//     #[test]
+//     fn test_installation_date() -> Result<()> {
+//         let mock_client_id = "client-1".to_string();
+//         let tmp_dir = TempDir::new("test_installation_date")?;
+//         // Step 1: We first test that the SDK will default to using the
+//         // value in the app context if it exists
+//         let three_days_ago = Utc::now() - Duration::days(3);
+//         let time_stamp = three_days_ago.timestamp_millis();
+//         let mut app_context = AppContext {
+//             installation_date: Some(time_stamp),
+//             home_directory: Some(tmp_dir.path().to_str().unwrap().to_string()),
+//             ..Default::default()
+//         };
+//         let client = NimbusClient::new(
+//             app_context.clone(),
+//             tmp_dir.path(),
+//             None,
+//             AvailableRandomizationUnits {
+//                 client_id: Some(mock_client_id.clone()),
+//                 ..AvailableRandomizationUnits::default()
+//             },
+//         )?;
+
+//         client.initialize()?;
+//         client.apply_pending_experiments()?;
+
+//         // We verify that it's three days, ago. Because that's the date
+//         // passed into the context
+//         let targeting_attributes = client.get_targeting_attributes();
+//         assert!(matches!(targeting_attributes.days_since_install, Some(3)));
+//         // Ok(())
+
+// // ====================================================
+//         // We now clear the persisted storage
+//         // to make sure we start from a clear state
+//         let db = client.db()?;
+//         let mut writer = db.write()?;
+//         let store = db.get_store(StoreId::Meta);
+
+//         store.clear(&mut writer)?;
+//         writer.commit()?;
+
+//         // Step 2: We test that we will fallback to the
+//         // filesystem, and if that fails we
+//         // set Today's date.
+
+//         // We recreate our client to make sure
+//         // we wipe any non-persistent memory
+//         // this time, with a context that does not
+//         // include the timestamp
+//         app_context.installation_date = None;
+//         let client = NimbusClient::new(
+//             app_context.clone(),
+//             tmp_dir.path(),
+//             None,
+//             AvailableRandomizationUnits {
+//                 client_id: Some(mock_client_id.clone()),
+//                 ..AvailableRandomizationUnits::default()
+//             },
+//         )?;
+//         delete_test_creation_date(tmp_dir.path()).ok();
+//         // When we check the filesystem, we will fail. We haven't `set_test_creation_date`
+//         // yet.
+//         client.initialize()?;
+//         client.apply_pending_experiments()?;
+//         // We verify that it's today.
+//         let targeting_attributes = client.get_targeting_attributes();
+//         assert!(matches!(targeting_attributes.days_since_install, Some(0)));
+//       //  Ok(())
+
+//  // ==============================
+//         // Step 3: We test that persisted storage takes precedence over
+//         // checking the filesystem
+
+//         // We recreate our client to make sure
+//         // we wipe any non-persistent memory
+//         let client = NimbusClient::new(
+//             app_context.clone(),
+//             tmp_dir.path(),
+//             None,
+//             AvailableRandomizationUnits {
+//                 client_id: Some(mock_client_id.clone()),
+//                 ..AvailableRandomizationUnits::default()
+//             },
+//         )?;
+//         client.initialize()?;
+//         // We now store a date for days ago in our file system
+//         // this shouldn't change the installation date for the nimbus client
+//         // since client already persisted the date seen earlier.
+//         let four_days_ago = Utc::now() - Duration::days(4);
+//         set_test_creation_date(four_days_ago, tmp_dir.path())?;
+//         client.apply_pending_experiments()?;
+//         let targeting_attributes = client.get_targeting_attributes();
+//         // We will **STILL** get a 0 `days_since_install` since we persisted the value
+//         // we got on the previous run, therefore we did not check the file system.
+//         assert!(matches!(targeting_attributes.days_since_install, Some(0)));
+
+//         // We now clear the persisted storage
+//         // to make sure we start from a clear state
+//         let db = client.db()?;
+//         let mut writer = db.write()?;
+//         let store = db.get_store(StoreId::Meta);
+
+//         store.clear(&mut writer)?;
+//         writer.commit()?;
+//       //  Ok(())
+
+//  // ==============================
+//         // Step 4: We test that if the storage is clear, we will fallback to the
+//         let client = NimbusClient::new(
+//             app_context,
+//             tmp_dir.path(),
+//             None,
+//             AvailableRandomizationUnits {
+//                 client_id: Some(mock_client_id),
+//                 ..AvailableRandomizationUnits::default()
+//             },
+//         )?;
+//         client.initialize()?;
+//         // now that the store is clear, we will fallback again to the
+//         // file system, and retrieve the four_days_ago number we stored earlier
+//         client.apply_pending_experiments()?;
+//         let targeting_attributes = client.get_targeting_attributes();
+//         assert!(matches!(targeting_attributes.days_since_install, Some(4)));
+//         Ok(())
+//     }
+// }
 
 #[cfg(test)]
 mod test_schema_deserialization {

--- a/components/nimbus/tests/test_lib.rs
+++ b/components/nimbus/tests/test_lib.rs
@@ -1,0 +1,654 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Testing lib.rs
+
+use chrono::{DateTime, Utc};
+use serde_json::json;
+use tempdir::TempDir;
+
+use nimbus::{
+    enrollment::{EnrolledReason, EnrollmentStatus, ExperimentEnrollment},
+    error::Result,
+    persistence::StoreId,
+    AppContext, AvailableRandomizationUnits, Experiment, NimbusClient, TargetingAttributes,
+    DB_KEY_APP_VERSION, DB_KEY_UPDATE_DATE,
+};
+
+use std::{io::Write, path::Path};
+
+// #[test]
+// fn test_installation_date() -> Result<()> {
+//     let mock_client_id = "client-1".to_string();
+//     let tmp_dir = TempDir::new("test_installation_date")?;
+//     // Step 1: We first test that the SDK will default to using the
+//     // value in the app context if it exists
+//     let three_days_ago = Utc::now() - Duration::days(3);
+//     let time_stamp = three_days_ago.timestamp_millis();
+//     let mut app_context = AppContext {
+//         installation_date: Some(time_stamp),
+//         home_directory: Some(tmp_dir.path().to_str().unwrap().to_string()),
+//         ..Default::default()
+//     };
+//     let client = NimbusClient::new(
+//         app_context.clone(),
+//         tmp_dir.path(),
+//         None,
+//         AvailableRandomizationUnits {
+//             client_id: Some(mock_client_id.clone()),
+//             ..AvailableRandomizationUnits::default()
+//         },
+//     )?;
+
+//     client.initialize()?;
+//     client.apply_pending_experiments()?;
+
+//     // We verify that it's three days, ago. Because that's the date
+//     // passed into the context
+//     let targeting_attributes = client.get_targeting_attributes();
+//     assert!(matches!(targeting_attributes.days_since_install, Some(3)));
+
+//     // We now clear the persisted storage
+//     // to make sure we start from a clear state
+//     let db = client.db()?;
+//     let mut writer = db.write()?;
+//     let store = db.get_store(StoreId::Meta);
+
+//     store.clear(&mut writer)?;
+//     writer.commit()?;
+
+//     // Step 2: We test that we will fallback to the
+//     // filesystem, and if that fails we
+//     // set Today's date.
+
+//     // We recreate our client to make sure
+//     // we wipe any non-persistent memory
+//     // this time, with a context that does not
+//     // include the timestamp
+//     app_context.installation_date = None;
+//     let client = NimbusClient::new(
+//         app_context.clone(),
+//         tmp_dir.path(),
+//         None,
+//         AvailableRandomizationUnits {
+//             client_id: Some(mock_client_id.clone()),
+//             ..AvailableRandomizationUnits::default()
+//         },
+//     )?;
+//     delete_test_creation_date(tmp_dir.path()).ok();
+//     // When we check the filesystem, we will fail. We haven't `set_test_creation_date`
+//     // yet.
+//     client.initialize()?;
+//     client.apply_pending_experiments()?;
+//     // We verify that it's today.
+//     let targeting_attributes = client.get_targeting_attributes();
+//     assert!(matches!(targeting_attributes.days_since_install, Some(0)));
+
+//     // Step 3: We test that persisted storage takes precedence over
+//     // checking the filesystem
+
+//     // We recreate our client to make sure
+//     // we wipe any non-persistent memory
+//     let client = NimbusClient::new(
+//         app_context.clone(),
+//         tmp_dir.path(),
+//         None,
+//         AvailableRandomizationUnits {
+//             client_id: Some(mock_client_id.clone()),
+//             ..AvailableRandomizationUnits::default()
+//         },
+//     )?;
+//     client.initialize()?;
+//     // We now store a date for days ago in our file system
+//     // this shouldn't change the installation date for the nimbus client
+//     // since client already persisted the date seen earlier.
+//     let four_days_ago = Utc::now() - Duration::days(4);
+//     set_test_creation_date(four_days_ago, tmp_dir.path())?;
+//     client.apply_pending_experiments()?;
+//     let targeting_attributes = client.get_targeting_attributes();
+//     // We will **STILL** get a 0 `days_since_install` since we persisted the value
+//     // we got on the previous run, therefore we did not check the file system.
+//     assert!(matches!(targeting_attributes.days_since_install, Some(0)));
+
+//     // We now clear the persisted storage
+//     // to make sure we start from a clear state
+//     let db = client.db()?;
+//     let mut writer = db.write()?;
+//     let store = db.get_store(StoreId::Meta);
+
+//     store.clear(&mut writer)?;
+//     writer.commit()?;
+
+//     // Step 4: We test that if the storage is clear, we will fallback to the
+//     let client = NimbusClient::new(
+//         app_context,
+//         tmp_dir.path(),
+//         None,
+//         AvailableRandomizationUnits {
+//             client_id: Some(mock_client_id),
+//             ..AvailableRandomizationUnits::default()
+//         },
+//     )?;
+//     client.initialize()?;
+//     // now that the store is clear, we will fallback again to the
+//     // file system, and retrieve the four_days_ago number we stored earlier
+//     client.apply_pending_experiments()?;
+//     let targeting_attributes = client.get_targeting_attributes();
+//     assert!(matches!(targeting_attributes.days_since_install, Some(4)));
+//     Ok(())
+// }
+
+#[test]
+fn test_telemetry_reset() -> Result<()> {
+    let mock_client_id = "client-1".to_string();
+    let mock_exp_slug = "exp-1".to_string();
+    let mock_exp_branch = "branch-1".to_string();
+
+    let tmp_dir = TempDir::new("test_telemetry_reset")?;
+    let client = NimbusClient::new(
+        AppContext::default(),
+        tmp_dir.path(),
+        None,
+        AvailableRandomizationUnits {
+            client_id: Some(mock_client_id.clone()),
+            ..AvailableRandomizationUnits::default()
+        },
+    )?;
+
+    let get_client_id = || {
+        client
+            .mutable_state
+            .lock()
+            .unwrap()
+            .available_randomization_units
+            .client_id
+            .clone()
+    };
+
+    // Mock being enrolled in a single experiment.
+    let db = client.db()?;
+    let mut writer = db.write()?;
+    db.get_store(StoreId::Experiments).put(
+        &mut writer,
+        &mock_exp_slug,
+        &Experiment {
+            slug: mock_exp_slug.clone(),
+            ..Experiment::default()
+        },
+    )?;
+    db.get_store(StoreId::Enrollments).put(
+        &mut writer,
+        &mock_exp_slug,
+        &ExperimentEnrollment {
+            slug: mock_exp_slug.clone(),
+            status: EnrollmentStatus::new_enrolled(EnrolledReason::Qualified, &mock_exp_branch),
+        },
+    )?;
+    writer.commit()?;
+
+    client.initialize()?;
+
+    // Check expected state before resetting telemetry.
+    let orig_nimbus_id = client.nimbus_id()?;
+    assert_eq!(get_client_id(), Some(mock_client_id));
+
+    let events = client.reset_telemetry_identifiers(AvailableRandomizationUnits::default())?;
+
+    // We should have reset our nimbus_id.
+    assert_ne!(orig_nimbus_id, client.nimbus_id()?);
+
+    // We should have updated the randomization units.
+    assert_eq!(get_client_id(), None);
+
+    // We should have been disqualified from the enrolled experiment.
+    assert_eq!(client.get_experiment_branch(mock_exp_slug)?, None);
+
+    // We should have returned a single event.
+    assert_eq!(events.len(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn test_days_since_update_changes_with_context() -> Result<()> {
+    let mock_client_id = "client-1".to_string();
+    let tmp_dir = TempDir::new("test_days_since_update")?;
+    let client = NimbusClient::new(
+        AppContext::default(),
+        tmp_dir.path(),
+        None,
+        AvailableRandomizationUnits {
+            client_id: Some(mock_client_id.clone()),
+            ..AvailableRandomizationUnits::default()
+        },
+    )?;
+    client.initialize()?;
+
+    // Step 1: Test what happens if we have no persisted app version,
+    // but we got a new version in our app_context.
+    // We should set our update date to today.
+
+    // We re-create the client, with an app context that includes
+    // a version
+    let mut app_context = AppContext {
+        app_version: Some("v94.0.0".into()),
+        ..Default::default()
+    };
+    let client = NimbusClient::new(
+        app_context.clone(),
+        tmp_dir.path(),
+        None,
+        AvailableRandomizationUnits {
+            client_id: Some(mock_client_id.clone()),
+            ..AvailableRandomizationUnits::default()
+        },
+    )?;
+    client.initialize()?;
+    client.apply_pending_experiments()?;
+    let targeting_attributes = client.get_targeting_attributes();
+    // The days_since_update should be zero
+    assert!(matches!(targeting_attributes.days_since_update, Some(0)));
+    let db = client.db()?;
+    let reader = db.read()?;
+    let store = db.get_store(StoreId::Meta);
+    let app_version: String = store.get(&reader, DB_KEY_APP_VERSION)?.unwrap();
+    // we make sure we persisted the version we saw
+    assert_eq!(app_version, "v94.0.0");
+    let update_date: DateTime<Utc> = store.get(&reader, DB_KEY_UPDATE_DATE)?.unwrap();
+    let diff_with_today = Utc::now() - update_date;
+    // we make sure the persisted date, is today
+    assert_eq!(diff_with_today.num_days(), 0);
+
+    // Step 2: Test what happens if there is already a persisted date
+    // but we get a new one in our context that is the **same**
+    // the update_date should not change
+    let client = NimbusClient::new(
+        app_context.clone(),
+        tmp_dir.path(),
+        None,
+        AvailableRandomizationUnits {
+            client_id: Some(mock_client_id.clone()),
+            ..AvailableRandomizationUnits::default()
+        },
+    )?;
+    client.initialize()?;
+    client.apply_pending_experiments()?;
+
+    // We repeat the same tests we did above first
+    let targeting_attributes = client.get_targeting_attributes();
+    // The days_since_update should still be zero
+    assert!(matches!(targeting_attributes.days_since_update, Some(0)));
+    let db = client.db()?;
+    let reader = db.read()?;
+    let store = db.get_store(StoreId::Meta);
+    let app_version: String = store.get(&reader, DB_KEY_APP_VERSION)?.unwrap();
+    // we make sure we persisted the version we saw
+    assert_eq!(app_version, "v94.0.0");
+    let new_update_date: DateTime<Utc> = store.get(&reader, DB_KEY_UPDATE_DATE)?.unwrap();
+    // we make sure the persisted date, is **EXACTLY** the same
+    // one we persisted earler, not that the `DateTime` object here
+    // includes time to the nanoseconds, so this is a valid way
+    // to ensure the objects are the same
+    assert_eq!(new_update_date, update_date);
+
+    // Step 3: Test what happens if there is a persisted date,
+    // but the app_context includes a newer date, the update_date
+    // should be updated
+
+    app_context.app_version = Some("v94.0.1".into()); // A different version
+    let client = NimbusClient::new(
+        app_context,
+        tmp_dir.path(),
+        None,
+        AvailableRandomizationUnits {
+            client_id: Some(mock_client_id),
+            ..AvailableRandomizationUnits::default()
+        },
+    )?;
+    client.initialize()?;
+    client.apply_pending_experiments()?;
+
+    // We repeat some of the same tests we did above first
+    let targeting_attributes = client.get_targeting_attributes();
+    // The days_since_update should still be zero
+    assert!(matches!(targeting_attributes.days_since_update, Some(0)));
+    let db = client.db()?;
+    let reader = db.read()?;
+    let store = db.get_store(StoreId::Meta);
+    let app_version: String = store.get(&reader, DB_KEY_APP_VERSION)?.unwrap();
+    // we make sure we persisted the **NEW** version we saw
+    assert_eq!(app_version, "v94.0.1");
+    let new_update_date: DateTime<Utc> = store.get(&reader, DB_KEY_UPDATE_DATE)?.unwrap();
+    // we make sure the persisted date is newer and different
+    // than the old one. This helps us ensure that there was indeed
+    // an update to the date
+    assert!(new_update_date > update_date);
+
+    Ok(())
+}
+
+#[test]
+fn test_days_since_install() -> Result<()> {
+    let mock_client_id = "client-1".to_string();
+
+    let temp_dir = TempDir::new("test_days_since_install_failed")?;
+    let app_context = AppContext {
+        app_name: "fenix".to_string(),
+        app_id: "org.mozilla.fenix".to_string(),
+        channel: "nightly".to_string(),
+        ..Default::default()
+    };
+    let mut client = NimbusClient::new(
+        app_context.clone(),
+        temp_dir.path(),
+        None,
+        AvailableRandomizationUnits {
+            client_id: Some(mock_client_id),
+            ..AvailableRandomizationUnits::default()
+        },
+    )?;
+    let targeting_attributes = TargetingAttributes {
+        app_context,
+        days_since_install: Some(10),
+        days_since_update: None,
+        is_already_enrolled: false,
+    };
+    client.with_targeting_attributes(targeting_attributes);
+    client.initialize()?;
+    let experiment_json = serde_json::to_string(&json!({
+        "data": [{
+            "schemaVersion": "1.0.0",
+            "slug": "secure-gold",
+            "endDate": null,
+            "featureIds": ["some-feature"],
+            "branches": [
+                {
+                "slug": "control",
+                "ratio": 1
+                },
+                {
+                "slug": "treatment",
+                "ratio": 1
+                }
+            ],
+            "channel": "nightly",
+            "probeSets": [],
+            "startDate": null,
+            "appName": "fenix",
+            "appId": "org.mozilla.fenix",
+            "bucketConfig": {
+                "count": 10000,
+                "start": 0,
+                "total": 10000,
+                "namespace": "secure-gold",
+                "randomizationUnit": "nimbus_id"
+            },
+            "targeting": "days_since_install == 10",
+            "userFacingName": "test experiment",
+            "referenceBranch": "control",
+            "isEnrollmentPaused": false,
+            "proposedEnrollment": 7,
+            "userFacingDescription": "This is a test experiment for testing purposes.",
+            "id": "secure-copper",
+            "last_modified": 1_602_197_324_372i64,
+        }
+    ]}))?;
+    client.set_experiments_locally(experiment_json)?;
+    client.apply_pending_experiments()?;
+
+    // The targeting targeted days_since_install == 10, which is true in the client
+    // so we should be enrolled in that experiment
+    let active_experiments = client.get_active_experiments()?;
+    assert_eq!(active_experiments.len(), 1);
+    assert_eq!(active_experiments[0].slug, "secure-gold");
+    Ok(())
+}
+
+#[test]
+fn test_days_since_install_failed_targeting() -> Result<()> {
+    let mock_client_id = "client-1".to_string();
+
+    let temp_dir = TempDir::new("test_days_since_install_failed")?;
+    let app_context = AppContext {
+        app_name: "fenix".to_string(),
+        app_id: "org.mozilla.fenix".to_string(),
+        channel: "nightly".to_string(),
+        ..Default::default()
+    };
+    let mut client = NimbusClient::new(
+        app_context.clone(),
+        temp_dir.path(),
+        None,
+        AvailableRandomizationUnits {
+            client_id: Some(mock_client_id),
+            ..AvailableRandomizationUnits::default()
+        },
+    )?;
+    let targeting_attributes = TargetingAttributes {
+        app_context,
+        days_since_install: Some(10),
+        days_since_update: None,
+        is_already_enrolled: false,
+    };
+    client.with_targeting_attributes(targeting_attributes);
+    client.initialize()?;
+    let experiment_json = serde_json::to_string(&json!({
+        "data": [{
+            "schemaVersion": "1.0.0",
+            "slug": "secure-gold",
+            "endDate": null,
+            "featureIds": ["some-feature"],
+            "branches": [
+                {
+                "slug": "control",
+                "ratio": 1
+                },
+                {
+                "slug": "treatment",
+                "ratio": 1
+                }
+            ],
+            "channel": "nightly",
+            "probeSets": [],
+            "startDate": null,
+            "appName": "fenix",
+            "appId": "org.mozilla.fenix",
+            "bucketConfig": {
+                "count": 10000,
+                "start": 0,
+                "total": 10000,
+                "namespace": "secure-gold",
+                "randomizationUnit": "nimbus_id"
+            },
+            "targeting": "days_since_install < 10",
+            "userFacingName": "test experiment",
+            "referenceBranch": "control",
+            "isEnrollmentPaused": false,
+            "proposedEnrollment": 7,
+            "userFacingDescription": "This is a test experiment for testing purposes.",
+            "id": "secure-copper",
+            "last_modified": 1_602_197_324_372i64,
+        }
+    ]}))?;
+    client.set_experiments_locally(experiment_json)?;
+    client.apply_pending_experiments()?;
+
+    // The targeting targeted days_since_install < 10, which is false in the client
+    // so we should be enrolled in that experiment
+    let active_experiments = client.get_active_experiments()?;
+    assert_eq!(active_experiments.len(), 0);
+    Ok(())
+}
+
+#[test]
+fn test_days_since_update() -> Result<()> {
+    let mock_client_id = "client-1".to_string();
+
+    let temp_dir = TempDir::new("test_days_since_update")?;
+    let app_context = AppContext {
+        app_name: "fenix".to_string(),
+        app_id: "org.mozilla.fenix".to_string(),
+        channel: "nightly".to_string(),
+        ..Default::default()
+    };
+    let mut client = NimbusClient::new(
+        app_context.clone(),
+        temp_dir.path(),
+        None,
+        AvailableRandomizationUnits {
+            client_id: Some(mock_client_id),
+            ..AvailableRandomizationUnits::default()
+        },
+    )?;
+    let targeting_attributes = TargetingAttributes {
+        app_context,
+        days_since_install: None,
+        days_since_update: Some(10),
+        is_already_enrolled: false,
+    };
+    client.with_targeting_attributes(targeting_attributes);
+    client.initialize()?;
+    let experiment_json = serde_json::to_string(&json!({
+        "data": [{
+            "schemaVersion": "1.0.0",
+            "slug": "secure-gold",
+            "endDate": null,
+            "featureIds": ["some-feature"],
+            "branches": [
+                {
+                "slug": "control",
+                "ratio": 1
+                },
+                {
+                "slug": "treatment",
+                "ratio": 1
+                }
+            ],
+            "channel": "nightly",
+            "probeSets": [],
+            "startDate": null,
+            "appName": "fenix",
+            "appId": "org.mozilla.fenix",
+            "bucketConfig": {
+                "count": 10000,
+                "start": 0,
+                "total": 10000,
+                "namespace": "secure-gold",
+                "randomizationUnit": "nimbus_id"
+            },
+            "targeting": "days_since_update == 10",
+            "userFacingName": "test experiment",
+            "referenceBranch": "control",
+            "isEnrollmentPaused": false,
+            "proposedEnrollment": 7,
+            "userFacingDescription": "This is a test experiment for testing purposes.",
+            "id": "secure-copper",
+            "last_modified": 1_602_197_324_372i64,
+        }
+    ]}))?;
+    client.set_experiments_locally(experiment_json)?;
+    client.apply_pending_experiments()?;
+
+    // The targeting targeted days_since_update == 10, which is true in the client
+    // so we should be enrolled in that experiment
+    let active_experiments = client.get_active_experiments()?;
+    assert_eq!(active_experiments.len(), 1);
+    assert_eq!(active_experiments[0].slug, "secure-gold");
+    Ok(())
+}
+
+#[test]
+fn test_days_since_update_failed_targeting() -> Result<()> {
+    let mock_client_id = "client-1".to_string();
+
+    let temp_dir = TempDir::new("test_days_since_update_failed")?;
+    let app_context = AppContext {
+        app_name: "fenix".to_string(),
+        app_id: "org.mozilla.fenix".to_string(),
+        channel: "nightly".to_string(),
+        ..Default::default()
+    };
+    let mut client = NimbusClient::new(
+        app_context.clone(),
+        temp_dir.path(),
+        None,
+        AvailableRandomizationUnits {
+            client_id: Some(mock_client_id),
+            ..AvailableRandomizationUnits::default()
+        },
+    )?;
+    let targeting_attributes = TargetingAttributes {
+        app_context,
+        days_since_install: None,
+        days_since_update: Some(10),
+        is_already_enrolled: false,
+    };
+    client.with_targeting_attributes(targeting_attributes);
+    client.initialize()?;
+    let experiment_json = serde_json::to_string(&json!({
+        "data": [{
+            "schemaVersion": "1.0.0",
+            "slug": "secure-gold",
+            "endDate": null,
+            "featureIds": ["some-feature"],
+            "branches": [
+                {
+                "slug": "control",
+                "ratio": 1
+                },
+                {
+                "slug": "treatment",
+                "ratio": 1
+                }
+            ],
+            "channel": "nightly",
+            "probeSets": [],
+            "startDate": null,
+            "appName": "fenix",
+            "appId": "org.mozilla.fenix",
+            "bucketConfig": {
+                "count": 10000,
+                "start": 0,
+                "total": 10000,
+                "namespace": "secure-gold",
+                "randomizationUnit": "nimbus_id"
+            },
+            "targeting": "days_since_update < 10",
+            "userFacingName": "test experiment",
+            "referenceBranch": "control",
+            "isEnrollmentPaused": false,
+            "proposedEnrollment": 7,
+            "userFacingDescription": "This is a test experiment for testing purposes.",
+            "id": "secure-copper",
+            "last_modified": 1_602_197_324_372i64,
+        }
+    ]}))?;
+    client.set_experiments_locally(experiment_json)?;
+    client.apply_pending_experiments()?;
+
+    // The targeting targeted days_since_update < 10, which is false in the client
+    // so we should be enrolled in that experiment
+    let active_experiments = client.get_active_experiments()?;
+    assert_eq!(active_experiments.len(), 0);
+    Ok(())
+}
+
+fn set_test_creation_date<P: AsRef<Path>>(date: DateTime<Utc>, path: P) -> Result<()> {
+    use std::fs::OpenOptions;
+    let test_path = path.as_ref().with_file_name("test.json");
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(test_path)
+        .unwrap();
+    file.write_all(serde_json::to_string(&date).unwrap().as_bytes())?;
+    Ok(())
+}
+
+fn delete_test_creation_date<P: AsRef<Path>>(path: P) -> Result<()> {
+    let test_path = path.as_ref().with_file_name("test.json");
+    std::fs::remove_file(test_path)?;
+    Ok(())
+}

--- a/components/nimbus/tests/test_lib_bw_compat.rs
+++ b/components/nimbus/tests/test_lib_bw_compat.rs
@@ -1,0 +1,628 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use nimbus::{Branch, Experiment, FeatureConfig};
+use serde_json::json;
+
+/// A suite of tests for b/w compat of data storage schema.
+///
+/// We use the `Serialize/`Deserialize` impls on various structs in order to persist them
+/// into rkv, and it's important that we be able to read previously-persisted data even
+/// if the struct definitions change over time.
+///
+/// This is a suite of tests specifically to check for backward compatibility with data
+/// that may have been written to disk by previous versions of the library.
+///
+/// ⚠️ Warning : Do not change the JSON data used by these tests. ⚠️
+/// ⚠️ The whole point of the tests is to check things work with that data. ⚠️
+///
+
+#[test]
+fn test_without_probe_sets_and_enabled() {
+    // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
+    // this is an experiment following the schema after the removal
+    // of the `enabled` and `probe_sets` fields which were removed
+    // together in the same proposal
+    serde_json::from_value::<Experiment>(json!({
+        "schemaVersion": "1.0.0",
+        "slug": "secure-gold",
+        "appName": "fenix",
+        "appId": "bobo",
+        "channel": "nightly",
+        "endDate": null,
+        "branches":[
+            {
+                "slug": "control",
+                "ratio": 1,
+                "features": [{
+                    "featureId": "feature1",
+                    "value": {
+                        "key": "value1"
+                    }
+                },
+                {
+                    "featureId": "feature2",
+                    "value": {
+                        "key": "value2"
+                    }
+                }]
+            },
+            {
+                "slug": "treatment",
+                "ratio":1,
+                "features": [{
+                    "featureId": "feature3",
+                    "value": {
+                        "key": "value3"
+                    }
+                },
+                {
+                    "featureId": "feature4",
+                    "value": {
+                        "key": "value4"
+                    }
+                }]
+            }
+        ],
+        "startDate":null,
+        "application":"fenix",
+        "bucketConfig":{
+            "count":10_000,
+            "start":0,
+            "total":10_000,
+            "namespace":"secure-gold",
+            "randomizationUnit":"nimbus_id"
+        },
+        "userFacingName":"Diagnostic test experiment",
+        "referenceBranch":"control",
+        "isEnrollmentPaused":false,
+        "proposedEnrollment":7,
+        "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+        "id":"secure-gold",
+        "last_modified":1_602_197_324_372i64
+    }))
+    .unwrap();
+}
+
+#[test]
+fn test_multifeature_branch_schema() {
+    // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
+    // this is an experiment following the schema after the addition
+    // of multiple features per branch
+    let exp: Experiment = serde_json::from_value(json!({
+        "schemaVersion": "1.0.0",
+        "slug": "secure-gold",
+        "appName": "fenix",
+        "appId": "bobo",
+        "channel": "nightly",
+        "endDate": null,
+        "branches":[
+            {
+                "slug": "control",
+                "ratio": 1,
+                "features": [{
+                    "featureId": "feature1",
+                    "enabled": true,
+                    "value": {
+                        "key": "value1"
+                    }
+                },
+                {
+                    "featureId": "feature2",
+                    "enabled": false,
+                    "value": {
+                        "key": "value2"
+                    }
+                }]
+            },
+            {
+                "slug": "treatment",
+                "ratio":1,
+                "features": [{
+                    "featureId": "feature3",
+                    "enabled": true,
+                    "value": {
+                        "key": "value3"
+                    }
+                },
+                {
+                    "featureId": "feature4",
+                    "enabled": false,
+                    "value": {
+                        "key": "value4"
+                    }
+                }]
+            }
+        ],
+        "probeSets":[],
+        "startDate":null,
+        "application":"fenix",
+        "bucketConfig":{
+            "count":10_000,
+            "start":0,
+            "total":10_000,
+            "namespace":"secure-gold",
+            "randomizationUnit":"nimbus_id"
+        },
+        "userFacingName":"Diagnostic test experiment",
+        "referenceBranch":"control",
+        "isEnrollmentPaused":false,
+        "proposedEnrollment":7,
+        "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+        "id":"secure-gold",
+        "last_modified":1_602_197_324_372i64
+    }))
+    .unwrap();
+    assert_eq!(
+        exp.branches[0].get_feature_configs(),
+        vec![
+            FeatureConfig {
+                feature_id: "feature1".to_string(),
+                value: vec![("key".to_string(), json!("value1"))]
+                    .into_iter()
+                    .collect()
+            },
+            FeatureConfig {
+                feature_id: "feature2".to_string(),
+                value: vec![("key".to_string(), json!("value2"))]
+                    .into_iter()
+                    .collect()
+            }
+        ]
+    );
+    assert_eq!(
+        exp.branches[1].get_feature_configs(),
+        vec![
+            FeatureConfig {
+                feature_id: "feature3".to_string(),
+                value: vec![("key".to_string(), json!("value3"))]
+                    .into_iter()
+                    .collect()
+            },
+            FeatureConfig {
+                feature_id: "feature4".to_string(),
+                value: vec![("key".to_string(), json!("value4"))]
+                    .into_iter()
+                    .collect()
+            }
+        ]
+    );
+    assert!(exp.branches[0].feature.is_none());
+    assert!(exp.branches[1].feature.is_none());
+}
+
+#[test]
+fn test_only_one_feature_branch_schema() {
+    // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
+    // this is an experiment following the schema before the addition
+    // of multiple features per branch
+    let exp: Experiment = serde_json::from_value(json!({
+        "schemaVersion": "1.0.0",
+        "slug": "secure-gold",
+        "appName": "fenix",
+        "appId": "bobo",
+        "channel": "nightly",
+        "endDate": null,
+        "branches":[
+            {
+                "slug": "control",
+                "ratio": 1,
+                "feature": {
+                    "featureId": "feature1",
+                    "enabled": true,
+                    "value": {
+                        "key": "value"
+                    }
+                }
+            },
+            {
+                "slug": "treatment",
+                "ratio":1,
+                "feature": {
+                    "featureId": "feature2",
+                    "enabled": true,
+                    "value": {
+                        "key": "value2"
+                    }
+                }
+            }
+        ],
+        "probeSets":[],
+        "startDate":null,
+        "application":"fenix",
+        "bucketConfig":{
+            "count":10_000,
+            "start":0,
+            "total":10_000,
+            "namespace":"secure-gold",
+            "randomizationUnit":"nimbus_id"
+        },
+        "userFacingName":"Diagnostic test experiment",
+        "referenceBranch":"control",
+        "isEnrollmentPaused":false,
+        "proposedEnrollment":7,
+        "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+        "id":"secure-gold",
+        "last_modified":1_602_197_324_372i64
+    }))
+    .unwrap();
+    assert_eq!(
+        exp.branches[0].get_feature_configs(),
+        vec![FeatureConfig {
+            feature_id: "feature1".to_string(),
+            value: vec![("key".to_string(), json!("value"))]
+                .into_iter()
+                .collect()
+        }]
+    );
+    assert_eq!(
+        exp.branches[1].get_feature_configs(),
+        vec![FeatureConfig {
+            feature_id: "feature2".to_string(),
+            value: vec![("key".to_string(), json!("value2"))]
+                .into_iter()
+                .collect()
+        }]
+    );
+    assert!(exp.branches[0].features.is_none());
+    assert!(exp.branches[1].features.is_none());
+}
+
+#[test]
+fn test_feature_and_features_in_one_branch() {
+    // Single feature, no features
+    let branch: Branch = serde_json::from_value(json!(
+        {
+            "slug": "control",
+            "ratio": 1,
+            "feature": {
+                "featureId": "feature1",
+                "value": {
+                    "key": "value"
+                }
+            }
+        }
+    ))
+    .unwrap();
+
+    let configs = branch.get_feature_configs();
+
+    assert_eq!(
+        configs,
+        vec![FeatureConfig {
+            feature_id: "feature1".to_string(),
+            value: json!({"key": "value"}).as_object().unwrap().clone()
+        }]
+    );
+
+    // No feature, multiple features
+    let branch: Branch = serde_json::from_value(json!(
+        {
+            "slug": "control",
+            "ratio": 1,
+            "features": [{
+                "featureId": "feature1",
+                "value": {
+                    "key": "value"
+                }
+            },
+            {
+                "featureId": "feature2",
+                "value": {
+                    "key": "value"
+                }
+            }]
+        }
+    ))
+    .unwrap();
+
+    let configs = branch.get_feature_configs();
+
+    assert_eq!(
+        configs,
+        vec![
+            FeatureConfig {
+                feature_id: "feature1".to_string(),
+                value: json!({"key": "value"}).as_object().unwrap().clone()
+            },
+            FeatureConfig {
+                feature_id: "feature2".to_string(),
+                value: json!({"key": "value"}).as_object().unwrap().clone()
+            }
+        ]
+    );
+
+    // Both feature AND features
+    // Some versions of desktop need both, but features are prioritized (https://mozilla-hub.atlassian.net/browse/SDK-440)
+    let branch: Branch = serde_json::from_value(json!(
+        {
+            "slug": "control",
+            "ratio": 1,
+            "feature": {
+                "featureId": "wrong",
+                "value": {
+                    "key": "value"
+                }
+            },
+            "features": [{
+                "featureId": "feature1",
+                "value": {
+                    "key": "value"
+                }
+            },
+            {
+                "featureId": "feature2",
+                "value": {
+                    "key": "value"
+                }
+            }]
+        }
+    ))
+    .unwrap();
+
+    let configs = branch.get_feature_configs();
+
+    assert_eq!(
+        configs,
+        vec![
+            FeatureConfig {
+                feature_id: "feature1".to_string(),
+                value: json!({"key": "value"}).as_object().unwrap().clone()
+            },
+            FeatureConfig {
+                feature_id: "feature2".to_string(),
+                value: json!({"key": "value"}).as_object().unwrap().clone()
+            }
+        ]
+    );
+}
+
+#[test]
+// This was the `Experiment` object schema as it originally shipped to Fenix Nightly.
+// It was missing some fields that have since been added.
+fn test_experiment_schema_initial_release() {
+    // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
+    let exp: Experiment = serde_json::from_value(json!({
+        "schemaVersion": "1.0.0",
+        "slug": "secure-gold",
+        "endDate": null,
+        "branches":[
+            {
+                "slug": "control",
+                "ratio": 1,
+            },
+            {
+                "slug": "treatment",
+                "ratio":1,
+            }
+        ],
+        "probeSets":[],
+        "startDate":null,
+        "application":"fenix",
+        "bucketConfig":{
+            "count":10_000,
+            "start":0,
+            "total":10_000,
+            "namespace":"secure-gold",
+            "randomizationUnit":"nimbus_id"
+        },
+        "userFacingName":"Diagnostic test experiment",
+        "referenceBranch":"control",
+        "isEnrollmentPaused":false,
+        "proposedEnrollment":7,
+        "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+        "id":"secure-gold",
+        "last_modified":1_602_197_324_372i64
+    }))
+    .unwrap();
+    assert!(exp.get_feature_ids().is_empty());
+}
+
+// In #96 we added a `featureIds` field to the Experiment schema.
+// This tests the data as it was after that change.
+#[test]
+fn test_experiment_schema_with_feature_ids() {
+    // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
+    let exp: Experiment = serde_json::from_value(json!({
+        "schemaVersion": "1.0.0",
+        "slug": "secure-gold",
+        "endDate": null,
+        "featureIds": ["some_control"],
+        "branches":[
+            {
+                "slug": "control",
+                "ratio": 1,
+                "feature": {
+                    "featureId": "some_control",
+                    "enabled": false
+                }
+            },
+            {
+                "slug": "treatment",
+                "ratio":1,
+                "feature": {
+                    "featureId": "some_control",
+                    "enabled": true
+                }
+            }
+        ],
+        "probeSets":[],
+        "startDate":null,
+        "application":"fenix",
+        "bucketConfig":{
+            "count":10_000,
+            "start":0,
+            "total":10_000,
+            "namespace":"secure-gold",
+            "randomizationUnit":"nimbus_id"
+        },
+        "userFacingName":"Diagnostic test experiment",
+        "referenceBranch":"control",
+        "isEnrollmentPaused":false,
+        "proposedEnrollment":7,
+        "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+        "id":"secure-gold",
+        "last_modified":1_602_197_324_372i64
+    }))
+    .unwrap();
+    assert_eq!(exp.get_feature_ids(), vec!["some_control"]);
+}
+
+// In #97 we deprecated `application` and added `app_name`, `app_id`,
+// and `channel`.  This tests the ability to deserialize both variants.
+#[test]
+fn test_experiment_schema_with_adr0004_changes() {
+    // ⚠️ Warning : Do not change the JSON data used by this test. ⚠️
+
+    // First, test deserializing an `application` format experiment
+    // to ensure the presence of `application` doesn't fail.
+    let exp: Experiment = serde_json::from_value(json!({
+        "schemaVersion": "1.0.0",
+        "slug": "secure-gold",
+        "endDate": null,
+        "featureIds": ["some_control"],
+        "branches":[
+            {
+                "slug": "control",
+                "ratio": 1,
+                "feature": {
+                    "featureId": "some_control",
+                    "enabled": false
+                }
+            },
+            {
+                "slug": "treatment",
+                "ratio":1,
+                "feature": {
+                    "featureId": "some_control",
+                    "enabled": true
+                }
+            }
+        ],
+        "probeSets":[],
+        "startDate":null,
+        "application":"fenix",
+        "bucketConfig":{
+            "count":10_000,
+            "start":0,
+            "total":10_000,
+            "namespace":"secure-gold",
+            "randomizationUnit":"nimbus_id"
+        },
+        "userFacingName":"Diagnostic test experiment",
+        "referenceBranch":"control",
+        "isEnrollmentPaused":false,
+        "proposedEnrollment":7,
+        "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+        "id":"secure-gold",
+        "last_modified":1_602_197_324_372i64
+    }))
+    .unwrap();
+    // Without the fields in the experiment, the resulting fields in the struct
+    // should be `None`
+    assert_eq!(exp.app_name, None);
+    assert_eq!(exp.app_id, None);
+    assert_eq!(exp.channel, None);
+
+    // Next, test deserializing an experiment with `app_name`, `app_id`,
+    // and `channel`.
+    let exp: Experiment = serde_json::from_value(json!({
+        "schemaVersion": "1.0.0",
+        "slug": "secure-gold",
+        "endDate": null,
+        "featureIds": ["some_control"],
+        "branches":[
+            {
+                "slug": "control",
+                "ratio": 1,
+                "feature": {
+                    "featureId": "some_control",
+                    "enabled": false
+                }
+            },
+            {
+                "slug": "treatment",
+                "ratio":1,
+                "feature": {
+                    "featureId": "some_control",
+                    "enabled": true
+                }
+            }
+        ],
+        "probeSets":[],
+        "startDate":null,
+        "appName":"fenix",
+        "appId":"org.mozilla.fenix",
+        "channel":"nightly",
+        "bucketConfig":{
+            "count":10_000,
+            "start":0,
+            "total":10_000,
+            "namespace":"secure-gold",
+            "randomizationUnit":"nimbus_id"
+        },
+        "userFacingName":"Diagnostic test experiment",
+        "referenceBranch":"control",
+        "isEnrollmentPaused":false,
+        "proposedEnrollment":7,
+        "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+        "id":"secure-gold",
+        "last_modified":1_602_197_324_372i64
+    }))
+    .unwrap();
+    assert_eq!(exp.app_name, Some("fenix".to_string()));
+    assert_eq!(exp.app_id, Some("org.mozilla.fenix".to_string()));
+    assert_eq!(exp.channel, Some("nightly".to_string()));
+
+    // Finally, test deserializing an experiment with `app_name`, `app_id`,
+    // `channel` AND `application` to ensure nothing fails.
+    let exp: Experiment = serde_json::from_value(json!({
+        "schemaVersion": "1.0.0",
+        "slug": "secure-gold",
+        "endDate": null,
+        "featureIds": ["some_control"],
+        "branches":[
+            {
+                "slug": "control",
+                "ratio": 1,
+                "feature": {
+                    "featureId": "some_control",
+                    "enabled": false
+                }
+            },
+            {
+                "slug": "treatment",
+                "ratio":1,
+                "feature": {
+                    "featureId": "some_control",
+                    "enabled": true
+                }
+            }
+        ],
+        "probeSets":[],
+        "startDate":null,
+        "application":"org.mozilla.fenix",
+        "appName":"fenix",
+        "appId":"org.mozilla.fenix",
+        "channel":"nightly",
+        "bucketConfig":{
+            "count":10_000,
+            "start":0,
+            "total":10_000,
+            "namespace":"secure-gold",
+            "randomizationUnit":"nimbus_id"
+        },
+        "userFacingName":"Diagnostic test experiment",
+        "referenceBranch":"control",
+        "isEnrollmentPaused":false,
+        "proposedEnrollment":7,
+        "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+        "id":"secure-gold",
+        "last_modified":1_602_197_324_372i64
+    }))
+    .unwrap();
+    assert_eq!(exp.app_name, Some("fenix".to_string()));
+    assert_eq!(exp.app_id, Some("org.mozilla.fenix".to_string()));
+    assert_eq!(exp.channel, Some("nightly".to_string()));
+}


### PR DESCRIPTION
[EXP-2012](https://mozilla-hub.atlassian.net/browse/EXP-2012)

This moves `mod test`s out of `lib.rs` and creates new test files for them: 
* `tests/test_lib.rs` - **todo:** `test_installation_date()` failing in new file
* `tests/test_lib_bw_compat.rs`
* ...


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
