### PR TITLE
Update to ktlint 0.45.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -312,21 +312,25 @@ configurations {
 }
 
 dependencies {
-    ktlint "com.github.shyiko:ktlint:0.31.0"
+    ktlint("com.pinterest:ktlint:0.45.1") {
+        attributes {
+            attribute(Bundling.BUNDLING_ATTRIBUTE, getObjects().named(Bundling, Bundling.EXTERNAL))
+        }
+    }
 }
 
 task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
-    main = "com.github.shyiko.ktlint.Main"
-    args "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build", "!**/templates", "!components/external"
+    mainClass.set("com.pinterest.ktlint.Main")
+    args "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build/**", "!**/templates/**", "!**/components/external/**"
 }
 
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
-    main = "com.github.shyiko.ktlint.Main"
-    args "-F", "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build", "!components/external"
+    mainClass.set("com.pinterest.ktlint.Main")
+    args "-F", "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build/**", "!**/templates/**", "!**/components/external/**"
 }
 
 // Extremely unsophisticated way to publish a local development version while hiding implementation details.

--- a/components/autofill/android/src/test/java/mozilla/appservices/autofill/AutofillTest.kt
+++ b/components/autofill/android/src/test/java/mozilla/appservices/autofill/AutofillTest.kt
@@ -1,12 +1,11 @@
-import mozilla.appservices.autofill.Store
 import mozilla.appservices.Megazord
+import mozilla.appservices.autofill.Store
 import mozilla.appservices.syncmanager.SyncManager
-
-import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/PersistedFirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/PersistedFirefoxAccount.kt
@@ -28,17 +28,20 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      * This does not make network requests, and can be used on the main thread.
      *
      */
