### PR TITLE
Avoid Option<DeviceType> in all structs

### DIFF
--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -893,7 +893,7 @@ dictionary TabHistoryEntry {
 dictionary AttachedClient {
   string? client_id;
   string? device_id;
-  DeviceType? device_type;
+  DeviceType device_type;
   boolean is_current_session;
   string? name;
   i64? created_time;

--- a/components/fxa-client/src/internal/http_client.rs
+++ b/components/fxa-client/src/internal/http_client.rs
@@ -776,7 +776,7 @@ pub struct DeviceUpdateRequest<'a> {
     display_name: Option<Option<&'a str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "type")]
-    device_type: Option<Option<&'a DeviceType>>,
+    device_type: Option<&'a DeviceType>,
     #[serde(flatten)]
     push_subscription: Option<&'a PushSubscription>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -786,7 +786,7 @@ pub struct DeviceUpdateRequest<'a> {
 
 #[allow(clippy::option_option)]
 pub struct DeviceUpdateRequestBuilder<'a> {
-    device_type: Option<Option<&'a DeviceType>>,
+    device_type: Option<&'a DeviceType>,
     display_name: Option<Option<&'a str>>,
     push_subscription: Option<&'a PushSubscription>,
     available_commands: Option<Option<&'a HashMap<String, String>>>,
@@ -828,7 +828,7 @@ impl<'a> DeviceUpdateRequestBuilder<'a> {
     }
 
     pub fn device_type(mut self, device_type: &'a DeviceType) -> Self {
-        self.device_type = Some(Some(device_type));
+        self.device_type = Some(device_type);
         self
     }
 
@@ -893,7 +893,7 @@ pub struct GetAttachedClientResponse {
     pub session_token_id: Option<String>,
     pub refresh_token_id: Option<String>,
     pub device_id: Option<String>,
-    pub device_type: Option<DeviceType>,
+    pub device_type: DeviceType,
     pub is_current_session: bool,
     pub name: Option<String>,
     pub created_time: Option<u64>,

--- a/components/fxa-client/src/internal/oauth/attached_clients.rs
+++ b/components/fxa-client/src/internal/oauth/attached_clients.rs
@@ -37,7 +37,7 @@ impl TryFrom<AttachedClient> for crate::AttachedClient {
         Ok(crate::AttachedClient {
             client_id: c.client_id,
             device_id: c.device_id,
-            device_type: c.device_type.map(Into::into),
+            device_type: c.device_type,
             is_current_session: c.is_current_session,
             name: c.name,
             created_time: c.created_time.map(TryInto::try_into).transpose()?,
@@ -69,7 +69,7 @@ mod tests {
                 session_token_id: None,
                 refresh_token_id: None,
                 device_id: None,
-                device_type: Some(DeviceType::Desktop),
+                device_type: DeviceType::Desktop,
                 is_current_session: true,
                 name: None,
                 created_time: None,

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -1255,7 +1255,7 @@ pub struct TabHistoryEntry {
 pub struct AttachedClient {
     pub client_id: Option<String>,
     pub device_id: Option<String>,
-    pub device_type: Option<DeviceType>,
+    pub device_type: DeviceType,
     pub is_current_session: bool,
     pub name: Option<String>,
     pub created_time: Option<i64>,

--- a/components/sync15/src/client_types.rs
+++ b/components/sync15/src/client_types.rs
@@ -5,7 +5,8 @@
 //! This module has to be here because of some hard-to-avoid hacks done for the
 //! tabs engine... See issue #2590
 
-use serde::{Deserialize, Serialize, Serializer};
+use crate::DeviceType;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 /// Argument to Store::prepare_for_sync. See comment there for more info. Only
@@ -24,150 +25,62 @@ pub struct RemoteClient {
     pub fxa_device_id: Option<String>,
     pub device_name: String,
     #[serde(default)]
-    #[serde(deserialize_with = "deserialize_option_device_type")]
-    #[serde(serialize_with = "serialize_option_device_type")]
-    pub device_type: Option<DeviceType>,
-}
-
-fn deserialize_option_device_type<'de, D>(d: D) -> std::result::Result<Option<DeviceType>, D::Error>
-where
-    D: serde::de::Deserializer<'de>,
-{
-    let opt_device_type: Option<DeviceType> = Option::deserialize(d)?;
-    Ok(match opt_device_type {
-        Some(val) => match val {
-            DeviceType::Unknown => None,
-            _ => Some(val),
-        },
-        None => None,
-    })
-}
-
-fn serialize_option_device_type<S>(id: &Option<DeviceType>, s: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    match id {
-        Some(DeviceType::Unknown) => s.serialize_none(),
-        Some(d) => d.serialize(s),
-        None => s.serialize_none(),
-    }
-}
-
-/// Enumeration for the different types of device.
-///
-/// Firefox Accounts and the broader Sync universe separates devices into broad categories for
-/// display purposes, such as distinguishing a desktop PC from a mobile phone.
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum DeviceType {
-    #[serde(rename = "desktop")]
-    Desktop,
-    #[serde(rename = "mobile")]
-    Mobile,
-    #[serde(rename = "tablet")]
-    Tablet,
-    #[serde(rename = "vr")]
-    VR,
-    #[serde(rename = "tv")]
-    TV,
-    // Unknown is a bit odd - it should never be set (ie, it's never serialized)
-    // and exists really just so we can avoid using an Option<>.
-    #[serde(other)]
-    #[serde(skip_serializing)] // Don't you dare trying.
-    Unknown,
+    pub device_type: DeviceType,
 }
 
 #[cfg(test)]
-mod device_type_tests {
+mod client_types_tests {
     use super::*;
 
     #[test]
-    fn test_serde_ser() {
-        assert_eq!(
-            serde_json::to_string(&DeviceType::Desktop).unwrap(),
-            "\"desktop\""
-        );
-        assert_eq!(
-            serde_json::to_string(&DeviceType::Mobile).unwrap(),
-            "\"mobile\""
-        );
-        assert_eq!(
-            serde_json::to_string(&DeviceType::Tablet).unwrap(),
-            "\"tablet\""
-        );
-        assert_eq!(serde_json::to_string(&DeviceType::VR).unwrap(), "\"vr\"");
-        assert_eq!(serde_json::to_string(&DeviceType::TV).unwrap(), "\"tv\"");
-        assert!(serde_json::to_string(&DeviceType::Unknown).is_err());
-    }
-
-    #[test]
-    fn test_serde_de() {
-        assert!(matches!(
-            serde_json::from_str::<DeviceType>("\"desktop\"").unwrap(),
-            DeviceType::Desktop
-        ));
-        assert!(matches!(
-            serde_json::from_str::<DeviceType>("\"mobile\"").unwrap(),
-            DeviceType::Mobile
-        ));
-        assert!(matches!(
-            serde_json::from_str::<DeviceType>("\"tablet\"").unwrap(),
-            DeviceType::Tablet
-        ));
-        assert!(matches!(
-            serde_json::from_str::<DeviceType>("\"vr\"").unwrap(),
-            DeviceType::VR
-        ));
-        assert!(matches!(
-            serde_json::from_str::<DeviceType>("\"tv\"").unwrap(),
-            DeviceType::TV
-        ));
-        assert!(matches!(
-            serde_json::from_str::<DeviceType>("\"something-else\"").unwrap(),
-            DeviceType::Unknown,
-        ));
-    }
-
-    #[test]
     fn test_remote_client() {
-        // Missing `device_type` gets None.
+        // Missing `device_type` gets DeviceType::Unknown.
         let dt = serde_json::from_str::<RemoteClient>("{\"device_name\": \"foo\"}").unwrap();
-        assert_eq!(dt.device_type, None);
+        assert_eq!(dt.device_type, DeviceType::Unknown);
         // But reserializes as null.
         assert_eq!(
             serde_json::to_string(&dt).unwrap(),
             "{\"fxa_device_id\":null,\"device_name\":\"foo\",\"device_type\":null}"
         );
 
-        // Unknown device_type string deserializes as None.
+        // explicit null is also unknown.
+        assert_eq!(
+            serde_json::from_str::<RemoteClient>(
+                "{\"device_name\": \"foo\", \"device_type\": null}",
+            )
+            .unwrap()
+            .device_type,
+            DeviceType::Unknown
+        );
+
+        // Unknown device_type string deserializes as DeviceType::Unknown.
         let dt = serde_json::from_str::<RemoteClient>(
             "{\"device_name\": \"foo\", \"device_type\": \"foo\"}",
         )
         .unwrap();
-        assert_eq!(dt.device_type, None);
+        assert_eq!(dt.device_type, DeviceType::Unknown);
         // The None gets re-serialized as null.
         assert_eq!(
             serde_json::to_string(&dt).unwrap(),
             "{\"fxa_device_id\":null,\"device_name\":\"foo\",\"device_type\":null}"
         );
 
-        // Some(DeviceType::Unknown) gets serialized as null.
+        // DeviceType::Unknown gets serialized as null.
         let dt = RemoteClient {
             device_name: "bar".to_string(),
             fxa_device_id: None,
-            device_type: Some(DeviceType::Unknown),
+            device_type: DeviceType::Unknown,
         };
         assert_eq!(
             serde_json::to_string(&dt).unwrap(),
             "{\"fxa_device_id\":null,\"device_name\":\"bar\",\"device_type\":null}"
         );
 
-        // Some(DeviceType::Desktop) gets serialized as "desktop".
+        // DeviceType::Desktop gets serialized as "desktop".
         let dt = RemoteClient {
             device_name: "bar".to_string(),
             fxa_device_id: Some("fxa".to_string()),
-            device_type: Some(DeviceType::Desktop),
+            device_type: DeviceType::Desktop,
         };
         assert_eq!(
             serde_json::to_string(&dt).unwrap(),
@@ -185,7 +98,7 @@ mod device_type_tests {
                     RemoteClient {
                         fxa_device_id: None,
                         device_name: "my device".to_string(),
-                        device_type: None,
+                        device_type: DeviceType::Unknown,
                     },
                 ),
                 (
@@ -193,7 +106,7 @@ mod device_type_tests {
                     RemoteClient {
                         fxa_device_id: None,
                         device_name: "device with no tabs".to_string(),
-                        device_type: None,
+                        device_type: DeviceType::Unknown,
                     },
                 ),
                 (
@@ -201,13 +114,14 @@ mod device_type_tests {
                     RemoteClient {
                         fxa_device_id: None,
                         device_name: "device with a tab".to_string(),
-                        device_type: Some(DeviceType::Desktop),
+                        device_type: DeviceType::Desktop,
                     },
                 ),
             ]),
         };
         //serialize
         let client_data_ser = serde_json::to_string(&client_data).unwrap();
+        println!("SER: {}", client_data_ser);
         // deserialize
         let client_data_des: ClientData = serde_json::from_str(&client_data_ser).unwrap();
         assert_eq!(client_data_des, client_data);

--- a/components/sync15/src/clients_engine/engine.rs
+++ b/components/sync15/src/clients_engine/engine.rs
@@ -205,7 +205,7 @@ impl<'a> Driver<'a> {
         ClientRecord {
             id: settings.fxa_device_id.clone(),
             name: settings.device_name.clone(),
-            typ: settings.device_type.into(),
+            typ: settings.device_type,
             commands: Vec::new(),
             fxa_device_id: Some(settings.fxa_device_id.clone()),
             version: None,
@@ -489,17 +489,17 @@ mod tests {
             RemoteClient {
                 fxa_device_id: Some("deviceAAAAAA".to_string()),
                 device_name: "Laptop".into(),
-                device_type: Some(DeviceType::Desktop),
+                device_type: DeviceType::Desktop,
             },
             RemoteClient {
                 fxa_device_id: Some("iPhooooooone".to_string()),
                 device_name: "iPhone".into(),
-                device_type: Some(DeviceType::Mobile),
+                device_type: DeviceType::Mobile,
             },
             RemoteClient {
                 fxa_device_id: Some("deviceCCCCCC".to_string()),
                 device_name: "Fenix".into(),
-                device_type: Some(DeviceType::Mobile),
+                device_type: DeviceType::Mobile,
             },
         ];
         let actual_remote_clients = expected_ids
@@ -624,12 +624,12 @@ mod tests {
             RemoteClient {
                 fxa_device_id: Some("deviceAAAAAA".to_string()),
                 device_name: "Laptop".into(),
-                device_type: Some(DeviceType::Desktop),
+                device_type: DeviceType::Desktop,
             },
             RemoteClient {
                 fxa_device_id: Some("iPhooooooone".to_string()),
                 device_name: "iPhone".into(),
-                device_type: Some(DeviceType::Mobile),
+                device_type: DeviceType::Mobile,
             },
         ];
         let actual_remote_clients = expected_ids
@@ -768,12 +768,12 @@ mod tests {
             RemoteClient {
                 fxa_device_id: Some("deviceAAAAAA".to_string()),
                 device_name: "Laptop".into(),
-                device_type: Some(DeviceType::Desktop),
+                device_type: DeviceType::Desktop,
             },
             RemoteClient {
                 fxa_device_id: Some("iPhooooooone".to_string()),
                 device_name: "iPhone".into(),
-                device_type: Some(DeviceType::Mobile),
+                device_type: DeviceType::Mobile,
             },
         ];
         let actual_remote_clients = expected_ids

--- a/components/sync15/src/clients_engine/record.rs
+++ b/components/sync15/src/clients_engine/record.rs
@@ -15,8 +15,8 @@ pub struct ClientRecord {
 
     pub name: String,
 
-    #[serde(default, rename = "type")]
-    pub typ: Option<crate::DeviceType>,
+    #[serde(rename = "type")]
+    pub typ: crate::DeviceType,
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub commands: Vec<CommandRecord>,

--- a/components/sync15/src/device_type.rs
+++ b/components/sync15/src/device_type.rs
@@ -1,0 +1,152 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This type is strictly owned by FxA, but is defined in this crate because of
+//! some hard-to-avoid hacks done for the tabs engine... See issue #2590.
+//!
+//! Thus, fxa-client ends up taking a dep on this crate, which is roughly
+//! the opposite of reality.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Enumeration for the different types of device.
+///
+/// Firefox Accounts and the broader Sync universe separates devices into broad categories for
+/// various purposes, such as distinguishing a desktop PC from a mobile phone.
+///
+/// A special variant in this enum, `DeviceType::Unknown` is used to capture
+/// the string values we don't recognise. It also has a custom serde serializer and deserializer
+/// which implements the following semantics:
+/// * deserializing a `DeviceType` which uses a string value we don't recognise or null will return
+///   `DeviceType::Unknown` rather than returning an error.
+/// * serializing `DeviceType::Unknown` will serialize `null`.
+///
+/// This has a few important implications:
+/// * In general, `Option<DeviceType>` should be avoided, and a plain `DeviceType` used instead,
+///   because in that case, `None` would be semantically identical to `DeviceType::Unknown` and
+///   as mentioned above, `null` already deserializes as `DeviceType::Unknown`.
+/// * Any unknown device types can not be round-tripped via this enum - eg, if you deserialize
+///   a struct holding a `DeviceType` string value we don't recognize, then re-serialize it, the
+///   original string value is lost. We don't consider this a problem because in practice, we only
+///   upload records with *this* device's type, not the type of other devices, and it's reasonable
+///   to assume that this module knows about all valid device types for the device type it is
+///   deployed on.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum DeviceType {
+    Desktop,
+    Mobile,
+    Tablet,
+    VR,
+    TV,
+    // See docstrings above re how Unknown is serialized and deserialized.
+    Unknown,
+}
+
+impl Default for DeviceType {
+    fn default() -> Self {
+        DeviceType::Unknown
+    }
+}
+
+impl<'de> Deserialize<'de> for DeviceType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(match String::deserialize(deserializer) {
+            Ok(s) => match s.as_str() {
+                "desktop" => DeviceType::Desktop,
+                "mobile" => DeviceType::Mobile,
+                "tablet" => DeviceType::Tablet,
+                "vr" => DeviceType::VR,
+                "tv" => DeviceType::TV,
+                // There's a vague possibility that desktop might serialize "phone" for mobile
+                // devices - https://searchfox.org/mozilla-central/rev/a156a65ced2dae5913ae35a68e9445b8ee7ca457/services/sync/modules/engines/clients.js#292
+                "phone" => DeviceType::Mobile,
+                // Everything else is Unknown.
+                _ => DeviceType::Unknown,
+            },
+            // Anything other than a string is "unknown" - this isn't ideal - we really only want
+            // to handle null and, eg, a number probably should be an error, but meh.
+            Err(_) => DeviceType::Unknown,
+        })
+    }
+}
+impl Serialize for DeviceType {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            // It's unfortunate we need to duplicate the strings here...
+            DeviceType::Desktop => s.serialize_unit_variant("DeviceType", 0, "desktop"),
+            DeviceType::Mobile => s.serialize_unit_variant("DeviceType", 1, "mobile"),
+            DeviceType::Tablet => s.serialize_unit_variant("DeviceType", 2, "tablet"),
+            DeviceType::VR => s.serialize_unit_variant("DeviceType", 3, "vr"),
+            DeviceType::TV => s.serialize_unit_variant("DeviceType", 4, "tv"),
+            // This is the important bit - Unknown -> None
+            DeviceType::Unknown => s.serialize_none(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod device_type_tests {
+    use super::*;
+
+    #[test]
+    fn test_serde_ser() {
+        assert_eq!(
+            serde_json::to_string(&DeviceType::Desktop).unwrap(),
+            "\"desktop\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DeviceType::Mobile).unwrap(),
+            "\"mobile\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DeviceType::Tablet).unwrap(),
+            "\"tablet\""
+        );
+        assert_eq!(serde_json::to_string(&DeviceType::VR).unwrap(), "\"vr\"");
+        assert_eq!(serde_json::to_string(&DeviceType::TV).unwrap(), "\"tv\"");
+        assert_eq!(serde_json::to_string(&DeviceType::Unknown).unwrap(), "null");
+    }
+
+    #[test]
+    fn test_serde_de() {
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"desktop\"").unwrap(),
+            DeviceType::Desktop
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"mobile\"").unwrap(),
+            DeviceType::Mobile
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"tablet\"").unwrap(),
+            DeviceType::Tablet
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"vr\"").unwrap(),
+            DeviceType::VR
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"tv\"").unwrap(),
+            DeviceType::TV
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("\"something-else\"").unwrap(),
+            DeviceType::Unknown,
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("null").unwrap(),
+            DeviceType::Unknown,
+        ));
+        assert!(matches!(
+            serde_json::from_str::<DeviceType>("99").unwrap(),
+            DeviceType::Unknown,
+        ));
+    }
+}

--- a/components/sync15/src/lib.rs
+++ b/components/sync15/src/lib.rs
@@ -8,6 +8,8 @@
 pub mod bso;
 #[cfg(feature = "sync-client")]
 pub mod client;
+// Type to describe device types
+mod device_type;
 // Types to describe client records
 mod client_types;
 // Note that `clients_engine` should probably be in `sync_client`, but let's not make
@@ -25,7 +27,8 @@ mod record_types;
 mod server_timestamp;
 pub mod telemetry;
 
-pub use crate::client_types::{ClientData, DeviceType, RemoteClient};
+pub use crate::client_types::{ClientData, RemoteClient};
+pub use crate::device_type::DeviceType;
 pub use crate::error::{Error, Result};
 #[cfg(feature = "crypto")]
 pub use enc_payload::EncryptedPayload;

--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -277,7 +277,7 @@ mod tests {
     use crate::sync::record::TabsRecordTab;
     use serde_json::json;
     use std::collections::HashMap;
-    use sync15::{ClientData, RemoteClient};
+    use sync15::{ClientData, DeviceType, RemoteClient};
 
     const TTL_1_YEAR: u32 = 31_622_400;
 
@@ -315,7 +315,7 @@ mod tests {
                     RemoteClient {
                         fxa_device_id: None,
                         device_name: "my device".to_string(),
-                        device_type: None,
+                        device_type: sync15::DeviceType::Unknown,
                     },
                 ),
                 (
@@ -323,7 +323,7 @@ mod tests {
                     RemoteClient {
                         fxa_device_id: None,
                         device_name: "device with no tabs".to_string(),
-                        device_type: None,
+                        device_type: DeviceType::Unknown,
                     },
                 ),
                 (
@@ -331,7 +331,7 @@ mod tests {
                     RemoteClient {
                         fxa_device_id: None,
                         device_name: "device with a tab".to_string(),
-                        device_type: None,
+                        device_type: DeviceType::Unknown,
                     },
                 ),
             ]),

--- a/components/tabs/src/sync/engine.rs
+++ b/components/tabs/src/sync/engine.rs
@@ -49,7 +49,7 @@ impl ClientRemoteTabs {
         Self {
             client_id,
             client_name: remote_client.device_name.clone(),
-            device_type: remote_client.device_type.unwrap_or(DeviceType::Unknown),
+            device_type: remote_client.device_type,
             last_modified: last_modified.as_millis(),
             remote_tabs: record.tabs.iter().map(RemoteTab::from_record_tab).collect(),
         }
@@ -199,12 +199,7 @@ impl TabsSyncImpl {
             let (client_name, device_type) = self
                 .remote_clients
                 .get(&local_id)
-                .map(|client| {
-                    (
-                        client.device_name.clone(),
-                        client.device_type.unwrap_or(DeviceType::Unknown),
-                    )
-                })
+                .map(|client| (client.device_name.clone(), client.device_type))
                 .unwrap_or_else(|| (String::new(), DeviceType::Unknown));
             let local_record = ClientRemoteTabs {
                 client_id: local_id.clone(),


### PR DESCRIPTION
Fixes #4860 

It's unfortunate that anyone who deserializes needs to remember to add the custom default path, but we can't add `#[serde(default=...)]` to the enum itself because that's only supported for structs. A default deserialize implementation sounds a little like overkill.

Welcome all feedback, so I'm just marking this as a draft now.