### PR TITLE
For EXP-2012: Moving tests for versioning.rs into their own file

### DIFF
--- a/components/nimbus/src/tests/mod.rs
+++ b/components/nimbus/src/tests/mod.rs
@@ -9,3 +9,4 @@ mod test_lib;
 mod test_lib_bw_compat;
 mod test_lib_schema_deserialization;
 mod test_persistence;
+mod test_versioning;

--- a/components/nimbus/src/tests/test_versioning.rs
+++ b/components/nimbus/src/tests/test_versioning.rs
@@ -1,0 +1,212 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::versioning::*;
+use crate::{error::Result, NimbusError};
+
+#[test]
+fn test_wild_card_to_version_part() -> Result<()> {
+    let s = "*";
+    let version_part = VersionPart::try_from(s)?;
+    assert_eq!(version_part.num_a, i32::MAX);
+    assert_eq!(version_part.str_b, "");
+    assert_eq!(version_part.num_c, 0);
+    assert_eq!(version_part.extra_d, "");
+    Ok(())
+}
+
+#[test]
+fn test_empty_string_to_version_part() -> Result<()> {
+    let s = "";
+    let version_part = VersionPart::try_from(s)?;
+    assert_eq!(version_part.num_a, 0);
+    assert_eq!(version_part.str_b, "");
+    assert_eq!(version_part.num_c, 0);
+    assert_eq!(version_part.extra_d, "");
+    Ok(())
+}
+
+#[test]
+fn test_only_num_a_to_version_part() -> Result<()> {
+    let s = "98382";
+    let version_part = VersionPart::try_from(s)?;
+    assert_eq!(version_part.num_a, 98382);
+    assert_eq!(version_part.str_b, "");
+    assert_eq!(version_part.num_c, 0);
+    assert_eq!(version_part.extra_d, "");
+    Ok(())
+}
+
+#[test]
+fn test_num_a_and_plus_str_b() -> Result<()> {
+    let s = "92+";
+    let version_part = VersionPart::try_from(s)?;
+    assert_eq!(version_part.num_a, 93);
+    assert_eq!(version_part.str_b, "pre");
+    assert_eq!(version_part.num_c, 0);
+    assert_eq!(version_part.extra_d, "");
+    Ok(())
+}
+
+#[test]
+fn test_num_a_and_str_b() -> Result<()> {
+    let s = "92beta";
+    let version_part = VersionPart::try_from(s)?;
+    assert_eq!(version_part.num_a, 92);
+    assert_eq!(version_part.str_b, "beta");
+    assert_eq!(version_part.num_c, 0);
+    assert_eq!(version_part.extra_d, "");
+    Ok(())
+}
+
+#[test]
+fn test_num_a_str_b_and_num_c() -> Result<()> {
+    let s = "92beta72";
+    let version_part = VersionPart::try_from(s)?;
+    assert_eq!(version_part.num_a, 92);
+    assert_eq!(version_part.str_b, "beta");
+    assert_eq!(version_part.num_c, 72);
+    assert_eq!(version_part.extra_d, "");
+    Ok(())
+}
+
+#[test]
+fn test_full_valid_string_to_version_part() -> Result<()> {
+    let s = "1pre3extrabithere";
+    let version_part = VersionPart::try_from(s)?;
+    assert_eq!(version_part.num_a, 1);
+    assert_eq!(version_part.str_b, "pre");
+    assert_eq!(version_part.num_c, 3);
+    assert_eq!(version_part.extra_d, "extrabithere");
+    Ok(())
+}
+
+#[test]
+
+fn test_parse_full_version() -> Result<()> {
+    let s = "92+.10.1.beta";
+    let versions = Version::try_from(s.to_string())?;
+    // assert!(versions.ok(), true);
+    assert_eq!(
+        vec![
+            VersionPart {
+                num_a: 93,
+                str_b: "pre".into(),
+                ..Default::default()
+            },
+            VersionPart {
+                num_a: 10,
+                ..Default::default()
+            },
+            VersionPart {
+                num_a: 1,
+                ..Default::default()
+            },
+            VersionPart {
+                num_a: 0,
+                str_b: "beta".into(),
+                ..Default::default()
+            }
+        ],
+        versions.0
+    );
+    Ok(())
+}
+
+#[test]
+fn test_compare_two_versions() -> Result<()> {
+    let v1 = Version::try_from("92beta.1.2".to_string())?;
+    let v2 = Version::try_from("92beta.1.2pre".to_string())?;
+    assert!(v1 > v2);
+    Ok(())
+}
+
+#[test]
+fn smoke_test_version_compare() -> Result<()> {
+    // Test values from https://searchfox.org/mozilla-central/rev/5909d5b7f3e247dddff8229e9499db017eb438e2/xpcom/base/nsIVersionComparator.idl#24-31
+    let v1 = Version::try_from("1.0pre1")?;
+    let v2 = Version::try_from("1.0pre2")?;
+    let v3 = Version::try_from("1.0")?;
+    let v4 = Version::try_from("1.0.0")?;
+    let v5 = Version::try_from("1.0.0.0")?;
+    let v6 = Version::try_from("1.1pre")?;
+    let v7 = Version::try_from("1.1pre0")?;
+    let v8 = Version::try_from("1.0+")?;
+    let v9 = Version::try_from("1.1pre1a")?;
+    let v10 = Version::try_from("1.1pre1")?;
+    let v11 = Version::try_from("1.1pre10a")?;
+    let v12 = Version::try_from("1.1pre10")?;
+    assert!(v1 < v2);
+    assert!(v2 < v3);
+    assert!(v3 == v4);
+    assert!(v4 == v5);
+    assert!(v5 < v6);
+    assert!(v6 == v7);
+    assert!(v7 == v8);
+    assert!(v8 < v9);
+    assert!(v9 < v10);
+    assert!(v10 < v11);
+    assert!(v11 < v12);
+    Ok(())
+}
+
+#[test]
+fn test_compare_wild_card() -> Result<()> {
+    let v1 = Version::try_from("*")?;
+    let v2 = Version::try_from("95.2pre")?;
+    assert!(v1 > v2);
+    Ok(())
+}
+
+#[test]
+fn test_non_ascii_throws_error() -> Result<()> {
+    let err = Version::try_from("92🥲.1.2pre").expect_err("Should have thrown error");
+    if let NimbusError::VersionParsingError(_) = err {
+        // Good!
+    } else {
+        panic!("Expected VersionParsingError, got {:?}", err)
+    }
+    Ok(())
+}
+
+#[test]
+fn test_version_number_parsing_overflows() -> Result<()> {
+    // This i32::MAX, should parse OK
+    let v1 = VersionPart::try_from("2147483647")?;
+    assert_eq!(v1.num_a, i32::MAX);
+    // this is greater than i32::MAX, should return an error
+    let err =
+        VersionPart::try_from("2147483648").expect_err("Should throw error, it overflows an i32");
+    if let NimbusError::VersionParsingError(_) = err {
+        // OK
+    } else {
+        panic!("Expected a VersionParsingError, got {:?}", err)
+    }
+    Ok(())
+}
+
+#[test]
+fn test_version_part_with_dashes() -> Result<()> {
+    let v1 = VersionPart::try_from("0-beta")?;
+    assert_eq!(
+        VersionPart {
+            num_a: 0,
+            str_b: "".into(),
+            num_c: 0,
+            extra_d: "-beta".into(),
+        },
+        v1
+    );
+    Ok(())
+}
+
+#[test]
+fn test_exclamation_mark() -> Result<()> {
+    let v1 = Version::try_from("93.!")?;
+    let v2 = Version::try_from("93.1")?;
+    let v3 = Version::try_from("93.0-beta")?;
+    let v4 = Version::try_from("93.alpha")?;
+    assert!(v1 < v2 && v1 < v3 && v1 < v4);
+    Ok(())
+}

