### PR TITLE
Exposes deleteVisitFor for places iOS

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -27,3 +27,6 @@ Use the template below to make assigning a version number during the release cut
 ## Places
 ### What's Fixed:
 - Fixed a bug in Android where non-fatal errors were crashing. ([#4941](https://github.com/mozilla/application-services/pull/4941))
+### What's new:
+- Exposed the `deleteVisitsFor` function in iOS, the function can be used to delete history metadata. ([#4946](https://github.com/mozilla/application-services/pull/4946))
+  - Note: The API is meant to delete all history, however, iOS does **not** use the `places` Rust component for regular history yet.

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -765,4 +765,15 @@ public class PlacesWriteConnection: PlacesReadConnection {
             )
         }
     }
+
+    /** Deletes all history and history metadata for the given url
+     * - Parameters:
+     *      - url: The url to delete all history for
+     **/
+    open func deleteVisitsFor(url: Url) throws {
+        try queue.sync {
+            try self.checkApi()
+            try self.conn.deleteVisitsFor(url: url)
+        }
+    }
 }


### PR DESCRIPTION
fixes #4908 

Exposes `deleteVisitFor` in our iOS api and adds some tests for it


@electricRGB this should hopefully unblock you once we release it (i'm planning to later today or tomorrow based on other changes I'm waiting for the release). Also, if there are any other tests you would like to see to make sure it satisfies your use case I could also add them here 😄

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
