### PR TITLE
add NimbusQueues to NimbusApi

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -19,6 +19,11 @@ Use the template below to make assigning a version number during the release cut
 
 -->
 
+## Nimbus
+
+### What's Changed
+  - Fixed an issue where the NimbusQueues protocol was missing from the NimbusApi ([#5298](https://github.com/mozilla/application-services/pull/5298))
+
 ## Tabs
 
 ### What's Changed

--- a/components/nimbus/ios/Nimbus/NimbusApi.swift
+++ b/components/nimbus/ios/Nimbus/NimbusApi.swift
@@ -17,7 +17,7 @@ import Glean
 ///
 public protocol NimbusApi: FeaturesInterface, NimbusStartup,
     NimbusUserConfiguration, NimbusBranchInterface, GleanPlumbProtocol,
-    NimbusEvents {}
+    NimbusEvents, NimbusQueues {}
 
 public protocol NimbusBranchInterface {
     /// Get the currently enrolled branch for the given experiment


### PR DESCRIPTION
Fixes an issue where I forgot to add a protocol to the NimbusApi 🙃 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
