### PR TITLE
Brings back InternalError to catch non-fatal unexpected errors

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -24,3 +24,6 @@ Use the template below to make assigning a version number during the release cut
   - New API in the `FeatureHolder`, both iOS and Android to control the output of the `value()` call:
     - to cache the values given to callers; this can be cleared with `FxNimbus.invalidatedCachedValues()`
     - to add a custom initializer with `with(initializer:_)`/`withInitializer(_)`.
+## Places
+### What's Fixed:
+- Fixed a bug in Android where non-fatal errors were crashing. ([#4941](https://github.com/mozilla/application-services/pull/4941))

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -221,10 +221,8 @@ pub enum PlacesError {
     #[error("CannotUpdateRoot error: {0}")]
     CannotUpdateRoot(String),
 
-    // XX - We should kill this and replace
-    // it with other specific errors
-    // It is only alive because `UnexpectedPlacesException`
-    // is a fatal exception on android
+    // XX - Having `InternalError` is a smell and ideally it wouldn't exist
+    // it exists to catch non-fatal unexpected errors
     /// Thrown when we catch an unexpected error
     /// that shouldn't be fatal
     #[error("Unexpected error: {0}")]

--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -220,6 +220,15 @@ pub enum PlacesError {
     /// - Attempting to delete any of the bookmark roots.
     #[error("CannotUpdateRoot error: {0}")]
     CannotUpdateRoot(String),
+
+    // XX - We should kill this and replace
+    // it with other specific errors
+    // It is only alive because `UnexpectedPlacesException`
+    // is a fatal exception on android
+    /// Thrown when we catch an unexpected error
+    /// that shouldn't be fatal
+    #[error("Unexpected error: {0}")]
+    InternalError(String),
 }
 
 // A port of the error conversion stuff that was in ffi.rs - it turns our
@@ -291,7 +300,7 @@ fn make_places_error(error: &Error) -> PlacesError {
 
         err => {
             log::error!("Unexpected error: {:?}", err);
-            PlacesError::UnexpectedPlacesException(label)
+            PlacesError::InternalError(label)
         }
     }
 }

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -323,6 +323,7 @@ enum PlacesError {
     "UrlTooLong",
     "InvalidBookmarkUpdate", // XXX - can we kill this?
     "CannotUpdateRoot",
+    "InternalError",
 };
 
 dictionary BookmarkData {


### PR DESCRIPTION
related to https://github.com/mozilla-mobile/android-components/issues/12099

This should fix the crashes in android in newer AS versions

The **real** fix here would be to expose a variant for that specific error and return it

We should in the future audit all the cases that get transformed into an `InternalError` to see if there are ones that really should be fatal - but this is the least disruptive way of making sure our a-s releases don't have any other hidden side-effects from this

(PS: I didn't name it `InternalPanic` like it used to be named because Rust panics were not involved at all in this error 😬)
