### PR TITLE
Update where mac cross compiler fetches precompiled NSS [ci full][ff-android: main][fenix: main]

### DIFF
--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -23,6 +23,12 @@ pub enum LinkingKind {
 pub struct NoNssDir;
 
 pub fn link_nss() -> Result<(), NoNssDir> {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    println!(
+        "(link_nss) target_arch: {}, target_os: {}",
+        target_arch, target_os
+    );
     let is_gecko = env::var_os("MOZ_TOPOBJDIR").is_some();
     if !is_gecko {
         let (lib_dir, include_dir) = get_nss()?;
@@ -114,12 +120,13 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
             // Hardware specific libs.
             let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
             let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-            // https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#278-296
+            // https://searchfox.org/nss/rev/0d5696b3edce5124353f03159d2aa15549db8306/lib/freebl/freebl.gyp#508-542
             if target_arch == "arm" || target_arch == "aarch64" {
                 static_libs.push("armv8_c_lib");
             }
             if target_arch == "x86_64" || target_arch == "x86" {
                 static_libs.push("gcm-aes-x86_c_lib");
+                static_libs.push("sha-x86_c_lib");
             }
             if target_arch == "arm" {
                 static_libs.push("gcm-aes-arm32-neon_c_lib")
@@ -141,6 +148,9 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
                     static_libs.push("intel-gcm-s_lib");
                 }
             }
+            if (target_os == "macos") && (target_arch == "x86_64") {
+                static_libs.push("pkixtop");
+            }
             static_libs
         }
         LinkingKind::Dynamic { folded_libs } => {
@@ -155,11 +165,23 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
 
 pub fn env(name: &str) -> Option<OsString> {
     println!("cargo:rerun-if-env-changed={}", name);
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    println!(
+        "(env) target_arch: {}, target_os: {}",
+        target_arch, target_os
+    );
     env::var_os(name)
 }
 
 pub fn env_str(name: &str) -> Option<String> {
     println!("cargo:rerun-if-env-changed={}", name);
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    println!(
+        "(env_str) target_arch: {}, target_os: {}",
+        target_arch, target_os
+    );
     env::var(name).ok()
 }
 

--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -142,22 +142,6 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
                     static_libs.push("intel-gcm-s_lib");
                 }
             }
-            // We need this due to using the NSS CI, which enables PKIX lib by default
-            // However this is only used for Macs testing android on desktop
-            // https://searchfox.org/mozilla-central/source/security/nss/lib/libpkix/libpkix.gyp#15-25
-            if (target_os == "macos") && (target_arch == "x86_64") {
-                static_libs.push("pkixcertsel");
-                static_libs.push("pkixchecker");
-                static_libs.push("pkixcrlsel");
-                static_libs.push("pkixparams");
-                static_libs.push("pkixresults");
-                static_libs.push("pkixstore");
-                static_libs.push("pkixtop");
-                static_libs.push("pkixutil");
-                static_libs.push("pkixmodule");
-                static_libs.push("pkixpki");
-                static_libs.push("pkixsystem");
-            }
             static_libs
         }
         LinkingKind::Dynamic { folded_libs } => {

--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -23,12 +23,6 @@ pub enum LinkingKind {
 pub struct NoNssDir;
 
 pub fn link_nss() -> Result<(), NoNssDir> {
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    println!(
-        "(link_nss) target_arch: {}, target_os: {}",
-        target_arch, target_os
-    );
     let is_gecko = env::var_os("MOZ_TOPOBJDIR").is_some();
     if !is_gecko {
         let (lib_dir, include_dir) = get_nss()?;
@@ -148,8 +142,21 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
                     static_libs.push("intel-gcm-s_lib");
                 }
             }
+            // We need this due to using the NSS CI, which enables PKIX lib by default
+            // However this is only used for Macs testing android on desktop
+            // https://searchfox.org/mozilla-central/source/security/nss/lib/libpkix/libpkix.gyp#15-25
             if (target_os == "macos") && (target_arch == "x86_64") {
+                static_libs.push("pkixcertsel");
+                static_libs.push("pkixchecker");
+                static_libs.push("pkixcrlsel");
+                static_libs.push("pkixparams");
+                static_libs.push("pkixresults");
+                static_libs.push("pkixstore");
                 static_libs.push("pkixtop");
+                static_libs.push("pkixutil");
+                static_libs.push("pkixmodule");
+                static_libs.push("pkixpki");
+                static_libs.push("pkixsystem");
             }
             static_libs
         }
@@ -165,23 +172,11 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
 
 pub fn env(name: &str) -> Option<OsString> {
     println!("cargo:rerun-if-env-changed={}", name);
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    println!(
-        "(env) target_arch: {}, target_os: {}",
-        target_arch, target_os
-    );
     env::var_os(name)
 }
 
 pub fn env_str(name: &str) -> Option<String> {
     println!("cargo:rerun-if-env-changed={}", name);
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    println!(
-        "(env_str) target_arch: {}, target_os: {}",
-        target_arch, target_os
-    );
     env::var(name).ok()
 }
 

--- a/components/support/sql/build.rs
+++ b/components/support/sql/build.rs
@@ -8,17 +8,10 @@
 //! Work around the fact that `sqlcipher` might get enabled by a cargo feature
 //! another crate in the workspace needs, without setting up nss. (This is a
 //! gross hack).
-use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     // If NSS_DIR isn't set, we don't really care, ignore the Err case.
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
-    println!(
-        "(sql) target_arch: {}, target_os: {}",
-        target_arch, target_os
-    );
     let _ = nss_build_common::link_nss();
 }

