### PR TITLE
Prepare components for using uniffi Custom types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3806,9 +3806,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "uniffi"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472b6bbce3490a55f4f889e382a64803693929fea11e05c1057c0363af8fe019"
+checksum = "8c70e9d90cc703c4bfa842b5be1647c039578f00e3fd575f796d5acb90bae3fa"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3821,9 +3821,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e8e61e7f6d03d3bf70fe16c956061b7b5a5ef571171bb7bec160c86b5a5779"
+checksum = "f70a820a6a598cd6026e097a1a1520e429fb846efe4719934f816f264d3ba96a"
 dependencies = [
  "anyhow",
  "askama",
@@ -3838,9 +3838,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e41292abe9503cfdc682f53566b785f322548ca728e5b3b6183b0f2694b4225"
+checksum = "b7b35d8e19c773c42176343a92ce8480443e5aa19f02deb75572acf7f8a51bbb"
 dependencies = [
  "anyhow",
  "uniffi_bindgen",
@@ -3848,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ce535e537d6a3004d503b405bde5971a0c0952a836a4c756af23bf09acd823"
+checksum = "5fb8e1cc005baa085499d4802f9ffe5137f8d251b1fc75045b0767372199b21d"
 dependencies = [
  "glob",
  "proc-macro2",

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -23,7 +23,7 @@ sync15 = { path = "../sync15" }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.16"
+uniffi = "^0.17"
 url = { version = "2.2", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -36,4 +36,4 @@ libsqlite3-sys = "0.20.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.16", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.17", features = [ "builtin-bindgen" ]}

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,8 +9,8 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = "^0.16"
-uniffi_macros = "^0.16"
+uniffi = "^0.17"
+uniffi_macros = "^0.17"
 
 [build-dependencies]
-uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.17", features=["builtin-bindgen"] }

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,11 +24,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.16"
-uniffi_macros = "^0.16"
+uniffi = "^0.17"
+uniffi_macros = "^0.17"
 
 [build-dependencies]
-uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.17", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -26,15 +26,15 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.16"
-uniffi_macros = "^0.16"
+uniffi = "^0.17"
+uniffi_macros = "^0.17"
 
 [dependencies.rusqlite]
 version = "0.24.2"
 features = ["sqlcipher", "limits", "unlock_notify"]
 
 [build-dependencies]
-uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.17", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 more-asserts = "0.2"

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -32,11 +32,11 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "^0.16", optional = true }
+uniffi = { version = "^0.17", optional = true }
 chrono = { version = "0.4", features = ["serde"]}
 
 [build-dependencies]
-uniffi_build = { version = "^0.16", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.17", features = [ "builtin-bindgen" ], optional = true }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/GleanPlumbHelpers.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/GleanPlumbHelpers.kt
@@ -30,9 +30,9 @@ class GleanPlumbMessageHelper(
 ) {
     fun evalJexl(expression: String): Boolean = targetingHelper.evalJexl(expression, null)
     fun evalJexl(expression: String, json: JSONObject) =
-        targetingHelper.evalJexl(expression, json.toString())
+        targetingHelper.evalJexl(expression, json)
 }
 
 class AlwaysFalseTargetingHelper : NimbusTargetingHelperInterface {
-    override fun evalJexl(expression: String, json: String?): Boolean = false
+    override fun evalJexl(expression: String, json: JSONObject?): Boolean = false
 }

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
@@ -94,45 +94,4 @@ class GleanPlumbTests {
             )
         )
     }
-
-    fun `invalid json throws an exception`() {
-        // This is only a problem if we allow access to strings being sent directly into Rust.
-        val developmentAppInfo = NimbusAppInfo(appName = "ThatApp", channel = "production")
-
-        val nimbus = Nimbus(
-            context = context,
-            appInfo = developmentAppInfo,
-            server = null,
-            deviceInfo = deviceInfo,
-            delegate = nimbusDelegate
-        )
-        nimbus.initializeOnThisThread()
-
-        val nimbusClient = NimbusClient(
-            nimbus.buildExperimentContext(context, developmentAppInfo, deviceInfo),
-            context.dataDir.absolutePath + "/test-path",
-            null,
-            AvailableRandomizationUnits(null, 0)
-        )
-
-        val helper = nimbusClient.createTargetingHelper()
-        assertTrue(helper.evalJexl("true", null))
-        assertTrue(helper.evalJexl("true", "{}"))
-
-        assertThrows("invalid json", NimbusException::class.java) {
-            helper.evalJexl("true", "{")
-        }
-
-        assertThrows("not an object", NimbusException::class.java) {
-            helper.evalJexl("true", "[]")
-        }
-
-        assertThrows("not an object", NimbusException::class.java) {
-            helper.evalJexl("true", "1")
-        }
-
-        assertThrows("not an object", NimbusException::class.java) {
-            helper.evalJexl("true", "true")
-        }
-    }
 }

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
@@ -15,8 +15,6 @@ import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.experiments.nimbus.internal.AvailableRandomizationUnits
-import org.mozilla.experiments.nimbus.internal.NimbusClient
 import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.Executors

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -729,13 +729,11 @@ impl NimbusTargetingHelper {
 
 type JsonObject = Map<String, Value>;
 
-// This will need to a UniffiCustomTypeConverter once uniffi 0.17
-// is released and adopted by application-services
 #[cfg(feature = "uniffi-bindings")]
-impl UniffiCustomTypeWrapper for JsonObject {
-    type Wrapped = String;
+impl UniffiCustomTypeConverter for JsonObject {
+    type Builtin = String;
 
-    fn wrap(val: Self::Wrapped) -> uniffi::Result<JsonObject> {
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
         let json: Value = serde_json::from_str(&val)?;
 
         match json.as_object() {
@@ -746,7 +744,7 @@ impl UniffiCustomTypeWrapper for JsonObject {
         }
     }
 
-    fn unwrap(obj: Self) -> Self::Wrapped {
+    fn from_custom(obj: Self) -> Self::Builtin {
         serde_json::Value::Object(obj).to_string()
     }
 }

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -191,8 +191,7 @@ interface NimbusClient {
     NimbusTargetingHelper create_targeting_helper();
 };
 
-// This will change to [Custom] when application-services adopts uniffi v0.17.
-[Wrapped]
+[Custom]
 typedef string JsonObject;
 
 interface NimbusTargetingHelper {

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -32,8 +32,8 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.16"
-uniffi_macros = "^0.16"
+uniffi = "^0.17"
+uniffi_macros = "^0.17"
 
 [dependencies.rusqlite]
 version = "0.24.2"
@@ -45,4 +45,4 @@ tempfile = "3.1"
 env_logger = {version = "0.7", default-features = false}
 
 [build-dependencies]
-uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.17", features=["builtin-bindgen"] }

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -52,53 +52,53 @@ type BookmarkFolder = crate::storage::bookmarks::fetch::Folder;
 type BookmarkSeparator = crate::storage::bookmarks::fetch::Separator;
 use crate::storage::bookmarks::fetch::BookmarkData;
 
-impl UniffiCustomTypeWrapper for Url {
-    type Wrapped = String;
+impl UniffiCustomTypeConverter for Url {
+    type Builtin = String;
 
-    fn wrap(val: Self::Wrapped) -> uniffi::Result<url::Url> {
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<url::Url> {
         match Url::parse(val.as_str()) {
             Ok(url) => Ok(url),
             Err(e) => Err(PlacesError::UrlParseFailed(e.to_string()).into()),
         }
     }
 
-    fn unwrap(obj: Self) -> Self::Wrapped {
+    fn from_custom(obj: Self) -> Self::Builtin {
         obj.into()
     }
 }
 
-impl UniffiCustomTypeWrapper for Timestamp {
-    type Wrapped = i64;
+impl UniffiCustomTypeConverter for Timestamp {
+    type Builtin = i64;
 
-    fn wrap(val: Self::Wrapped) -> uniffi::Result<Self> {
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
         Ok(Timestamp(val as u64))
     }
 
-    fn unwrap(obj: Self) -> Self::Wrapped {
+    fn from_custom(obj: Self) -> Self::Builtin {
         obj.as_millis() as i64
     }
 }
 
-impl UniffiCustomTypeWrapper for VisitTransitionSet {
-    type Wrapped = i32;
+impl UniffiCustomTypeConverter for VisitTransitionSet {
+    type Builtin = i32;
 
-    fn wrap(val: Self::Wrapped) -> uniffi::Result<Self> {
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
         Ok(VisitTransitionSet::from_u16(val as u16).expect("Bug: Invalid VisitTransitionSet"))
     }
 
-    fn unwrap(obj: Self) -> Self::Wrapped {
+    fn from_custom(obj: Self) -> Self::Builtin {
         VisitTransitionSet::into_u16(obj) as i32
     }
 }
 
-impl UniffiCustomTypeWrapper for Guid {
-    type Wrapped = String;
+impl UniffiCustomTypeConverter for Guid {
+    type Builtin = String;
 
-    fn wrap(val: Self::Wrapped) -> uniffi::Result<Guid> {
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Guid> {
         Ok(Guid::new(val.as_str()))
     }
 
-    fn unwrap(obj: Self) -> Self::Wrapped {
+    fn from_custom(obj: Self) -> Self::Builtin {
         obj.into()
     }
 }

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-[Wrapped]
+[Custom]
 typedef string Url;
-[Wrapped]
+[Custom]
 typedef i64 Timestamp;
-[Wrapped]
+[Custom]
 typedef i32 VisitTransitionSet;
-[Wrapped]
+[Custom]
 typedef string Guid;
 
 namespace places {

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -20,11 +20,11 @@ viaduct = { path = "../viaduct" }
 sql-support = { path = "../support/sql" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }
 thiserror = "1.0"
-uniffi = "^0.16"
-uniffi_macros = "^0.16"
+uniffi = "^0.17"
+uniffi_macros = "^0.17"
 
 [build-dependencies]
-uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.17", features=["builtin-bindgen"] }
 
 
 [dev-dependencies]

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -23,8 +23,8 @@ serde_derive = "1"
 serde_json = "1"
 parking_lot = "0.5"
 interrupt-support = { path = "../support/interrupt" }
-uniffi = "^0.16"
-uniffi_macros = "^0.16"
+uniffi = "^0.17"
+uniffi_macros = "^0.17"
 
 [build-dependencies]
-uniffi_build = { version = "^0.16", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.17", features=["builtin-bindgen"] }

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -19,8 +19,8 @@ interrupt-support = { path = "../support/interrupt" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.16"
-uniffi_macros = "^0.16"
+uniffi = "^0.17"
+uniffi_macros = "^0.17"
 
 [build-dependencies]
-uniffi_build = { version = "^0.16", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.17", features = [ "builtin-bindgen" ]}

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.16"
+uniffi_bindgen = "^0.17"


### PR DESCRIPTION
Nimbus would like to start using `[Custom]` types from Uniffi 0.17.0, first implemented as `[Wrapped]` types in a previous version of Uniffi.

This PR builds components against a local copy of uniffi v0.17, updating all uses of `[Wrapped]` to `[Custom]`, thereby fixing the breaking change that would be introduced by Uniffi 0.17.

It is not expected to build cleanly until:

 * uniffi 0.17 is published to Crates.io: https://github.com/mozilla/uniffi-rs/pull/1163

Once that happens, this PR should be rebased and rerun.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.