-    constructor(config: Config, persistCallback: PersistCallback? = null) : this(FirefoxAccount(
-        // This is kind of dumb - we take a Config object on the Kotlin side, destructure it into its fields
-        // to pass over the FFI, then the Rust side turns it back into its own variant of a Config object!
-        // That made sense when we had to write the FFI layer by hand, but we should see whether we can nicely
-        // expose the Rust Config interface to Kotlin and Swift and then just accept a Config here in the
-        // underlying `FirefoxAccount` constructor.
-        config.contentUrl,
-        config.clientId,
-        config.redirectUri,
-        config.tokenServerUrlOverride
-    ), persistCallback) {
+    constructor(config: Config, persistCallback: PersistCallback? = null) : this(
+        FirefoxAccount(
+            // This is kind of dumb - we take a Config object on the Kotlin side, destructure it into its fields
+            // to pass over the FFI, then the Rust side turns it back into its own variant of a Config object!
+            // That made sense when we had to write the FFI layer by hand, but we should see whether we can nicely
+            // expose the Rust Config interface to Kotlin and Swift and then just accept a Config here in the
+            // underlying `FirefoxAccount` constructor.
+            config.contentUrl,
+            config.clientId,
+            config.redirectUri,
+            config.tokenServerUrlOverride
+        ),
+        persistCallback
+    ) {
         // Persist the newly created instance state.
         this.tryPersistState()
     }

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -4,18 +4,9 @@
 
 package mozilla.appservices.logins
 
-import org.mozilla.appservices.logins.GleanMetrics.LoginsStore as LoginsStoreMetrics
-
-/**
- * Import some private Glean types, so that we can use them in type declarations.
- *
- * I do not like importing these private classes, but I do like the nice generic
- * code they allow me to write! By agreement with the Glean team, we must not
- * instantiate anything from these classes, and it's on us to fix any bustage
- * on version updates.
- */
 import mozilla.telemetry.glean.private.CounterMetricType
 import mozilla.telemetry.glean.private.LabeledMetricType
+import org.mozilla.appservices.logins.GleanMetrics.LoginsStore as LoginsStoreMetrics
 
 /**
  * An artifact of the uniffi conversion - a thin-ish wrapper around a

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeatureVariables.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeatureVariables.kt
@@ -468,7 +468,8 @@ private inline fun <reified T> JSONObject.asMap(): Map<String, T>? {
 class NullVariables : Variables {
     override val context: Context
         get() = this._context
-            ?: throw NimbusFeatureException("""
+            ?: throw NimbusFeatureException(
+                """
                 Nimbus hasn't been initialized yet.
 
                 Calling NullVariables.instance.setContext(context) earlier in the app startup will

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -29,9 +29,9 @@ import org.mozilla.experiments.nimbus.internal.EnrolledExperiment
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEvent
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEventType
 import org.mozilla.experiments.nimbus.internal.ExperimentBranch
-import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.mozilla.experiments.nimbus.internal.NimbusClient
 import org.mozilla.experiments.nimbus.internal.NimbusClientInterface
+import org.mozilla.experiments.nimbus.internal.NimbusException
 import org.mozilla.experiments.nimbus.internal.RemoteSettingsConfig
 import java.io.File
 
@@ -373,9 +373,11 @@ open class Nimbus(
         try {
             nimbusClient.getFeatureConfigVariables(featureId)?.let { JSONObject(it) }
         } catch (e: NimbusException.DatabaseNotReady) {
-            NimbusHealth.cacheNotReadyForFeature.record(NimbusHealth.CacheNotReadyForFeatureExtra(
-                featureId = featureId
-            ))
+            NimbusHealth.cacheNotReadyForFeature.record(
+                NimbusHealth.CacheNotReadyForFeatureExtra(
+                    featureId = featureId
+                )
+            )
             null
         } catch (e: Throwable) {
             reportError(e)
@@ -402,7 +404,7 @@ open class Nimbus(
             }
             JSONVariables(context, json)
         }
-        ?: NullVariables.instance
+            ?: NullVariables.instance
 
     @WorkerThread
     override fun getExperimentBranches(experimentId: String): List<Branch>? = withCatchAll {
@@ -576,25 +578,31 @@ open class Nimbus(
         enrollmentChangeEvents.forEach { event ->
             when (event.change) {
                 EnrollmentChangeEventType.ENROLLMENT -> {
-                    NimbusEvents.enrollment.record(NimbusEvents.EnrollmentExtra(
-                        experiment = event.experimentSlug,
-                        branch = event.branchSlug,
-                        enrollmentId = event.enrollmentId
-                    ))
+                    NimbusEvents.enrollment.record(
+                        NimbusEvents.EnrollmentExtra(
+                            experiment = event.experimentSlug,
+                            branch = event.branchSlug,
+                            enrollmentId = event.enrollmentId
+                        )
+                    )
                 }
                 EnrollmentChangeEventType.DISQUALIFICATION -> {
-                    NimbusEvents.disqualification.record(NimbusEvents.DisqualificationExtra(
-                        experiment = event.experimentSlug,
-                        branch = event.branchSlug,
-                        enrollmentId = event.enrollmentId
-                    ))
+                    NimbusEvents.disqualification.record(
+                        NimbusEvents.DisqualificationExtra(
+                            experiment = event.experimentSlug,
+                            branch = event.branchSlug,
+                            enrollmentId = event.enrollmentId
+                        )
+                    )
                 }
                 EnrollmentChangeEventType.UNENROLLMENT -> {
-                    NimbusEvents.unenrollment.record(NimbusEvents.UnenrollmentExtra(
-                        experiment = event.experimentSlug,
-                        branch = event.branchSlug,
-                        enrollmentId = event.enrollmentId
-                    ))
+                    NimbusEvents.unenrollment.record(
+                        NimbusEvents.UnenrollmentExtra(
+                            experiment = event.experimentSlug,
+                            branch = event.branchSlug,
+                            enrollmentId = event.enrollmentId
+                        )
+                    )
                 }
             }
         }
@@ -614,11 +622,13 @@ open class Nimbus(
     internal fun recordExposureOnThisThread(featureId: String) = withCatchAll {
         val activeExperiments = getActiveExperiments()
         activeExperiments.find { it.featureIds.contains(featureId) }?.also { experiment ->
-            NimbusEvents.exposure.record(NimbusEvents.ExposureExtra(
-                experiment = experiment.slug,
-                branch = experiment.branchSlug,
-                enrollmentId = experiment.enrollmentId
-            ))
+            NimbusEvents.exposure.record(
+                NimbusEvents.ExposureExtra(
+                    experiment = experiment.slug,
+                    branch = experiment.branchSlug,
+                    enrollmentId = experiment.enrollmentId
+                )
+            )
         }
     }
 
@@ -648,6 +658,7 @@ open class Nimbus(
             osVersion = Build.VERSION.RELEASE,
             installationDate = packageInfo?.firstInstallTime,
             homeDirectory = context.applicationInfo?.dataDir,
-            customTargetingAttributes = appInfo.customTargetingAttributes)
+            customTargetingAttributes = appInfo.customTargetingAttributes
+        )
     }
 }

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
@@ -5,10 +5,10 @@
 package org.mozilla.experiments.nimbus.internal
 
 import android.content.Context
-import org.mozilla.experiments.nimbus.GleanMetrics.NimbusHealth
 import org.mozilla.experiments.nimbus.FeaturesInterface
-import org.mozilla.experiments.nimbus.Variables
+import org.mozilla.experiments.nimbus.GleanMetrics.NimbusHealth
 import org.mozilla.experiments.nimbus.NullVariables
+import org.mozilla.experiments.nimbus.Variables
 import java.util.concurrent.locks.ReentrantLock
 
 /**
@@ -47,9 +47,11 @@ class FeatureHolder<T>(
                 cachedValue!!
             } else {
                 val variables = getSdk()?.getVariables(featureId, false) ?: run {
-                    NimbusHealth.sdkUnavailableForFeature.record(NimbusHealth.SdkUnavailableForFeatureExtra(
-                        featureId = featureId
-                    ))
+                    NimbusHealth.sdkUnavailableForFeature.record(
+                        NimbusHealth.SdkUnavailableForFeatureExtra(
+                            featureId = featureId
+                        )
+                    )
                     NullVariables.instance
                 }
                 create(variables).also { value ->

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/FeatureVariablesTest.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/FeatureVariablesTest.kt
@@ -22,9 +22,11 @@ class FeatureVariablesTest {
 
     @Test
     fun `test values coerce into simple types`() {
-        val json = JSONObject("""
+        val json = JSONObject(
+            """
             {"stringVariable": "string", "intVariable": 3, "booleanVariable": true}
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val variables: Variables = JSONVariables(context, json)
 
@@ -35,9 +37,11 @@ class FeatureVariablesTest {
 
     @Test
     fun `test values are null if the wrong type`() {
-        val json = JSONObject("""
+        val json = JSONObject(
+            """
             {"stringVariable": "string", "intVariable": 3, "booleanVariable": true}
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val variables: Variables = JSONVariables(context, json)
 
@@ -54,7 +58,8 @@ class FeatureVariablesTest {
 
     @Test
     fun `test nested values are make another variables object`() {
-        val json = JSONObject("""
+        val json = JSONObject(
+            """
             {
                 "inner": {
                     "stringVariable": "string",
@@ -63,7 +68,8 @@ class FeatureVariablesTest {
                 },
                 "really-a-string": "a string"
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val outer: Variables = JSONVariables(context, json)
 
@@ -80,13 +86,15 @@ class FeatureVariablesTest {
 
     @Test
     fun `test arrays of strings`() {
-        val json = JSONObject("""
+        val json = JSONObject(
+            """
             {
                 "empty": [],
                 "all-strings": ["x", "y", "z"],
                 "some-strings": [1, true, "one", "two", false, 0, [], {}]
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val outer: Variables = JSONVariables(context, json)
 
@@ -97,13 +105,15 @@ class FeatureVariablesTest {
 
     @Test
     fun `test map of strings to raw type (int)`() {
-        val json = JSONObject("""
+        val json = JSONObject(
+            """
             {
                 "empty": {},
                 "all-strings": {"one": 1, "two": 2},
                 "some-strings": {"one": 1, "two": 2, "three": "not at int", "four": true}
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val outer = JSONVariables(context, json)
 
@@ -114,13 +124,15 @@ class FeatureVariablesTest {
 
     @Test
     fun `test map of strings to raw type (strings)`() {
-        val json = JSONObject("""
+        val json = JSONObject(
+            """
             {
                 "empty": {},
                 "all-strings": {"one": "ONE", "two": "TWO"},
                 "some-strings": {"one": 1, "two": 2, "three": "THREE", "four": true}
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val outer = JSONVariables(context, json)
 
@@ -131,13 +143,15 @@ class FeatureVariablesTest {
 
     @Test
     fun `test map of strings to raw type (bool)`() {
-        val json = JSONObject("""
+        val json = JSONObject(
+            """
             {
                 "empty": {},
                 "all-bools": {"one": true, "two": false},
                 "some-bools": {"one": 1, "two": 2, "three": "THREE", "four": true}
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val outer = JSONVariables(context, json)
 
@@ -148,13 +162,15 @@ class FeatureVariablesTest {
 
     @Test
     fun `test transforming enum keys and values`() {
-        val json = JSONObject("""
+        val json = JSONObject(
+            """
             {
                 "num-bools": {"one": true, "two": false},
                 "string-num": {"one": "one", "two": "two", "three": "three"},
                 "some-nums": ["one", "one", "two", "three"]
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val variables: Variables = JSONVariables(context, json)
 
@@ -181,7 +197,8 @@ class FeatureVariablesTest {
 
     @Test
     fun `test ordering of menu items`() {
-        val json = JSONObject("""
+        val json = JSONObject(
+            """
             {
                 "items": {
                     "settings": {
@@ -202,7 +219,8 @@ class FeatureVariablesTest {
                 },
                 "item-order": ["settings", "history", "addBookmark", "bookmarks", "open_bad_site"]
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
 
         val variables: Variables = JSONVariables(context, json)
 

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
@@ -83,7 +83,8 @@ class GleanPlumbTests {
         val context = JSONObject(
             """{
                     "test_value_from_json": 42
-                }""".trimIndent()
+                }
+            """.trimIndent()
         )
 
         assertThrows("no context, so no variable", NimbusException::class.java) {
@@ -116,7 +117,8 @@ class GleanPlumbTests {
         val context = JSONObject(
             """{
                     "test_string": "foobar"
-                }""".trimIndent()
+                }
+            """.trimIndent()
         )
 
         val helper = nimbus.createMessageHelper(context)

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -12,9 +12,9 @@ import kotlinx.coroutines.asCoroutineDispatcher
 import mozilla.telemetry.glean.BuildInfo
 import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.config.Configuration
-import mozilla.telemetry.glean.testing.GleanTestRule
-import mozilla.telemetry.glean.net.PingUploader
 import mozilla.telemetry.glean.net.HttpStatus
+import mozilla.telemetry.glean.net.PingUploader
+import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -29,8 +29,8 @@ import org.mozilla.experiments.nimbus.GleanMetrics.NimbusEvents
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEvent
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEventType
 import org.robolectric.RobolectricTestRunner
-import java.util.concurrent.Executors
 import java.util.Calendar
+import java.util.concurrent.Executors
 
 @RunWith(RobolectricTestRunner::class)
 class NimbusTests {

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -4,35 +4,35 @@
 
 package mozilla.appservices.places
 
+import mozilla.appservices.places.uniffi.BookmarkItem
 import mozilla.appservices.places.uniffi.BookmarkPosition
+import mozilla.appservices.places.uniffi.BookmarkUpdateInfo
 import mozilla.appservices.places.uniffi.ConnectionType
 import mozilla.appservices.places.uniffi.DocumentType
 import mozilla.appservices.places.uniffi.FrecencyThresholdOption
-import mozilla.appservices.places.uniffi.PlacesException
 import mozilla.appservices.places.uniffi.HistoryHighlight
 import mozilla.appservices.places.uniffi.HistoryHighlightWeights
 import mozilla.appservices.places.uniffi.HistoryMetadata
 import mozilla.appservices.places.uniffi.HistoryMetadataObservation
-import mozilla.appservices.places.uniffi.TopFrecentSiteInfo
-import mozilla.appservices.places.uniffi.PlacesApi as UniffiPlacesApi
-import mozilla.appservices.places.uniffi.PlacesConnection as UniffiPlacesConnection
-import mozilla.appservices.places.uniffi.placesApiNew
-import mozilla.appservices.places.uniffi.VisitObservation
 import mozilla.appservices.places.uniffi.HistoryVisitInfo
 import mozilla.appservices.places.uniffi.HistoryVisitInfosWithBound
-import mozilla.appservices.places.uniffi.SearchResult
-import mozilla.appservices.places.uniffi.SqlInterruptHandle
-import mozilla.appservices.places.uniffi.BookmarkItem
 import mozilla.appservices.places.uniffi.InsertableBookmark
 import mozilla.appservices.places.uniffi.InsertableBookmarkFolder
 import mozilla.appservices.places.uniffi.InsertableBookmarkItem
 import mozilla.appservices.places.uniffi.InsertableBookmarkSeparator
-import mozilla.appservices.places.uniffi.BookmarkUpdateInfo
+import mozilla.appservices.places.uniffi.PlacesException
+import mozilla.appservices.places.uniffi.SearchResult
+import mozilla.appservices.places.uniffi.SqlInterruptHandle
+import mozilla.appservices.places.uniffi.TopFrecentSiteInfo
+import mozilla.appservices.places.uniffi.VisitObservation
+import mozilla.appservices.places.uniffi.placesApiNew
 import mozilla.appservices.sync15.SyncTelemetryPing
 import mozilla.telemetry.glean.private.CounterMetricType
 import mozilla.telemetry.glean.private.LabeledMetricType
 import org.json.JSONObject
 import java.lang.ref.WeakReference
+import mozilla.appservices.places.uniffi.PlacesApi as UniffiPlacesApi
+import mozilla.appservices.places.uniffi.PlacesConnection as UniffiPlacesConnection
 import org.mozilla.appservices.places.GleanMetrics.PlacesManager as PlacesManagerMetrics
 
 typealias Url = String
@@ -87,21 +87,21 @@ class PlacesApi(path: String) : PlacesManager, AutoCloseable {
 
     override fun syncHistory(syncInfo: SyncAuthInfo): SyncTelemetryPing {
         val pingJSONString = this.api.historySync(
-                syncInfo.kid,
-                syncInfo.fxaAccessToken,
-                syncInfo.syncKey,
-                syncInfo.tokenserverURL
-            )
+            syncInfo.kid,
+            syncInfo.fxaAccessToken,
+            syncInfo.syncKey,
+            syncInfo.tokenserverURL
+        )
         return SyncTelemetryPing.fromJSONString(pingJSONString)
     }
 
     override fun syncBookmarks(syncInfo: SyncAuthInfo): SyncTelemetryPing {
         val pingJSONString = this.api.bookmarksSync(
-                syncInfo.kid,
-                syncInfo.fxaAccessToken,
-                syncInfo.syncKey,
-                syncInfo.tokenserverURL
-            )
+            syncInfo.kid,
+            syncInfo.fxaAccessToken,
+            syncInfo.syncKey,
+            syncInfo.tokenserverURL
+        )
         return SyncTelemetryPing.fromJSONString(pingJSONString)
     }
 

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -6,19 +6,19 @@ package mozilla.appservices.places
 import androidx.test.core.app.ApplicationProvider
 import kotlinx.coroutines.runBlocking
 import mozilla.appservices.Megazord
+import mozilla.appservices.places.uniffi.BookmarkItem
 import mozilla.appservices.places.uniffi.DocumentType
+import mozilla.appservices.places.uniffi.FrecencyThresholdOption
+import mozilla.appservices.places.uniffi.PlacesException
 import mozilla.appservices.places.uniffi.VisitObservation
 import mozilla.appservices.places.uniffi.VisitTransition
-import mozilla.appservices.places.uniffi.FrecencyThresholdOption
 import mozilla.appservices.syncmanager.SyncManager
-import mozilla.appservices.places.uniffi.PlacesException
-import mozilla.appservices.places.uniffi.BookmarkItem
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
-import org.junit.Assert.assertFalse
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Rule
@@ -187,28 +187,36 @@ class PlacesConnectionTest {
 
     @Test
     fun testObservingPreviewImage() {
-        db.noteObservation(VisitObservation(
-            url = "https://www.example.com/0",
-            visitType = VisitTransition.LINK)
+        db.noteObservation(
+            VisitObservation(
+                url = "https://www.example.com/0",
+                visitType = VisitTransition.LINK
+            )
         )
 
-        db.noteObservation(VisitObservation(
-            url = "https://www.example.com/1",
-            visitType = VisitTransition.LINK)
+        db.noteObservation(
+            VisitObservation(
+                url = "https://www.example.com/1",
+                visitType = VisitTransition.LINK
+            )
         )
 
         // Can change preview image.
-        db.noteObservation(VisitObservation(
-            url = "https://www.example.com/1",
-            visitType = VisitTransition.LINK,
-            previewImageUrl = "https://www.example.com/1/previewImage.png")
+        db.noteObservation(
+            VisitObservation(
+                url = "https://www.example.com/1",
+                visitType = VisitTransition.LINK,
+                previewImageUrl = "https://www.example.com/1/previewImage.png"
+            )
         )
 
         // Can make an initial observation with the preview image.
-        db.noteObservation(VisitObservation(
-            url = "https://www.example.com/2",
-            visitType = VisitTransition.LINK,
-            previewImageUrl = "https://www.example.com/2/previewImage.png")
+        db.noteObservation(
+            VisitObservation(
+                url = "https://www.example.com/2",
+                visitType = VisitTransition.LINK,
+                previewImageUrl = "https://www.example.com/2/previewImage.png"
+            )
         )
 
         val all = db.getVisitInfos(0)

--- a/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
+++ b/components/push/android/src/test/java/mozilla/appservices/push/PushTest.kt
@@ -1,15 +1,15 @@
 package mozilla.appservices.push
 
 import mozilla.appservices.Megazord
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.Assert.assertEquals
-import org.junit.Assert.fail
 import java.nio.charset.Charset
 
 @RunWith(RobolectricTestRunner::class)
@@ -28,37 +28,37 @@ class PushTest {
     }
 
     protected val private_key_raw = "MHcCAQEEIKiZMcVhlVccuwSr62jWN4YPBrPmPKotJUWl1id0d2ifoAoGCCq" +
-            "GSM49AwEHoUQDQgAEFwl1-zUa0zLKYVO23LqUgZZEVesS0k_jQN_SA69ENHgPwIpWCoTq-VhHu0JiSwhF0o" +
-            "PUzEM-FBWYoufO6J97nQ"
+        "GSM49AwEHoUQDQgAEFwl1-zUa0zLKYVO23LqUgZZEVesS0k_jQN_SA69ENHgPwIpWCoTq-VhHu0JiSwhF0o" +
+        "PUzEM-FBWYoufO6J97nQ"
     protected val auth_raw = "LsuUOBKVQRY6-l7_Ajo-Ag"
     protected val public_key_raw = "BBcJdfs1GtMyymFTtty6lIGWRFXrEtJP40Df0gOvRDR4D8CKVgqE6vlYR7tC" +
-            "YksIRdKD1MxDPhQVmKLnzuife50"
+        "YksIRdKD1MxDPhQVmKLnzuife50"
 
     // This is the older, but still used message encryption format.
     // this does not use mock calls.
     protected val aesgcmBlock = hashMapOf(
-            "body" to "BNKu5uTFhjyS-06eECU9-6O61int3Rr7ARbm-xPhFuyDO5sfxVs-HywGaVonvzkarvfvXE9IR" +
-                    "T_YNA81Og2uSqDasdMuwqm1zd0O3f7049IkQep3RJ2pEZTy5DqvI7kwMLDLzea9nroq3EMH5hYh" +
-                    "vQtQgtKXeWieEL_3yVDQVg",
-            "dh" to "dh=BMOebOMWSRisAhWpRK9ZPszJC8BL9MiWvLZBoBU6pG6Kh6vUFSW4BHFMh0b83xCg3_7IgfQZ" +
-                    "XwmVuyu27vwiv5c",
-            "salt" to "salt=tSf2qu43C9BD0zkvRW5eUg",
-            "enc" to "aesgcm"
+        "body" to "BNKu5uTFhjyS-06eECU9-6O61int3Rr7ARbm-xPhFuyDO5sfxVs-HywGaVonvzkarvfvXE9IR" +
+            "T_YNA81Og2uSqDasdMuwqm1zd0O3f7049IkQep3RJ2pEZTy5DqvI7kwMLDLzea9nroq3EMH5hYh" +
+            "vQtQgtKXeWieEL_3yVDQVg",
+        "dh" to "dh=BMOebOMWSRisAhWpRK9ZPszJC8BL9MiWvLZBoBU6pG6Kh6vUFSW4BHFMh0b83xCg3_7IgfQZ" +
+            "XwmVuyu27vwiv5c",
+        "salt" to "salt=tSf2qu43C9BD0zkvRW5eUg",
+        "enc" to "aesgcm"
     )
 
     // This is the offical WebPush encryption format.
     // this does not use mock calls.
     protected val aes128gcmBlock = hashMapOf(
-            "body" to "Ek7iQgliMqS9kjFoiVOqRgAAEABBBFirfBtF6XTeHVPABFDveb1iu7uO1XVA_MYJeAo-4ih8W" +
-                    "YUsXSTIYmkKMv5_UB3tZuQI7BQ2EVpYYQfvOCrWZVMRL8fJCuB5wVXcoRoTaFJwTlJ5hnw6IMSi" +
-                    "aMqGVlc8drX7Hzy-ugzzAKRhGPV2x-gdsp58DZh9Ww5vHpHyT1xwVkXzx3KTyeBZu4gl_zR0Q00" +
-                    "li17g0xGsE6Dg3xlkKEmaalgyUyObl6_a8RA6Ko1Rc6RhAy2jdyY1LQbBUnA",
-            "dh" to "",
-            "salt" to "",
-            "enc" to "aes128gcm"
+        "body" to "Ek7iQgliMqS9kjFoiVOqRgAAEABBBFirfBtF6XTeHVPABFDveb1iu7uO1XVA_MYJeAo-4ih8W" +
+            "YUsXSTIYmkKMv5_UB3tZuQI7BQ2EVpYYQfvOCrWZVMRL8fJCuB5wVXcoRoTaFJwTlJ5hnw6IMSi" +
+            "aMqGVlc8drX7Hzy-ugzzAKRhGPV2x-gdsp58DZh9Ww5vHpHyT1xwVkXzx3KTyeBZu4gl_zR0Q00" +
+            "li17g0xGsE6Dg3xlkKEmaalgyUyObl6_a8RA6Ko1Rc6RhAy2jdyY1LQbBUnA",
+        "dh" to "",
+        "salt" to "",
+        "enc" to "aes128gcm"
     )
     protected val plaintext = "Amidst the mists and coldest frosts I thrust my fists against the" +
-            "\nposts and still demand to see the ghosts.\n\n"
+        "\nposts and still demand to see the ghosts.\n\n"
 
     protected val testChannelid = "deadbeef00000000decafbad00000000"
 
@@ -72,13 +72,13 @@ class PushTest {
     protected val mockSenderId = "test"
 
     protected val vapidPubKey = "BBCcCWavxjfIyW6NRhqclO9IZj9oW1gFKUBSgwcigfNcpXSfRk5JQTOcahMLjzO" +
-            "1bkHMoiw4b6L7YTyF8foLEEU"
+        "1bkHMoiw4b6L7YTyF8foLEEU"
 
     protected fun getPushManager(): PushManager {
         val pm = PushManager(
-                senderId = mockSenderId,
-                bridgeType = BridgeType.TEST,
-                databasePath = dbFile
+            senderId = mockSenderId,
+            bridgeType = BridgeType.TEST,
+            databasePath = dbFile
         )
         pm.update("TestRegistrationId")
         return pm
@@ -142,11 +142,11 @@ class PushTest {
 
         // These values should come from the delivered message content.
         val result = manager.decrypt(
-                channelId = testChannelid,
-                body = aesgcmBlock["body"].toString(),
-                encoding = aesgcmBlock["enc"].toString(),
-                salt = aesgcmBlock["salt"].toString(),
-                dh = aesgcmBlock["dh"].toString()
+            channelId = testChannelid,
+            body = aesgcmBlock["body"].toString(),
+            encoding = aesgcmBlock["enc"].toString(),
+            salt = aesgcmBlock["salt"].toString(),
+            dh = aesgcmBlock["dh"].toString()
         ).toByteArray()
         val sresult = result.toString(Charset.forName("UTF-8"))
         assertEquals("Result", plaintext, sresult)
@@ -176,11 +176,11 @@ class PushTest {
         // call this to set the (hardcoded) test key and auth
         manager.subscribe(testChannelid, "foo")
         val result = manager.decrypt(
-                channelId = testChannelid,
-                body = aes128gcmBlock["body"].toString(),
-                encoding = aes128gcmBlock["enc"].toString(),
-                salt = aes128gcmBlock["salt"].toString(),
-                dh = aes128gcmBlock["dh"].toString()
+            channelId = testChannelid,
+            body = aes128gcmBlock["body"].toString(),
+            encoding = aes128gcmBlock["enc"].toString(),
+            salt = aes128gcmBlock["salt"].toString(),
+            dh = aes128gcmBlock["dh"].toString()
         ).toByteArray()
         val sresult = result.toString(Charset.forName("UTF-8"))
         assertEquals("Result", plaintext, sresult)
@@ -195,8 +195,10 @@ class PushTest {
         assertEquals("ChannelID Check", testChannelid, subscriptionResponse.channelId)
         assertEquals("Auth Check", auth_raw, subscriptionResponse.subscriptionInfo.keys.auth)
         assertEquals("p256 Check", public_key_raw, subscriptionResponse.subscriptionInfo.keys.p256dh)
-        assertEquals("endpoint Check", "http://push.example.com/test/opaque",
-            subscriptionResponse.subscriptionInfo.endpoint)
+        assertEquals(
+            "endpoint Check", "http://push.example.com/test/opaque",
+            subscriptionResponse.subscriptionInfo.endpoint
+        )
     }
 
     @Test

--- a/components/rc_log/android/src/main/java/mozilla/appservices/rustlog/LibRustLogAdapter.kt
+++ b/components/rc_log/android/src/main/java/mozilla/appservices/rustlog/LibRustLogAdapter.kt
@@ -4,8 +4,8 @@
 
 package mozilla.appservices.rustlog
 
-import com.sun.jna.Library
 import com.sun.jna.Callback
+import com.sun.jna.Library
 import com.sun.jna.Pointer
 import com.sun.jna.PointerType
 import mozilla.appservices.support.native.loadIndirect

--- a/components/rc_log/android/src/main/java/mozilla/appservices/rustlog/RustLogAdapter.kt
+++ b/components/rc_log/android/src/main/java/mozilla/appservices/rustlog/RustLogAdapter.kt
@@ -53,11 +53,11 @@ class RustLogAdapter private constructor(
             }
             // Tell JNA to reuse the callback thread.
             val initializer = CallbackThreadInitializer(
-                    // Don't block JVM shutdown waiting for this thread to exit.
-                    /* daemon */ true,
-                    // Don't detach the JVM from this thread after invoking the callback.
-                    /* detach */ false,
-                    /* name */ "RustLogThread"
+                // Don't block JVM shutdown waiting for this thread to exit.
+                /* daemon */ true,
+                // Don't detach the JVM from this thread after invoking the callback.
+                /* detach */ false,
+                /* name */ "RustLogThread"
             )
             val callbackImpl = RawLogCallbackImpl(onLog)
             Native.setCallbackThreadInitializer(callbackImpl, initializer)
