### PR TITLE
Put the new error-reporting capability behind a feature

### DIFF
--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -27,7 +27,7 @@ idna = "0.2"
 memchr = "2.3"
 dogear = "0.4"
 interrupt-support = { path = "../support/interrupt" }
-error-support = { path = "../support/error" }
+error-support = { path = "../support/error", features = ["reporting"] }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 thiserror = "1.0"
 anyhow = "1.0"

--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -7,14 +7,18 @@ license = "MPL-2.0"
 
 [dependencies]
 log = "0.4"
-parking_lot = ">=0.11,<=0.12"
-lazy_static = "1.4"
-uniffi = "^0.18"
-uniffi_macros = "^0.18"
+lazy_static = { version = "1.4", optional = true }
+parking_lot = { version = ">=0.11,<=0.12", optional = true }
+uniffi = { version = "^0.18", optional = true }
+uniffi_macros = { version = "^0.18", optional = true }
 
 [dependencies.backtrace]
 optional = true
 version = "0.3"
 
+[features]
+default = []
+reporting = ["lazy_static", "parking_lot", "uniffi", "uniffi_macros", "uniffi_build"]
+
 [build-dependencies]
-uniffi_build = { version = "^0.18", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.18", features=["builtin-bindgen"], optional = true }

--- a/components/support/error/build.rs
+++ b/components/support/error/build.rs
@@ -4,5 +4,6 @@
  */
 
 fn main() {
+    #[cfg(feature = "reporting")]
     uniffi_build::generate_scaffolding("./src/errorsupport.udl").unwrap();
 }

--- a/components/support/error/src/lib.rs
+++ b/components/support/error/src/lib.rs
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 mod macros;
-mod reporting;
 
 #[cfg(feature = "backtrace")]
 /// Re-export of the `backtrace` crate for use in macros and
@@ -25,6 +24,9 @@ pub mod backtrace {
     }
 }
 
+#[cfg(feature = "reporting")]
+mod reporting;
+#[cfg(feature = "reporting")]
 pub use reporting::{
     report_breadcrumb, report_error, set_application_error_reporter, ApplicationErrorReporter,
 };
@@ -147,4 +149,5 @@ macro_rules! define_error {
     };
 }
 
+#[cfg(feature = "reporting")]
 uniffi_macros::include_scaffolding!("errorsupport");

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0"
 anyhow = "1.0"
 lazy_static = "1.4"
 log = "0.4"
-error-support = { path = "../support/error" }
+error-support = { path = "../support/error", features = ["reporting"] }
 sql-support = { path = "../support/sql" }
 url = "2.2"
 serde = "1"


### PR DESCRIPTION
I noticed that the new error reporting capability meant that webext-storage ended up taking a dependency on uniffi etc, which is doesn't need in practice and makes vendoring into m-c a bit painful at this instant. Even though m-c is going to end up with uniffi, there's no need for webext-storage to take the small hit, so I put the error reporting behind a feature.

This seems to work for me locally, and if I missed something I hope CI will point it out! Ben, wdyt?