### PR TITLE
places: delete_visits_for() now also deletes history metadata when the item is bookmarked

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -6,6 +6,11 @@
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
+## Places
+### What's New
+- The `delete_visits_for()` function now deletes all history metadata even when the item is
+  bookmarked.
+
 Use the template below to make assigning a version number during the release cutting process easier.
 
 ## [Component Name]

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -12,7 +12,9 @@ use crate::history_sync::engine::{
     COLLECTION_SYNCID_META_KEY, GLOBAL_SYNCID_META_KEY, LAST_SYNC_META_KEY,
 };
 use crate::observation::VisitObservation;
-use crate::storage::{delete_meta, delete_pending_temp_tables, get_meta, put_meta};
+use crate::storage::{
+    delete_meta, delete_pending_temp_tables, get_meta, history_metadata, put_meta,
+};
 use crate::types::{SyncStatus, VisitTransition, VisitTransitionSet};
 use rusqlite::types::ToSql;
 use rusqlite::Result as RusqliteResult;
@@ -254,6 +256,9 @@ fn delete_visits_for_in_tx(db: &PlacesDb, guid: &SyncGuid) -> Result<()> {
         PageToClean::from_row,
         true,
     )?;
+    // Note that history metadata has an `ON DELETE CASCADE` for the place ID - so if we
+    // call `delete_page` here, we assume history metadata dies too. Otherwise we
+    // explicitly delete the metadata after we delete the visits themself.
     match to_clean {
         Some(PageToClean {
             id,
@@ -269,6 +274,7 @@ fn delete_visits_for_in_tx(db: &PlacesDb, guid: &SyncGuid) -> Result<()> {
             // definitely intended).
             insert_tombstones_for_all_page_visits(db, id)?;
             delete_all_visits_for_page(db, id)?;
+            history_metadata::delete_all_metadata_for_page(db, id)?;
         }
         Some(PageToClean {
             id,
@@ -291,6 +297,8 @@ fn delete_visits_for_in_tx(db: &PlacesDb, guid: &SyncGuid) -> Result<()> {
             // we still can't delete it; we must delete its visits. But we
             // don't need to write any tombstones for those deleted visits.
             delete_all_visits_for_page(db, id)?;
+            // and we need to delete all history metadata.
+            history_metadata::delete_all_metadata_for_page(db, id)?;
         }
         Some(PageToClean {
             id,
@@ -319,7 +327,8 @@ fn insert_tombstones_for_all_page_visits(db: &PlacesDb, page_id: RowId) -> Resul
     Ok(())
 }
 
-/// Removes all visits from a page.
+/// Removes all visits from a page. DOES NOT remove history_metadata - use
+/// `history_metadata::delete_all_metadata_for_page` for that.
 fn delete_all_visits_for_page(db: &PlacesDb, page_id: RowId) -> Result<()> {
     db.execute_cached(
         "DELETE FROM moz_historyvisits


### PR DESCRIPTION
While looking into #4908, I noticed that `delete_visits_for()` also deleted history_metadata as a side-effect when the `moz_places` row is deleted due to an [`ON DELETE CASCADE`](https://github.com/mozilla/application-services/blob/1f01918d43ba2eba4bac921724f2be26e09ab249/components/places/sql/create_shared_schema.sql#L261) clause. The "problem" is that if the page is bookmarked, the `moz_places` row isn't deleted. This patch fixes that, and adds fairly extensive tests for this case.