### PR TITLE
Exposes reset function swift

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -20,5 +20,13 @@ Use the template below to make assigning a version number during the release cut
 -->
 
 ## FxA Client
+
+### What's new
+- Exposed a new function for swift consumers `resetPersistedState`
+   - `resetPersistedState` can be used to refresh the account manager to reflect the latest persisted state.
+   - `resetPersistedState` should be called in between a different account manager instance persisting the state, and the current account manager persisting state
+     - For example, the Notification Service in iOS creates its own instance of the account manager, changes its state (by changing the index of the last retrieved send tab)
+     - The main account manager held by the application should call` resetPersistedState` before calling any other method that might change its state. This way it can retrieve the most up to date index that the Notification Services persisted.
 ### What's changed
-- The `processRawIncomingAccountEvent` function will now process all commands, not just one. This moves the responsibilty of ensuring each push gets a UI element to the caller.\
+- The `processRawIncomingAccountEvent` function will now process all commands, not just one. This moves the responsibilty of ensuring each push gets a UI element to the caller.
+

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -71,11 +71,15 @@ open class FxAccountManager {
             state == .authenticationProblem ||
             state == .canAutoretryMigration
     }
-    
-    // Resets the inner Persisted Account based on the persisted state
-    public func resetPersistedAccount() throws {
-        self.account = accountStorage.read()
-        self.account?.registerPersistCallback(statePersistenceCallback)
+
+    /// Resets the inner Persisted Account based on the persisted state
+    /// Callers can use this method to refresh the account manager to reflect
+    /// the latest persisted state.
+    /// It's possible for the account manager to go out sync with the persisted state
+    /// in case an extension (Notification Service for example) modifies the persisted state
+    public func resetPersistedAccount() {
+        account = accountStorage.read()
+        account?.registerPersistCallback(statePersistenceCallback)
     }
 
     /// Returns true if the account needs re-authentication.

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -71,6 +71,12 @@ open class FxAccountManager {
             state == .authenticationProblem ||
             state == .canAutoretryMigration
     }
+    
+    // Resets the inner Persisted Account based on the persisted state
+    public func resetPersistedAccount() throws {
+        self.account = accountStorage.read()
+        self.account?.registerPersistCallback(statePersistenceCallback)
+    }
 
     /// Returns true if the account needs re-authentication.
     /// Your app should present the option to start a new OAuth flow.


### PR DESCRIPTION
## Why
I came across this when adding polling to firefox-ios. I noticed that **my polls were launching the same tabs I just got via push notification**. I tracked it down to be that the Notification Service that handles the push notifications runs as a separate process and has its own instance of our FxA client, but uses the same backing persisted state.

### What happens when a notification arrives:
- Notification service creates a new instance of the account manager
- notification service polls for the tab it just got
-  it would increment the index in-memory
- It would then persist a new state with the new index

**However, the account manager held by firefox-ios doesn't have the updated index in memory. Unless the user relaunches the app in between the push notification and the next scheduled poll (once a day) the poll would get back the same tab.**

and even if the user relaunches the app, a lot of the FxA APIs persist the state, and since our state is a simple JSON, the state persisted by the notification service could have been overwritten by then


### How it'll be used:
This PR creates a method to allow the account manager held by firefox-ios to refresh its in-memory values by re-loading the persisted state from disk.


Firefox-iOS would call this API when it's first foregrounded and notices it received a tab (there is an existing mechanism for that)This way firefox-ios would get the up-to-date index before any poll (or any other API) is run.
