### PR TITLE
Have the tabs-sync example write a dummy tab if there's no clipboard

### DIFF
--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -170,5 +170,11 @@ fn read_local_state() -> Vec<RemoteTabRecord> {
 fn read_local_state() -> Vec<RemoteTabRecord> {
     println!("This module is build without the `clipboard` feature, so we can't");
     println!("read the local state.");
-    vec![]
+    println!("Instead, we'll write one dummy tab:");
+    vec![RemoteTabRecord {
+        title: "Mozilla".to_string(),
+        url_history: vec!["https://www.mozilla.org".to_string()],
+        icon: None,
+        last_used: 0,
+    }]
 }


### PR DESCRIPTION
It was difficult to use the tabs-sync example on Windows as it was impossible to upload any tabs. This change will make it write a dummy tab if there's no clipboard support.