### PR TITLE
Fix autofill sync failures when tombstones are in the mirror.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -19,6 +19,11 @@ Use the template below to make assigning a version number during the release cut
 
 -->
 
+## Autofill
+
+### What's Fixed
+  - Fixed syncing of autofill when tombstones exist in the local mirror (#5030)
+
 ## Nimbus FML ⛅️🔬🔭🔧
 
 ### What's New

--- a/components/autofill/src/sync/address/mod.rs
+++ b/components/autofill/src/sync/address/mod.rs
@@ -61,7 +61,7 @@ impl SyncEngineStorageImpl<InternalAddress> for AddressesEngineStorageImpl {
     }
 }
 
-// These structs are what's stored on the sync server.
+// These structs are what's stored on the sync server for non-tombstone records.
 #[derive(Default, Deserialize, Serialize)]
 struct AddressPayload {
     id: Guid,

--- a/components/autofill/src/sync/address/outgoing.rs
+++ b/components/autofill/src/sync/address/outgoing.rs
@@ -47,7 +47,10 @@ impl ProcessOutgoingRecordImpl for OutgoingAddressesImpl {
 
         let tombstones_sql = "SELECT guid FROM addresses_tombstones";
 
-        // save outgoing records to the mirror table
+        // save outgoing records to the mirror table.
+        // unlike credit-cards, which stores records encrypted as they are
+        // on the server to protect the sensitive fields, we just store the
+        // plaintext payload.
         let staging_records = common_get_outgoing_staging_records(
             tx,
             &data_sql,

--- a/components/autofill/src/sync/credit_card/incoming.rs
+++ b/components/autofill/src/sync/credit_card/incoming.rs
@@ -133,7 +133,12 @@ impl ProcessIncomingRecordImpl for IncomingCreditCardsImpl {
                         Some(m_payload) => {
                             let payload =
                                 PersistablePayload::make_cc_payload(&m_payload, &self.encdec)?;
-                            Some(InternalCreditCard::from_payload(payload, &self.encdec)?)
+                            // a tombstone in the mirror can be treated as though it's missing.
+                            if payload.is_tombstone() {
+                                None
+                            } else {
+                                Some(InternalCreditCard::from_payload(payload, &self.encdec)?)
+                            }
                         }
                         None => None,
                     }
@@ -296,6 +301,7 @@ mod tests {
         let mut db = new_syncable_mem_db();
         struct TestCase {
             incoming_records: Vec<Value>,
+            mirror_records: Vec<Value>,
             expected_record_count: usize,
             expected_tombstone_count: usize,
         }
@@ -303,11 +309,13 @@ mod tests {
         let test_cases = vec![
             TestCase {
                 incoming_records: vec![test_json_record('A')],
+                mirror_records: vec![],
                 expected_record_count: 1,
                 expected_tombstone_count: 0,
             },
             TestCase {
                 incoming_records: vec![test_json_tombstone('A')],
+                mirror_records: vec![],
                 expected_record_count: 0,
                 expected_tombstone_count: 1,
             },
@@ -317,7 +325,15 @@ mod tests {
                     test_json_record('C'),
                     test_json_tombstone('B'),
                 ],
+                mirror_records: vec![],
                 expected_record_count: 2,
+                expected_tombstone_count: 1,
+            },
+            // incoming tombstone with existing tombstone in the mirror
+            TestCase {
+                incoming_records: vec![test_json_tombstone('B')],
+                mirror_records: vec![test_json_tombstone('B')],
+                expected_record_count: 0,
                 expected_tombstone_count: 1,
             },
         ];
@@ -326,6 +342,21 @@ mod tests {
             log::info!("starting new testcase");
             let tx = db.transaction()?;
             let encdec = EncryptorDecryptor::new_test_key();
+
+            // Add required items to the mirrors.
+            let mirror_sql = "INSERT OR REPLACE INTO credit_cards_mirror (guid, payload)
+                              VALUES (:guid, :payload)";
+            for payload in tc.mirror_records {
+                tx.execute(
+                    mirror_sql,
+                    rusqlite::named_params! {
+                        ":guid": payload["id"].as_str().unwrap(),
+                        ":payload": encdec.encrypt(&payload.to_string())?,
+                    },
+                )
+                .expect("should insert mirror record");
+            }
+
             let ri = IncomingCreditCardsImpl { encdec };
             ri.stage_incoming(
                 &tx,
@@ -348,6 +379,8 @@ mod tests {
 
             assert_eq!(record_count, tc.expected_record_count);
             assert_eq!(tombstone_count, tc.expected_tombstone_count);
+
+            ri.fetch_incoming_states(&tx)?;
 
             tx.execute("DELETE FROM temp.credit_cards_sync_staging;", [])?;
         }

--- a/components/autofill/src/sync/credit_card/mod.rs
+++ b/components/autofill/src/sync/credit_card/mod.rs
@@ -71,7 +71,7 @@ impl SyncEngineStorageImpl<InternalCreditCard> for CreditCardsEngineStorageImpl 
     }
 }
 
-// These structs are what's stored on the sync server.
+// These structs are what's stored on the sync server for non-tombstone records.
 #[derive(Default, Debug, Deserialize, Serialize)]
 struct CreditCardPayload {
     id: Guid,

--- a/components/autofill/src/sync/mod.rs
+++ b/components/autofill/src/sync/mod.rs
@@ -207,7 +207,9 @@ pub enum MergeResult<T> {
 pub struct IncomingState<T> {
     incoming: IncomingRecord<T>,
     local: LocalRecordInfo<T>,
-    // We don't have an enum for the mirror - an Option<> is fine because we
+    // We don't have an enum for the mirror - an Option<> is fine because
+    // although we do store tombstones there, we ignore them when reconciling
+    // (ie, we ignore tombstones in the mirror)
     // don't store tombstones there.
     mirror: Option<T>,
 }


### PR DESCRIPTION
The new tests, without the corresponding change in incoming.rs, fail with
`Error: JsonError(Error("missing field `entry`", line: 0, column: 0))`, which

This is the only way I can see how #5020 can come about - but the problem
solved in this PR should only come up very rarely - eg, typically only by
people disconnecting and reconnecting their sync account on any device.

So while I'm yet to be confident this is exactly #5020, I am confident
it is fixing a real issue.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
