### PR TITLE
Bug 1689162 - Update to Glean Metrics schema v2

### DIFF
--- a/components/logins/android/metrics.yaml
+++ b/components/logins/android/metrics.yaml
@@ -15,7 +15,7 @@
 #  * Fenix for Andriod
 
 ---
-$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 logins_store:
   # These track when we need to regenerate the encryption key which causes all

--- a/components/logins/ios/metrics.yaml
+++ b/components/logins/ios/metrics.yaml
@@ -15,7 +15,7 @@
 #  * Fenix for Andriod
 
 ---
-$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 logins_store_migration:
 

--- a/components/nimbus/metrics.yaml
+++ b/components/nimbus/metrics.yaml
@@ -7,7 +7,7 @@
 # PyPI package.
 ---
 
-$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 nimbus_events:
   enrollment:

--- a/components/places/android/metrics.yaml
+++ b/components/places/android/metrics.yaml
@@ -15,7 +15,7 @@
 #  * Fenix for Andriod
 
 ---
-$schema: moz://mozilla.org/schemas/glean/metrics/1-0-0
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 places_manager:
 


### PR DESCRIPTION
No functional changes, just a little bit of cleanup.
[Schema v2 has landed about a year ago](https://github.com/mozilla/glean_parser/blob/fd23d588ce0bced4d496ac642e6f98ee2659fa88/CHANGELOG.md#200-2021-02-05).
app-services should already be compatible with it without further changes.