### PR TITLE
Allow viaduct to make requests to the android emulator loopback address.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -30,3 +30,9 @@ Use the template below to make assigning a version number during the release cut
    - `importBookmarksFromFennec`
    - `importPinnedSitesFromFennec`
    - `importVisitsFromFennec`
+
+## Viaduct
+### What's New
+  - Allow viaduct to make requests to the android emulator's host address via
+    a new viaduct_allow_android_emulator_loopback() (in Rust)/allowAndroidEmulatorLoopback() (in Kotlin)
+    ([#5270](https://github.com/mozilla/application-services/pull/5270))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3791,6 +3791,7 @@ dependencies = [
  "ffi-support",
  "log",
  "once_cell",
+ "parking_lot",
  "prost",
  "prost-derive",
  "serde",
@@ -3804,8 +3805,8 @@ name = "viaduct-reqwest"
 version = "0.2.0"
 dependencies = [
  "ffi-support",
- "lazy_static",
  "log",
+ "once_cell",
  "reqwest",
  "viaduct",
 ]

--- a/components/support/viaduct-reqwest/Cargo.toml
+++ b/components/support/viaduct-reqwest/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["lib"]
 viaduct = { path = "../../viaduct" }
 reqwest = { version = "0.11", features = ["blocking", "native-tls-vendored"] }
 ffi-support = "0.4"
-lazy_static = "1.4"
 log = "0.4"
+once_cell = "1.5"
+

--- a/components/viaduct/Cargo.toml
+++ b/components/viaduct/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4"
 serde = "1"
 serde_json = "1"
 once_cell = "1.5"
+parking_lot = { version = ">=0.11,<=0.12" }
 prost = "0.8"
 prost-derive = "0.8"
 ffi-support = "0.4"

--- a/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/HttpConfig.kt
+++ b/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/HttpConfig.kt
@@ -54,6 +54,18 @@ object RustHttpConfig {
         }
     }
 
+    /** Allows connections to the hard-coded address the Android Emulator uses
+      * to connect to the emulator's host (ie, http://10.0.2.2) - if you don't
+      * call this, viaduct will fail to use that address as it isn't https. The
+      * expectation is that you will only call this in debug builds or if you
+      * are sure you are running on an emulator.
+      */
+    fun allowAndroidEmulatorLoopback() {
+        lock.read {
+            LibViaduct.INSTANCE.viaduct_allow_android_emulator_loopback()
+        }
+    }
+
     internal fun convertRequest(request: MsgTypes.Request): Request {
         val headers = MutableHeaders()
         for (h in request.headersMap) {

--- a/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/LibViaduct.kt
+++ b/components/viaduct/android/src/main/java/mozilla/appservices/httpconfig/LibViaduct.kt
@@ -26,6 +26,8 @@ internal interface LibViaduct : Library {
     fun viaduct_alloc_bytebuffer(sz: Int): RustBuffer.ByValue
     // Returns 0 to indicate redundant init.
     fun viaduct_initialize(cb: RawFetchCallback): Byte
+    // No return value, never fails.
+    fun viaduct_allow_android_emulator_loopback()
 
     fun viaduct_log_error(s: String)
 }

--- a/components/viaduct/src/settings.rs
+++ b/components/viaduct/src/settings.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use once_cell::sync::Lazy;
+use parking_lot::RwLock;
 use std::time::Duration;
+use url::Url;
 
 /// Note: reqwest allows these only to be specified per-Client. concept-fetch
 /// allows these to be specified on each call to fetch. I think it's worth
@@ -20,6 +23,9 @@ pub struct Settings {
     pub connect_timeout: Option<Duration>,
     pub follow_redirects: bool,
     pub use_caches: bool,
+    // For testing purposes, we allow exactly one additional Url which is
+    // allowed to not be https.
+    pub addn_allowed_insecure_url: Option<Url>,
 }
 
 #[cfg(target_os = "ios")]
@@ -29,9 +35,12 @@ const TIMEOUT_DURATION: Duration = Duration::from_secs(7);
 const TIMEOUT_DURATION: Duration = Duration::from_secs(10);
 
 // The singleton instance of our settings.
-pub static GLOBAL_SETTINGS: &Settings = &Settings {
-    read_timeout: Some(TIMEOUT_DURATION),
-    connect_timeout: Some(TIMEOUT_DURATION),
-    follow_redirects: true,
-    use_caches: false,
-};
+pub static GLOBAL_SETTINGS: Lazy<RwLock<Settings>> = Lazy::new(|| {
+    RwLock::new(Settings {
+        read_timeout: Some(TIMEOUT_DURATION),
+        connect_timeout: Some(TIMEOUT_DURATION),
+        follow_redirects: true,
+        use_caches: false,
+        addn_allowed_insecure_url: None,
+    })
+});


### PR DESCRIPTION
Viaduct itself gets the ability to allow exactly 1 arbitrary address to be connected to which isn't a https:// URL, but the FFI adds an android specific function which hard-codes the accepted address.

@csadilek said this seems to work in his testing. I don't think it's a breaking change but will require an a-c patch to expose the new method.

@badboy already pointed out my check should check just the host, but I also included the scheme. LMK if you would prefer different semantics.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
