### PR TITLE
Instrument requesting features before init in Nimbus with Glean event

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
@@ -5,6 +5,7 @@
 package org.mozilla.experiments.nimbus.internal
 
 import android.content.Context
+import org.mozilla.experiments.nimbus.GleanMetrics.NimbusHealth
 import org.mozilla.experiments.nimbus.FeaturesInterface
 import org.mozilla.experiments.nimbus.Variables
 import org.mozilla.experiments.nimbus.NullVariables
@@ -45,7 +46,12 @@ class FeatureHolder<T>(
             if (cachedValue != null) {
                 cachedValue!!
             } else {
-                val variables = getSdk()?.getVariables(featureId, false) ?: NullVariables.instance
+                val variables = getSdk()?.getVariables(featureId, false) ?: run {
+                    NimbusHealth.featureRequestError.record(NimbusHealth.FeatureRequestErrorExtra(
+                        featureId = featureId
+                    ))
+                    NullVariables.instance
+                }
                 create(variables).also { value ->
                     cachedValue = value
                 }

--- a/components/nimbus/ios/Nimbus/FeatureHolder.swift
+++ b/components/nimbus/ios/Nimbus/FeatureHolder.swift
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import Foundation
+import Glean
 
 public typealias GetSdk = () -> FeaturesInterface?
 
@@ -42,7 +43,14 @@ public class FeatureHolder<T> {
         if let v = cachedValue {
             return v
         }
-        let variables = getSdk()?.getVariables(featureId: featureId, sendExposureEvent: false) ?? NilVariables.instance
+        var variables: Variables = NilVariables.instance
+        if let sdk = getSdk() {
+            variables = sdk.getVariables(featureId: featureId, sendExposureEvent: false) ?? NilVariables.instance
+        } else {
+            GleanMetrics.NimbusHealth.featureRequestError.record(GleanMetrics.NimbusHealth.FeatureRequestErrorExtra(
+                featureId: featureId
+            ))
+        }
         let v = create(variables)
         cachedValue = v
         return v

--- a/components/nimbus/metrics.yaml
+++ b/components/nimbus/metrics.yaml
@@ -115,3 +115,23 @@ nimbus_events:
     notification_emails:
       - tlong@mozilla.com, telemetry-team@mozilla.com
     expires: never
+nimbus_health:
+  feature_request_error:
+    type: event
+    description: >
+      Recorded when an application or library requests a feature configuration
+      prior to Nimbus initialization.
+    extra_keys:
+      feature_id:
+        type: string
+        description: The feature id of the configuration that was requested
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/EXP-2689
+      - https://mozilla-hub.atlassian.net/browse/EXP-2690
+    data_reviews:
+      - https://github.com/mozilla/application-services/pull/5091#issuecomment-1218359426
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - tlong@mozilla.com, telemetry-team@mozilla.com
+    expires: never


### PR DESCRIPTION
This adds a Glean event that is recorded when an app or library requests a feature configuration before Nimbus is initialized.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
