### PR TITLE
Update the bridged_engine to not rely on sync15_traits::Payload.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3260,6 +3260,7 @@ dependencies = [
  "anyhow",
  "base16",
  "base64 0.13.0",
+ "env_logger 0.7.1",
  "error-support",
  "ffi-support",
  "interrupt-support",

--- a/components/support/sync15-traits/Cargo.toml
+++ b/components/support/sync15-traits/Cargo.toml
@@ -28,3 +28,6 @@ log = "0.4"
 ffi-support = "0.4"
 thiserror = "1.0"
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
+
+[dev-dependencies]
+env_logger = { version = "0.7", default-features = false }

--- a/components/support/sync15-traits/src/bridged_engine.rs
+++ b/components/support/sync15-traits/src/bridged_engine.rs
@@ -2,11 +2,89 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::{error::Error, fmt};
-
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-use super::{Guid, Payload, ServerTimestamp};
+use super::Guid;
+
+use crate::error;
+
+// This module hold structs which will eventually live outside of this
+// module and will be re-used by bso_record. It lives here temporarily
+// as we move the bridged_engine away from Payload so we can see the shape
+// that this and bso_record will share.
+
+// It is a separate module here to help split it out later.
+pub mod public {
+    use crate::{Guid, ServerTimestamp};
+    use serde::{Deserialize, Serialize};
+
+    /// An envelope for an incoming item. Envelopes carry all the metadata for
+    /// a Sync BSO record (`id`, `modified`, `sortindex`), *but not* the payload
+    /// itself.
+    #[derive(Debug, Clone, Deserialize)]
+    pub struct IncomingEnvelope {
+        pub id: Guid,
+
+        #[serde(skip_serializing)]
+        // If we don't give it a default, we fail to deserialize
+        // items we wrote out during tests and such.
+        // XXX - we should probably fix the tests and  kill this.
+        #[serde(default = "ServerTimestamp::default")]
+        pub modified: ServerTimestamp,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub sortindex: Option<i32>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub ttl: Option<u32>,
+    }
+
+    /// An envelope for an outgoing item. This is conceptually identical to
+    /// [IncomingEnvelope], but omits fields that are only set by the server,
+    /// like `modified`.
+    #[derive(Debug, Default, Clone, Serialize, PartialEq)]
+    pub struct OutgoingEnvelope {
+        pub id: Guid,
+        pub sortindex: Option<i32>,
+        pub ttl: Option<u32>,
+    }
+
+    // Allow an envelope to be constructed with nothing but a guid.
+    impl From<Guid> for OutgoingEnvelope {
+        fn from(id: Guid) -> Self {
+            OutgoingEnvelope {
+                id,
+                ..Default::default()
+            }
+        }
+    }
+
+    /// The result of deserializing or decrypting an incoming payload. Note that decryption failures
+    /// are intentionally an error and not captured in this enum.
+    /// Note we don't carry either the GUID for Tombstone, nor the raw payload for
+    /// Malformed as assume the caller still owns the envelope and raw payload.
+    pub enum IncomingDeserPayload<T> {
+        /// A good T.
+        Record(T),
+        /// A tombstone
+        Tombstone,
+        /// Either not JSON, or can't be made into a T.
+        Malformed,
+    }
+
+    impl<T> IncomingDeserPayload<T> {
+        /// Returns Some(record) if [IncomingDeserPayload::Record], None otherwise.
+        pub fn record(self) -> Option<T> {
+            match self {
+                Self::Record(t) => Some(t),
+                _ => None,
+            }
+        }
+    }
+}
+
+pub use public::{IncomingDeserPayload, IncomingEnvelope, OutgoingEnvelope};
 
 /// A BridgedEngine acts as a bridge between application-services, rust
 /// implemented sync engines and sync engines as defined by Desktop Firefox.
@@ -57,7 +135,10 @@ pub trait BridgedEngine {
     /// times per sync, once for each batch. Implementations can use the
     /// signal to check if the operation was aborted, and cancel any
     /// pending work.
-    fn store_incoming(&self, incoming_cleartexts: &[IncomingEnvelope]) -> Result<(), Self::Error>;
+    fn store_incoming(
+        &self,
+        incoming_cleartexts: &[IncomingBridgeRecord],
+    ) -> Result<(), Self::Error>;
 
     /// Applies all staged records, reconciling changes on both sides and
     /// resolving conflicts. Returns a list of records to upload.
@@ -87,7 +168,7 @@ pub trait BridgedEngine {
 #[derive(Clone, Debug, Default)]
 pub struct ApplyResults {
     /// List of records
-    pub envelopes: Vec<OutgoingEnvelope>,
+    pub records: Vec<OutgoingBridgeRecord>,
     /// The number of incoming records whose contents were merged because they
     /// changed on both sides. None indicates we aren't reporting this
     /// information.
@@ -95,126 +176,326 @@ pub struct ApplyResults {
 }
 
 impl ApplyResults {
-    pub fn new(envelopes: Vec<OutgoingEnvelope>, num_reconciled: impl Into<Option<usize>>) -> Self {
+    pub fn new(
+        records: Vec<OutgoingBridgeRecord>,
+        num_reconciled: impl Into<Option<usize>>,
+    ) -> Self {
         Self {
-            envelopes,
+            records,
             num_reconciled: num_reconciled.into(),
         }
     }
 }
 
 // Shorthand for engines that don't care.
-impl From<Vec<OutgoingEnvelope>> for ApplyResults {
-    fn from(envelopes: Vec<OutgoingEnvelope>) -> Self {
+impl From<Vec<OutgoingBridgeRecord>> for ApplyResults {
+    fn from(records: Vec<OutgoingBridgeRecord>) -> Self {
         Self {
-            envelopes,
+            records,
             num_reconciled: None,
         }
     }
 }
 
-/// An envelope for an incoming item, passed to `BridgedEngine::store_incoming`.
-/// Envelopes are a halfway point between BSOs, the format used for all items on
-/// the Sync server, and records, which are specific to each engine.
-///
-/// Specifically, the "envelope" has all the metadata plus the JSON payload
-/// as clear-text - the analogy is that it's got all the info needed to get the
-/// data from the server to the engine without knowing what the contents holds,
-/// and without the engine needing to know how to decrypt.
-///
-/// A BSO is a JSON object with metadata fields (`id`, `modifed`, `sortindex`),
-/// and a BSO payload that is itself a JSON string. For encrypted records, the
-/// BSO payload has a ciphertext, which must be decrypted to yield a cleartext.
-/// The cleartext is a JSON string (that's three levels of JSON wrapping, if
-/// you're keeping score: the BSO itself, BSO payload, and cleartext) with the
-/// actual record payload.
-///
-/// An envelope combines the metadata fields from the BSO, and the cleartext
-/// from the encrypted BSO payload.
+/// TODO: integrate IncomingBridgeRecord and OutgoingBridgeRecord with bso_record,
+/// but the decryption and cleartext semantics don't quite align, so let's look
+/// at doing that later.
 #[derive(Clone, Debug, Deserialize)]
-pub struct IncomingEnvelope {
-    pub id: Guid,
-    pub modified: ServerTimestamp,
-    #[serde(default)]
-    pub sortindex: Option<i32>,
-    #[serde(default)]
-    pub ttl: Option<u32>,
+pub struct IncomingBridgeRecord {
+    #[serde(flatten)]
+    pub envelope: IncomingEnvelope,
     // Don't provide access to the cleartext directly. We want all callers to
-    // use `IncomingEnvelope::payload`, so that we can validate the cleartext.
+    // use `IncomingEnvelope::payload`, so that we can validate the cleartext
+    // (where 'validate' in this context means 'let serde fail if it's invalid`)
     cleartext: String,
 }
 
-impl IncomingEnvelope {
-    /// Parses and returns the record payload from this envelope. Returns an
-    /// error if the envelope's cleartext isn't valid JSON, or the payload is
-    /// invalid.
-    pub fn payload(&self) -> Result<Payload, PayloadError> {
-        let payload: Payload = serde_json::from_str(&self.cleartext)?;
-        if payload.id != self.id {
-            return Err(PayloadError::MismatchedId {
-                envelope: self.id.clone(),
-                payload: payload.id,
-            });
+impl IncomingBridgeRecord {
+    /// Parses and returns an IncomingDeserPayload describing the record.
+    /// All JSON errors are treated as [IncomingDeserPayload::Malformed].
+    pub fn payload<T>(&self) -> IncomingDeserPayload<T>
+    where
+        T: DeserializeOwned,
+    {
+        let mut json = match serde_json::from_str(&self.cleartext) {
+            Ok(v) => v,
+            Err(_) => {
+                log::warn!("Invalid incoming json {}", self.envelope.id);
+                return IncomingDeserPayload::Malformed;
+            }
+        };
+
+        if let serde_json::Value::Object(ref map) = json {
+            if map.contains_key("deleted") {
+                return IncomingDeserPayload::Tombstone;
+            }
+        };
+
+        // In general, the payload does not carry 'id', but <T> does - so put
+        // it into the json before deserializing the record.
+        if let serde_json::Value::Object(ref mut map) = json {
+            match map.get("id").and_then(|v| v.as_str()) {
+                Some(id) => {
+                    // It exists in the payload! Note that this *should not* happen in practice
+                    // (the `id` should *never* be in the payload), but if that does happen
+                    // we should do the "right" thing, which is treat a mismatch as malformed.
+                    if id != self.envelope.id {
+                        log::warn!(
+                            "malformed incoming record: envelope id: {} payload id: {}",
+                            self.envelope.id,
+                            id
+                        );
+                        return IncomingDeserPayload::Malformed;
+                    }
+                    if !self.envelope.id.is_valid_for_sync_server() {
+                        log::warn!("malformed incoming record: id is not valid: {}", id);
+                        return IncomingDeserPayload::Malformed;
+                    }
+                    log::warn!("incoming record has 'id' in the payload - it does match, but is still unexpected");
+                }
+                None => {
+                    let id = &self.envelope.id;
+                    if !id.is_valid_for_sync_server() {
+                        log::warn!("malformed incoming record: id is not valid: {}", id);
+                        return IncomingDeserPayload::Malformed;
+                    }
+                    map.insert("id".to_string(), id.to_string().into());
+                }
+            }
         }
-        // Remove auto field data from payload and replace with real data
-        Ok(payload
-            .with_auto_field("ttl", self.ttl)
-            .with_auto_field("sortindex", self.sortindex))
+
+        match serde_json::from_value::<T>(json) {
+            Ok(v) => IncomingDeserPayload::Record(v),
+            Err(_) => {
+                log::warn!("Incoming JSON can't be turned into T: {}", self.envelope.id);
+                IncomingDeserPayload::Malformed
+            }
+        }
     }
 }
 
-/// An envelope for an outgoing item, returned from `BridgedEngine::apply`. This
-/// is conceptually identical to [IncomingEnvelope], but omits fields that are
-/// only set by the server, like `modified`.
 #[derive(Clone, Debug, Serialize)]
-pub struct OutgoingEnvelope {
-    id: Guid,
+pub struct OutgoingBridgeRecord {
+    #[serde(flatten)]
+    pub envelope: OutgoingEnvelope,
+    // cleartext private to force use of from_record.
     cleartext: String,
-    sortindex: Option<i32>,
-    ttl: Option<u32>,
 }
 
-impl From<Payload> for OutgoingEnvelope {
-    fn from(mut payload: Payload) -> Self {
-        let id = payload.id.clone();
-        // Remove auto field data from OutgoingEnvelope payload
-        let ttl = payload.take_auto_field("ttl");
-        let sortindex = payload.take_auto_field("sortindex");
-        OutgoingEnvelope {
-            id,
-            cleartext: payload.into_json_string(),
-            sortindex,
-            ttl,
+impl OutgoingBridgeRecord {
+    pub fn new_tombstone(envelope: OutgoingEnvelope) -> Self {
+        Self {
+            envelope,
+            cleartext: serde_json::json!({"deleted": true}).to_string(),
         }
+    }
+
+    /// Create an Outgoing record with a default envelope, where the id
+    /// can be found in the record's json payload.
+    pub fn from_record_with_id<T>(record: T) -> error::Result<Self>
+    where
+        T: Serialize,
+    {
+        let mut payload = serde_json::to_value(record)?;
+        let envelope = match payload.as_object_mut() {
+            Some(ref mut map) => {
+                match map.remove("id").as_ref().and_then(|v| v.as_str()) {
+                    Some(id) => {
+                        let id: Guid = id.into();
+                        assert!(id.is_valid_for_sync_server(), "record's ID is invalid");
+                        OutgoingEnvelope {
+                            id,
+                            sortindex: None,
+                            ttl: None,
+                        }
+                    }
+                    // This is a "static" error and not influenced by runtime behavior
+                    None => panic!("record does not have an ID in the payload"),
+                }
+            }
+            None => panic!("record is not a json object"),
+        };
+        Ok(Self {
+            envelope,
+            cleartext: serde_json::to_string(&payload)?,
+        })
+    }
+
+    /// Create an Outgoing record with an explicit envelope. Will panic if the
+    /// payload has an ID but it doesn't match the envelope
+    pub fn from_record<T>(envelope: OutgoingEnvelope, record: T) -> error::Result<Self>
+    where
+        T: Serialize,
+    {
+        let mut payload = serde_json::to_value(record)?;
+        if let Some(ref mut map) = payload.as_object_mut() {
+            if let Some(id) = map.remove("id").as_ref().and_then(|v| v.as_str()) {
+                assert_eq!(id, envelope.id);
+                assert!(
+                    envelope.id.is_valid_for_sync_server(),
+                    "record's ID is invalid"
+                );
+            }
+        };
+        Ok(Self {
+            envelope,
+            cleartext: serde_json::to_string(&payload)?,
+        })
     }
 }
 
-/// An error that indicates a payload is invalid.
-#[derive(Debug)]
-pub enum PayloadError {
-    /// The payload contains invalid JSON.
-    Invalid(serde_json::Error),
-    /// The ID of the BSO in the envelope doesn't match the ID in the payload.
-    MismatchedId { envelope: Guid, payload: Guid },
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
 
-impl Error for PayloadError {}
-
-impl From<serde_json::Error> for PayloadError {
-    fn from(err: serde_json::Error) -> PayloadError {
-        PayloadError::Invalid(err)
+    #[derive(Default, Debug, PartialEq, Serialize, Deserialize)]
+    struct TestStruct {
+        id: Guid,
+        data: u32,
     }
-}
+    #[test]
+    fn test_bridge_deser() {
+        env_logger::try_init().ok();
+        let json = json!({
+            "id": "test",
+            "cleartext": json!({"data": 1}).to_string(),
+        });
+        let incoming: IncomingBridgeRecord = serde_json::from_value(json).unwrap();
+        assert_eq!(incoming.envelope.id, "test");
+        let record = incoming.payload::<TestStruct>().record().unwrap();
+        let expected = TestStruct {
+            id: Guid::new("test"),
+            data: 1,
+        };
+        assert_eq!(record, expected);
+    }
 
-impl fmt::Display for PayloadError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            PayloadError::Invalid(err) => err.fmt(f),
-            PayloadError::MismatchedId { envelope, payload } => write!(
-                f,
-                "ID `{}` in envelope doesn't match `{}` in payload",
-                envelope, payload
-            ),
+    #[test]
+    fn test_bridge_deser_empty_id() {
+        env_logger::try_init().ok();
+        let json = json!({
+            "id": "",
+            "cleartext": json!({"data": 1}).to_string(),
+        });
+        let incoming: IncomingBridgeRecord = serde_json::from_value(json).unwrap();
+        // The envelope has an invalid ID, but it's not handled until we try and deserialize
+        // it into a T
+        assert_eq!(incoming.envelope.id, "");
+        let deser_payload = incoming.payload::<TestStruct>();
+        assert!(matches!(deser_payload, IncomingDeserPayload::Malformed));
+    }
+
+    #[test]
+    fn test_bridge_deser_invalid() {
+        env_logger::try_init().ok();
+        // And a non-empty but still invalid guid.
+        let json = json!({
+            "id": "X".repeat(65),
+            "cleartext": json!({"data": 1}).to_string(),
+        });
+        let incoming: IncomingBridgeRecord = serde_json::from_value(json).unwrap();
+        let deser_payload = incoming.payload::<TestStruct>();
+        assert!(matches!(deser_payload, IncomingDeserPayload::Malformed));
+    }
+
+    #[test]
+    fn test_bridge_ser_with_id() {
+        env_logger::try_init().ok();
+        // When serializing, expect the ID to be in the top-level payload (ie,
+        // in the envelope) but should not appear in the `cleartext` part of
+        // the payload.
+        let val = TestStruct {
+            id: Guid::new("test"),
+            data: 1,
+        };
+        let outgoing = OutgoingBridgeRecord::from_record_with_id(val).unwrap();
+
+        // The envelope should have our ID.
+        assert_eq!(outgoing.envelope.id, Guid::new("test"));
+
+        // and make sure `cleartext` part of the payload only has data.
+        let ct_payload = serde_json::from_str::<serde_json::Value>(&outgoing.cleartext).unwrap();
+        let ct_map = ct_payload.as_object().unwrap();
+        assert_eq!(ct_map.len(), 1);
+        assert_eq!(ct_map.get("id"), None);
+        assert_eq!(ct_map.get("data").unwrap().as_u64().unwrap(), 1);
+    }
+
+    #[test]
+    fn test_bridge_ser_with_envelope() {
+        env_logger::try_init().ok();
+        // When serializing, expect the ID to be in the top-level payload (ie,
+        // in the envelope) but should not appear in the `cleartext` part of
+        // the payload.
+        let val = TestStruct {
+            id: Guid::new("test"),
+            data: 1,
+        };
+        let envelope: OutgoingEnvelope = Guid::new("test").into();
+        let outgoing = OutgoingBridgeRecord::from_record(envelope, val).unwrap();
+
+        // The envelope should have our ID.
+        assert_eq!(outgoing.envelope.id, Guid::new("test"));
+
+        // and make sure `cleartext` part of the payload only has data.
+        let ct_payload = serde_json::from_str::<serde_json::Value>(&outgoing.cleartext).unwrap();
+        let ct_map = ct_payload.as_object().unwrap();
+        assert_eq!(ct_map.len(), 1);
+        assert_eq!(ct_map.get("id"), None);
+        assert_eq!(ct_map.get("data").unwrap().as_u64().unwrap(), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bridge_ser_no_ids() {
+        env_logger::try_init().ok();
+        #[derive(Serialize)]
+        struct StructWithNoId {
+            data: u32,
         }
+        let val = StructWithNoId { data: 1 };
+        let _ = OutgoingBridgeRecord::from_record_with_id(val);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bridge_ser_not_object() {
+        env_logger::try_init().ok();
+        let _ = OutgoingBridgeRecord::from_record_with_id(json!("string"));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bridge_ser_mismatched_ids() {
+        env_logger::try_init().ok();
+        let val = TestStruct {
+            id: Guid::new("test"),
+            data: 1,
+        };
+        let envelope: OutgoingEnvelope = Guid::new("different").into();
+        let _ = OutgoingBridgeRecord::from_record(envelope, val);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bridge_empty_id() {
+        env_logger::try_init().ok();
+        let val = TestStruct {
+            id: Guid::new(""),
+            data: 1,
+        };
+        let _ = OutgoingBridgeRecord::from_record_with_id(val);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_bridge_invalid_id() {
+        env_logger::try_init().ok();
+        let val = TestStruct {
+            id: Guid::new(&"X".repeat(65)),
+            data: 1,
+        };
+        let _ = OutgoingBridgeRecord::from_record_with_id(val);
     }
 }

--- a/components/support/sync15-traits/src/error.rs
+++ b/components/support/sync15-traits/src/error.rs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// `Result` is unused with default features, but used with `feature=crypto`
-#[cfg(feature = "crypto")]
 pub type Result<T> = std::result::Result<T, SyncTraitsError>;
 
 // Concrete errors returned by this module. Note that the sync15 crate has

--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use interrupt_support::Interrupted;
-use sync15_traits::bridged_engine;
+use sync15_traits::SyncTraitsError;
 
 #[derive(Debug)]
 pub enum QuotaReason {
@@ -50,8 +50,8 @@ pub enum ErrorKind {
     #[error("Error opening database: {0}")]
     OpenDatabaseError(#[from] sql_support::open_database::Error),
 
-    #[error("{0}")]
-    IncomingPayloadError(#[from] bridged_engine::PayloadError),
+    #[error("Sync Payload Error: {0}")]
+    IncomingPayloadError(#[from] SyncTraitsError),
 }
 
 error_support::define_error! {
@@ -61,7 +61,7 @@ error_support::define_error! {
         (IoError, std::io::Error),
         (InterruptedError, Interrupted),
         (Utf8Error, std::str::Utf8Error),
-        (IncomingPayloadError, bridged_engine::PayloadError),
+        (IncomingPayloadError, SyncTraitsError),
         (OpenDatabaseError, sql_support::open_database::Error),
     }
 }

--- a/components/webext-storage/src/sync/incoming.rs
+++ b/components/webext-storage/src/sync/incoming.rs
@@ -6,18 +6,15 @@
 // working out a plan for them, updating the local data and mirror, etc.
 
 use interrupt_support::Interruptee;
-use rusqlite::{
-    types::{Null, ToSql},
-    Connection, Row, Transaction,
-};
+use rusqlite::{Connection, Row, Transaction};
 use sql_support::ConnExt;
-use sync15_traits::Payload;
+use sync15_traits::bridged_engine::{IncomingBridgeRecord, IncomingDeserPayload};
 use sync_guid::Guid as SyncGuid;
 
 use crate::api::{StorageChanges, StorageValueChange};
 use crate::error::*;
 
-use super::{merge, remove_matching_keys, JsonMap, Record, RecordData};
+use super::{merge, remove_matching_keys, JsonMap, WebextRecord};
 
 /// The state data can be in. Could be represented as Option<JsonMap>, but this
 /// is clearer and independent of how the data is stored.
@@ -69,43 +66,44 @@ fn json_map_from_row(row: &Row<'_>, col: &str) -> Result<DataState> {
 /// The actual processing is done via this table.
 pub fn stage_incoming(
     tx: &Transaction<'_>,
-    incoming_payloads: Vec<Payload>,
+    incoming_records: &[IncomingBridgeRecord],
     signal: &dyn Interruptee,
 ) -> Result<()> {
-    let mut incoming_records = Vec::with_capacity(incoming_payloads.len());
-    for payload in incoming_payloads {
-        incoming_records.push(payload.into_record::<Record>()?);
-    }
     sql_support::each_sized_chunk(
-        &incoming_records,
+        incoming_records,
         // We bind 3 params per chunk.
         sql_support::default_max_variable_number() / 3,
         |chunk, _| -> Result<()> {
-            let sql = format!(
-                "INSERT OR REPLACE INTO temp.storage_sync_staging
-                (guid, ext_id, data)
-                VALUES {}",
-                sql_support::repeat_multi_values(chunk.len(), 3)
-            );
             let mut params = Vec::with_capacity(chunk.len() * 3);
             for record in chunk {
                 signal.err_if_interrupted()?;
-                params.push(&record.guid as &dyn ToSql);
-                match &record.data {
-                    RecordData::Data {
-                        ref ext_id,
-                        ref data,
-                    } => {
-                        params.push(ext_id);
-                        params.push(data);
+                match record.payload::<WebextRecord>() {
+                    IncomingDeserPayload::Record(r) => {
+                        params.push(Some(record.envelope.id.to_string()));
+                        params.push(Some(r.ext_id.to_string()));
+                        params.push(Some(r.data));
                     }
-                    RecordData::Tombstone => {
-                        params.push(&Null);
-                        params.push(&Null);
+                    IncomingDeserPayload::Tombstone => {
+                        params.push(Some(record.envelope.id.to_string()));
+                        params.push(None);
+                        params.push(None);
+                    }
+                    IncomingDeserPayload::Malformed => {
+                        log::error!("Ignoring incoming malformed record: {}", record.envelope.id);
                     }
                 }
             }
-            tx.execute(&sql, rusqlite::params_from_iter(params))?;
+            // we might have skipped records
+            let actual_len = params.len() / 3;
+            if actual_len != 0 {
+                let sql = format!(
+                    "INSERT OR REPLACE INTO temp.storage_sync_staging
+                    (guid, ext_id, data)
+                    VALUES {}",
+                    sql_support::repeat_multi_values(actual_len, 3)
+                );
+                tx.execute(&sql, rusqlite::params_from_iter(params))?;
+            }
             Ok(())
         },
     )?;
@@ -482,7 +480,7 @@ mod tests {
     use crate::api;
     use interrupt_support::NeverInterrupts;
     use serde_json::{json, Value};
-    use sync15_traits::Payload;
+    use sync15_traits::bridged_engine::OutgoingBridgeRecord;
 
     // select simple int
     fn ssi(conn: &Connection, stmt: &str) -> u32 {
@@ -491,11 +489,15 @@ mod tests {
             .unwrap_or_default()
     }
 
-    fn array_to_incoming(mut array: Value) -> Vec<Payload> {
+    fn array_to_incoming(mut array: Value) -> Vec<IncomingBridgeRecord> {
         let jv = array.as_array_mut().expect("you must pass a json array");
         let mut result = Vec::with_capacity(jv.len());
         for elt in jv {
-            result.push(Payload::from_json(elt.take()).expect("must be valid"));
+            // Need to go via outgoing.
+            let out = OutgoingBridgeRecord::from_record_with_id(elt.take()).unwrap();
+            let json = serde_json::to_value(out).unwrap();
+            let inc = serde_json::from_value::<IncomingBridgeRecord>(json).unwrap();
+            result.push(inc);
         }
         result
     }
@@ -561,7 +563,7 @@ mod tests {
             }
         ]};
 
-        stage_incoming(&tx, array_to_incoming(incoming), &NeverInterrupts)?;
+        stage_incoming(&tx, &array_to_incoming(incoming), &NeverInterrupts)?;
         // check staging table
         assert_eq!(
             ssi(&tx, "SELECT count(*) FROM temp.storage_sync_staging"),

--- a/components/webext-storage/src/sync/mod.rs
+++ b/components/webext-storage/src/sync/mod.rs
@@ -12,7 +12,7 @@ mod sync_tests;
 use crate::api::{StorageChanges, StorageValueChange};
 use crate::db::StorageDb;
 use crate::error::*;
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use serde_derive::*;
 use sql_support::ConnExt;
 use sync_guid::Guid as SyncGuid;
@@ -24,40 +24,14 @@ type JsonMap = serde_json::Map<String, serde_json::Value>;
 
 pub const STORAGE_VERSION: usize = 1;
 
-// Note that we never use serde to serialize a tombstone, so it doesn't matter
-// how that looks - but we care about how a Record with RecordData::Data looks.
-// However, deserializing is trickier still - it seems tricky to tell serde
-// how to unpack a tombstone - if we used `Tombstone { deleted: bool }` and
-// enforced bool must only be ever true it might be possible, but that's quite
-// clumsy for the rest of the code. So we just capture serde's failure to
-// unpack it and treat it as a tombstone.
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
-#[serde(untagged)]
-pub enum RecordData {
-    Data {
-        #[serde(rename = "extId")]
-        ext_id: String,
-        data: String,
-    },
-    #[serde(skip_deserializing)]
-    Tombstone,
-}
-
-#[allow(clippy::unnecessary_wraps)]
-fn deserialize_record_data<'de, D>(deserializer: D) -> Result<RecordData, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Ok(RecordData::deserialize(deserializer).unwrap_or(RecordData::Tombstone))
-}
-
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Record {
+pub struct WebextRecord {
     #[serde(rename = "id")]
     guid: SyncGuid,
-    #[serde(flatten, deserialize_with = "deserialize_record_data")]
-    data: RecordData,
+    #[serde(rename = "extId")]
+    ext_id: String,
+    data: String,
 }
 
 // Perform a 2-way or 3-way merge, where the incoming value wins on confict.
@@ -221,34 +195,14 @@ mod tests {
     #[test]
     fn test_serde_record_ser() {
         assert_eq!(
-            serde_json::to_string(&Record {
+            serde_json::to_string(&WebextRecord {
                 guid: "guid".into(),
-                data: RecordData::Data {
-                    ext_id: "ext_id".to_string(),
-                    data: "data".to_string()
-                }
+                ext_id: "ext_id".to_string(),
+                data: "data".to_string()
             })
             .unwrap(),
             r#"{"id":"guid","extId":"ext_id","data":"data"}"#
         );
-    }
-
-    #[test]
-    fn test_serde_record_de() {
-        let p: Record = serde_json::from_str(r#"{"id":"guid","deleted":true}"#).unwrap();
-        assert_eq!(p.data, RecordData::Tombstone);
-        let p: Record =
-            serde_json::from_str(r#"{"id":"guid","extId": "ext-id", "data":"foo"}"#).unwrap();
-        assert_eq!(
-            p.data,
-            RecordData::Data {
-                ext_id: "ext-id".into(),
-                data: "foo".into()
-            }
-        );
-        // invalid are treated as tombstones.
-        let p: Record = serde_json::from_str(r#"{"id":"guid"}"#).unwrap();
-        assert_eq!(p.data, RecordData::Tombstone);
     }
 
     // a macro for these tests - constructs a serde_json::Value::Object

--- a/components/webext-storage/src/sync/outgoing.rs
+++ b/components/webext-storage/src/sync/outgoing.rs
@@ -8,28 +8,28 @@
 use interrupt_support::Interruptee;
 use rusqlite::{Connection, Row, Transaction};
 use sql_support::ConnExt;
-use sync15_traits::Payload;
+use sync15_traits::bridged_engine::OutgoingBridgeRecord;
 use sync_guid::Guid as SyncGuid;
 
 use crate::error::*;
 
-use super::{Record, RecordData};
+use super::WebextRecord;
 
-fn outgoing_from_row(row: &Row<'_>) -> Result<Payload> {
+fn outgoing_from_row(row: &Row<'_>) -> Result<OutgoingBridgeRecord> {
     let guid: SyncGuid = row.get("guid")?;
     let ext_id: String = row.get("ext_id")?;
     let raw_data: Option<String> = row.get("data")?;
-    let payload = match raw_data {
-        Some(raw_data) => Payload::from_record(Record {
-            guid,
-            data: RecordData::Data {
+    Ok(match raw_data {
+        Some(raw_data) => {
+            let record = WebextRecord {
+                guid,
                 ext_id,
                 data: raw_data,
-            },
-        })?,
-        None => Payload::new_tombstone(guid),
-    };
-    Ok(payload)
+            };
+            OutgoingBridgeRecord::from_record_with_id(record)?
+        }
+        None => OutgoingBridgeRecord::new_tombstone(guid.into()),
+    })
 }
 
 /// Stages info about what should be uploaded in a temp table. This should be
@@ -69,8 +69,11 @@ pub fn stage_outgoing(tx: &Transaction<'_>) -> Result<()> {
     Ok(())
 }
 
-/// Returns a vec of the payloads which should be uploaded.
-pub fn get_outgoing(conn: &Connection, signal: &dyn Interruptee) -> Result<Vec<Payload>> {
+/// Returns a vec of the outgoing records which should be uploaded.
+pub fn get_outgoing(
+    conn: &Connection,
+    signal: &dyn Interruptee,
+) -> Result<Vec<OutgoingBridgeRecord>> {
     let sql = "SELECT guid, ext_id, data FROM storage_sync_outgoing_staging";
     let elts = conn
         .conn()
@@ -139,13 +142,19 @@ mod tests {
         stage_outgoing(&tx)?;
         let changes = get_outgoing(&tx, &NeverInterrupts)?;
         assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].data["extId"], "ext_with_changes".to_string());
+        // jump through hoops to inspect the private cleartext.
+        let json = serde_json::to_value(&changes[0]).unwrap();
+        let record: serde_json::Value =
+            serde_json::from_str(json.get("cleartext").unwrap().as_str().unwrap()).unwrap();
+        let ext_id = record.get("extId").unwrap().as_str().unwrap();
+
+        assert_eq!(ext_id, "ext_with_changes");
 
         record_uploaded(
             &tx,
             changes
                 .into_iter()
-                .map(|p| p.id)
+                .map(|p| p.envelope.id)
                 .collect::<Vec<SyncGuid>>()
                 .as_slice(),
             &NeverInterrupts,
@@ -160,20 +169,28 @@ mod tests {
 
     #[test]
     fn test_payload_serialization() {
-        let payload = Payload::from_record(Record {
+        let record = WebextRecord {
             guid: SyncGuid::new("guid"),
-            data: RecordData::Data {
-                ext_id: "ext-id".to_string(),
-                data: "{}".to_string(),
-            },
-        })
+            ext_id: "ext-id".to_string(),
+            data: "{}".to_string(),
+        };
+
+        let outgoing = OutgoingBridgeRecord::from_record_with_id(record).unwrap();
+
+        // The envelope should have our ID.
+        assert_eq!(outgoing.envelope.id, SyncGuid::new("guid"));
+
+        // cleartext is private, so we need to serialize the entire record.
+        let outgoing_json = serde_json::to_value(outgoing).unwrap();
+        let outgoing_payload = serde_json::from_str::<serde_json::Value>(
+            outgoing_json.get("cleartext").unwrap().as_str().unwrap(),
+        )
         .unwrap();
-        // The payload should have the ID.
-        assert_eq!(payload.id.to_string(), "guid");
-        // The data in the payload should have only `data` and `extId` - not the guid.
-        assert!(!payload.data.contains_key("id"));
-        assert!(payload.data.contains_key("data"));
-        assert!(payload.data.contains_key("extId"));
-        assert_eq!(payload.data.len(), 2);
+        let outgoing_map = outgoing_payload.as_object().unwrap();
+
+        assert!(!outgoing_map.contains_key("id"));
+        assert!(outgoing_map.contains_key("data"));
+        assert!(outgoing_map.contains_key("extId"));
+        assert_eq!(outgoing_map.len(), 2);
     }
 }

--- a/components/webext-storage/src/sync/sync_tests.rs
+++ b/components/webext-storage/src/sync/sync_tests.rs
@@ -12,17 +12,19 @@ use crate::schema::create_empty_sync_temp_tables;
 use crate::sync::incoming::{apply_actions, get_incoming, plan_incoming, stage_incoming};
 use crate::sync::outgoing::{get_outgoing, record_uploaded, stage_outgoing};
 use crate::sync::test::new_syncable_mem_db;
-use crate::sync::{Record, RecordData};
 use interrupt_support::NeverInterrupts;
 use rusqlite::{Connection, Row, Transaction};
 use serde_json::json;
 use sql_support::ConnExt;
-use sync15_traits::Payload;
+use sync15_traits::bridged_engine::{IncomingBridgeRecord, OutgoingBridgeRecord};
 use sync_guid::Guid;
 
 // Here we try and simulate everything done by a "full sync", just minus the
 // engine. Returns the records we uploaded.
-fn do_sync(tx: &Transaction<'_>, incoming_payloads: Vec<Payload>) -> Result<Vec<Payload>> {
+fn do_sync(
+    tx: &Transaction<'_>,
+    incoming_payloads: &[IncomingBridgeRecord],
+) -> Result<Vec<OutgoingBridgeRecord>> {
     log::info!("test do_sync() starting");
     // First we stage the incoming in the temp tables.
     stage_incoming(tx, incoming_payloads, &NeverInterrupts)?;
@@ -42,7 +44,7 @@ fn do_sync(tx: &Transaction<'_>, incoming_payloads: Vec<Payload>) -> Result<Vec<
         tx,
         outgoing
             .iter()
-            .map(|p| p.id.clone())
+            .map(|p| p.envelope.id.clone())
             .collect::<Vec<Guid>>()
             .as_slice(),
         &NeverInterrupts,
@@ -69,11 +71,11 @@ fn check_finished_with(conn: &Connection, ext_id: &str, val: serde_json::Value) 
     Ok(())
 }
 
-fn get_mirror_guid(conn: &Connection, extid: &str) -> Result<String> {
+fn get_mirror_guid(conn: &Connection, extid: &str) -> Result<Guid> {
     let guid = conn.query_row_and_then(
         "SELECT m.guid FROM storage_sync_mirror m WHERE m.ext_id = ?;",
         [extid],
-        |row| row.get::<_, String>(0),
+        |row| row.get::<_, Guid>(0),
     )?;
     Ok(guid)
 }
@@ -105,7 +107,7 @@ fn _get(conn: &Connection, id_name: &str, expected_extid: &str, table: &str) -> 
         DbData::NoRow
     } else {
         let item = items.pop().expect("it exists");
-        assert_eq!(item.0, expected_extid);
+        assert_eq!(Guid::new(&item.0), expected_extid);
         match item.1 {
             None => DbData::NullRow,
             Some(v) => DbData::Data(v),
@@ -121,6 +123,16 @@ fn get_local_data(conn: &Connection, expected_extid: &str) -> DbData {
     _get(conn, "ext_id", expected_extid, "storage_sync_data")
 }
 
+fn make_incoming(guid: &Guid, ext_id: &str, data: &serde_json::Value) -> IncomingBridgeRecord {
+    let json = json!({"id": guid, "cleartext": json!({"extId": ext_id, "data": data.to_string()}).to_string()});
+    serde_json::from_value(json).unwrap()
+}
+
+fn make_incoming_tombstone(guid: &Guid) -> IncomingBridgeRecord {
+    let json = json!({"id": guid, "cleartext": json!({"deleted": true}).to_string()});
+    serde_json::from_value(json).unwrap()
+}
+
 #[test]
 fn test_simple_outgoing_sync() -> Result<()> {
     // So we are starting with an empty local store and empty server store.
@@ -128,7 +140,7 @@ fn test_simple_outgoing_sync() -> Result<()> {
     let tx = db.transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data.clone())?;
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     check_finished_with(&tx, "ext-id", data)?;
     Ok(())
 }
@@ -138,14 +150,8 @@ fn test_simple_incoming_sync() -> Result<()> {
     let mut db = new_syncable_mem_db();
     let tx = db.transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
-    let payload = Payload::from_record(Record {
-        guid: Guid::from("guid"),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: data.to_string(),
-        },
-    })?;
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    let bridge_record = make_incoming(&Guid::new("guid"), "ext-id", &data);
+    assert_eq!(do_sync(&tx, &[bridge_record])?.len(), 0);
     let key1_from_api = get(&tx, "ext-id", json!("key1"))?;
     assert_eq!(key1_from_api, json!({"key1": "key1-value"}));
     check_finished_with(&tx, "ext-id", data)?;
@@ -169,7 +175,7 @@ fn test_outgoing_tombstone() -> Result<()> {
     assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
     // now set data again and sync and *then* remove.
     set(&tx, "ext-id", data)?;
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     assert!(get_local_data(&tx, "ext-id").has_data());
     let guid = get_mirror_guid(&tx, "ext-id")?;
     assert!(get_mirror_data(&tx, &guid).has_data());
@@ -177,7 +183,7 @@ fn test_outgoing_tombstone() -> Result<()> {
     assert_eq!(get_local_data(&tx, "ext-id"), DbData::NullRow);
     // then after syncing, the tombstone will be in the mirror but the local row
     // has been removed.
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
     assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
     Ok(())
@@ -196,15 +202,14 @@ fn test_incoming_tombstone_exists() -> Result<()> {
         DbData::Data(data.to_string())
     );
     // sync to get data in our mirror.
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     assert!(get_local_data(&tx, "ext-id").has_data());
     let guid = get_mirror_guid(&tx, "ext-id")?;
     assert!(get_mirror_data(&tx, &guid).has_data());
     // Now an incoming tombstone for it.
-    let payload = Payload::new_tombstone(guid.clone());
-
+    let tombstone = make_incoming_tombstone(&guid);
     assert_eq!(
-        do_sync(&tx, vec![payload])?.len(),
+        do_sync(&tx, &[tombstone])?.len(),
         0,
         "expect no outgoing records"
     );
@@ -218,17 +223,16 @@ fn test_incoming_tombstone_not_exists() -> Result<()> {
     let mut db = new_syncable_mem_db();
     let tx = db.transaction()?;
     // An incoming tombstone for something that's not anywhere locally.
-    let guid = "guid";
-    let payload = Payload::new_tombstone(guid);
-
+    let guid = Guid::new("guid");
+    let tombstone = make_incoming_tombstone(&guid);
     assert_eq!(
-        do_sync(&tx, vec![payload])?.len(),
+        do_sync(&tx, &[tombstone])?.len(),
         0,
         "expect no outgoing records"
     );
     // But we still keep the tombstone in the mirror.
     assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
-    assert_eq!(get_mirror_data(&tx, guid), DbData::NullRow);
+    assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
     Ok(())
 }
 
@@ -239,15 +243,9 @@ fn test_reconciled() -> Result<()> {
     let data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", data)?;
     // Incoming payload with the same data
-    let payload = Payload::from_record(Record {
-        guid: Guid::from("guid"),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: json!({"key1": "key1-value"}).to_string(),
-        },
-    })?;
+    let record = make_incoming(&Guid::new("guid"), "ext-id", &json!({"key1": "key1-value"}));
     // Should be no outgoing records as we reconciled.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 0);
     check_finished_with(&tx, "ext-id", json!({"key1": "key1-value"}))?;
     Ok(())
 }
@@ -261,21 +259,15 @@ fn test_reconcile_with_null_payload() -> Result<()> {
     let data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", data.clone())?;
     // We try to push this change on the next sync.
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     let guid = get_mirror_guid(&tx, "ext-id")?;
     assert_eq!(get_mirror_data(&tx, &guid), DbData::Data(data.to_string()));
     // Incoming payload with the same data.
     // This could happen if, for example, another client changed the
     // key and then put it back the way it was.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from(guid),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: data.to_string(),
-        },
-    })?;
+    let record = make_incoming(&guid, "ext-id", &data);
     // Should be no outgoing records as we reconciled.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 0);
     check_finished_with(&tx, "ext-id", data)?;
     Ok(())
 }
@@ -288,20 +280,15 @@ fn test_accept_incoming_when_local_is_deleted() -> Result<()> {
     // uploaded before being deleted.
     let data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", data)?;
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     let guid = get_mirror_guid(&tx, "ext-id")?;
     clear(&tx, "ext-id")?;
     // Incoming payload without 'key1'. Because we previously uploaded
     // key1, this means another client deleted it.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from(guid),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: json!({"key2": "key2-value"}).to_string(),
-        },
-    })?;
+    let record = make_incoming(&guid, "ext-id", &json!({"key2": "key2-value"}));
+
     // We completely accept the incoming record.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 0);
     check_finished_with(&tx, "ext-id", json!({"key2": "key2-value"}))?;
     Ok(())
 }
@@ -312,20 +299,16 @@ fn test_accept_incoming_when_local_is_deleted_no_mirror() -> Result<()> {
     let tx = db.transaction()?;
     let data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", data)?;
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     clear(&tx, "ext-id")?;
-    let payload = Payload::from_record(Record {
-        // Use a random guid so that we don't find the mirrored data.
-        // This test is somewhat bad because deduping might obviate
-        // the need for it.
-        guid: Guid::from("guid"),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: json!({"key2": "key2-value"}).to_string(),
-        },
-    })?;
+
+    // Use a random guid so that we don't find the mirrored data.
+    // This test is somewhat bad because deduping might obviate
+    // the need for it.
+    let record = make_incoming(&Guid::new("guid"), "ext-id", &json!({"key2": "key2-value"}));
+
     // We completely accept the incoming record.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 0);
     check_finished_with(&tx, "ext-id", json!({"key2": "key2-value"}))?;
     Ok(())
 }
@@ -336,19 +319,13 @@ fn test_accept_deleted_key_mirrored() -> Result<()> {
     let tx = db.transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data)?;
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     let guid = get_mirror_guid(&tx, "ext-id")?;
     // Incoming payload without 'key1'. Because we previously uploaded
     // key1, this means another client deleted it.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from(guid),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: json!({"key2": "key2-value"}).to_string(),
-        },
-    })?;
+    let record = make_incoming(&guid, "ext-id", &json!({"key2": "key2-value"}));
     // We completely accept the incoming record.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 0);
     check_finished_with(&tx, "ext-id", json!({"key2": "key2-value"}))?;
     Ok(())
 }
@@ -362,14 +339,8 @@ fn test_merged_no_mirror() -> Result<()> {
     // Incoming payload without 'key1' and some data for 'key2'.
     // Because we never uploaded 'key1', we merge our local values
     // with the remote.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from("guid"),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: json!({"key2": "key2-value"}).to_string(),
-        },
-    })?;
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    let record = make_incoming(&Guid::new("guid"), "ext-id", &json!({"key2": "key2-value"}));
+    assert_eq!(do_sync(&tx, &[record])?.len(), 1);
     check_finished_with(
         &tx,
         "ext-id",
@@ -384,7 +355,7 @@ fn test_merged_incoming() -> Result<()> {
     let tx = db.transaction()?;
     let old_data = json!({"key1": "key1-value", "key2": "key2-value", "doomed_key": "deletable"});
     set(&tx, "ext-id", old_data)?;
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     let guid = get_mirror_guid(&tx, "ext-id")?;
     // We update 'key1' locally.
     let local_data = json!({"key1": "key1-new", "key2": "key2-value", "doomed_key": "deletable"});
@@ -393,15 +364,13 @@ fn test_merged_incoming() -> Result<()> {
     // the 'doomed_key'.
     // Because we never uploaded our data, we'll merge our
     // key1 in, but otherwise keep the server's changes.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from(guid),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: json!({"key1": "key1-value", "key2": "key2-incoming"}).to_string(),
-        },
-    })?;
+    let record = make_incoming(
+        &guid,
+        "ext-id",
+        &json!({"key1": "key1-value", "key2": "key2-incoming"}),
+    );
     // We should send our 'key1'
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 1);
     check_finished_with(
         &tx,
         "ext-id",
@@ -417,7 +386,7 @@ fn test_merged_with_null_payload() -> Result<()> {
     let old_data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", old_data.clone())?;
     // Push this change remotely.
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     let guid = get_mirror_guid(&tx, "ext-id")?;
     assert_eq!(
         get_mirror_data(&tx, &guid),
@@ -426,16 +395,10 @@ fn test_merged_with_null_payload() -> Result<()> {
     let local_data = json!({"key1": "key1-new", "key2": "key2-value"});
     set(&tx, "ext-id", local_data.clone())?;
     // Incoming payload with the same old data.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from(guid),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: old_data.to_string(),
-        },
-    })?;
+    let record = make_incoming(&guid, "ext-id", &old_data);
     // Three-way-merge will not detect any change in key1, so we
     // should keep our entire new value.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 1);
     check_finished_with(&tx, "ext-id", local_data)?;
     Ok(())
 }
@@ -446,16 +409,13 @@ fn test_deleted_mirrored_object_accept() -> Result<()> {
     let tx = db.transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data)?;
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     let guid = get_mirror_guid(&tx, "ext-id")?;
     // Incoming payload with data deleted.
     // We synchronize this deletion by deleting the keys we think
     // were on the server.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from(guid.clone()),
-        data: RecordData::Tombstone,
-    })?;
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    let record = make_incoming_tombstone(&guid);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 0);
     assert_eq!(get_local_data(&tx, "ext-id"), DbData::NoRow);
     assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
     Ok(())
@@ -466,7 +426,7 @@ fn test_deleted_mirrored_object_merged() -> Result<()> {
     let mut db = new_syncable_mem_db();
     let tx = db.transaction()?;
     set(&tx, "ext-id", json!({"key1": "key1-value"}))?;
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     let guid = get_mirror_guid(&tx, "ext-id")?;
     set(
         &tx,
@@ -476,12 +436,9 @@ fn test_deleted_mirrored_object_merged() -> Result<()> {
     // Incoming payload with data deleted.
     // We synchronize this deletion by deleting the keys we think
     // were on the server.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from(guid),
-        data: RecordData::Tombstone,
-    })?;
+    let record = make_incoming_tombstone(&guid);
     // This overrides the change to 'key1', but we still upload 'key2'.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 1);
     check_finished_with(&tx, "ext-id", json!({"key2": "key2-value"}))?;
     Ok(())
 }
@@ -493,25 +450,19 @@ fn test_deleted_mirrored_tombstone_merged() -> Result<()> {
     let tx = db.transaction()?;
     // Sync some data so we can get the guid for this extension.
     set(&tx, "ext-id", json!({"key1": "key1-value"}))?;
-    assert_eq!(do_sync(&tx, vec![])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[])?.len(), 1);
     let guid = get_mirror_guid(&tx, "ext-id")?;
     // Sync a delete for this data so we have a tombstone in the mirror.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from(guid.clone()),
-        data: RecordData::Tombstone,
-    })?;
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 0);
+    let record = make_incoming_tombstone(&guid);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 0);
     assert_eq!(get_mirror_data(&tx, &guid), DbData::NullRow);
 
     // Set some data and sync it simultaneously with another incoming delete.
     set(&tx, "ext-id", json!({"key2": "key2-value"}))?;
-    let payload = Payload::from_record(Record {
-        guid: Guid::from(guid),
-        data: RecordData::Tombstone,
-    })?;
+    let record = make_incoming_tombstone(&guid);
     // We cannot delete any matching keys because there are no
     // matching keys. Instead we push our data.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 1);
     check_finished_with(&tx, "ext-id", json!({"key2": "key2-value"}))?;
     Ok(())
 }
@@ -523,14 +474,11 @@ fn test_deleted_not_mirrored_object_merged() -> Result<()> {
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data)?;
     // Incoming payload with data deleted.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from("guid"),
-        data: RecordData::Tombstone,
-    })?;
+    let record = make_incoming_tombstone(&Guid::new("guid"));
     // We normally delete the keys we think were on the server, but
     // here we have no information about what was on the server, so we
     // don't delete anything. We merge in all undeleted keys.
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 1);
     check_finished_with(
         &tx,
         "ext-id",
@@ -548,19 +496,29 @@ fn test_conflicting_incoming() -> Result<()> {
     // Incoming payload without 'key1' and conflicting for 'key2'.
     // Because we never uploaded either of our keys, we'll merge our
     // key1 in, but the server key2 wins.
-    let payload = Payload::from_record(Record {
-        guid: Guid::from("guid"),
-        data: RecordData::Data {
-            ext_id: "ext-id".to_string(),
-            data: json!({"key2": "key2-incoming"}).to_string(),
-        },
-    })?;
+    let record = make_incoming(
+        &Guid::new("guid"),
+        "ext-id",
+        &json!({"key2": "key2-incoming"}),
+    );
     // We should send our 'key1'
-    assert_eq!(do_sync(&tx, vec![payload])?.len(), 1);
+    assert_eq!(do_sync(&tx, &[record])?.len(), 1);
     check_finished_with(
         &tx,
         "ext-id",
         json!({"key1": "key1-value", "key2": "key2-incoming"}),
     )?;
+    Ok(())
+}
+
+#[test]
+fn test_invalid_incoming() -> Result<()> {
+    let mut db = new_syncable_mem_db();
+    let tx = db.transaction()?;
+    let json = json!({"id": "id", "cleartext": json!("").to_string()});
+    let record: IncomingBridgeRecord = serde_json::from_value(json).unwrap();
+
+    // Should do nothing.
+    assert_eq!(do_sync(&tx, &[record])?.len(), 0);
     Ok(())
 }


### PR DESCRIPTION
Sorry for the large PR - there's no hurry here and I'm happy to discuss the motivations behind this some more. I'm open to bikeshedding here, because some of the names and concepts will later reach further into the sync crates. This will impact the branch with Sammy's tabs work, but the fixes should be easy and I'll do them once this lands.

---
This shows how I envisage sync15_traits should work for both the bridged
engine and the bso_record based (ie, sync15) engines. This patch only
touched the bridged_engine to keep the patch small with a future
patch using this shape for the rest of the crate soon.

It leans further into the "envelope" concept introduced by the
bridged_engine, but the envelope is now split from the payload
so it can be used by bso_record.

Now, instead of going to and from the sync15_traits::Payload, we just
move to and from <T> directly:

* When converting from an incoming record to a <T>, the result is
  captured in a new enum, `IncomingDeserPayload`, which allows us
  to capture incoming tombstones and invalid record. No errors are
  returned deserializing <T>, the enum variants cover all cases.

* When converting from T to an outgoing record, we will panic if
  various constraints are not met - eg, if you have specified an
  invalid GUID. All such errors are considered "static" errors
  and aren't influenced by runtime conditions, so a panic means
  we don't have to introduce new error handling for these "impossible"
  states.

It also kills the concept of "auto" fields - it's no longer necessary
to have a field called, say, 'ttl' in your record to arrange for a TTL
on the record - these are now handled by the envelope. Note that the
'id' field on the payload does remain somewhat magic.
