### PR TITLE
Fix fml optional enums and objects

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,6 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Nimbus FML
+- Bug fix where optional enums and objects in both Kotlin and Swift did not work properly and failed to compile due to a type mismatch.

--- a/components/support/nimbus-fml/fixtures/fe/dx_improvements.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/dx_improvements.yaml
@@ -24,6 +24,24 @@ features:
           alice: 11
           bob: 22
           charlie: 33
+      an-optional-object:
+        description: An optional object
+        type: Option<TestObject>
+        default: null
+      an-optional-enum:
+        description: An optional enum
+        type: Option<TestEnum>
+        default: null
+      non-null-optional-object:
+        description: An optional object
+        type: Option<TestObject>
+        default:
+          name: Optional Object
+          optional-int: 9
+      non-null-optional-enum:
+        description: An optional object
+        type: Option<TestEnum>
+        default: alice
     defaults: []
 objects:
   TestObject:

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/ObjectTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/ObjectTemplate.kt
@@ -6,8 +6,10 @@
 public class {{ class_name }}
     {% call kt::render_class_body(inner) %}
 
-    internal fun _mergeWith(defaults: {{class_name}}): {{class_name}} =
-        {{class_name}}(_variables = this._variables, _defaults = defaults._defaults)
+    internal fun _mergeWith(defaults: {{class_name}}?): {{class_name}} =
+        defaults?.let {
+            {{class_name}}(_variables = this._variables, _defaults = it._defaults)
+        } ?: this
 
     companion object {
         internal fun create(variables: Variables): {{class_name}}? =

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/object.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/object.rs
@@ -47,11 +47,17 @@ impl CodeType for ObjectCodeType {
             getter
         };
 
-        if let Some(merger) = self.value_merger(oracle, default) {
-            format!("{getter}.{merger}", getter = getter, merger = merger)
+        let getter = if let Some(merger) = self.value_merger(oracle, default) {
+            format!("{getter}?.{merger}", getter = getter, merger = merger)
         } else {
             getter
-        }
+        };
+
+        format!(
+            "{getter} ?? {fallback}",
+            getter = getter,
+            fallback = default
+        )
     }
 
     fn value_getter(
@@ -269,7 +275,8 @@ mod unit_tests {
     fn test_getter_with_fallback() {
         let ct = code_type("AnObject");
         assert_eq!(
-            r#"AnObject.create(vars.getVariables("the-property"))._mergeWith(default)"#.to_string(),
+            r#"AnObject.create(vars.getVariables("the-property"))?._mergeWith(default) ?? default"#
+                .to_string(),
             getter_with_fallback(&*ct, &"vars", &"the-property", &"default")
         );
     }

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/structural.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/structural.rs
@@ -67,6 +67,10 @@ impl CodeType for OptionalCodeType {
         code_type::value_mapper(self, oracle)
     }
 
+    fn value_merger(&self, oracle: &dyn CodeOracle, default: &dyn Display) -> Option<String> {
+        oracle.find(&self.inner).value_merger(oracle, default)
+    }
+
     /// The name of the type as it's represented in the `Variables` object.
     /// The string return may be used to combine with an indentifier, e.g. a `Variables` method name.
     fn create_transform(&self, oracle: &dyn CodeOracle) -> Option<String> {

--- a/components/support/nimbus-fml/src/backends/swift/templates/ObjectTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/ObjectTemplate.swift
@@ -4,12 +4,20 @@
 {% let class_name = inner.name()|class_name -%}
 
 public extension {{class_name}} {
-    func _mergeWith(_ defaults: {{class_name}}) -> {{class_name}} {
-        return {{class_name}}(variables: self._variables, defaults: defaults._defaults)
+    func _mergeWith(_ defaults: {{class_name}}?) -> {{class_name}} {
+        if let defaults = defaults {
+            return {{class_name}}(variables: self._variables, defaults: defaults._defaults)
+        }
+        // This will only happen in optional objects where their defaults is nil
+        // no merging is required, we simply return this instance
+        return self
     }
 
-    static func create(_ variables: Variables?) -> {{class_name}} {
-        return {{class_name}}(variables ?? NilVariables.instance)
+    static func create(_ variables: Variables?) -> {{class_name}}? {
+        if let variables = variables {
+            return {{class_name}}(variables)
+        }
+        return nil
     }
 
     static func mergeWith(_ overrides: {{class_name}}, _ defaults: {{class_name}}) -> {{class_name}} {

--- a/components/support/nimbus-fml/src/workflows.rs
+++ b/components/support/nimbus-fml/src/workflows.rs
@@ -247,6 +247,17 @@ mod test {
     }
 
     #[test]
+    fn test_with_dx_improvements_swift() -> Result<()> {
+        generate_and_assert(
+            "test/dx_improvements_testing.swift",
+            "fixtures/fe/dx_improvements.yaml",
+            "testing",
+            false,
+        )?;
+        Ok(())
+    }
+
+    #[test]
     fn test_with_app_menu() -> Result<()> {
         generate_and_assert(
             "test/app_menu.kts",

--- a/components/support/nimbus-fml/test/dx_improvements_testing.kts
+++ b/components/support/nimbus-fml/test/dx_improvements_testing.kts
@@ -22,3 +22,15 @@ assert(obj.enumMap == mapOf(TestEnum.ALICE to 1, TestEnum.BOB to 2, TestEnum.CHA
 
 // The instance of test object which is specified in the feature has an overridden enum map.
 assert(feature.anObject.enumMap == mapOf(TestEnum.ALICE to 11, TestEnum.BOB to 2, TestEnum.CHARLIE to 3)) { feature.anObject.enumMap }
+
+// Optional enums are handled properly and can default to null
+assert(feature.anOptionalEnum == null)
+
+// Optional objects are handled properly and can default to null
+assert(feature.anOptionalObject == null)
+
+// Optional enums can default to their variants properly
+assert(feature.nonNullOptionalEnum == TestEnum.ALICE)
+
+// Optional Object can default to a non-null object properly
+assert(feature.nonNullOptionalObject!!.optionalInt == 9)

--- a/components/support/nimbus-fml/test/dx_improvements_testing.swift
+++ b/components/support/nimbus-fml/test/dx_improvements_testing.swift
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import FeatureManifest
+import Foundation
+
+let nimbus = MyNimbus.shared;
+let feature = nimbus.features.testFeature.value()
+
+
+// A feature variable which is an enum map should have all variants represented
+assert(feature.anEnumMap == [TestEnum.alice:  11, TestEnum.bob: 22, TestEnum.charlie: 33])
+
+// An empty test object should have all variants represented
+let obj = TestObject()
+assert(obj.enumMap == [TestEnum.alice: 1, TestEnum.bob: 2, TestEnum.charlie: 3])
+
+// The instance of test object which is specified in the feature has an overridden enum map.
+assert(feature.anObject.enumMap == [TestEnum.alice: 11, TestEnum.bob: 2, TestEnum.charlie: 3])
+
+// Optional enums are handled properly and can default to null
+assert(feature.anOptionalEnum == nil)
+
+// Optional objects are handled properly and can default to null
+
+assert(feature.anOptionalObject == nil)
+
+// Optional enums can default to their variants properly
+assert(feature.nonNullOptionalEnum == TestEnum.alice)
+
+// Optional Object can default to a non-null object properly
+assert(feature.nonNullOptionalObject!.optionalInt == 9)


### PR DESCRIPTION
@bendk caught a bug where optional enums generated code that didn't compile which prevented us from upgrading AS in Fenix

I'm concerned that we didn't catch this earlier, especially with https://github.com/mozilla-mobile/fenix/blob/main/nimbus.fml.yaml#L71 in Fenix having an optional enum - @jhugman is it possible that this broke recently (I don't think so?)

Regardless this PR attempts to fix the problem and adds test coverage for optionals (including enums and objects)
