### PR TITLE
Adds a 10,000 visit limit to the history migration

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,7 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Places
+### What's changed
+  - Limited the number of visits to migrate for History to 10,000 visits. ([#5310](https://github.com/mozilla/application-services/pull/5310))

--- a/testing/separated/places-tests/src/ios_history.rs
+++ b/testing/separated/places-tests/src/ios_history.rs
@@ -175,7 +175,7 @@ fn generate_test_history(
     let mut last_visit_id = 1;
     (1..=num_history)
         .map(|id| IOSHistory {
-            id: id,
+            id,
             guid: format!("Example GUID {}", id),
             url: Some(format!("https://example{}.com", id)),
             title: format!("Example Title {}", id),

--- a/testing/separated/places-tests/src/ios_history.rs
+++ b/testing/separated/places-tests/src/ios_history.rs
@@ -77,6 +77,35 @@ impl HistoryTable {
         }
         Ok(())
     }
+
+    fn populate_one(conn: &Connection, history_item: &IOSHistory) -> Result<()> {
+        let mut stmt = conn.prepare(
+            "INSERT INTO history(
+                id,
+                guid,
+                url,
+                title,
+                is_deleted,
+                should_upload
+            ) VALUES (
+                :id,
+                :guid,
+                :url,
+                :title,
+                :is_deleted,
+                :should_upload
+            )",
+        )?;
+        stmt.execute(rusqlite::named_params! {
+            ":guid": history_item.id,
+            ":guid": history_item.guid,
+            ":url": history_item.url,
+            ":title": history_item.title,
+            ":is_deleted": history_item.is_deleted,
+            ":should_upload": history_item.should_upload,
+        })?;
+        Ok(())
+    }
 }
 
 impl VisitTable {
@@ -107,6 +136,74 @@ impl VisitTable {
         }
         Ok(())
     }
+
+    fn populate_one(conn: &Connection, visit: &IOSVisit) -> Result<()> {
+        let mut stmt = conn.prepare(
+            "INSERT INTO visits (
+                id,
+                siteID,
+                date,
+                type,
+                is_local
+            ) VALUES (
+                :id,
+                :siteID,
+                :date,
+                :type,
+                :is_local
+            )",
+        )?;
+        stmt.execute(rusqlite::named_params! {
+            ":id": visit.id,
+            ":siteID": visit.site_id,
+            ":date": visit.date,
+            ":type": visit.type_,
+            ":is_local": visit.is_local,
+        })?;
+        Ok(())
+    }
+}
+
+fn generate_test_history(
+    ios_db: &Connection,
+    num_history: u64,
+    num_visits_per: u64,
+    start_timestamp: Timestamp,
+    seconds_between_visits: u64,
+) -> Result<()> {
+    let mut start_timestamp = start_timestamp;
+    let mut last_visit_id = 1;
+    (1..=num_history)
+        .map(|id| IOSHistory {
+            id: id,
+            guid: format!("Example GUID {}", id),
+            url: Some(format!("https://example{}.com", id)),
+            title: format!("Example Title {}", id),
+            is_deleted: false,
+            should_upload: false,
+        })
+        .for_each(|h| {
+            HistoryTable::populate_one(ios_db, &h).unwrap();
+            (0..num_visits_per).for_each(|v_id| {
+                let res = IOSVisit {
+                    id: v_id + last_visit_id,
+                    site_id: h.id,
+                    date: start_timestamp
+                        .checked_add(Duration::from_secs(seconds_between_visits))
+                        .unwrap()
+                        .as_millis_i64()
+                        * 1000,
+                    type_: 1,
+                    ..Default::default()
+                };
+                start_timestamp = start_timestamp
+                    .checked_add(Duration::from_secs(seconds_between_visits))
+                    .unwrap();
+                VisitTable::populate_one(ios_db, &res).unwrap();
+            });
+            last_visit_id += num_visits_per;
+        });
+    Ok(())
 }
 
 #[test]
