### PR TITLE
Update tabs component for iOS integration

### DIFF
--- a/components/sync15/ios/SyncUnlockInfo.swift
+++ b/components/sync15/ios/SyncUnlockInfo.swift
@@ -12,12 +12,14 @@ open class SyncUnlockInfo {
     public var syncKey: String
     public var tokenserverURL: String
     public var loginEncryptionKey: String
+    public var tabsLocalId: String
 
-    public init(kid: String, fxaAccessToken: String, syncKey: String, tokenserverURL: String, loginEncryptionKey: String) {
+    public init(kid: String, fxaAccessToken: String, syncKey: String, tokenserverURL: String, loginEncryptionKey: String, tabsLocalId: String) {
         self.kid = kid
         self.fxaAccessToken = fxaAccessToken
         self.syncKey = syncKey
         self.tokenserverURL = tokenserverURL
         self.loginEncryptionKey = loginEncryptionKey
+        self.tabsLocalId = tabsLocalId
     }
 }

--- a/components/tabs/android/src/main/java/mozilla/appservices/tabs/DeviceType.kt
+++ b/components/tabs/android/src/main/java/mozilla/appservices/tabs/DeviceType.kt
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.remotetabs
+
+// We needed to rename the tabs `DeviceType` as it conflicts with the `DeviceType` we are exposing for FxA
+// in iOS. However renaming `DeviceType` to `TabsDeviceType` creates a breaking change for the Android code.
+// So we are aliasing `TabsDeviceType` back to `DeviceType` in order to prevent the breaking change.
+typealias DeviceType = TabsDeviceType

--- a/components/tabs/android/src/main/java/mozilla/appservices/tabs/RemoteTab.kt
+++ b/components/tabs/android/src/main/java/mozilla/appservices/tabs/RemoteTab.kt
@@ -1,0 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.remotetabs
+
+// We needed to rename the Rust `RemoteTab` struct to `RemoteTabRecord` in order to circumvent the naming conflict in
+// iOS with the native `RemoteTab` struct. But that creates a breaking change for the Android code. So we are aliasing
+// `RemoteTabRecord` back to `RemoteTab` to prevent a breaking change.
+typealias RemoteTab = RemoteTabRecord

--- a/components/tabs/ios/Tabs/Tabs.swift
+++ b/components/tabs/ios/Tabs/Tabs.swift
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+open class TabsStorage {
+    private var store: TabsStore
+    private let queue = DispatchQueue(label: "com.mozilla.tabs-storage")
+
+    public init(databasePath: String) {
+        store = TabsStore(path: databasePath)
+    }
+
+    /// Get all tabs by client.
+    open func getAll() -> [ClientRemoteTabs] {
+        return queue.sync {
+            return self.store.getAll()
+        }
+    }
+
+    /// Set the local tabs.
+    open func setLocalTabs(remoteTabs: [RemoteTabRecord]) {
+        queue.sync {
+            self.store.setLocalTabs(remoteTabs: remoteTabs)
+        }
+    }
+
+    open func reset() throws {
+        try queue.sync {
+            try self.store.reset()
+        }
+    }
+
+    open func sync(unlockInfo: SyncUnlockInfo) throws -> String {
+        return try queue.sync {
+            return try self.store
+                .sync(
+                    keyId: unlockInfo.kid,
+                    accessToken: unlockInfo.fxaAccessToken,
+                    syncKey: unlockInfo.syncKey,
+                    tokenserverUrl: unlockInfo.tokenserverURL,
+                    localId: unlockInfo.tabsLocalId
+                )
+        }
+    }
+}

--- a/components/tabs/src/error.rs
+++ b/components/tabs/src/error.rs
@@ -3,9 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #[derive(Debug, thiserror::Error)]
-pub enum ErrorKind {
+pub enum TabsError {
     #[error("Error synchronizing: {0}")]
     SyncAdapterError(#[from] sync15::Error),
+
+    #[error("Sync reset error: {0}")]
+    SyncResetError(#[from] anyhow::Error),
 
     #[error("Error parsing JSON data: {0}")]
     JsonError(#[from] serde_json::Error),
@@ -20,12 +23,4 @@ pub enum ErrorKind {
     OpenDatabaseError(#[from] sql_support::open_database::Error),
 }
 
-error_support::define_error! {
-    ErrorKind {
-        (SyncAdapterError, sync15::Error),
-        (JsonError, serde_json::Error),
-        (UrlParseError, url::ParseError),
-        (SqlError, rusqlite::Error),
-        (OpenDatabaseError, sql_support::open_database::Error),
-    }
-}
+pub type Result<T> = std::result::Result<T, TabsError>;

--- a/components/tabs/src/lib.rs
+++ b/components/tabs/src/lib.rs
@@ -13,10 +13,10 @@ mod sync;
 
 uniffi_macros::include_scaffolding!("tabs");
 
-pub use crate::storage::{ClientRemoteTabs, RemoteTab};
+pub use crate::storage::{ClientRemoteTabs, RemoteTabRecord, TabsDeviceType};
 pub use crate::sync::engine::TabsEngine;
 pub use crate::sync::store::TabsStore;
-pub use error::{Error, ErrorKind, Result};
+use error::TabsError;
 use sync15::DeviceType;
 
 pub use crate::sync::store::get_registered_sync_engine;

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -16,6 +16,9 @@ use sql_support::ConnExt;
 use std::cell::RefCell;
 use std::path::{Path, PathBuf};
 
+pub type TabsDeviceType = crate::DeviceType;
+pub type RemoteTabRecord = RemoteTab;
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RemoteTab {
     pub title: String,

--- a/components/tabs/src/tabs.udl
+++ b/components/tabs/src/tabs.udl
@@ -2,25 +2,41 @@ namespace tabs {
 
 };
 
+[Error]
+enum TabsError {
+    "SyncAdapterError",
+    "SyncResetError",
+    "JsonError",
+    "UrlParseError",
+    "SqlError",
+    "OpenDatabaseError",
+};
+
 
 interface TabsStore {
     constructor(string path);
 
     sequence<ClientRemoteTabs> get_all();
 
-    void set_local_tabs(sequence<RemoteTab> remote_tabs);
+    void set_local_tabs(sequence<RemoteTabRecord> remote_tabs);
 
     [Self=ByArc]
     void register_with_sync_manager();
+
+    [Throws=TabsError, Self=ByArc]
+    void reset();
+
+    [Throws=TabsError, Self=ByArc]
+    string sync(string key_id, string access_token, string sync_key, string tokenserver_url, string local_id);
 };
 
 // Note that this enum is duplicated in fxa-client.udl (although the underlying type *is*
 // shared). This duplication exists because there's no direct dependency between that crate and
 // this one. We can probably remove the duplication when sync15 gets a .udl file, then we could
 // reference it via an `[Extern=...]typedef`
-enum DeviceType { "Desktop", "Mobile", "Tablet", "VR", "TV", "Unknown" };
+enum TabsDeviceType { "Desktop", "Mobile", "Tablet", "VR", "TV", "Unknown" };
 
-dictionary RemoteTab {
+dictionary RemoteTabRecord {
     string title;
     sequence<string> url_history;
     string? icon;
@@ -30,6 +46,6 @@ dictionary RemoteTab {
 dictionary ClientRemoteTabs {
     string client_id;
     string client_name;
-    DeviceType device_type;
-    sequence<RemoteTab> remote_tabs;
+    TabsDeviceType device_type;
+    sequence<RemoteTabRecord> remote_tabs;
 };

--- a/examples/cli-support/src/fxa_creds.rs
+++ b/examples/cli-support/src/fxa_creds.rs
@@ -78,7 +78,7 @@ pub fn get_default_fxa_config() -> Config {
     Config::release(CLIENT_ID, REDIRECT_URI)
 }
 
-fn get_account_and_token(
+pub fn get_account_and_token(
     config: Config,
     cred_file: &str,
 ) -> Result<(FirefoxAccount, AccessTokenInfo)> {


### PR DESCRIPTION
This PR includes a few updates to the tab component to allow the integration of the tabs component in iOS. It includes:

- Resolving the naming conflict of the `DeviceType` enum that is exposed in FxA and Tabs which prevented `rust-components-swift` from generating Tabs code
- Exposing the tabs `reset` function and errors
- Updating the sync function's parameters to match the `SyncUnlockInfo` parameters
- Fixing the tabs sync example

**Note:** This PR blocks [RCS PR #58](https://github.com/mozilla/rust-components-swift/pull/58) and [Firefox iOS PR #10553](https://github.com/mozilla-mobile/firefox-ios/pull/10553).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
