### PR TITLE
Reverting the Android NDK upgrade (#5165) [ci full]

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,9 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## General
+
+### What's Changed
+
+- Android: Reverted NDK back to r21d from r25b. ([#5156](https://github.com/mozilla/application-services/issues/5165))

--- a/automation/upload_android_symbols.sh
+++ b/automation/upload_android_symbols.sh
@@ -35,13 +35,14 @@ fi
 # Keep the 3 in sync.
 TARGET_ARCHS=("x86_64" "x86" "arm64" "arm")
 JNI_LIBS_TARGETS=("x86_64" "x86" "arm64-v8a" "armeabi-v7a")
+OBJCOPY_BINS=("x86_64-linux-android-objcopy" "i686-linux-android-objcopy" "aarch64-linux-android-objcopy" "arm-linux-androideabi-objcopy")
 
 rm -rf "${OUTPUT_FOLDER}"
 mkdir -p "${OUTPUT_FOLDER}"
 
 # 1. Generate the symbols.
 for i in "${!TARGET_ARCHS[@]}"; do
-  export OBJCOPY="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${NDK_HOST_TAG}/bin/llvm-objcopy"
+  export OBJCOPY="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${NDK_HOST_TAG}/bin/${OBJCOPY_BINS[${i}]}"
   JNI_SO_PATH="${PROJECT_PATH}/build/rustJniLibs/android/${JNI_LIBS_TARGETS[${i}]}"
   for sofile in "${JNI_SO_PATH}"/*.so; do
     python3 automation/symbols-generation/symbolstore.py -c -s . --vcs-info "${DUMP_SYMS_DIR}"/dump_syms "${OUTPUT_FOLDER}" "${sofile}"

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
     }
 
     ext.build = [
-        ndkVersion: "25.1.8937393", // Keep it in sync in TC Dockerfile.
+        ndkVersion: "21.3.6528147", // Keep it in sync in TC Dockerfile.
         compileSdkVersion: 32,
         targetSdkVersion: 32,
         minSdkVersion: 21, // So that we can publish for aarch64.

--- a/docs/building.md
+++ b/docs/building.md
@@ -99,7 +99,7 @@ The following instructions assume that you are building `application-services` f
    1. Configure the required versions of NDK
   `Configure menu > System Settings > Android SDK > SDK Tools > NDK > Show Package Details > NDK (Side by side)`
         - 21.4.7075529 (required by Fenix; note: a specific NDK version isn't configured, this maps to default [NDK version](https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp) for the [AGP version](https://github.com/mozilla-mobile/fenix/blob/main/buildSrc/src/main/java/Dependencies.kt#L11))
-        - 25.1.8937393 (required by Application Services, [as configured](https://github.com/mozilla/application-services/blob/main/build.gradle#L30))
+        - 21.3.6528147 (required by Application Services, [as configured](https://github.com/mozilla/application-services/blob/main/build.gradle#L30))
 1. If you are on Windows using WSL - drop to the section below, [Windows setup
 for Android (WSL)](building.md#windows-setup-for-android-via-wsl) before proceeding.
 1. Check dependencies, environment variables

--- a/docs/howtos/locally-building-jna.md
+++ b/docs/howtos/locally-building-jna.md
@@ -17,8 +17,8 @@ Here are the steps that worked for me:
   for each target platform are in your `$PATH`. On my Mac with Android Studio the
   config was as follows:
     ```
-    export NDK_ROOT="$HOME/Library/Android/sdk/ndk/25.1.8937393"
-    export NDK_PLATFORM="$NDK_ROOT/platforms/android-25"
+    export NDK_ROOT="$HOME/Library/Android/sdk/ndk/21.3.6528147"
+    export NDK_PLATFORM="$NDK_ROOT/platforms/android-21"
     export PATH="$PATH:$NDK_ROOT/toolchains/llvm/prebuilt/darwin-x86_64/bin"
     export PATH="$PATH:$NDK_ROOT/toolchains/aarch64-linux-android-4.9/prebuilt/darwin-x86_64/bin"
     export PATH="$PATH:$NDK_ROOT/toolchains/arm-linux-androideabi-4.9/prebuilt/darwin-x86_64/bin"

--- a/libs/build-nss-android.sh
+++ b/libs/build-nss-android.sh
@@ -42,18 +42,20 @@ else
 fi
 NSPR_64="${NSPR_64:-""}"
 
-export AR="${TOOLCHAIN_PATH}/bin/llvm-ar"
+export AR="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-ar"
 export CC="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}${ANDROID_NDK_API_VERSION}-clang"
 export CXX="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}${ANDROID_NDK_API_VERSION}-clang++"
-# For 32-bit ARM, the compiler is prefixed with armv7a-linux-androideabi
+# https://developer.android.com/ndk/guides/other_build_systems:
+# For 32-bit ARM, the compiler is prefixed with armv7a-linux-androideabi,
+# but the binutils tools are prefixed with arm-linux-androideabi.
 if [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]; then
   export CC="${TOOLCHAIN_PATH}/bin/armv7a-linux-androideabi${ANDROID_NDK_API_VERSION}-clang"
   export CXX="${TOOLCHAIN_PATH}/bin/armv7a-linux-androideabi${ANDROID_NDK_API_VERSION}-clang++"
 fi
-export LD="${TOOLCHAIN_PATH}/bin/ld"
-export NM="${TOOLCHAIN_PATH}/bin/llvm-nm"
-export RANLIB="${TOOLCHAIN_PATH}/bin/llvm-ranlib"
-export READELF="${TOOLCHAIN_PATH}/bin/llvm-readelf"
+export LD="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-ld"
+export NM="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-nm"
+export RANLIB="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-ranlib"
+export READELF="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-readelf"
 
 # Build NSPR
 NSPR_BUILD_DIR=$(mktemp -d)

--- a/libs/build-sqlcipher-android.sh
+++ b/libs/build-sqlcipher-android.sh
@@ -23,16 +23,18 @@ if [[ -d "${DIST_DIR}" ]]; then
   exit 0
 fi
 
-export AR="${TOOLCHAIN_PATH}/bin/llvm-ar"
+export AR="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-ar"
 export CC="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}${ANDROID_NDK_API_VERSION}-clang"
 export CXX="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}${ANDROID_NDK_API_VERSION}-clang++"
-# For 32-bit ARM, the compiler is prefixed with armv7a-linux-androideabi
+# https://developer.android.com/ndk/guides/other_build_systems:
+# For 32-bit ARM, the compiler is prefixed with armv7a-linux-androideabi,
+# but the binutils tools are prefixed with arm-linux-androideabi.
 if [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]; then
   export CC="${TOOLCHAIN_PATH}/bin/armv7a-linux-androideabi${ANDROID_NDK_API_VERSION}-clang"
   export CXX="${TOOLCHAIN_PATH}/bin/armv7a-linux-androideabi${ANDROID_NDK_API_VERSION}-clang++"
 fi
-export LD="${TOOLCHAIN_PATH}/bin/ld"
-export RANLIB="${TOOLCHAIN_PATH}/bin/llvm-ranlib"
+export LD="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-ld"
+export RANLIB="${TOOLCHAIN_PATH}/bin/${TOOLCHAIN}-ranlib"
 
 if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]]
 then

--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /builds/worker/
 ENV ANDROID_BUILD_TOOLS "33.0.0"
 ENV ANDROID_TOOLS_VERSION "8512546"
 ENV ANDROID_PLATFORM_VERSION "32"
-ENV ANDROID_NDK_VERSION "25.1.8937393"
+ENV ANDROID_NDK_VERSION "21.3.6528147"
 
 # Set up the language variables to avoid problems (we run locale-gen later).
 ENV LANG en_US.UTF-8
@@ -132,7 +132,7 @@ RUN curl -sfSL --retry 5 --retry-delay 10 https://dl.google.com/android/reposito
         "build-tools;${ANDROID_BUILD_TOOLS}" \
         "extras;android;m2repository" \
         "extras;google;m2repository" \
-        "ndk;25.1.8937393"
+        "ndk;21.3.6528147"
 
 RUN chown -R worker:worker /builds/worker/android-sdk
 


### PR DESCRIPTION
I tested `v94.3.0` using the `x86_64-33_r06` image and it crashed with the `Unable to load library 'megazord':` error.  Reverting the NDK commit stopped the crash, so I think the hypothesis is correct.

I also reverted my objcopy commit, which I think depended on the NDK upgrade.  I'm building the full CI to confirm this.

This patch is against main, if we merge it I'll cherry pick it into the `v93` branch.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
