### PR TITLE
Fixes name conflict in swift generated code

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,7 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## General
+### What's fixed
+- Fixed a bug released in 94.3.1. The bug broke firefox-ios builds due to a name conflict. ([#5181](https://github.com/mozilla/application-services/pull/5181))

--- a/components/tabs/android/src/main/java/mozilla/appservices/tabs/Guid.kt
+++ b/components/tabs/android/src/main/java/mozilla/appservices/tabs/Guid.kt
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("InvalidPackageDeclaration")
+package mozilla.appservices.remotetabs
+
+// We needed to rename the Rust `TabsGuid` struct to `Guid` in order to circumvent the naming conflict in
+// iOS with the Guid exposed in `places.udl`. But that creates a breaking change for the Android code. So we are aliasing
+// `TabsGuid` back to `Guid` to prevent a breaking change.
+typealias Guid = TabsGuid

--- a/components/tabs/src/lib.rs
+++ b/components/tabs/src/lib.rs
@@ -15,12 +15,12 @@ mod sync;
 uniffi_macros::include_scaffolding!("tabs");
 
 // Our UDL uses a `Guid` type.
-use sync_guid::Guid;
-impl UniffiCustomTypeConverter for Guid {
+use sync_guid::Guid as TabsGuid;
+impl UniffiCustomTypeConverter for TabsGuid {
     type Builtin = String;
 
-    fn into_custom(val: Self::Builtin) -> uniffi::Result<Guid> {
-        Ok(Guid::new(val.as_str()))
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<TabsGuid> {
+        Ok(TabsGuid::new(val.as_str()))
     }
 
     fn from_custom(obj: Self) -> Self::Builtin {

--- a/components/tabs/src/tabs.udl
+++ b/components/tabs/src/tabs.udl
@@ -1,5 +1,5 @@
 [Custom]
-typedef string Guid;
+typedef string TabsGuid;
 
 namespace tabs {
 
@@ -95,7 +95,7 @@ interface TabsBridgedEngine {
     sequence<string> apply();
 
     [Throws=TabsError]
-    void set_uploaded(i64 new_timestamp, sequence<Guid> uploaded_ids);
+    void set_uploaded(i64 new_timestamp, sequence<TabsGuid> uploaded_ids);
 
     [Throws=TabsError]
     void sync_finished();


### PR DESCRIPTION
I noticed that main was broken for iOS today and tracked it to https://github.com/mozilla/application-services/commit/a1168751231ed4e88c44d85f6dccc09c3b412bd2 

This PR fixes that name conflict. We have #4820 for the namespacing problem


cc @skhamis not sure if this has implications on desktop (I don't think so?)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
