### PR TITLE
[Don't Merge] Expose the `logins::EncryptorDecryptor` as an UniFFI interface

### DIFF
--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -80,30 +80,30 @@ class DatabaseLoginsStorage(dbPath: String) : AutoCloseable {
     }
 
     @Throws(LoginsApiException::class)
-    fun findLoginToUpdate(look: LoginEntry, encryptionKey: String): Login? {
+    fun findLoginToUpdate(look: LoginEntry, encdec: EncryptorDecryptor): Login? {
         return readQueryCounters.measure {
-            store.findLoginToUpdate(look, encryptionKey)
+            store.findLoginToUpdate(look, encdec)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun add(entry: LoginEntry, encryptionKey: String): EncryptedLogin {
+    fun add(entry: LoginEntry, encdec: EncryptorDecryptor): EncryptedLogin {
         return writeQueryCounters.measure {
-            store.add(entry, encryptionKey)
+            store.add(entry, encdec)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun update(id: String, entry: LoginEntry, encryptionKey: String): EncryptedLogin {
+    fun update(id: String, entry: LoginEntry, encdec: EncryptorDecryptor): EncryptedLogin {
         return writeQueryCounters.measure {
-            store.update(id, entry, encryptionKey)
+            store.update(id, entry, encdec)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun addOrUpdate(entry: LoginEntry, encryptionKey: String): EncryptedLogin {
+    fun addOrUpdate(entry: LoginEntry, encdec: EncryptorDecryptor): EncryptedLogin {
         return writeQueryCounters.measure {
-            store.addOrUpdate(entry, encryptionKey)
+            store.addOrUpdate(entry, encdec)
         }
     }
 
@@ -132,10 +132,10 @@ class DatabaseLoginsStorage(dbPath: String) : AutoCloseable {
     }
 }
 
-fun migrateLoginsWithMetrics(newDbPath: String, newDbEncKey: String, sqlCipherDbPath: String, sqlCipherEncKey: String) {
+fun migrateLoginsWithMetrics(newDbPath: String, encdec: EncryptorDecryptor, sqlCipherDbPath: String, sqlCipherEncKey: String) {
     try {
         // last param is the "salt" which is only used on iOS.
-        migrateLogins(newDbPath, newDbEncKey, sqlCipherDbPath, sqlCipherEncKey, null)
+        migrateLogins(newDbPath, encdec, sqlCipherDbPath, sqlCipherEncKey, null)
     } catch (e: LoginsApiException) {
         // Ignore all migration errors. There's nothing the consuming app can
         // do about it, and we are never going to retry.

--- a/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
+++ b/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
@@ -38,7 +38,7 @@ class DatabaseLoginsStorageTest {
         return DatabaseLoginsStorage(dbPath = dbPath.absolutePath)
     }
 
-    protected val encryptionKey = createKey()
+    protected val encdec = EncryptorDecryptor()
 
     protected fun getTestStore(): DatabaseLoginsStorage {
         val store = createTestStore()
@@ -57,7 +57,7 @@ class DatabaseLoginsStorageTest {
                     password = "hunter2"
                 )
             ),
-            encryptionKey
+            encdec
         )
 
         store.add(
@@ -74,7 +74,7 @@ class DatabaseLoginsStorageTest {
                     username = "Foobar2000"
                 )
             ),
-            encryptionKey
+            encdec
         )
 
         return store
@@ -106,7 +106,7 @@ class DatabaseLoginsStorageTest {
                     password = "hunter2"
                 )
             ),
-            encryptionKey
+            encdec
         )
 
         assertEquals(LoginsStoreMetrics.writeQueryCount.testGetValue(), 1)
@@ -128,7 +128,7 @@ class DatabaseLoginsStorageTest {
         )
 
         try {
-            store.add(invalid, encryptionKey)
+            store.add(invalid, encdec)
             fail("Should have thrown")
         } catch (e: LoginsApiException.InvalidRecord) {
             // All good.

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -62,17 +62,17 @@ open class LoginsStorage {
     /// then this throws `LoginStoreError.DuplicateGuid` if there is a collision
     ///
     /// Returns the `id` of the newly inserted record.
-    open func add(login: LoginEntry, encryptionKey: String) throws -> EncryptedLogin {
+    open func add(login: LoginEntry, encdec: EncryptorDecryptor) throws -> EncryptedLogin {
         return try queue.sync {
-            return try self.store.add(login: login, encryptionKey: encryptionKey)
+            return try self.store.add(login: login, encdec: encdec)
         }
     }
 
     /// Update `login` in the database. If `login.id` does not refer to a known
     /// login, then this throws `LoginStoreError.NoSuchRecord`.
-    open func update(id: String, login: LoginEntry, encryptionKey: String) throws -> EncryptedLogin {
+    open func update(id: String, login: LoginEntry, encdec: EncryptorDecryptor) throws -> EncryptedLogin {
         return try queue.sync {
-            return try self.store.update(id: id, login: login, encryptionKey: encryptionKey)
+            return try self.store.update(id: id, login: login, encdec: encdec)
         }
     }
 
@@ -112,7 +112,7 @@ open class LoginsStorage {
                     accessToken: unlockInfo.fxaAccessToken,
                     syncKey: unlockInfo.syncKey,
                     tokenserverUrl: unlockInfo.tokenserverURL,
-                    localEncryptionKey: unlockInfo.loginEncryptionKey
+                    encdec: EncryptorDecryptor.fromKey(encryptionKey: unlockInfo.loginEncryptionKey)
                 )
         }
     }
@@ -120,7 +120,7 @@ open class LoginsStorage {
 
 public func migrateLoginsFromSqlcipher(
     path: String,
-    newEncryptionKey: String,
+    encdec: EncryptorDecryptor,
     sqlcipherPath: String,
     sqlcipherKey: String,
     salt: String
@@ -129,7 +129,7 @@ public func migrateLoginsFromSqlcipher(
 
     if (try? migrateLogins(
         path: path,
-        newEncryptionKey: newEncryptionKey,
+        encdec: encdec,
         sqlcipherPath: sqlcipherPath,
         sqlcipherKey: sqlcipherKey,
         salt: salt

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -20,7 +20,7 @@ mod util;
 uniffi_macros::include_scaffolding!("logins");
 
 pub use crate::db::LoginDb;
-use crate::encryption::{check_canary, create_canary, create_key};
+use crate::encryption::EncryptorDecryptor;
 pub use crate::error::*;
 pub use crate::login::*;
 pub use crate::migrate_sqlcipher_db::migrate_logins;
@@ -29,30 +29,26 @@ pub use crate::sync::LoginsSyncEngine;
 
 // Public encryption functions.  We publish these as top-level functions to expose them across
 // UniFFI
-fn encrypt_login(login: Login, enc_key: &str) -> ApiResult<EncryptedLogin> {
+fn encrypt_login(login: Login, encdec: &EncryptorDecryptor) -> ApiResult<EncryptedLogin> {
     handle_error! {
-        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-        login.encrypt(&encdec)
+        login.encrypt(encdec)
     }
 }
 
-fn decrypt_login(login: EncryptedLogin, enc_key: &str) -> ApiResult<Login> {
+fn decrypt_login(login: EncryptedLogin, encdec: &EncryptorDecryptor) -> ApiResult<Login> {
     handle_error! {
-        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-        login.decrypt(&encdec)
+        login.decrypt(encdec)
     }
 }
 
-fn encrypt_fields(sec_fields: SecureLoginFields, enc_key: &str) -> ApiResult<String> {
+fn encrypt_fields(sec_fields: SecureLoginFields, encdec: &EncryptorDecryptor) -> ApiResult<String> {
     handle_error! {
-        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
-        sec_fields.encrypt(&encdec)
+        sec_fields.encrypt(encdec)
     }
 }
 
-fn decrypt_fields(sec_fields: String, enc_key: &str) -> ApiResult<SecureLoginFields> {
+fn decrypt_fields(sec_fields: String, encdec: &EncryptorDecryptor) -> ApiResult<SecureLoginFields> {
     handle_error! {
-        let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
         encdec.decrypt_struct(&sec_fields)
     }
 }

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -3,40 +3,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 namespace logins {
-    // We expose the crypto primitives on the namespace
-
-    // Create a new, random, encryption key.
-    [Throws=LoginsApiError]
-    string create_key();
-
     // Decrypt an `EncryptedLogin` to a `Login`
     [Throws=LoginsApiError]
-    Login decrypt_login(EncryptedLogin login, [ByRef]string encryption_key);
-
+    Login decrypt_login(EncryptedLogin login, [ByRef]EncryptorDecryptor encdec);
+ 
     // Encrypt a `Login` to an `EncryptedLogin`
     [Throws=LoginsApiError]
-    EncryptedLogin encrypt_login(Login login, [ByRef]string encryption_key);
-
+    EncryptedLogin encrypt_login(Login login, [ByRef]EncryptorDecryptor encdec);
+ 
     // Decrypt an encrypted `string` to `SecureLoginFields`
     [Throws=LoginsApiError]
-    SecureLoginFields decrypt_fields(string sec_fields, [ByRef]string encryption_key);
-
+    SecureLoginFields decrypt_fields(string sec_fields, [ByRef]EncryptorDecryptor encdec);
+ 
     // Encrypt `SecureLoginFields` to an encrypted `string`
     [Throws=LoginsApiError]
-    string encrypt_fields(SecureLoginFields sec_fields, [ByRef]string encryption_key);
-
-    // Create a "canary" string, which can be used to test if the encryption key is still valid for the logins data
-    [Throws=LoginsApiError]
-    string create_canary([ByRef]string text, [ByRef]string encryption_key);
-
-    // Check that key is still valid using the output of `create_canary`.  `text` much match the text you initially passed to `create_canary()`
-    [Throws=LoginsApiError]
-    boolean check_canary([ByRef]string canary, [ByRef]string text, [ByRef]string encryption_key);
+    string encrypt_fields(SecureLoginFields sec_fields, [ByRef]EncryptorDecryptor encdec);
 
     [Throws=LoginsApiError]
     void migrate_logins(
         [ByRef]string path,
-        [ByRef]string new_encryption_key,
+        [ByRef]EncryptorDecryptor encdec,
         [ByRef]string sqlcipher_path,
         [ByRef]string sqlcipher_key,
         string? salt
@@ -115,19 +101,18 @@ interface LoginsApiError {
     UnexpectedLoginsApiError(string reason);
 };
 
-
 interface LoginStore {
     [Throws=LoginsApiError]
     constructor(string path);
 
     [Throws=LoginsApiError]
-    EncryptedLogin add(LoginEntry login, [ByRef]string encryption_key);
+    EncryptedLogin add(LoginEntry login, [ByRef]EncryptorDecryptor encdec);
 
     [Throws=LoginsApiError]
-    EncryptedLogin update([ByRef] string id, LoginEntry login, [ByRef]string encryption_key);
+    EncryptedLogin update([ByRef] string id, LoginEntry login, [ByRef]EncryptorDecryptor encdec);
 
     [Throws=LoginsApiError]
-    EncryptedLogin add_or_update(LoginEntry login, [ByRef]string encryption_key);
+    EncryptedLogin add_or_update(LoginEntry login, [ByRef]EncryptorDecryptor encdec);
 
     [Throws=LoginsApiError]
     boolean delete([ByRef] string id);
@@ -151,7 +136,7 @@ interface LoginStore {
     sequence<EncryptedLogin> get_by_base_domain([ByRef] string base_domain);
 
     [Throws=LoginsApiError]
-    Login? find_login_to_update(LoginEntry look, [ByRef]string encryption_key);
+    Login? find_login_to_update(LoginEntry look, [ByRef]EncryptorDecryptor encdec);
 
     [Throws=LoginsApiError]
     EncryptedLogin? get([ByRef] string id);
@@ -160,5 +145,25 @@ interface LoginStore {
     void register_with_sync_manager();
 
     [Throws=LoginsApiError, Self=ByArc]
-    string sync(string key_id, string access_token, string sync_key, string tokenserver_url, string local_encryption_key);
+    string sync(string key_id, string access_token, string sync_key, string tokenserver_url, EncryptorDecryptor encdec);
+};
+
+interface EncryptorDecryptor {
+    [Throws=LoginsApiError]
+    constructor();
+
+    [Name=from_key, Throws=LoginsApiError]
+    constructor([ByRef]string encryption_key);
+
+    [Throws=LoginsApiError]
+    string get_key();
+
+    // Create a "canary" string, which can be used to test if the encryption key is still valid for the logins data
+    [Throws=LoginsApiError]
+    string create_canary([ByRef] string text);
+
+    // Check that key is still valid using the output of `create_canary`
+    //
+    // `text` much match the text you initially passed to `create_canary()`
+    boolean check_canary([ByRef] string canary, [ByRef] string text);
 };

--- a/components/logins/src/sync/engine.rs
+++ b/components/logins/src/sync/engine.rs
@@ -443,7 +443,7 @@ impl SyncEngine for LoginsSyncEngine {
     }
 
     fn set_local_encryption_key(&mut self, key: &str) -> anyhow::Result<()> {
-        self.encdec = Some(EncryptorDecryptor::new(key)?);
+        self.encdec = Some(EncryptorDecryptor::_from_key(key)?);
         Ok(())
     }
 
@@ -510,7 +510,7 @@ impl SyncEngine for LoginsSyncEngine {
 mod tests {
     use super::*;
     use crate::db::test_utils::insert_login;
-    use crate::encryption::test_utils::{TEST_ENCRYPTION_KEY, TEST_ENCRYPTOR};
+    use crate::encryption::test_utils::TEST_ENCRYPTOR;
     use crate::login::test_utils::enc_login;
     use crate::{LoginEntry, LoginFields, RecordFields, SecureLoginFields};
     use std::collections::HashMap;
@@ -523,7 +523,7 @@ mod tests {
     ) -> (Vec<SyncLoginData>, telemetry::EngineIncoming) {
         let mut engine = LoginsSyncEngine::new(Arc::new(store)).unwrap();
         engine
-            .set_local_encryption_key(&TEST_ENCRYPTION_KEY)
+            .set_local_encryption_key(&TEST_ENCRYPTOR.get_key().unwrap())
             .unwrap();
         let mut telem = sync15::telemetry::EngineIncoming::new();
         (
@@ -537,7 +537,7 @@ mod tests {
     fn run_fetch_outgoing(store: LoginStore) -> OutgoingChangeset {
         let mut engine = LoginsSyncEngine::new(Arc::new(store)).unwrap();
         engine
-            .set_local_encryption_key(&TEST_ENCRYPTION_KEY)
+            .set_local_encryption_key(&TEST_ENCRYPTOR.get_key().unwrap())
             .unwrap();
         engine
             .fetch_outgoing(sync15::ServerTimestamp(10000), &engine.scope)
@@ -754,7 +754,7 @@ mod tests {
             },
         };
         let first_id = store
-            .add(to_add, &TEST_ENCRYPTION_KEY)
+            .add(to_add, &TEST_ENCRYPTOR)
             .expect("should insert first")
             .record
             .id;
@@ -771,7 +771,7 @@ mod tests {
             },
         };
         let second_id = store
-            .add(to_add, &TEST_ENCRYPTION_KEY)
+            .add(to_add, &TEST_ENCRYPTOR)
             .expect("should insert second")
             .record
             .id;
@@ -788,14 +788,14 @@ mod tests {
             },
         };
         let no_form_origin_id = store
-            .add(to_add, &TEST_ENCRYPTION_KEY)
+            .add(to_add, &TEST_ENCRYPTOR)
             .expect("should insert second")
             .record
             .id;
 
         let mut engine = LoginsSyncEngine::new(Arc::new(store)).unwrap();
         engine
-            .set_local_encryption_key(&TEST_ENCRYPTION_KEY)
+            .set_local_encryption_key(&TEST_ENCRYPTOR.get_key().unwrap())
             .unwrap();
 
         let to_find = make_enc_login("test", "test", Some("https://www.example.com".into()), None);

--- a/testing/sync-test/src/logins.rs
+++ b/testing/sync-test/src/logins.rs
@@ -4,7 +4,7 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 use crate::auth::TestClient;
 use crate::testing::TestGroup;
 use anyhow::Result;
-use logins::encryption::{create_key, EncryptorDecryptor};
+use logins::encryption::EncryptorDecryptor;
 use logins::{
     ApiResult as LoginResult, Login, LoginEntry, LoginFields, LoginStore, SecureLoginFields,
 };
@@ -26,22 +26,20 @@ pub fn times_used_for_id(s: &LoginStore, id: &str) -> i64 {
         .times_used
 }
 
-pub fn add_login(s: &LoginStore, l: LoginEntry, key: &str) -> LoginResult<Login> {
-    let encrypted = s.add(l, key)?;
+pub fn add_login(s: &LoginStore, l: LoginEntry, encdec: &EncryptorDecryptor) -> LoginResult<Login> {
+    let encrypted = s.add(l, encdec)?;
     let fetched = s
         .get(&encrypted.guid())?
         .expect("Login we just added to exist");
-    let encdec = EncryptorDecryptor::new(key).unwrap();
-    Ok(fetched.decrypt(&encdec).unwrap())
+    Ok(fetched.decrypt(encdec).unwrap())
 }
 
-pub fn verify_login(s: &LoginStore, l: &Login, key: &str) {
-    let encdec = EncryptorDecryptor::new(key).unwrap();
+pub fn verify_login(s: &LoginStore, l: &Login, encdec: &EncryptorDecryptor) {
     let equivalent = s
         .get(&l.guid())
         .expect("get() to succeed")
         .expect("Expected login to be present")
-        .decrypt(&encdec)
+        .decrypt(encdec)
         .expect("should decrypt");
 
     assert_logins_equiv(&equivalent, l);
@@ -58,35 +56,38 @@ pub fn verify_missing_login(s: &LoginStore, id: &str) {
 pub fn update_login<F: FnMut(&mut Login)>(
     s: &LoginStore,
     id: &str,
-    key: &str,
+    encdec: &EncryptorDecryptor,
     mut callback: F,
 ) -> LoginResult<Login> {
-    let encdec = EncryptorDecryptor::new(key).unwrap();
     let encrypted = s.get(id)?.expect("No such login!");
-    let mut login = encrypted.decrypt(&encdec).unwrap();
+    let mut login = encrypted.decrypt(encdec).unwrap();
     callback(&mut login);
     let to_update = LoginEntry {
         fields: login.fields,
         sec_fields: login.sec_fields,
     };
-    s.update(id, to_update, key)?;
+    s.update(id, to_update, encdec)?;
     Ok(s.get(id)?
         .expect("Just updated this")
-        .decrypt(&encdec)
+        .decrypt(encdec)
         .unwrap())
 }
 
-pub fn touch_login(s: &LoginStore, id: &str, times: usize, key: &str) -> LoginResult<Login> {
+pub fn touch_login(
+    s: &LoginStore,
+    id: &str,
+    times: usize,
+    encdec: &EncryptorDecryptor,
+) -> LoginResult<Login> {
     for _ in 0..times {
         s.touch(id)?;
     }
-    let encdec = EncryptorDecryptor::new(key).unwrap();
-    Ok(s.get(id)?.unwrap().decrypt(&encdec).unwrap())
+    Ok(s.get(id)?.unwrap().decrypt(encdec).unwrap())
 }
 
-pub fn sync_logins(client: &mut TestClient, key: &str) -> Result<()> {
+pub fn sync_logins(client: &mut TestClient, encdec: &EncryptorDecryptor) -> Result<()> {
     let mut local_encryption_keys = HashMap::new();
-    local_encryption_keys.insert("passwords".to_string(), key.to_string());
+    local_encryption_keys.insert("passwords".to_string(), encdec.get_key()?);
     client.sync(&["passwords".to_string()], local_encryption_keys)
 }
 
@@ -95,7 +96,7 @@ pub fn sync_logins(client: &mut TestClient, key: &str) -> Result<()> {
 fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Add some logins to client0");
 
-    let key = create_key().unwrap();
+    let encdec = EncryptorDecryptor::new().unwrap();
 
     let l0id = add_login(
         &c0.logins_store,
@@ -112,12 +113,12 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "hunter2".into(),
             },
         },
-        &key,
+        &encdec,
     )
     .expect("add l0")
     .guid();
 
-    let login0_c0 = touch_login(&c0.logins_store, &l0id, 2, &key).expect("touch0 c0");
+    let login0_c0 = touch_login(&c0.logins_store, &l0id, 2, &encdec).expect("touch0 c0");
     assert_eq!(login0_c0.record.times_used, 3);
 
     let login1_c0 = add_login(
@@ -133,25 +134,25 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "sekret".into(),
             },
         },
-        &key,
+        &encdec,
     )
     .expect("add l1");
     let l1id = login1_c0.guid();
 
     log::info!("Syncing client0");
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0, &encdec).expect("c0 sync to work");
 
     // Should be the same after syncing.
-    verify_login(&c0.logins_store, &login0_c0, &key);
-    verify_login(&c0.logins_store, &login1_c0, &key);
+    verify_login(&c0.logins_store, &login0_c0, &encdec);
+    verify_login(&c0.logins_store, &login1_c0, &encdec);
 
     log::info!("Syncing client1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1, &encdec).expect("c1 sync to work");
 
     log::info!("Check state");
 
-    verify_login(&c1.logins_store, &login0_c0, &key);
-    verify_login(&c1.logins_store, &login1_c0, &key);
+    verify_login(&c1.logins_store, &login0_c0, &encdec);
+    verify_login(&c1.logins_store, &login1_c0, &encdec);
 
     assert_eq!(
         times_used_for_id(&c1.logins_store, &l0id),
@@ -162,31 +163,31 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Update logins");
 
     // Change login0 on both
-    update_login(&c1.logins_store, &l0id, &key, |l| {
+    update_login(&c1.logins_store, &l0id, &encdec, |l| {
         l.sec_fields.password = "testtesttest".into();
     })
     .unwrap();
 
-    let login0_c0 = update_login(&c0.logins_store, &l0id, &key, |l| {
+    let login0_c0 = update_login(&c0.logins_store, &l0id, &encdec, |l| {
         l.fields.username_field = "users_name".into();
     })
     .unwrap();
 
     // and login1 on remote.
-    let login1_c1 = update_login(&c1.logins_store, &l1id, &key, |l| {
+    let login1_c1 = update_login(&c1.logins_store, &l1id, &encdec, |l| {
         l.sec_fields.username = "less_cool_username".into();
     })
     .unwrap();
 
     log::info!("Sync again");
 
-    sync_logins(c1, &key).expect("c1 sync 2");
-    sync_logins(c0, &key).expect("c0 sync 2");
+    sync_logins(c1, &encdec).expect("c1 sync 2");
+    sync_logins(c0, &encdec).expect("c0 sync 2");
 
     log::info!("Check state again");
 
     // Ensure the remotely changed password change made it through
-    verify_login(&c0.logins_store, &login1_c1, &key);
+    verify_login(&c0.logins_store, &login1_c1, &encdec);
 
     // And that the conflicting one did too.
     verify_login(
@@ -202,7 +203,7 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
             },
             record: login0_c0.record,
         },
-        &key,
+        &encdec,
     );
 
     assert_eq!(
@@ -220,7 +221,7 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
 
 fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Add some logins to client0");
-    let key = create_key().unwrap();
+    let encdec = EncryptorDecryptor::new().unwrap();
 
     let login0 = add_login(
         &c0.logins_store,
@@ -237,7 +238,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "hunter2".into(),
             },
         },
-        &key,
+        &encdec,
     )
     .expect("add l0");
     let l0id = login0.guid();
@@ -255,7 +256,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "sekret".into(),
             },
         },
-        &key,
+        &encdec,
     )
     .expect("add l1");
     let l1id = login1.guid();
@@ -273,7 +274,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "123454321".into(),
             },
         },
-        &key,
+        &encdec,
     )
     .expect("add l2");
     let l2id = login2.guid();
@@ -291,29 +292,29 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "aaaaa".into(),
             },
         },
-        &key,
+        &encdec,
     )
     .expect("add l3");
     let l3id = login3.guid();
 
     log::info!("Syncing client0");
 
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0, &encdec).expect("c0 sync to work");
 
     // Should be the same after syncing.
-    verify_login(&c0.logins_store, &login0, &key);
-    verify_login(&c0.logins_store, &login1, &key);
-    verify_login(&c0.logins_store, &login2, &key);
-    verify_login(&c0.logins_store, &login3, &key);
+    verify_login(&c0.logins_store, &login0, &encdec);
+    verify_login(&c0.logins_store, &login1, &encdec);
+    verify_login(&c0.logins_store, &login2, &encdec);
+    verify_login(&c0.logins_store, &login3, &encdec);
 
     log::info!("Syncing client1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1, &encdec).expect("c1 sync to work");
 
     log::info!("Check state");
-    verify_login(&c1.logins_store, &login0, &key);
-    verify_login(&c1.logins_store, &login1, &key);
-    verify_login(&c1.logins_store, &login2, &key);
-    verify_login(&c1.logins_store, &login3, &key);
+    verify_login(&c1.logins_store, &login0, &encdec);
+    verify_login(&c1.logins_store, &login1, &encdec);
+    verify_login(&c1.logins_store, &login2, &encdec);
+    verify_login(&c1.logins_store, &login3, &encdec);
 
     // The 4 logins are for the for possible scenarios. All of them should result in the record
     // being deleted.
@@ -335,7 +336,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
 
     // case 3a. c0 modifies record (c1 will delete it after c0 syncs so the timestamps line up)
     log::info!("Updating {} on c0", l2id);
-    let login2_new = update_login(&c0.logins_store, &l2id, &key, |l| {
+    let login2_new = update_login(&c0.logins_store, &l2id, &encdec, |l| {
         l.sec_fields.username = "foobar".into();
     })
     .unwrap();
@@ -345,30 +346,30 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
 
     // Sync c1
     log::info!("Syncing c1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1, &encdec).expect("c1 sync to work");
     log::info!("Checking c1 state after sync");
 
     verify_missing_login(&c1.logins_store, &l0id);
     verify_missing_login(&c1.logins_store, &l1id);
-    verify_login(&c1.logins_store, &login2, &key);
+    verify_login(&c1.logins_store, &login2, &encdec);
     verify_missing_login(&c1.logins_store, &l3id);
 
     log::info!("Update {} on c0", l3id);
     // 4b
-    update_login(&c0.logins_store, &l3id, &key, |l| {
+    update_login(&c0.logins_store, &l3id, &encdec, |l| {
         l.sec_fields.password = "quux".into();
     })
     .unwrap();
 
     // Sync c0
     log::info!("Syncing c0");
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0, &encdec).expect("c0 sync to work");
 
     log::info!("Checking c0 state after sync");
 
     verify_missing_login(&c0.logins_store, &l0id);
     verify_missing_login(&c0.logins_store, &l1id);
-    verify_login(&c0.logins_store, &login2_new, &key);
+    verify_login(&c0.logins_store, &login2_new, &encdec);
     verify_missing_login(&c0.logins_store, &l3id);
 
     log::info!("Delete {} on c1", l2id);
@@ -376,14 +377,14 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     assert!(c1.logins_store.delete(&l2id).expect("Delete should work"));
 
     log::info!("Syncing c1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1, &encdec).expect("c1 sync to work");
 
     log::info!("{} should stay dead", l2id);
     // Ensure we didn't revive it.
     verify_missing_login(&c1.logins_store, &l2id);
 
     log::info!("Syncing c0");
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0, &encdec).expect("c0 sync to work");
     log::info!("Should delete {}", l2id);
     verify_missing_login(&c0.logins_store, &l2id);
 }

--- a/testing/sync-test/src/sync15.rs
+++ b/testing/sync-test/src/sync15.rs
@@ -14,12 +14,12 @@ use log::*;
 use serde_derive::*;
 use std::cell::{Cell, RefCell};
 use std::mem;
+use sync15::bso::OutgoingBso;
 use sync15::client::{sync_multiple, MemoryCachedState, Sync15StorageClientInit};
 use sync15::engine::{
     CollectionRequest, EngineSyncAssociation, IncomingChangeset, OutgoingChangeset, SyncEngine,
 };
 use sync15::{telemetry, ServerTimestamp};
-use sync15::bso::OutgoingBso;
 use sync_guid::Guid;
 
 use crate::auth::TestClient;


### PR DESCRIPTION
Change the logins API to use `EncryptorDecryptor` directly rather than inputting keys.  The main benefit of this is that we only construct the `EncryptorDecryptor` once, rather than for each API call.

Also, the autofill API is very similar to the logins one.  We could consider moving `EncryptorDecryptor` to some shared place, like a support crate, and using that for both.  That would avoid some code duplication.  It also is one way to sidestep an issue we have with Swift namespaces for a bit longer.  Currently, if we started using `autofill.udl` on Swift we would have a name collision with `create_key() (see uniffi-rs#1426 for details on this).

Don't merge this one yet for a couple reasons:
  - We'd need to resolve the breaking changes for Swift and Kotlin first
  - We're not sure how we want to handle Objects like this on Kotlin yet.  Right now we'd need to manually call the `destroy()` function for each `EncryptorDecryptor`.  Part of the motivation for this PR is to provide an example for the general discussion.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
