### PR TITLE
Added method to unset the error reporter

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,7 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+
+# General
+  - Added function to unset the app-services error reporter

--- a/components/support/error/src/errorsupport.udl
+++ b/components/support/error/src/errorsupport.udl
@@ -4,6 +4,7 @@
 
 namespace errorsupport {
     void set_application_error_reporter(ApplicationErrorReporter error_reporter);
+    void unset_application_error_reporter();
 };
 
 callback interface ApplicationErrorReporter {

--- a/components/support/error/src/lib.rs
+++ b/components/support/error/src/lib.rs
@@ -27,7 +27,7 @@ pub mod backtrace {
 mod reporting;
 pub use reporting::{
     report_breadcrumb, report_error_to_app, set_application_error_reporter,
-    ApplicationErrorReporter,
+    unset_application_error_reporter, ApplicationErrorReporter,
 };
 
 mod handling;

--- a/components/support/error/src/reporting.rs
+++ b/components/support/error/src/reporting.rs
@@ -53,6 +53,10 @@ pub fn set_application_error_reporter(reporter: Box<dyn ApplicationErrorReporter
     *APPLICATION_ERROR_REPORTER.write() = reporter;
 }
 
+pub fn unset_application_error_reporter() {
+    *APPLICATION_ERROR_REPORTER.write() = Box::new(DefaultApplicationErrorReporter)
+}
+
 pub fn report_error_to_app(type_name: String, message: String) {
     APPLICATION_ERROR_REPORTER
         .read()


### PR DESCRIPTION
As part of the UniFFI Desktop callback interface review, we were asked to provide a way to drop callback interfaces on shutdown to break up the reference cycles.

I didn't add any tests for this since it seemed fairly trivial.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ac: android-components-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
