### PR TITLE
Error converting and reporting

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -21,3 +21,8 @@ Use the template below to make assigning a version number during the release cut
 
 ### What's Changed
   - Added `MOZ_APPSERVICES_MODULE` environment variable to specify the megazord module for iOS ([#5042](https://github.com/mozilla/application-services/pull/5042)). If it is missing, no module is imported.
+
+## Logins
+
+### ⚠️ Breaking Changes ⚠️
+  - Updated the `LoginsStorageError` hierarchy.

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -24,5 +24,6 @@ Use the template below to make assigning a version number during the release cut
 
 ## Logins
 
-### ⚠️ Breaking Changes ⚠️
-  - Updated the `LoginsStorageError` hierarchy.
+  - Updated the `LoginsStorageError` implementation and introduce error reporting for unexpected errors.
+    Note that some errors were removed, which is technically a breaking change, but none of our
+    consumers use those errors so it's not a breaking change in practice.

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -21,7 +21,7 @@ url = "2.2"
 sql-support = { path = "../support/sql" }
 jwcrypto = { path = "../support/jwcrypto" }
 interrupt-support = { path = "../support/interrupt" }
-error-support = { path = "../support/error" }
+error-support = { path = "../support/error", features = ["reporting"] }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 thiserror = "1.0"
 anyhow = "1.0"

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -193,14 +193,8 @@ class LoginsStoreCounterMetrics(
                 throw e
             }
             when (e) {
-                is LoginsStorageException.MismatchedLock -> {
-                    errCount["mismatched_lock"].add()
-                }
                 is LoginsStorageException.NoSuchRecord -> {
                     errCount["no_such_record"].add()
-                }
-                is LoginsStorageException.InvalidKey -> {
-                    errCount["invalid_key"].add()
                 }
                 is LoginsStorageException.Interrupted -> {
                     errCount["interrupted"].add()

--- a/components/logins/src/encryption.rs
+++ b/components/logins/src/encryption.rs
@@ -40,7 +40,7 @@ impl EncryptorDecryptor {
     pub fn new(key: &str) -> Result<Self> {
         match serde_json::from_str(key) {
             Ok(jwk) => Ok(EncryptorDecryptor { jwk }),
-            Err(_) => Err(ErrorKind::InvalidKey.into()),
+            Err(_) => Err(LoginsError::InvalidKey),
         }
     }
 
@@ -130,16 +130,15 @@ mod test {
         assert_eq!(ed.decrypt(&ciphertext).unwrap(), cleartext);
         let ed2 = EncryptorDecryptor::new(&create_key().unwrap()).unwrap();
         assert!(matches!(
-            ed2.decrypt(&ciphertext).err().unwrap().kind(),
-            ErrorKind::CryptoError(_)
+            ed2.decrypt(&ciphertext).err().unwrap(),
+            LoginsError::CryptoError(_)
         ));
     }
 
     #[test]
     fn test_key_error() {
-        let storage_err: LoginsStorageError =
-            EncryptorDecryptor::new("bad-key").err().unwrap().into();
-        assert!(matches!(storage_err, LoginsStorageError::InvalidKey(_)));
+        let storage_err = EncryptorDecryptor::new("bad-key").err().unwrap();
+        assert!(matches!(storage_err, LoginsError::InvalidKey));
     }
 
     #[test]
@@ -153,9 +152,8 @@ mod test {
         assert!(matches!(
             check_canary(&canary, CANARY_TEXT, &different_key)
                 .err()
-                .unwrap()
-                .kind(),
-            ErrorKind::CryptoError(_)
+                .unwrap(),
+            LoginsError::CryptoError(_)
         ));
     }
 }

--- a/components/logins/src/encryption.rs
+++ b/components/logins/src/encryption.rs
@@ -83,17 +83,23 @@ impl EncryptorDecryptor {
 //     - If it returns true, then it's safe to assume the key can decrypt the DB data
 //     - If it returns false, then the key is no longer valid.  It should be regenerated and the DB
 //       data should be wiped since we can no longer read it properly
-pub fn create_canary(text: &str, key: &str) -> Result<String> {
-    EncryptorDecryptor::new(key)?.encrypt(text)
+pub fn create_canary(text: &str, key: &str) -> ApiResult<String> {
+    handle_error! {
+        EncryptorDecryptor::new(key)?.encrypt(text)
+    }
 }
 
-pub fn check_canary(canary: &str, text: &str, key: &str) -> Result<bool> {
-    Ok(EncryptorDecryptor::new(key)?.decrypt(canary)? == text)
+pub fn check_canary(canary: &str, text: &str, key: &str) -> ApiResult<bool> {
+    handle_error! {
+        Ok(EncryptorDecryptor::new(key)?.decrypt(canary)? == text)
+    }
 }
 
-pub fn create_key() -> Result<String> {
-    let key = jwcrypto::Jwk::new_direct_key(None)?;
-    Ok(serde_json::to_string(&key)?)
+pub fn create_key() -> ApiResult<String> {
+    handle_error! {
+        let key = jwcrypto::Jwk::new_direct_key(None)?;
+        Ok(serde_json::to_string(&key)?)
+    }
 }
 
 #[cfg(test)]
@@ -153,7 +159,7 @@ mod test {
             check_canary(&canary, CANARY_TEXT, &different_key)
                 .err()
                 .unwrap(),
-            LoginsError::CryptoError(_)
+            LoginsStorageError::IncorrectKey
         ));
     }
 }

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -139,52 +139,50 @@ impl GetErrorHandling for LoginsError {
         // forwarding that error message into ours without attempting to sanitize.
         match self {
             Self::InvalidLogin(why) => {
-                ErrorHandling::passthrough(LoginsStorageError::InvalidRecord(why.to_string()))
+                ErrorHandling::convert(LoginsStorageError::InvalidRecord(why.to_string()))
             }
             // Our internal "no such record" error is converted to our public "no such record" error, with no logging and no error reporting.
             Self::NoSuchRecord(guid) => {
-                ErrorHandling::passthrough(LoginsStorageError::NoSuchRecord(guid.to_string()))
+                ErrorHandling::convert(LoginsStorageError::NoSuchRecord(guid.to_string()))
             }
             // NonEmptyTable error is just a sanity check to ensure we aren't asked to migrate into an
             // existing DB - consumers should never actually do this, and will never expect to handle this as a specific
             // error - so it gets reported to the error reporter and converted to an "internal" error.
-            Self::NonEmptyTable => ErrorHandling::unexpected(
-                LoginsStorageError::UnexpectedLoginsStorageError(
+            Self::NonEmptyTable => {
+                ErrorHandling::convert(LoginsStorageError::UnexpectedLoginsStorageError(
                     "must be an empty DB to migrate".to_string(),
-                ),
-                Some("migration"),
-            ),
+                ))
+                .report_error("logins:migration")
+            }
             Self::CryptoError(_) => {
-                ErrorHandling::log(LoginsStorageError::IncorrectKey, log::Level::Warn)
+                ErrorHandling::convert(LoginsStorageError::IncorrectKey).log_warning()
             }
             Self::Interrupted(_) => {
-                ErrorHandling::passthrough(LoginsStorageError::Interrupted(self.to_string()))
+                ErrorHandling::convert(LoginsStorageError::Interrupted(self.to_string()))
             }
             Self::SyncAdapterError(e) => match e.kind() {
                 Sync15ErrorKind::TokenserverHttpError(401) | Sync15ErrorKind::BadKeyLength(..) => {
-                    ErrorHandling::log(
-                        LoginsStorageError::SyncAuthInvalid(e.to_string()),
-                        log::Level::Warn,
-                    )
+                    ErrorHandling::convert(LoginsStorageError::SyncAuthInvalid(e.to_string()))
+                        .log_warning()
                 }
-                Sync15ErrorKind::RequestError(_) => ErrorHandling::log(
-                    LoginsStorageError::RequestFailed(e.to_string()),
-                    log::Level::Warn,
-                ),
-                _ => ErrorHandling::unexpected(
-                    LoginsStorageError::UnexpectedLoginsStorageError(self.to_string()),
-                    Some("sync"),
-                ),
+                Sync15ErrorKind::RequestError(_) => {
+                    ErrorHandling::convert(LoginsStorageError::RequestFailed(e.to_string()))
+                        .log_warning()
+                }
+                _ => ErrorHandling::convert(LoginsStorageError::UnexpectedLoginsStorageError(
+                    self.to_string(),
+                ))
+                .report_error("logins:sync"),
             },
             // This list is partial - not clear if a best-practice should be to ask that every
             // internal error is listed here (and remove this default branch) to ensure every error
             // is considered, or whether this default is fine for obscure errors?
             // But it's fine for now because errors were always converted with a default
             // branch to "unexpected"
-            _ => ErrorHandling::unexpected(
-                LoginsStorageError::UnexpectedLoginsStorageError(self.to_string()),
-                None,
-            ),
+            _ => ErrorHandling::convert(LoginsStorageError::UnexpectedLoginsStorageError(
+                self.to_string(),
+            ))
+            .report_error("logins:unexpected"),
         }
     }
 }

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -29,22 +29,30 @@ pub use crate::sync::LoginsSyncEngine;
 
 // Public encryption functions.  We publish these as top-level functions to expose them across
 // UniFFI
-fn encrypt_login(login: Login, enc_key: &str) -> Result<EncryptedLogin> {
-    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-    login.encrypt(&encdec)
+fn encrypt_login(login: Login, enc_key: &str) -> ApiResult<EncryptedLogin> {
+    handle_error! {
+        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+        login.encrypt(&encdec)
+    }
 }
 
-fn decrypt_login(login: EncryptedLogin, enc_key: &str) -> Result<Login> {
-    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-    login.decrypt(&encdec)
+fn decrypt_login(login: EncryptedLogin, enc_key: &str) -> ApiResult<Login> {
+    handle_error! {
+        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+        login.decrypt(&encdec)
+    }
 }
 
-fn encrypt_fields(sec_fields: SecureLoginFields, enc_key: &str) -> Result<String> {
-    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-    sec_fields.encrypt(&encdec)
+fn encrypt_fields(sec_fields: SecureLoginFields, enc_key: &str) -> ApiResult<String> {
+    handle_error! {
+        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+        sec_fields.encrypt(&encdec)
+    }
 }
 
-fn decrypt_fields(sec_fields: String, enc_key: &str) -> Result<SecureLoginFields> {
-    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-    encdec.decrypt_struct(&sec_fields)
+fn decrypt_fields(sec_fields: String, enc_key: &str) -> ApiResult<SecureLoginFields> {
+    handle_error! {
+        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+        encdec.decrypt_struct(&sec_fields)
+    }
 }

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -91,15 +91,13 @@ dictionary EncryptedLogin {
 
 [Error]
 enum LoginsStorageError {
-    "UnexpectedLoginsStorageError",
-    "SyncAuthInvalid",
-    "MismatchedLock",
-    "NoSuchRecord",
     "InvalidRecord",
+    "NoSuchRecord",
     "CryptoError",
-    "InvalidKey",
+    "SyncAuthInvalid",
     "RequestFailed",
     "Interrupted",
+    "UnexpectedLoginsError",
 };
 
 interface LoginStore {

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -89,16 +89,36 @@ dictionary EncryptedLogin {
     string sec_fields; // ciphertext of a SecureLoginFields
 };
 
+// These are the errors returned by our public API.
 [Error]
 enum LoginsStorageError {
+    // The login data supplied is invalid. The message will indicate what's wrong with it.
     "InvalidRecord",
+
+    // Asking to do something with a guid which doesn't exist.
     "NoSuchRecord",
-    "CryptoError",
-    "SyncAuthInvalid",
-    "RequestFailed",
+
+    // The encryption key supplied of the correct format, but not the correct key.
+    "IncorrectKey",
+
+    // An operation was interrupted at the request of the consuming app.
     "Interrupted",
-    "UnexpectedLoginsError",
+
+    // Sync reported that authentication failed and the user should re-enter their FxA password.
+    // TODO: remove this at the same time as remove the sync() method in favour of the SyncManager.
+    "SyncAuthInvalid",
+
+    // Sync reported that a request failed.
+    // TODO: remove this at the same time as remove the sync() method in favour of the SyncManager.
+    "RequestFailed",
+
+    // something internal went wrong which doesn't have a public error value
+    // because the consuming app can not reasonably take any action to resolve it.
+    // The underlying error will have been logged and reported.
+    // (ideally would just be `Unexpected`, but that would be a breaking change)
+    "UnexpectedLoginsStorageError",
 };
+
 
 interface LoginStore {
     [Throws=LoginsStorageError]

--- a/components/logins/src/sync/engine.rs
+++ b/components/logins/src/sync/engine.rs
@@ -35,10 +35,10 @@ pub struct LoginsSyncEngine {
 
 impl LoginsSyncEngine {
     fn encdec(&self) -> Result<&EncryptorDecryptor> {
-        Ok(match &self.encdec {
-            Some(encdec) => encdec,
-            None => throw!(ErrorKind::EncryptionKeyMissing),
-        })
+        match &self.encdec {
+            Some(encdec) => Ok(encdec),
+            None => Err(LoginsError::EncryptionKeyMissing),
+        }
     }
 
     pub fn new(store: Arc<LoginStore>) -> Result<Self> {

--- a/components/logins/src/sync/mod.rs
+++ b/components/logins/src/sync/mod.rs
@@ -27,7 +27,7 @@ impl SyncStatus {
             0 => Ok(SyncStatus::Synced),
             1 => Ok(SyncStatus::Changed),
             2 => Ok(SyncStatus::New),
-            v => throw!(ErrorKind::BadSyncStatus(v)),
+            v => Err(LoginsError::BadSyncStatus(v)),
         }
     }
 }

--- a/components/support/error/src/handling.rs
+++ b/components/support/error/src/handling.rs
@@ -1,0 +1,101 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Helpers for components to "handle" errors.
+
+/// Describes what error reporting action should be taken.
+#[derive(Debug, Default)]
+pub struct ErrorReporting {
+    /// If Some(level), will write a log message at that level.
+    log_level: Option<log::Level>,
+    /// If Some(report_class) will call the error reporter with details.
+    report_class: Option<String>,
+}
+
+/// Specifies how an "internal" error is converted to an "external" public error and
+/// any logging or reporting that should happen.
+pub struct ErrorHandling<E> {
+    /// The external error that should be returned.
+    pub err: E,
+    /// How the error should be reported.
+    pub reporting: ErrorReporting,
+}
+
+impl<E> ErrorHandling<E> {
+    // Some helpers to cut the verbosity down.
+    /// Just convert the error without any special logging or error reporting.
+    pub fn passthrough(err: E) -> Self {
+        Self {
+            err,
+            reporting: ErrorReporting::default(),
+        }
+    }
+
+    /// Just convert and log the error without any special error reporting.
+    pub fn log(err: E, level: log::Level) -> Self {
+        Self {
+            err,
+            reporting: ErrorReporting {
+                log_level: Some(level),
+                ..Default::default()
+            },
+        }
+    }
+
+    /// Convert, report and log the error.
+    pub fn report(err: E, level: log::Level, report_class: String) -> Self {
+        Self {
+            err,
+            reporting: ErrorReporting {
+                log_level: Some(level),
+                report_class: Some(report_class),
+            },
+        }
+    }
+
+    /// Convert, report and log the error in a way suitable for "unexpected" errors.
+    // (With more generics we might be able to abstract away the creation of `err`,
+    // but that will have a significant complexity cost for only marginal value)
+    pub fn unexpected(err: E, report_class: Option<&str>) -> Self {
+        Self::report(
+            err,
+            log::Level::Error,
+            report_class.unwrap_or("unexpected").to_string(),
+        )
+    }
+}
+
+/// A trait to define how errors are converted and reported.
+pub trait GetErrorHandling {
+    type ExternalError;
+
+    /// Return how to handle our internal errors
+    fn get_error_handling(&self) -> ErrorHandling<Self::ExternalError>;
+}
+
+/// Handle the specified "internal" error, taking any logging or error
+/// reporting actions and converting the error to the public error.
+/// Called by our `handle_error` macro so needs to be public.
+pub fn convert_log_report_error<IE, EE>(e: IE) -> EE
+where
+    IE: GetErrorHandling<ExternalError = EE> + std::error::Error,
+    EE: std::error::Error,
+{
+    let handling = e.get_error_handling();
+    let reporting = handling.reporting;
+    if let Some(level) = reporting.log_level {
+        log::log!(level, "{}", e.to_string());
+    }
+    if let Some(report_class) = reporting.report_class {
+        // notify the error reporter if the feature is enabled.
+        // XXX - should we arrange for the `report_class` to have the
+        // original crate calling this as a prefix, or will we still be
+        // able to identify that?
+        #[cfg(feature = "reporting")]
+        crate::report_error(report_class, e.to_string());
+        #[cfg(not(feature = "reporting"))]
+        let _ = report_class; // avoid clippy warning when feature's not enabled.
+    }
+    handling.err
+}

--- a/components/support/error/src/lib.rs
+++ b/components/support/error/src/lib.rs
@@ -31,6 +31,12 @@ pub use reporting::{
     report_breadcrumb, report_error, set_application_error_reporter, ApplicationErrorReporter,
 };
 
+mod handling;
+pub use handling::{convert_log_report_error, ErrorHandling, ErrorReporting, GetErrorHandling};
+
+/// XXX - Most of this is now considered deprecated - only FxA uses it, and
+/// should be replaced with the facilities in the `handling` module.
+
 /// Define a wrapper around the the provided ErrorKind type.
 /// See also `define_error` which is more likely to be what you want.
 #[macro_export]

--- a/components/support/error/src/macros.rs
+++ b/components/support/error/src/macros.rs
@@ -60,3 +60,16 @@ macro_rules! breadcrumb {
         }
     };
 }
+
+/// Function wrapper macro to convert from a component's internal errors to external errors
+/// and optionally log and report the error.
+#[macro_export]
+macro_rules! handle_error {
+    { $($tt:tt)* } => {
+        let body = || {
+            $($tt)*
+        };
+        let result: Result<_> = body();
+        result.map_err($crate::convert_log_report_error)
+    }
+}

--- a/components/sync_manager/src/error.rs
+++ b/components/sync_manager/src/error.rs
@@ -21,7 +21,7 @@ pub enum SyncManagerError {
     #[error("Error parsing JSON data: {0}")]
     JsonError(#[from] serde_json::Error),
     #[error("Logins error: {0}")]
-    LoginsError(#[from] logins::Error),
+    LoginsError(#[from] logins::LoginsError),
     #[error("Places error: {0}")]
     PlacesError(#[from] places::Error),
     // We should probably upgrade this crate to anyhow, which would mean this

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -369,7 +369,6 @@ fn set_encryption_key(store: &LoginStore, key: &str) -> rusqlite::Result<()> {
 fn main() -> Result<()> {
     cli_support::init_trace_logging();
     viaduct_reqwest::use_reqwest_backend();
-    std::env::set_var("RUST_BACKTRACE", "1");
 
     let matches = clap::App::new("sync_pass_sql")
         .about("CLI login syncing tool (backed by sqlcipher)")
@@ -504,7 +503,6 @@ fn main() -> Result<()> {
                                 ) {
                     Err(e) => {
                         log::warn!("Sync failed! {}", e);
-                        log::warn!("BT: {:?}", e.backtrace());
                     },
                     Ok(sync_ping) => {
                         log::info!("Sync was successful!");
@@ -523,7 +521,6 @@ fn main() -> Result<()> {
                     match store.get_by_base_domain(&basedomain) {
                         Err(e) => {
                             log::warn!("Base domain lookup failed! {}", e);
-                            log::warn!("BT: {:?}", e.backtrace());
                         },
                         Ok(result) => {
                             log::info!("Base domain result: {:?}", result);


### PR DESCRIPTION
This is built on top of @bendk's #5004, taking the concepts in that PR much further. Ben and I discussed this a little in-person, so this shouldn't be a surprise to him.

Like that branch, it splits the "internal" errors from the "external" errors returned to the consumers.

It extends that patch in the following ways:
* Instead of `Into()` to covert between the 2 error types and log/report as a side-effect, it uses an explicit conversion mechanism.
* That explicit conversion also specifies how each error should be reported and logged.
* Due to the above, there's a new `handle_error` macro, shamelessly stolen from an earlier iteration of Ben's patch, which all public functions must use. This converts and does the logging/reporting.
* It's still possible to convert between errors and/or get logging/reporting information without using that macro - so the error reporting and logging facilities are still "explicit" - it's just they are usually hidden behind that `handle_error` macro.

Open questions:
* Does this actually make sense?
* Is it an improvement and something we should take on for all components? I've kept a few commits, so it would be easy to keep this as a logins-only change if necessary, but I'm inclined to think it works OK.
* Does it work? :) Tests all pass etc, including Android tests (so I don't think this is actually a breaking change) but I'm yet to actually test it in a product.
* Assuming a positive reception, how should we land this? I think we should fold the 3 patches of mine into 1, leaving one commit from Ben and one from me we can land.

Feedback welcome. Bikesheds welcome (I'm relatively happy with the names, but welcome improvements). Happy to consider alternatives or other ideas.