### PR TITLE
Dont reset the tabs engine every sync, use the db for storing last sync

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -23,8 +23,8 @@ Use the template below to make assigning a version number during the release cut
 
 ### What's Changed
 
-The Tabs engine no longer resets after every sync:
+The Tabs engine is now more efficient in how it fetches its records:
 
-- Tabs will be stored in a DB per client.
-- Tabs now tracks the last time it synced and only fetches tabs that have changed since last sync.
-- Tabs will keep records for up to 180 days, the same as the clients engine.
+- The Tabs engine no longer clears the DB on every sync.
+- Tabs now tracks the last time it synced and only fetches tabs that have changed since the last sync.
+- Tabs will keep records for up to 180 days, in parity with the clients engine. To prevent the DB from getting too large.

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,13 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Tabs
+
+### What's Changed
+
+The Tabs engine no longer resets after every sync:
+
+- Tabs will be stored in a DB per client.
+- Tabs now tracks the last time it synced and only fetches tabs that have changed since last sync.
+- Tabs will keep records for up to 180 days, the same as the clients engine.

--- a/components/tabs/src/schema.rs
+++ b/components/tabs/src/schema.rs
@@ -34,9 +34,9 @@ const CREATE_META_TABLE_SQL: &str = "
 pub(crate) static LAST_SYNC_META_KEY: &str = "last_sync_time";
 pub(crate) static GLOBAL_SYNCID_META_KEY: &str = "global_sync_id";
 pub(crate) static COLLECTION_SYNCID_META_KEY: &str = "tabs_sync_id";
-// Tabs stores this in the meta table due to a unique requirement that we only know
-// the list of connected clients when syncing, however getting list of tabs could be
-// called at anytime -- thus we need to store this in a way we can retrieve the clients list on the fly
+// Tabs stores this in the meta table due to a unique requirement that we only know the list
+// of connected clients when syncing, however getting the list of tabs could be called at anytime
+// so we store it so we can translate from the tabs sync record ID to the FxA device id for the client
 pub(crate) static REMOTE_CLIENTS_KEY: &str = "remote_clients";
 
 pub struct TabsMigrationLogic;

