### PR TITLE
Update AC and Gradle Protobuf plugin to latest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         kotlin_coroutines_version = '1.6.4'
         jna_version = '5.12.1'
         android_gradle_plugin_version = '7.3.0'
-        android_components_version = '106.0.3'
+        android_components_version = '107.0.2'
         glean_version = '51.2.0'
 
         // NOTE: AndroidX libraries should be synced with AC to avoid compatibility issues
@@ -25,7 +25,7 @@ buildscript {
         rust_android_gradle_version = '0.9.3'
         espresso_core_version = '3.4.0'
         protobuf_version = '3.21.7'
-        gradle_protobuf_version = '0.8.19'
+        gradle_protobuf_version = '0.9.1'
     }
 
     ext.build = [


### PR DESCRIPTION
I left Glean alone for now, but do we want to pick up a newer release at some point?