### PR TITLE
Attempt to switch AC builds to firefox-android repo [ac: main] [fenix: main]

### DIFF
--- a/taskcluster/app_services_taskgraph/transforms/branch_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/branch_build.py
@@ -128,7 +128,7 @@ def setup_android_components(task, branch_build_params):
     task['run']['pre-gradlew'].extend([
         ['rsync', '-a', '/builds/worker/fetches/.m2/', '/builds/worker/.m2/'],
         setup_branch_build_command_line(branch_build_params, setup_fenix=False),
-        ['cd', 'android-components'],
+        ['cd', 'firefox-android/android-components'],
         ['git', 'rev-parse', '--short', 'HEAD'],
         # Building this up-front seems to make the build more stable.  I think
         # having multiple components all try to execute the

--- a/taskcluster/scripts/setup-branch-build.py
+++ b/taskcluster/scripts/setup-branch-build.py
@@ -33,7 +33,7 @@ def parse_args():
     return parser.parse_args()
 
 def android_components_repo(args):
-    return f'https://github.com/{args.android_components_owner}/android-components'
+    return f'https://github.com/{args.android_components_owner}/firefox-android'
 
 def fenix_repo(args):
     return f'https://github.com/{args.fenix_owner}/fenix'


### PR DESCRIPTION
The canonical home for AC is now the firefox-android repo. We should switch over to that.