### PR TITLE
Move the bso_record and key_bundle into the sync15_traits crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3258,11 +3258,19 @@ name = "sync15-traits"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base16",
+ "base64 0.13.0",
+ "error-support",
  "ffi-support",
+ "interrupt-support",
+ "lazy_static",
  "log",
+ "rc_crypto",
  "serde",
+ "serde_derive",
  "serde_json",
  "sync-guid",
+ "thiserror",
  "url",
 ]
 

--- a/components/fxa-client/src/internal/error.rs
+++ b/components/fxa-client/src/internal/error.rs
@@ -148,6 +148,19 @@ error_support::define_error_conversions! {
     }
 }
 
+// Adapts errors from the sync15_traits crate into sync15 errors.
+impl From<sync15::SyncTraitsError> for ErrorKind {
+    fn from(e: sync15::SyncTraitsError) -> Self {
+        ErrorKind::SyncError(e.into())
+    }
+}
+
+impl From<sync15::SyncTraitsError> for Error {
+    fn from(e: sync15::SyncTraitsError) -> Self {
+        Error::from(ErrorKind::from(e))
+    }
+}
+
 // The public FFI puts the errors into three buckets, this helps us
 // convert between them. Maybe in future we can use uniffi to expose
 // more error info to the caller?

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -121,6 +121,13 @@ pub enum InvalidLogin {
     IllegalFieldValue { field_info: String },
 }
 
