### PR TITLE
Downgrade places api log from error to warn

### DIFF
--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -51,7 +51,7 @@ pub fn get_registered_sync_engine(engine_id: &SyncEngineId) -> Option<Box<dyn Sy
         Some(places_api) => match create_sync_engine(&places_api, engine_id) {
             Ok(engine) => Some(engine),
             Err(e) => {
-                log::error!("places: get_registered_sync_engine: {}", e);
+                log::warn!("places: get_registered_sync_engine: {}", e);
                 None
             }
         },


### PR DESCRIPTION
The reason this is getting downgraded is due to the current state of what's happening https://github.com/mozilla/application-services/issues/4856

Summary steps:
1. Android calls tabs engine sync only (for MR1 homescreen sync work)
2. sync manager eventually calls `iter_registered_engines` which calls every engine
  - This causes each engine to run `get_registered_sync_engine`
    - most engines will return None if the engine lost it's connection
    - However, places runs a `log:error` which what is hitting sentry
3. Sync manager filters based on SyncEngineSelection
4. tabs successfully sync 

While there is a bigger discussion to be had about what `iter_registered_engines` should be doing but for now, we should lower how noisy sentry is becoming with this patch.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
