### PR TITLE
Makes GetSdk public for FeatureHolder

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,6 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+## Nimbus
+### What's fixed
+- Fixed a bug where the visibility of `GetSdk` was internal and it was used in generated FML code. ([#4927](https://github.com/mozilla/application-services/pull/4927))

--- a/components/nimbus/ios/Nimbus/FeatureHolder.swift
+++ b/components/nimbus/ios/Nimbus/FeatureHolder.swift
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-typealias GetSdk = () -> FeaturesInterface?
+public typealias GetSdk = () -> FeaturesInterface?
 
 public class FeatureHolder<T> {
     private let getSdk: GetSdk


### PR DESCRIPTION
`GetSdk` is used in the generated FML code and isn't public - tried building 93.0.3 locally and it failed with this build error

cc @jhugman, we might need to change up our tests to make it so the visibility is the same as the end app