--- a/components/nimbus/src/versioning.rs
+++ b/components/nimbus/src/versioning.rs
@@ -84,20 +84,19 @@
 //!           < 1.1pre10a
 //!             < 1.1pre10
 
+use crate::NimbusError;
 use std::cmp::Ordering;
 
-use crate::NimbusError;
-
 #[derive(Debug, Default, Clone, PartialEq)]
-struct VersionPart {
-    num_a: i32,
-    str_b: String,
-    num_c: i32,
-    extra_d: String,
+pub(crate) struct VersionPart {
+    pub(crate) num_a: i32,
+    pub(crate) str_b: String,
+    pub(crate) num_c: i32,
+    pub(crate) extra_d: String,
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct Version(Vec<VersionPart>);
+pub struct Version(pub(crate) Vec<VersionPart>);
 
 impl PartialEq for Version {
     fn eq(&self, other: &Self) -> bool {
@@ -295,215 +294,5 @@ impl TryFrom<&'_ str> for VersionPart {
         // Step 4: Assign all the remaining to extra_d
         res.extra_d = value[curr_idx..].into();
         Ok(res)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::Result;
-    #[test]
-    fn test_wild_card_to_version_part() -> Result<()> {
-        let s = "*";
-        let version_part = VersionPart::try_from(s)?;
-        assert_eq!(version_part.num_a, i32::MAX);
-        assert_eq!(version_part.str_b, "");
-        assert_eq!(version_part.num_c, 0);
-        assert_eq!(version_part.extra_d, "");
-        Ok(())
-    }
-
-    #[test]
-    fn test_empty_string_to_version_part() -> Result<()> {
-        let s = "";
-        let version_part = VersionPart::try_from(s)?;
-        assert_eq!(version_part.num_a, 0);
-        assert_eq!(version_part.str_b, "");
-        assert_eq!(version_part.num_c, 0);
-        assert_eq!(version_part.extra_d, "");
-        Ok(())
-    }
-
-    #[test]
-    fn test_only_num_a_to_version_part() -> Result<()> {
-        let s = "98382";
-        let version_part = VersionPart::try_from(s)?;
-        assert_eq!(version_part.num_a, 98382);
-        assert_eq!(version_part.str_b, "");
-        assert_eq!(version_part.num_c, 0);
-        assert_eq!(version_part.extra_d, "");
-        Ok(())
-    }
-
-    #[test]
-    fn test_num_a_and_plus_str_b() -> Result<()> {
-        let s = "92+";
-        let version_part = VersionPart::try_from(s)?;
-        assert_eq!(version_part.num_a, 93);
-        assert_eq!(version_part.str_b, "pre");
-        assert_eq!(version_part.num_c, 0);
-        assert_eq!(version_part.extra_d, "");
-        Ok(())
-    }
-
-    #[test]
-    fn test_num_a_and_str_b() -> Result<()> {
-        let s = "92beta";
-        let version_part = VersionPart::try_from(s)?;
-        assert_eq!(version_part.num_a, 92);
-        assert_eq!(version_part.str_b, "beta");
-        assert_eq!(version_part.num_c, 0);
-        assert_eq!(version_part.extra_d, "");
-        Ok(())
-    }
-
-    #[test]
-    fn test_num_a_str_b_and_num_c() -> Result<()> {
-        let s = "92beta72";
-        let version_part = VersionPart::try_from(s)?;
-        assert_eq!(version_part.num_a, 92);
-        assert_eq!(version_part.str_b, "beta");
-        assert_eq!(version_part.num_c, 72);
-        assert_eq!(version_part.extra_d, "");
-        Ok(())
-    }
-
-    #[test]
-    fn test_full_valid_string_to_version_part() -> Result<()> {
-        let s = "1pre3extrabithere";
-        let version_part = VersionPart::try_from(s)?;
-        assert_eq!(version_part.num_a, 1);
-        assert_eq!(version_part.str_b, "pre");
-        assert_eq!(version_part.num_c, 3);
-        assert_eq!(version_part.extra_d, "extrabithere");
-        Ok(())
-    }
-
-    #[test]
-
-    fn test_parse_full_version() -> Result<()> {
-        let s = "92+.10.1.beta";
-        let versions = Version::try_from(s.to_string())?;
-        assert_eq!(
-            vec![
-                VersionPart {
-                    num_a: 93,
-                    str_b: "pre".into(),
-                    ..Default::default()
-                },
-                VersionPart {
-                    num_a: 10,
-                    ..Default::default()
-                },
-                VersionPart {
-                    num_a: 1,
-                    ..Default::default()
-                },
-                VersionPart {
-                    num_a: 0,
-                    str_b: "beta".into(),
-                    ..Default::default()
-                }
-            ],
-            versions.0
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_compare_two_versions() -> Result<()> {
-        let v1 = Version::try_from("92beta.1.2".to_string())?;
-        let v2 = Version::try_from("92beta.1.2pre".to_string())?;
-        assert!(v1 > v2);
-        Ok(())
-    }
-
-    #[test]
-    fn smoke_test_version_compare() -> Result<()> {
-        // Test values from https://searchfox.org/mozilla-central/rev/5909d5b7f3e247dddff8229e9499db017eb438e2/xpcom/base/nsIVersionComparator.idl#24-31
-        let v1 = Version::try_from("1.0pre1")?;
-        let v2 = Version::try_from("1.0pre2")?;
-        let v3 = Version::try_from("1.0")?;
-        let v4 = Version::try_from("1.0.0")?;
-        let v5 = Version::try_from("1.0.0.0")?;
-        let v6 = Version::try_from("1.1pre")?;
-        let v7 = Version::try_from("1.1pre0")?;
-        let v8 = Version::try_from("1.0+")?;
-        let v9 = Version::try_from("1.1pre1a")?;
-        let v10 = Version::try_from("1.1pre1")?;
-        let v11 = Version::try_from("1.1pre10a")?;
-        let v12 = Version::try_from("1.1pre10")?;
-        assert!(v1 < v2);
-        assert!(v2 < v3);
-        assert!(v3 == v4);
-        assert!(v4 == v5);
-        assert!(v5 < v6);
-        assert!(v6 == v7);
-        assert!(v7 == v8);
-        assert!(v8 < v9);
-        assert!(v9 < v10);
-        assert!(v10 < v11);
-        assert!(v11 < v12);
-        Ok(())
-    }
-
-    #[test]
-    fn test_compare_wild_card() -> Result<()> {
-        let v1 = Version::try_from("*")?;
-        let v2 = Version::try_from("95.2pre")?;
-        assert!(v1 > v2);
-        Ok(())
-    }
-
-    #[test]
-    fn test_non_ascii_throws_error() -> Result<()> {
-        let err = Version::try_from("92🥲.1.2pre").expect_err("Should have thrown error");
-        if let NimbusError::VersionParsingError(_) = err {
-            // Good!
-        } else {
-            panic!("Expected VersionParsingError, got {:?}", err)
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn test_version_number_parsing_overflows() -> Result<()> {
-        // This i32::MAX, should parse OK
-        let v1 = VersionPart::try_from("2147483647")?;
-        assert_eq!(v1.num_a, i32::MAX);
-        // this is greater than i32::MAX, should return an error
-        let err = VersionPart::try_from("2147483648")
-            .expect_err("Should throw error, it overflows an i32");
-        if let NimbusError::VersionParsingError(_) = err {
-            // OK
-        } else {
-            panic!("Expected a VersionParsingError, got {:?}", err)
-        }
-        Ok(())
-    }
-
-    #[test]
-    fn test_version_part_with_dashes() -> Result<()> {
-        let v1 = VersionPart::try_from("0-beta")?;
-        assert_eq!(
-            VersionPart {
-                num_a: 0,
-                str_b: "".into(),
-                num_c: 0,
-                extra_d: "-beta".into(),
-            },
-            v1
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_exclamation_mark() -> Result<()> {
-        let v1 = Version::try_from("93.!")?;
-        let v2 = Version::try_from("93.1")?;
-        let v3 = Version::try_from("93.0-beta")?;
-        let v4 = Version::try_from("93.alpha")?;
-        assert!(v1 < v2 && v1 < v3 && v1 < v4);
-        Ok(())
     }
 }


### PR DESCRIPTION
[EXP-2012](https://mozilla-hub.atlassian.net/browse/EXP-2012)

This moves the `mod test`s out of `versioning.rs` and creates new test files for them: 
* `tests/test_versioning.rs`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
