### PR TITLE
Add environment variable to specify the megazord

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,6 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+### What's Changed
+  - Added `MOZ_APPSERVICES_MODULE` environment variable to specify the megazord module for iOS ([#5042](https://github.com/mozilla/application-services/pull/5042)). If it is missing, no module is imported.

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
@@ -83,6 +83,11 @@ impl<'a> FeatureManifestDeclaration<'a> {
         let oracle = &self.oracle;
         // Filter out our own module.
         let my_module = &self.fm.about.nimbus_module_name();
+        // Get the app-services module from an environment variable.
+        // If it doesn't exist, then we don't add it.
+        let as_module = std::env::var("MOZ_APPSERVICES_MODULE")
+            .map(|s| vec![s])
+            .unwrap_or_else(|_| vec![]);
         let mut imports: Vec<String> = self
             .members()
             .into_iter()
@@ -95,6 +100,7 @@ impl<'a> FeatureManifestDeclaration<'a> {
                     .filter_map(|type_| self.oracle.find(&type_).imports(oracle))
                     .flatten(),
             )
+            .chain(as_module)
             .filter(|i| i != my_module)
             .collect::<HashSet<String>>()
             .into_iter()


### PR DESCRIPTION
No bug.

This PR adds an environment variable to set the module that Nimbus is contained within.

Eventually, this should have a default, but we need to be able to support [the current scheme](https://github.com/mozilla-mobile/firefox-ios/blob/main/bin/nimbus-fml.sh#L218-L220) while upgrading the apps.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
