### PR TITLE
Update tabs to use uniffi v0.v21

### DIFF
--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -33,8 +33,8 @@ sql-support = { path = "../support/sql" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
-uniffi = ">=0.20.0, <=0.21" # m-c is on 20.0, a-s is on 0.21.0
-uniffi_macros = ">=0.20.0, <=0.21" # m-c is on 20.0, a-s is on 0.21.0
+uniffi = "^0.21"
+uniffi_macros = "^0.21"
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [dev-dependencies]
@@ -42,5 +42,4 @@ tempfile = "3.1"
 env_logger = { version = "0.8.0", default-features = false, features = ["termcolor", "atty", "humantime"] }
 
 [build-dependencies]
-# uniffi: m-c is on 20.0, a-s is on 0.21.0
-uniffi_build = { version = ">=0.20.0, <=0.21", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.21", features = [ "builtin-bindgen" ]}


### PR DESCRIPTION
Now that mozilla-central uses uniffi v0.21 https://phabricator.services.mozilla.com/D159689 via Glean update https://bugzilla.mozilla.org/show_bug.cgi?id=1796087. We should remove the hack in tabs so we can land https://bugzilla.mozilla.org/show_bug.cgi?id=1791851

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
