### PR TITLE
Cut release v93.1.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 93.0.4
+libraryVersion: 93.1.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# v93.1.0 (_2022-05-06_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.4...v93.1.0)
+
+## Nimbus ⛅️🔬🔭
+
+### What's New
+  - New API in the `FeatureHolder`, both iOS and Android to control the output of the `value()` call:
+    - to cache the values given to callers; this can be cleared with `FxNimbus.invalidatedCachedValues()`
+    - to add a custom initializer with `with(initializer:_)`/`withInitializer(_)`.
+## Places
+### What's Fixed:
+- Fixed a bug in Android where non-fatal errors were crashing. ([#4941](https://github.com/mozilla/application-services/pull/4941))
+- Fixed a bug where querying history metadata would return a sql error instead of the result ([4940](https://github.com/mozilla/application-services/pull/4940))
+### What's new:
+- Exposed the `deleteVisitsFor` function in iOS, the function can be used to delete history metadata. ([#4946](https://github.com/mozilla/application-services/pull/4946))
+  - Note: The API is meant to delete all history, however, iOS does **not** use the `places` Rust component for regular history yet.
+
 # v93.0.4 (_2022-04-28_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.3...v93.0.4)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.4...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v93.1.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,16 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-## Nimbus ⛅️🔬🔭
-
-### What's New
-  - New API in the `FeatureHolder`, both iOS and Android to control the output of the `value()` call:
-    - to cache the values given to callers; this can be cleared with `FxNimbus.invalidatedCachedValues()`
-    - to add a custom initializer with `with(initializer:_)`/`withInitializer(_)`.
-## Places
-### What's Fixed:
-- Fixed a bug in Android where non-fatal errors were crashing. ([#4941](https://github.com/mozilla/application-services/pull/4941))
-- Fixed a bug where querying history metadata would return a sql error instead of the result ([4940](https://github.com/mozilla/application-services/pull/4940))
-### What's new:
-- Exposed the `deleteVisitsFor` function in iOS, the function can be used to delete history metadata. ([#4946](https://github.com/mozilla/application-services/pull/4946))
-  - Note: The API is meant to delete all history, however, iOS does **not** use the `places` Rust component for regular history yet.


### PR DESCRIPTION
Cuts release v93.1.0

This has:
- The fixes for https://github.com/mozilla-mobile/android-components/issues/12099
- Exposed the `deleteVisitsFor` api
- FML changes related to the FeatureHolder iOS incident 