### PR TITLE
Store the keys in the GlobalState as an EncryptedPayload instead of E…

### DIFF
--- a/components/sync15/src/clients/engine.rs
+++ b/components/sync15/src/clients/engine.rs
@@ -280,8 +280,11 @@ impl<'a> Engine<'a> {
     ) -> Result<()> {
         log::info!("Syncing collection clients");
 
-        let coll_keys =
-            CollectionKeys::from_encrypted_bso(global_state.keys.clone(), root_sync_key)?;
+        let coll_keys = CollectionKeys::from_encrypted_payload(
+            global_state.keys.clone(),
+            global_state.keys_timestamp,
+            root_sync_key,
+        )?;
         let mut coll_state = CollState {
             config: global_state.config.clone(),
             last_modified: global_state

--- a/components/sync15/src/coll_state.rs
+++ b/components/sync15/src/coll_state.rs
@@ -73,8 +73,9 @@ impl<'state> LocalCollStateMachine<'state> {
                             if ids.global == meta_global.sync_id
                                 && ids.coll == engine_meta.sync_id =>
                         {
-                            let coll_keys = CollectionKeys::from_encrypted_bso(
+                            let coll_keys = CollectionKeys::from_encrypted_payload(
                                 self.global_state.keys.clone(),
+                                self.global_state.keys_timestamp,
                                 self.root_key,
                             )?;
                             Ok(LocalCollState::Ready {
@@ -181,7 +182,7 @@ mod tests {
     fn get_global_state(root_key: &KeyBundle) -> GlobalState {
         let keys = CollectionKeys::new_random()
             .unwrap()
-            .to_encrypted_bso(root_key)
+            .to_encrypted_payload(root_key)
             .unwrap();
         GlobalState {
             config: InfoConfiguration::default(),
@@ -203,6 +204,7 @@ mod tests {
             },
             global_timestamp: ServerTimestamp::default(),
             keys,
+            keys_timestamp: ServerTimestamp::default(),
         }
     }
 


### PR DESCRIPTION
…ncryptedBso

We stored the keys as an EncryptedBso so that the timestamp was available
"for free", but this gets in the way of moving towards different types for
incoming and outgoing server records/payloads.

We now store the EncryptedPayload and the modified timestamp explicitly.
The semantics don't change, just what concrete type we hold in memory.

This makes sense even without the bso_record refactoring work I've been discussing with Ben, and landing it first makes future reviews of that work easier, so here it is!
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
