### PR TITLE
[ci full] Remove unused unlock_notify feature from rustqlite.

### DIFF
--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -28,7 +28,7 @@ url = { version = "2.2", features = ["serde"] }
 
 [dependencies.rusqlite]
 version = "0.27.0"
-features = ["functions", "bundled", "serde_json", "unlock_notify"]
+features = ["functions", "bundled", "serde_json"]
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -30,7 +30,7 @@ uniffi_macros = "^0.17"
 
 [dependencies.rusqlite]
 version = "0.27.0"
-features = ["sqlcipher", "limits", "unlock_notify"]
+features = ["sqlcipher", "limits"]
 
 [build-dependencies]
 uniffi_build = { version = "^0.17", features=["builtin-bindgen"] }

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -36,7 +36,7 @@ uniffi_macros = "^0.17"
 
 [dependencies.rusqlite]
 version = "0.27.0"
-features = ["functions", "window", "bundled", "unlock_notify"]
+features = ["functions", "window", "bundled"]
 
 [dev-dependencies]
 pretty_assertions = "0.6"

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -14,7 +14,7 @@ bincode = "1.2"
 lazy_static = "1.4"
 base64 = "0.12"
 log = "0.4"
-rusqlite = { version = "0.27.0", features = ["bundled", "unlock_notify"] }
+rusqlite = { version = "0.27.0", features = ["bundled"] }
 url = "2.2"
 viaduct = { path = "../viaduct" }
 sql-support = { path = "../support/sql" }

--- a/components/support/interrupt/Cargo.toml
+++ b/components/support/interrupt/Cargo.toml
@@ -11,4 +11,4 @@ parking_lot = "0.5"
 
 [dependencies.rusqlite]
 version = "0.27.0"
-features = ["functions", "limits", "bundled", "unlock_notify"]
+features = ["functions", "limits", "bundled"]

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -18,7 +18,7 @@ tempfile = "3.1.0"
 
 [dependencies.rusqlite]
 version = "0.27.0"
-features = ["functions", "limits", "bundled", "unlock_notify"]
+features = ["functions", "limits", "bundled"]
 
 [dev-dependencies]
 env_logger = {version = "0.7", default-features = false}

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -12,7 +12,7 @@ error-support = { path = "../support/error" }
 interrupt-support = { path = "../support/interrupt" }
 lazy_static = "1.4"
 log = "0.4"
-rusqlite = { version = "0.27.0", features = ["bundled", "unlock_notify"] }
+rusqlite = { version = "0.27.0", features = ["bundled"] }
 serde = "1"
 serde_derive = "1"
 serde_json = "1"

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -25,7 +25,7 @@ url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
 version = "0.27.0"
-features = ["functions", "bundled", "serde_json", "unlock_notify", "column_decltype"]
+features = ["functions", "bundled", "serde_json", "column_decltype"]
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }

--- a/examples/autofill-utils/Cargo.toml
+++ b/examples/autofill-utils/Cargo.toml
@@ -17,7 +17,7 @@ cli-support = { path = "../cli-support" }
 fxa-client = { path = "../../components/fxa-client" }
 interrupt-support = { path = "../../components/support/interrupt" } # XXX - should be removed once we do interrupts correctly!
 log = "0.4"
-rusqlite = {version = "0.27.0", features = ["functions", "bundled", "serde_json", "unlock_notify"]}
+rusqlite = {version = "0.27.0", features = ["functions", "bundled", "serde_json"]}
 serde_json = "1"
 sql-support = { path = "../../components/support/sql" }
 structopt = "0.3"


### PR DESCRIPTION
This was causing my build to fail locally with an undefined reference to
sqlite3_unlock_notify. It seems nothing makes use of this feature tho.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: No behavior change.
- [x] **Changelog**: Probably not worth putting this in the changelog.
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
