### PR TITLE
add active_experiments map to TargetingAttributes and verify jexl interactions

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -25,3 +25,6 @@ Use the template below to make assigning a version number during the release cut
 
 ### What's Changed
   - Add `channels` value for defaults and add support for multiple channels in `channel` via comma separation. ([#5101](https://github.com/mozilla/application-services/pull/5101))
+
+### What's New
+  - JEXL targeting allows for using the `in` keyword with objects and a map of active experiments has been added to TargetingAttributes. The map will always be empty at this time. ([#5104](https://github.com/mozilla/application-services/pull/5104))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,9 +1584,9 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jexl-eval"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c015085093f5f4836054483386ffcd18500f4816e9178daec7cfea6fb80fab"
+checksum = "41bb0cb58f20e39d58869c2cf1a69b88aaa7854557904ed404e829d3b64e1046"
 dependencies = [
  "anyhow",
  "jexl-parser",
@@ -1597,9 +1597,9 @@ dependencies = [
 
 [[package]]
 name = "jexl-parser"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad099b3290c625d9147b51810c0a63b9087e1439039840c9e3f974a2747deb20"
+checksum = "0ab43a7eb505d3871a8debbaebc35b3402e26968dd4bcac258e6f40881238673"
 dependencies = [
  "lalrpop-util",
  "regex",

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -27,7 +27,7 @@ viaduct = { path = "../viaduct" }
 thiserror = "1"
 url = "2.2"
 rkv = "0.17"
-jexl-eval = "0.2.1"
+jexl-eval = "0.2.2"
 uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -15,6 +15,7 @@ use crate::{Branch, Experiment};
 use jexl_eval::Evaluator;
 use serde_derive::*;
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use uuid::Uuid;
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Bucket {}
@@ -35,6 +36,7 @@ pub struct TargetingAttributes {
     pub is_already_enrolled: bool,
     pub days_since_install: Option<i32>,
     pub days_since_update: Option<i32>,
+    pub active_experiments: Option<HashMap<String, String>>,
 }
 
 impl From<AppContext> for TargetingAttributes {


### PR DESCRIPTION
- Update jexl-eval to 0.2.2
- Add active_experiments  map to TargetingAttributes
- Verify jexl interactions with the active_experiments map

[EXP-2545](https://mozilla-hub.atlassian.net/browse/EXP-2545)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
