### PR TITLE
Additional error checking/logging for #5040

### DIFF
--- a/components/support/error/src/reporting.rs
+++ b/components/support/error/src/reporting.rs
@@ -3,6 +3,25 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use parking_lot::RwLock;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+/// Counter for breadcrumb messages
+///
+/// We are currently seeing breadcrumbs that may indicate that the reporting is unreliable.  In
+/// some reports, the breadcrumbs seem like they may be duplicated and/or out of order.  This
+/// counter is a temporary measure to check out that theory.
+static BREADCRUMB_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn get_breadcrumb_counter_value() -> u32 {
+    // Notes:
+    //   - fetch_add is specified to wrap around in case of overflow, which seems okay.
+    //   - By itself, this does not guarentee that breadcrumb logs will be ordered the same way as
+    //     the counter values.  If two threads are running at the same time, it's very possible
+    //     that thread A gets the lower breadcrumb value, but thread B wins the race to report its
+    //     breadcrumb. However, if we expect operations to be synchronized, like with places DB,
+    //     then the breadcrumb counter values should always increase by 1.
+    BREADCRUMB_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
 
 /// Application error reporting trait
 ///
@@ -41,6 +60,7 @@ pub fn report_error(type_name: String, message: String) {
 }
 
 pub fn report_breadcrumb(message: String, module: String, line: u32, column: u32) {
+    let message = format!("{} ({})", message, get_breadcrumb_counter_value());
     APPLICATION_ERROR_REPORTER
         .read()
         .report_breadcrumb(message, module, line, column);


### PR DESCRIPTION
Based on the latest results, we have 2 theories of what could be
happening.  The user might have triggered some edge case where they have
multiple places write connections open and/or the Sentry breadcrumb
logging might be not reliable and printing duplicate breadcrumbs.  Both
of these seem unlikely, but then again everything about this error seems
unlikely.

Added checks for both of those cases so that we can confirm or deny if
they're happening.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