@@ -105,8 +105,8 @@ class RustLogAdapter private constructor(
             if (isEnabled) {
                 rustCall { e ->
                     LibRustLogAdapter.INSTANCE.rc_log_adapter_set_max_level(
-                            level.value,
-                            e
+                        level.value,
+                        e
                     )
                 }
             }

--- a/components/rc_log/android/src/test/java/mozilla/appservices/rustlog/LogTest.kt
+++ b/components/rc_log/android/src/test/java/mozilla/appservices/rustlog/LogTest.kt
@@ -3,12 +3,12 @@
 
 package mozilla.appservices.rustlog
 
+import mozilla.appservices.Megazord
+import org.junit.Assert.assertEquals
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import mozilla.appservices.Megazord
-import org.junit.Test
-import org.junit.Assert.assertEquals
 import java.lang.RuntimeException
 import java.util.WeakHashMap
 

--- a/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
+++ b/components/sync15/android/src/main/java/mozilla/appservices/sync15/SyncTelemetryPing.kt
@@ -78,18 +78,24 @@ data class SyncTelemetryPing(
         result.put("version", version)
         result.put("uid", uid)
         if (!events.isEmpty()) {
-            result.put("events", JSONArray().apply {
-                events.forEach {
-                    put(it.toJSON())
+            result.put(
+                "events",
+                JSONArray().apply {
+                    events.forEach {
+                        put(it.toJSON())
+                    }
                 }
-            })
+            )
         }
         if (!syncs.isEmpty()) {
-            result.put("syncs", JSONArray().apply {
-                syncs.forEach {
-                    put(it.toJSON())
+            result.put(
+                "syncs",
+                JSONArray().apply {
+                    syncs.forEach {
+                        put(it.toJSON())
+                    }
                 }
-            })
+            )
         }
         return result
     }
@@ -137,11 +143,14 @@ data class SyncInfo(
             result.put("took", took)
         }
         if (!engines.isEmpty()) {
-            result.put("engines", JSONArray().apply {
-                engines.forEach {
-                    put(it.toJSON())
+            result.put(
+                "engines",
+                JSONArray().apply {
+                    engines.forEach {
+                        put(it.toJSON())
+                    }
                 }
-            })
+            )
         }
         failureReason?.let {
             result.put("failureReason", it.toJSON())
@@ -212,11 +221,14 @@ data class EngineInfo(
             result.put("incoming", it.toJSON())
         }
         if (!outgoing.isEmpty()) {
-            result.put("outgoing", JSONArray().apply {
-                outgoing.forEach {
-                    put(it.toJSON())
+            result.put(
+                "outgoing",
+                JSONArray().apply {
+                    outgoing.forEach {
+                        put(it.toJSON())
+                    }
                 }
-            })
+            )
         }
         failureReason?.let {
             result.put("failureReason", it.toJSON())
@@ -325,11 +337,14 @@ data class ValidationInfo(
         val result = JSONObject()
         result.put("version", version)
         if (!problems.isEmpty()) {
-            result.put("problems", JSONArray().apply {
-                problems.forEach {
-                    put(it.toJSON())
+            result.put(
+                "problems",
+                JSONArray().apply {
+                    problems.forEach {
+                        put(it.toJSON())
+                    }
                 }
-            })
+            )
         }
         failureReason?.let {
             result.put("failueReason", it.toJSON())

--- a/components/tabs/android/src/test/java/mozilla/appservices/remotetabs/RemoteTabsTest.kt
+++ b/components/tabs/android/src/test/java/mozilla/appservices/remotetabs/RemoteTabsTest.kt
@@ -2,14 +2,14 @@ package mozilla.appservices.remotetabs
 
 import mozilla.appservices.Megazord
 import mozilla.appservices.syncmanager.SyncManager
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
@@ -31,20 +31,22 @@ class RemoteTabsTest {
     fun setLocalTabsTest() {
         val store = getTestStore()
         store.use { tabs ->
-            tabs.setLocalTabs(listOf(
-                RemoteTab(
-                    title = "cool things to look at in your remote tabs",
-                    urlHistory = listOf("https://example.com"),
-                    icon = null,
-                    lastUsed = 0
-                ),
-                RemoteTab(
-                    title = "cool things to look at in your remote tabs",
-                    urlHistory = listOf(),
-                    icon = null,
-                    lastUsed = 12
+            tabs.setLocalTabs(
+                listOf(
+                    RemoteTab(
+                        title = "cool things to look at in your remote tabs",
+                        urlHistory = listOf("https://example.com"),
+                        icon = null,
+                        lastUsed = 0
+                    ),
+                    RemoteTab(
+                        title = "cool things to look at in your remote tabs",
+                        urlHistory = listOf(),
+                        icon = null,
+                        lastUsed = 12
+                    )
                 )
-            ))
+            )
         }
     }
 

--- a/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/HttpConfig.kt
+++ b/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/HttpConfig.kt
@@ -60,23 +60,23 @@ object RustHttpConfig {
             headers.append(h.key, h.value)
         }
         return Request(
-                url = request.url,
-                method = convertMethod(request.method),
-                headers = headers,
-                connectTimeout = Pair(request.connectTimeoutSecs.toLong(), TimeUnit.SECONDS),
-                readTimeout = Pair(request.readTimeoutSecs.toLong(), TimeUnit.SECONDS),
-                body = if (request.hasBody()) {
-                    Request.Body(request.body.newInput())
-                } else {
-                    null
-                },
-                redirect = if (request.followRedirects) {
-                    Request.Redirect.FOLLOW
-                } else {
-                    Request.Redirect.MANUAL
-                },
-                cookiePolicy = Request.CookiePolicy.OMIT,
-                useCaches = request.useCaches
+            url = request.url,
+            method = convertMethod(request.method),
+            headers = headers,
+            connectTimeout = Pair(request.connectTimeoutSecs.toLong(), TimeUnit.SECONDS),
+            readTimeout = Pair(request.readTimeoutSecs.toLong(), TimeUnit.SECONDS),
+            body = if (request.hasBody()) {
+                Request.Body(request.body.newInput())
+            } else {
+                null
+            },
+            redirect = if (request.followRedirects) {
+                Request.Redirect.FOLLOW
+            } else {
+                Request.Redirect.MANUAL
+            },
+            cookiePolicy = Request.CookiePolicy.OMIT,
+            useCaches = request.useCaches
         )
     }
 
@@ -90,11 +90,13 @@ object RustHttpConfig {
                     // we wouldn't have yet initialized
                     val resp = client!!.value.fetch(convertRequest(request))
                     val rb = MsgTypes.Response.newBuilder()
-                            .setUrl(resp.url)
-                            .setStatus(resp.status)
-                            .setBody(resp.body.useStream {
+                        .setUrl(resp.url)
+                        .setStatus(resp.status)
+                        .setBody(
+                            resp.body.useStream {
                                 ByteString.readFrom(it)
-                            })
+                            }
+                        )
 
                     for (h in resp.headers) {
                         rb.putHeaders(h.name, h.value)


### PR DESCRIPTION
On a local checkout with `components/external/glean` checked out the older ktlint fails, because of trailing commas in Glean files (really these should be ignored regardless, so I'm adding that too).
Despite what ktlint says that's valid kotlin code and newer ktlint can handle that.

Now ktlint did move location. Glean is using that for a while now, and so is android-components, so it seems safe to switch.

Files were reformatted using `./gradlew ktlintFormat`.
Not super critical and it is a bit of churn for a whole lot of files, so feel free to drop this or defer it.