### PR TITLE
Add extra locking and caching to FeatureHolder

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,9 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+## Nimbus ⛅️🔬🔭
+
+### What's New
+  - New API in the `FeatureHolder`, both iOS and Android to control the output of the `value()` call:
+    - to cache the values given to callers; this can be cleared with `FxNimbus.invalidatedCachedValues()`
+    - to add a custom initializer with `with(initializer:_)`/`withInitializer(_)`.

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
@@ -1,5 +1,10 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package org.mozilla.experiments.nimbus.internal
 
+import android.content.Context
 import org.mozilla.experiments.nimbus.FeaturesInterface
 import org.mozilla.experiments.nimbus.Variables
 import org.mozilla.experiments.nimbus.NullVariables
@@ -27,11 +32,15 @@ class FeatureHolder<T>(
      * in the feature manifest. This is done each call of the method, so the method should be called once, and the
      * result used for the configuration of the feature.
      *
+     * The unused parameter `Context` was relevant for `Text` and `Image` typed properties, but is no longer necessary.
+     * It will be removed in later releases.
+     *
      * @returns T
      * @throws NimbusFeatureException thrown before the Nimbus object has been constructed or `FxNimbus.initialize` has not been set.
      * This can be resolved by setting `FxNimbus.initialize`, and after that by passing in a `Context` object.
      */
-    fun value(): T =
+    @Suppress("UNUSED_PARAMETER")
+    fun value(context: Context? = null): T =
         lock.runBlock {
             if (cachedValue != null) {
                 cachedValue!!
@@ -51,12 +60,22 @@ class FeatureHolder<T>(
         getSdk()?.recordExposureEvent(featureId)
     }
 
+    /**
+     * This overwrites the cached value with the passed one.
+     *
+     * This is most likely useful during testing only.
+     */
     fun withCachedValue(value: T?) {
         lock.runBlock {
             cachedValue = value
         }
     }
 
+    /**
+     * This changes the mapping between a `Variables` and the feature configuration object.
+     *
+     * This is most likely useful during testing and other generated code.
+     */
     fun withInitializer(create: (Variables) -> T) {
         lock.runBlock {
             this.create = create

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
@@ -1,33 +1,47 @@
 package org.mozilla.experiments.nimbus.internal
 
-import android.content.Context
 import org.mozilla.experiments.nimbus.FeaturesInterface
 import org.mozilla.experiments.nimbus.Variables
 import org.mozilla.experiments.nimbus.NullVariables
+import java.util.concurrent.locks.ReentrantLock
 
+/**
+ * `FeatureHolder` is a class that unpacks a JSON object from the Nimbus SDK and transforms it into a useful
+ * type safe object, generated from a feature manifest (a `.fml.yaml` file).
+ *
+ * The two routinely useful methods are the `value()` and `recordExposure()` events.
+ *
+ * There are methods useful for testing, and more advanced uses: these all start with `with`.
+ */
 class FeatureHolder<T>(
     private val getSdk: () -> FeaturesInterface?,
     private val featureId: String,
-    private val create: (Variables) -> T
+    private var create: (Variables) -> T
 ) {
+    private val lock = ReentrantLock()
+
+    private var cachedValue: T? = null
 
     /**
      * Get the JSON configuration from the Nimbus SDK and transform it into a configuration object as specified
      * in the feature manifest. This is done each call of the method, so the method should be called once, and the
      * result used for the configuration of the feature.
      *
-     * An optional `Context` object is taken which is used to look up resources. Most of the time this isn't required, and the context can be
-     * derived from the `Nimbus` singleton object. This is now deprecated, and will be removed in future releases.
-     *
      * @returns T
-     * @throws NimbusFeatureException thrown before the Nimbus object has been constructed or `FxNimbus.api` has not been set.
-     * This can be resolved by setting `FxNimbus.api`, and after that by passing in a `Context` object.
+     * @throws NimbusFeatureException thrown before the Nimbus object has been constructed or `FxNimbus.initialize` has not been set.
+     * This can be resolved by setting `FxNimbus.initialize`, and after that by passing in a `Context` object.
      */
-    @Suppress("UNUSED_PARAMETER")
-    fun value(context: Context? = null): T {
-        val variables = getSdk()?.getVariables(featureId, false) ?: NullVariables.instance
-        return create(variables)
-    }
+    fun value(): T =
+        lock.runBlock {
+            if (cachedValue != null) {
+                cachedValue!!
+            } else {
+                val variables = getSdk()?.getVariables(featureId, false) ?: NullVariables.instance
+                create(variables).also { value ->
+                    cachedValue = value
+                }
+            }
+        }
 
     /**
      * Send an exposure event for this feature. This should be done when the user is shown the feature, and may change
@@ -35,6 +49,28 @@ class FeatureHolder<T>(
      */
     fun recordExposure() {
         getSdk()?.recordExposureEvent(featureId)
+    }
+
+    fun withCachedValue(value: T?) {
+        lock.runBlock {
+            cachedValue = value
+        }
+    }
+
+    fun withInitializer(create: (Variables) -> T) {
+        lock.runBlock {
+            this.create = create
+            this.cachedValue = null
+        }
+    }
+
+    private fun <T> ReentrantLock.runBlock(block: () -> T): T {
+        lock.lock()
+        try {
+            return block.invoke()
+        } finally {
+            lock.unlock()
+        }
     }
 }
 

--- a/components/nimbus/ios/Nimbus/FeatureHolder.swift
+++ b/components/nimbus/ios/Nimbus/FeatureHolder.swift
@@ -55,6 +55,8 @@ public class FeatureHolder<T> {
     }
 
     /// This overwrites the cached value with the passed one.
+    ///
+    /// This is most likely useful during testing only.
     public func with(cachedValue value: T?) {
         lock.lock()
         defer { self.lock.unlock() }
@@ -62,6 +64,8 @@ public class FeatureHolder<T> {
     }
 
     /// This changes the mapping between a `Variables` and the feature configuration object.
+    ///
+    /// This is most likely useful during testing and other generated code.
     public func with(initializer: @escaping (Variables) -> T) {
         lock.lock()
         defer { self.lock.unlock() }

--- a/components/nimbus/ios/Nimbus/FeatureHolder.swift
+++ b/components/nimbus/ios/Nimbus/FeatureHolder.swift
@@ -14,7 +14,7 @@ public typealias GetSdk = () -> FeaturesInterface?
 ///
 public class FeatureHolder<T> {
     private let lock = NSLock()
-    private var cachedValue: T? = nil
+    private var cachedValue: T?
 
     private let getSdk: GetSdk
     private let featureId: String

--- a/components/nimbus/ios/Nimbus/FeatureHolder.swift
+++ b/components/nimbus/ios/Nimbus/FeatureHolder.swift
@@ -1,13 +1,25 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import Foundation
 
 public typealias GetSdk = () -> FeaturesInterface?
 
+/// `FeatureHolder` is a class that unpacks a JSON object from the Nimbus SDK and transforms it into a useful
+/// type safe object, generated from a feature manifest (a `.fml.yaml` file).
+///
+/// The two routinely useful methods are the `value()` and `recordExposure()` events.
+///
+/// There are methods useful for testing, and more advanced uses: these all start with `with`.
+///
 public class FeatureHolder<T> {
+    private let lock = NSLock()
+    private var cachedValue: T? = nil
+
     private let getSdk: GetSdk
     private let featureId: String
-    private let create: (Variables) -> T
+
+    private var create: (Variables) -> T
 
     public init(_ getSdk: @escaping () -> FeaturesInterface?,
                 featureId: String,
@@ -18,12 +30,42 @@ public class FeatureHolder<T> {
         self.create = create
     }
 
+    /// Get the JSON configuration from the Nimbus SDK and transform it into a configuration object as specified
+    /// in the feature manifest. This is done each call of the method, so the method should be called once, and the
+    /// result used for the configuration of the feature.
+    ///
+    /// Some care is taken to cache the value, this is for performance critical uses of the API.
+    /// It is possible to invalidate the cache with `FxNimbus.invalidateCachedValues()` or `with(cachedValue: nil)`.
     public func value() -> T {
+        lock.lock()
+        defer { self.lock.unlock() }
+        if let v = cachedValue {
+            return v
+        }
         let variables = getSdk()?.getVariables(featureId: featureId, sendExposureEvent: false) ?? NilVariables.instance
-        return create(variables)
+        let v = create(variables)
+        cachedValue = v
+        return v
     }
 
+    /// Send an exposure event for this feature. This should be done when the user is shown the feature, and may change
+    /// their behavior because of it.
     public func recordExposure() {
         getSdk()?.recordExposureEvent(featureId: featureId)
+    }
+
+    /// This overwrites the cached value with the passed one.
+    public func with(cachedValue value: T?) {
+        lock.lock()
+        defer { self.lock.unlock() }
+        cachedValue = value
+    }
+
+    /// This changes the mapping between a `Variables` and the feature configuration object.
+    public func with(initializer: @escaping (Variables) -> T) {
+        lock.lock()
+        defer { self.lock.unlock() }
+        cachedValue = nil
+        create = initializer
     }
 }

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureManifestTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureManifestTemplate.kt
@@ -59,8 +59,18 @@ object {{ nimbus_object }} {
     }
 
     private var getSdk: () -> FeaturesInterface? = {
-        null
+        this.api
     }
+
+    /**
+     * This is the connection between the Nimbus SDK (and thus the Nimbus server) and the generated code.
+     *
+     * This is no longer the recommended way of doing this, and will be removed in future releases.
+     *
+     * The recommended method is to use the `initialize(getSdk)` method, much earlier in the application
+     * startup process.
+     */
+    public var api: FeaturesInterface? = null
 
     public fun invalidateCachedValues() {
         {% for f in self.iter_feature_defs() -%}

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureManifestTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureManifestTemplate.kt
@@ -25,7 +25,7 @@ import {{ imported_class }}
  *
  * ```
  * val nimbus: Nimbus = connectToNimbusSDK()
- * {{ nimbus_object }}.api = nimbus
+ * {{ nimbus_object }}.initialize(getSdk = { nimbus })
  * ```
  *
  * Once initialized, this can be used to access typesafe configuration object via the `features` member.
@@ -59,18 +59,14 @@ object {{ nimbus_object }} {
     }
 
     private var getSdk: () -> FeaturesInterface? = {
-        this.api
+        null
     }
 
-    /**
-     * This should be populated at app launch.
-     *
-     * This property has to be set after the Nimbus SDK, which causes race-conditions. Please use
-     * `initialize()` much earlier in the application startup sequence.file
-     *
-     * This will be removed in future releases.
-     */
-    var api: FeaturesInterface? = null
+    public fun invalidateCachedValues() {
+        {% for f in self.iter_feature_defs() -%}
+        features.{{- f.name()|var_name -}}.withCachedValue(null)
+        {% endfor %}
+    }
 
     /**
      * Accessor object for generated configuration classes extracted from Nimbus, with built-in

--- a/components/support/nimbus-fml/src/backends/swift/templates/FeatureManifestTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/FeatureManifestTemplate.swift
@@ -36,6 +36,14 @@ public class {{ nimbus_object }} {
     ///
     public let features = {{ nimbus_object }}Features()
 
+    /// Clear all cached values for all features.
+    /// This should be called after `applyPendingExperiments` is finished.
+    public func invalidateCachedValues() {
+        {% for f in self.iter_feature_defs() -%}
+        features.{{- f.name()|var_name -}}.with(cachedValue: nil)
+        {% endfor %}
+    }
+
     ///
     /// A singleton instance of {{ nimbus_object }}
     ///

--- a/components/support/nimbus-fml/test/app_menu.kts
+++ b/components/support/nimbus-fml/test/app_menu.kts
@@ -5,8 +5,11 @@
 import android.content.Context as MockContext
 import org.mozilla.experiments.nimbus.MockNimbus
 
+var injected: MockNimbus? = null
+MyNimbus.initialize { injected }
+
 // Exercise a map of booleans
-val feature = MyNimbus.features.appMenu.value(MockContext())
+val feature = MyNimbus.features.appMenu.value()
 assert(feature.itemEnabled[MenuItemId.START_GAME] == true)
 assert(feature.itemEnabled[MenuItemId.RESUME_GAME] == false)
 assert(feature.itemEnabled[MenuItemId.SETTINGS] == true)
@@ -30,7 +33,7 @@ assert(feature.profileItems[PlayerProfile.ADULT]!![MenuItemId.RESUME_GAME]?.labe
 assert(feature.profileItems[PlayerProfile.ADULT]!![MenuItemId.SETTINGS]?.label == "SETTINGS")
 
 // Now let's merge it with JSON we might have got from Rust.
-MyNimbus.api = MockNimbus("app-menu" to """{
+injected = MockNimbus("app-menu" to """{
     "items": {
         "start-game": {
             "label": "Start Nimbus",
@@ -59,6 +62,7 @@ MyNimbus.api = MockNimbus("app-menu" to """{
         }
     }
 }""")
+MyNimbus.invalidateCachedValues()
 
 val feature1 = MyNimbus.features.appMenu.value()
 assert(feature1.items[MenuItemId.START_GAME]?.label == "Start Nimbus")

--- a/components/support/nimbus-fml/test/app_menu.swift
+++ b/components/support/nimbus-fml/test/app_menu.swift
@@ -31,7 +31,7 @@ assert(feature.profileItems[PlayerProfile.adult]![MenuItemId.resumeGame]?.label 
 assert(feature.profileItems[PlayerProfile.adult]![MenuItemId.settings]?.label == "SETTINGS")
 
 // Now let's merge it with JSON we might have got from Rust.
-nimbus.api = MockNimbus(("app-menu",
+let api = MockNimbus(("app-menu",
 """
 {
     "items": {
@@ -63,7 +63,9 @@ nimbus.api = MockNimbus(("app-menu",
     }
 }
 """))
+nimbus.api = api
 
+nimbus.invalidateCachedValues()
 let feature1 = nimbus.features.appMenu.value()
 assert(feature1.items[MenuItemId.startGame]?.label == "Start Nimbus")
 assert(feature1.items[MenuItemId.resumeGame]?.label == "Resume Nimbus")

--- a/components/support/nimbus-fml/test/bundled_resources.kts
+++ b/components/support/nimbus-fml/test/bundled_resources.kts
@@ -6,7 +6,8 @@ import android.content.Context as MockContext
 import com.example.app.R
 import org.mozilla.experiments.nimbus.MockNimbus
 
-MyNimbus.api = MockNimbus()
+var injected: MockNimbus? = MockNimbus()
+MyNimbus.initialize { injected }
 
 val feature = MyNimbus.features.myStrings.value()
 

--- a/components/support/nimbus-fml/test/fenix_nightly.kts
+++ b/components/support/nimbus-fml/test/fenix_nightly.kts
@@ -8,9 +8,13 @@ import com.example.nightly.FxNimbus as MyNimbus
 import com.example.nightly.HomeScreenSection
 import org.mozilla.experiments.nimbus.MockNimbus
 
+var injected: MockNimbus? = null
+MyNimbus.initialize { injected }
+
 // Test the default map with an enum to Boolean maping based
 // on the nighlty defaults
-val feature = MyNimbus.features.homescreen.value(MockContext())
+
+val feature = MyNimbus.features.homescreen.value()
 assert(feature.sectionsEnabled[HomeScreenSection.TOP_SITES] == true)
 assert(feature.sectionsEnabled[HomeScreenSection.JUMP_BACK_IN] == true)
 assert(feature.sectionsEnabled[HomeScreenSection.RECENTLY_SAVED] == true)
@@ -27,7 +31,9 @@ val api = MockNimbus("homescreen" to """{
 }""", "search-term-groups" to """{
     "enabled": true
 }""")
-MyNimbus.api = api
+injected = api
+MyNimbus.invalidateCachedValues()
+
 val feature1 = MyNimbus.features.homescreen.value()
 assert(feature1.sectionsEnabled[HomeScreenSection.TOP_SITES] == true)
 assert(feature1.sectionsEnabled[HomeScreenSection.JUMP_BACK_IN] == true)

--- a/components/support/nimbus-fml/test/fenix_nightly.swift
+++ b/components/support/nimbus-fml/test/fenix_nightly.swift
@@ -31,6 +31,7 @@ let api = MockNimbus(("homescreen", """
 }
 """))
 nimbus.api = api
+nimbus.invalidateCachedValues()
 let feature1 = nimbus.features.homescreen.value()
 assert(feature1.sectionsEnabled[HomeScreenSection.topSites] == true)
 assert(feature1.sectionsEnabled[HomeScreenSection.jumpBackIn] == true)

--- a/components/support/nimbus-fml/test/fenix_release.kts
+++ b/components/support/nimbus-fml/test/fenix_release.kts
@@ -9,7 +9,9 @@ import com.example.release.HomeScreenSection
 import org.mozilla.experiments.nimbus.MockNimbus
 
 // Test the default map with an enum to Boolean maping.
-val feature = MyNimbus.features.homescreen.value(MockContext())
+var injected: MockNimbus? = null
+MyNimbus.initialize { injected }
+val feature = MyNimbus.features.homescreen.value()
 assert(feature.sectionsEnabled[HomeScreenSection.TOP_SITES] == true)
 assert(feature.sectionsEnabled[HomeScreenSection.JUMP_BACK_IN] == false)
 assert(feature.sectionsEnabled[HomeScreenSection.RECENTLY_SAVED] == false)
@@ -26,7 +28,9 @@ val api = MockNimbus("homescreen" to """{
 }""", "search-term-groups" to """{
     "enabled": true
 }""")
-MyNimbus.api = api
+
+injected = api
+MyNimbus.invalidateCachedValues()
 val feature1 = MyNimbus.features.homescreen.value()
 assert(feature1.sectionsEnabled[HomeScreenSection.TOP_SITES] == true)
 assert(feature1.sectionsEnabled[HomeScreenSection.JUMP_BACK_IN] == false)

--- a/components/support/nimbus-fml/test/fenix_release.swift
+++ b/components/support/nimbus-fml/test/fenix_release.swift
@@ -31,6 +31,7 @@ let api = MockNimbus(("homescreen", """
 }
 """))
 nimbus.api = api
+nimbus.invalidateCachedValues()
 let feature1 = nimbus.features.homescreen.value()
 assert(feature1.sectionsEnabled[HomeScreenSection.topSites] == true)
 assert(feature1.sectionsEnabled[HomeScreenSection.jumpBackIn] == false)

--- a/components/support/nimbus-fml/test/firefox_ios_release.swift
+++ b/components/support/nimbus-fml/test/firefox_ios_release.swift
@@ -35,6 +35,7 @@ let api = MockNimbus(("homescreen", """
 }
 """))
 nimbus.api = api
+nimbus.invalidateCachedValues()
 let feature1 = nimbus.features.homescreen.value()
 assert(feature1.sectionsEnabled[HomeScreenSection.topSites] == true)
 assert(feature1.sectionsEnabled[HomeScreenSection.jumpBackIn] == false)

--- a/components/support/nimbus-fml/test/full_homescreen.kts
+++ b/components/support/nimbus-fml/test/full_homescreen.kts
@@ -4,9 +4,10 @@
 
 import android.content.Context as MockContext
 import org.mozilla.experiments.nimbus.MockNimbus
+import org.mozilla.experiments.nimbus.internal.FeatureHolder
 
 // Test the default map with an enum to Boolean maping.
-val feature = MyNimbus.features.homescreen.value(MockContext())
+val feature = MyNimbus.features.homescreen.value()
 assert(feature.sectionsEnabled[HomeScreenSection.TOP_SITES] == true)
 assert(feature.sectionsEnabled[HomeScreenSection.JUMP_BACK_IN] == false)
 assert(feature.sectionsEnabled[HomeScreenSection.RECENTLY_SAVED] == false)
@@ -19,8 +20,8 @@ val api = MockNimbus("homescreen" to """{
         "pocket": true
     }
 }""")
-MyNimbus.api = api
-val feature1 = MyNimbus.features.homescreen.value()
+val holder = FeatureHolder(getSdk = { api }, featureId = "homescreen") { Homescreen(it) }
+val feature1 = holder.value()
 assert(feature1.sectionsEnabled[HomeScreenSection.TOP_SITES] == true)
 assert(feature1.sectionsEnabled[HomeScreenSection.JUMP_BACK_IN] == false)
 assert(feature1.sectionsEnabled[HomeScreenSection.RECENTLY_SAVED] == false)
@@ -28,5 +29,5 @@ assert(feature1.sectionsEnabled[HomeScreenSection.RECENT_EXPLORATIONS] == false)
 assert(feature1.sectionsEnabled[HomeScreenSection.POCKET] == true)
 
 // Record the exposure and test it.
-MyNimbus.features.homescreen.recordExposure()
+holder.recordExposure()
 assert(api.isExposed("homescreen"))

--- a/components/support/nimbus-fml/test/simple_nimbus_validation.kts
+++ b/components/support/nimbus-fml/test/simple_nimbus_validation.kts
@@ -5,7 +5,10 @@
 import android.content.Context as MockContext
 import org.mozilla.experiments.nimbus.MockNimbus
 
-val feature = MyNimbus.features.nimbusValidation.value(MockContext())
+var injected: MockNimbus? = null
+MyNimbus.initialize { injected }
+
+val feature = MyNimbus.features.nimbusValidation.value()
 
 // Test the property level defaults.
 assert(feature.enabled == true)
@@ -22,7 +25,8 @@ val api = MockNimbus("nimbus-validation" to """{
     "menu-position": "top",
     "enum-map": { "top": true, "bottom": false }
 }""")
-MyNimbus.api = api
+injected = api
+MyNimbus.invalidateCachedValues()
 
 // Completely override the defaults using the above JSON.
 val feature1 = MyNimbus.features.nimbusValidation.value()

--- a/components/support/nimbus-fml/test/with_objects.kts
+++ b/components/support/nimbus-fml/test/with_objects.kts
@@ -8,7 +8,9 @@ import android.content.Context as MockContext
 // Get the feature from the MyNimbus.features.
 // The api isn't ready yet.
 val ctx = MockContext()
-val feature = MyNimbus.features.withObjectsFeature.value(ctx)
+var injected: MockNimbus? = null
+MyNimbus.initialize { injected }
+val feature = MyNimbus.features.withObjectsFeature.value()
 
 // Show the property level defaults.
 assert(feature.anObject.aString == "yes")
@@ -32,7 +34,8 @@ val api = MockNimbus("with-objects-feature" to """{
         }
     }
 }""")
-MyNimbus.api = api
+injected = api
+MyNimbus.invalidateCachedValues()
 
 // Now test the selectively overidden properties of the feature.
 val feature1 = MyNimbus.features.withObjectsFeature.value()

--- a/components/support/nimbus-fml/test/with_objects.swift
+++ b/components/support/nimbus-fml/test/with_objects.swift
@@ -34,6 +34,7 @@ let api = MockNimbus(("with-objects-feature",  """
 }
 """))
 nimbus.api = api
+nimbus.invalidateCachedValues()
 
 // Now test the selectively overidden properties of the feature.
 let feature1 = nimbus.features.withObjectsFeature.value()


### PR DESCRIPTION
This PR fixes [EXP-2393][0]

This is part of the work to make FeatureHolder more reliable and functional on iOS.

[0]: https://mozilla-hub.atlassian.net/browse/EXP-2393

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
