### PR TITLE
Remove the not-quite-functional test-utils feature from sync15

### DIFF
--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -32,7 +32,6 @@ features = ["functions", "bundled", "serde_json", "unlock_notify"]
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }
 libsqlite3-sys = "0.24.1"
-sync15 = { path = "../sync15", features = ["test-utils"] }
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -41,4 +41,3 @@ uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
 more-asserts = "0.2"
 tempfile = "3.2.0"
 env_logger = { version = "0.7", default-features = false }
-sync15 = { path = "../sync15", features=["test-utils"] }

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -44,7 +44,6 @@ features = ["functions", "window", "bundled", "unlock_notify"]
 pretty_assertions = "0.6"
 tempfile = "3.1"
 env_logger = {version = "0.7", default-features = false}
-sync15 = { path = "../sync15", features=["test-utils"] }
 
 [build-dependencies]
 uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -44,9 +44,6 @@ sync-client = ["sync-engine", "crypto", "viaduct", "url"]
 # upgraded to make the sync-client part truly optional.
 standalone-sync = ["sync-client"]
 
-# A feature designed to be enabled in dev_dependencies.
-test-utils = []
-
 [dependencies]
 anyhow = "1.0"
 base16 = { version = "0.2", optional = true }

--- a/components/sync15/src/bso/mod.rs
+++ b/components/sync15/src/bso/mod.rs
@@ -81,7 +81,9 @@ pub use crypto::{IncomingEncryptedBso, OutgoingEncryptedBso};
 
 mod content;
 
-#[cfg(feature = "test-utils")]
+// A feature for this would be ideal, but (a) the module is small and (b) it
+// doesn't really fit the "features" model for sync15 to have a dev-dependency
+// against itself but with a different feature set.
 pub mod test_utils;
 
 /// An envelope for an incoming item. Envelopes carry all the metadata for

--- a/components/sync15/src/bso/test_utils.rs
+++ b/components/sync15/src/bso/test_utils.rs
@@ -3,9 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 //! Utilities for tests to make IncomingBsos and Content from test data.
-//! Note that this is only available if you enable the `test-utils` feature,
-//! which external crates are able to do just for their tests.
-
 use super::{IncomingBso, IncomingEnvelope, OutgoingBso};
 use crate::{Guid, ServerTimestamp};
 

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -39,7 +39,6 @@ url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [dev-dependencies]
 env_logger = { version = "0.8.0", default-features = false, features = ["termcolor", "atty", "humantime"] }
-sync15 = { path = "../sync15", features = ["test-utils"] }
 tempfile = "3.1"
 
 [build-dependencies]

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -30,7 +30,6 @@ features = ["functions", "bundled", "serde_json", "unlock_notify", "column_declt
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }
 prettytable-rs = "0.8"
-sync15 = {path = "../../components/sync15", features=["test-utils"]}
 tempfile = "3"
 # A *direct* dep on the -sys crate is required for our build.rs
 # to see the DEP_SQLITE3_LINK_TARGET env var that cargo sets

--- a/testing/separated/places-tests/Cargo.toml
+++ b/testing/separated/places-tests/Cargo.toml
@@ -15,7 +15,7 @@ sql-support = { path = "../../../components/support/sql" }
 sync-guid = { path = "../../../components/support/guid" }
 types = { path = "../../../components/support/types" }
 places = { path = "../../../components/places" }
-sync15 = { path = "../../../components/sync15", features = ["test-utils"] }
+sync15 = { path = "../../../components/sync15" }
 serde_json = "1.0"
 url = "2.2"
 dogear = "0.4"


### PR DESCRIPTION
When doing #5139 I tried to have a test-utils feature for sync15, which didn't really work out for various reasons but it was left in.

Currently `cargo test -p sync15 --features=sync-client` fails, although CI doesn't every run that (it runs with default and all features)

This PR kills that feature entirely.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
