### PR TITLE
Cut release v93.0.2

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 93.0.1
+libraryVersion: 93.0.2
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v93.0.2 (_2022-04-25_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.1...v93.0.2)
+
+## Nimbus FML
+### What's fixed
+- (iOS only) Made the extensions on `String` and `Variables` public. The extended functions are used in the generated code and that didn't compile in consumers when internal.
+
 # v93.0.1 (_2022-04-20_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.0...v93.0.1)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.1...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.2...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,7 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-
-## Nimbus FML
-### What's fixed
-- (iOS only) Made the extensions on `String` and `Variables` public. The extended functions are used in the generated code and that didn't compile in consumers when internal.


### PR DESCRIPTION
Cuts release 93.0.2 with a [patch to fix an iOS build problem](https://github.com/mozilla/application-services/pull/4920) that was caused by nimbus FML code