### PR TITLE
EXP-2339 Generate Swift code to override a component feature config

### DIFF
--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
@@ -113,6 +113,11 @@ impl<'a> FeatureManifestDeclaration<'a> {
 
     pub fn imports(&self) -> Vec<String> {
         let oracle = &self.oracle;
+        // We'll filter out objects from the package we're in.
+        let my_package = format!(
+            "{}.*",
+            self.fm.about.nimbus_package_name().unwrap_or_default()
+        );
         let mut imports: Vec<String> = self
             .members()
             .into_iter()
@@ -130,6 +135,7 @@ impl<'a> FeatureManifestDeclaration<'a> {
                 "org.mozilla.experiments.nimbus.FeaturesInterface".to_string(),
                 format!("{}.R", self.fm.about.resource_package_name()),
             ])
+            .filter(|i| i != &my_package)
             .collect::<HashSet<String>>()
             .into_iter()
             .collect();

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/enum_.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/enum_.rs
@@ -70,7 +70,7 @@ impl CodeType for EnumCodeType {
     /// N.B. `Literal` is aliased from `serde_json::Value`.
     fn literal(
         &self,
-        oracle: &dyn CodeOracle,
+        _oracle: &dyn CodeOracle,
         _ctx: &dyn Display,
         _renderer: &dyn LiteralRenderer,
         literal: &Literal,
@@ -80,11 +80,7 @@ impl CodeType for EnumCodeType {
             _ => unreachable!(),
         };
 
-        format!(
-            "{}.{}",
-            self.type_label(oracle),
-            common::enum_variant_name(variant)
-        )
+        format!(".{}", common::enum_variant_name(variant))
     }
 }
 #[derive(Template)]
@@ -159,15 +155,15 @@ mod unit_tests {
         let finder = &TestRenderer;
         let ctx = String::from("ctx");
         assert_eq!(
-            "AEnum.foo".to_string(),
+            ".foo".to_string(),
             ct.literal(oracle, &ctx, finder, &json!("foo"))
         );
         assert_eq!(
-            "AEnum.barBaz".to_string(),
+            ".barBaz".to_string(),
             ct.literal(oracle, &ctx, finder, &json!("barBaz"))
         );
         assert_eq!(
-            "AEnum.aBC".to_string(),
+            ".aBC".to_string(),
             ct.literal(oracle, &ctx, finder, &json!("a-b-c"))
         );
     }

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/imports.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/imports.rs
@@ -2,11 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{
-    backends::{CodeDeclaration, CodeOracle},
-    intermediate_representation::ImportedModule,
-};
+use std::fmt::Display;
 
+use super::{filters, object::object_literal};
+use crate::{
+    backends::{CodeDeclaration, CodeOracle, LiteralRenderer, TypeIdentifier},
+    intermediate_representation::{ImportedModule, Literal},
+};
+use askama::Template;
+
+#[derive(Template)]
+#[template(
+    syntax = "swift",
+    escape = "none",
+    path = "ImportedModuleInitializationTemplate.swift"
+)]
 pub(crate) struct ImportedModuleInitialization<'a> {
     pub(crate) inner: ImportedModule<'a>,
 }
@@ -26,10 +36,22 @@ impl CodeDeclaration for ImportedModuleInitialization<'_> {
     }
 
     fn initialization_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
