### PR TITLE
Use incremental vacuum for places maintenance

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,8 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## places
+
+### What's Changed
+  - Switch to using incremental vacuums for maintenance, which should speed up the process.

--- a/components/autofill/src/db/schema.rs
+++ b/components/autofill/src/db/schema.rs
@@ -80,7 +80,7 @@ impl ConnectionInitializer for AutofillConnectionInitializer {
     const NAME: &'static str = "autofill db";
     const END_VERSION: u32 = 2;
 
-    fn prepare(&self, conn: &Connection) -> Result<()> {
+    fn prepare(&self, conn: &Connection, _db_empty: bool) -> Result<()> {
         define_functions(conn)?;
 
         let initial_pragmas = "

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -47,7 +47,7 @@ impl ConnectionInitializer for PlacesInitializer {
         Ok(schema::upgrade_from(tx, version)?)
     }
 
-    fn prepare(&self, conn: &Connection) -> open_database::Result<()> {
+    fn prepare(&self, conn: &Connection, _db_empty: bool) -> open_database::Result<()> {
         let initial_pragmas = "
             -- The value we use was taken from Desktop Firefox, and seems necessary to
             -- help ensure good performance on autocomplete-style queries.

--- a/components/tabs/src/schema.rs
+++ b/components/tabs/src/schema.rs
@@ -29,7 +29,7 @@ impl MigrationLogic for TabsMigrationLogin {
     const NAME: &'static str = "tabs storage db";
     const END_VERSION: u32 = 1;
 
-    fn prepare(&self, conn: &Connection) -> MigrationResult<()> {
+    fn prepare(&self, conn: &Connection, _db_empty: bool) -> MigrationResult<()> {
         let initial_pragmas = "
             -- We don't care about temp tables being persisted to disk.
             PRAGMA temp_store = 2;

--- a/components/webext-storage/src/schema.rs
+++ b/components/webext-storage/src/schema.rs
@@ -18,7 +18,7 @@ impl MigrationLogic for WebExtMigrationLogin {
     const NAME: &'static str = "webext storage db";
     const END_VERSION: u32 = 2;
 
-    fn prepare(&self, conn: &Connection) -> MigrationResult<()> {
+    fn prepare(&self, conn: &Connection, _db_empty: bool) -> MigrationResult<()> {
         let initial_pragmas = "
             -- We don't care about temp tables being persisted to disk.
             PRAGMA temp_store = 2;


### PR DESCRIPTION
Metrics from GLAM indicate the VACUUM command is taking a long time and doesn't seem to be dropping.  After reading the docs a bit, it seems to me that VACUUM always copies the entire database which could indeed be slow for large DBs.

Switched to using an incremental vacuum.  This only tries to truncate N pages (set to 2 here) at time rather than all free pages.  But the real speed improvement comes from only trimming completely free pages, not trying to defragment pages, which is what VACUUM does and why it needs to copy the DB.

Incremental vacuum requires a PRAGMA setting.  If that setting isn't set before there is data in the DB, then we still need to do a single full VACUUM before it can be used.

I think the result of all of this should be that we will do one slow vacuum, but future vacuums should be quick.

Also added a places-utils command to run maintenance.  I used this to test that the incremental vacuum is ineed faster.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
