### PR TITLE
Re-add the record ID to the BSO payload.

### DIFF
--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -412,6 +412,7 @@ mod tests {
         let expected = json!({
             "id": "my-device".to_string(),
             "payload": json!({
+                "id": "my-device".to_string(),
                 "clientName": "my device",
                 "tabs": serde_json::to_value(expected_tabs).unwrap(),
             }).to_string(),

--- a/components/webext-storage/src/sync/outgoing.rs
+++ b/components/webext-storage/src/sync/outgoing.rs
@@ -178,9 +178,9 @@ mod tests {
             serde_json::from_str::<serde_json::Value>(&outgoing.payload).unwrap();
         let outgoing_map = outgoing_payload.as_object().unwrap();
 
-        assert!(!outgoing_map.contains_key("id"));
+        assert!(outgoing_map.contains_key("id"));
         assert!(outgoing_map.contains_key("data"));
         assert!(outgoing_map.contains_key("extId"));
-        assert_eq!(outgoing_map.len(), 2);
+        assert_eq!(outgoing_map.len(), 3);
     }
 }


### PR DESCRIPTION
It turns out that in #5139 I was too agressive about removing the ID from a BSO payload - some things in desktop got a little upset, all of which are fixable, but this change might cause subtle breakage when syncing to older devices.

This PR ensures that the record's ID is in the JSON payload.

Once this is approved I'll vendor this into m-c