### PR TITLE
Update to Glean v51.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,7 +1303,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glean-build"
-version = "6.1.1"
+version = "6.1.2"
 dependencies = [
  "xshell-venv",
 ]
@@ -1630,7 +1630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877e398ffb23c1c311c417ef5e72e8699c3822dbf835468f009c6ce91b6c206b"
 dependencies = [
  "ahash",
- "base64 0.13.0",
+ "base64 0.12.3",
  "bytecount",
  "fancy-regex",
  "fraction",

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jna_version = '5.8.0'
         android_gradle_plugin_version = '7.2.2'
         android_components_version = '104.0.2'
-        glean_version = '51.1.0'
+        glean_version = '51.2.0'
         androidx_annotation_version = '1.2.0'
         androidx_core_version = '1.3.2'
         androidx_test_version = '1.4.0'

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -938,7 +938,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 51.0.1;
+				minimumVersion = 51.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mozilla/glean-swift",
         "state": {
           "branch": null,
-          "revision": "3cbb2c255aeb18805d3783248d89a93a845acaac",
-          "version": "51.0.1"
+          "revision": "5b810598dbe39579703af99af4afe4de92811d0c",
+          "version": "51.2.0"
         }
       }
     ]


### PR DESCRIPTION
This should be the last release where we _require_ a a-s release to go along with the update in A-C.