-        None
+        Some(self.render().unwrap())
     }
 
     fn definition_code(&self, _oracle: &dyn CodeOracle) -> Option<String> {
         None
+    }
+}
+
+impl LiteralRenderer for ImportedModuleInitialization<'_> {
+    fn literal(
+        &self,
+        oracle: &dyn CodeOracle,
+        typ: &TypeIdentifier,
+        value: &Literal,
+        ctx: &dyn Display,
+    ) -> String {
+        object_literal(self.inner.fm, &self, oracle, typ, value, ctx)
     }
 }

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
@@ -94,6 +94,8 @@ impl<'a> FeatureManifestDeclaration<'a> {
 
     pub fn imports(&self) -> Vec<String> {
         let oracle = &self.oracle;
+        // Filter out our own module.
+        let my_module = &self.fm.about.nimbus_module_name();
         let mut imports: Vec<String> = self
             .members()
             .into_iter()
@@ -106,6 +108,7 @@ impl<'a> FeatureManifestDeclaration<'a> {
                     .filter_map(|type_| self.oracle.find(&type_).imports(oracle))
                     .flatten(),
             )
+            .filter(|i| i != my_module)
             .collect::<HashSet<String>>()
             .into_iter()
             .collect();

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/structural.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/structural.rs
@@ -509,7 +509,7 @@ mod unit_tests {
 
         let ct = list_type("AnEnum");
         assert_eq!(
-            r#"[AnEnum.x, AnEnum.y, AnEnum.z]"#.to_string(),
+            r#"[.x, .y, .z]"#.to_string(),
             ct.literal(oracle, &ctx, finder, &json!(["x", "y", "z"]))
         );
     }
@@ -578,13 +578,13 @@ mod unit_tests {
 
         let ct = map_type("String", "AnEnum");
         assert_eq!(
-            r#"["a": AnEnum.a, "b": AnEnum.b]"#.to_string(),
+            r#"["a": .a, "b": .b]"#.to_string(),
             ct.literal(oracle, &ctx, finder, &json!({"a": "a", "b": "b"}))
         );
 
         let ct = map_type("AnEnum", "String");
         assert_eq!(
-            r#"[AnEnum.a: "a", AnEnum.b: "b"]"#.to_string(),
+            r#"[.a: "a", .b: "b"]"#.to_string(),
             ct.literal(oracle, &ctx, finder, &json!({"a": "a", "b": "b"}))
         );
     }

--- a/components/support/nimbus-fml/src/backends/swift/templates/EnumTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/EnumTemplate.swift
@@ -2,7 +2,7 @@
 {% let inner = self.inner() %}
 {% let class_name = inner.name()|class_name %}
 {{ inner.doc()|comment("") }}
-public enum {{ class_name }}: String {
+public enum {{ class_name }}: String, CaseIterable {
     {% for variant in inner.variants() %}
     {{ variant.doc()|comment("    ") }}
     case {{ variant.name()|enum_variant_name }} = {{variant.name()|quoted}}

--- a/components/support/nimbus-fml/src/backends/swift/templates/FeatureManifestTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/FeatureManifestTemplate.swift
@@ -33,6 +33,7 @@ public class {{ nimbus_object }} {
         {%- for f in self.fm.iter_imported_files() %}
         {{ f.about().nimbus_object_name_swift() }}.shared.initialize(with: getSdk)
         {%- endfor %}
+        self.reinitialize()
     }
 
     fileprivate lazy var getSdk: GetSdk = { [self] in self.api }
@@ -41,6 +42,24 @@ public class {{ nimbus_object }} {
     /// Represents all the features supported by Nimbus
     ///
     public let features = {{ nimbus_object }}Features()
+
+    {% let blocks = self.initialization_code() -%}
+    ///
+    /// All generated initialization code. Clients shouldn't need to override or call
+    /// this.
+    /// We put it in a separate method because we have to be quite careful about what order
+    /// the initialization happens in— e.g. when importing other FML files.
+    ///
+    private func reinitialize() {
+        {%- if !blocks.is_empty() %}
+        {%- for code in blocks %}
+        {{ code }}
+        {%- endfor %}
+        {%- else %}
+        // Nothing left to do.
+        {%- endif %}
+    }
+
 
     ///
     /// Refresh the cache of configuration objects.
@@ -77,11 +96,6 @@ public class {{ nimbus_object }}Features {
     }()
     {%- endfor %}
 }
-
-
-{%- for code in self.initialization_code() %}
-{{ code }}
-{%- endfor %}
 
 // Public interface members begin here.
 {% for code in self.declaration_code() %}

--- a/components/support/nimbus-fml/src/backends/swift/templates/ImportedModuleInitializationTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/ImportedModuleInitializationTemplate.swift
@@ -1,0 +1,13 @@
+{% import "macros.swift" as swift %}
+{%- let variables = "variables" %}
+{%- let context = "" %}
+{%- let class_name = self.inner.about().nimbus_object_name_swift() %}
+        {%- for f in self.inner.features() %}
+        {{ class_name }}.shared.features.{{ f.name()|var_name }}.with(initializer: { {{ variables }} in
+            {{ f.name()|class_name }}(
+                {{ variables }}, {%- for p in f.props() %}
+                {{p.name()|var_name}}: {{ p.typ()|literal(self, p.default(), context) }}{% if !loop.last %},{% endif %}
+                {%- endfor %}
+            )
+        })
+        {%- endfor %}

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -3,7 +3,7 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::Display,
 };
 
@@ -48,7 +48,9 @@ pub(crate) struct FieldBody {
 pub(crate) struct ObjectBody {
     description: String,
     failable: Option<bool>,
-    fields: HashMap<String, FieldBody>,
+    // We need these in a deterministic order, so they are stable across multiple
+    // runs of the same manifests.
+    fields: BTreeMap<String, FieldBody>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
@@ -112,7 +114,11 @@ pub(crate) struct ImportBlock {
 #[serde(deny_unknown_fields)]
 pub(crate) struct FeatureBody {
     description: String,
-    variables: HashMap<String, FieldBody>,
+    // We need these in a deterministic order, so they are stable across multiple
+    // runs of the same manifests:
+    // 1. Swift insists on args in the same order they were declared.
+    // 2. imported features are declared and constructed in different runs of the tool.
+    variables: BTreeMap<String, FieldBody>,
     #[serde(alias = "defaults")]
     default: Option<Vec<DefaultBlock>>,
 }

--- a/components/support/nimbus-fml/src/workflows.rs
+++ b/components/support/nimbus-fml/src/workflows.rs
@@ -440,6 +440,18 @@ mod test {
     }
 
     #[test]
+    fn test_importing_override_defaults_ios() -> Result<()> {
+        generate_multiple_and_assert(
+            "test/importing/overrides/app_debug.swift",
+            &[
+                ("fixtures/fe/importing/overrides/app.fml.yaml", "debug"),
+                ("fixtures/fe/importing/overrides/lib.fml.yaml", "debug"),
+            ],
+        )?;
+        Ok(())
+    }
+
+    #[test]
     fn test_importing_override_defaults_coverall_android() -> Result<()> {
         generate_multiple_and_assert(
             "test/importing/overrides-coverall/app_debug.kts",
@@ -458,12 +470,28 @@ mod test {
     }
 
     #[test]
-    fn test_importing_diamond_overrides() -> Result<()> {
+    fn test_importing_diamond_overrides_android() -> Result<()> {
         // In this test, sublib implements a feature.
         // Both lib and app offer some configuration, and both app and lib
         // need to import sublib.
         generate_multiple_and_assert(
             "test/importing/diamond/00-app.kts",
+            &[
+                ("fixtures/fe/importing/diamond/00-app.yaml", "debug"),
+                ("fixtures/fe/importing/diamond/01-lib.yaml", "debug"),
+                ("fixtures/fe/importing/diamond/02-sublib.yaml", "debug"),
+            ],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_importing_diamond_overrides_ios() -> Result<()> {
+        // In this test, sublib implements a feature.
+        // Both lib and app offer some configuration, and both app and lib
+        // need to import sublib.
+        generate_multiple_and_assert(
+            "test/importing/diamond/00-app.swift",
             &[
                 ("fixtures/fe/importing/diamond/00-app.yaml", "debug"),
                 ("fixtures/fe/importing/diamond/01-lib.yaml", "debug"),

--- a/components/support/nimbus-fml/test/importing/diamond/00-app.swift
+++ b/components/support/nimbus-fml/test/importing/diamond/00-app.swift
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import FeatureManifest
+import Foundation
+
+let injected: MockNimbus = MockNimbus()
+
+AppNimbus.shared.initialize { injected }
+
+let value = SubLibNimbus.shared.features.deeplyNestedFeature.value()
+assert(value.noOverride == .none)
+assert(value.libFml == .libFml)
+assert(value.appFml == .appFml)
+assert(value.orderDependent == .libFml)

--- a/components/support/nimbus-fml/test/importing/overrides/app_debug.swift
+++ b/components/support/nimbus-fml/test/importing/overrides/app_debug.swift
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import FeatureManifest
+import Foundation
+
+let injected: MockNimbus = MockNimbus(
+    (
+        "property-overrides-test",
+        """
+        {
+            "variables-json": "variables-json"
+        }
+        """
+    )
+)
+
+AppNimbus.shared.initialize { injected }
+
+let value = LibNimbus.shared.features.propertyOverridesTest.value()
+assert(value.noOverride == .none)
+assert(value.libFml == .libFml)
+assert(value.appFml == .appFml)
+assert(value.variablesJson == .variablesJson)


### PR DESCRIPTION
Fixes [EXP-2339](https://mozilla-hub.atlassian.net/browse/EXP-2339).

This is the Swift equivalent of [EXP-2338](https://mozilla-hub.atlassian.net/browse/EXP-2338).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
