### PR TITLE
Be more careful with URL redaction

### DIFF
--- a/components/support/error/src/redact.rs
+++ b/components/support/error/src/redact.rs
@@ -4,9 +4,37 @@
 
 //! Functions to redact strings to remove PII before logging them
 
-/// Redact a URL, replacing all characters other than [`:`, `/`] with `x`
+/// Redact a URL.
+///
+/// It's tricky to redact an URL without revealing PII.  We check for various known bad URL forms
+/// and report them, otherwise we just log "<URL>".
 pub fn redact_url(url: &str) -> String {
-    url.replace(|ch| ch != ':' && ch != '/', "x")
+    if url.is_empty() {
+        return "<URL (empty)>".to_string();
+    }
+    match url.find(':') {
+        None => "<URL (no scheme)>".to_string(),
+        Some(n) => {
+            let mut chars = url[0..n].chars();
+            match chars.next() {
+                // No characters in the scheme
+                None => return "<URL (empty scheme)>".to_string(),
+                Some(c) => {
+                    // First character must be alphabetic
+                    if !c.is_ascii_alphabetic() {
+                        return "<URL (invalid scheme)>".to_string();
+                    }
+                }
+            }
+            for c in chars {
+                // Subsequent characters must be in the set ( alpha | digit | "+" | "-" | "." )
+                if !(c.is_ascii_alphanumeric() || c == '+' || c == '-' || c == '.') {
+                    return "<URL (invalid scheme)>".to_string();
+                }
+            }
+            "<URL>".to_string()
+        }
+    }
 }
 
 /// Redact compact jwe string (Five base64 segments, separated by `.` chars)
@@ -20,13 +48,23 @@ mod test {
 
     #[test]
     fn test_redact_url() {
+        assert_eq!(redact_url("http://some.website.com/index.html"), "<URL>");
+        assert_eq!(redact_url("about:config"), "<URL>");
+        assert_eq!(redact_url(""), "<URL (empty)>");
+        assert_eq!(redact_url("://some.website.com/"), "<URL (empty scheme)>");
+        assert_eq!(redact_url("some.website.com/"), "<URL (no scheme)>");
+        assert_eq!(redact_url("some.website.com/"), "<URL (no scheme)>");
         assert_eq!(
-            redact_url("http://some.website.com/index.html"),
-            "xxxx://xxxxxxxxxxxxxxxx/xxxxxxxxxx"
+            redact_url("abc%@=://some.website.com/"),
+            "<URL (invalid scheme)>"
         );
         assert_eq!(
-            redact_url("http://some.website.com:8000/foo/bar/baz"),
-            "xxxx://xxxxxxxxxxxxxxxx:xxxx/xxx/xxx/xxx"
+            redact_url("0https://some.website.com/"),
+            "<URL (invalid scheme)>"
+        );
+        assert_eq!(
+            redact_url("a+weird-but.lega1-SCHEME://some.website.com/"),
+            "<URL>"
         );
     }
 


### PR DESCRIPTION
I thought that the initial scheme was what Desktop used, but that was just wrong.  If we're going to be using a new method, then let's be extremely careful about any potential PII leaks.

The initial scheme potentially leaked PII, since URLs with many path segments would have a relatively unique redacted version.  Therefore if you had a known URL in mind like that, you could compare the redacted string to the redacted versions of the URLs in the Sentry breadcrumbs and potentially determine that it was likely the user visited the URL.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
