### PR TITLE
Removed the code to add indexes to the nightly tasks

### DIFF
--- a/taskcluster/app_services_taskgraph/transforms/branch_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/branch_build.py
@@ -8,8 +8,6 @@ from taskgraph.transforms.base import TransformSequence
 from taskgraph.util.schema import validate_schema, Schema
 from voluptuous import Optional, Required, In
 
-NIGHTLY_INDEX = "index.project.application-services.v2.nightlies"
-
 # Schema for the job dictionary from kinds.yml
 branch_build_schema = Schema({
   # Which repository are we working on
@@ -96,7 +94,6 @@ def setup(config, tasks):
         else:
             raise ValueError("Invalid branch build operation: {}".format(operation))
         task['description'] = '{} {}'.format(operation, repo_name)
-        setup_routes(task, config.params)
         yield task
 
 def setup_application_services(task):
@@ -177,7 +174,3 @@ def setup_fenix_build(task):
 
 def setup_test(task, repo_name):
     task['run']['gradlew'] = ['testDebugUnitTest']
-
-def setup_routes(task, params):
-    if params.get('nightly-build'):
-        task.setdefault('routes', []).append(NIGHTLY_INDEX)

--- a/taskcluster/test/params/cron-nightly.yml
+++ b/taskcluster/test/params/cron-nightly.yml
@@ -22,4 +22,4 @@ pushlog_id: '0'
 repository_type: git
 target_tasks_method: default
 tasks_for: cron
-nighly-build: true
+nightly-build: true


### PR DESCRIPTION
This didn't work out well in practice, since an index can only store one
task.  So if we have all the branch build task using the same index,
whichever one runs last wins.  I think what we really want is to index
the task group, but I don't think that's possible.  Probably the best we
can do is what was already there by default, which is to index the
decision task, then find the task group from that.

Also fixed the spelling of "nightly" in the test param YAML file.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
