### PR TITLE
Remove DispatchQueue usage from logins component

### DIFF
--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -8,14 +8,8 @@ import UIKit
 
 typealias LoginsStoreError = LoginsStorageError
 
-/*
- ** We probably should have this class go away eventually as it's really only a thin wrapper
- * similar to its kotlin equiavlent, however the only thing preventing this from being removed is
- * the queue.sync which we should be moved over to the consumer side of things
- */
 open class LoginsStorage {
     private var store: LoginStore
-    private let queue = DispatchQueue(label: "com.mozilla.logins-storage")
 
     public init(databasePath: String) throws {
         store = try LoginStore(path: databasePath)
@@ -24,38 +18,28 @@ open class LoginsStorage {
     /// Delete all locally stored login sync metadata. It's unclear if
     /// there's ever a reason for users to call this
     open func reset() throws {
-        try queue.sync {
-            try self.store.reset()
-        }
+        try store.reset()
     }
 
     /// Delete all locally stored login data.
     open func wipe() throws {
-        try queue.sync {
-            try self.store.wipe()
-        }
+        try store.wipe()
     }
 
     open func wipeLocal() throws {
-        try queue.sync {
-            try self.store.wipeLocal()
-        }
+        try store.wipeLocal()
     }
 
     /// Delete the record with the given ID. Returns false if no such record existed.
     open func delete(id: String) throws -> Bool {
-        return try queue.sync {
-            return try self.store.delete(id: id)
-        }
+        return try store.delete(id: id)
     }
 
     /// Bump the usage count for the record with the given id.
     ///
     /// Throws `LoginStoreError.NoSuchRecord` if there was no such record.
     open func touch(id: String) throws {
-        try queue.sync {
-            try self.store.touch(id: id)
-        }
+        try store.touch(id: id)
     }
 
     /// Insert `login` into the database. If `login.id` is not empty,
@@ -63,58 +47,44 @@ open class LoginsStorage {
     ///
     /// Returns the `id` of the newly inserted record.
     open func add(login: LoginEntry, encryptionKey: String) throws -> EncryptedLogin {
-        return try queue.sync {
-            return try self.store.add(login: login, encryptionKey: encryptionKey)
-        }
+        return try store.add(login: login, encryptionKey: encryptionKey)
     }
 
     /// Update `login` in the database. If `login.id` does not refer to a known
     /// login, then this throws `LoginStoreError.NoSuchRecord`.
     open func update(id: String, login: LoginEntry, encryptionKey: String) throws -> EncryptedLogin {
-        return try queue.sync {
-            return try self.store.update(id: id, login: login, encryptionKey: encryptionKey)
-        }
+        return try store.update(id: id, login: login, encryptionKey: encryptionKey)
     }
 
     /// Get the record with the given id. Returns nil if there is no such record.
     open func get(id: String) throws -> EncryptedLogin? {
-        return try queue.sync {
-            return try self.store.get(id: id)
-        }
+        return try store.get(id: id)
     }
 
     /// Get the entire list of records.
     open func list() throws -> [EncryptedLogin] {
-        return try queue.sync {
-            return try self.store.list()
-        }
+        return try store.list()
     }
 
     /// Get the list of records for some base domain.
     open func getByBaseDomain(baseDomain: String) throws -> [EncryptedLogin] {
-        return try queue.sync {
-            return try self.store.getByBaseDomain(baseDomain: baseDomain)
-        }
+        return try store.getByBaseDomain(baseDomain: baseDomain)
     }
 
     /// Register with the sync manager
     open func registerWithSyncManager() throws {
-        return queue.sync {
-            return self.store.registerWithSyncManager()
-        }
+        return store.registerWithSyncManager()
     }
 
     open func sync(unlockInfo: SyncUnlockInfo) throws -> String {
-        return try queue.sync {
-            return try self.store
-                .sync(
-                    keyId: unlockInfo.kid,
-                    accessToken: unlockInfo.fxaAccessToken,
-                    syncKey: unlockInfo.syncKey,
-                    tokenserverUrl: unlockInfo.tokenserverURL,
-                    localEncryptionKey: unlockInfo.loginEncryptionKey
-                )
-        }
+        return try store
+            .sync(
+                keyId: unlockInfo.kid,
+                accessToken: unlockInfo.fxaAccessToken,
+                syncKey: unlockInfo.syncKey,
+                tokenserverUrl: unlockInfo.tokenserverURL,
+                localEncryptionKey: unlockInfo.loginEncryptionKey
+            )
     }
 }
 

--- a/docs/adr/0005-swift-dispatchqueue-usage.md
+++ b/docs/adr/0005-swift-dispatchqueue-usage.md
@@ -1,0 +1,73 @@
+<!-- This ADR is using a lighter weight template created by Michael Nygard (see [here](https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md) for details). It is -->
+
+# Remove Unnecessary Swift `DispatchQueue` Usage
+
+## Status
+
+* Proposed
+
+## Context
+
+### `DispatchQueue` Overview
+
+A `DispatchQueue` is a Swift abstraction used to manage the serial or concurrent execution of tasks. When a `DispatchQueue` is created, a thread pool (comprised of one or more reallocated or newly-created threads) is assigned to the queue by the system. `DispatchQueue`s can be configured to execute tasks, or "work items", serially by default or concurrently if the [attributes](https://developer.apple.com/documentation/dispatch/dispatchqueue/attributes) parameter of the constructor is appropriately set.
+
+Other [constructor parameters](https://developer.apple.com/documentation/dispatch/dispatchqueue/2300059-init) allow for additional configurations but they are not relevant here as the custom queues created in our rust components and in the corresponding [firefox-ios storage layer](https://github.com/mozilla-mobile/firefox-ios/tree/main/Storage/Rust) set the `label` parameter of the `DispatchQueue` constructor at most and therefore execute serially with default settings.
+
+We also make use of the two non-custom `DispatchQueue`s, the [main](https://developer.apple.com/documentation/dispatch/dispatchqueue/1781006-main) and [global](https://developer.apple.com/documentation/dispatch/dispatchqueue/2300077-global) queues, in the FxA component. Unsurprisingly, the main queue executes on the main thread. The global queues (high, default, low, and background queues) execute concurrently and are shared by the whole system. Generally, best practice dictates that the main queue be reserved for UI/UX updates and global and custom queues (which are ultimately performed by global queues) do the remainder of the work.
+
+Lastly, tasks can be submitted to a `DispatchQueue` either synchronously (which blocks the queue until the submitted task is complete) or asynchronously (which returns immediately after the task is submitted to the queue). Best practice advises that synchronous calls be used only when needed and should be avoided entirely when scheduleding tasks concurrently or on the main queue.
+
+### Our `DispatchQueue` Usage
+
+There are places in application services code where `DispatchQueues` are appropriately used. In the FxA component where we have functions that update the UI (mostly via [closure function parameters](https://github.com/mozilla/application-services/blob/451bcc2fe8fe6675ca3de962a4b38b3fa181a806/components/fxa-client/ios/FxAClient/FxAccountManager.swift#L108)) or [dispatch notifications via `NotificationCenter`](https://github.com/mozilla/application-services/blob/72b827c3e0f883163762857fd766df1aeb060725/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift#L49), our use of non-custom queues makes sense.
+
+The same is true of the custom `DispatchQueue` usage in the RustLog crate where we want to ensure that the `state` property of the singleton is accurate. However our usage of `DispatchQueue`s in the places, logins, and tabs rust components is unnecessary and potentially problematic. In these components we create a custom `DispatchQueue` for our API functions and submit tasks to the queue for synchronous execution similar to the snippet below.
+
+```
+// The swift layer in appServices
+
+private let queue = DispatchQueue(label: "com.mozilla.logins-storage")
+...
+open func reset() throws {
+    try queue.sync {
+        try self.store.reset()
+    }
+}
+```
+Then in the Firefox iOS where these functions are called, they are submitted for asynchronous execution to another custom `DispatchQueue` created specifically for the storage layer of the respective component as shown below.
+
+```
+// The storage layer in Firefox iOS
+
+queue = DispatchQueue(label: "RustLogins queue: \(databasePath)", attributes: [])
+...
+public func resetSync() -> Success {
+    let deferred = Success()
+
+    queue.async {
+        ...
+        try self.storage?.reset()
+        ...
+    }
+    ...
+}
+```
+
+In practice this means there are two queues with fairly similar call stacks. At minimum this is unintentional duplication that has minimal adverse impact. But depending on how the system allocates threads for the `DispatchQueue`s in question we may be causing unnecessary thread creation or forcing tasks that should be executing aynchronously to execute synchronously (as in the above example).
+
+## Decision
+
+We will be removing `DispatchQueue` usage in application services from the places, logins, and tabs components. We will start with the logins component because it is currently stable. If that removal is successful, we will remove our queue usage from the other two components.
+
+## Consequences
+
+* This will give the iOS team and any future consumers of the places, logins, and tabs components more control over how system resources are managed for their respective applications.
+* The application services swift layer will become a bit easier to reason about.
+
+## Resources
+
+* [Swift DispatchQueue Documentation](https://developer.apple.com/documentation/dispatch/dispatchqueue)
+* [Understanding Queue Types](https://www.raywenderlich.com/28540615-grand-central-dispatch-tutorial-for-swift-5-part-1-2#toc-anchor-005)
+* [Appropriately using DispatchQueue.main](https://www.donnywals.com/appropriately-using-dispatchqueue-main/)
+* [Concurrent vs Serial DispatchQueue: Concurrency in Swift explained](https://www.avanderlee.com/swift/concurrent-serial-dispatchqueue/)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ This log lists the architectural decisions for MADR.
 * [ADR-0002](0002-database-corruption.md) - Handling Database Corruption
 * [ADR-0003](0003-swift-packaging.md) - Distributing Swift Packages
 * [ADR-0004](0004-early-startup-experiments.md) - Running experiments on first run early startup
+* [ADR-0005](0005-swift-dispatchqueue-usage.md) - Remove Unnecessary Swift `DispatchQueue` Usage
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
This fixes #5012.

In the Swift layer of some of our components we are unnecessarily executing our API calls with `DispatchQueue`s. This is most likely a remnant of the manual FFI layer that existed prior to our UniFFI usage. What remains is an anti-pattern in which a call in our Swift layer executes with a `DispatchQueue` as below

```
private let queue = DispatchQueue(label: "com.mozilla.logins-storage")
...
open func reset() throws {
    try queue.sync {
        try self.store.reset()
    }
}
```

and is then called in the iOS repo with another `DispatchQueue`

```
queue = DispatchQueue(label: "RustLogins queue: \(databasePath)", attributes: [])
...
public func resetSync() -> Success {
    let deferred = Success()

    queue.async {
        ...
        try self.storage?.reset()
        ...
    }
    ...
}
```

In these cases our usage of `DispatchQueue`s is needless and potentially problematic. To address this issue, we're removing our `DispatchQueue` usage from the logins component because it is currently stable. If that removal is successful, we will address issue #5013 which addresses the remaining calls.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
