### PR TITLE
Cut release v92.0.1

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 92.0.0
+libraryVersion: 92.0.1
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v92.0.1 (_2022-03-24_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v92.0.0...v92.0.1)
+
+## Nimbus FML ⛅️🔬🔭🔧
+
+### What's Fixed
+
+- Swift: a bug in our understanding of Swift optional chaining rules meant that maps with a mapping and merging produced invalid code. ([#4885](https://github.com/mozilla/application-services/pull/4885))
+
+## General
+
+### What's Changed
+
+- Added documentation of our sqlite pragma usage. ([#4876](https://github.com/mozilla/application-services/pull/4876))
+
 # v92.0.0 (_2022-03-17_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v91.1.0...v92.0.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v92.0.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v92.0.1...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,15 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-
-## Nimbus FML ⛅️🔬🔭🔧
-
-### What's Fixed
-
-- Swift: a bug in our understanding of Swift optional chaining rules meant that maps with a mapping and merging produced invalid code. ([#4885](https://github.com/mozilla/application-services/pull/4885))
-
-## General
-
-### What's Changed
-
-- Added documentation of our sqlite pragma usage. ([#4876](https://github.com/mozilla/application-services/pull/4876))


### PR DESCRIPTION
Creates a patch release (92.0.1) for the Nimbus FML for https://github.com/mozilla/application-services/pull/4885

cc @jhugman
