### PR TITLE
Downgrade androidx.core to 1.3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,14 @@ buildscript {
         android_gradle_plugin_version = '7.2.2'
         android_components_version = '105.0.7'
         glean_version = '51.2.0'
+
+        // NOTE: AndroidX libraries should be synced with AC to avoid compatibility issues
         androidx_annotation_version = '1.3.0'
-        androidx_core_version = '1.8.0'
+        androidx_core_version = '1.3.2'
         androidx_test_version = '1.4.0'
         androidx_test_junit_version = '1.1.3'
         androidx_work_testing_version = '2.7.1'
+
         detekt_version = '1.21.0'
         gradle_download_task_version = '5.2.0'
         junit_version = '4.13.2'


### PR DESCRIPTION
As noted on Slack, updating to version 1.8.0 is causing issues with Fenix which still uses 1.3.2. Downgrade back to 1.3.2 for now until the 1.8.0 bump lands downstream. Also, add a note about the dependency to hopefully avoid this happening in the future.