### PR TITLE
Add JEXL evaluator access from Swift and Kotlin

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,6 +18,13 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-## Nimbus
+## ⛅️🔬🔭 Nimbus SDK
+
 ### What's fixed
+
 - Fixes a bug where disabling studies did not disable rollouts. ([#4807](https://github.com/mozilla/application-services/pull/4807))
+
+### ✨ What's New ✨
+
+- JEXL is now available for evaluation from application code in Swift and Android ([#4813](https://github.com/mozilla/application-services/pull/4813)).
+    This is the next piece of the puzzle for supporting Messaging Experiments.

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/GleanPlumbHelpers.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/GleanPlumbHelpers.kt
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.experiments.nimbus
+
+import org.json.JSONObject
+import org.mozilla.experiments.nimbus.internal.NimbusTargetingHelperInterface
+
+/**
+ * Instances of this class are useful for implementing a messaging service based upon
+ * Nimbus.
+ */
+interface GleanPlumbInterface {
+    fun createMessageHelper(): GleanPlumbMessageHelper =
+        GleanPlumbMessageHelper(AlwaysFalseTargetingHelper())
+}
+
+/**
+ * A helper object to make working with Strings uniform across multiple implementations of the messaging
+ * system.
+ *
+ * This object provides access to a JEXL evaluator which runs against the same context as provided by
+ * Nimbus targeting.
+ *
+ * It should also provide a similar function for String substitution, though this scheduled for EXP-2159.
+ */
+class GleanPlumbMessageHelper(
+    private val targetingHelper: NimbusTargetingHelperInterface
+) {
+    fun evalJexl(expression: String): Boolean = targetingHelper.evalJexl(expression, null)
+    fun evalJexl(expression: String, json: JSONObject) =
+        targetingHelper.evalJexl(expression, json.toString())
+}
+
+class AlwaysFalseTargetingHelper : NimbusTargetingHelperInterface {
+    override fun evalJexl(expression: String, json: String?): Boolean = false
+}

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -45,7 +45,7 @@ typealias EnrolledExperiment = EnrolledExperiment
 /**
  * This is the main experiments API, which is exposed through the global [Nimbus] object.
  */
-interface NimbusInterface : FeaturesInterface {
+interface NimbusInterface : FeaturesInterface, GleanPlumbInterface {
 
     /**
      * Get the list of currently enrolled experiments
@@ -534,6 +534,9 @@ open class Nimbus(
     override fun recordExposureEvent(featureId: String) {
         recordExposure(featureId)
     }
+
+    override fun createMessageHelper(): GleanPlumbMessageHelper =
+        GleanPlumbMessageHelper(nimbusClient.createTargetingHelper())
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun recordExperimentTelemetry(experiments: List<EnrolledExperiment>) {

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
@@ -15,6 +15,8 @@ import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.experiments.nimbus.internal.AvailableRandomizationUnits
+import org.mozilla.experiments.nimbus.internal.NimbusClient
 import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.Executors
@@ -91,5 +93,46 @@ class GleanPlumbTests {
                 context
             )
         )
+    }
+
+    fun `invalid json throws an exception`() {
+        // This is only a problem if we allow access to strings being sent directly into Rust.
+        val developmentAppInfo = NimbusAppInfo(appName = "ThatApp", channel = "production")
+
+        val nimbus = Nimbus(
+            context = context,
+            appInfo = developmentAppInfo,
+            server = null,
+            deviceInfo = deviceInfo,
+            delegate = nimbusDelegate
+        )
+        nimbus.initializeOnThisThread()
+
+        val nimbusClient = NimbusClient(
+            nimbus.buildExperimentContext(context, developmentAppInfo, deviceInfo),
+            context.dataDir.absolutePath + "/test-path",
+            null,
+            AvailableRandomizationUnits(null, 0)
+        )
+
+        val helper = nimbusClient.createTargetingHelper()
+        assertTrue(helper.evalJexl("true", null))
+        assertTrue(helper.evalJexl("true", "{}"))
+
+        assertThrows("invalid json", NimbusException::class.java) {
+            helper.evalJexl("true", "{")
+        }
+
+        assertThrows("not an object", NimbusException::class.java) {
+            helper.evalJexl("true", "[]")
+        }
+
+        assertThrows("not an object", NimbusException::class.java) {
+            helper.evalJexl("true", "1")
+        }
+
+        assertThrows("not an object", NimbusException::class.java) {
+            helper.evalJexl("true", "true")
+        }
     }
 }

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
@@ -1,0 +1,95 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.experiments.nimbus
+
+import android.content.Context
+import android.util.Log
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+import org.json.JSONObject
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.experiments.nimbus.internal.NimbusException
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.Executors
+
+@RunWith(RobolectricTestRunner::class)
+class GleanPlumbTests {
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val deviceInfo = NimbusDeviceInfo(
+        localeTag = "en-GB"
+    )
+
+    private val nimbusDelegate = NimbusDelegate(
+        dbScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()),
+        fetchScope = CoroutineScope(Executors.newSingleThreadExecutor().asCoroutineDispatcher()),
+        logger = { Log.i("NimbusTest", it) },
+        errorReporter = { message, e -> Log.e("NimbusTest", message, e) }
+    )
+
+    @Test
+    fun `jexl can be run against the targeting attributes`() {
+        val developmentAppInfo = NimbusAppInfo(appName = "ThatApp", channel = "production")
+
+        val nimbus = Nimbus(
+            context = context,
+            appInfo = developmentAppInfo,
+            server = null,
+            deviceInfo = deviceInfo,
+            delegate = nimbusDelegate
+        )
+        nimbus.initializeOnThisThread()
+
+        val messageHelper = nimbus.createMessageHelper()
+        // Evaluate two different expressions that give true and false answers
+        // to prove we're actually parsing JEXL, rather than always returning true.
+        assertTrue(messageHelper.evalJexl("app_name == 'ThatApp'"))
+        assertFalse(messageHelper.evalJexl("app_name == 'ppAtahT'"))
+
+        assertThrows("invalid jexl", NimbusException::class.java) {
+            messageHelper.evalJexl("appName == 'ThatApp'")
+        }
+    }
+
+    @Test
+    fun `jexl can be run against the json context`() {
+        val developmentAppInfo = NimbusAppInfo(appName = "ThatApp", channel = "production")
+
+        val nimbus = Nimbus(
+            context = context,
+            appInfo = developmentAppInfo,
+            server = null,
+            deviceInfo = deviceInfo,
+            delegate = nimbusDelegate
+        )
+        nimbus.initializeOnThisThread()
+
+        val messageHelper = nimbus.createMessageHelper()
+        // Evaluate two different expressions that give true and false answers
+        // to prove we're actually parsing JEXL, rather than always returning true.
+        val context = JSONObject(
+            """{
+                    "test_value_from_json": 42
+                }""".trimIndent()
+        )
+
+        assertThrows("invalid jexl", NimbusException::class.java) {
+            messageHelper.evalJexl("test_value_from_json == 42")
+        }
+
+        assertTrue(
+            messageHelper.evalJexl(
+                "test_value_from_json == 42",
+                context
+            )
+        )
+    }
+}

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -34,7 +34,7 @@ import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.Executors
 
 @RunWith(RobolectricTestRunner::class)
-class NimbusTest {
+class NimbusTests {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
@@ -76,7 +76,8 @@ class NimbusTest {
         // init it with a mock client so we don't upload anything.
         val mockClient: Client = mock()
         `when`(mockClient.fetch(any())).thenReturn(
-            Response("URL", 200, mock(), mock()))
+            Response("URL", 200, mock(), mock())
+        )
         Glean.initialize(
             context,
             true,
@@ -90,13 +91,15 @@ class NimbusTest {
     @Test
     fun `recordExperimentTelemetry correctly records the experiment and branch`() {
         // Create a list of experiments to test the telemetry enrollment recording
-        val enrolledExperiments = listOf(EnrolledExperiment(
-            enrollmentId = "enrollment-id",
-            slug = "test-experiment",
-            featureIds = listOf(),
-            branchSlug = "test-branch",
-            userFacingDescription = "A test experiment for testing experiments",
-            userFacingName = "Test Experiment")
+        val enrolledExperiments = listOf(
+            EnrolledExperiment(
+                enrollmentId = "enrollment-id",
+                slug = "test-experiment",
+                featureIds = listOf(),
+                branchSlug = "test-branch",
+                userFacingDescription = "A test experiment for testing experiments",
+                userFacingName = "Test Experiment"
+            )
         )
 
         nimbus.recordExperimentTelemetry(experiments = enrolledExperiments)
@@ -142,27 +145,59 @@ class NimbusTest {
         val enrollmentEvents = NimbusEvents.enrollment.testGetValue()
         assertEquals("Event count must match", enrollmentEvents.count(), 1)
         val enrollmentEventExtras = enrollmentEvents.first().extra!!
-        assertEquals("Experiment slug must match", "test-experiment", enrollmentEventExtras["experiment"])
+        assertEquals(
+            "Experiment slug must match",
+            "test-experiment",
+            enrollmentEventExtras["experiment"]
+        )
         assertEquals("Experiment branch must match", "test-branch", enrollmentEventExtras["branch"])
-        assertEquals("Experiment enrollment-id must match", "test-enrollment-id", enrollmentEventExtras["enrollment_id"])
+        assertEquals(
+            "Experiment enrollment-id must match",
+            "test-enrollment-id",
+            enrollmentEventExtras["enrollment_id"]
+        )
 
         // Unenrollment
         assertTrue("Event must have a value", NimbusEvents.unenrollment.testHasValue())
         val unenrollmentEvents = NimbusEvents.unenrollment.testGetValue()
         assertEquals("Event count must match", unenrollmentEvents.count(), 1)
         val unenrollmentEventExtras = unenrollmentEvents.first().extra!!
-        assertEquals("Experiment slug must match", "test-experiment", unenrollmentEventExtras["experiment"])
-        assertEquals("Experiment branch must match", "test-branch", unenrollmentEventExtras["branch"])
-        assertEquals("Experiment enrollment-id must match", "test-enrollment-id", unenrollmentEventExtras["enrollment_id"])
+        assertEquals(
+            "Experiment slug must match",
+            "test-experiment",
+            unenrollmentEventExtras["experiment"]
+        )
+        assertEquals(
+            "Experiment branch must match",
+            "test-branch",
+            unenrollmentEventExtras["branch"]
+        )
+        assertEquals(
+            "Experiment enrollment-id must match",
+            "test-enrollment-id",
+            unenrollmentEventExtras["enrollment_id"]
+        )
 
         // Disqualification
         assertTrue("Event must have a value", NimbusEvents.disqualification.testHasValue())
         val disqualificationEvents = NimbusEvents.disqualification.testGetValue()
         assertEquals("Event count must match", disqualificationEvents.count(), 1)
         val disqualificationEventExtras = disqualificationEvents.first().extra!!
-        assertEquals("Experiment slug must match", "test-experiment", disqualificationEventExtras["experiment"])
-        assertEquals("Experiment branch must match", "test-branch", disqualificationEventExtras["branch"])
-        assertEquals("Experiment enrollment-id must match", "test-enrollment-id", disqualificationEventExtras["enrollment_id"])
+        assertEquals(
+            "Experiment slug must match",
+            "test-experiment",
+            disqualificationEventExtras["experiment"]
+        )
+        assertEquals(
+            "Experiment branch must match",
+            "test-branch",
+            disqualificationEventExtras["branch"]
+        )
+        assertEquals(
+            "Experiment enrollment-id must match",
+            "test-enrollment-id",
+            disqualificationEventExtras["enrollment_id"]
+        )
     }
 
     @Test
@@ -172,7 +207,10 @@ class NimbusTest {
         nimbus.setUpTestExperiments(packageName, appInfo)
 
         // Assert that there are no events to start with
-        assertFalse("There must not be any pre-existing events", NimbusEvents.exposure.testHasValue())
+        assertFalse(
+            "There must not be any pre-existing events",
+            NimbusEvents.exposure.testHasValue()
+        )
 
         // Record a valid exposure event in Glean that matches the featureId from the test experiment
         nimbus.recordExposureOnThisThread("about_welcome")
@@ -182,9 +220,16 @@ class NimbusTest {
         val enrollmentEvents = NimbusEvents.exposure.testGetValue()
         assertEquals("Event count must match", enrollmentEvents.count(), 1)
         val enrollmentEventExtras = enrollmentEvents.first().extra!!
-        assertEquals("Experiment slug must match", "test-experiment", enrollmentEventExtras["experiment"])
+        assertEquals(
+            "Experiment slug must match",
+            "test-experiment",
+            enrollmentEventExtras["experiment"]
+        )
         assertEquals("Experiment branch must match", "test-branch", enrollmentEventExtras["branch"])
-        assertNotNull("Experiment enrollment-id must not be null", enrollmentEventExtras["enrollment_id"])
+        assertNotNull(
+            "Experiment enrollment-id must not be null",
+            enrollmentEventExtras["enrollment_id"]
+        )
 
         // Attempt to record an event for a non-existent or feature we are not enrolled in an
         // experiment in to ensure nothing is recorded.
@@ -196,9 +241,20 @@ class NimbusTest {
         val enrollmentEventsTryTwo = NimbusEvents.exposure.testGetValue()
         assertEquals("Event count must match", enrollmentEventsTryTwo.count(), 1)
         val enrollmentEventExtrasTryTwo = enrollmentEventsTryTwo.first().extra!!
-        assertEquals("Experiment slug must match", "test-experiment", enrollmentEventExtrasTryTwo["experiment"])
-        assertEquals("Experiment branch must match", "test-branch", enrollmentEventExtrasTryTwo["branch"])
-        assertNotNull("Experiment enrollment-id must not be null", enrollmentEventExtrasTryTwo["enrollment_id"])
+        assertEquals(
+            "Experiment slug must match",
+            "test-experiment",
+            enrollmentEventExtrasTryTwo["experiment"]
+        )
+        assertEquals(
+            "Experiment branch must match",
+            "test-branch",
+            enrollmentEventExtrasTryTwo["branch"]
+        )
+        assertNotNull(
+            "Experiment enrollment-id must not be null",
+            enrollmentEventExtrasTryTwo["enrollment_id"]
+        )
     }
 
     @Test
@@ -221,9 +277,16 @@ class NimbusTest {
         val disqualificationEvents = NimbusEvents.disqualification.testGetValue()
         assertEquals("Event count must match", disqualificationEvents.count(), 1)
         val enrollmentEventExtras = disqualificationEvents.first().extra!!
-        assertEquals("Experiment slug must match", "test-experiment", enrollmentEventExtras["experiment"])
+        assertEquals(
+            "Experiment slug must match",
+            "test-experiment",
+            enrollmentEventExtras["experiment"]
+        )
         assertEquals("Experiment branch must match", "test-branch", enrollmentEventExtras["branch"])
-        assertNotNull("Experiment enrollment-id must not be null", enrollmentEventExtras["enrollment_id"])
+        assertNotNull(
+            "Experiment enrollment-id must not be null",
+            enrollmentEventExtras["enrollment_id"]
+        )
     }
 
     @Test
@@ -246,13 +309,21 @@ class NimbusTest {
         val disqualificationEvents = NimbusEvents.disqualification.testGetValue()
         assertEquals("Event count must match", disqualificationEvents.count(), 1)
         val enrollmentEventExtras = disqualificationEvents.first().extra!!
-        assertEquals("Experiment slug must match", "test-experiment", enrollmentEventExtras["experiment"])
+        assertEquals(
+            "Experiment slug must match",
+            "test-experiment",
+            enrollmentEventExtras["experiment"]
+        )
         assertEquals("Experiment branch must match", "test-branch", enrollmentEventExtras["branch"])
-        assertNotNull("Experiment enrollment-id must not be null", enrollmentEventExtras["enrollment_id"])
+        assertNotNull(
+            "Experiment enrollment-id must not be null",
+            enrollmentEventExtras["enrollment_id"]
+        )
     }
 
     private fun Nimbus.setUpTestExperiments(appId: String, appInfo: NimbusAppInfo) {
-        this.setExperimentsLocallyOnThisThread("""
+        this.setExperimentsLocallyOnThisThread(
+            """
                 {"data": [{
                   "schemaVersion": "1.0.0",
                   "slug": "test-experiment",
@@ -292,7 +363,8 @@ class NimbusTest {
                   "id": "test-experiment",
                   "last_modified": 1602197324372
                 }]}
-            """.trimIndent())
+            """.trimIndent()
+        )
         this.applyPendingExperimentsOnThisThread()
     }
 

--- a/components/nimbus/ios/Nimbus/GleanPlumbHelpers.swift
+++ b/components/nimbus/ios/Nimbus/GleanPlumbHelpers.swift
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/**
+ * Instances of this class are useful for implementing a messaging service based upon
+ * Nimbus.
+ */
+public protocol GleanPlumbProtocol {
+    func createMessageHelper() -> GleanPlumbMessageHelper
+}
+
+/**
+ * A helper object to make working with Strings uniform across multiple implementations of the messaging
+ * system.
+ *
+ * This object provides access to a JEXL evaluator which runs against the same context as provided by
+ * Nimbus targeting.
+ *
+ * It should also provide a similar function for String substitution, though this scheduled for EXP-2159.
+ */
+public class GleanPlumbMessageHelper {
+    private let targetingHelper: NimbusTargetingHelperProtocol
+
+    init(targetingHelper: NimbusTargetingHelperProtocol) {
+        self.targetingHelper = targetingHelper
+    }
+
+    public func evalJexl(expression: String) throws -> Bool {
+        try targetingHelper.evalJexl(expression: expression, json: nil)
+    }
+
+    public func evalJexl(expression: String, json: [String: Any]) throws -> Bool {
+        let string = String(data: try JSONSerialization.data(withJSONObject: json, options: []), encoding: .utf8)
+        return try targetingHelper.evalJexl(expression: expression, json: string)
+    }
+
+    public func evalJexl<T: Encodable>(expression: String, context: T) throws -> Bool {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+
+        let data = try encoder.encode(context)
+        let string = String(data: data, encoding: .utf8)!
+
+        return try targetingHelper.evalJexl(expression: expression, json: string)
+    }
+}
+
+public class AlwaysFalseTargetingHelper: NimbusTargetingHelperProtocol {
+    public func evalJexl(expression _: String, json _: String?) throws -> Bool {
+        false
+    }
+}

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -306,6 +306,13 @@ extension Nimbus: NimbusBranchInterface {
     }
 }
 
+extension Nimbus: GleanPlumbProtocol {
+    public func createMessageHelper() -> GleanPlumbMessageHelper {
+        let targetingHelper = nimbusClient.createTargetingHelper()
+        return GleanPlumbMessageHelper(targetingHelper: targetingHelper)
+    }
+}
+
 public class NimbusDisabled: NimbusApi {
     public static let shared = NimbusDisabled()
 
@@ -349,5 +356,10 @@ public extension NimbusDisabled {
 
     func getExperimentBranches(_: String) -> [Branch]? {
         return nil
+    }
+
+    func createMessageHelper() -> GleanPlumbMessageHelper {
+        let targetingHelper = AlwaysFalseTargetingHelper()
+        return GleanPlumbMessageHelper(targetingHelper: targetingHelper)
     }
 }

--- a/components/nimbus/ios/Nimbus/NimbusApi.swift
+++ b/components/nimbus/ios/Nimbus/NimbusApi.swift
@@ -15,7 +15,7 @@ import Foundation
 /// `Nimbus` into their app should use the methods in `NimbusStartup`.
 ///
 public protocol NimbusApi: FeaturesInterface, NimbusStartup,
-    NimbusUserConfiguration, NimbusBranchInterface {}
+    NimbusUserConfiguration, NimbusBranchInterface, GleanPlumbProtocol {}
 
 public protocol NimbusBranchInterface {
     /// Get the currently enrolled branch for the given experiment

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -712,15 +712,15 @@ pub struct NimbusTargetingHelper {
 }
 
 impl NimbusTargetingHelper {
-    pub fn eval_jexl(&self, expr: String) -> Result<bool> {
-        // let json = match json_string {
-        //     Some(string) => {
-        //         let value: serde_json::Value = serde_json::from_str(&string)?;
-        //         value
-        //     },
-        //     _ => None,
-        // };
-        Ok(evaluator::jexl_eval(&expr, &self.targeting_context, None)?)
+    pub fn eval_jexl(&self, expr: String, json_string: Option<String>) -> Result<bool> {
+        let json = match json_string {
+            Some(string) => {
+                let value: serde_json::Value = serde_json::from_str(&string)?;
+                Some(value)
+            },
+            _ => None,
+        };
+        Ok(evaluator::jexl_eval(&expr, &self.targeting_context, json)?)
     }
 }
 

--- a/components/nimbus/src/matcher.rs
+++ b/components/nimbus/src/matcher.rs
@@ -5,33 +5,11 @@
 //! This module defines all the information needed to match a user with an experiment.
 //! Soon it will also include a `match` function of some sort that does the matching.
 //!
-//! It has two main types, the `Matcher` retrieved from the server, and the `AppContext`
+//! It contains the `AppContext`
 //! provided by the consuming client.
 //!
 use serde_derive::*;
 use std::collections::HashMap;
-
-#[derive(Deserialize, Serialize, Debug, Clone, Default)]
-pub struct Matcher {
-    pub app_name: String,
-    pub app_id: String,
-    pub channel: String,
-    pub app_display_version: Option<String>,
-    pub app_min_version: Option<String>,
-    pub app_max_version: Option<String>,
-    pub app_build: Option<String>,
-    pub app_min_build: Option<String>,
-    pub app_max_build: Option<String>,
-    pub architecture: Option<String>,
-    pub device_manufacturer: Option<String>,
-    pub device_model: Option<String>,
-    pub locale: Option<String>,
-    pub os: Option<String>,
-    pub os_version: Option<String>,
-    pub android_sdk_version: Option<String>,
-    pub debug_tags: Vec<String>,
-}
-
 /// The `AppContext` object represents the parameters and characteristics of the
 /// consuming application that we are interested in for targeting purposes. The
 /// `app_name` and `channel` fields are not optional as they are expected

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -191,10 +191,11 @@ interface NimbusClient {
     NimbusTargetingHelper create_targeting_helper();
 };
 
-// [Custom]
-// typedef string JsonObject;
+// This will change to [Custom] when application-services adopts uniffi v0.17.
+[Wrapped]
+typedef string JsonObject;
 
 interface NimbusTargetingHelper {
     [Throws=NimbusError]
-    boolean eval_jexl(string expression, optional string? json_string = null);
+    boolean eval_jexl(string expression, optional JsonObject? json = null);
 };

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -13,7 +13,7 @@ dictionary AppContext {
     string? os_version;
     string? android_sdk_version;
     string? debug_tag;
-    // Note that installation date is 
+    // Note that installation date is
     // the unix time, which is milliseconds since epoch
     i64? installation_date;
     string? home_directory;
@@ -153,7 +153,7 @@ interface NimbusClient {
 
     // A convenience method for apps to set the experiments from a local source
     // for either testing, or before the first fetch has finished.
-    // 
+    //
     // Experiments set with this method are not applied until `apply_pending_updates()` is called.
     [Throws=NimbusError]
     void set_experiments_locally(string experiments_json);
@@ -186,4 +186,15 @@ interface NimbusClient {
     //
     [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> reset_telemetry_identifiers(AvailableRandomizationUnits new_randomization_units);
+
+    // This provides low level access to the targeting machinery for other uses by the application (e.g. messages)
+    NimbusTargetingHelper create_targeting_helper();
+};
+
+// [Custom]
+// typedef string JsonObject;
+
+interface NimbusTargetingHelper {
+    [Throws=NimbusError]
+    boolean eval_jexl(string expression /*, optional string? json_string = null */);
 };

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -196,5 +196,5 @@ interface NimbusClient {
 
 interface NimbusTargetingHelper {
     [Throws=NimbusError]
-    boolean eval_jexl(string expression /*, optional string? json_string = null */);
+    boolean eval_jexl(string expression, optional string? json_string = null);
 };

--- a/components/nimbus/tests/test_message_helpers.rs
+++ b/components/nimbus/tests/test_message_helpers.rs
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Testing get_experiment_branch semantics.
+
+mod common;
+#[allow(unused_imports)]
+#[allow(unused_attributes)]
+#[macro_use]
+use nimbus::error::Result;
+
+
+
+#[cfg(feature = "rkv-safe-mode")]
+#[cfg(test)]
+mod message_tests {
+
+    use nimbus::{AppContext, TargetingAttributes};
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn test_jexl_expression() -> Result<()> {
+
+        let nimbus = common::new_test_client("jexl_test")?;
+        nimbus.initialize()?;
+
+        let helper = nimbus.create_targeting_helper();
+
+        // We get a boolean back from a string!
+        assert!(
+            helper.eval_jexl("app_name == 'fenix'".to_string(), None)?
+        );
+
+        // We get true and false back from two similar JEXL expressions!
+        // I think we can convince ourselves that JEXL is being evaluated against the
+        // AppContext.
+        assert!(
+            !helper.eval_jexl("app_name == 'xinef'".to_string(), None)?
+        );
+
+        // The expression contains a variable not declared (snek_case Good, camelCase Bad)
+        assert!(
+            helper.eval_jexl("appName == 'fenix'".to_string(), None).is_err()
+        );
+
+        // Check the versionCompare function, just to prove to ourselves that it's the same JEXL evaluator.
+        assert!(
+            helper.eval_jexl(
+                "(version|versionCompare('95.!') >= 0) && (version|versionCompare('96.!') < 0)".to_string(),
+                json!({
+                    "version": "95.1.0".to_string(),
+                }).as_object().cloned(),
+            )?
+        );
+
+        assert!(
+            !helper.eval_jexl(
+                "(version|versionCompare('95.!') >= 0) && (version|versionCompare('96.!') < 0)".to_string(),
+                json!({
+                    "version": "94.0.0".to_string(),
+                }).as_object().cloned(),
+            )?
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_jexl_expression_with_targeting_attributes() -> Result<()> {
+        let mut nimbus = common::new_test_client("jexl_test_days_since")?;
+        nimbus.initialize()?;
+
+        let helper = nimbus.create_targeting_helper();
+
+        assert!(
+            helper.eval_jexl("days_since_install == 0".to_string(), None)?
+        );
+
+        assert!(
+            helper.eval_jexl("days_since_update == 0".to_string(), None)?
+        );
+
+        let app_context = AppContext {
+            app_name: "fenix".to_string(),
+            app_id: "org.mozilla.fenix".to_string(),
+            channel: "nightly".to_string(),
+            ..Default::default()
+        };
+
+        let targeting_attributes = TargetingAttributes {
+            app_context,
+            days_since_install: Some(10),
+            days_since_update: Some(5),
+            is_already_enrolled: false,
+        };
+
+        nimbus.with_targeting_attributes(targeting_attributes);
+
+        let helper = nimbus.create_targeting_helper();
+        assert!(
+            helper.eval_jexl("days_since_install == 10".to_string(), None)?
+        );
+
+        assert!(
+            helper.eval_jexl("days_since_update == 5".to_string(), None)?
+        );
+
+        Ok(())
+    }
+}

--- a/components/nimbus/tests/test_message_helpers.rs
+++ b/components/nimbus/tests/test_message_helpers.rs
@@ -10,8 +10,6 @@ mod common;
 #[macro_use]
 use nimbus::error::Result;
 
-
-
 #[cfg(feature = "rkv-safe-mode")]
 #[cfg(test)]
 mod message_tests {
@@ -23,47 +21,44 @@ mod message_tests {
 
     #[test]
     fn test_jexl_expression() -> Result<()> {
-
         let nimbus = common::new_test_client("jexl_test")?;
         nimbus.initialize()?;
 
         let helper = nimbus.create_targeting_helper();
 
         // We get a boolean back from a string!
-        assert!(
-            helper.eval_jexl("app_name == 'fenix'".to_string(), None)?
-        );
+        assert!(helper.eval_jexl("app_name == 'fenix'".to_string(), None)?);
 
         // We get true and false back from two similar JEXL expressions!
         // I think we can convince ourselves that JEXL is being evaluated against the
         // AppContext.
-        assert!(
-            !helper.eval_jexl("app_name == 'xinef'".to_string(), None)?
-        );
+        assert!(!helper.eval_jexl("app_name == 'xinef'".to_string(), None)?);
 
         // The expression contains a variable not declared (snek_case Good, camelCase Bad)
-        assert!(
-            helper.eval_jexl("appName == 'fenix'".to_string(), None).is_err()
-        );
+        assert!(helper
+            .eval_jexl("appName == 'fenix'".to_string(), None)
+            .is_err());
 
         // Check the versionCompare function, just to prove to ourselves that it's the same JEXL evaluator.
-        assert!(
-            helper.eval_jexl(
-                "(version|versionCompare('95.!') >= 0) && (version|versionCompare('96.!') < 0)".to_string(),
-                json!({
-                    "version": "95.1.0".to_string(),
-                }).as_object().cloned(),
-            )?
-        );
+        assert!(helper.eval_jexl(
+            "(version|versionCompare('95.!') >= 0) && (version|versionCompare('96.!') < 0)"
+                .to_string(),
+            json!({
+                "version": "95.1.0".to_string(),
+            })
+            .as_object()
+            .cloned(),
+        )?);
 
-        assert!(
-            !helper.eval_jexl(
-                "(version|versionCompare('95.!') >= 0) && (version|versionCompare('96.!') < 0)".to_string(),
-                json!({
-                    "version": "94.0.0".to_string(),
-                }).as_object().cloned(),
-            )?
-        );
+        assert!(!helper.eval_jexl(
+            "(version|versionCompare('95.!') >= 0) && (version|versionCompare('96.!') < 0)"
+                .to_string(),
+            json!({
+                "version": "94.0.0".to_string(),
+            })
+            .as_object()
+            .cloned(),
+        )?);
 
         Ok(())
     }
@@ -75,13 +70,9 @@ mod message_tests {
 
         let helper = nimbus.create_targeting_helper();
 
-        assert!(
-            helper.eval_jexl("days_since_install == 0".to_string(), None)?
-        );
+        assert!(helper.eval_jexl("days_since_install == 0".to_string(), None)?);
 
-        assert!(
-            helper.eval_jexl("days_since_update == 0".to_string(), None)?
-        );
+        assert!(helper.eval_jexl("days_since_update == 0".to_string(), None)?);
 
         let app_context = AppContext {
             app_name: "fenix".to_string(),
@@ -100,13 +91,9 @@ mod message_tests {
         nimbus.with_targeting_attributes(targeting_attributes);
 
         let helper = nimbus.create_targeting_helper();
-        assert!(
-            helper.eval_jexl("days_since_install == 10".to_string(), None)?
-        );
+        assert!(helper.eval_jexl("days_since_install == 10".to_string(), None)?);
 
-        assert!(
-            helper.eval_jexl("days_since_update == 5".to_string(), None)?
-        );
+        assert!(helper.eval_jexl("days_since_update == 5".to_string(), None)?);
 
         Ok(())
     }

--- a/components/nimbus/uniffi.toml
+++ b/components/nimbus/uniffi.toml
@@ -2,6 +2,15 @@
 package_name = "org.mozilla.experiments.nimbus.internal"
 cdylib = "megazord"
 
+[bindings.kotlin.custom_types.JsonObject]
+# Name of the type in the Kotlin code
+type_name = "JSONObject"
+# Classes that need to be imported
+imports = [ "org.json.JSONObject" ]
+# Functions to convert between strings and URLs
+into_custom = "JSONObject({})"
+from_custom = "{}.toString()"
+
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"
 ffi_module_filename = "nimbusFFI"

--- a/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
+++ b/megazords/ios/MozillaAppServices.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		394D6C622600E64E008F9CE5 /* NimbusCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 394D6C612600E64E008F9CE5 /* NimbusCreate.swift */; };
 		395992B625FBC91500E3185F /* NimbusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395992B525FBC91500E3185F /* NimbusTests.swift */; };
 		395992B825FBE40300E3185F /* NimbusApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395992B725FBE40300E3185F /* NimbusApi.swift */; };
+		397087DF27A8B76E005F344B /* GleanPlumbHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397087DE27A8B76E005F344B /* GleanPlumbHelpers.swift */; };
+		397087E127A96B84005F344B /* GleanPlumbTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397087E027A96B84005F344B /* GleanPlumbTests.swift */; };
 		398A4149264986E200AA22F1 /* FeatureVariables.swift in Sources */ = {isa = PBXBuildFile; fileRef = 398A4148264986E200AA22F1 /* FeatureVariables.swift */; };
 		39C13795264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C13794264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift */; };
 		45B794B4279E3B9C00C17D49 /* Collections+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B794B1279E3B9C00C17D49 /* Collections+.swift */; };
@@ -171,6 +173,8 @@
 		394D6C612600E64E008F9CE5 /* NimbusCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusCreate.swift; sourceTree = "<group>"; };
 		395992B525FBC91500E3185F /* NimbusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusTests.swift; sourceTree = "<group>"; };
 		395992B725FBE40300E3185F /* NimbusApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusApi.swift; sourceTree = "<group>"; };
+		397087DE27A8B76E005F344B /* GleanPlumbHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbHelpers.swift; sourceTree = "<group>"; };
+		397087E027A96B84005F344B /* GleanPlumbTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GleanPlumbTests.swift; sourceTree = "<group>"; };
 		398A4148264986E200AA22F1 /* FeatureVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureVariables.swift; sourceTree = "<group>"; };
 		39C13794264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusFeatureVariablesTests.swift; sourceTree = "<group>"; };
 		45B794B1279E3B9C00C17D49 /* Collections+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Collections+.swift"; sourceTree = "<group>"; };
@@ -321,6 +325,7 @@
 				395992B725FBE40300E3185F /* NimbusApi.swift */,
 				394D6C612600E64E008F9CE5 /* NimbusCreate.swift */,
 				398A4148264986E200AA22F1 /* FeatureVariables.swift */,
+				397087DE27A8B76E005F344B /* GleanPlumbHelpers.swift */,
 			);
 			name = Nimbus;
 			path = ../../components/nimbus/ios/Nimbus;
@@ -613,6 +618,7 @@
 				39C13794264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift */,
 				395992B525FBC91500E3185F /* NimbusTests.swift */,
 				CE3A2F37225BDE5300EA569C /* PlacesTests.swift */,
+				397087E027A96B84005F344B /* GleanPlumbTests.swift */,
 			);
 			path = MozillaAppServicesTests;
 			sourceTree = "<group>";
@@ -820,6 +826,7 @@
 				CD5ECD192716FB88009D10CC /* QuantityMetric.swift in Sources */,
 				CE1445AC23D6058B00B1E808 /* FxAccountConfig.swift in Sources */,
 				CD85A45422361E890099BFA9 /* Places.swift in Sources */,
+				397087DF27A8B76E005F344B /* GleanPlumbHelpers.swift in Sources */,
 				1B9B8F00267439F800C8A918 /* places.udl in Sources */,
 				BF1A87AC25064A8100FED88E /* MemoryUnit.swift in Sources */,
 				BF1A87BE25064A9400FED88E /* HttpPingUploader.swift in Sources */,
@@ -859,6 +866,7 @@
 				CE3A2F38225BDE5300EA569C /* PlacesTests.swift in Sources */,
 				CEB1A06823D8A42D005BD4DD /* FxAccountMocks.swift in Sources */,
 				39C13795264DAAB6003DC662 /* NimbusFeatureVariablesTests.swift in Sources */,
+				397087E127A96B84005F344B /* GleanPlumbTests.swift in Sources */,
 				CD4CFDD3221DFA5100EB3B33 /* LogTest.swift in Sources */,
 				EB879D8B22123FD900753DC9 /* LoginsTests.swift in Sources */,
 				CE90D1BB23D7570A00FD9A5F /* FxAccountManagerTests.swift in Sources */,

--- a/megazords/ios/MozillaAppServicesTests/GleanPlumbTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/GleanPlumbTests.swift
@@ -45,6 +45,8 @@ class GleanPlumbTests: XCTestCase {
         XCTAssertTrue(try helper.evalJexl(expression: "test_value_from_json == 42", context: context))
 
         XCTAssertThrowsError(try helper.evalJexl(expression: "testValueFromJson == 42", context: context))
+
+        XCTAssertThrowsError(try helper.evalJexl(expression: "true", context: 1))
     }
 }
 

--- a/megazords/ios/MozillaAppServicesTests/GleanPlumbTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/GleanPlumbTests.swift
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import XCTest
+
+@testable import MozillaAppServices
+
+class GleanPlumbTests: XCTestCase {
+    func createDatabasePath() -> String {
+        let directory = NSTemporaryDirectory()
+        let filename = "testdb-\(UUID().uuidString).db"
+        let fileURL = URL(fileURLWithPath: directory).appendingPathComponent(filename)
+        return fileURL.absoluteString
+    }
+
+    func createNimbus() throws -> GleanPlumbProtocol {
+        let appSettings = NimbusAppSettings(appName: "GleanPlumbTest", channel: "nightly")
+        let nimbusEnabled = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath())
+        XCTAssert(nimbusEnabled is Nimbus)
+        if let nimbus = nimbusEnabled as? Nimbus {
+            try nimbus.initializeOnThisThread()
+        }
+        return nimbusEnabled
+    }
+
+    func testJexlHelper() throws {
+        let nimbus = try createNimbus()
+
+        let helper = nimbus.createMessageHelper()
+        XCTAssertTrue(try helper.evalJexl(expression: "app_name == 'GleanPlumbTest'"))
+        XCTAssertFalse(try helper.evalJexl(expression: "app_name == 'tseTbmulPnaelG'"))
+
+        XCTAssertThrowsError(try helper.evalJexl(expression: "appName == 'snake_case_only'"))
+    }
+
+    func testJexlHelperWithJson() throws {
+        let nimbus = try createNimbus()
+
+        let helper = nimbus.createMessageHelper()
+
+        XCTAssertTrue(try helper.evalJexl(expression: "test_value_from_json == 42", json: ["test_value_from_json": 42]))
+
+        let context = DummyContext(testValueFromJson: 42)
+        XCTAssertTrue(try helper.evalJexl(expression: "test_value_from_json == 42", context: context))
+
+        XCTAssertThrowsError(try helper.evalJexl(expression: "testValueFromJson == 42", context: context))
+    }
+}
+
+private struct DummyContext: Encodable {
+    let testValueFromJson: Int
+}
+
+private extension Device {
+    static func isSimulator() -> Bool {
+        return ProcessInfo.processInfo.environment["SIMULATOR_ROOT"] != nil
+    }
+}

--- a/megazords/ios/MozillaAppServicesTests/NimbusTests.swift
+++ b/megazords/ios/MozillaAppServicesTests/NimbusTests.swift
@@ -369,7 +369,7 @@ class NimbusTests: XCTestCase {
     }
 }
 
-extension Device {
+private extension Device {
     static func isSimulator() -> Bool {
         return ProcessInfo.processInfo.environment["SIMULATOR_ROOT"] != nil
     }


### PR DESCRIPTION
Fixes [EXP-2158][1].

This PR refactors the targeting infrastructure to allow JEXL to be available for external applications.

This is relatively specialised: it allows evaluation against the targeting attributes Nimbus uses, and allows a JSON object/Codable to be add extra variables.

[1]: https://mozilla-hub.atlassian.net/browse/EXP-2158

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
