### PR TITLE
Do not try to lint external components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -321,14 +321,14 @@ task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
     main = "com.github.shyiko.ktlint.Main"
-    args "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build", "!**/templates"
+    args "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build", "!**/templates", "!components/external"
 }
 
 task ktlintFormat(type: JavaExec, group: "formatting") {
     description = "Fix Kotlin code style deviations."
     classpath = configurations.ktlint
     main = "com.github.shyiko.ktlint.Main"
-    args "-F", "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build"
+    args "-F", "${projectDir}/components/**/*.kt", "${projectDir}/gradle-plugin/**/*.kt", "buildSrc/**/*.kt", "!**/build", "!components/external"
 }
 
 // Extremely unsophisticated way to publish a local development version while hiding implementation details.


### PR DESCRIPTION
That's only the "ignore Glean" part of #4992, no ktlint update, no reformatting, because [right now `main` is failing](https://firefox-ci-tc.services.mozilla.com/tasks/Uq56uiogRmeBHKYrG5e3ng/runs/1/logs/public/logs/live.log), so this might be quicker to apply then the lots-of-churn-because-reformatting PR.