### PR TITLE
Cut release v96.2.1

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 96.2.0
+libraryVersion: 96.2.1
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v96.2.1 (_2023-01-04_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v96.2.0...v96.2.1)
+
+## Places
+### What's changed
+  - Limited the number of visits to migrate for History to 10,000 visits. ([#5310](https://github.com/mozilla/application-services/pull/5310))
+
 # v96.2.0 (_2023-01-03_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v96.1.3...v96.2.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v96.2.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v96.2.1...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,7 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-
-## Places
-### What's changed
-  - Limited the number of visits to migrate for History to 10,000 visits. ([#5310](https://github.com/mozilla/application-services/pull/5310))


### PR DESCRIPTION
Cuts 96.2.1 to add the 10,000 limit on the history migration.
