### PR TITLE
Fixes missing titles in iOS history migration

### DIFF
--- a/components/places/src/import/ios/history.rs
+++ b/components/places/src/import/ios/history.rs
@@ -142,7 +142,7 @@ lazy_static::lazy_static! {
    "UPDATE main.moz_places
         SET title = ( SELECT t.title
                             FROM temp.iOSHistoryStaging t
-                            WHERE t.url = main.moz_places.url AND t.url_hash = main.moz_places.url_hash )"
+                            WHERE t.url_hash = main.moz_places.url_hash AND t.url = main.moz_places.url )"
     ;
 
    // Insert any missing entries into moz_places that we'll need for this.

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -155,18 +155,6 @@ pub fn apply_observation_direct(
     Ok(visit_row_id)
 }
 
-pub fn update_frecencies(db: &PlacesDb) -> Result<()> {
-    let need_frecency_update = db.query_rows_and_then(
-        "SELECT id FROM moz_places h WHERE h.frecency = -1",
-        [],
-        |r| r.get::<_, RowId>(0),
-    )?;
-    for row in need_frecency_update {
-        update_frecency(db, row, None)?
-    }
-    Ok(())
-}
-
 pub fn update_frecency(db: &PlacesDb, id: RowId, redirect_boost: Option<bool>) -> Result<()> {
     let score = frecency::calculate_frecency(
         db.conn(),

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -155,6 +155,18 @@ pub fn apply_observation_direct(
     Ok(visit_row_id)
 }
 
+pub fn update_frecencies(db: &PlacesDb) -> Result<()> {
+    let need_frecency_update = db.query_rows_and_then(
+        "SELECT id FROM moz_places h WHERE h.frecency = -1",
+        [],
+        |r| r.get::<_, RowId>(0),
+    )?;
+    for row in need_frecency_update {
+        update_frecency(db, row, None)?
+    }
+    Ok(())
+}
+
 pub fn update_frecency(db: &PlacesDb, id: RowId, redirect_boost: Option<bool>) -> Result<()> {
     let score = frecency::calculate_frecency(
         db.conn(),

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -14,7 +14,9 @@ use crate::db::PlacesDb;
 use crate::error::{ErrorKind, InvalidPlaceInfo, Result};
 use crate::ffi::HistoryVisitInfo;
 use crate::ffi::TopFrecentSiteInfo;
+use crate::frecency::{calculate_frecency, DEFAULT_FRECENCY_SETTINGS};
 use crate::types::{SyncStatus, VisitTransition};
+use interrupt_support::SqlInterruptScope;
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::Result as RusqliteResult;
 use rusqlite::Row;
@@ -250,6 +252,61 @@ pub fn run_maintenance(conn: &PlacesDb, db_size_limit: u32) -> Result<RunMainten
         db_size_before,
         db_size_after,
     })
+}
+
+pub fn update_all_frecencies_at_once(db: &PlacesDb, scope: &SqlInterruptScope) -> Result<()> {
+    let tx = db.begin_transaction()?;
+
+    let need_frecency_update = db.query_rows_and_then(
+        "SELECT place_id FROM moz_places_stale_frecencies",
+        [],
+        |r| r.get::<_, i64>(0),
+    )?;
+    scope.err_if_interrupted()?;
+    let frecencies = need_frecency_update
+        .iter()
+        .map(|places_id| {
+            scope.err_if_interrupted()?;
+            Ok((
+                *places_id,
+                calculate_frecency(db, &DEFAULT_FRECENCY_SETTINGS, *places_id, Some(false))?,
+            ))
+        })
+        .collect::<Result<Vec<(i64, i32)>>>()?;
+
+    if frecencies.is_empty() {
+        return Ok(());
+    }
+    // Update all frecencies in one fell swoop
+    db.execute_batch(&format!(
+        "WITH frecencies(id, frecency) AS (
+            VALUES {}
+            )
+            UPDATE moz_places SET
+            frecency = (SELECT frecency FROM frecencies f
+                        WHERE f.id = id)
+            WHERE id IN (SELECT f.id FROM frecencies f)",
+        sql_support::repeat_display(frecencies.len(), ",", |index, f| {
+            let (id, frecency) = frecencies[index];
+            write!(f, "({}, {})", id, frecency)
+        })
+    ))?;
+
+    scope.err_if_interrupted()?;
+
+    // ...And remove them from the stale table.
+    db.execute_batch(&format!(
+        "DELETE FROM moz_places_stale_frecencies
+         WHERE place_id IN ({})",
+        sql_support::repeat_display(frecencies.len(), ",", |index, f| {
+            let (id, _) = frecencies[index];
+            write!(f, "{}", id)
+        })
+    ))?;
+
+    tx.commit()?;
+
+    Ok(())
 }
 
 pub(crate) fn put_meta(db: &PlacesDb, key: &str, value: &dyn ToSql) -> Result<()> {

--- a/testing/separated/places-tests/src/ios_history.rs
+++ b/testing/separated/places-tests/src/ios_history.rs
@@ -233,7 +233,7 @@ fn test_update_missing_title() -> Result<()> {
         } else if visit.url.to_string() == "https://mozilla.org/" {
             assert_eq!(visit.title, Some("Mozilla!".to_string()))
         } else {
-            panic!("Unexpected visit: {}", visit.url.to_string())
+            panic!("Unexpected visit: {}", visit.url)
         }
     }
 
@@ -276,7 +276,7 @@ fn test_update_missing_title() -> Result<()> {
         } else if visit.url.to_string() == "https://mozilla.org/" {
             assert_eq!(visit.title, Some("New Mozilla Title".to_string()))
         } else {
-            panic!("Unexpected visit: {}", visit.url.to_string())
+            panic!("Unexpected visit: {}", visit.url)
         }
     }
 


### PR DESCRIPTION
Fixes the bug where sometimes the titles would be missing.

The issue comes from history metadata. When an item is inserted there, sometimes it's without a title (this is really a bug in the iOS implementation)

However, since we want to re-use `mozplaces` rows, we ended up not updating those rows with new titles. This PR makes sure that we go through any older mozplaces rows that don't have titles and sets them to be the appropriate values
