### PR TITLE
Don't dismiss stale reviews for the release-management team

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,6 +15,7 @@ pull_request_rules:
       - base=main
       - author!=@mozilla/application-services
       - author!=@mozilla/application-services-collaborators
+      - author!=@mozilla/release-management
     actions:
       dismiss_reviews:
         message: The pull request has been modified, dismissing previous reviews.


### PR DESCRIPTION
We don't allow mergify to merge stale reviews for reasons noted in 4185342a01a68925722ed815b56e57337fc7dbcd. We might be able to fix that, but we don't want to regress what that commit fixed, so it might not be trivial.

Combining this with the fact that we reset approvals on rebase for many people, it leave @rvandermeulen in a state where he almost always needs to get multiple approvals before landing anything.

This patch means stale reviews for the release-management team should not be automatically reset. It's a copy-paste and I'm not sure how to test it other than to land it! Any thoughts/concerns?