### PR TITLE
Stop recording login migration metrics.

### DIFF
--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -100,7 +100,7 @@ pub enum InvalidLogin {
 impl Error {
     // Get a short textual label identifying the type of error that occurred,
     // but without including any potentially-sensitive information.
-    pub fn label(&self) -> &'static str {
+    fn label(&self) -> &'static str {
         match self.kind() {
             ErrorKind::BadSyncStatus(_) => "BadSyncStatus",
             ErrorKind::NoSuchRecord(_) => "NoSuchRecord",

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -19,7 +19,7 @@ mod util;
 
 uniffi_macros::include_scaffolding!("logins");
 
-pub use crate::db::{LoginDb, MigrationMetrics, MigrationPhaseMetrics};
+pub use crate::db::LoginDb;
 use crate::encryption::{check_canary, create_canary, create_key};
 pub use crate::error::*;
 pub use crate::login::*;

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -34,7 +34,7 @@ namespace logins {
     boolean check_canary([ByRef]string canary, [ByRef]string text, [ByRef]string encryption_key);
 
     [Throws=LoginsStorageError]
-    string migrate_logins(
+    void migrate_logins(
         [ByRef]string path,
         [ByRef]string new_encryption_key,
         [ByRef]string sqlcipher_path,


### PR DESCRIPTION
 In #5017/#5019 @bendk stopped the mobile code from recording
 migration metrics. This PR stops our Rust code even collecting it.

This has the added bonus of making the logins error code @bendk and I have been discussing easier.
