### PR TITLE
Fix "Nightly" spelling

### DIFF
--- a/taskcluster/app_services_taskgraph/transforms/branch_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/branch_build.py
@@ -8,7 +8,7 @@ from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import validate_schema, Schema
 from voluptuous import Optional, Required, In
 
-NIGHLY_INDEX = "index.project.application-services.v2.nightlies"
+NIGHTLY_INDEX = "index.project.application-services.v2.nightlies"
 
 # Schema for the job dictionary from kinds.yml
 branch_build_schema = Schema({
@@ -179,5 +179,5 @@ def setup_test(task, repo_name):
     task['run']['gradlew'] = ['testDebugUnitTest']
 
 def setup_routes(task, params):
-    if params.get('nighly-build'):
-        task.setdefault('routes', []).append(NIGHLY_INDEX)
+    if params.get('nightly-build'):
+        task.setdefault('routes', []).append(NIGHTLY_INDEX)


### PR DESCRIPTION
I was hoping to see a nightly build in the index this morning, but was thrwarted by my terible spellng :)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
