### PR TITLE
update CLIENTS_TTL to be 180 days instead of 21

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -21,3 +21,4 @@ Use the template below to make assigning a version number during the release cut
 ## Nimbus FML ⛅️🔬🔭
 ### What's Changed
   - Validate the configuration passed from a top-level FML file to imported files. ([#5055](https://github.com/mozilla/application-services/pull/5055))
+  - `CLIENTS_TTL` has been updated to be 180 days instead of 21 ([#5054](https://github.com/mozilla/application-services/pull/5054))

--- a/components/sync15/src/clients/mod.rs
+++ b/components/sync15/src/clients/mod.rs
@@ -14,7 +14,7 @@ pub use engine::Engine;
 pub use sync15_traits::client::{ClientData, RemoteClient};
 
 // These are what desktop uses.
-const CLIENTS_TTL: u32 = 1_814_400; // 21 days
+const CLIENTS_TTL: u32 = 15_552_000; // 180 days
 pub(crate) const CLIENTS_TTL_REFRESH: u64 = 604_800; // 7 days
 
 /// A command processor applies incoming commands like wipes and resets for all


### PR DESCRIPTION
### Pull Request checklist ###
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one

`CLIENTS_TTL` has been updated to be 180 days instead of 21 days. This change has been landed in m-c.

No test changes are necessary as far as I can tell.

[Bug 1719392](https://bugzilla.mozilla.org/show_bug.cgi?id=1719392)
