### PR TITLE
Allow tabs to use uniffi 0.19 or 0.20

### DIFF
--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -33,8 +33,8 @@ sql-support = { path = "../support/sql" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
-uniffi = "^0.20"
-uniffi_macros = "^0.20"
+uniffi = ">=0.19.6, <=0.20" # m-c is on 19.6, a-s is on 0.20.0
+uniffi_macros = ">=0.19.6, <=0.20" # m-c is on 19.6, a-s is on 0.20.0
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [dev-dependencies]
@@ -42,4 +42,5 @@ tempfile = "3.1"
 env_logger = { version = "0.8.0", default-features = false, features = ["termcolor", "atty", "humantime"] }
 
 [build-dependencies]
-uniffi_build = { version = "^0.20", features = [ "builtin-bindgen" ]}
+# uniffi: m-c is on 19.6, a-s is on 0.20.0
+uniffi_build = { version = ">=0.19.6, <=0.20", features = [ "builtin-bindgen" ]}


### PR DESCRIPTION
This seems to allow us to vendor into m-c using 0.19