### PR TITLE
Quieter error handling

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -27,7 +27,15 @@ Use the template below to make assigning a version number during the release cut
   - Don't report sentry errors when we try to decrypt the empty string.  This happens when the consumer tries to decript
     a CC number after `scrub_encrypted_data()` is called.
 
+## logins
+
+### What's Changed
+  -  Don't report `Origin is Malformed` errors to Sentry.  This is a known issue stemming from FF Desktop sending us
+     URLs without a scheme.  See #5233 for details.
+
 ## places
 
 ### What's Changed
   - Switch to using incremental vacuums for maintenance, which should speed up the process.
+  - Don't report places `relative URL without a base` to Sentry.  This is a known issue caused by Fenix sending us URLs
+    with an invalid scheme (see #5235)

--- a/components/logins/src/error.rs
+++ b/components/logins/src/error.rs
@@ -102,6 +102,10 @@ pub enum InvalidLogin {
     BothTargets,
     #[error("Neither `formActionOrigin` or `httpRealm` are present")]
     NoTarget,
+    // Login has an illegal origin field, split off from IllegalFieldValue since this is a known
+    // issue with the Desktop logins and we don't want to report it to Sentry (see #5233).
+    #[error("Login has illegal origin")]
+    IllegalOrigin,
     #[error("Login has illegal field: {field_info}")]
     IllegalFieldValue { field_info: String },
 }

--- a/components/logins/src/login.rs
+++ b/components/logins/src/login.rs
@@ -342,10 +342,7 @@ impl LoginFields {
                     error_support::redact_url(origin)
                 );
                 // We can't fixup completely invalid records, so always throw.
-                Err(InvalidLogin::IllegalFieldValue {
-                    field_info: "Origin is Malformed".into(),
-                }
-                .into())
+                Err(InvalidLogin::IllegalOrigin.into())
             }
         }
     }
@@ -1126,7 +1123,7 @@ mod tests {
             TestCase {
                 login: login_with_malformed_origin_parens,
                 should_err: true,
-                expected_err: "Invalid login: Login has illegal field: Origin is Malformed",
+                expected_err: "Invalid login: Login has illegal origin",
             },
             TestCase {
                 login: login_with_host_unicode,


### PR DESCRIPTION
This changes things so the errors from #5233, #5235 don't get reported to Sentry.  The first two seem to be caused by issues in consumer code.  The last issue is caused by SQLITE_BUSY errors on slow devices.  It seems like we've gotten all the useful data we're going to get out of Sentry, so let's stop reporting them.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
