### PR TITLE
For EXP-2012: Move tests for null_client.rs into their own file

### DIFF
--- a/components/nimbus/src/client/mod.rs
+++ b/components/nimbus/src/client/mod.rs
@@ -4,7 +4,7 @@
 
 mod fs_client;
 pub(crate) mod http_client;
-mod null_client;
+pub(crate) mod null_client;
 use crate::error::{NimbusError, Result};
 use crate::Experiment;
 use crate::RemoteSettingsConfig;

--- a/components/nimbus/src/client/null_client.rs
+++ b/components/nimbus/src/client/null_client.rs
@@ -24,23 +24,3 @@ impl SettingsClient for NullClient {
         Ok(Default::default())
     }
 }
-
-#[cfg(feature = "rkv-safe-mode")]
-#[test]
-fn test_null_client() -> Result<()> {
-    use crate::NimbusClient;
-    use tempdir::TempDir;
-
-    let _ = env_logger::try_init();
-
-    let tmp_dir = TempDir::new("test_null_client-test_null")?;
-
-    let aru = Default::default();
-    let client = NimbusClient::new(Default::default(), tmp_dir.path(), None, aru)?;
-    client.fetch_experiments()?;
-    client.apply_pending_experiments()?;
-
-    let experiments = client.get_all_experiments()?;
-    assert_eq!(experiments.len(), 0);
-    Ok(())
-}

--- a/components/nimbus/src/tests/client/test_null_client.rs
+++ b/components/nimbus/src/tests/client/test_null_client.rs
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::error::Result;
+
+#[cfg(feature = "rkv-safe-mode")]
+#[test]
+fn test_null_client() -> Result<()> {
+    use crate::NimbusClient;
+    use tempdir::TempDir;
+
+    let _ = env_logger::try_init();
+
+    let tmp_dir = TempDir::new("test_null_client-test_null")?;
+
+    let aru = Default::default();
+    let client = NimbusClient::new(Default::default(), tmp_dir.path(), None, aru)?;
+    client.fetch_experiments()?;
+    client.apply_pending_experiments()?;
+
+    let experiments = client.get_all_experiments()?;
+    assert_eq!(experiments.len(), 0);
+    Ok(())
+}

--- a/components/nimbus/src/tests/client/test_null_client.rs
+++ b/components/nimbus/src/tests/client/test_null_client.rs
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+ // Allow this to run in "safe mode"
+#![allow(unused_imports)]
+
 use crate::error::Result;
 
 #[cfg(feature = "rkv-safe-mode")]

--- a/components/nimbus/src/tests/mod.rs
+++ b/components/nimbus/src/tests/mod.rs
@@ -15,4 +15,5 @@ mod test_versioning;
 
 mod client {
     mod test_http_client;
+    mod test_null_client;
 }


### PR DESCRIPTION
[EXP-2012](https://mozilla-hub.atlassian.net/browse/EXP-2012)

This moves the `mod test` out of `null_client.rs` and creates a new test file for it: 
* `tests/client/test_null_client.rs`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
