### PR TITLE
Teach FML that Swift's optional chaining is different to Kotlin's optional chaining

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -19,6 +19,12 @@ Use the template below to make assigning a version number during the release cut
 
 -->
 
+## Nimbus FML ⛅️🔬🔭🔧
+
+### What's Fixed
+
+- Swift: a bug in our understanding of Swift optional chaining rules meant that maps with a mapping and merging produced invalid code. ([#4885](https://github.com/mozilla/application-services/pull/4885))
+
 ## General
 
 ### What's Changed

--- a/components/support/nimbus-fml/fixtures/fe/fenix.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/fenix.yaml
@@ -47,6 +47,21 @@ features:
         description: The drawable displayed in the app menu for Settings
         type: Drawable
         default: mozac_ic_settings
+      string-map:
+        description: A string map that was causing problem
+        type: Map<String, String>
+        default: {}
+      string-int-map:
+        description: A string map that was causing problem
+        type: Map<String, Int>
+        default: {}
+      eum-map:
+        description: A string map that was causing problem
+        type: Map<IconType, Int>
+        default:
+          screenshot: 1
+          letter: 2
+          favicon: 3
   search-term-groups:
     description: A feature allowing the grouping of URLs around the search term that it came from.
     variables:
@@ -70,3 +85,12 @@ types:
             description: The tab groups
           pocket:
             description: The pocket section. This should only be available in the US.
+    IconType:
+      description: The different types of icons
+      variants:
+        screenshot:
+          description: A screenshot icon
+        favicon:
+          description: A favicon icon
+        letter:
+          description: A letter icon

--- a/components/support/nimbus-fml/fixtures/fe/ios.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/ios.yaml
@@ -42,6 +42,21 @@ features:
         description: The drawable displayed in the app menu for Settings
         type: String
         default: "menu-Settings"
+      string-map:
+        description: A string map that was causing problem
+        type: Map<String, String>
+        default: {}
+      string-int-map:
+        description: A string map that was causing problem
+        type: Map<String, Int>
+        default: {}
+      eum-map:
+        description: A string map that was causing problem
+        type: Map<IconType, Int>
+        default:
+          screenshot: 1
+          letter: 2
+          favicon: 3
   homescreen:
     description: The homescreen that the user goes to when they press home or new tab.
     variables:
@@ -93,7 +108,7 @@ types:
           default: ""
           description: "Is the description of spotlight"
           required: true
-        use-html-content: 
+        use-html-content:
           type: Boolean
           default: true
           description: "Describes whether spotlight should use html content"

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
@@ -124,7 +124,7 @@ impl ConcreteCodeOracle {
             TypeIdentifier::EnumMap(ref k_type, ref v_type) => {
                 Box::new(structural::MapCodeType::new(k_type, v_type))
             }
-            _ => unimplemented!(),
+            _ => unimplemented!("Text and Image are to be implemented in EXP-2147"),
         }
     }
 }

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/structural.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/structural.rs
@@ -232,7 +232,11 @@ impl CodeType for MapCodeType {
             })
             .collect();
 
-        format!("[{}]", src.join(", "))
+        if src.is_empty() {
+            "[:]".to_string()
+        } else {
+            format!("[{}]", src.join(", "))
+        }
     }
 }
 

--- a/components/support/nimbus-fml/src/backends/swift/templates/FeatureTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/FeatureTemplate.swift
@@ -5,9 +5,9 @@
 
 {{ inner.doc()|comment("") }}
 public class {{class_name}} {
-    private var _variables: Variables
-    var _defaults: Defaults
-    init(_ _variables: Variables = NilVariables.instance,_ _defaults: Defaults) {
+    private let _variables: Variables
+    private let _defaults: Defaults
+    private init(_ _variables: Variables = NilVariables.instance,_ _defaults: Defaults) {
         self._variables = _variables
         self._defaults = _defaults
     }


### PR DESCRIPTION
During initial phases of messaging work, @nishant2718 found that `Map<String, String>` produced invalid Swift code. Works fine for `Map<Enum, String>` and `Map<String, T>`.

This PR adds tests and a fix. Issue was Swift's optional chaining is different to Kotlin's safe call.

A A-S release needs to happen before iOS can use this. This does not affect application services code _shipped_ with the app, just tooling.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
