### PR TITLE
Run Rust 1.61 tests with -j2 to prevent OOM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,12 @@ jobs:
       - setup-rust-min-version
       # tests.py doesn't support skipping tests, and we need to skip the systests on this rust version.
       # It's not in the default workspace members, so just `cargo test` is OK.
-      - run: RUST_LOG=trace cargo test
+      #
+      # Note "-j" here and below - we saw OOM errors which this tries to workaround and is
+      # hopefully a cheaper workaround than an "resource_class: xlarge".
+      # Probably https://github.com/rust-lang/rust/issues/97549 which is a 1.61 issue.
+      # We should revert this once we move past 1.61
+      - run: RUST_LOG=trace cargo test -j2
       - save-sccache-cache
   # These run periodically (driven by cron).
   Rust tests - beta:


### PR DESCRIPTION
@rvandermeulen notes our min-rust-version tests are flakey for the same reason we discovered in uniffi. This takes the same approach we took there.