### PR TITLE
Add an PRAGMA for `busy_timeout`

### DIFF
--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -83,7 +83,11 @@ impl ConnectionInitializer for PlacesInitializer {
 
             -- How often to autocheckpoint (in units of pages).
             -- 2048000 (our max desired WAL size) / 32760 (page size).
-            PRAGMA wal_autocheckpoint=62
+            PRAGMA wal_autocheckpoint=62;
+
+            -- How long to wait for a lock before returning SQLITE_BUSY (in ms)
+            -- See `doc/sql_concurrency.md` for details.
+            PRAGMA busy_timeout = 5000;
         ";
         conn.execute_batch(initial_pragmas)?;
         define_functions(conn, self.api_id)?;


### PR DESCRIPTION
We have a lot of code to handle contention between transactions, so it seems good to explicitly set it rather than rely on the default.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