@@ -143,7 +240,7 @@ fn test_import_basic() -> Result<()> {
     // We subtract a bit because our sanitization logic is smart and rejects
     // visits that have a future timestamp,
     let before_first_visit_ts = Timestamp::now()
-        .checked_sub(Duration::from_secs(10000))
+        .checked_sub(Duration::from_secs(30 * 24 * 60 * 60))
         .unwrap();
     let first_visit_ts = before_first_visit_ts
         .checked_add(Duration::from_secs(100))
@@ -218,13 +315,19 @@ fn test_update_missing_title() -> Result<()> {
             .with_title(Some("Mozilla!".to_string()))
             .with_visit_type(Some(VisitTransition::Link)),
     )?;
+    apply_observation(
+        &mut conn,
+        VisitObservation::new(Url::parse("https://firefox.com/").unwrap())
+            .with_title(Some("Firefox!".to_string()))
+            .with_visit_type(Some(VisitTransition::Link)),
+    )?;
     let visit_infos = get_visit_infos(
         &conn,
         Timestamp::EARLIEST,
         Timestamp::now(),
         VisitTransitionSet::empty(),
     )?;
-    assert_eq!(visit_infos.len(), 2);
+    assert_eq!(visit_infos.len(), 3);
     // We verify that before the migration example.com had no title
     // and mozilla.org had "Mozilla!" as title
     for visit in visit_infos {
@@ -232,6 +335,8 @@ fn test_update_missing_title() -> Result<()> {
             assert!(visit.title.is_none())
         } else if visit.url.to_string() == "https://mozilla.org/" {
             assert_eq!(visit.title, Some("Mozilla!".to_string()))
+        } else if visit.url.to_string() == "https://firefox.com/" {
+            assert_eq!(visit.title, Some("Firefox!".to_string()))
         } else {
             panic!("Unexpected visit: {}", visit.url)
         }
@@ -249,16 +354,43 @@ fn test_update_missing_title() -> Result<()> {
     };
 
     let mozilla_org_entry = IOSHistory {
-        id: 1,
+        id: 2,
         guid: "EXAMPLE GUID2".to_string(),
         url: Some("https://mozilla.org/".to_string()),
         title: "New Mozilla Title".to_string(),
         is_deleted: false,
         should_upload: false,
     };
+    // We subtract a bit because our sanitization logic is smart and rejects
+    // visits that have a future timestamp,
+    let before_first_visit_ts = Timestamp::now()
+        .checked_sub(Duration::from_secs(30 * 24 * 60 * 60))
+        .unwrap();
 
-    let history_table = HistoryTable(vec![example_com_entry, mozilla_org_entry]);
+    let history_entries = vec![example_com_entry, mozilla_org_entry];
+    let visits = vec![
+        IOSVisit {
+            id: 0,
+            site_id: 1,
+            type_: 1,
+            date: before_first_visit_ts.as_millis_i64() * 1000,
+            is_local: true,
+        },
+        IOSVisit {
+            id: 1,
+            site_id: 2,
+            type_: 1,
+            date: before_first_visit_ts.as_millis_i64() * 1000 + 2,
+            is_local: true,
+        },
+    ];
+
+    assert_eq!(visits.len(), 2);
+
+    let history_table = HistoryTable(history_entries);
+    let visit_table = VisitTable(visits);
     history_table.populate(&ios_db)?;
+    visit_table.populate(&ios_db)?;
 
     // We now run the migration, both places should get an updated title
     places::import::import_ios_history(&conn, ios_path, 0)?;
@@ -268,17 +400,41 @@ fn test_update_missing_title() -> Result<()> {
         Timestamp::now(),
         VisitTransitionSet::empty(),
     )?;
-    assert_eq!(visit_infos.len(), 2);
+
+    // Three visits we manually added, and 2 imported from iOS
+    assert_eq!(visit_infos.len(), 5);
 
     for visit in visit_infos {
         if visit.url.to_string() == "https://example.com/" {
             assert_eq!(visit.title, Some("Example(dot)com".to_string()))
         } else if visit.url.to_string() == "https://mozilla.org/" {
             assert_eq!(visit.title, Some("New Mozilla Title".to_string()))
+        } else if visit.url.to_string() == "https://firefox.com/" {
+            assert_eq!(visit.title, Some("Firefox!".to_string()))
         } else {
             panic!("Unexpected visit: {}", visit.url)
         }
     }
 
+    Ok(())
+}
+
+#[test]
+fn test_import_a_lot() -> Result<()> {
+    let tmpdir = tempdir().unwrap();
+    let ios_path = tmpdir.path().join("browser.db");
+    let ios_db = empty_ios_db(&ios_path)?;
+
+    // We subtract a bit because our sanitization logic is smart and rejects
+    // visits that have a future timestamp,
+    let before_first_visit_ts = Timestamp::now()
+        .checked_sub(Duration::from_secs(30 * 24 * 60 * 60))
+        .unwrap();
+    generate_test_history(&ios_db, 101, 100, before_first_visit_ts, 1)?;
+
+    let places_api = PlacesApi::new(tmpdir.path().join("places.sqlite"))?;
+    let conn = places_api.open_connection(ConnectionType::ReadWrite)?;
+    let results = places::import::import_ios_history(&conn, &ios_path, 0)?;
+    assert_eq!(results.num_succeeded, 10000);
     Ok(())
 }


### PR DESCRIPTION
Adds a 10,000 visit limit for visits migrated. based on https://docs.google.com/document/d/1fC55c9m66E18ztQwEFhfmesJdSWfes3eSQLcfaq4Kjo/edit


Benchmarked this a little, on my iPhone history with 100,000 visits get migrated in less than 1 second (used to take 3 to 4 seconds).

Benchmarked 1,000,000 visits, it takes around 3 seconds on my computer (not on my phone), where previously it took too long for me to measure :)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
