### PR TITLE
Cut release v93.2.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 93.1.0
+libraryVersion: 93.2.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v93.2.0 (_2022-05-11_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v93.1.0...v93.2.0)
+
+## General
+### What's new
+- Application services now releases an xcframework with only the components needed by focus-ios (namely Nimbus, Viaduct and Rustlog). ([#4953](https://github.com/mozilla/application-services/pull/4953))
+
 # v93.1.0 (_2022-05-06_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v93.0.4...v93.1.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v93.1.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v93.2.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,6 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-## General
-### What's new
-- Application services now releases an xcframework with only the components needed by focus-ios (namely Nimbus, Viaduct and Rustlog). ([#4953](https://github.com/mozilla/application-services/pull/4953))


### PR DESCRIPTION
Cuts 93.2.0

Only for the focus-ios megazord - so that we can use it in `rust-components-swift` and update focus-ios
