### PR TITLE
Add language and region to TargetingAttributes

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,9 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Nimbus ⛅️🔭🔬
+
+### What's New
+  - Added targeting attributes for `language` and `region`, based upon the `locale`. [#4919](https://github.com/mozilla/application-services/pull/4919)
+    - This also comes with an update in the JEXL evaluator to handle cases where `region` is not available.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,9 +1543,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jexl-eval"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c208de9bf204836fe5894bb756cd850075ba3acf3f327d04b656fb84046e1a4"
+checksum = "e2103d20630a3b46bcd30b7cc27632c2d1e62b22fbd45bafb8fb237a00362083"
 dependencies = [
  "anyhow",
  "jexl-parser",
@@ -1556,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "jexl-parser"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e7c453f4c7dde64c914aa5ddd1183fc61dd446112d2b80a7f62390b9f0487c"
+checksum = "4e94562bd4781bba67847daf068de27283bd09d5241fbba824389e9134f0f2ae"
 dependencies = [
  "lalrpop-util",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,9 +1543,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "jexl-eval"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2103d20630a3b46bcd30b7cc27632c2d1e62b22fbd45bafb8fb237a00362083"
+checksum = "70c015085093f5f4836054483386ffcd18500f4816e9178daec7cfea6fb80fab"
 dependencies = [
  "anyhow",
  "jexl-parser",
@@ -1556,9 +1556,9 @@ dependencies = [
 
 [[package]]
 name = "jexl-parser"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e94562bd4781bba67847daf068de27283bd09d5241fbba824389e9134f0f2ae"
+checksum = "ad099b3290c625d9147b51810c0a63b9087e1439039840c9e3f974a2747deb20"
 dependencies = [
  "lalrpop-util",
  "regex",

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -27,7 +27,7 @@ viaduct = { path = "../viaduct" }
 thiserror = "1"
 url = "2.2"
 rkv = "0.17"
-jexl-eval = "0.1.7"
+jexl-eval = "0.2.0"
 uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -27,7 +27,7 @@ viaduct = { path = "../viaduct" }
 thiserror = "1"
 url = "2.2"
 rkv = "0.17"
-jexl-eval = "0.2.0"
+jexl-eval = "0.2.1"
 uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
@@ -15,11 +15,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.robolectric.RobolectricTestRunner
 import java.util.UUID
 import java.util.concurrent.Executors
@@ -59,9 +57,12 @@ class GleanPlumbTests {
         assertTrue(messageHelper.evalJexl("app_name == 'ThatApp'"))
         assertFalse(messageHelper.evalJexl("app_name == 'ppAtahT'"))
 
-        assertThrows("invalid jexl", NimbusException::class.java) {
-            messageHelper.evalJexl("appName == 'ThatApp'")
-        }
+        // The JEXL evaluator handles undefined attributes as `null`.
+        // This https://github.com/mozilla/jexl-rs/issues/24 should be
+        // fixed before enabling the following test.
+        // assertThrows("invalid jexl", NimbusException::class.java) {
+        //     messageHelper.evalJexl("appName == 'ThatApp'")
+        // }
     }
 
     @Test
@@ -85,10 +86,12 @@ class GleanPlumbTests {
                 }""".trimIndent()
         )
 
-        assertThrows("no context, so no variable", NimbusException::class.java) {
-            val messageHelper = nimbus.createMessageHelper()
-            messageHelper.evalJexl("test_value_from_json == 42")
-        }
+        // The JEXL evaluator handles undefined attributes as `null`. This https://github.com/mozilla/jexl-rs/issues/24 should be
+        // fixed before enabling the following test.
+        // assertThrows("no context, so no variable", NimbusException::class.java) {
+        //     val messageHelper = nimbus.createMessageHelper()
+        //     messageHelper.evalJexl("test_value_from_json == 42")
+        // }
 
         val messageHelper = nimbus.createMessageHelper(context)
         assertTrue(

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
@@ -15,9 +15,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.robolectric.RobolectricTestRunner
 import java.util.UUID
 import java.util.concurrent.Executors
@@ -57,12 +59,10 @@ class GleanPlumbTests {
         assertTrue(messageHelper.evalJexl("app_name == 'ThatApp'"))
         assertFalse(messageHelper.evalJexl("app_name == 'ppAtahT'"))
 
-        // The JEXL evaluator handles undefined attributes as `null`.
-        // This https://github.com/mozilla/jexl-rs/issues/24 should be
-        // fixed before enabling the following test.
-        // assertThrows("invalid jexl", NimbusException::class.java) {
-        //     messageHelper.evalJexl("appName == 'ThatApp'")
-        // }
+        // The JEXL evaluator should error for unknown identifiers
+        assertThrows("invalid jexl", NimbusException::class.java) {
+            messageHelper.evalJexl("appName == 'ThatApp'")
+        }
     }
 
     @Test
@@ -86,12 +86,10 @@ class GleanPlumbTests {
                 }""".trimIndent()
         )
 
-        // The JEXL evaluator handles undefined attributes as `null`. This https://github.com/mozilla/jexl-rs/issues/24 should be
-        // fixed before enabling the following test.
-        // assertThrows("no context, so no variable", NimbusException::class.java) {
-        //     val messageHelper = nimbus.createMessageHelper()
-        //     messageHelper.evalJexl("test_value_from_json == 42")
-        // }
+        assertThrows("no context, so no variable", NimbusException::class.java) {
+            val messageHelper = nimbus.createMessageHelper()
+            messageHelper.evalJexl("test_value_from_json == 42")
+        }
 
         val messageHelper = nimbus.createMessageHelper(context)
         assertTrue(

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -352,10 +352,7 @@ fn main() -> Result<()> {
                 // options.
                 let uuid = uuid::Uuid::new_v4();
                 let aru = AvailableRandomizationUnits::with_client_id(&client_id);
-                let targeting_attributes = TargetingAttributes {
-                    app_context: context.clone(),
-                    ..Default::default()
-                };
+                let targeting_attributes = context.clone().into();
                 let enrollment =
                     nimbus::evaluate_enrollment(&uuid, &aru, &targeting_attributes, &exp)?;
                 let key = match enrollment.status.clone() {

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -59,14 +59,6 @@ pub const DB_KEY_INSTALLATION_DATE: &str = "installation-date";
 pub const DB_KEY_UPDATE_DATE: &str = "update-date";
 pub const DB_KEY_APP_VERSION: &str = "app-version";
 
-impl From<AppContext> for TargetingAttributes {
-    fn from(app_context: AppContext) -> Self {
-        Self {
-            app_context,
-            ..Default::default()
-        }
-    }
-}
 // The main `NimbusClient` struct must not expose any methods that make an `&mut self`,
 // in order to be compatible with the uniffi's requirements on objects. This is a helper
 // struct to contain the bits that do actually need to be mutable, so they can be

--- a/components/nimbus/src/tests/test_evaluator.rs
+++ b/components/nimbus/src/tests/test_evaluator.rs
@@ -380,7 +380,9 @@ fn test_targeting_custom_targeting_attributes() {
     .into();
     assert!(matches!(
         targeting(expression_statement, &targeting_attributes),
-        Some(EnrollmentStatus::NotEnrolled { reason: NotEnrolledReason::NotTargeted })
+        Some(EnrollmentStatus::NotEnrolled {
+            reason: NotEnrolledReason::NotTargeted
+        })
     ));
 }
 

--- a/components/nimbus/src/tests/test_evaluator.rs
+++ b/components/nimbus/src/tests/test_evaluator.rs
@@ -378,11 +378,10 @@ fn test_targeting_custom_targeting_attributes() {
         ..Default::default()
     }
     .into();
+    // We haven't defined `is_first_run` here, so this should error out, i.e. return an error.
     assert!(matches!(
         targeting(expression_statement, &targeting_attributes),
-        Some(EnrollmentStatus::NotEnrolled {
-            reason: NotEnrolledReason::NotTargeted
-        })
+        Some(EnrollmentStatus::Error { .. })
     ));
 }
 

--- a/components/nimbus/src/tests/test_lib.rs
+++ b/components/nimbus/src/tests/test_lib.rs
@@ -348,6 +348,7 @@ fn test_days_since_install() -> Result<()> {
         days_since_install: Some(10),
         days_since_update: None,
         is_already_enrolled: false,
+        ..Default::default()
     };
     client.with_targeting_attributes(targeting_attributes);
     client.initialize()?;
@@ -425,6 +426,7 @@ fn test_days_since_install_failed_targeting() -> Result<()> {
         days_since_install: Some(10),
         days_since_update: None,
         is_already_enrolled: false,
+        ..Default::default()
     };
     client.with_targeting_attributes(targeting_attributes);
     client.initialize()?;
@@ -501,6 +503,7 @@ fn test_days_since_update() -> Result<()> {
         days_since_install: None,
         days_since_update: Some(10),
         is_already_enrolled: false,
+        ..Default::default()
     };
     client.with_targeting_attributes(targeting_attributes);
     client.initialize()?;
@@ -578,6 +581,7 @@ fn test_days_since_update_failed_targeting() -> Result<()> {
         days_since_install: None,
         days_since_update: Some(10),
         is_already_enrolled: false,
+        ..Default::default()
     };
     client.with_targeting_attributes(targeting_attributes);
     client.initialize()?;

--- a/components/nimbus/tests/common/mod.rs
+++ b/components/nimbus/tests/common/mod.rs
@@ -37,6 +37,7 @@ fn new_test_client_internal(
         app_name: "fenix".to_string(),
         app_id: "org.mozilla.fenix".to_string(),
         channel: "nightly".to_string(),
+        locale: Some("en-GB".to_string()),
         ..Default::default()
     };
     NimbusClient::new(ctx, tmp_dir.path(), Some(config), aru)

--- a/components/nimbus/tests/test_message_helpers.rs
+++ b/components/nimbus/tests/test_message_helpers.rs
@@ -35,7 +35,7 @@ mod message_tests {
         assert!(!helper.eval_jexl("app_name == 'xinef'".to_string())?);
 
         // The expression contains a variable not declared (snek_case Good, camelCase Bad)
-        assert!(helper.eval_jexl("appName == 'fenix'".to_string()).is_err());
+        assert!(!helper.eval_jexl("appName == 'fenix'".to_string())?);
 
         let helper = nimbus.create_targeting_helper(
             json!(
@@ -62,6 +62,53 @@ mod message_tests {
     }
 
     #[test]
+    fn test_derived_targeting_attributes_available()  -> Result<()> {
+        let nimbus = common::new_test_client("jexl_test")?;
+        nimbus.initialize()?;
+
+        let helper = nimbus.create_targeting_helper(None)?;
+
+        assert!(helper.eval_jexl(
+            "locale == 'en-GB'".to_string()
+        )?);
+
+        assert!(helper.eval_jexl(
+            "language == 'en'".to_string()
+        )?);
+
+        assert!(helper.eval_jexl(
+            "region == 'GB'".to_string()
+        )?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_derived_targeting_attributes_none()  -> Result<()> {
+        let mut nimbus = common::new_test_client("jexl_test")?;
+        nimbus.initialize()?;
+
+        nimbus.with_targeting_attributes(
+            Default::default()
+        );
+
+        let helper = nimbus.create_targeting_helper(None)?;
+
+        assert!(!helper.eval_jexl(
+            "(locale||'NONE') == 'en'".to_string()
+        )?);
+
+        // assert!(helper.eval_jexl(
+        //     "language == null".to_string()
+        // )?);
+
+        // assert!(helper.eval_jexl(
+        //     "region == null".to_string()
+        // )?);
+
+        Ok(())
+    }
+    #[test]
     fn test_jexl_expression_with_targeting_attributes() -> Result<()> {
         let mut nimbus = common::new_test_client("jexl_test_days_since")?;
         nimbus.initialize()?;
@@ -84,6 +131,7 @@ mod message_tests {
             days_since_install: Some(10),
             days_since_update: Some(5),
             is_already_enrolled: false,
+            ..Default::default()
         };
 
         nimbus.with_targeting_attributes(targeting_attributes);

--- a/components/nimbus/tests/test_message_helpers.rs
+++ b/components/nimbus/tests/test_message_helpers.rs
@@ -62,41 +62,31 @@ mod message_tests {
     }
 
     #[test]
-    fn test_derived_targeting_attributes_available()  -> Result<()> {
+    fn test_derived_targeting_attributes_available() -> Result<()> {
         let nimbus = common::new_test_client("jexl_test")?;
         nimbus.initialize()?;
 
         let helper = nimbus.create_targeting_helper(None)?;
 
-        assert!(helper.eval_jexl(
-            "locale == 'en-GB'".to_string()
-        )?);
+        assert!(helper.eval_jexl("locale == 'en-GB'".to_string())?);
 
-        assert!(helper.eval_jexl(
-            "language == 'en'".to_string()
-        )?);
+        assert!(helper.eval_jexl("language == 'en'".to_string())?);
 
-        assert!(helper.eval_jexl(
-            "region == 'GB'".to_string()
-        )?);
+        assert!(helper.eval_jexl("region == 'GB'".to_string())?);
 
         Ok(())
     }
 
     #[test]
-    fn test_derived_targeting_attributes_none()  -> Result<()> {
+    fn test_derived_targeting_attributes_none() -> Result<()> {
         let mut nimbus = common::new_test_client("jexl_test")?;
         nimbus.initialize()?;
 
-        nimbus.with_targeting_attributes(
-            Default::default()
-        );
+        nimbus.with_targeting_attributes(Default::default());
 
         let helper = nimbus.create_targeting_helper(None)?;
 
-        assert!(!helper.eval_jexl(
-            "(locale||'NONE') == 'en'".to_string()
-        )?);
+        assert!(!helper.eval_jexl("(locale||'NONE') == 'en'".to_string())?);
 
         // assert!(helper.eval_jexl(
         //     "language == null".to_string()

--- a/components/nimbus/tests/test_message_helpers.rs
+++ b/components/nimbus/tests/test_message_helpers.rs
@@ -35,7 +35,7 @@ mod message_tests {
         assert!(!helper.eval_jexl("app_name == 'xinef'".to_string())?);
 
         // The expression contains a variable not declared (snek_case Good, camelCase Bad)
-        assert!(!helper.eval_jexl("appName == 'fenix'".to_string())?);
+        assert!(helper.eval_jexl("appName == 'fenix'".to_string()).is_err());
 
         let helper = nimbus.create_targeting_helper(
             json!(

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/GleanPlumbTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/GleanPlumbTests.swift
@@ -33,10 +33,8 @@ class GleanPlumbTests: XCTestCase {
         XCTAssertTrue(try helper.evalJexl(expression: "app_name == 'GleanPlumbTest'"))
         XCTAssertFalse(try helper.evalJexl(expression: "app_name == 'tseTbmulPnaelG'"))
 
-        // The JEXL evaluator handles undefined attributes as `null`.
-        // This https://github.com/mozilla/jexl-rs/issues/24 should be
-        // fixed before enabling the following test.
-        // XCTAssertThrowsError(try helper.evalJexl(expression: "appName == 'snake_case_only'"))
+        // The JEXL evaluator should error for unknown identifiers
+        XCTAssertThrowsError(try helper.evalJexl(expression: "appName == 'snake_case_only'"))
     }
 
     func testJexlHelperWithJsonSerialization() throws {
@@ -54,10 +52,9 @@ class GleanPlumbTests: XCTestCase {
 
         // Snake case only
         XCTAssertTrue(try helper.evalJexl(expression: "test_value_from_json == 42"))
-        // The JEXL evaluator handles undefined attributes as `null`.
-        // This https://github.com/mozilla/jexl-rs/issues/24 should be
-        // fixed before enabling the following test.
-        // XCTAssertThrowsError(try helper.evalJexl(expression: "testValueFromJson == 42"))
+        // Codable's encode in snake case, so even if the codable is mixed case,
+        // the JEXL must use snake case.
+        XCTAssertThrowsError(try helper.evalJexl(expression: "testValueFromJson == 42"))
     }
 
     func testStringHelperWithJsonSerialization() throws {

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/GleanPlumbTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/GleanPlumbTests.swift
@@ -33,7 +33,10 @@ class GleanPlumbTests: XCTestCase {
         XCTAssertTrue(try helper.evalJexl(expression: "app_name == 'GleanPlumbTest'"))
         XCTAssertFalse(try helper.evalJexl(expression: "app_name == 'tseTbmulPnaelG'"))
 
-        XCTAssertThrowsError(try helper.evalJexl(expression: "appName == 'snake_case_only'"))
+        // The JEXL evaluator handles undefined attributes as `null`.
+        // This https://github.com/mozilla/jexl-rs/issues/24 should be
+        // fixed before enabling the following test.
+        // XCTAssertThrowsError(try helper.evalJexl(expression: "appName == 'snake_case_only'"))
     }
 
     func testJexlHelperWithJsonSerialization() throws {
@@ -51,7 +54,10 @@ class GleanPlumbTests: XCTestCase {
 
         // Snake case only
         XCTAssertTrue(try helper.evalJexl(expression: "test_value_from_json == 42"))
-        XCTAssertThrowsError(try helper.evalJexl(expression: "testValueFromJson == 42"))
+        // The JEXL evaluator handles undefined attributes as `null`.
+        // This https://github.com/mozilla/jexl-rs/issues/24 should be
+        // fixed before enabling the following test.
+        // XCTAssertThrowsError(try helper.evalJexl(expression: "testValueFromJson == 42"))
     }
 
     func testStringHelperWithJsonSerialization() throws {


### PR DESCRIPTION
Fixes [EXP-2322][1], for adding `language`.
Fixes [EXP-2351][2], for adding `region`.

Also relevant: https://github.com/mozilla/jexl-rs/pull/23

[1]: https://mozilla-hub.atlassian.net/browse/EXP-2322
[2]: https://mozilla-hub.atlassian.net/browse/EXP-2315

This calculates the region and language from the locale.

Ready for new JEXL evaluator

Update jexl-evaluator

Ensure TargetingAttributes use AppContext.into()


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.