+// Adapts errors from the sync15_traits crate into sync15 errors.
+impl From<sync15::SyncTraitsError> for LoginsError {
+    fn from(e: sync15::SyncTraitsError) -> Self {
+        LoginsError::SyncAdapterError(e.into())
+    }
+}
+
 // Define how our internal errors are handled and converted to external errors.
 impl GetErrorHandling for LoginsError {
     type ExternalError = LoginsStorageError;

--- a/components/support/sync15-traits/Cargo.toml
+++ b/components/support/sync15-traits/Cargo.toml
@@ -7,12 +7,24 @@ edition = "2021"
 
 [features]
 random-guid = ["sync-guid/random"]
+# Some consumers of this - notably things which just use the "bridged engine",
+# don't actually need to encrypt and decrypt payloads, so we put all
+# crypto behind a feature so they don't pointlessly link the crypto libs.
+crypto = ["rc_crypto", "base16", "base64"]
 
 [dependencies]
+anyhow = "1.0"
+base16 = { version = "0.2", optional = true }
+base64 = { version = "0.13", optional = true }
+error-support = { path = "../error" }
+interrupt-support = { path = "../interrupt" }
+rc_crypto = { path = "../rc_crypto", features = ["hawk"], optional = true }
 sync-guid = { path = "../guid" }
 serde = { version = "1", features = ["derive"] }
+serde_derive = "1"
 serde_json = "1"
+lazy_static = "1.4"
 log = "0.4"
 ffi-support = "0.4"
+thiserror = "1.0"
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
-anyhow = "1.0"

--- a/components/support/sync15-traits/src/bso_record.rs
+++ b/components/support/sync15-traits/src/bso_record.rs
@@ -4,13 +4,13 @@
 
 use crate::error;
 use crate::key_bundle::KeyBundle;
-use crate::util::ServerTimestamp;
+use crate::Payload;
+use crate::ServerTimestamp;
 use lazy_static::lazy_static;
 use serde::de::{Deserialize, DeserializeOwned};
 use serde::ser::Serialize;
 use serde_derive::*;
 use std::ops::{Deref, DerefMut};
-pub use sync15_traits::Payload;
 use sync_guid::Guid;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -437,8 +437,8 @@ mod tests {
             .expect_err("Should fail because wrong keybundle");
 
         // Note: ErrorKind isn't PartialEq, so.
-        match e.kind() {
-            error::ErrorKind::CryptoError(_) => {
+        match e {
+            error::SyncTraitsError::CryptoError(_) => {
                 // yay.
             }
             other => {

--- a/components/support/sync15-traits/src/error.rs
+++ b/components/support/sync15-traits/src/error.rs
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// `Result` is unused with default features, but used with `feature=crypto`
+#[cfg(feature = "crypto")]
+pub type Result<T> = std::result::Result<T, SyncTraitsError>;
+
+// Concrete errors returned by this module. Note that the sync15 crate has
+// the ability to turn these errors into a `sync15::Error`, so most consumers
+// should leverage that rather than create an error variant specific to this
+// crate.
+#[derive(Debug, thiserror::Error)]
+pub enum SyncTraitsError {
+    #[cfg(feature = "crypto")]
+    #[error("Key {0} had wrong length, got {1}, expected {2}")]
+    BadKeyLength(&'static str, usize, usize),
+
+    #[cfg(feature = "crypto")]
+    #[error("SHA256 HMAC Mismatch error")]
+    HmacMismatch,
+
+    #[cfg(feature = "crypto")]
+    #[error("Crypto/NSS error: {0}")]
+    CryptoError(#[from] rc_crypto::Error),
+
+    #[cfg(feature = "crypto")]
+    #[error("Base64 decode error: {0}")]
+    Base64Decode(#[from] base64::DecodeError),
+
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+
+    #[error("Bad cleartext UTF8: {0}")]
+    BadCleartextUtf8(#[from] std::string::FromUtf8Error),
+
+    #[cfg(feature = "crypto")]
+    #[error("HAWK error: {0}")]
+    HawkError(#[from] rc_crypto::hawk::Error),
+}

--- a/components/support/sync15-traits/src/key_bundle.rs
+++ b/components/support/sync15-traits/src/key_bundle.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::error::{ErrorKind, Result};
+use crate::error::{Result, SyncTraitsError as Error};
 use rc_crypto::{
     aead::{self, OpeningKey, SealingKey},
     rand,
@@ -26,11 +26,11 @@ impl KeyBundle {
     pub fn new(enc: Vec<u8>, mac: Vec<u8>) -> Result<KeyBundle> {
         if enc.len() != 32 {
             log::error!("Bad key length (enc_key): {} != 32", enc.len());
-            return Err(ErrorKind::BadKeyLength("enc_key", enc.len(), 32).into());
+            return Err(Error::BadKeyLength("enc_key", enc.len(), 32));
         }
         if mac.len() != 32 {
             log::error!("Bad key length (mac_key): {} != 32", mac.len());
-            return Err(ErrorKind::BadKeyLength("mac_key", mac.len(), 32).into());
+            return Err(Error::BadKeyLength("mac_key", mac.len(), 32));
         }
         Ok(KeyBundle {
             enc_key: enc,
@@ -47,7 +47,7 @@ impl KeyBundle {
     pub fn from_ksync_bytes(ksync: &[u8]) -> Result<KeyBundle> {
         if ksync.len() != 64 {
             log::error!("Bad key length (kSync): {} != 64", ksync.len());
-            return Err(ErrorKind::BadKeyLength("kSync", ksync.len(), 64).into());
+            return Err(Error::BadKeyLength("kSync", ksync.len(), 64));
         }
         Ok(KeyBundle {
             enc_key: ksync[0..32].into(),
@@ -90,7 +90,7 @@ impl KeyBundle {
         let mut decoded_hmac = vec![0u8; 32];
         if base16::decode_slice(hmac_base16, &mut decoded_hmac).is_err() {
             log::warn!("Garbage HMAC verification string: contained non base16 characters");
-            return Err(ErrorKind::HmacMismatch.into());
+            return Err(Error::HmacMismatch);
         }
         let iv = base64::decode(iv_base64)?;
         let ciphertext_bytes = base64::decode(enc_base64)?;

--- a/components/support/sync15-traits/src/lib.rs
+++ b/components/support/sync15-traits/src/lib.rs
@@ -15,17 +15,27 @@
 
 #![warn(rust_2018_idioms)]
 pub mod bridged_engine;
+#[cfg(feature = "crypto")]
+mod bso_record;
 mod changeset;
 pub mod client;
 mod engine;
+mod error;
+#[cfg(feature = "crypto")]
+mod key_bundle;
 mod payload;
 pub mod request;
 mod server_timestamp;
 pub mod telemetry;
 
 pub use bridged_engine::{ApplyResults, BridgedEngine, IncomingEnvelope, OutgoingEnvelope};
+#[cfg(feature = "crypto")]
+pub use bso_record::{BsoRecord, CleartextBso, EncryptedBso, EncryptedPayload};
 pub use changeset::{IncomingChangeset, OutgoingChangeset, RecordChangeset};
 pub use engine::{CollSyncIds, EngineSyncAssociation, SyncEngine, SyncEngineId};
+pub use error::SyncTraitsError;
+#[cfg(feature = "crypto")]
+pub use key_bundle::KeyBundle;
 pub use payload::Payload;
 pub use request::{CollectionRequest, RequestOrder};
 pub use server_timestamp::ServerTimestamp;

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -21,7 +21,7 @@ viaduct = { path = "../viaduct" }
 interrupt-support = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["random"] }
-sync15-traits = {path = "../support/sync15-traits"}
+sync15-traits = {path = "../support/sync15-traits", features = ["crypto"] }
 thiserror = "1.0"
 anyhow = "1.0"
 

--- a/components/sync15/src/changeset.rs
+++ b/components/sync15/src/changeset.rs
@@ -2,15 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bso_record::{CleartextBso, EncryptedBso};
 use crate::client::{Sync15ClientResponse, Sync15StorageClient};
 use crate::error::{self, ErrorKind, ErrorResponse, Result};
-use crate::key_bundle::KeyBundle;
 use crate::request::{CollectionRequest, NormalResponseHandler, UploadInfo};
 use crate::util::ServerTimestamp;
 use crate::CollState;
 use std::borrow::Cow;
-
+use sync15_traits::{CleartextBso, EncryptedBso, KeyBundle};
 pub use sync15_traits::{IncomingChangeset, OutgoingChangeset, RecordChangeset};
 
 pub fn encrypt_outgoing(o: OutgoingChangeset, key: &KeyBundle) -> Result<Vec<EncryptedBso>> {
@@ -21,7 +19,11 @@ pub fn encrypt_outgoing(o: OutgoingChangeset, key: &KeyBundle) -> Result<Vec<Enc
     } = o;
     changes
         .into_iter()
-        .map(|change| CleartextBso::from_payload(change, collection.clone()).encrypt(key))
+        .map(|change| {
+            CleartextBso::from_payload(change, collection.clone())
+                .encrypt(key)
+                .map_err(|e| e.into())
+        })
         .collect()
 }
 

--- a/components/sync15/src/client.rs
+++ b/components/sync15/src/client.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bso_record::{BsoRecord, EncryptedBso};
 use crate::error::{self, ErrorKind, ErrorResponse};
 use crate::record_types::MetaGlobalRecord;
 use crate::request::{
@@ -14,6 +13,7 @@ use crate::util::ServerTimestamp;
 use serde_json::Value;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU32, Ordering};
+use sync15_traits::{BsoRecord, EncryptedBso};
 use url::Url;
 use viaduct::{
     header_names::{self, AUTHORIZATION},

--- a/components/sync15/src/clients/engine.rs
+++ b/components/sync15/src/clients/engine.rs
@@ -5,17 +5,15 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    bso_record::Payload,
     changeset::{CollectionUpdate, IncomingChangeset, OutgoingChangeset},
     client::Sync15StorageClient,
     coll_state::CollState,
     collection_keys::CollectionKeys,
-    key_bundle::KeyBundle,
     request::{CollectionRequest, InfoConfiguration},
     state::GlobalState,
 };
 use interrupt_support::Interruptee;
-use sync15_traits::client::ClientData;
+use sync15_traits::{client::ClientData, KeyBundle, Payload};
 
 use super::{
     record::{ClientRecord, CommandRecord},

--- a/components/sync15/src/coll_state.rs
+++ b/components/sync15/src/coll_state.rs
@@ -4,13 +4,12 @@
 
 use crate::collection_keys::CollectionKeys;
 use crate::error;
-use crate::key_bundle::KeyBundle;
 use crate::request::InfoConfiguration;
 use crate::state::GlobalState;
 use crate::sync::SyncEngine;
 use crate::util::ServerTimestamp;
 
-pub use sync15_traits::{CollSyncIds, EngineSyncAssociation};
+pub use sync15_traits::{CollSyncIds, EngineSyncAssociation, KeyBundle};
 
 /// Holds state for a collection. In general, only the CollState is
 /// needed to sync a collection (but a valid GlobalState is needed to obtain

--- a/components/sync15/src/collection_keys.rs
+++ b/components/sync15/src/collection_keys.rs
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bso_record::{EncryptedBso, Payload};
 use crate::error::Result;
-use crate::key_bundle::KeyBundle;
 use crate::record_types::CryptoKeysRecord;
 use crate::util::ServerTimestamp;
 use std::collections::HashMap;
+use sync15_traits::{EncryptedBso, KeyBundle, Payload};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct CollectionKeys {
@@ -55,7 +54,7 @@ impl CollectionKeys {
                 .collect(),
         };
         let bso = crate::CleartextBso::from_payload(Payload::from_record(record)?, "crypto");
-        bso.encrypt(root_key)
+        Ok(bso.encrypt(root_key)?)
     }
 
     pub fn key_for_collection<'a>(&'a self, collection: &str) -> &'a KeyBundle {

--- a/components/sync15/src/lib.rs
+++ b/components/sync15/src/lib.rs
@@ -5,14 +5,12 @@
 #![allow(unknown_lints, clippy::implicit_hasher)]
 #![warn(rust_2018_idioms)]
 
-mod bso_record;
 pub mod changeset;
 mod client;
 pub mod clients;
 mod coll_state;
 mod collection_keys;
 mod error;
-mod key_bundle;
 mod migrate_state;
 mod record_types;
 mod request;
@@ -25,7 +23,6 @@ mod token;
 mod util;
 
 // Re-export some of the types callers are likely to want for convenience.
-pub use crate::bso_record::{BsoRecord, CleartextBso, EncryptedBso, EncryptedPayload, Payload};
 pub use crate::changeset::{IncomingChangeset, OutgoingChangeset, RecordChangeset};
 pub use crate::client::{
     SetupStorageClient, Sync15ClientResponse, Sync15StorageClient, Sync15StorageClientInit,
@@ -33,7 +30,6 @@ pub use crate::client::{
 pub use crate::coll_state::{CollState, CollSyncIds, EngineSyncAssociation};
 pub use crate::collection_keys::CollectionKeys;
 pub use crate::error::{Error, ErrorKind, Result};
-pub use crate::key_bundle::KeyBundle;
 pub use crate::migrate_state::extract_v1_state;
 pub use crate::request::CollectionRequest;
 pub use crate::state::{GlobalState, SetupStateMachine};
@@ -43,6 +39,9 @@ pub use crate::sync_multiple::{
     sync_multiple, sync_multiple_with_command_processor, MemoryCachedState, SyncRequestInfo,
 };
 pub use sync15_traits::client::DeviceType;
+pub use sync15_traits::SyncTraitsError;
 
 pub use crate::util::ServerTimestamp;
-pub use sync15_traits::SyncEngineId;
+pub use sync15_traits::{
+    BsoRecord, CleartextBso, EncryptedBso, EncryptedPayload, KeyBundle, Payload, SyncEngineId,
+};

--- a/components/sync15/src/request.rs
+++ b/components/sync15/src/request.rs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bso_record::EncryptedBso;
 use crate::client::Sync15ClientResponse;
 use crate::error::{self, ErrorKind, Result};
 use crate::util::ServerTimestamp;
@@ -10,6 +9,7 @@ use serde_derive::*;
 use std::collections::HashMap;
 use std::default::Default;
 use std::ops::Deref;
+use sync15_traits::EncryptedBso;
 pub use sync15_traits::{CollectionRequest, RequestOrder};
 use sync_guid::Guid;
 use viaduct::status_codes;
@@ -491,11 +491,11 @@ impl<Poster> PostQueue<Poster, NormalResponseHandler> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::bso_record::{BsoRecord, EncryptedPayload};
     use lazy_static::lazy_static;
     use std::cell::RefCell;
     use std::collections::VecDeque;
     use std::rc::Rc;
+    use sync15_traits::{BsoRecord, EncryptedPayload};
     use url::Url;
     #[test]
     fn test_url_building() {

--- a/components/sync15/src/state.rs
+++ b/components/sync15/src/state.rs
@@ -4,16 +4,15 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::bso_record::EncryptedBso;
 use crate::client::{SetupStorageClient, Sync15ClientResponse};
 use crate::collection_keys::CollectionKeys;
 use crate::error::{self, ErrorKind, ErrorResponse};
-use crate::key_bundle::KeyBundle;
 use crate::record_types::{MetaGlobalEngine, MetaGlobalRecord};
 use crate::request::{InfoCollections, InfoConfiguration};
 use crate::util::ServerTimestamp;
 use interrupt_support::Interruptee;
 use serde_derive::*;
+use sync15_traits::{EncryptedBso, KeyBundle};
 use sync_guid::Guid;
 
 use self::SetupState::*;
@@ -664,9 +663,9 @@ fn is_same_timestamp(local: ServerTimestamp, collections: &InfoCollections, key:
 mod tests {
     use super::*;
 
-    use crate::bso_record::{BsoRecord, EncryptedBso, EncryptedPayload, Payload};
     use crate::record_types::CryptoKeysRecord;
     use interrupt_support::NeverInterrupts;
+    use sync15_traits::{BsoRecord, EncryptedBso, EncryptedPayload, Payload};
 
     struct InMemoryClient {
         info_configuration: error::Result<Sync15ClientResponse<InfoConfiguration>>,
@@ -790,7 +789,7 @@ mod tests {
             let mut bso =
                 crate::CleartextBso::from_payload(Payload::from_record(record)?, "crypto");
             bso.modified = modified;
-            bso.encrypt(root_key)
+            Ok(bso.encrypt(root_key)?)
         }
     }
 

--- a/components/sync15/src/sync.rs
+++ b/components/sync15/src/sync.rs
@@ -7,12 +7,10 @@ use crate::client::Sync15StorageClient;
 use crate::clients;
 use crate::coll_state::LocalCollStateMachine;
 use crate::error::Error;
-use crate::key_bundle::KeyBundle;
 use crate::state::GlobalState;
 use crate::telemetry;
 use interrupt_support::Interruptee;
-
-pub use sync15_traits::{IncomingChangeset, SyncEngine};
+pub use sync15_traits::{IncomingChangeset, KeyBundle, SyncEngine};
 
 pub fn synchronize(
     client: &Sync15StorageClient,

--- a/components/sync15/src/sync_multiple.rs
+++ b/components/sync15/src/sync_multiple.rs
@@ -9,7 +9,6 @@ use crate::client::{BackoffListener, Sync15StorageClient, Sync15StorageClientIni
 use crate::clients::{self, CommandProcessor, CLIENTS_TTL_REFRESH};
 use crate::coll_state::EngineSyncAssociation;
 use crate::error::Error;
-use crate::key_bundle::KeyBundle;
 use crate::state::{EngineChangesNeeded, GlobalState, PersistedGlobalState, SetupStateMachine};
 use crate::status::{ServiceStatus, SyncResult};
 use crate::sync::{self, SyncEngine};
@@ -19,6 +18,7 @@ use std::collections::HashMap;
 use std::mem;
 use std::result;
 use std::time::{Duration, SystemTime};
+use sync15_traits::KeyBundle;
 
 /// Info about the client to use. We reuse the client unless
 /// we discover the client_init has changed, in which case we re-create one.

--- a/components/sync_manager/src/error.rs
+++ b/components/sync_manager/src/error.rs
@@ -30,4 +30,11 @@ pub enum SyncManagerError {
     AnyhowError(#[from] anyhow::Error),
 }
 
+// Adapts errors from the sync15_traits crate into sync15 errors.
+impl From<sync15::SyncTraitsError> for SyncManagerError {
+    fn from(e: sync15::SyncTraitsError) -> Self {
+        SyncManagerError::Sync15Error(e.into())
+    }
+}
+
 pub type Result<T> = std::result::Result<T, SyncManagerError>;

--- a/components/tabs/src/error.rs
+++ b/components/tabs/src/error.rs
@@ -26,4 +26,11 @@ pub enum TabsError {
     OpenDatabaseError(#[from] sql_support::open_database::Error),
 }
 
+// Adapts errors from the sync15_traits crate into sync15 errors.
+impl From<sync15::SyncTraitsError> for TabsError {
+    fn from(e: sync15::SyncTraitsError) -> Self {
+        TabsError::SyncAdapterError(e.into())
+    }
+}
+
 pub type Result<T> = std::result::Result<T, TabsError>;


### PR DESCRIPTION
(Which further reinforces that the name of that crate should be something like
`sync15-types`)

This is preparatory work for a much larger patch that will get us further down
the path to #2841 and also fix #2712. It should not change any behaviour.

As part of this, the sync15_traits errors needs to be addressed. It's not
reasonable to just create another enum that we expect clients to add to
their error types because many of the errors overlap which makes handling
them very difficult (eg, if we want to catch a serde error, you don't want
to know which crate it originated in) - so sync15 duplicates the sync15_traits
errors and can convert between them - so consumers can continue to catch
sync15::Error and still get errors which originated in sync15-traits.

sync15-traits now has a `crypto` feature - sync15 enables that feature, but
crates which just use a `bridged_engine` do not. This means that when
vendoring into Desktop Firefox, this feature isn't enabled, so we don't
pull in any of the crypto libs there.

@tarikeshaq and @bendk, I'd welcome all feedback here, particularly around the error changes. They make sense to me, but I might be missing something! Note that I'll probably hold off merging this until that larger patch is up for initial review.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
