### PR TITLE
Fix iOS  naming conflict

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -32,3 +32,8 @@ Use the template below to make assigning a version number during the release cut
 
 ### What's Changed
   - Fixed a regression causing failure to read old tabs databases ([#5286](https://github.com/mozilla/application-services/pull/5286))
+
+## Autofill
+
+## What's Changed
+  - Exposed autofill api to iOS consumer and resolved `createKey` function conflict with the Logins component.

--- a/components/autofill/android/src/main/java/mozilla/appservices/autofill/CreateKey.kt
+++ b/components/autofill/android/src/main/java/mozilla/appservices/autofill/CreateKey.kt
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.autofill
+
+// We needed to rename the the autofill `createKey` function as it conflicts with the `createKey` function we
+// are exposing for Logins in iOS. However renaming `createKey` to `createAutofillKey` creates a breaking change
+// for the Android code. So we are aliasing `createAutofillKey` back to `createKey` in order to prevent the
+// breaking change.
+
+fun createKey() = createAutofillKey()

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -3,7 +3,7 @@ namespace autofill {
 
     // Create a new, random, encryption key.
     [Throws=AutofillApiError]
-    string create_key();
+    string create_autofill_key();
 
     // Encrypt an arbitrary string - `key` must have come from `create_key()`
     [Throws=AutofillApiError]

--- a/components/autofill/src/encryption.rs
+++ b/components/autofill/src/encryption.rs
@@ -88,7 +88,7 @@ pub fn decrypt_string(key: String, ciphertext: String) -> ApiResult<String> {
     }
 }
 
-pub fn create_key() -> ApiResult<String> {
+pub fn create_autofill_key() -> ApiResult<String> {
     handle_error! {
         let key = jwcrypto::Jwk::new_direct_key(None)?;
         Ok(serde_json::to_string(&key)?)
@@ -101,11 +101,11 @@ mod test {
 
     #[test]
     fn test_encrypt() {
-        let ed = EncryptorDecryptor::new(&create_key().unwrap()).unwrap();
+        let ed = EncryptorDecryptor::new(&create_autofill_key().unwrap()).unwrap();
         let cleartext = "secret";
         let ciphertext = ed.encrypt(cleartext).unwrap();
         assert_eq!(ed.decrypt(&ciphertext).unwrap(), cleartext);
-        let ed2 = EncryptorDecryptor::new(&create_key().unwrap()).unwrap();
+        let ed2 = EncryptorDecryptor::new(&create_autofill_key().unwrap()).unwrap();
         assert!(matches!(
             ed2.decrypt(&ciphertext),
             Err(Error::CryptoError(_))
@@ -114,7 +114,7 @@ mod test {
 
     #[test]
     fn test_decryption_errors() {
-        let ed = EncryptorDecryptor::new(&create_key().unwrap()).unwrap();
+        let ed = EncryptorDecryptor::new(&create_autofill_key().unwrap()).unwrap();
         assert!(matches!(
             ed.decrypt("invalid-ciphertext").unwrap_err(),
             Error::CryptoError(_)

--- a/components/autofill/src/lib.rs
+++ b/components/autofill/src/lib.rs
@@ -18,7 +18,7 @@ pub use crate::db::store::get_registered_sync_engine;
 use crate::db::models::address::*;
 use crate::db::models::credit_card::*;
 use crate::db::store::Store;
-use crate::encryption::{create_key, decrypt_string, encrypt_string};
+use crate::encryption::{create_autofill_key, decrypt_string, encrypt_string};
 pub use error::{ApiResult, AutofillApiError, Error, Result};
 
 include!(concat!(env!("OUT_DIR"), "/autofill.uniffi.rs"));

--- a/components/autofill/src/sync/credit_card/mod.rs
+++ b/components/autofill/src/sync/credit_card/mod.rs
@@ -250,7 +250,7 @@ fn test_last_4() {
 
 #[test]
 fn test_to_from_payload() {
-    let key = crate::encryption::create_key().unwrap();
+    let key = crate::encryption::create_autofill_key().unwrap();
     let cc_number = "1234567812345678";
     let cc_number_enc =
         crate::encryption::encrypt_string(key.clone(), cc_number.to_string()).unwrap();

--- a/components/autofill/src/sync/engine.rs
+++ b/components/autofill/src/sync/engine.rs
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn test_credit_card_engine_sync_finished() -> Result<()> {
         let mut credit_card_engine = create_engine();
-        let test_key = crate::encryption::create_key().unwrap();
+        let test_key = crate::encryption::create_autofill_key().unwrap();
         credit_card_engine
             .set_local_encryption_key(&test_key)
             .unwrap();

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -9,7 +9,7 @@ use autofill::db::{
     models::{address, credit_card},
     store::Store,
 };
-use autofill::encryption::{create_key, EncryptorDecryptor};
+use autofill::encryption::{create_autofill_key, EncryptorDecryptor};
 use autofill::error::Error;
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
 use cli_support::prompt::{prompt_string, prompt_usize};
@@ -488,7 +488,7 @@ fn get_encryption_key(store: &Store, db_path: &str, opts: &Opts) -> Result<Strin
     }
     // ok, generate it.
     println!("***** Generating and storing example key");
-    let key = create_key()?;
+    let key = create_autofill_key()?;
     put_meta(&db, "example-encryption-key", &key)?;
     Ok(key)
 }

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		15DAE213294418F600DB06FE /* autofill.udl in Sources */ = {isa = PBXBuildFile; fileRef = 15DAE20D2944155E00DB06FE /* autofill.udl */; };
 		1B3BC93F27B1D62800229CF6 /* Bookmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAC5A527AE0F2E00DAFEF2 /* Bookmark.swift */; };
 		1B3BC94027B1D62800229CF6 /* Places.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAC5A727AE0F2E00DAFEF2 /* Places.swift */; };
 		1B3BC94127B1D62800229CF6 /* HistoryMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAC5A627AE0F2E00DAFEF2 /* HistoryMetadata.swift */; };
@@ -106,6 +107,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		15DAE20D2944155E00DB06FE /* autofill.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = autofill.udl; path = ../../../components/autofill/src/autofill.udl; sourceTree = SOURCE_ROOT; };
+		15DAE2102944165300DB06FE /* autofillFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = autofillFFI.h; sourceTree = "<group>"; };
+		15DAE2112944165300DB06FE /* autofill.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = autofill.swift; sourceTree = "<group>"; };
 		1B3BC97527B1D9B700229CF6 /* Collections+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Collections+.swift"; path = "../../../components/nimbus/ios/Nimbus/Collections+.swift"; sourceTree = SOURCE_ROOT; };
 		1B3BC97627B1D9B700229CF6 /* FeatureHolder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FeatureHolder.swift; path = ../../../components/nimbus/ios/Nimbus/FeatureHolder.swift; sourceTree = SOURCE_ROOT; };
 		1B3BC97727B1D9B700229CF6 /* NimbusApi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NimbusApi.swift; path = ../../../components/nimbus/ios/Nimbus/NimbusApi.swift; sourceTree = SOURCE_ROOT; };
@@ -200,6 +204,26 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		15DAE2082944142000DB06FE /* Autofill */ = {
+			isa = PBXGroup;
+			children = (
+				15DAE20F294415B100DB06FE /* Generated */,
+				15DAE20D2944155E00DB06FE /* autofill.udl */,
+			);
+			name = Autofill;
+			path = ../../../../components/autofill/ios;
+			sourceTree = "<group>";
+		};
+		15DAE20F294415B100DB06FE /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				15DAE2112944165300DB06FE /* autofill.swift */,
+				15DAE2102944165300DB06FE /* autofillFFI.h */,
+			);
+			name = Generated;
+			path = ../../../components/autofill/ios/Generated;
+			sourceTree = SOURCE_ROOT;
+		};
 		1B3BC97427B1D99A00229CF6 /* Nimbus */ = {
 			isa = PBXGroup;
 			children = (
@@ -277,6 +301,7 @@
 		1BBAC4FA27AE049500DAFEF2 /* MozillaTestServices */ = {
 			isa = PBXGroup;
 			children = (
+				15DAE2082944142000DB06FE /* Autofill */,
 				45CC574328AD9BC8006D55AA /* ErrorSupport */,
 				1BFC469427C99F250034E0A5 /* Generated */,
 				1BB64C7B27B1FF9F00A4247F /* TestClient */,
@@ -620,6 +645,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				15DAE213294418F600DB06FE /* autofill.udl in Sources */,
 				45CC574A28AD9C86006D55AA /* errorsupport.udl in Sources */,
 				1BE9B60D27C9CD770029D11A /* crashtest.udl in Sources */,
 				1BE9B60E27C9CD770029D11A /* nimbus.udl in Sources */,

--- a/testing/sync-test/src/autofill.rs
+++ b/testing/sync-test/src/autofill.rs
@@ -10,7 +10,7 @@ use autofill::{
         models::credit_card::{CreditCard, UpdatableCreditCardFields},
         store::Store as AutofillStore,
     },
-    encryption::{create_key, encrypt_string},
+    encryption::{create_autofill_key, encrypt_string},
     error::ApiResult as AutofillResult,
 };
 use std::collections::HashMap;
@@ -111,7 +111,7 @@ pub fn assert_credit_cards_equiv(a: &CreditCard, b: &CreditCard) {
 fn test_autofill_credit_cards_general(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Add some credit cards to client0");
 
-    let key = create_key().expect("encryption key created");
+    let key = create_autofill_key().expect("encryption key created");
 
     let cc1 = add_credit_card(
         &c0.autofill_store,


### PR DESCRIPTION
Exposing the autofill component's API for the iOS consumer in support of the credit card autofill effort. There is also a related [rust-components-swift PR](https://github.com/mozilla/rust-components-swift/pull/88) to generate the autofill bindings which will be released after this PR is merged and released since the `createKey` naming collision between autofill and logins is resolved in this PR.

Additionally there is an [iOS PR](https://github.com/mozilla-mobile/firefox-ios/pull/12784) where the credit card storage logic has been implemented which is dependent on the logic in this PR and the aforementioned r-c-s PR.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