--- a/components/support/sql/build.rs
+++ b/components/support/sql/build.rs
@@ -8,10 +8,17 @@
 //! Work around the fact that `sqlcipher` might get enabled by a cargo feature
 //! another crate in the workspace needs, without setting up nss. (This is a
 //! gross hack).
+use std::env;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     // If NSS_DIR isn't set, we don't really care, ignore the Err case.
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+    println!(
+        "(sql) target_arch: {}, target_os: {}",
+        target_arch, target_os
+    );
     let _ = nss_build_common::link_nss();
 }

--- a/libs/build-all-ios.sh
+++ b/libs/build-all-ios.sh
@@ -64,6 +64,7 @@ universal_lib "nss" "libssl.a" "${TARGET_ARCHS[@]}"
 universal_lib "nss" "libhw-acc-crypto-avx.a" "x86_64"
 universal_lib "nss" "libhw-acc-crypto-avx2.a" "x86_64"
 universal_lib "nss" "libgcm-aes-x86_c_lib.a" "x86_64"
+universal_lib "nss" "libsha-x86_c_lib.a" "x86_64"
 universal_lib "nss" "libgcm-aes-aarch64_c_lib.a" "arm64"
 universal_lib "nss" "libarmv8_c_lib.a" "arm64"
 

--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -5,10 +5,10 @@ set -euvx
 SQLCIPHER_VERSION="4.5.2"
 SQLCIPHER_SHA256="6925f012deb5582e39761a7d4816883cc15b41851a8e70b447c223b8ef406e2a"
 
-NSS="nss-3.85"
-NSS_ARCHIVE="nss-3.85-with-nspr-4.35.tar.gz"
-NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_85_RTM/src/${NSS_ARCHIVE}"
-NSS_SHA256="6d897db1c32de761205440e9fe9fd27dedb1c460c9eea8d2c97b925e37eed49a"
+NSS="nss-3.86"
+NSS_ARCHIVE="nss-3.86-with-nspr-4.35.tar.gz"
+NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_86_RTM/src/${NSS_ARCHIVE}"
+NSS_SHA256="8b5a2e9e3d632a78ad4d9c8d2ea502d2790d7a8e7b1986d173107232eca27432"
 
 # End of configuration.
 

--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -5,10 +5,10 @@ set -euvx
 SQLCIPHER_VERSION="4.5.2"
 SQLCIPHER_SHA256="6925f012deb5582e39761a7d4816883cc15b41851a8e70b447c223b8ef406e2a"
 
