### PR TITLE
Updating UniFFI to 0.21.0

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -23,6 +23,9 @@ Use the template below to make assigning a version number during the release cut
 ### What's fixed
 - Fixed a bug released in 94.3.1. The bug broke firefox-ios builds due to a name conflict. ([#5181](https://github.com/mozilla/application-services/pull/5181))
 
+### What's Changed
+  - Updated UniFFI to 0.21.0.  This improves the string display of the fielded errors on Kotlin.  Currently only logins is using these errors, but we plan to start using them for all components.
+
 ## Nimbus ⛅️🔬🔭
 
 ### What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3661,9 +3661,9 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uniffi"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff9d73a665e4e94d566f069fc0c6b92d13fc7de25ae128dd20402023884b551"
+checksum = "f54af5ada67d1173457a99a7bb44a7917f63e7466764cb4714865c7a6678b830"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3678,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195251b1b0dbb221759ea4d79e3090e5c08a60fc4040c9e945b255def155ea90"
+checksum = "12cc4af3c0180c7e86c4a3acf2b6587af04ba2567b1e948993df10f421796621"
 dependencies = [
  "anyhow",
  "askama 0.11.1",
@@ -3701,9 +3701,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b65ae1c0bac70369bb0d9df6fae578b1ca130bf4cb6203e2636e2d6969dba5"
+checksum = "510287c368a9386eb731ebe824a6fc6c82a105e20d020af1aa20519c1c1561db"
 dependencies = [
  "anyhow",
  "camino",
@@ -3712,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efddfb993c5b394a75042c0d144665388af2ad3db628401ab8f4fb6f6d07e54"
+checksum = "5c8604503caa2cbcf271578dc51ca236d40e3b22e1514ffa2e638e2c39f6ad10"
 dependencies = [
  "bincode",
  "camino",
@@ -3731,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1767e693cbd11fc22c37a4033d82eb9d891c3862e45329b4a891c1d8395df5"
+checksum = "cd9417cc653937681436b93838d8c5f97a5b8c58697813982ee8810bd1dc3b57"
 dependencies = [
  "serde",
 ]

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -22,7 +22,7 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.20"
+uniffi = "^0.21"
 url = { version = "2.2", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -35,4 +35,4 @@ libsqlite3-sys = "0.24.1"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.20", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.21", features = [ "builtin-bindgen" ]}

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,8 +9,8 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = "^0.20"
-uniffi_macros = "^0.20"
+uniffi = "^0.21"
+uniffi_macros = "^0.21"
 
 [build-dependencies]
-uniffi_build = { version = "^0.20", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,11 +24,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.20"
-uniffi_macros = "^0.20"
+uniffi = "^0.21"
+uniffi_macros = "^0.21"
 
 [build-dependencies]
-uniffi_build = { version = "^0.20", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -27,15 +27,15 @@ error-support = { path = "../support/error", features = ["reporting"] }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.20"
-uniffi_macros = "^0.20"
+uniffi = "^0.21"
+uniffi_macros = "^0.21"
 
 [dependencies.rusqlite]
 version = "0.27.0"
 features = ["sqlcipher", "limits", "unlock_notify"]
 
 [build-dependencies]
-uniffi_build = { version = "^0.20", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 more-asserts = "0.2"

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -32,12 +32,12 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "^0.20", optional = true }
+uniffi = { version = "^0.21", optional = true }
 chrono = { version = "0.4", features = ["serde"]}
 unicode-segmentation = "1.8.0"
 
 [build-dependencies]
-uniffi_build = { version = "^0.20", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.21", features = [ "builtin-bindgen" ], optional = true }
 glean-build = { path = "../external/glean/glean-core/build" }
 
 [dev-dependencies]

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -33,8 +33,8 @@ error-support = { path = "../support/error", features = ["reporting"] }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.20"
-uniffi_macros = "^0.20"
+uniffi = "^0.21"
+uniffi_macros = "^0.21"
 
 [dependencies.rusqlite]
 version = "0.27.0"
@@ -46,4 +46,4 @@ tempfile = "3.1"
 env_logger = {version = "0.7", default-features = false}
 
 [build-dependencies]
-uniffi_build = { version = "^0.20", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -20,11 +20,11 @@ viaduct = { path = "../viaduct" }
 sql-support = { path = "../support/sql" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }
 thiserror = "1.0"
-uniffi = "^0.20"
-uniffi_macros = "^0.20"
+uniffi = "^0.21"
+uniffi_macros = "^0.21"
 
 [build-dependencies]
-uniffi_build = { version = "^0.20", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
 
 
 [dev-dependencies]

--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -9,8 +9,8 @@ license = "MPL-2.0"
 log = "0.4"
 lazy_static = { version = "1.4", optional = true }
 parking_lot = { version = ">=0.11,<=0.12", optional = true }
-uniffi = { version = "^0.20", optional = true }
-uniffi_macros = { version = "^0.20", optional = true }
+uniffi = { version = "^0.21", optional = true }
+uniffi_macros = { version = "^0.21", optional = true }
 
 [dependencies.backtrace]
 optional = true
@@ -21,4 +21,4 @@ default = []
 reporting = ["lazy_static", "parking_lot", "uniffi", "uniffi_macros", "uniffi_build"]
 
 [build-dependencies]
-uniffi_build = { version = "^0.20", features=["builtin-bindgen"], optional = true }
+uniffi_build = { version = "^0.21", features=["builtin-bindgen"], optional = true }

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -24,8 +24,8 @@ serde_derive = "1"
 serde_json = "1"
 parking_lot = ">=0.11,<=0.12"
 interrupt-support = { path = "../support/interrupt" }
-uniffi = "^0.20"
-uniffi_macros = "^0.20"
+uniffi = "^0.21"
+uniffi_macros = "^0.21"
 
 [build-dependencies]
-uniffi_build = { version = "^0.20", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -33,8 +33,8 @@ sql-support = { path = "../support/sql" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
-uniffi = ">=0.19.6, <=0.20" # m-c is on 19.6, a-s is on 0.20.0
-uniffi_macros = ">=0.19.6, <=0.20" # m-c is on 19.6, a-s is on 0.20.0
+uniffi = ">=0.20.0, <=0.21" # m-c is on 20.0, a-s is on 0.21.0
+uniffi_macros = ">=0.20.0, <=0.21" # m-c is on 20.0, a-s is on 0.21.0
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [dev-dependencies]
@@ -42,5 +42,5 @@ tempfile = "3.1"
 env_logger = { version = "0.8.0", default-features = false, features = ["termcolor", "atty", "humantime"] }
 
 [build-dependencies]
-# uniffi: m-c is on 19.6, a-s is on 0.20.0
-uniffi_build = { version = ">=0.19.6, <=0.20", features = [ "builtin-bindgen" ]}
+# uniffi: m-c is on 20.0, a-s is on 0.21.0
+uniffi_build = { version = ">=0.20.0, <=0.21", features = [ "builtin-bindgen" ]}

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.20"
+uniffi_bindgen = "^0.21"


### PR DESCRIPTION
This accomplishes a couple things:
  - Improves the Kotlin `message` for fielded errors.  I think we should do this before we merge #5166, which converts all our error types to the fielded-style.
  - Adds support for callback interfaces errors, which we need to support callaback interfaces on desktop.  I'm not sure if it matters, but I don't want our app-services components holding that back.
  
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
