### PR TITLE
Disable sdk-not-ready-for-feature event (#5185) r=travis

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,8 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Nimbus ⛅️🔬🔭
+
+### What's Changed
+  - Disabled Glean events recorded when the SDK is not ready for a feature ([#5185](https://github.com/mozilla/application-services/pull/5185))

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -25,6 +25,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -461,6 +462,7 @@ class NimbusTests {
     }
 
     @Test
+    @Ignore
     fun `in memory cache not ready logs an event`() {
         // we haven't initialized nimbus at all, it should not log any error, but it should log an
         // event

--- a/components/nimbus/metrics.yaml
+++ b/components/nimbus/metrics.yaml
@@ -125,9 +125,11 @@ nimbus_health:
       feature_id:
         type: string
         description: The feature id of the configuration that was requested
+    disabled: true
     bugs:
       - https://mozilla-hub.atlassian.net/browse/EXP-2689
       - https://mozilla-hub.atlassian.net/browse/EXP-2690
+      - https://mozilla-hub.atlassian.net/browse/EXP-2852
     data_reviews:
       - https://github.com/mozilla/application-services/pull/5091#issuecomment-1218359426
     data_sensitivity:
@@ -144,8 +146,10 @@ nimbus_health:
       feature_id:
         type: string
         description: The feature id of the configuration that was requested
+    disabled: true
     bugs:
       - https://mozilla-hub.atlassian.net/browse/EXP-2743
+      - https://mozilla-hub.atlassian.net/browse/EXP-2852
     data_reviews:
       - https://github.com/mozilla/application-services/pull/5118#issuecomment-1235827006
     data_sensitivity:


### PR DESCRIPTION
For uplift to v94.2.2.

Fixes [EXP-2852](https://mozilla-hub.atlassian.net/browse/EXP-2852).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
