### PR TITLE
Cut release v94.0.1

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 94.0.0
+libraryVersion: 94.0.1
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v94.0.1 (_2022-08-09_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v94.0.0...v94.0.1)
+
+## Nimbus FML
+### What's fixed
+  - Linux releases for the FML were missing, there are available again now. ([#5080](https://github.com/mozilla/application-services/pull/5080))
+
 # v94.0.0 (_2022-08-02_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v93.8.0...v94.0.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v94.0.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v94.0.1...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,6 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-## Nimbus FML
-### What's fixed
-  - Linux releases for the FML were missing, there are available again now. ([#5080](https://github.com/mozilla/application-services/pull/5080))


### PR DESCRIPTION
Cuts v94.0.1 for #5080 which didn't release nimbus-fml binaries for linux
