### PR TITLE
Fixup missing mapper when working with optionals

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,8 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Nimbus FML ⛅️🔬🔭🔧
+
+### What's Fixed
+  - Handling of optional types which require a mapping to a usable type. ([#4915](https://github.com/mozilla/application-services/pull/4915))

--- a/components/nimbus/ios/Nimbus/Collections+.swift
+++ b/components/nimbus/ios/Nimbus/Collections+.swift
@@ -96,3 +96,17 @@ public extension Array where Element == Bundle {
         return nil
     }
 }
+
+/// Convenience extensions to make working elements coming from the `Variables`
+/// object slightly easier/regular.
+extension String {
+    func map<V>(_ transform: (Self) throws -> V?) rethrows -> V? {
+        return try transform(self)
+    }
+}
+
+extension Variables {
+    func map<V>(_ transform: (Self) throws -> V) rethrows -> V {
+        return try transform(self)
+    }
+}

--- a/components/support/nimbus-fml/fixtures/fe/fenix.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/fenix.yaml
@@ -52,16 +52,44 @@ features:
         type: Map<String, String>
         default: {}
       string-int-map:
-        description: A string map that was causing problem
+        description: A int map that was causing problem
         type: Map<String, Int>
         default: {}
+      icon-type:
+        type: Option<IconType>
+        default: letter
+        description: "Describes the icon of spotlight"
       eum-map:
-        description: A string map that was causing problem
+        description: A enum map that was causing problem
         type: Map<IconType, Int>
         default:
           screenshot: 1
           letter: 2
           favicon: 3
+      nested:
+        description: Test of single nested object
+        type: ValidationObject
+        default:
+          is-useful: true
+      nested-optional:
+        description: Test of optional nested object
+        type: Option<ValidationObject>
+        default: null
+      nested-list:
+        description: Test of list of nested object
+        type: List<ValidationObject>
+        default: []
+      nested-map:
+        description: Test of map of nested object
+        type: Map<String, ValidationObject>
+        default: {}
+      nested-enum-map:
+        description: Test of map of nested object
+        type: Map<IconType, ValidationObject>
+        default:
+          screenshot: {}
+          letter: {}
+          favicon: {}
   search-term-groups:
     description: A feature allowing the grouping of URLs around the search term that it came from.
     variables:
@@ -70,7 +98,14 @@ features:
         type: Boolean
         default: false
 types:
-  objects: {}
+  objects:
+    ValidationObject:
+      description: Used in NimbusValidation
+      fields:
+        is-useful:
+          description: Is this useful?
+          type: Boolean
+          default: false
   enums:
     HomeScreenSection:
         description: The identifiers for the sections of the homescreen.

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/structural.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/structural.rs
@@ -66,6 +66,21 @@ impl CodeType for OptionalCodeType {
         oracle.find(&self.inner).variables_type(oracle)
     }
 
+    /// The method call here will use the `create_transform` to transform the value coming out of
+    /// the `Variables` object into the desired type.
+    fn value_mapper(&self, oracle: &dyn CodeOracle) -> Option<String> {
+        oracle.find(&self.inner).value_mapper(oracle)
+    }
+
+    /// The method call to merge the value with the defaults.
+    ///
+    /// This may use the `merge_transform`.
+    ///
+    /// If this returns `None`, no merging happens, and implicit `null` replacement happens.
+    fn value_merger(&self, oracle: &dyn CodeOracle, default: &dyn Display) -> Option<String> {
+        oracle.find(&self.inner).value_merger(oracle, default)
+    }
+
     fn defaults_type(&self, oracle: &dyn CodeOracle) -> String {
         let inner = oracle.find(&self.inner).defaults_type(oracle);
         format!("{}?", inner)

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/ObjectTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/ObjectTemplate.kt
@@ -6,8 +6,8 @@
 public class {{ class_name }}
     {% call kt::render_class_body(inner) %}
 
-    internal fun _mergeWith(defaults: {{class_name}}): {{class_name}} =
-        {{class_name}}(_variables = this._variables, _defaults = defaults._defaults)
+    internal fun _mergeWith(defaults: {{class_name}}?): {{class_name}} =
+        defaults?.let { {{class_name}}(_variables = this._variables, _defaults = it._defaults) } ?: this
 
     companion object {
         internal fun create(variables: Variables): {{class_name}}? =

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/enum_.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/enum_.rs
@@ -36,24 +36,7 @@ impl CodeType for EnumCodeType {
         prop: &dyn Display,
         default: &dyn Display,
     ) -> String {
-        let getter = self.value_getter(oracle, vars, prop);
-        let getter = if let Some(mapper) = self.value_mapper(oracle) {
-            format!("{mapper}({getter})", getter = getter, mapper = mapper)
-        } else {
-            getter
-        };
-
-        let getter = if let Some(merger) = self.value_merger(oracle, default) {
-            format!("{getter}.{merger}", getter = getter, merger = merger)
-        } else {
-            getter
-        };
-
-        format!(
-            "{getter} ?? {fallback}",
-            getter = getter,
-            fallback = default
-        )
+        code_type::property_getter(self, oracle, vars, prop, default)
     }
 
     fn value_getter(
@@ -66,8 +49,7 @@ impl CodeType for EnumCodeType {
     }
 
     fn value_mapper(&self, oracle: &dyn CodeOracle) -> Option<String> {
-        let transform = self.create_transform(oracle)?;
-        Some(transform)
+        code_type::value_mapper(self, oracle)
     }
 
     /// The name of the type as it's represented in the `Variables` object.
@@ -207,7 +189,7 @@ mod unit_tests {
         let oracle = &*oracle();
 
         assert_eq!(
-            r#"AEnum.enumValue(v.getString("the-property")) ?? def"#.to_string(),
+            r#"v.getString("the-property")?.map(AEnum.enumValue) ?? def"#.to_string(),
             ct.property_getter(oracle, &"v", &"the-property", &"def")
         );
     }

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/structural.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/structural.rs
@@ -66,6 +66,21 @@ impl CodeType for OptionalCodeType {
         oracle.find(&self.inner).variables_type(oracle)
     }
 
+    /// The method call here will use the `create_transform` to transform the value coming out of
+    /// the `Variables` object into the desired type.
+    fn value_mapper(&self, oracle: &dyn CodeOracle) -> Option<String> {
+        oracle.find(&self.inner).value_mapper(oracle)
+    }
+
+    /// The method call to merge the value with the defaults.
+    ///
+    /// This may use the `merge_transform`.
+    ///
+    /// If this returns `None`, no merging happens, and implicit `null` replacement happens.
+    fn value_merger(&self, oracle: &dyn CodeOracle, default: &dyn Display) -> Option<String> {
+        oracle.find(&self.inner).value_merger(oracle, default)
+    }
+
     fn defaults_type(&self, oracle: &dyn CodeOracle) -> String {
         format!("{}?", oracle.find(&self.inner).defaults_type(oracle))
     }

--- a/components/support/nimbus-fml/src/backends/swift/templates/ObjectTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/ObjectTemplate.swift
@@ -4,7 +4,10 @@
 {% let class_name = inner.name()|class_name -%}
 
 public extension {{class_name}} {
-    func _mergeWith(_ defaults: {{class_name}}) -> {{class_name}} {
+    func _mergeWith(_ defaults: {{class_name}}?) -> {{class_name}} {
+        guard let defaults = defaults else {
+            return self
+        }
         return {{class_name}}(variables: self._variables, defaults: defaults._defaults)
     }
 


### PR DESCRIPTION
This PR fixes a bug in FML's handling of values of optional types that require mapping to another type. (e.g. enums and objects).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.