### PR TITLE
Update NSS to version 3.84

### DIFF
--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -114,12 +114,13 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
             // Hardware specific libs.
             let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
             let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-            // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#278-296
+            // https://searchfox.org/nss/rev/bff8bec06d9f17895882a0430a1d961a5f7a8e9d/lib/freebl/freebl.gyp#508-542
             if target_arch == "arm" || target_arch == "aarch64" {
                 static_libs.push("armv8_c_lib");
             }
             if target_arch == "x86_64" || target_arch == "x86" {
                 static_libs.push("gcm-aes-x86_c_lib");
+                static_libs.push("sha-x86_c_lib");
             }
             if target_arch == "arm" {
                 static_libs.push("gcm-aes-arm32-neon_c_lib")

--- a/libs/build-all-ios.sh
+++ b/libs/build-all-ios.sh
@@ -64,6 +64,7 @@ universal_lib "nss" "libssl.a" "${TARGET_ARCHS[@]}"
 universal_lib "nss" "libhw-acc-crypto-avx.a" "x86_64"
 universal_lib "nss" "libhw-acc-crypto-avx2.a" "x86_64"
 universal_lib "nss" "libgcm-aes-x86_c_lib.a" "x86_64"
+universal_lib "nss" "libsha-x86_c_lib.a" "x86_64"
 universal_lib "nss" "libgcm-aes-aarch64_c_lib.a" "arm64"
 universal_lib "nss" "libarmv8_c_lib.a" "arm64"
 

--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -5,10 +5,10 @@ set -euvx
 SQLCIPHER_VERSION="4.5.2"
 SQLCIPHER_SHA256="6925f012deb5582e39761a7d4816883cc15b41851a8e70b447c223b8ef406e2a"
 
-NSS="nss-3.66"
-NSS_ARCHIVE="nss-3.66-with-nspr-4.30.tar.gz"
-NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_66_RTM/src/${NSS_ARCHIVE}"
-NSS_SHA256="4eb72ca78b497a2a425139fdcfb9068cbd318dd51542baaa5365fcfbcb165009"
+NSS="nss-3.84"
+NSS_ARCHIVE="nss-3.84-with-nspr-4.35.tar.gz"
+NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_84_RTM/src/${NSS_ARCHIVE}"
+NSS_SHA256="0342347a01545a990860849d39e62aec901c8fabbd614e768c6a5df5d18debeb"
 
 # End of configuration.
 

--- a/libs/build-nss-android.sh
+++ b/libs/build-nss-android.sh
@@ -112,9 +112,10 @@ cp -p -L "${BUILD_DIR}/lib/libsmime.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libsoftokn_static.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libssl.a" "${DIST_DIR}/lib"
 # HW specific.
-# https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#278-296
+# https://searchfox.org/nss/rev/bff8bec06d9f17895882a0430a1d961a5f7a8e9d/lib/freebl/freebl.gyp#508-542
 if [[ "${TOOLCHAIN}" == "i686-linux-android" ]] || [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libsha-x86_c_lib.a" "${DIST_DIR}/lib"
 fi
 if [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]] || [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -60,18 +60,18 @@ fi
 # TODO We do not know how to cross compile these, so we cheat by downloading them and the how is pretty disgusting.
 # https://github.com/mozilla/application-services/issues/962
 if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
-  # Generated from nss-try@111b54aaa644978464bec98848ecba6f69d3f42e.
-  curl -sfSL --retry 5 --retry-delay 10 -O "https://fxa-dev-bucket.s3-us-west-2.amazonaws.com/a-s/nss_nspr_static_3.66_darwin.tar.bz2"
-  SHA256="2ad7c85b7b009120c7e883ccd367bbd3653857a4ed3adb4c5471b197d1844141"
-  echo "${SHA256}  nss_nspr_static_3.66_darwin.tar.bz2" | shasum -a 256 -c - || exit 2
-  tar xvjf nss_nspr_static_3.66_darwin.tar.bz2 && rm -rf nss_nspr_static_3.66_darwin.tar.bz2
+  # Generated from nss-try@9930fc7c03092ebc139d0f613d3eeb4cd2c07c94.
+  curl -sfSL --retry 5 --retry-delay 10 -O "https://fxa-dev-bucket.s3-us-west-2.amazonaws.com/a-s/nss_nspr_static_3.84_darwin.tar.bz2"
+  SHA256="b1ede8b88e4ca3ba8dfbe32775f0b936a74399dbd282cf8ee02f3471878392b5"
+  echo "${SHA256}  nss_nspr_static_3.84_darwin.tar.bz2" | shasum -a 256 -c - || exit 2
+  tar xvjf nss_nspr_static_3.84_darwin.tar.bz2 && rm -rf nss_nspr_static_3.84_darwin.tar.bz2
   NSS_DIST_DIR=$(abspath "dist")
 elif [[ "${CROSS_COMPILE_TARGET}" =~ "win32-x86-64" ]]; then
-  # Generated from nss-try@111b54aaa644978464bec98848ecba6f69d3f42e.
-  curl -sfSL --retry 5 --retry-delay 10 -O "https://fxa-dev-bucket.s3-us-west-2.amazonaws.com/a-s/nss_nspr_static_3.66_mingw.7z"
-  SHA256="d245ea7790602ef062ad6e6bac38f2d0452d753bf428c33ced46f022398a53ff"
-  echo "${SHA256}  nss_nspr_static_3.66_mingw.7z" | shasum -a 256 -c - || exit 2
-  7z x nss_nspr_static_3.66_mingw.7z -aoa && rm -rf nss_nspr_static_3.66_mingw.7z
+  # Generated from nss-try@9930fc7c03092ebc139d0f613d3eeb4cd2c07c94.
+  curl -sfSL --retry 5 --retry-delay 10 -O "https://fxa-dev-bucket.s3-us-west-2.amazonaws.com/a-s/nss_nspr_static_3.84_mingw.7z"
+  SHA256="cfbf6b04d65d8fb8f8649717a92e62cd3f28583eda36fca1d0dff471fe50d461"
+  echo "${SHA256}  nss_nspr_static_3.84_mingw.7z" | shasum -a 256 -c - || exit 2
+  7z x nss_nspr_static_3.84_mingw.7z -aoa && rm -rf nss_nspr_static_3.84_mingw.7z
   NSS_DIST_DIR=$(abspath "dist")
 elif [[ "$(uname -s)" == "Darwin" ]] || [[ "$(uname -s)" == "Linux" ]]; then
   "${NSS_SRC_DIR}"/nss/build.sh \
@@ -120,6 +120,7 @@ else
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libhw-acc-crypto-avx.a" "${DIST_DIR}/lib"
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libhw-acc-crypto-avx2.a" "${DIST_DIR}/lib"
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libsha-x86_c_lib.a" "${DIST_DIR}/lib"
 fi
 # https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#224-233
 if [[ "${TARGET_OS}" == "windows" ]] || [[ "${TARGET_OS}" == "linux" ]]; then

--- a/libs/build-nss-ios.sh
+++ b/libs/build-nss-ios.sh
@@ -106,6 +106,7 @@ if [[ "${ARCH}" == "x86_64" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
   cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx.a" "${DIST_DIR}/lib"
   cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx2.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libsha-x86_c_lib.a" "${DIST_DIR}/lib"
 elif [[ "${ARCH}" == "arm64" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-aarch64_c_lib.a" "${DIST_DIR}/lib"
   cp -p -L "${BUILD_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"

--- a/libs/build-sqlcipher-android.sh
+++ b/libs/build-sqlcipher-android.sh
@@ -102,7 +102,7 @@ LIBS="\
 "
 
 if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]] || [[ "${TOOLCHAIN}" == "i686-linux-android" ]]; then
-  LIBS="${LIBS} -lgcm-aes-x86_c_lib"
+  LIBS="${LIBS} -lgcm-aes-x86_c_lib -lsha-x86_c_lib"
 fi
 if [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]] || [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]; then
   LIBS="${LIBS} -larmv8_c_lib"

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -117,7 +117,7 @@ elif [[ "${TARGET_OS}" == "linux" ]]; then
 elif [[ "${TARGET_ARCH}" == "aarch64" ]]; then
   LIBS="${LIBS} -lgcm-aes-aarch64_c_lib -larmv8_c_lib"
 else
-  LIBS="${LIBS} -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 -lgcm-aes-x86_c_lib"
+  LIBS="${LIBS} -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 -lgcm-aes-x86_c_lib -lsha-x86_c_lib"
 fi
 
 BUILD_DIR=$(mktemp -d)

--- a/libs/build-sqlcipher-ios.sh
+++ b/libs/build-sqlcipher-ios.sh
@@ -112,7 +112,7 @@ LIBS="\
 "
 
 if [[ "${ARCH}" == "x86_64" ]]; then
-  LIBS="${LIBS} -lgcm-aes-x86_c_lib -lhw-acc-crypto-avx -lhw-acc-crypto-avx2"
+  LIBS="${LIBS} -lgcm-aes-x86_c_lib -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 -lsha-x86_c_lib"
 else
   LIBS="${LIBS} -lgcm-aes-aarch64_c_lib -larmv8_c_lib"
 fi


### PR DESCRIPTION
I could use some help getting the pre-built macOS & Windows archives uploaded to S3 rather than going through the steps of requesting access for myself to do it. Here's a link to the NSS Try push:
https://treeherder.mozilla.org/jobs?repo=nss-try&revision=9930fc7c03092ebc139d0f613d3eeb4cd2c07c94