### PR TITLE
Make tabs example work on Windows and upgrade to StructOpt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,11 +941,11 @@ name = "example-tabs-sync"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
  "cli-support",
  "clipboard",
  "log",
  "serde_json",
+ "structopt",
  "tabs",
  "viaduct-reqwest",
 ]

--- a/examples/tabs-sync/Cargo.toml
+++ b/examples/tabs-sync/Cargo.toml
@@ -6,6 +6,15 @@ license = "MPL-2.0"
 edition = "2021"
 publish = false
 
+[features]
+default = ["with-clipboard"]
+
+# The `clipboard` module we use appears to want to link against X11, which
+# is a problem in some cases (notably, Windows/WSL)
+# Running this example with, eg, `--no-default-features` will avoid using that module,
+# but disable certain functionality.
+with-clipboard = []
+
 [[example]]
 name = "tabs-sync"
 path = "src/tabs-sync.rs"
@@ -16,6 +25,6 @@ serde_json = "1"
 log = "0.4"
 anyhow = "1.0"
 clipboard = "0.5"
-clap = "2.33"
+structopt = "0.3"
 cli-support = { path = "../cli-support" }
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }

--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -6,33 +6,32 @@
 
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
 use cli_support::prompt::prompt_char;
-use clipboard::{ClipboardContext, ClipboardProvider};
 use std::sync::Arc;
+use structopt::StructOpt;
 use tabs::{RemoteTab, TabsStore};
 
 use anyhow::Result;
 
+#[derive(Clone, Debug, StructOpt)]
+#[structopt(name = "tabs_sync", about = "CLI for Sync tabs store")]
+pub struct Opts {
+    #[structopt(
+        name = "credential_file",
+        value_name = "CREDENTIAL_JSON",
+        long = "credentials",
+        short = "c",
+        default_value = "./credentials.json"
+    )]
+    /// Path to credentials.json.
+    pub creds_file: String,
+}
+
 fn main() -> Result<()> {
     viaduct_reqwest::use_reqwest_backend();
     cli_support::init_logging();
-    let matches = clap::App::new("tabs_sync")
-        .about("CLI for Sync tabs store")
-        .arg(
-            clap::Arg::with_name("credential_file")
-                .short("c")
-                .long("credentials")
-                .value_name("CREDENTIAL_JSON")
-                .takes_value(true)
-                .help(
-                    "Path to store our cached fxa credentials (defaults to \"./credentials.json\"",
-                ),
-        )
-        .get_matches();
-    let cred_file = matches
-        .value_of("credential_file")
-        .unwrap_or("./credentials.json");
+    let opts = Opts::from_args();
 
-    let mut cli_fxa = get_cli_fxa(get_default_fxa_config(), cred_file)?;
+    let mut cli_fxa = get_cli_fxa(get_default_fxa_config(), &opts.creds_file)?;
     let device_id = cli_fxa.account.get_current_device_id()?;
 
     let store = Arc::new(TabsStore::new());
@@ -107,7 +106,9 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "with-clipboard")]
 fn read_local_state() -> Vec<RemoteTab> {
+    use clipboard::{ClipboardContext, ClipboardProvider};
     println!("Please run the following command in the Firefox Browser Toolbox and copy it.");
     println!(
         "   JSON.stringify(await Weave.Service.engineManager.get(\"tabs\")._store.getAllTabs())"
@@ -147,4 +148,11 @@ fn read_local_state() -> Vec<RemoteTab> {
         });
     }
     local_state
+}
+
+#[cfg(not(feature = "with-clipboard"))]
+fn read_local_state() -> Vec<RemoteTab> {
+    println!("This module is build without the `clipboard` feature, so we can't");
+    println!("read the local state.");
+    vec![]
 }


### PR DESCRIPTION
The tabs example never worked on Windows or WSL, so I needed to fix that as part of the tabs persistence work, but thought I'd split it out. I'll also be adding another cmdline option, so figured I'd update to `StructOpt` at the same time to bring us in line with our other complex examples (eg, places_utils).

CC @lougeniaC64 as she is also working with tabs at the moment.