### PR TITLE
Use `Into` trait instead of a new trait for error conversions

### DIFF
--- a/components/logins/src/encryption.rs
+++ b/components/logins/src/encryption.rs
@@ -84,22 +84,16 @@ impl EncryptorDecryptor {
 //     - If it returns false, then the key is no longer valid.  It should be regenerated and the DB
 //       data should be wiped since we can no longer read it properly
 pub fn create_canary(text: &str, key: &str) -> ApiResult<String> {
-    handle_error! {
-        EncryptorDecryptor::new(key)?.encrypt(text)
-    }
+    Ok(EncryptorDecryptor::new(key)?.encrypt(text)?)
 }
 
 pub fn check_canary(canary: &str, text: &str, key: &str) -> ApiResult<bool> {
-    handle_error! {
-        Ok(EncryptorDecryptor::new(key)?.decrypt(canary)? == text)
-    }
+    Ok(EncryptorDecryptor::new(key)?.decrypt(canary)? == text)
 }
 
 pub fn create_key() -> ApiResult<String> {
-    handle_error! {
-        let key = jwcrypto::Jwk::new_direct_key(None)?;
-        Ok(serde_json::to_string(&key)?)
-    }
+    let key = jwcrypto::Jwk::new_direct_key(None)?;
+    Ok(serde_json::to_string(&key)?)
 }
 
 #[cfg(test)]

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -7,8 +7,8 @@ pub type Result<T> = std::result::Result<T, LoginsError>;
 // Functions which are part of the public API should use this Result.
 pub type ApiResult<T> = std::result::Result<T, LoginsStorageError>;
 
-use error_support::ErrorHandling;
-pub use error_support::{breadcrumb, handle_error, report_error};
+pub use error_support::{breadcrumb, report_error};
+use error_support::{expose_error, ErrorHandling};
 use sync15::Error as Sync15Error;
 
 // Errors we return via the public interface.
@@ -184,3 +184,5 @@ impl From<LoginsError> for ErrorHandling<LoginsStorageError> {
         }
     }
 }
+
+expose_error!(LoginsError as LoginsStorageError);

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -30,29 +30,21 @@ pub use crate::sync::LoginsSyncEngine;
 // Public encryption functions.  We publish these as top-level functions to expose them across
 // UniFFI
 fn encrypt_login(login: Login, enc_key: &str) -> ApiResult<EncryptedLogin> {
-    handle_error! {
-        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-        login.encrypt(&encdec)
-    }
+    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+    Ok(login.encrypt(&encdec)?)
 }
 
 fn decrypt_login(login: EncryptedLogin, enc_key: &str) -> ApiResult<Login> {
-    handle_error! {
-        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-        login.decrypt(&encdec)
-    }
+    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+    Ok(login.decrypt(&encdec)?)
 }
 
 fn encrypt_fields(sec_fields: SecureLoginFields, enc_key: &str) -> ApiResult<String> {
-    handle_error! {
-        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-        sec_fields.encrypt(&encdec)
-    }
+    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+    Ok(sec_fields.encrypt(&encdec)?)
 }
 
 fn decrypt_fields(sec_fields: String, enc_key: &str) -> ApiResult<SecureLoginFields> {
-    handle_error! {
-        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-        encdec.decrypt_struct(&sec_fields)
-    }
+    let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
+    Ok(encdec.decrypt_struct(&sec_fields)?)
 }