--- a/components/tabs/src/schema.rs
+++ b/components/tabs/src/schema.rs
@@ -18,9 +18,9 @@ use sql_support::{
 // store each client as its own row.
 const CREATE_SCHEMA_SQL: &str = "
     CREATE TABLE IF NOT EXISTS tabs (
-        guid             TEXT NOT NULL PRIMARY KEY,
-        record              TEXT NOT NULL,
-        last_modified    INTEGER NOT NULL
+        guid            TEXT NOT NULL PRIMARY KEY,
+        record          TEXT NOT NULL,
+        last_modified   INTEGER NOT NULL
     );
 ";
 
@@ -67,7 +67,6 @@ impl MigrationLogic for TabsMigrationLogic {
     }
 
     fn upgrade_from(&self, db: &Transaction<'_>, version: u32) -> MigrationResult<()> {
-        log::debug!("upgrading from {}", version);
         match version {
             1 => upgrade_from_v1(db),
             _ => Err(MigrationError::IncompatibleVersion(version)),

--- a/components/tabs/src/schema.rs
+++ b/components/tabs/src/schema.rs
@@ -7,27 +7,43 @@
 // syncChangeCounter/syncStatus nor a mirror etc.
 
 use rusqlite::{Connection, Transaction};
-use sql_support::open_database::{
-    ConnectionInitializer as MigrationLogic, Error as MigrationError, Result as MigrationResult,
+use sql_support::{
+    open_database::{
+        ConnectionInitializer as MigrationLogic, Error as MigrationError, Result as MigrationResult,
+    },
+    ConnExt,
 };
 
-// The payload is json and this module doesn't need to deserialize, so we just
-// store each "payload" as a row.
-// On each Sync we delete all local rows re-populate them with every record on
-// the server. When we read the DB, we also read every single record.
-// So we have no primary keys, no foreign keys, and really completely waste the
-// fact we are using sql.
+// The record is the TabsRecord struct in json and this module doesn't need to deserialize, so we just
+// store each client as its own row.
 const CREATE_SCHEMA_SQL: &str = "
     CREATE TABLE IF NOT EXISTS tabs (
-        payload TEXT NOT NULL
+        guid             TEXT NOT NULL PRIMARY KEY,
+        record              TEXT NOT NULL,
+        last_modified    INTEGER NOT NULL
     );
 ";
 
-pub struct TabsMigrationLogin;
+const CREATE_META_TABLE_SQL: &str = "
+    CREATE TABLE IF NOT EXISTS moz_meta (
+        key    TEXT PRIMARY KEY,
+        value  NOT NULL
+    )
+";
 
-impl MigrationLogic for TabsMigrationLogin {
+pub(crate) static LAST_SYNC_META_KEY: &str = "last_sync_time";
+pub(crate) static GLOBAL_SYNCID_META_KEY: &str = "global_sync_id";
+pub(crate) static COLLECTION_SYNCID_META_KEY: &str = "tabs_sync_id";
+// Tabs stores this in the meta table due to a unique requirement that we only know
+// the list of connected clients when syncing, however getting list of tabs could be
+// called at anytime -- thus we need to store this in a way we can retrieve the clients list on the fly
+pub(crate) static REMOTE_CLIENTS_KEY: &str = "remote_clients";
+
+pub struct TabsMigrationLogic;
+
+impl MigrationLogic for TabsMigrationLogic {
     const NAME: &'static str = "tabs storage db";
-    const END_VERSION: u32 = 1;
+    const END_VERSION: u32 = 2;
 
     fn prepare(&self, conn: &Connection, _db_empty: bool) -> MigrationResult<()> {
         let initial_pragmas = "
@@ -45,20 +61,43 @@ impl MigrationLogic for TabsMigrationLogin {
     }
 
     fn init(&self, db: &Transaction<'_>) -> MigrationResult<()> {
-        log::debug!("Creating schema");
-        db.execute_batch(CREATE_SCHEMA_SQL)?;
+        log::debug!("Creating schemas");
+        db.execute_all(&[CREATE_SCHEMA_SQL, CREATE_META_TABLE_SQL])?;
         Ok(())
     }
 
-    fn upgrade_from(&self, _db: &Transaction<'_>, version: u32) -> MigrationResult<()> {
-        Err(MigrationError::IncompatibleVersion(version))
+    fn upgrade_from(&self, db: &Transaction<'_>, version: u32) -> MigrationResult<()> {
+        log::debug!("upgrading from {}", version);
+        match version {
+            1 => upgrade_from_v1(db),
+            _ => Err(MigrationError::IncompatibleVersion(version)),
+        }
     }
+}
+
+fn upgrade_from_v1(db: &Connection) -> MigrationResult<()> {
+    // The previous version stored the entire payload in one row
+    // and cleared on each sync -- it's fine to just drop it
+    db.execute_batch("DROP TABLE tabs;")?;
+    // Recreate the world
+    db.execute_all(&[CREATE_SCHEMA_SQL, CREATE_META_TABLE_SQL])?;
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::storage::TabsStorage;
+    use rusqlite::OptionalExtension;
+    use serde_json::json;
+    use sql_support::open_database::test_utils::MigratedDatabaseFile;
+
+    const CREATE_V1_SCHEMA_SQL: &str = "
+        CREATE TABLE IF NOT EXISTS tabs (
+            payload TEXT NOT NULL
+        );
+        PRAGMA user_version=1;
+    ";
 
     #[test]
     fn test_create_schema_twice() {
@@ -66,5 +105,47 @@ mod tests {
         let conn = db.open_or_create().unwrap();
         conn.execute_batch(CREATE_SCHEMA_SQL)
             .expect("should allow running twice");
+    }
+
+    #[test]
+    fn test_tabs_db_upgrade_from_v1() {
+        let db_file = MigratedDatabaseFile::new(TabsMigrationLogic, CREATE_V1_SCHEMA_SQL);
+        db_file.run_all_upgrades();
+        // Verify we can open the DB just fine, since migration is essentially a drop
+        // we don't need to check any data integrity
+        let mut storage = TabsStorage::new(db_file.path);
+        storage.open_or_create().unwrap();
+        assert!(storage.open_if_exists().unwrap().is_some());
+
+        let test_payload = json!({
+            "id": "device-with-a-tab",
+            "clientName": "device with a tab",
+            "tabs": [{
+                "title": "the title",
+                "urlHistory": [
+                    "https://mozilla.org/"
+                ],
+                "icon": "https://mozilla.org/icon",
+                "lastUsed": 1643764207,
+            }]
+        });
+        let db = storage.open_if_exists().unwrap().unwrap();
+        // We should be able to insert without a SQL error after upgrade
+        db.execute(
+            "INSERT INTO tabs (guid, record, last_modified) VALUES (:guid, :record, :last_modified);",
+            rusqlite::named_params! {
+                ":guid": "my-device",
+                ":record": serde_json::to_string(&test_payload).unwrap(),
+                ":last_modified": "1643764207"
+            },
+        )
+        .unwrap();
+
+        let row: Option<String> = db
+            .query_row("SELECT guid FROM tabs;", [], |row| row.get(0))
+            .optional()
+            .unwrap();
+        // Verify we can query for a valid guid now
+        assert_eq!(row.unwrap(), "my-device");
     }
 }

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -238,6 +238,7 @@ impl TabsStorage {
                 // could happen - in most cases though, it will be due to a disconnected client -
                 // so we really should consider just dropping it? (Sadly though, it does seem
                 // possible it's actually a very recently connected client, so we keep it)
+                // We should get rid of this eventually - https://github.com/mozilla/application-services/issues/5199
                 log::info!(
                     "Storing tabs from a client that doesn't appear in the devices list: {}",
                     id,
@@ -258,8 +259,9 @@ impl TabsStorage {
         if let Some(conn) = self.open_if_exists()? {
             if let Some(last_sync) = last_sync {
                 let client_ttl_ms = (TABS_CLIENT_TTL as i64) * 1000;
-                // On desktop, a quick write sets the last_sync to FAR_FUTURE
-                // which means we'll most likely trash all our records (as it's more than any TTL we'd ever do)
+                // On desktop, a quick write temporarily sets the last_sync to FAR_FUTURE
+                // but if it doesn't set it back to the original (crash, etc) it
+                // means we'll most likely trash all our records (as it's more than any TTL we'd ever do)
                 // so we need to detect this for now until we have native quick write support
                 if last_sync - client_ttl_ms >= 0 && last_sync != (FAR_FUTURE * 1000) {
                     let tx = conn.unchecked_transaction()?;

--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -272,13 +272,11 @@ impl TabsBridgedEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::RemoteTab;
+    use crate::storage::{RemoteTab, TABS_CLIENT_TTL};
     use crate::sync::record::TabsRecordTab;
     use serde_json::json;
     use std::collections::HashMap;
     use sync15::{ClientData, DeviceType, RemoteClient};
-
-    const TABS_CLIENT_TTL: u32 = 15_552_000; // same as in storage.rs
 
     // A copy of the normal "engine" tests but which go via the bridge
     #[test]

--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -68,7 +68,7 @@ impl BridgedEngine for BridgedEngineImpl {
 
     fn sync_id(&self) -> ApiResult<Option<String>> {
         handle_error! {
-            Ok(match self.sync_impl.lock().unwrap().get_sync_assoc().unwrap() {
+            Ok(match self.sync_impl.lock().unwrap().get_sync_assoc()? {
                 EngineSyncAssociation::Connected(id) => Some(id.coll.to_string()),
                 EngineSyncAssociation::Disconnected => None,
             })
@@ -93,7 +93,7 @@ impl BridgedEngine for BridgedEngineImpl {
     fn ensure_current_sync_id(&self, sync_id: &str) -> ApiResult<String> {
         handle_error! {
             let mut sync_impl = self.sync_impl.lock().unwrap();
-            let assoc = sync_impl.get_sync_assoc().unwrap();
+            let assoc = sync_impl.get_sync_assoc()?;
             if matches!(assoc, EngineSyncAssociation::Connected(c) if c.coll == sync_id) {
                 log::debug!("ensure_current_sync_id is current");
             } else {
@@ -369,19 +369,6 @@ mod tests {
                     ],
                     "icon": "https://mozilla.org/icon",
                     "lastUsed": 1643764207
-                }]
-            }),
-            // test an updated payload will replace the previous record
-            json!({
-                "id": "device-with-a-tab",
-                "clientName": "updated device with a tab",
-                "tabs": [{
-                    "title": "the title",
-                    "urlHistory": [
-                        "https://mozilla.org/"
-                    ],
-                    "icon": "https://mozilla.org/icon",
-                    "lastUsed": 1643764208
                 }]
             }),
             // This has the main payload as OK but the tabs part invalid.

--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -278,7 +278,7 @@ mod tests {
     use std::collections::HashMap;
     use sync15::{ClientData, DeviceType, RemoteClient};
 
-    const TTL_3_WEEKS: u32 = 15_552_000; // 21 days
+    const TABS_CLIENT_TTL: u32 = 15_552_000; // same as in storage.rs
 
     // A copy of the normal "engine" tests but which go via the bridge
     #[test]
@@ -415,7 +415,7 @@ mod tests {
                 "clientName": "my device",
                 "tabs": serde_json::to_value(expected_tabs).unwrap(),
             }).to_string(),
-            "ttl": TTL_3_WEEKS,
+            "ttl": TABS_CLIENT_TTL,
         });
 
         assert_eq!(ours, expected);

--- a/components/tabs/src/sync/engine.rs
+++ b/components/tabs/src/sync/engine.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::schema;
-use crate::storage::{ClientRemoteTabs, RemoteTab, TTL_3_WEEKS};
+use crate::storage::{ClientRemoteTabs, RemoteTab, TABS_CLIENT_TTL};
 use crate::store::TabsStore;
 use crate::sync::record::{TabsRecord, TabsRecordTab};
 use crate::Result;
@@ -191,7 +191,7 @@ impl TabsSyncImpl {
             log::trace!("outgoing {:?}", local_record);
             let envelope = OutgoingEnvelope {
                 id: local_id.into(),
-                ttl: Some(TTL_3_WEEKS),
+                ttl: Some(TABS_CLIENT_TTL),
                 ..Default::default()
             };
             vec![OutgoingBso::from_content(

--- a/components/tabs/src/sync/engine.rs
+++ b/components/tabs/src/sync/engine.rs
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::storage::{ClientRemoteTabs, RemoteTab};
+use crate::schema;
+use crate::storage::{ClientRemoteTabs, RemoteTab, TTL_3_WEEKS};
 use crate::store::TabsStore;
 use crate::sync::record::{TabsRecord, TabsRecordTab};
 use crate::Result;
@@ -10,13 +11,11 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Weak};
 use sync15::bso::{IncomingBso, OutgoingBso, OutgoingEnvelope};
 use sync15::engine::{
-    CollectionRequest, EngineSyncAssociation, IncomingChangeset, OutgoingChangeset, SyncEngine,
-    SyncEngineId,
+    CollSyncIds, CollectionRequest, EngineSyncAssociation, IncomingChangeset, OutgoingChangeset,
+    SyncEngine, SyncEngineId,
 };
 use sync15::{telemetry, ClientData, DeviceType, RemoteClient, ServerTimestamp};
 use sync_guid::Guid;
-
-const TTL_1_YEAR: u32 = 31_622_400;
 
 // Our "sync manager" will use whatever is stashed here.
 lazy_static::lazy_static! {
@@ -39,8 +38,9 @@ pub fn get_registered_sync_engine(engine_id: &SyncEngineId) -> Option<Box<dyn Sy
     }
 }
 
+/// XXX - move to storage.rs? The struct is defined there
 impl ClientRemoteTabs {
-    fn from_record_with_remote_client(
+    pub(crate) fn from_record_with_remote_client(
         client_id: String,
         last_modified: ServerTimestamp,
         remote_client: &RemoteClient,
@@ -59,7 +59,11 @@ impl ClientRemoteTabs {
     // If we don't have a `RemoteClient` record, then we don't know whether the ID passed here is
     // the fxa_device_id (which is must be) or the client_id (which it will be if this ends up being
     // called for desktop records, where client_id != fxa_device_id)
-    fn from_record(client_id: String, last_modified: ServerTimestamp, record: TabsRecord) -> Self {
+    pub(crate) fn from_record(
+        client_id: String,
+        last_modified: ServerTimestamp,
+        record: TabsRecord,
+    ) -> Self {
         Self {
             client_id,
             client_name: record.client_name,
@@ -82,7 +86,7 @@ impl ClientRemoteTabs {
 }
 
 impl RemoteTab {
-    fn from_record_tab(tab: &TabsRecordTab) -> Self {
+    pub(crate) fn from_record_tab(tab: &TabsRecordTab) -> Self {
         Self {
             title: tab.title.clone(),
             url_history: tab.url_history.clone(),
@@ -104,9 +108,6 @@ impl RemoteTab {
 // (We hope to get these 2 engines even closer in the future, but for now, we suck this up)
 pub struct TabsSyncImpl {
     pub(super) store: Arc<TabsStore>,
-    remote_clients: HashMap<String, RemoteClient>,
-    pub(super) last_sync: Option<ServerTimestamp>,
-    sync_store_assoc: EngineSyncAssociation,
     pub(super) local_id: String,
 }
 
@@ -114,15 +115,19 @@ impl TabsSyncImpl {
     pub fn new(store: Arc<TabsStore>) -> Self {
         Self {
             store,
-            remote_clients: HashMap::new(),
-            last_sync: None,
-            sync_store_assoc: EngineSyncAssociation::Disconnected,
             local_id: Default::default(),
         }
     }
 
     pub fn prepare_for_sync(&mut self, client_data: ClientData) -> Result<()> {
-        self.remote_clients = client_data.recent_clients;
+        let mut storage = self.store.storage.lock().unwrap();
+        // We only know the client list at sync time, but need to return tabs potentially
+        // at any time -- so we store the clients in the meta table to be able to properly
+        // return a ClientRemoteTab struct
+        storage.put_meta(
+            schema::REMOTE_CLIENTS_KEY,
+            &serde_json::to_string(&client_data.recent_clients).unwrap(),
+        )?;
         self.local_id = client_data.local_client_id;
         Ok(())
     }
@@ -136,6 +141,16 @@ impl TabsSyncImpl {
         let mut remote_tabs = Vec::with_capacity(inbound.len());
         let mut incoming_telemetry = telemetry::EngineIncoming::new();
 
+        let remote_clients: HashMap<String, RemoteClient> = {
+            let mut storage = self.store.storage.lock().unwrap();
+            match storage
+                .get_meta::<String>(schema::REMOTE_CLIENTS_KEY)
+                .unwrap()
+            {
+                None => HashMap::default(),
+                Some(json) => serde_json::from_str(&json).unwrap(),
+            }
+        };
         for incoming in inbound {
             if incoming.envelope.id == local_id {
                 // That's our own record, ignore it.
@@ -151,38 +166,7 @@ impl TabsSyncImpl {
                     continue;
                 }
             };
-            let id = record.id.clone();
-            let crt = if let Some(remote_client) = self.remote_clients.get(&id) {
-                ClientRemoteTabs::from_record_with_remote_client(
-                    remote_client
-                        .fxa_device_id
-                        .as_ref()
-                        .unwrap_or(&id)
-                        .to_owned(),
-                    modified,
-                    remote_client,
-                    record,
-                )
-            } else {
-                // A record with a device that's not in our remote clients seems unlikely, but
-                // could happen - in most cases though, it will be due to a disconnected client -
-                // so we really should consider just dropping it? (Sadly though, it does seem
-                // possible it's actually a very recently connected client, so we keep it)
-
-                // XXX - this is actually a foot-gun, particularly for desktop. If we don't know
-                // the device, we assume the device ID is the fxa-device-id, which may not be the
-                // case.
-                // So we should drop these records! But we can't do this now because stand alone
-                // syncing (ie, store.sync()) doesn't allow us to pass the device list in, so
-                // we'd get no rows!
-                // See also: https://github.com/mozilla/application-services/issues/5199
-                log::info!(
-                    "Storing tabs from a client that doesn't appear in the devices list: {}",
-                    id,
-                );
-                ClientRemoteTabs::from_record(id, modified, record)
-            };
-            remote_tabs.push(crt);
+            remote_tabs.push((record, modified));
         }
 
         // We want to keep the mutex for as short as possible
@@ -193,11 +177,11 @@ impl TabsSyncImpl {
             if !remote_tabs.is_empty() {
                 storage.replace_remote_tabs(remote_tabs)?;
             }
+            storage.remove_stale_clients()?;
             storage.prepare_local_tabs_for_upload()
         };
         let outgoing = if let Some(local_tabs) = local_tabs {
-            let (client_name, device_type) = self
-                .remote_clients
+            let (client_name, device_type) = remote_clients
                 .get(&local_id)
                 .map(|client| (client.device_name.clone(), client.device_type))
                 .unwrap_or_else(|| (String::new(), DeviceType::Unknown));
@@ -211,7 +195,7 @@ impl TabsSyncImpl {
             log::trace!("outgoing {:?}", local_record);
             let envelope = OutgoingEnvelope {
                 id: local_id.into(),
-                ttl: Some(TTL_1_YEAR),
+                ttl: Some(TTL_3_WEEKS),
                 ..Default::default()
             };
             vec![OutgoingBso::from_content(
@@ -234,28 +218,59 @@ impl TabsSyncImpl {
             "sync completed after uploading {} records",
             records_synced.len()
         );
-        self.last_sync = Some(new_timestamp);
+        self.set_last_sync(new_timestamp)?;
         Ok(())
     }
 
-    pub fn reset(&mut self, assoc: EngineSyncAssociation) -> Result<()> {
-        self.remote_clients.clear();
-        self.sync_store_assoc = assoc;
-        self.last_sync = None;
-        self.store.storage.lock().unwrap().wipe_remote_tabs()?;
+    pub fn reset(&mut self, assoc: &EngineSyncAssociation) -> Result<()> {
+        self.set_last_sync(ServerTimestamp(0))?;
+        let mut storage = self.store.storage.lock().unwrap();
+        storage.delete_meta(schema::REMOTE_CLIENTS_KEY)?;
+        storage.wipe_remote_tabs()?;
+        storage.wipe_local_tabs();
+        match assoc {
+            EngineSyncAssociation::Disconnected => {
+                storage.delete_meta(schema::GLOBAL_SYNCID_META_KEY)?;
+                storage.delete_meta(schema::COLLECTION_SYNCID_META_KEY)?;
+            }
+            EngineSyncAssociation::Connected(ids) => {
+                storage.put_meta(schema::GLOBAL_SYNCID_META_KEY, &ids.global.to_string())?;
+                storage.put_meta(schema::COLLECTION_SYNCID_META_KEY, &ids.coll.to_string())?;
+            }
+        };
         Ok(())
     }
 
     pub fn wipe(&mut self) -> Result<()> {
-        self.reset(EngineSyncAssociation::Disconnected)?;
-        // not clear why we need to wipe the local tabs - the app is just going
-        // to re-add them?
-        self.store.storage.lock().unwrap().wipe_local_tabs();
+        self.reset(&EngineSyncAssociation::Disconnected)?;
         Ok(())
     }
 
-    pub fn get_sync_assoc(&self) -> &EngineSyncAssociation {
-        &self.sync_store_assoc
+    pub fn get_sync_assoc(&self) -> anyhow::Result<EngineSyncAssociation> {
+        let mut storage = self.store.storage.lock().unwrap();
+        let global = storage.get_meta::<String>(schema::GLOBAL_SYNCID_META_KEY)?;
+        let coll = storage.get_meta::<String>(schema::COLLECTION_SYNCID_META_KEY)?;
+        Ok(if let (Some(global), Some(coll)) = (global, coll) {
+            EngineSyncAssociation::Connected(CollSyncIds {
+                global: Guid::from_string(global),
+                coll: Guid::from_string(coll),
+            })
+        } else {
+            EngineSyncAssociation::Disconnected
+        })
+    }
+
+    pub fn set_last_sync(&self, last_sync: ServerTimestamp) -> Result<()> {
+        let mut storage = self.store.storage.lock().unwrap();
+        log::debug!("Updating last sync to {}", last_sync);
+        let last_sync_millis = last_sync.as_millis() as i64;
+        storage.put_meta(schema::LAST_SYNC_META_KEY, &last_sync_millis)
+    }
+
+    pub fn get_last_sync(&self) -> Result<Option<ServerTimestamp>> {
+        let mut storage = self.store.storage.lock().unwrap();
+        let millis = storage.get_meta::<i64>(schema::LAST_SYNC_META_KEY)?;
+        Ok(millis.map(ServerTimestamp))
     }
 }
 
@@ -321,7 +336,12 @@ impl SyncEngine for TabsEngine {
         &self,
         server_timestamp: ServerTimestamp,
     ) -> anyhow::Result<Vec<CollectionRequest>> {
-        let since = self.sync_impl.lock().unwrap().last_sync.unwrap_or_default();
+        let since = self
+            .sync_impl
+            .lock()
+            .unwrap()
+            .get_last_sync()?
+            .unwrap_or_default();
         Ok(if since == server_timestamp {
             vec![]
         } else {
@@ -330,11 +350,11 @@ impl SyncEngine for TabsEngine {
     }
 
     fn get_sync_assoc(&self) -> anyhow::Result<EngineSyncAssociation> {
-        Ok(self.sync_impl.lock().unwrap().get_sync_assoc().clone())
+        self.sync_impl.lock().unwrap().get_sync_assoc()
     }
 
     fn reset(&self, assoc: &EngineSyncAssociation) -> anyhow::Result<()> {
-        Ok(self.sync_impl.lock().unwrap().reset(assoc.clone())?)
+        Ok(self.sync_impl.lock().unwrap().reset(assoc)?)
     }
 
     fn wipe(&self) -> anyhow::Result<()> {

--- a/components/tabs/src/sync/full_sync.rs
+++ b/components/tabs/src/sync/full_sync.rs
@@ -14,7 +14,7 @@ impl TabsStore {
     pub fn reset(self: Arc<Self>) -> ApiResult<()> {
         handle_error! {
             let mut sync_impl = TabsSyncImpl::new(Arc::clone(&self));
-            sync_impl.reset(EngineSyncAssociation::Disconnected)?;
+            sync_impl.reset(&EngineSyncAssociation::Disconnected)?;
             Ok(())
         }
     }

--- a/components/tabs/src/sync/mod.rs
+++ b/components/tabs/src/sync/mod.rs
@@ -4,7 +4,7 @@
 
 pub(crate) mod bridge;
 pub(crate) mod engine;
-mod record;
+pub(crate) mod record;
 
 #[cfg(feature = "full-sync")]
 pub mod full_sync;

--- a/components/tabs/src/sync/record.rs
+++ b/components/tabs/src/sync/record.rs
@@ -15,6 +15,7 @@ pub struct TabsRecordTab {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+// This struct mirrors what is stored on the server
 pub struct TabsRecord {
     // `String` instead of `SyncGuid` because some IDs are FxA device ID (XXX - that doesn't
     // matter though - this could easily be a Guid!)


### PR DESCRIPTION
Based on bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1800186

- We stop resetting on every sync
- Instead of storing the entire payload in one row, we do it per client_id (one row per client)
- [x] Tested on Desktop
- [x] Tested on iOS
- [x] Tested on Android


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
