### PR TITLE
Update protobuf to latest releases.

### DIFF
--- a/build-scripts/protobuf-common.gradle
+++ b/build-scripts/protobuf-common.gradle
@@ -20,13 +20,7 @@ android {
 
 protobuf {
     protoc {
-        // This is a hack for Apple M1 since protobuf does not compile for M1s yet
-        // However, M1s can just use the x86_64 just fine
-        if (osdetector.os == "osx") {
-            artifact = 'com.google.protobuf:protoc:3.11.4:osx-x86_64'
-        } else {
-            artifact = 'com.google.protobuf:protoc:3.11.4'
-        }
+        artifact = 'com.google.protobuf:protoc:3.21.2'
     }
     generateProtoTasks {
         all().each { task ->

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ buildscript {
         robolectric_core_version = '4.5.1'
         rust_android_gradle_version = '0.9.1'
         espresso_core_version = '3.3.0'
-        protobuf_version = '3.11.4'
-        gradle_protobuf_version = '0.8.14'
+        protobuf_version = '3.21.2'
+        gradle_protobuf_version = '0.8.18'
     }
 
     ext.build = [


### PR DESCRIPTION
Updates protobuf to version 3.21.2 and the gradle plugin to version 0.8.18.
Upstream protobuf also has native M1 Mac support now, so remove a hack which
isn't needed anymore.