### PR TITLE
Generate yaml for experimenter manifest instead of json

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -47,3 +47,5 @@ Use the template below to make assigning a version number during the release cut
   - More helpful validation error reporting
   - Better handling of defaults in objects and enum maps
   - More YAML syntactic checking.
+- Allow experimenter to output to a YAML file, as well as JSON. [#4874](https://github.com/mozilla/application-services/pull/4874)
+  - If the file extension is `yaml`, then output as YAML, otherwise, output as JSON.

--- a/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
@@ -161,7 +161,11 @@ pub(crate) fn generate_manifest(
         None => TargetLanguage::ExperimenterJSON,
     };
     let output_str = match language {
-        TargetLanguage::ExperimenterJSON => serde_json::to_string(&experiment_manifest)?,
+        TargetLanguage::ExperimenterJSON => serde_json::to_string_pretty(&experiment_manifest)?,
+        // This is currently just a re-render of the JSON in YAML.
+        // However, the YAML format will diverge in time, so experimenter can support
+        // a richer manifest format (probably involving generating schema that can validate
+        // JSON patches in the FeatureConfig.)
         TargetLanguage::ExperimenterYAML => serde_yaml::to_string(&experiment_manifest)?,
 
         // If in doubt, output the previously generated default.

--- a/components/support/nimbus-fml/src/main.rs
+++ b/components/support/nimbus-fml/src/main.rs
@@ -180,6 +180,8 @@ pub enum TargetLanguage {
     Kotlin,
     Swift,
     IR,
+    ExperimenterYAML,
+    ExperimenterJSON,
 }
 
 impl TargetLanguage {
@@ -189,6 +191,8 @@ impl TargetLanguage {
             TargetLanguage::Kotlin => "kt",
             TargetLanguage::Swift => "swift",
             TargetLanguage::IR => "fml.json",
+            TargetLanguage::ExperimenterJSON => "json",
+            TargetLanguage::ExperimenterYAML => "yaml",
         }
     }
 }
@@ -199,6 +203,8 @@ impl TryFrom<&str> for TargetLanguage {
         Ok(match value.to_ascii_lowercase().as_str() {
             "kotlin" | "kt" | "kts" => TargetLanguage::Kotlin,
             "swift" => TargetLanguage::Swift,
+            "yaml" => TargetLanguage::ExperimenterYAML,
+            "json" => TargetLanguage::ExperimenterJSON,
             _ => bail!("Unknown or unsupported target language: \"{}\"", value),
         })
     }

--- a/components/support/nimbus-fml/src/workflows.rs
+++ b/components/support/nimbus-fml/src/workflows.rs
@@ -22,6 +22,10 @@ pub(crate) fn generate_struct(config: Config, cmd: GenerateStructCmd) -> Result<
         }
         TargetLanguage::Kotlin => backends::kotlin::generate_struct(ir, config, cmd)?,
         TargetLanguage::Swift => backends::swift::generate_struct(ir, config, cmd)?,
+        _ => unimplemented!(
+            "Unsupported output language for structs: {}",
+            language.extension()
+        ),
     };
     Ok(())
 }
@@ -31,7 +35,6 @@ pub(crate) fn generate_experimenter_manifest(
     cmd: GenerateExperimenterManifestCmd,
 ) -> Result<()> {
     let ir = load_feature_manifest(&cmd.manifest, cmd.load_from_ir, &cmd.channel)?;
-    println!("\tOutput file: {:?}", cmd.output.as_os_str());
     backends::experimenter_manifest::generate_manifest(ir, config, cmd)?;
     Ok(())
 }
@@ -321,8 +324,8 @@ mod test {
         schema_path: P,
         generated_yaml: &serde_yaml::Value,
     ) -> Result<()> {
-        use crate::backends::experimenter_manifest::ExperimenterFeatureManifest2;
-        let generated_manifest: ExperimenterFeatureManifest2 =
+        use crate::backends::experimenter_manifest::ExperimenterManifest;
+        let generated_manifest: ExperimenterManifest =
             serde_yaml::from_value(generated_yaml.to_owned())?;
         let generated_json = serde_json::to_value(generated_manifest)?;
 


### PR DESCRIPTION
Fixes [EXP-2111][1]

[1]: https://mozilla-hub.atlassian.net/browse/EXP-2111

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.