### PR TITLE
Refactor autofill so it doesn't lean as heavily on sync15::Payload

### DIFF
--- a/components/autofill/src/db/credit_cards.rs
+++ b/components/autofill/src/db/credit_cards.rs
@@ -556,7 +556,7 @@ pub(crate) mod tests {
 
         // create a mirror record to check that a tombstone record is created upon deletion
         let cc2_guid = saved_credit_card2.guid.clone();
-        let payload = saved_credit_card2.into_payload(&encdec).expect("is json");
+        let payload = saved_credit_card2.into_sync_payload(&encdec);
 
         test_insert_mirror_record(&db, payload);
 

--- a/components/autofill/src/sync/engine.rs
+++ b/components/autofill/src/sync/engine.rs
@@ -240,6 +240,13 @@ mod tests {
     use crate::encryption::EncryptorDecryptor;
     use sql_support::ConnExt;
 
+    impl InternalCreditCard {
+        pub fn into_sync_payload(self, encdec: &EncryptorDecryptor) -> sync15::Payload {
+            sync15::Payload::from_record(self.into_payload(encdec).expect("is json"))
+                .expect("can get sync payload")
+        }
+    }
+
     // We use the credit-card engine here.
     fn create_engine() -> ConfigSyncEngine<InternalCreditCard> {
         let store = crate::db::store::Store::new_memory();
@@ -335,7 +342,7 @@ mod tests {
             let tx = db.writer.unchecked_transaction()?;
             // create a normal record, a mirror record and a tombstone.
             add_internal_credit_card(&tx, &cc)?;
-            test_insert_mirror_record(&tx, cc.clone().into_payload(&encdec).expect("is json"));
+            test_insert_mirror_record(&tx, cc.clone().into_sync_payload(&encdec));
             insert_tombstone_record(&tx, Guid::random().to_string())?;
             tx.commit()?;
         }
@@ -387,7 +394,7 @@ mod tests {
             // re-populating the tables
             let tx = conn.unchecked_transaction()?;
             add_internal_credit_card(&tx, &cc)?;
-            test_insert_mirror_record(&tx, cc.into_payload(&encdec).expect("is json"));
+            test_insert_mirror_record(&tx, cc.into_sync_payload(&encdec));
             insert_tombstone_record(&tx, Guid::random().to_string())?;
             tx.commit()?;
         }

--- a/components/autofill/src/sync/mod.rs
+++ b/components/autofill/src/sync/mod.rs
@@ -21,12 +21,15 @@ use types::Timestamp;
 // for sync in various ways - and one non-obvious way is that the tables that
 // store sync payloads can't just store them directly as they are not encrypted
 // in that form.
-// So this type abstracts that away - addresses will just store the json version
-// of the payload, where credit-cards will store an encrypted version.
-struct PersistablePayload {
-    guid: Guid,
-    payload: String,
-}
+// ie, in the database, an address record's "payload" column looks like:
+// > '{"entry":{"address-level1":"VIC", "street-address":"2/25 Somewhere St","timeCreated":1497567116554, "version":1},"id":"29ac67adae7d"}'
+// or a tombstone: '{"deleted":true,"id":"6544992973e6"}'
+// > (Note a number of fields have been removed from 'entry' for clarity)
+// and in the database a credit-card's "payload" looks like:
+// > 'eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0..<snip>-<snip>.<snip lots more>'
+// > while a tombstone here remains encrypted but has the 'deleted' entry after decryption.
+// (Note also that the address entry, and the decrypted credit-card json both have an "id" in
+// the JSON, but we ignore that when deserializing and will stop persisting that soon)
 
 // Some traits that help us abstract away much of the sync functionality.
 
@@ -179,6 +182,13 @@ impl Metadata {
 // An "incoming" record can be in only 2 states.
 #[derive(Debug)]
 enum IncomingRecord<T> {
+    Record { record: T },
+    Tombstone { guid: Guid },
+}
+
+// Ditto for outgoing - either a record or a tombstone
+#[derive(Debug)]
+enum OutgoingRecord<T> {
     Record { record: T },
     Tombstone { guid: Guid },
 }


### PR DESCRIPTION
We used to convert from sync15::Payload into (eg) AddressPayload, then finally into InternalAddress as late as possible. We now convert into the AddressPayload much earlier, so sync15::Payload doesn't bleed as far into the implementations.

Also deletes `PersistablePayload` as it was just an extra layer of confusion for no good reason.

Helps on the path to #5139. No hurry on this at all.