--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -58,31 +58,29 @@ pub fn migrate_logins(
     // The salt arg is for iOS where the salt is stored externally.
     salt: Option<String>,
 ) -> ApiResult<()> {
-    handle_error! {
-        let path = path.as_ref();
-        let sqlcipher_path = sqlcipher_path.as_ref();
+    let path = path.as_ref();
+    let sqlcipher_path = sqlcipher_path.as_ref();
 
-        // If the sqlcipher db doesn't exist we can't do anything.
-        if !sqlcipher_path.exists() {
-            return Err(LoginsError::InvalidDatabaseFile(
-                sqlcipher_path.to_string_lossy().to_string(),
-            ));
-        }
-
-        // If the target does exist we fail as we don't want to migrate twice.
-        if path.exists() {
-            return Err(LoginsError::MigrationError(
-                "target database already exists".to_string(),
-            ));
-        }
-        migrate_sqlcipher_db_to_plaintext(
-            &sqlcipher_path,
-            &path,
-            sqlcipher_key,
-            new_encryption_key,
-            salt.as_ref(),
-        )
+    // If the sqlcipher db doesn't exist we can't do anything.
+    if !sqlcipher_path.exists() {
+        return Err(LoginsError::InvalidDatabaseFile(
+            sqlcipher_path.to_string_lossy().to_string(),
+        ))?;
     }
+
+    // If the target does exist we fail as we don't want to migrate twice.
+    if path.exists() {
+        return Err(LoginsError::MigrationError(
+            "target database already exists".to_string(),
+        ))?;
+    }
+    Ok(migrate_sqlcipher_db_to_plaintext(
+        &sqlcipher_path,
+        &path,
+        sqlcipher_key,
+        new_encryption_key,
+        salt.as_ref(),
+    )?)
 }
 
 fn migrate_sqlcipher_db_to_plaintext(

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -53,10 +53,8 @@ pub struct LoginStore {
 
 impl LoginStore {
     pub fn new(path: impl AsRef<Path>) -> ApiResult<Self> {
-        handle_error! {
-            let db = Mutex::new(LoginDb::open(path)?);
-            Ok(Self { db })
-        }
+        let db = Mutex::new(LoginDb::open(path)?);
+        Ok(Self { db })
     }
 
     pub fn new_from_db(db: LoginDb) -> Self {
@@ -64,28 +62,20 @@ impl LoginStore {
     }
 
     pub fn new_in_memory() -> ApiResult<Self> {
-        handle_error! {
-            let db = Mutex::new(LoginDb::open_in_memory()?);
-            Ok(Self { db })
-        }
+        let db = Mutex::new(LoginDb::open_in_memory()?);
+        Ok(Self { db })
     }
 
     pub fn list(&self) -> ApiResult<Vec<EncryptedLogin>> {
-        handle_error! {
-            self.db.lock().get_all()
-        }
+        Ok(self.db.lock().get_all()?)
     }
 
     pub fn get(&self, id: &str) -> ApiResult<Option<EncryptedLogin>> {
-        handle_error! {
-            self.db.lock().get_by_id(id)
-        }
+        Ok(self.db.lock().get_by_id(id)?)
     }
 
     pub fn get_by_base_domain(&self, base_domain: &str) -> ApiResult<Vec<EncryptedLogin>> {
-        handle_error! {
-            self.db.lock().get_by_base_domain(base_domain)
-        }
+        Ok(self.db.lock().get_by_base_domain(base_domain)?)
     }
 
     pub fn find_login_to_update(
@@ -93,22 +83,16 @@ impl LoginStore {
         entry: LoginEntry,
         enc_key: &str,
     ) -> ApiResult<Option<Login>> {
-        handle_error! {
-            let encdec = EncryptorDecryptor::new(enc_key)?;
-            self.db.lock().find_login_to_update(entry, &encdec)
-        }
+        let encdec = EncryptorDecryptor::new(enc_key)?;
+        Ok(self.db.lock().find_login_to_update(entry, &encdec)?)
     }
 
     pub fn touch(&self, id: &str) -> ApiResult<()> {
-        handle_error! {
-            self.db.lock().touch(id)
-        }
+        Ok(self.db.lock().touch(id)?)
     }
 
     pub fn delete(&self, id: &str) -> ApiResult<bool> {
-        handle_error! {
-            self.db.lock().delete(id)
-        }
+        Ok(self.db.lock().delete(id)?)
     }
 
     pub fn wipe(&self) -> ApiResult<()> {
@@ -117,61 +101,47 @@ impl LoginStore {
         // sense though.
         // TODO: this is exposed to android-components consumers - we should
         // check if anyone actually calls it.
-        handle_error! {
-            let db = self.db.lock();
-            let scope = db.begin_interrupt_scope()?;
-            db.wipe(&scope)?;
-            Ok(())
-        }
+        let db = self.db.lock();
+        let scope = db.begin_interrupt_scope()?;
+        db.wipe(&scope)?;
+        Ok(())
     }
 
     pub fn wipe_local(&self) -> ApiResult<()> {
-        handle_error! {
-            self.db.lock().wipe_local()?;
-            Ok(())
-        }
+        self.db.lock().wipe_local()?;
+        Ok(())
     }
 
     pub fn reset(self: Arc<Self>) -> ApiResult<()> {
         // Reset should not exist here - all resets should be done via the
         // sync manager. It seems that actual consumers don't use this, but
         // some tests do, so it remains for now.
-        handle_error! {
-            let engine = LoginsSyncEngine::new(Arc::clone(&self))?;
-            engine.do_reset(&EngineSyncAssociation::Disconnected)?;
-            Ok(())
-        }
+        let engine = LoginsSyncEngine::new(Arc::clone(&self))?;
+        engine.do_reset(&EngineSyncAssociation::Disconnected)?;
+        Ok(())
     }
 
     pub fn update(&self, id: &str, entry: LoginEntry, enc_key: &str) -> ApiResult<EncryptedLogin> {
-        handle_error! {
-            let encdec = EncryptorDecryptor::new(enc_key)?;
-            self.db.lock().update(id, entry, &encdec)
-        }
+        let encdec = EncryptorDecryptor::new(enc_key)?;
+        Ok(self.db.lock().update(id, entry, &encdec)?)
     }
 
     pub fn add(&self, entry: LoginEntry, enc_key: &str) -> ApiResult<EncryptedLogin> {
-        handle_error! {
-            let encdec = EncryptorDecryptor::new(enc_key)?;
-            self.db.lock().add(entry, &encdec)
-        }
+        let encdec = EncryptorDecryptor::new(enc_key)?;
+        Ok(self.db.lock().add(entry, &encdec)?)
     }
 
     pub fn add_or_update(&self, entry: LoginEntry, enc_key: &str) -> ApiResult<EncryptedLogin> {
-        handle_error! {
-            let encdec = EncryptorDecryptor::new(enc_key)?;
-            self.db.lock().add_or_update(entry, &encdec)
-        }
+        let encdec = EncryptorDecryptor::new(enc_key)?;
+        Ok(self.db.lock().add_or_update(entry, &encdec)?)
     }
 
     pub fn import_multiple(&self, logins: Vec<Login>, enc_key: &str) -> ApiResult<String> {
-        handle_error! {
-            let encdec = EncryptorDecryptor::new(enc_key)?;
-            self.db.lock().import_multiple(logins, &encdec)?;
-            // We want to return a JSON string to keep API compatability, but the function doesn't
-            // acutally return anything.  Serialize the unit struct for now.
-            Ok(serde_json::to_string(&())?)
-        }
+        let encdec = EncryptorDecryptor::new(enc_key)?;
+        self.db.lock().import_multiple(logins, &encdec)?;
+        // We want to return a JSON string to keep API compatability, but the function doesn't
+        // acutally return anything.  Serialize the unit struct for now.
+        Ok(serde_json::to_string(&())?)
     }
 
     /// A convenience wrapper around sync_multiple.
@@ -187,48 +157,46 @@ impl LoginStore {
         tokenserver_url: String,
         local_encryption_key: String,
     ) -> ApiResult<String> {
-        handle_error! {
-            let mut engine = LoginsSyncEngine::new(Arc::clone(&self))?;
-            engine
-                .set_local_encryption_key(&local_encryption_key)
-                .unwrap();
+        let mut engine = LoginsSyncEngine::new(Arc::clone(&self))?;
+        engine
+            .set_local_encryption_key(&local_encryption_key)
+            .unwrap();
 
-            // This is a bit hacky but iOS still uses sync() and we can only pass strings over ffi
-            // Below was ported from the "C" ffi code that does essentially the same thing
-            let storage_init = &Sync15StorageClientInit {
-                key_id,
-                access_token,
-                tokenserver_url: url::Url::parse(tokenserver_url.as_str())?,
-            };
-            let root_sync_key = &sync15::KeyBundle::from_ksync_base64(sync_key.as_str())?;
+        // This is a bit hacky but iOS still uses sync() and we can only pass strings over ffi
+        // Below was ported from the "C" ffi code that does essentially the same thing
+        let storage_init = &Sync15StorageClientInit {
+            key_id,
+            access_token,
+            tokenserver_url: url::Url::parse(tokenserver_url.as_str())?,
+        };
+        let root_sync_key = &sync15::KeyBundle::from_ksync_base64(sync_key.as_str())?;
 
-            let mut disk_cached_state = engine.get_global_state()?;
-            let mut mem_cached_state = MemoryCachedState::default();
+        let mut disk_cached_state = engine.get_global_state()?;
+        let mut mem_cached_state = MemoryCachedState::default();
 
-            let mut result = sync_multiple(
-                &[&engine],
-                &mut disk_cached_state,
-                &mut mem_cached_state,
-                storage_init,
-                root_sync_key,
-                &engine.scope,
-                None,
-            );
-            // We always update the state - sync_multiple does the right thing
-            // if it needs to be dropped (ie, they will be None or contain Nones etc)
-            engine.set_global_state(&disk_cached_state)?;
+        let mut result = sync_multiple(
+            &[&engine],
+            &mut disk_cached_state,
+            &mut mem_cached_state,
+            storage_init,
+            root_sync_key,
+            &engine.scope,
+            None,
+        );
+        // We always update the state - sync_multiple does the right thing
+        // if it needs to be dropped (ie, they will be None or contain Nones etc)
+        engine.set_global_state(&disk_cached_state)?;
 
-            // for b/w compat reasons, we do some dances with the result.
-            // XXX - note that this means telemetry isn't going to be reported back
-            // to the app - we need to check with lockwise about whether they really
-            // need these failures to be reported or whether we can loosen this.
-            if let Err(e) = result.result {
-                return Err(e.into());
-            }
-            match result.engine_results.remove("passwords") {
-                None | Some(Ok(())) => Ok(serde_json::to_string(&result.telemetry).unwrap()),
-                Some(Err(e)) => Err(e.into()),
-            }
+        // for b/w compat reasons, we do some dances with the result.
+        // XXX - note that this means telemetry isn't going to be reported back
+        // to the app - we need to check with lockwise about whether they really
+        // need these failures to be reported or whether we can loosen this.
+        if let Err(e) = result.result {
+            return Err(e.into());
+        }
+        match result.engine_results.remove("passwords") {
+            None | Some(Ok(())) => Ok(serde_json::to_string(&result.telemetry).unwrap()),
+            Some(Err(e)) => Err(e.into()),
         }
     }
 
@@ -249,9 +217,7 @@ impl LoginStore {
     // our example would link with places and logins etc, and it's not a big
     // deal really.
     pub fn create_logins_sync_engine(self: Arc<Self>) -> ApiResult<Box<dyn SyncEngine>> {
-        handle_error! {
-            Ok(Box::new(LoginsSyncEngine::new(self)?) as Box<dyn SyncEngine>)
-        }
+        Ok(Box::new(LoginsSyncEngine::new(self)?) as Box<dyn SyncEngine>)
     }
 }
 

--- a/components/support/error/src/handling.rs
+++ b/components/support/error/src/handling.rs
@@ -77,7 +77,7 @@ impl<E> ErrorHandling<E> {
 
 /// Handle the specified "internal" error, taking any logging or error
 /// reporting actions and converting the error to the public error.
-/// Called by our `handle_error` macro so needs to be public.
+/// Called by our `expose_error` macro so needs to be public.
 pub fn convert_log_report_error<IE, EE>(e: IE) -> EE
 where
     IE: Into<ErrorHandling<EE>> + std::error::Error,

--- a/components/support/error/src/lib.rs
+++ b/components/support/error/src/lib.rs
@@ -32,7 +32,7 @@ pub use reporting::{
 };
 
 mod handling;
-pub use handling::{convert_log_report_error, ErrorHandling, ErrorReporting, GetErrorHandling};
+pub use handling::{convert_log_report_error, ErrorHandling, ErrorReporting};
 
 /// XXX - Most of this is now considered deprecated - only FxA uses it, and
 /// should be replaced with the facilities in the `handling` module.

--- a/components/support/error/src/macros.rs
+++ b/components/support/error/src/macros.rs
@@ -61,15 +61,14 @@ macro_rules! breadcrumb {
     };
 }
 
-/// Function wrapper macro to convert from a component's internal errors to external errors
-/// and optionally log and report the error.
 #[macro_export]
-macro_rules! handle_error {
-    { $($tt:tt)* } => {
-        let body = || {
-            $($tt)*
-        };
-        let result: Result<_> = body();
-        result.map_err($crate::convert_log_report_error)
-    }
+macro_rules! expose_error {
+    ($internal:ty as $external:ty) => {
+        impl<T: Into<$internal>> From<T> for $external {
+            fn from(e: T) -> Self {
+                let internal_err: $internal = e.into();
+                $crate::convert_log_report_error(internal_err)
+            }
+        }
+    };
 }


### PR DESCRIPTION
A possible small improvement for the error handling work, using `Into<ErrorHandling<ExternalError>>` instead of a new `GetErrorHandling` trait

Thoughts?

(This could be useful because with this, and removing the `reporting` feature, we can probably completely get rid of  the `convert_log_report_error` function and inline it in the macros!)
