### PR TITLE
Fix the dep checker: the windows-rs repository moved its license files

### DIFF
--- a/.github/workflows/dependency-check.yaml
+++ b/.github/workflows/dependency-check.yaml
@@ -9,6 +9,7 @@ on:
      - '**requirements.txt'
      - '**DEPENDENCIES.md'
      - '**dependency-licenses.xml'
+     - '**dependency_summary.py'
   pull_request:
     branches: [ main ]
     paths:
@@ -17,6 +18,7 @@ on:
      - '**requirements.txt'
      - '**DEPENDENCIES.md'
      - '**dependency-licenses.xml'
+     - '**dependency_summary.py'
   schedule:
     # Runs at 7:00 UTC every day
      - cron: '0 7 * * *'

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -482,15 +482,15 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: windows-sys</name>
-    <url>https://github.com/microsoft/windows-rs/blob/master/.github/license-mit</url>
+    <url>https://github.com/microsoft/windows-rs/blob/master/license-mit</url>
   </license>
   <license>
     <name>Apache License 2.0: windows_x86_64_gnu</name>
-    <url>https://github.com/microsoft/windows-rs/blob/master/.github/license-mit</url>
+    <url>https://github.com/microsoft/windows-rs/blob/master/license-mit</url>
   </license>
   <license>
     <name>Apache License 2.0: windows_x86_64_msvc</name>
-    <url>https://github.com/microsoft/windows-rs/blob/master/.github/license-mit</url>
+    <url>https://github.com/microsoft/windows-rs/blob/master/license-mit</url>
   </license>
   <license>
     <name>MIT License: aho-corasick</name>

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -351,8 +351,8 @@ PACKAGE_METADATA_FIXUPS = {
         },
         "license_file": {
             "check": None,
-            "fixup": "https://raw.githubusercontent.com/microsoft/windows-rs/master/.github/license-mit",
-        }
+            "fixup": "https://raw.githubusercontent.com/microsoft/windows-rs/master/license-mit",
+        },
     },
     "windows_x86_64_msvc": {
         "repository": {
@@ -360,8 +360,8 @@ PACKAGE_METADATA_FIXUPS = {
         },
         "license_file": {
             "check": None,
-            "fixup": "https://raw.githubusercontent.com/microsoft/windows-rs/master/.github/license-mit",
-        }
+            "fixup": "https://raw.githubusercontent.com/microsoft/windows-rs/master/license-mit",
+        },
     },
     "windows_x86_64_gnu": {
         "repository": {
@@ -369,8 +369,8 @@ PACKAGE_METADATA_FIXUPS = {
         },
         "license_file": {
             "check": None,
-            "fixup": "https://raw.githubusercontent.com/microsoft/windows-rs/master/.github/license-mit",
-        }
+            "fixup": "https://raw.githubusercontent.com/microsoft/windows-rs/master/license-mit",
+        },
     },
     "kernel32-sys": {
         "repository": {


### PR DESCRIPTION
My recent PR is failing because just an hour or so ago, the license files in the windows-rs repo moved.