### PR TITLE
[Don't merge yet] Shutdown support (alternative try at #1684)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,11 +888,13 @@ dependencies = [
  "ctrlc",
  "find-places-db",
  "fxa-client",
+ "interrupt-support",
  "log",
  "places",
  "serde",
  "serde_derive",
  "serde_json",
+ "shutdown",
  "structopt",
  "sync-guid",
  "sync15",
@@ -2437,6 +2439,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "shutdown",
  "sql-support",
  "sync-guid",
  "sync15",
@@ -3258,6 +3261,14 @@ dependencies = [
  "cpufeatures",
  "digest",
  "opaque-debug",
+]
+
+[[package]]
+name = "shutdown"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "parking_lot 0.5.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "components/support/rc_crypto/nss/nss_build_common",
     "components/support/rc_crypto/nss/nss_sys",
     "components/support/rc_crypto/nss/systest",
+    "components/support/shutdown",
     "components/support/sql",
     "components/support/sync15-traits",
     "components/support/types",

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -28,6 +28,7 @@ idna = "0.2"
 memchr = "2.3"
 dogear = "0.4"
 interrupt-support = { path = "../support/interrupt" }
+shutdown = { path = "../support/shutdown" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 thiserror = "1.0"

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -10,7 +10,7 @@ use parking_lot::Mutex;
 use rusqlite::{self, Connection, Transaction};
 use sql_support::{
     open_database::{self, open_database_with_flags, ConnectionInitializer},
-    ConnExt, SqlInterruptHandle, SqlInterruptScope,
+    ConnExt, SqlInterruptHandle,
 };
 use std::collections::HashMap;
 use std::ops::Deref;
@@ -155,11 +155,6 @@ impl PlacesDb {
             self.db.get_interrupt_handle(),
             self.interrupt_counter.clone(),
         )
-    }
-
-    #[inline]
-    pub fn begin_interrupt_scope(&self) -> SqlInterruptScope {
-        SqlInterruptScope::new(self.interrupt_counter.clone())
     }
 
     #[inline]

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -43,6 +43,9 @@ pub enum ErrorKind {
     #[error("Operation interrupted")]
     InterruptedError(#[from] Interrupted),
 
+    #[error("Component shutdown")]
+    ShutdownError(#[from] shutdown::ShutdownError),
+
     #[error("Tried to close connection on wrong PlacesApi instance")]
     WrongApiForClose,
 
@@ -93,6 +96,7 @@ error_support::define_error! {
         (IoError, std::io::Error),
         (MergeError, dogear::Error),
         (InterruptedError, Interrupted),
+        (ShutdownError, shutdown::ShutdownError),
         (Utf8Error, std::str::Utf8Error),
         (OpenDatabaseError, sql_support::open_database::Error),
         (InvalidMetadataObservation, InvalidMetadataObservation),

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -104,10 +104,12 @@ impl UniffiCustomTypeWrapper for Guid {
 }
 
 impl PlacesApi {
-    fn new_connection(&self, conn_type: ConnectionType) -> Result<Arc<PlacesConnection>> {
-        let db = self.open_connection(conn_type)?;
-        let connection = PlacesConnection { db: Mutex::new(db) };
-        Ok(Arc::new(connection))
+    fn get_read_connection(&self) -> Arc<PlacesConnection> {
+        self.read_connection.clone()
+    }
+
+    fn get_write_connection(&self) -> Arc<PlacesConnection> {
+        self.write_connection.clone()
     }
 
     // NOTE: These methods are unused on Android but will remain needed for
@@ -191,6 +193,10 @@ pub struct PlacesConnection {
 }
 
 impl PlacesConnection {
+    pub fn new(db: PlacesDb) -> Self {
+        Self { db: Mutex::new(db) }
+    }
+
     // A helper that gets the connection from the mutex and converts errors.
     fn with_conn<F, T>(&self, f: F) -> Result<T>
     where

--- a/components/places/src/import/ios_bookmarks.rs
+++ b/components/places/src/import/ios_bookmarks.rs
@@ -87,8 +87,6 @@ fn do_import_ios_bookmarks(places_api: &PlacesApi, ios_db_file_url: Url) -> Resu
     let conn_mutex = places_api.get_sync_connection()?;
     let conn = conn_mutex.lock();
 
-    let scope = conn.begin_interrupt_scope();
-
     sql_fns::define_functions(&conn)?;
 
     // Not sure why, but apparently beginning a transaction sometimes
@@ -107,26 +105,26 @@ fn do_import_ios_bookmarks(places_api: &PlacesApi, ios_db_file_url: Url) -> Resu
     // connection.
     log::debug!("Clearing mirror to prepare for import");
     conn.execute_batch(&WIPE_MIRROR)?;
-    scope.err_if_interrupted()?;
+    shutdown::err_if_shutdown()?;
 
     log::debug!("Creating staging table");
     conn.execute_batch(&CREATE_STAGING_TABLE)?;
 
     log::debug!("Importing from iOS to staging table");
     conn.execute_batch(&POPULATE_STAGING)?;
-    scope.err_if_interrupted()?;
+    shutdown::err_if_shutdown()?;
 
     log::debug!("Populating missing entries in moz_places");
     conn.execute_batch(&FILL_MOZ_PLACES)?;
-    scope.err_if_interrupted()?;
+    shutdown::err_if_shutdown()?;
 
     log::debug!("Populating mirror");
     conn.execute_batch(&POPULATE_MIRROR)?;
-    scope.err_if_interrupted()?;
+    shutdown::err_if_shutdown()?;
 
     log::debug!("Populating mirror tags");
     populate_mirror_tags(&conn)?;
-    scope.err_if_interrupted()?;
+    shutdown::err_if_shutdown()?;
 
     // Ideally we could just do this right after `CREATE_AND_POPULATE_STAGING`,
     // but we have constraints on the mirror structure that prevent this (and
@@ -135,23 +133,23 @@ fn do_import_ios_bookmarks(places_api: &PlacesApi, ios_db_file_url: Url) -> Resu
     // everything in one go, that seems harder to debug.
     log::debug!("Populating mirror structure");
     conn.execute_batch(POPULATE_MIRROR_STRUCTURE)?;
-    scope.err_if_interrupted()?;
+    shutdown::err_if_shutdown()?;
 
     // log::debug!("Detaching iOS database");
     // drop(auto_detach);
-    // scope.err_if_interrupted()?;
+    // shutdown::err_if_shutdown()?;
 
-    let mut merger = Merger::new(&conn, &scope, Default::default());
+    let mut merger = Merger::new(&conn, Default::default());
     // We're already in a transaction.
     merger.set_external_transaction(true);
     log::debug!("Merging with local records");
     merger.merge()?;
-    scope.err_if_interrupted()?;
+    shutdown::err_if_shutdown()?;
 
     // Update last modification time, sync status, etc
     log::debug!("Fixing up bookmarks");
     conn.execute_batch(&FIXUP_MOZ_BOOKMARKS)?;
-    scope.err_if_interrupted()?;
+    shutdown::err_if_shutdown()?;
     log::debug!("Cleaning up mirror...");
     clear_mirror_on_drop.execute_now()?;
     log::debug!("Committing...");
@@ -160,7 +158,7 @@ fn do_import_ios_bookmarks(places_api: &PlacesApi, ios_db_file_url: Url) -> Resu
     // Note: update_frecencies manages its own transaction, which is fine,
     // since nothing that bad will happen if it is aborted.
     log::debug!("Updating frecencies");
-    update_frecencies(&conn, &scope)?;
+    update_frecencies(&conn)?;
 
     log::info!("Successfully imported bookmarks!");
 

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -30,9 +30,6 @@ interface PlacesApi {
     PlacesConnection get_read_connection();
     PlacesConnection get_write_connection();
 
-    [Throws=PlacesError]
-    SqlInterruptHandle new_sync_conn_interrupt_handle();
-
     [Self=ByArc]
     void register_with_sync_manager();
 

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -27,8 +27,8 @@ interface SqlInterruptHandle {
 };
 
 interface PlacesApi {
-    [Throws=PlacesError]
-    PlacesConnection new_connection(ConnectionType conn_type);
+    PlacesConnection get_read_connection();
+    PlacesConnection get_write_connection();
 
     [Throws=PlacesError]
     SqlInterruptHandle new_sync_conn_interrupt_handle();

--- a/components/places/src/storage/bookmarks/fetch.rs
+++ b/components/places/src/storage/bookmarks/fetch.rs
@@ -316,13 +316,12 @@ fn bookmark_from_row(row: &Row<'_>) -> Result<Option<BookmarkData>> {
 }
 
 pub fn search_bookmarks(db: &PlacesDb, search: &str, limit: u32) -> Result<Vec<BookmarkData>> {
-    let scope = db.begin_interrupt_scope();
     Ok(db
         .query_rows_into_cached::<Vec<Option<BookmarkData>>, _, _, _>(
             &SEARCH_QUERY,
             &[(":search", &search), (":limit", &limit)],
             |row| -> Result<_> {
-                scope.err_if_interrupted()?;
+                shutdown::err_if_shutdown()?;
                 bookmark_from_row(row)
             },
         )?
@@ -332,13 +331,12 @@ pub fn search_bookmarks(db: &PlacesDb, search: &str, limit: u32) -> Result<Vec<B
 }
 
 pub fn recent_bookmarks(db: &PlacesDb, limit: u32) -> Result<Vec<BookmarkData>> {
-    let scope = db.begin_interrupt_scope();
     Ok(db
         .query_rows_into_cached::<Vec<Option<BookmarkData>>, _, _, _>(
             &RECENT_BOOKMARKS_QUERY,
             &[(":limit", &limit)],
             |row| -> Result<_> {
-                scope.err_if_interrupted()?;
+                shutdown::err_if_shutdown()?;
                 bookmark_from_row(row)
             },
         )?

--- a/components/support/shutdown/Cargo.toml
+++ b/components/support/shutdown/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "shutdown"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+parking_lot = "0.5"
+lazy_static = "1.4"

--- a/components/support/shutdown/README.md
+++ b/components/support/shutdown/README.md
@@ -1,0 +1,15 @@
+Shutdown handling for application-services components
+
+This crate allows us to enter shutdown mode causing any long-running operations
+to be interrupted.  "Long-running" operations include both Rust code and
+rusqlite queries.  Once we enter shutdown, any future long-running operations
+will also be interrupted unless the `restart()` method is called.
+
+In onder to support shutdown, components must do a few things:
+
+  - Any potentially long-running function should regularly call
+    `shutdown::err_if_shutdown()?` throughout the operation.  Usually this means
+    checking at the start of the function and each loop.
+  - The `Store` class that manages database connections should implement the
+    `ShutdownInterrupt` trait and call `shutdown::register_interrupt` when
+    it's created.

--- a/components/support/shutdown/src/lib.rs
+++ b/components/support/shutdown/src/lib.rs
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use parking_lot::Mutex;
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Weak;
+
+static IN_SHUTDOWN: AtomicBool = AtomicBool::new(false);
+lazy_static::lazy_static! {
+   static ref REGISTERED_INTERRUPTS: Mutex<Vec<Weak<dyn ShutdownInterrupt>>> = Mutex::new(Vec::new());
+}
+
+/// Initiate shutdown:
+///
+/// - All registered `ShutdownInterrupt` instances will have their `interrupt()` methods called.
+/// - After this `err_if_shutdown` will always return a ShutdownError
+pub fn shutdown() {
+    IN_SHUTDOWN.store(true, Ordering::Relaxed);
+    for weak in REGISTERED_INTERRUPTS.lock().iter() {
+        if let Some(interrupt) = weak.upgrade() {
+            interrupt.interrupt()
+        }
+    }
+}
+
+/// Restart after a shutdown
+///
+/// - After this `err_if_shutdown` will no longer return a ShutdownError
+pub fn restart() {
+    IN_SHUTDOWN.store(false, Ordering::Relaxed);
+}
+
+/// Check if we're currently in shutdown mode
+pub fn in_shutdown() -> bool {
+    IN_SHUTDOWN.load(Ordering::Relaxed)
+}
+
+/// Return a ShutdownError if start_shutdown() has been called
+pub fn err_if_shutdown() -> Result<(), ShutdownError> {
+    if in_shutdown() {
+        Err(ShutdownError)
+    } else {
+        Ok(())
+    }
+}
+
+/// The error returned by err_if_shutdown
+#[derive(Debug, Clone, PartialEq)]
+pub struct ShutdownError;
+
+impl fmt::Display for ShutdownError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Application is shutting down")
+    }
+}
+
+impl std::error::Error for ShutdownError {}
+
+/// Trait to handle interruption at shutdown
+///
+/// The main use case this trait targets is ensuring that sqlite queries are interrupted when
+/// shutdown starts.  Usage:
+///
+///  - Each component implements `ShutdownInterrupt` on the Store struct that manages DB
+///    connections.
+///  - When those types get created, the components call `register_interrupt()`.
+///  - When `start_shutdown()` is called, each registered `ShutdownInterrupt` instance will have
+///    it's `interrupt()` method called
+///  - `interrupt()` should interrupt all open DB connections.
+pub trait ShutdownInterrupt: Send + Sync {
+    fn interrupt(&self);
+}
+
+/// Register a ShutdownInterrupt implementation
+///
+/// Call this function to ensure that your `interrupt()` function will be called at shutdown.
+pub fn register_interrupt(interrupt: Weak<dyn ShutdownInterrupt>) {
+    // Note: we push a weak ref to REGISTERED_INTERRUPTS, but don't ever check if it's still alive.
+    // This is fine for our current usage where we only create a limited number of Stores that
+    // implement ShutdownInterrupt.  But if that changes, we should update this code to ensure that
+    // REGISTERED_INTERRUPTS doesn't grow without bound.
+    REGISTERED_INTERRUPTS.lock().push(interrupt);
+}

--- a/examples/places-utils/Cargo.toml
+++ b/examples/places-utils/Cargo.toml
@@ -13,6 +13,8 @@ path = "src/places-utils.rs"
 [dev-dependencies]
 places = { path = "../../components/places" }
 sync-guid = { path = "../../components/support/guid" }
+interrupt-support = { path = "../../components/support/interrupt" }
+shutdown = { path = "../../components/support/shutdown" }
 types = { path = "../../components/support/types" }
 sync15 = { path = "../../components/sync15" }
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }


### PR DESCRIPTION
In the review for #4790, @mhammond suggested trying a one-shot approach at interruption.  This is my try at it.

Added a shutdown crate which handles shutting down app-services.  The idea is that when the app goes into shutdown mode, or goes to sleep, you can call `shutdown::shutdown()` and this will interrupt all in-progress DB queries, then make the `err_if_shutdown()` start returning errors which should cause long-runner operations to start failing.  If you want to resume after sleeping you can `shutdown::restart()`.  So this is like a one-shot approach, but it also supports resuming afterwards.

This required a lot refactoring and probably more is still needed:
  - The places autocomplete code needs some refactoring and also we should implement interruption support there
  - The other components would need to be refactored to use this approach (I think this should be easier than places)
  - The iOS and Android code needs to be updated to deal with the breaking changes.  I think this should be pretty trivial.

I updated places-utils to work with this code.  To make things compile, I just ripped out all the import/export code.  The iOS/fennec code is going to go a way soon.  I wasn't sure if the other import/export code was useful, we need it then I guess that's one more coding task.  You can use places-utils to test this, by doing multiple passes and hitting `ctrl-c` in the middle to initiate shutdown/resume.  For example:

 - Execute `cargo run --example places-utils sync --nsyncs 4 --wait 1000`
 - In the middle of the first sync hit ctrl-c
 - During the 1s wait period hit ctrl-c again
 - You should see that the first sync gets interrupted, but the subsequent syncs work.

@mhammond what do you think of this approach?

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
