### PR TITLE
Fixup request-tls for remote loading of manifests

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -24,6 +24,7 @@ Use the template below to make assigning a version number during the release cut
   - Added `MOZ_APPSERVICES_MODULE` environment variable to specify the megazord module for iOS ([#5042](https://github.com/mozilla/application-services/pull/5042)). If it is missing, no module is imported.
 ### ✨ What's New ✨
   - Enabled remote loading and using configuring of branches. ([#5041](https://github.com/mozilla/application-services/pull/5041))
+  - Add a `fetch` command to `nimbus-fml` to demo and test remote loading and paths. ([#5047](https://github.com/mozilla/application-services/pull/5047))
 
 ## Logins
 ### What's Changed

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -18,7 +18,7 @@ textwrap = "0.14.2"
 heck = "0.3.3"
 unicode-segmentation = "1.8.0"
 url = "2.2.2"
-reqwest = { version = "0.11.4", features = ["blocking"], default-features = false }
+reqwest = { version = "0.11", features = ["blocking", "native-tls-vendored"] }
 glob = "0.3.0"
 
 [dev-dependencies]

--- a/components/support/nimbus-fml/src/cli.yaml
+++ b/components/support/nimbus-fml/src/cli.yaml
@@ -71,14 +71,12 @@ subcommands:
             #     global: false
             #     takes_value: true
 
-            # These next two flags aren't wired up yet.
-            # This will be done in EXP-2573.
             - cache-dir:
-                help: The directory where downloaded files are cached (inactive until EXP-2573)
+                help: The directory where downloaded files are cached
                 long: cache-dir
                 takes_value: true
             - repo-file:
-                help: The file containing the version/refs/locations for other repos (inactive until EXP-2573)
+                help: The file containing the version/refs/locations for other repos
                 long: repo-file
                 takes_value: true
                 multiple: true
@@ -101,6 +99,22 @@ subcommands:
 
             # These next two flags aren't wired up yet.
             # This will be done in EXP-2573.
+            - cache-dir:
+                help: The directory where downloaded files are cached
+                long: cache-dir
+                takes_value: true
+            - repo-file:
+                help: The file containing the version/refs/locations for other repos
+                long: repo-file
+                takes_value: true
+                multiple: true
+    - fetch:
+        about: Get the input file, with the same rules that govern how FilePaths work.
+        args:
+            - INPUT:
+                help: Sets the input file to use
+                required: true
+                index: 1
             - cache-dir:
                 help: The directory where downloaded files are cached
                 long: cache-dir

--- a/components/support/nimbus-fml/src/commands.rs
+++ b/components/support/nimbus-fml/src/commands.rs
@@ -12,6 +12,7 @@ pub(crate) enum CliCmd {
     DeprecatedGenerate(GenerateStructCmd, AboutBlock),
     GenerateExperimenter(GenerateExperimenterManifestCmd),
     GenerateIR(GenerateIRCmd),
+    FetchFile(LoaderConfig, String),
 }
 
 #[derive(Clone)]

--- a/components/support/nimbus-fml/src/main.rs
+++ b/components/support/nimbus-fml/src/main.rs
@@ -47,6 +47,7 @@ fn process_command(cmd: &CliCmd) -> Result<()> {
         CliCmd::Generate(params) => workflows::generate_struct(params)?,
         CliCmd::GenerateExperimenter(params) => workflows::generate_experimenter_manifest(params)?,
         CliCmd::GenerateIR(params) => workflows::generate_ir(params)?,
+        CliCmd::FetchFile(files, nm) => workflows::fetch_file(files, nm)?,
     };
     Ok(())
 }
@@ -127,6 +128,9 @@ where
         ("generate-experimenter", Some(matches)) => CliCmd::GenerateExperimenter(
             create_generate_command_experimenter_from_cli(matches, cwd)?,
         ),
+        ("fetch", Some(matches)) => {
+            CliCmd::FetchFile(create_loader(matches, cwd)?, input_file(matches)?)
+        }
         (word, _) => unimplemented!("Command {} not implemented", word),
     })
 }

--- a/components/support/nimbus-fml/src/workflows.rs
+++ b/components/support/nimbus-fml/src/workflows.rs
@@ -148,6 +148,16 @@ fn load_feature_manifest(
     Ok(ir)
 }
 
+pub(crate) fn fetch_file(files: &crate::commands::LoaderConfig, nm: &str) -> Result<()> {
+    let files: FileLoader = files.try_into()?;
+    let file = files.file_path(nm)?;
+
+    let string = files.read_to_string(&file)?;
+
+    println!("{}", string);
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use std::fs;

--- a/components/support/nimbus-fml/test/test_command_line.sh
+++ b/components/support/nimbus-fml/test/test_command_line.sh
@@ -147,4 +147,11 @@ then
 	fail "New style 'generate' with glob and language = kotlin, and single channel files allowed"
 fi
 
+if ! cargo run -- fetch \
+	"@mozilla-mobile/android-components/version.txt" \
+    > /dev/null 2>&1;
+then
+	fail "Fetch from another repo"
+fi
+
 popd >/dev/null || exit 0


### PR DESCRIPTION
This PR fixes an issue with fetching of remote files via reqwest and tls.

It also introduces a `fetch` command to the `nimbus-fml` command line.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
