### PR TITLE
Fixes map on String and Variables being internal

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,7 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Nimbus FML
+### What's fixed
+- (iOS only) Made the extensions on `String` and `Variables` public. The extended functions are used in the generated code and that didn't compile in consumers when internal.

--- a/components/nimbus/ios/Nimbus/Collections+.swift
+++ b/components/nimbus/ios/Nimbus/Collections+.swift
@@ -99,13 +99,13 @@ public extension Array where Element == Bundle {
 
 /// Convenience extensions to make working elements coming from the `Variables`
 /// object slightly easier/regular.
-extension String {
+public extension String {
     func map<V>(_ transform: (Self) throws -> V?) rethrows -> V? {
         return try transform(self)
     }
 }
 
-extension Variables {
+public extension Variables {
     func map<V>(_ transform: (Self) throws -> V) rethrows -> V {
         return try transform(self)
     }


### PR DESCRIPTION
Trying to upgrade ios to 93.0.1 in https://github.com/mozilla-mobile/firefox-ios/pull/10297 the build failed with this error
it's only an issue with 93.0.1


I'll cut 93.0.2 after this lands and get it bumped over there