### PR TITLE
Sync Manager syncs engines in a deterministic order, fixes #5171

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -24,3 +24,8 @@ Use the template below to make assigning a version number during the release cut
 ### What's Changed
 
 - Android: Reverted NDK back to r21d from r25b. ([#5156](https://github.com/mozilla/application-services/issues/5165))
+
+## Sync Manager
+
+### What's Changed
+  - Syncing will sync each engine in a deterministic order which matches desktop ([#5171](https://github.com/mozilla/application-services/issues/5171))

--- a/components/sync15/src/engine/sync_engine.rs
+++ b/components/sync15/src/engine/sync_engine.rs
@@ -31,24 +31,30 @@ pub enum EngineSyncAssociation {
 /// The concrete `SyncEngine` implementations
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SyncEngineId {
+    // Note that we've derived PartialOrd etc, which uses lexicographic ordering
+    // of the variants. We leverage that such that the higher priority engines
+    // are listed first.
+    // This order matches desktop.
     Passwords,
-    History,
-    Bookmarks,
     Tabs,
+    Bookmarks,
     Addresses,
     CreditCards,
+    History,
 }
 
 impl SyncEngineId {
-    // Iterate over all possible engines
+    // Iterate over all possible engines. Note that we've made a policy decision
+    // that this should enumerate in "order" as defined by PartialCmp, and tests
+    // enforce this.
     pub fn iter() -> impl Iterator<Item = SyncEngineId> {
         [
             Self::Passwords,
-            Self::History,
-            Self::Bookmarks,
             Self::Tabs,
+            Self::Bookmarks,
             Self::Addresses,
             Self::CreditCards,
+            Self::History,
         ]
         .into_iter()
     }
@@ -194,4 +200,36 @@ pub trait SyncEngine {
     fn reset(&self, assoc: &EngineSyncAssociation) -> Result<()>;
 
     fn wipe(&self) -> Result<()>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::iter::zip;
+
+    #[test]
+    fn test_engine_priority() {
+        fn sorted(mut engines: Vec<SyncEngineId>) -> Vec<SyncEngineId> {
+            engines.sort();
+            engines
+        }
+        assert_eq!(
+            vec![SyncEngineId::Passwords, SyncEngineId::Tabs],
+            sorted(vec![SyncEngineId::Passwords, SyncEngineId::Tabs])
+        );
+        assert_eq!(
+            vec![SyncEngineId::Passwords, SyncEngineId::Tabs],
+            sorted(vec![SyncEngineId::Tabs, SyncEngineId::Passwords])
+        );
+    }
+
+    #[test]
+    fn test_engine_enum_order() {
+        let unsorted = SyncEngineId::iter().collect::<Vec<SyncEngineId>>();
+        let mut sorted = SyncEngineId::iter().collect::<Vec<SyncEngineId>>();
+        sorted.sort();
+
+        // iterating should supply identical elements in each.
+        assert!(zip(unsorted, sorted).fold(true, |acc, (a, b)| acc && (a == b)))
+    }
 }

--- a/components/sync_manager/src/manager.rs
+++ b/components/sync_manager/src/manager.rs
@@ -7,7 +7,7 @@ use crate::types::{ServiceStatus, SyncEngineSelection, SyncParams, SyncReason, S
 use crate::{reset, reset_all, wipe};
 use error_support::breadcrumb;
 use parking_lot::Mutex;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryFrom;
 use std::time::SystemTime;
 use sync15::client::{
@@ -203,7 +203,8 @@ impl SyncManager {
         &self,
         selection: &SyncEngineSelection,
     ) -> Result<Vec<Box<dyn SyncEngine>>> {
-        let mut engine_map: HashMap<_, _> = self.iter_registered_engines().collect();
+        // BTreeMap to ensure we sync the engines in priority order.
+        let mut engine_map: BTreeMap<_, _> = self.iter_registered_engines().collect();
         breadcrumb!(
             "Checking engines requested ({:?}) vs local engines ({:?})",
             selection,


### PR DESCRIPTION
Before this patch, Android logs show:
```
I  Syncing 5 engines
I  Synchronizing clients engine
I  Synchronizing engines
I  Syncing passwords engine!
I  Syncing bookmarks engine!
I  The creditcards engine is declined. Skipping
I  Syncing history engine!
I  Syncing tabs engine!
I  Finished syncing engines.
```
and with it:
```
I  Syncing 5 engines
I  Synchronizing clients engine
I  Synchronizing engines
I  Syncing passwords engine!
I  Syncing tabs engine!
I  Syncing bookmarks engine!
I  The creditcards engine is declined. Skipping
I  Syncing history engine!
I  Finished syncing engines.
```

@lougeniaC64, do you happen to know the order Firefox for iOS uses?