### PR TITLE
Bump up wrongly downgraded error

### DIFF
--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -51,7 +51,7 @@ pub fn get_registered_sync_engine(engine_id: &SyncEngineId) -> Option<Box<dyn Sy
         Some(places_api) => match create_sync_engine(&places_api, engine_id) {
             Ok(engine) => Some(engine),
             Err(e) => {
-                log::warn!("places: get_registered_sync_engine: {}", e);
+                log::error!("places: get_registered_sync_engine: {}", e);
                 None
             }
         },


### PR DESCRIPTION
This has the correct error to be downgraded (already in v91.1.2 release). However the previous PR https://github.com/mozilla/application-services/pull/4907 downgraded the wrong error. This fix is only to undo that before the eventual v93 release.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
