### PR TITLE
 Update to Glean v50 and adopt new APIs 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,24 +39,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_log-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
-
-[[package]]
-name = "android_logger"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ed09b18365ed295d722d0b5ed59c01b79a826ff2d2a8f73d5ecca8e6fb2f66"
-dependencies = [
- "android_log-sys",
- "env_logger 0.8.4",
- "lazy_static",
- "log",
-]
-
-[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,15 +595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
 name = "criterion"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,16 +726,6 @@ checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
 dependencies = [
  "nix",
  "winapi",
-]
-
-[[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if 1.0.0",
- "num_cpus",
 ]
 
 [[package]]
@@ -1095,18 +1058,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
-name = "flate2"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
-dependencies = [
- "cfg-if 1.0.0",
- "crc32fast",
- "libc",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,41 +1255,6 @@ name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
-
-[[package]]
-name = "glean-core"
-version = "43.0.2"
-dependencies = [
- "bincode",
- "chrono",
- "ffi-support",
- "flate2",
- "log",
- "once_cell",
- "rkv",
- "serde",
- "serde_json",
- "time 0.1.44",
- "uuid",
- "zeitstempel",
-]
-
-[[package]]
-name = "glean-ffi"
-version = "43.0.2"
-dependencies = [
- "android_logger",
- "env_logger 0.8.4",
- "ffi-support",
- "glean-core",
- "libc",
- "log",
- "once_cell",
- "oslog",
- "serde",
- "serde_json",
- "uuid",
-]
 
 [[package]]
 name = "glob"
@@ -1847,7 +1763,6 @@ dependencies = [
  "autofill",
  "crashtest",
  "fxa-client",
- "glean-ffi",
  "logins",
  "nimbus-sdk",
  "places",
@@ -2361,17 +2276,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-
-[[package]]
-name = "oslog"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8343ce955f18e7e68c0207dd0ea776ec453035685395ababd2ea651c569728b3"
-dependencies = [
- "cc",
- "dashmap",
- "log",
-]
 
 [[package]]
 name = "output_vt100"
@@ -4201,15 +4105,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "zeitstempel"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeea3eb6a30ed24e374f59368d3917c5180a845fdd4ed6f1b2278811a9e826f8"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "once_cell",
 ]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -13,7 +13,6 @@ the details of which are reproduced below.
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata](#mit-license-cargo_metadata)
 * [MIT License: caseless](#mit-license-caseless)
-* [MIT License: dashmap](#mit-license-dashmap)
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: h2](#mit-license-h2)
 * [MIT License: http-body](#mit-license-http-body)
@@ -21,12 +20,10 @@ the details of which are reproduced below.
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
 * [MIT License: matches](#mit-license-matches)
 * [MIT License: mime_guess](#mit-license-mime_guess)
-* [MIT License: miniz_oxide](#mit-license-miniz_oxide)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: openssl-sys](#mit-license-openssl-sys)
 * [MIT License: ordered-float](#mit-license-ordered-float)
-* [MIT License: oslog](#mit-license-oslog)
 * [MIT License: schannel](#mit-license-schannel)
 * [MIT License: slab](#mit-license-slab)
 * [MIT License: strsim](#mit-license-strsim)
@@ -38,7 +35,6 @@ the details of which are reproduced below.
 * [MIT License: try-lock](#mit-license-try-lock)
 * [MIT License: want](#mit-license-want)
 * [MIT License: weedle2](#mit-license-weedle2)
-* [MIT License: winapi-util](#mit-license-winapi-util)
 * [MIT License: winreg](#mit-license-winreg)
 * [CC0-1.0 License: base16](#cc0-10-license-base16)
 * [ISC License: ring](#isc-license-ring)
@@ -61,8 +57,7 @@ The following text applies to code linked from these dependencies:
 [uniffi](https://github.com/mozilla/uniffi-rs),
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
-[uniffi_macros](https://github.com/mozilla/uniffi-rs),
-[zeitstempel](https://github.com/badboy/zeitstempel)
+[uniffi_macros](https://github.com/mozilla/uniffi-rs)
 
 ```
 Mozilla Public License Version 2.0
@@ -444,10 +439,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 ## Apache License 2.0
 
 The following text applies to code linked from these dependencies:
-[adler](https://github.com/jonas-schievink/adler.git),
 [ahash](https://github.com/tkaitchuck/ahash),
-[android_log-sys](https://github.com/nercury/android_log-sys-rs),
-[android_logger](https://github.com/Nercury/android_logger-rs),
 [anyhow](https://github.com/dtolnay/anyhow),
 [askama](https://github.com/djc/askama),
 [askama_derive](https://github.com/djc/askama),
@@ -468,16 +460,13 @@ The following text applies to code linked from these dependencies:
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
 [core-foundation](https://github.com/servo/core-foundation-rs),
 [cpufeatures](https://github.com/RustCrypto/utils),
-[crc32fast](https://github.com/srijs/rust-crc32fast),
 [digest](https://github.com/RustCrypto/traits),
 [dogear](https://github.com/mozilla/dogear),
 [either](https://github.com/bluss/either),
-[env_logger](https://github.com/env-logger-rs/env_logger/),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
 [fastrand](https://github.com/smol-rs/fastrand),
 [ffi-support](https://github.com/mozilla/ffi-support),
-[flate2](https://github.com/rust-lang/flate2-rs),
 [fnv](https://github.com/servo/rust-fnv),
 [foreign-types-shared](https://github.com/sfackler/foreign-types),
 [foreign-types](https://github.com/sfackler/foreign-types),
@@ -497,7 +486,6 @@ The following text applies to code linked from these dependencies:
 [http](https://github.com/hyperium/http),
 [httparse](https://github.com/seanmonstar/httparse),
 [httpdate](https://github.com/pyfisch/httpdate),
-[humantime](https://github.com/tailhook/humantime),
 [hyper-tls](https://github.com/hyperium/hyper-tls),
 [id-arena](https://github.com/fitzgen/id-arena),
 [idna](https://github.com/servo/rust-url/),
@@ -595,7 +583,7 @@ The following text applies to code linked from these dependencies:
 ```
                               Apache License
                         Version 2.0, January 2004
-                     https://www.apache.org/licenses/LICENSE-2.0
+                     http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -787,7 +775,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	https://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -1017,36 +1005,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
-## MIT License: dashmap
-
-The following text applies to code linked from these dependencies:
-[dashmap](https://github.com/xacrimon/dashmap)
-
-```
-MIT License
-
-Copyright (c) 2019 Acrimon
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
 ## MIT License: generic-array
 
 The following text applies to code linked from these dependencies:
@@ -1266,36 +1224,6 @@ SOFTWARE.
 
 ```
 -------------
-## MIT License: miniz_oxide
-
-The following text applies to code linked from these dependencies:
-[miniz_oxide](https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide)
-
-```
-MIT License
-
-Copyright (c) 2017 Frommi
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
 ## MIT License: mio
 
 The following text applies to code linked from these dependencies:
@@ -1418,36 +1346,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: oslog
-
-The following text applies to code linked from these dependencies:
-[oslog](https://github.com/steven-joruk/oslog)
-
-```
-MIT License
-
-Copyright (c) 2020 Steven Joruk
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ```
 -------------
@@ -1781,36 +1679,6 @@ TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONIN
 THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
 CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-```
--------------
-## MIT License: winapi-util
-
-The following text applies to code linked from these dependencies:
-[winapi-util](https://github.com/BurntSushi/winapi-util)
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2017 Andrew Gallant
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
 ```
 -------------
 ## MIT License: winreg

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         jna_version = '5.8.0'
         android_gradle_plugin_version = '4.2.2'
         android_components_version = '94.0.0'
+        glean_version = '50.0.1'
         androidx_annotation_version = '1.2.0'
         androidx_core_version = '1.3.2'
         androidx_test_core_version = '1.4.0'
@@ -75,7 +76,7 @@ buildscript {
         // Since the Glean version depends on the Android components version,
         // it is very important to use a modern version of Glean and, ideally,
         // let this come from the embedding product itself.
-        classpath "org.mozilla.components:tooling-glean-gradle:$android_components_version"
+        classpath "org.mozilla.telemetry:glean-gradle-plugin:$glean_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -124,7 +125,7 @@ ext.libsGitSha = "git --git-dir=${rootProject.rootDir}/.git diff --name-only mai
 // downloaded libs.
 
 // XX: Since we switched the libs directory to be `darwin-x86-64` and `darwin-aarch64` in https://github.com/mozilla/application-services/pull/4792
-//     we have mimatch with the libs built on CI, since they have the libraries under `darwin`. 
+//     we have mimatch with the libs built on CI, since they have the libraries under `darwin`.
 //     Temporarily, we are disabling downloaded libs
 //     we should enable them once our CI builds libs the same way as our local environments
 //     see: https://github.com/mozilla/application-services/issues/4828

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -7,17 +7,18 @@ apply from: "$rootDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.
+ext.gleanNamespace = "mozilla.telemetry.glean"
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
 dependencies {
     // Part of the public API.
     api project(':sync15')
 
-    implementation "org.mozilla.components:service-glean:$android_components_version"
+    implementation "org.mozilla.telemetry:glean:$glean_version"
 
     testImplementation "androidx.test:core-ktx:$androidx_test_core_version"
     testImplementation "androidx.work:work-testing:$androidx_work_testing_version"
-    testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:$project.ext.glean_version"
+    testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:$glean_version"
     testImplementation project(":syncmanager")
 }
 

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -16,8 +16,8 @@ import org.mozilla.appservices.logins.GleanMetrics.LoginsStore as LoginsStoreMet
  * instantiate anything from these classes, and it's on us to fix any bustage
  * on version updates.
  */
-import mozilla.components.service.glean.private.CounterMetricType
-import mozilla.components.service.glean.private.LabeledMetricType
+import mozilla.telemetry.glean.private.CounterMetricType
+import mozilla.telemetry.glean.private.LabeledMetricType
 
 /**
  * An artifact of the uniffi conversion - a thin-ish wrapper around a

--- a/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
+++ b/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
@@ -6,7 +6,7 @@ package mozilla.appservices.logins
 import androidx.test.core.app.ApplicationProvider
 import mozilla.appservices.Megazord
 import mozilla.appservices.syncmanager.SyncManager
-import mozilla.components.service.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -89,8 +89,8 @@ class DatabaseLoginsStorageTest {
     fun testMetricsGathering() {
         val store = createTestStore()
 
-        assert(!LoginsStoreMetrics.writeQueryCount.testHasValue())
-        assert(!LoginsStoreMetrics.writeQueryErrorCount["invalid_record"].testHasValue())
+        assertNull(LoginsStoreMetrics.writeQueryCount.testGetValue())
+        assertNull(LoginsStoreMetrics.writeQueryErrorCount["invalid_record"].testGetValue())
 
         val login = store.add(
             LoginEntry(
@@ -110,7 +110,7 @@ class DatabaseLoginsStorageTest {
         )
 
         assertEquals(LoginsStoreMetrics.writeQueryCount.testGetValue(), 1)
-        assert(!LoginsStoreMetrics.writeQueryErrorCount["invalid_record"].testHasValue())
+        assertNull(LoginsStoreMetrics.writeQueryErrorCount["invalid_record"].testGetValue())
 
         // N.B. this is invalid due to `formActionOrigin` being an invalid url.
         val invalid = LoginEntry(
@@ -137,14 +137,14 @@ class DatabaseLoginsStorageTest {
         assertEquals(LoginsStoreMetrics.writeQueryCount.testGetValue(), 2)
         assertEquals(LoginsStoreMetrics.writeQueryErrorCount["invalid_record"].testGetValue(), 1)
 
-        assert(!LoginsStoreMetrics.readQueryCount.testHasValue())
-        assert(!LoginsStoreMetrics.readQueryErrorCount["storage_error"].testHasValue())
+        assertNull(LoginsStoreMetrics.readQueryCount.testGetValue())
+        assertNull(LoginsStoreMetrics.readQueryErrorCount["storage_error"].testGetValue())
 
         val record = store.get(login.record.id)!!
         assertEquals(record.fields.origin, "https://www.example.com")
 
         assertEquals(LoginsStoreMetrics.readQueryCount.testGetValue(), 1)
-        assert(!LoginsStoreMetrics.readQueryErrorCount["storage_error"].testHasValue())
+        assertNull(LoginsStoreMetrics.readQueryErrorCount["storage_error"].testGetValue())
 
         finishAndClose(store)
     }
@@ -231,7 +231,7 @@ class DatabaseLoginsStorageTest {
         assertEquals(3, LoginsStoreMetrics.migrationNumProcessed.testGetValue())
         assertEquals(2, LoginsStoreMetrics.migrationNumFailed.testGetValue())
         assertEquals(1, LoginsStoreMetrics.migrationNumSucceeded.testGetValue())
-        assertEquals(53, LoginsStoreMetrics.migrationTotalDuration.testGetValue())
+        assertEquals(53L, LoginsStoreMetrics.migrationTotalDuration.testGetValue())
         // Note the truncation of the first error string.
         assertEquals(listOf("Invalid login: Login has illegal field: Origin is ", "Invalid login: Origin is empty"), LoginsStoreMetrics.migrationErrors.testGetValue())
     }

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -165,7 +165,7 @@ func recordMigrationMetrics(jsonString: String) {
         GleanMetrics.LoginsStoreMigration.numFailed.add(failed)
     }
 
-    if let duration = metrics["total_duration"] as? UInt64 {
+    if let duration = metrics["total_duration"] as? Int64 {
         GleanMetrics.LoginsStoreMigration.totalDuration.setRawNanos(duration * 1_000_000)
     }
 

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -6,6 +6,7 @@ apply from: "$rootDir/build-scripts/component-common.gradle"
 apply from: "$rootDir/publish.gradle"
 
 ext.gleanYamlFiles = ["${project.projectDir}/../metrics.yaml"]
+ext.gleanNamespace = "mozilla.telemetry.glean"
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
 dependencies {
@@ -13,7 +14,7 @@ dependencies {
 
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$kotlin_coroutines_version"
 
-    implementation "org.mozilla.components:service-glean:$android_components_version"
+    implementation "org.mozilla.telemetry:glean:$glean_version"
     implementation "androidx.core:core-ktx:$androidx_core_version"
 
     testImplementation "androidx.test:core-ktx:$androidx_test_core_version"

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -18,7 +18,7 @@ import androidx.annotation.WorkerThread
 import androidx.core.content.pm.PackageInfoCompat
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import mozilla.components.service.glean.Glean
+import mozilla.telemetry.glean.Glean
 import org.json.JSONObject
 import org.mozilla.experiments.nimbus.GleanMetrics.NimbusEvents
 import org.mozilla.experiments.nimbus.internal.AppContext

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -94,7 +94,7 @@ extension Nimbus: FeaturesInterface {
     internal func recordExperimentTelemetry(_ experiments: [EnrolledExperiment]) {
         for experiment in experiments {
             Glean.shared.setExperimentActive(
-                experimentId: experiment.slug,
+                experiment.slug,
                 branch: experiment.branchSlug,
                 extra: ["enrollmentId": experiment.enrollmentId]
             )

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -7,17 +7,18 @@ apply from: "$rootDir/build-scripts/component-common.gradle"
 apply from: "$rootDir/build-scripts/protobuf-common.gradle"
 apply from: "$rootDir/publish.gradle"
 
+ext.gleanNamespace = "mozilla.telemetry.glean"
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
 
 dependencies {
     // Part of the public API.
     api project(':sync15')
 
-    implementation "org.mozilla.components:service-glean:$android_components_version"
+    implementation "org.mozilla.telemetry:glean:$glean_version"
 
     testImplementation "androidx.test:core-ktx:$androidx_test_core_version"
     testImplementation "androidx.work:work-testing:$androidx_work_testing_version"
-    testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:$project.ext.glean_version"
+    testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:$glean_version"
     testImplementation project(':syncmanager')
 }
 

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -29,8 +29,8 @@ import mozilla.appservices.places.uniffi.InsertableBookmarkItem
 import mozilla.appservices.places.uniffi.InsertableBookmarkSeparator
 import mozilla.appservices.places.uniffi.BookmarkUpdateInfo
 import mozilla.appservices.sync15.SyncTelemetryPing
-import mozilla.components.service.glean.private.CounterMetricType
-import mozilla.components.service.glean.private.LabeledMetricType
+import mozilla.telemetry.glean.private.CounterMetricType
+import mozilla.telemetry.glean.private.LabeledMetricType
 import org.json.JSONObject
 import java.lang.ref.WeakReference
 import org.mozilla.appservices.places.GleanMetrics.PlacesManager as PlacesManagerMetrics

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -13,7 +13,7 @@ import mozilla.appservices.places.uniffi.FrecencyThresholdOption
 import mozilla.appservices.syncmanager.SyncManager
 import mozilla.appservices.places.uniffi.PlacesException
 import mozilla.appservices.places.uniffi.BookmarkItem
-import mozilla.components.service.glean.testing.GleanTestRule
+import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -379,15 +379,15 @@ class PlacesConnectionTest {
 
     @Test
     fun testHistoryMetricsGathering() {
-        assert(!PlacesManagerMetrics.writeQueryCount.testHasValue())
-        assert(!PlacesManagerMetrics.writeQueryErrorCount["url_parse_failed"].testHasValue())
+        assertNull(PlacesManagerMetrics.writeQueryCount.testGetValue())
+        assertNull(PlacesManagerMetrics.writeQueryErrorCount["url_parse_failed"].testGetValue())
 
         db.noteObservation(VisitObservation(url = "https://www.example.com/2a", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 130000))
         db.noteObservation(VisitObservation(url = "https://www.example.com/2b", visitType = VisitTransition.LINK, at = 150000))
         db.noteObservation(VisitObservation(url = "https://www.example.com/3", visitType = VisitTransition.LINK, at = 200000))
 
         assertEquals(3, PlacesManagerMetrics.writeQueryCount.testGetValue())
-        assert(!PlacesManagerMetrics.writeQueryErrorCount["__other__"].testHasValue())
+        assertNull(PlacesManagerMetrics.writeQueryErrorCount["__other__"].testGetValue())
 
         try {
             db.noteObservation(VisitObservation(url = "4", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 160000))
@@ -397,16 +397,15 @@ class PlacesConnectionTest {
         }
 
         assertEquals(4, PlacesManagerMetrics.writeQueryCount.testGetValue())
-        assert(PlacesManagerMetrics.writeQueryErrorCount["url_parse_failed"].testHasValue())
         assertEquals(1, PlacesManagerMetrics.writeQueryErrorCount["url_parse_failed"].testGetValue())
 
-        assert(!PlacesManagerMetrics.readQueryCount.testHasValue())
-        assert(!PlacesManagerMetrics.readQueryErrorCount["__other__"].testHasValue())
+        assertNull(PlacesManagerMetrics.readQueryCount.testGetValue())
+        assertNull(PlacesManagerMetrics.readQueryErrorCount["__other__"].testGetValue())
 
         db.getVisitInfos(125000, 225000)
 
         assertEquals(1, PlacesManagerMetrics.readQueryCount.testGetValue())
-        assert(!PlacesManagerMetrics.readQueryErrorCount["__other__"].testHasValue())
+        assertNull(PlacesManagerMetrics.readQueryErrorCount["__other__"].testGetValue())
 
         db.deleteVisit("https://www.example.com/2a", 130000)
 
@@ -414,13 +413,13 @@ class PlacesConnectionTest {
         assertEquals(2, infos.size)
 
         assertEquals(5, PlacesManagerMetrics.writeQueryCount.testGetValue())
-        assert(!PlacesManagerMetrics.writeQueryErrorCount["_other_"].testHasValue())
+        assertNull(PlacesManagerMetrics.writeQueryErrorCount["_other_"].testGetValue())
     }
 
     @Test
     fun testBookmarksMetricsGathering() {
-        assert(!PlacesManagerMetrics.writeQueryCount.testHasValue())
-        assert(!PlacesManagerMetrics.writeQueryErrorCount["unknown_bookmark_item"].testHasValue())
+        assertNull(PlacesManagerMetrics.writeQueryCount.testGetValue())
+        assertNull(PlacesManagerMetrics.writeQueryErrorCount["unknown_bookmark_item"].testGetValue())
 
         val itemGUID = db.createBookmarkItem(
             parentGUID = BookmarkRoot.Unfiled.id,
@@ -429,7 +428,7 @@ class PlacesConnectionTest {
         )
 
         assertEquals(1, PlacesManagerMetrics.writeQueryCount.testGetValue())
-        assert(!PlacesManagerMetrics.writeQueryErrorCount["unknown_bookmark_item"].testHasValue())
+        assertNull(PlacesManagerMetrics.writeQueryErrorCount["unknown_bookmark_item"].testGetValue())
 
         try {
             db.createBookmarkItem(
@@ -443,16 +442,15 @@ class PlacesConnectionTest {
         }
 
         assertEquals(2, PlacesManagerMetrics.writeQueryCount.testGetValue())
-        assert(PlacesManagerMetrics.writeQueryErrorCount["url_parse_failed"].testHasValue())
         assertEquals(1, PlacesManagerMetrics.writeQueryErrorCount["url_parse_failed"].testGetValue())
 
-        assert(!PlacesManagerMetrics.readQueryCount.testHasValue())
-        assert(!PlacesManagerMetrics.readQueryErrorCount["__other__"].testHasValue())
+        assertNull(PlacesManagerMetrics.readQueryCount.testGetValue())
+        assertNull(PlacesManagerMetrics.readQueryErrorCount["__other__"].testGetValue())
 
         db.getBookmark(itemGUID)
 
         assertEquals(1, PlacesManagerMetrics.readQueryCount.testGetValue())
-        assert(!PlacesManagerMetrics.readQueryErrorCount["__other__"].testHasValue())
+        assertNull(PlacesManagerMetrics.readQueryErrorCount["__other__"].testGetValue())
 
         val folderGUID = db.createFolder(
             parentGUID = BookmarkRoot.Unfiled.id,

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -354,7 +354,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: rkv</name>
-    <url>https://github.com/mozilla/rkv/blob/master/LICENSE</url>
+    <url>https://github.com/mozilla/rkv/blob/main/LICENSE</url>
   </license>
   <license>
     <name>Apache License 2.0: ryu</name>

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -20,5 +20,4 @@ autofill = { path = "../../components/autofill" }
 push = { path = "../../components/push" }
 tabs = { path = "../../components/tabs" }
 places = {path = "../../components/places" }
-glean-ffi = { path = "../../components/external/glean/glean-core/ffi" }
 sync15 = {path = "../../components/sync15"}

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -13,7 +13,6 @@ the details of which are reproduced below.
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata](#mit-license-cargo_metadata)
 * [MIT License: caseless](#mit-license-caseless)
-* [MIT License: dashmap](#mit-license-dashmap)
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: h2](#mit-license-h2)
 * [MIT License: http-body](#mit-license-http-body)
@@ -21,11 +20,9 @@ the details of which are reproduced below.
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
 * [MIT License: matches](#mit-license-matches)
 * [MIT License: mime_guess](#mit-license-mime_guess)
-* [MIT License: miniz_oxide](#mit-license-miniz_oxide)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
-* [MIT License: oslog](#mit-license-oslog)
 * [MIT License: slab](#mit-license-slab)
 * [MIT License: strsim](#mit-license-strsim)
 * [MIT License: textwrap](#mit-license-textwrap)
@@ -55,8 +52,7 @@ The following text applies to code linked from these dependencies:
 [uniffi](https://github.com/mozilla/uniffi-rs),
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
-[uniffi_macros](https://github.com/mozilla/uniffi-rs),
-[zeitstempel](https://github.com/badboy/zeitstempel)
+[uniffi_macros](https://github.com/mozilla/uniffi-rs)
 
 ```
 Mozilla Public License Version 2.0
@@ -438,7 +434,6 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 ## Apache License 2.0
 
 The following text applies to code linked from these dependencies:
-[adler](https://github.com/jonas-schievink/adler.git),
 [ahash](https://github.com/tkaitchuck/ahash),
 [anyhow](https://github.com/dtolnay/anyhow),
 [askama](https://github.com/djc/askama),
@@ -460,16 +455,13 @@ The following text applies to code linked from these dependencies:
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
 [core-foundation](https://github.com/servo/core-foundation-rs),
 [cpufeatures](https://github.com/RustCrypto/utils),
-[crc32fast](https://github.com/srijs/rust-crc32fast),
 [digest](https://github.com/RustCrypto/traits),
 [dogear](https://github.com/mozilla/dogear),
 [either](https://github.com/bluss/either),
-[env_logger](https://github.com/env-logger-rs/env_logger/),
 [fallible-iterator](https://github.com/sfackler/rust-fallible-iterator),
 [fallible-streaming-iterator](https://github.com/sfackler/fallible-streaming-iterator),
 [fastrand](https://github.com/smol-rs/fastrand),
 [ffi-support](https://github.com/mozilla/ffi-support),
-[flate2](https://github.com/rust-lang/flate2-rs),
 [fnv](https://github.com/servo/rust-fnv),
 [form_urlencoded](https://github.com/servo/rust-url),
 [futures-channel](https://github.com/rust-lang/futures-rs),
@@ -487,7 +479,6 @@ The following text applies to code linked from these dependencies:
 [http](https://github.com/hyperium/http),
 [httparse](https://github.com/seanmonstar/httparse),
 [httpdate](https://github.com/pyfisch/httpdate),
-[humantime](https://github.com/tailhook/humantime),
 [hyper-tls](https://github.com/hyperium/hyper-tls),
 [id-arena](https://github.com/fitzgen/id-arena),
 [idna](https://github.com/servo/rust-url/),
@@ -574,7 +565,7 @@ The following text applies to code linked from these dependencies:
 ```
                               Apache License
                         Version 2.0, January 2004
-                     https://www.apache.org/licenses/LICENSE-2.0
+                     http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -766,7 +757,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	https://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -996,36 +987,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
-## MIT License: dashmap
-
-The following text applies to code linked from these dependencies:
-[dashmap](https://github.com/xacrimon/dashmap)
-
-```
-MIT License
-
-Copyright (c) 2019 Acrimon
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
 ## MIT License: generic-array
 
 The following text applies to code linked from these dependencies:
@@ -1245,36 +1206,6 @@ SOFTWARE.
 
 ```
 -------------
-## MIT License: miniz_oxide
-
-The following text applies to code linked from these dependencies:
-[miniz_oxide](https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide)
-
-```
-MIT License
-
-Copyright (c) 2017 Frommi
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
 ## MIT License: mio
 
 The following text applies to code linked from these dependencies:
@@ -1363,36 +1294,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: oslog
-
-The following text applies to code linked from these dependencies:
-[oslog](https://github.com/steven-joruk/oslog)
-
-```
-MIT License
-
-Copyright (c) 2020 Steven Joruk
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ```
 -------------

--- a/megazords/ios-rust/MozillaRustComponents.h
+++ b/megazords/ios-rust/MozillaRustComponents.h
@@ -10,7 +10,6 @@
 #import "autofillFFI.h"
 #import "crashtestFFI.h"
 #import "fxa_clientFFI.h"
-#import "glean.h"
 #import "loginsFFI.h"
 #import "nimbusFFI.h"
 #import "placesFFI.h"

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -915,7 +915,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 43.0.0;
+				minimumVersion = 50.0.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mozilla/glean-swift",
         "state": {
           "branch": null,
-          "revision": "e8fef341610de380b55cd5a057f9a3adf7cebb44",
-          "version": "43.0.2"
+          "revision": "07b706286cf153f5e0b85f489d861a2b49c7ed2d",
+          "version": "50.0.1"
         }
       }
     ]

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/LoginsTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/LoginsTests.swift
@@ -33,12 +33,12 @@ class LoginsTests: XCTestCase {
         """
 
         recordMigrationMetrics(jsonString: json)
-        XCTAssertEqual(3, try GleanMetrics.LoginsStoreMigration.numProcessed.testGetValue())
-        XCTAssertEqual(2, try GleanMetrics.LoginsStoreMigration.numFailed.testGetValue())
-        XCTAssertEqual(1, try GleanMetrics.LoginsStoreMigration.numSucceeded.testGetValue())
-        XCTAssertEqual(53, try GleanMetrics.LoginsStoreMigration.totalDuration.testGetValue())
+        XCTAssertEqual(3, GleanMetrics.LoginsStoreMigration.numProcessed.testGetValue())
+        XCTAssertEqual(2, GleanMetrics.LoginsStoreMigration.numFailed.testGetValue())
+        XCTAssertEqual(1, GleanMetrics.LoginsStoreMigration.numSucceeded.testGetValue())
+        XCTAssertEqual(53, GleanMetrics.LoginsStoreMigration.totalDuration.testGetValue())
 
         // Note the truncation of the first error string.
-        XCTAssertEqual(["Invalid login: Login has illegal field: Origin is ", "Invalid login: Origin is empty"], try GleanMetrics.LoginsStoreMigration.errors.testGetValue())
+        XCTAssertEqual(["Invalid login: Login has illegal field: Origin is ", "Invalid login: Origin is empty"], GleanMetrics.LoginsStoreMigration.errors.testGetValue())
     }
 }

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
@@ -198,7 +198,7 @@ class NimbusTests: XCTestCase {
         )]
 
         nimbus.recordExperimentTelemetry(enrolledExperiments)
-        XCTAssertTrue(Glean.shared.testIsExperimentActive(experimentId: "test-experiment"),
+        XCTAssertTrue(Glean.shared.testIsExperimentActive("test-experiment"),
                       "Experiment should be active")
         // TODO: Below fails due to branch and extra being private members Glean
         // We will need to change this if we want to remove glean as a submodule and instead
@@ -245,8 +245,8 @@ class NimbusTests: XCTestCase {
         // Use the Glean test API to check the recorded events
 
         // Enrollment
-        XCTAssertTrue(GleanMetrics.NimbusEvents.enrollment.testHasValue(), "Enrollment event must exist")
-        let enrollmentEvents = try GleanMetrics.NimbusEvents.enrollment.testGetValue()
+        XCTAssertNotNil(GleanMetrics.NimbusEvents.enrollment.testGetValue(), "Enrollment event must exist")
+        let enrollmentEvents = GleanMetrics.NimbusEvents.enrollment.testGetValue()!
         XCTAssertEqual(1, enrollmentEvents.count, "Enrollment event count must match")
         let enrollmentEventExtras = enrollmentEvents.first!.extra
         XCTAssertEqual("test-experiment", enrollmentEventExtras!["experiment"], "Enrollment event experiment must match")
@@ -254,8 +254,8 @@ class NimbusTests: XCTestCase {
         XCTAssertEqual("test-enrollment-id", enrollmentEventExtras!["enrollment_id"], "Enrollment event enrollment id must match")
 
         // Unenrollment
-        XCTAssertTrue(GleanMetrics.NimbusEvents.unenrollment.testHasValue(), "Unenrollment event must exist")
-        let unenrollmentEvents = try GleanMetrics.NimbusEvents.unenrollment.testGetValue()
+        XCTAssertNotNil(GleanMetrics.NimbusEvents.unenrollment.testGetValue(), "Unenrollment event must exist")
+        let unenrollmentEvents = GleanMetrics.NimbusEvents.unenrollment.testGetValue()!
         XCTAssertEqual(1, unenrollmentEvents.count, "Unenrollment event count must match")
         let unenrollmentEventExtras = unenrollmentEvents.first!.extra
         XCTAssertEqual("test-experiment", unenrollmentEventExtras!["experiment"], "Unenrollment event experiment must match")
@@ -263,8 +263,8 @@ class NimbusTests: XCTestCase {
         XCTAssertEqual("test-enrollment-id", unenrollmentEventExtras!["enrollment_id"], "Unenrollment event enrollment id must match")
 
         // Disqualification
-        XCTAssertTrue(GleanMetrics.NimbusEvents.disqualification.testHasValue(), "Disqualification event must exist")
-        let disqualificationEvents = try GleanMetrics.NimbusEvents.disqualification.testGetValue()
+        XCTAssertNotNil(GleanMetrics.NimbusEvents.disqualification.testGetValue(), "Disqualification event must exist")
+        let disqualificationEvents = GleanMetrics.NimbusEvents.disqualification.testGetValue()!
         XCTAssertEqual(1, disqualificationEvents.count, "Disqualification event count must match")
         let disqualificationEventExtras = disqualificationEvents.first!.extra
         XCTAssertEqual("test-experiment", disqualificationEventExtras!["experiment"], "Disqualification event experiment must match")
@@ -283,14 +283,14 @@ class NimbusTests: XCTestCase {
         try nimbus.applyPendingExperimentsOnThisThread()
 
         // Assert that there are no events to start with
-        XCTAssertFalse(GleanMetrics.NimbusEvents.exposure.testHasValue(), "Event must have a value")
+        XCTAssertNil(GleanMetrics.NimbusEvents.exposure.testGetValue(), "Event must not have a value")
 
         // Record a valid exposure event in Glean that matches the featureId from the test experiment
         nimbus.recordExposureEvent(featureId: "aboutwelcome")
 
         // Use the Glean test API to check that the valid event is present
-        XCTAssertTrue(GleanMetrics.NimbusEvents.exposure.testHasValue(), "Event must have a value")
-        let enrollmentEvents = try GleanMetrics.NimbusEvents.exposure.testGetValue()
+        XCTAssertNotNil(GleanMetrics.NimbusEvents.exposure.testGetValue(), "Event must have a value")
+        let enrollmentEvents = GleanMetrics.NimbusEvents.exposure.testGetValue()!
         XCTAssertEqual(1, enrollmentEvents.count, "Event count must match")
         let enrollmentEventExtras = enrollmentEvents.first!.extra
         XCTAssertEqual("secure-gold", enrollmentEventExtras!["experiment"], "Experiment slug must match")
@@ -306,7 +306,7 @@ class NimbusTests: XCTestCase {
 
         // Verify the invalid event was ignored by checking again that the valid event is still the only
         // event, and that it hasn't changed any of its extra properties.
-        let enrollmentEventsTryTwo = try GleanMetrics.NimbusEvents.exposure.testGetValue()
+        let enrollmentEventsTryTwo = GleanMetrics.NimbusEvents.exposure.testGetValue()!
         XCTAssertEqual(1, enrollmentEventsTryTwo.count, "Event count must match")
         let enrollmentEventExtrasTryTwo = enrollmentEventsTryTwo.first!.extra
         XCTAssertEqual("secure-gold", enrollmentEventExtrasTryTwo!["experiment"], "Experiment slug must match")
@@ -328,14 +328,14 @@ class NimbusTests: XCTestCase {
         try nimbus.applyPendingExperimentsOnThisThread()
 
         // Assert that there are no events to start with
-        XCTAssertFalse(GleanMetrics.NimbusEvents.exposure.testHasValue(), "Event must have a value")
+        XCTAssertNil(GleanMetrics.NimbusEvents.exposure.testGetValue(), "Event must not have a value")
 
         // Opt out of the experiment, which should generate a "disqualification" event
         try nimbus.optOutOnThisThread("secure-gold")
 
         // Use the Glean test API to check that the valid event is present
-        XCTAssertTrue(GleanMetrics.NimbusEvents.disqualification.testHasValue(), "Event must have a value")
-        let disqualificationEvents = try GleanMetrics.NimbusEvents.disqualification.testGetValue()
+        XCTAssertNotNil(GleanMetrics.NimbusEvents.disqualification.testGetValue(), "Event must have a value")
+        let disqualificationEvents = GleanMetrics.NimbusEvents.disqualification.testGetValue()!
         XCTAssertEqual(1, disqualificationEvents.count, "Event count must match")
         let disqualificationEventExtras = disqualificationEvents.first!.extra
         XCTAssertEqual("secure-gold", disqualificationEventExtras!["experiment"], "Experiment slug must match")
@@ -357,15 +357,15 @@ class NimbusTests: XCTestCase {
         try nimbus.applyPendingExperimentsOnThisThread()
 
         // Assert that there are no events to start with
-        XCTAssertFalse(GleanMetrics.NimbusEvents.exposure.testHasValue(), "Event must have a value")
+        XCTAssertNil(GleanMetrics.NimbusEvents.exposure.testGetValue(), "Event must not have a value")
 
         // Opt out of all experiments, which should generate a "disqualification" event for the enrolled
         // experiment
         try nimbus.setGlobalUserParticipationOnThisThread(false)
 
         // Use the Glean test API to check that the valid event is present
-        XCTAssertTrue(GleanMetrics.NimbusEvents.disqualification.testHasValue(), "Event must have a value")
-        let disqualificationEvents = try GleanMetrics.NimbusEvents.disqualification.testGetValue()
+        XCTAssertNotNil(GleanMetrics.NimbusEvents.disqualification.testGetValue(), "Event must have a value")
+        let disqualificationEvents = GleanMetrics.NimbusEvents.disqualification.testGetValue()!
         XCTAssertEqual(1, disqualificationEvents.count, "Event count must match")
         let disqualificationEventExtras = disqualificationEvents.first!.extra
         XCTAssertEqual("secure-gold", disqualificationEventExtras!["experiment"], "Experiment slug must match")

--- a/megazords/ios-rust/build-xcframework.sh
+++ b/megazords/ios-rust/build-xcframework.sh
@@ -150,7 +150,6 @@ $CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l 
 # We now only move/generate the rest of the headers if we are generating a full
 # iOS megazord
 if [ -z $IS_FOCUS ]; then
-  cp "$REPO_ROOT/components/external/glean/glean-core/ffi/glean.h" "$COMMON/Headers"
   # TODO: https://github.com/mozilla/uniffi-rs/issues/1060
   # it would be neat if there was a single UniFFI command that would spit out
   # all of the generated headers for all UniFFIed dependencies of a given crate.

--- a/megazords/ios-rust/src/lib.rs
+++ b/megazords/ios-rust/src/lib.rs
@@ -8,7 +8,6 @@
 pub use autofill;
 pub use crashtest;
 pub use fxa_client;
-pub use glean_ffi;
 pub use logins;
 pub use nimbus;
 pub use places;


### PR DESCRIPTION
~~This has been unused for a while now.~~

~~This requires https://github.com/mozilla-mobile/android-components/pull/12248 and an A-C update here.~~

This now uses Glean directly through the org.mozilla.telemetry:glean
package, instead of its Android Components release.
This is required to avoid a dependency cycle:
* The migration component in a-c requires Glean and a-s
* a-s requires Glean from a-c

But there can only be one Glean in the build.
So in order to not need to release individual components manually we
switch a-s to directly consume Glean.
Then we can update a-s and get that into a-c together with a Glean
update there.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