-NSS="nss-3.66"
-NSS_ARCHIVE="nss-3.66-with-nspr-4.30.tar.gz"
-NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_66_RTM/src/${NSS_ARCHIVE}"
-NSS_SHA256="4eb72ca78b497a2a425139fdcfb9068cbd318dd51542baaa5365fcfbcb165009"
+NSS="nss-3.85"
+NSS_ARCHIVE="nss-3.85-with-nspr-4.35.tar.gz"
+NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_85_RTM/src/${NSS_ARCHIVE}"
+NSS_SHA256="6d897db1c32de761205440e9fe9fd27dedb1c460c9eea8d2c97b925e37eed49a"
 
 # End of configuration.
 

--- a/libs/build-nss-android.sh
+++ b/libs/build-nss-android.sh
@@ -112,9 +112,10 @@ cp -p -L "${BUILD_DIR}/lib/libsmime.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libsoftokn_static.a" "${DIST_DIR}/lib"
 cp -p -L "${BUILD_DIR}/lib/libssl.a" "${DIST_DIR}/lib"
 # HW specific.
-# https://searchfox.org/nss/rev/08c4d05078d00089f8d7540651b0717a9d66f87e/lib/freebl/freebl.gyp#278-296
+# https://searchfox.org/nss/rev/0d5696b3edce5124353f03159d2aa15549db8306/lib/freebl/freebl.gyp#508-542
 if [[ "${TOOLCHAIN}" == "i686-linux-android" ]] || [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libsha-x86_c_lib.a" "${DIST_DIR}/lib"
 fi
 if [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]] || [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -58,10 +58,10 @@ fi
 # https://github.com/mozilla/application-services/issues/962
 if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   # Generated from nss-try@111b54aaa644978464bec98848ecba6f69d3f42e.
-  curl -sfSL --retry 5 --retry-delay 10 -O "https://fxa-dev-bucket.s3-us-west-2.amazonaws.com/a-s/nss_nspr_static_3.66_darwin.tar.bz2"
-  SHA256="2ad7c85b7b009120c7e883ccd367bbd3653857a4ed3adb4c5471b197d1844141"
-  echo "${SHA256}  nss_nspr_static_3.66_darwin.tar.bz2" | shasum -a 256 -c - || exit 2
-  tar xvjf nss_nspr_static_3.66_darwin.tar.bz2 && rm -rf nss_nspr_static_3.66_darwin.tar.bz2
+  curl -sfSL --retry 5 --retry-delay 10 -O "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/xSE_Od-YToytpjnPT-gCpQ/runs/0/artifacts/public/dist.tar.bz2"
+  SHA256="3b2d84122fce109db840bd916c923ca91413bd7d9ab7c632bde0df19c9d1ff9c"
+  echo "${SHA256}  dist.tar.bz2" | shasum -a 256 -c - || exit 2
+  tar xvjf dist.tar.bz2 && rm -rf dist.tar.bz2
   NSS_DIST_DIR=$(abspath "dist")
 elif [[ "$(uname -s)" == "Darwin" ]] || [[ "$(uname -s)" == "Linux" ]]; then
   "${NSS_SRC_DIR}"/nss/build.sh \
@@ -110,6 +110,7 @@ else
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libhw-acc-crypto-avx.a" "${DIST_DIR}/lib"
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libhw-acc-crypto-avx2.a" "${DIST_DIR}/lib"
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libsha-x86_c_lib.a" "${DIST_DIR}/lib"
 fi
 # https://searchfox.org/mozilla-central/rev/1eb05019f47069172ba81a6c108a584a409a24ea/security/nss/lib/freebl/freebl.gyp#224-233
 if [[ "${TARGET_OS}" == "windows" ]] || [[ "${TARGET_OS}" == "linux" ]]; then
@@ -119,6 +120,11 @@ if [[ "${TARGET_OS}" == "windows" ]] || [[ "${TARGET_OS}" == "linux" ]]; then
     cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libintel-gcm-s_lib.a" "${DIST_DIR}/lib"
   fi
 fi
+
+# Since NSS CI uses -enable_pkix=1
+if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixtop.a" "${DIST_DIR}/lib"
+fi 
 
 cp -p -L -R "${NSS_DIST_DIR}/public/nss/"* "${DIST_DIR}/include/nss"
 cp -p -L -R "${NSS_DIST_OBJ_DIR}/include/nspr/"* "${DIST_DIR}/include/nss"

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -121,9 +121,21 @@ if [[ "${TARGET_OS}" == "windows" ]] || [[ "${TARGET_OS}" == "linux" ]]; then
   fi
 fi
 
-# Since NSS CI uses -enable_pkix=1
+# Since NSS CI enables PKIX by default, we need to copy these libs over
+# This is only used by macs running android tests on desktop
+# https://searchfox.org/mozilla-central/source/security/nss/lib/libpkix/libpkix.gyp#15-25
 if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixcertsel.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixchecker.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixcrlsel.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixparams.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixresults.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixstore.a" "${DIST_DIR}/lib"
   cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixtop.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixutil.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixmodule.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixpki.a" "${DIST_DIR}/lib"
+  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixsystem.a" "${DIST_DIR}/lib"
 fi 
 
 cp -p -L -R "${NSS_DIST_DIR}/public/nss/"* "${DIST_DIR}/include/nss"

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -54,12 +54,12 @@ if [[ -d "${DIST_DIR}" ]]; then
   exit 0
 fi
 
-# TODO We do not know how to cross compile these, so we cheat by downloading them and the how is pretty disgusting.
+# We do not know how to cross compile these, so we pull pre-built versions from NSS CI
 # https://github.com/mozilla/application-services/issues/962
 if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
-  # Generated from nss-try@111b54aaa644978464bec98848ecba6f69d3f42e.
-  curl -sfSL --retry 5 --retry-delay 10 -O "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/xSE_Od-YToytpjnPT-gCpQ/runs/0/artifacts/public/dist.tar.bz2"
-  SHA256="3b2d84122fce109db840bd916c923ca91413bd7d9ab7c632bde0df19c9d1ff9c"
+  #https://treeherder.mozilla.org/jobs?repo=nss&revision=3ab9260101b1a0d5c3d709ba45975f7e4a9d0077
+  curl -sfSL --retry 5 --retry-delay 10 -O "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/op7XqxH-T1WN3Ob8N9cDHA/runs/0/artifacts/public/dist.tar.bz2"
+  SHA256="f90c29611de1d8f84c6eac382938da5849d3ea5e1487cf2a230947693f09aa89"
   echo "${SHA256}  dist.tar.bz2" | shasum -a 256 -c - || exit 2
   tar xvjf dist.tar.bz2 && rm -rf dist.tar.bz2
   NSS_DIST_DIR=$(abspath "dist")
@@ -120,23 +120,6 @@ if [[ "${TARGET_OS}" == "windows" ]] || [[ "${TARGET_OS}" == "linux" ]]; then
     cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libintel-gcm-s_lib.a" "${DIST_DIR}/lib"
   fi
 fi
-
-# Since NSS CI enables PKIX by default, we need to copy these libs over
-# This is only used by macs running android tests on desktop
-# https://searchfox.org/mozilla-central/source/security/nss/lib/libpkix/libpkix.gyp#15-25
-if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixcertsel.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixchecker.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixcrlsel.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixparams.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixresults.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixstore.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixtop.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixutil.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixmodule.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixpki.a" "${DIST_DIR}/lib"
-  cp -p -L "${NSS_DIST_OBJ_DIR}/lib/libpkixsystem.a" "${DIST_DIR}/lib"
-fi 
 
 cp -p -L -R "${NSS_DIST_DIR}/public/nss/"* "${DIST_DIR}/include/nss"
 cp -p -L -R "${NSS_DIST_OBJ_DIR}/include/nspr/"* "${DIST_DIR}/include/nss"

--- a/libs/build-nss-ios.sh
+++ b/libs/build-nss-ios.sh
@@ -106,6 +106,7 @@ if [[ "${ARCH}" == "x86_64" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-x86_c_lib.a" "${DIST_DIR}/lib"
   cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx.a" "${DIST_DIR}/lib"
   cp -p -L "${BUILD_DIR}/lib/libhw-acc-crypto-avx2.a" "${DIST_DIR}/lib"
+  cp -p -L "${BUILD_DIR}/lib/libsha-x86_c_lib.a" "${DIST_DIR}/lib"
 elif [[ "${ARCH}" == "arm64" ]]; then
   cp -p -L "${BUILD_DIR}/lib/libgcm-aes-aarch64_c_lib.a" "${DIST_DIR}/lib"
   cp -p -L "${BUILD_DIR}/lib/libarmv8_c_lib.a" "${DIST_DIR}/lib"

--- a/libs/build-sqlcipher-android.sh
+++ b/libs/build-sqlcipher-android.sh
@@ -102,7 +102,7 @@ LIBS="\
 "
 
 if [[ "${TOOLCHAIN}" == "x86_64-linux-android" ]] || [[ "${TOOLCHAIN}" == "i686-linux-android" ]]; then
-  LIBS="${LIBS} -lgcm-aes-x86_c_lib"
+  LIBS="${LIBS} -lgcm-aes-x86_c_lib -lsha-x86_c_lib"
 fi
 if [[ "${TOOLCHAIN}" == "arm-linux-androideabi" ]] || [[ "${TOOLCHAIN}" == "aarch64-linux-android" ]]; then
   LIBS="${LIBS} -larmv8_c_lib"

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -147,8 +147,6 @@ if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   # See https://searchfox.org/mozilla-central/rev/8848b9741fc4ee4e9bc3ae83ea0fc048da39979f/build/macosx/cross-mozconfig.common#12-13.
   export LD_LIBRARY_PATH=/tmp/clang/lib
 
-  LIBS="${LIBS} -lpkixtop"
-
   "${SQLCIPHER_SRC_DIR}/configure" \
     --with-pic \
     --disable-shared \

--- a/libs/build-sqlcipher-desktop.sh
+++ b/libs/build-sqlcipher-desktop.sh
@@ -113,7 +113,7 @@ elif [[ "${TARGET_OS}" == "linux" ]]; then
 elif [[ "${TARGET_ARCH}" == "aarch64" ]]; then
   LIBS="${LIBS} -lgcm-aes-aarch64_c_lib -larmv8_c_lib"
 else
-  LIBS="${LIBS} -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 -lgcm-aes-x86_c_lib"
+  LIBS="${LIBS} -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 -lgcm-aes-x86_c_lib -lsha-x86_c_lib"
 fi
 
 BUILD_DIR=$(mktemp -d)
@@ -146,6 +146,8 @@ if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
 
   # See https://searchfox.org/mozilla-central/rev/8848b9741fc4ee4e9bc3ae83ea0fc048da39979f/build/macosx/cross-mozconfig.common#12-13.
   export LD_LIBRARY_PATH=/tmp/clang/lib
+
+  LIBS="${LIBS} -lpkixtop"
 
   "${SQLCIPHER_SRC_DIR}/configure" \
     --with-pic \

--- a/libs/build-sqlcipher-ios.sh
+++ b/libs/build-sqlcipher-ios.sh
@@ -112,7 +112,7 @@ LIBS="\
 "
 
 if [[ "${ARCH}" == "x86_64" ]]; then
-  LIBS="${LIBS} -lgcm-aes-x86_c_lib -lhw-acc-crypto-avx -lhw-acc-crypto-avx2"
+  LIBS="${LIBS} -lgcm-aes-x86_c_lib -lhw-acc-crypto-avx -lhw-acc-crypto-avx2 -lsha-x86_c_lib"
 else
   LIBS="${LIBS} -lgcm-aes-aarch64_c_lib -larmv8_c_lib"
 fi


### PR DESCRIPTION
- Updating NSS using the [NSS CI](https://treeherder.mozilla.org/jobs?repo=nss), which now has static builds https://phabricator.services.mozilla.com/D162252
- Updated NSS to 3.85, since that is the first build that has my patch from above (and also probably good to do)
- Remove pulling from the S3 bucket (simplifies our NSS process)

One "unfortunate" thing is that NSS CI builds by default with `PKIX` lib enabled, which is used when NSS calls it's `init` method. We do not, so I had to add an extra pull in of those libs for macos users that are running android tests on desktop. This _shouldn't_ affect anything as we don't use the APIs from the `PKIX` lib, I ran the full branch builds to confirm and looks like everything passed fine! 


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
