### PR TITLE
Remove duplicate DeviceType enum from .udl files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3414,6 +3414,9 @@ dependencies = [
  "sync-guid",
  "sync15-traits",
  "thiserror",
+ "uniffi",
+ "uniffi_build",
+ "uniffi_macros",
  "url",
  "viaduct",
 ]

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -948,23 +948,8 @@ dictionary FxAMigrationResult {
 };
 
 
-
-// Enumeration for the different types of device.
-//
-// Firefox Accounts seprates devices into broad categories for display purposes,
-// such as distinguishing a desktop PC from a mobile phone. Upon signin, the
-// application should inspect the device it is running on and select an appropriate
-// [`DeviceType`] to include in its device registration record.
-//
-enum DeviceType {
-  "Desktop",
-  "Mobile",
-  "Tablet",
-  "VR",
-  "TV",
-  "Unknown",
-};
-
+[External="sync15"]
+typedef extern DeviceType;
 
 // A "capability" offered by a device.
 //

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -24,6 +24,11 @@ sync-guid = { path = "../support/guid", features = ["random"] }
 sync15-traits = {path = "../support/sync15-traits"}
 thiserror = "1.0"
 anyhow = "1.0"
+uniffi = "^0.17"
+uniffi_macros = "^0.17"
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }
+
+[build-dependencies]
+uniffi_build = { version = "^0.17", features=["builtin-bindgen"] }

--- a/components/sync15/build.rs
+++ b/components/sync15/build.rs
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+fn main() {
+    uniffi_build::generate_scaffolding("./src/sync15.udl").unwrap();
+}

--- a/components/sync15/src/lib.rs
+++ b/components/sync15/src/lib.rs
@@ -46,3 +46,5 @@ pub use sync15_traits::client::DeviceType;
 
 pub use crate::util::ServerTimestamp;
 pub use sync15_traits::SyncEngineId;
+
+uniffi_macros::include_scaffolding!("sync15");

--- a/components/sync15/src/sync15.udl
+++ b/components/sync15/src/sync15.udl
@@ -1,0 +1,19 @@
+// This file contains common sync15-related types which are used by various components.
+namespace sync15 {
+};
+
+// Enumeration for the different types of device.
+//
+// Firefox Accounts seprates devices into broad categories for display purposes,
+// such as distinguishing a desktop PC from a mobile phone. Upon signin, the
+// application should inspect the device it is running on and select an appropriate
+// [`DeviceType`] to include in its device registration record.
+//
+enum DeviceType {
+  "Desktop",
+  "Mobile",
+  "Tablet",
+  "VR",
+  "TV",
+  "Unknown",
+};

--- a/components/sync_manager/src/lib.rs
+++ b/components/sync_manager/src/lib.rs
@@ -10,7 +10,6 @@ pub mod manager;
 mod types;
 
 pub use error::{Result, SyncManagerError};
-use sync15::DeviceType;
 pub use types::*;
 
 use manager::SyncManager;

--- a/components/sync_manager/src/syncmanager.udl
+++ b/components/sync_manager/src/syncmanager.udl
@@ -69,14 +69,8 @@ dictionary DeviceSettings {
     DeviceType kind;
 };
 
-enum DeviceType {
-    "Desktop",
-    "Mobile",
-    "Tablet",
-    "VR",
-    "TV",
-    "Unknown",
-};
+[External="sync15"]
+typedef extern DeviceType;
 
 dictionary SyncResult {
     // Result from the sync server

--- a/components/tabs/src/tabs.udl
+++ b/components/tabs/src/tabs.udl
@@ -14,11 +14,8 @@ interface TabsStore {
     void register_with_sync_manager();
 };
 
-// Note that this enum is duplicated in fxa-client.udl (although the underlying type *is*
-// shared). This duplication exists because there's no direct dependency between that crate and
-// this one. We can probably remove the duplication when sync15 gets a .udl file, then we could
-// reference it via an `[Extern=...]typedef`
-enum DeviceType { "Desktop", "Mobile", "Tablet", "VR", "TV", "Unknown" };
+[External="sync15"]
+typedef extern DeviceType;
 
 dictionary RemoteTab {
     string title;


### PR DESCRIPTION
This is the other half of #4397. I'm not sure how I feel about it - on one hand, killing the dupe from .udl files seems great! OTOH though, adding a new .udl file to sync15 that contains exactly 1 enum sounds a bit like overkill, and it doesn't look like it will be growing anything new any time soon. Another option might be to create a "common types" crate - but even then, the amount of sharing isn't that great (but stuff like Guid and JsonObject support could live there). But maybe that's even more overkill. Another option is to just wait for something to arrive organically and add it then?

Clearly not urgent though, so marking as a draft, but welcome all thoughts.