### PR TITLE
Add fallback translation bundle method

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -22,3 +22,7 @@ Use the template below to make assigning a version number during the release cut
 ## Places
 ### What's changed
  - Removes old iOS bookmarks migration code. The function `migrateBookmarksFromBrowserDb` no longer exists. ([#5276](https://github.com/mozilla/application-services/pull/5276))
+
+## Nimbus ⛅️🔬🔭
+### What's New
+  - iOS: added a `Bundle.fallbackTranslationBundle()` method. ([#5314](https://github.com/mozilla/application-services/pull/5314))

--- a/components/nimbus/ios/Nimbus/Bundle+.swift
+++ b/components/nimbus/ios/Nimbus/Bundle+.swift
@@ -69,7 +69,8 @@ public extension Bundle {
     /// If no bundle for the language exists, then return `nil`.
     func fallbackTranslationBundle(language: String? = nil) -> Bundle? {
         if let lang = language ?? infoDictionary?["CFBundleDevelopmentRegion"] as? String,
-           let path = path(forResource: lang, ofType: "lproj") {
+           let path = path(forResource: lang, ofType: "lproj")
+        {
             return Bundle(path: path)
         } else {
             return nil

--- a/components/nimbus/ios/Nimbus/Bundle+.swift
+++ b/components/nimbus/ios/Nimbus/Bundle+.swift
@@ -1,0 +1,78 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+#if canImport(UIKit)
+    import UIKit
+#endif
+
+public extension Array where Element == Bundle {
+    /// Search through the resource bundles looking for an image of the given name.
+    ///
+    /// If no image is found in any of the `resourceBundles`, then the `nil` is returned.
+    func getImage(named name: String) -> UIImage? {
+        for bundle in self {
+            if let image = UIImage(named: name, in: bundle, compatibleWith: nil) {
+                return image
+            }
+        }
+        return nil
+    }
+
+    /// Search through the resource bundles looking for an image of the given name.
+    ///
+    /// If no image is found in any of the `resourceBundles`, then a fatal error is
+    /// thrown. This method is only intended for use with hard coded default images
+    /// when other images have been omitted or are missing.
+    ///
+    /// The two ways of fixing this would be to provide the image as its named in the `.fml.yaml`
+    /// file or to change the name of the image in the FML file.
+    func getImageNotNull(named name: String) -> UIImage {
+        guard let image = getImage(named: name) else {
+            fatalError(
+                "An image named \"\(name)\" has been named in a `.fml.yaml` file, but is missing from the asset bundle")
+        }
+        return image
+    }
+
+    /// Search through the resource bundles looking for localized strings with the given name.
+    /// If the `name` contains exactly one slash, it is split up and the first part of the string is used
+    /// as the `tableName` and the second the `key` in localized string lookup.
+    /// If no string is found in any of the `resourceBundles`, then the `name` is passed back unmodified.
+    func getString(named name: String) -> String? {
+        let parts = name.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: true).map { String($0) }
+        let key: String
+        let tableName: String?
+        switch parts.count {
+        case 2:
+            tableName = parts[0]
+            key = parts[1]
+        default:
+            tableName = nil
+            key = name
+        }
+
+        for bundle in self {
+            let value = bundle.localizedString(forKey: key, value: nil, table: tableName)
+            if value != key {
+                return value
+            }
+        }
+        return nil
+    }
+}
+
+public extension Bundle {
+    /// Loads the language bundle from this one.
+    /// If `language` is `nil`, then look for the development region language.
+    /// If no bundle for the language exists, then return `nil`.
+    func fallbackTranslationBundle(language: String? = nil) -> Bundle? {
+        if let lang = language ?? infoDictionary?["CFBundleDevelopmentRegion"] as? String,
+           let path = path(forResource: lang, ofType: "lproj") {
+            return Bundle(path: path)
+        } else {
+            return nil
+        }
+    }
+}

--- a/components/nimbus/ios/Nimbus/Collections+.swift
+++ b/components/nimbus/ios/Nimbus/Collections+.swift
@@ -4,10 +4,6 @@
 
 import Foundation
 
-#if canImport(UIKit)
-    import UIKit
-#endif
-
 public extension Dictionary {
     func mapKeysNotNull<K1>(_ transform: (Key) -> K1?) -> [K1: Value] {
         let transformed: [(K1, Value)] = compactMap { k, v in
@@ -38,62 +34,6 @@ public extension Dictionary {
         }
 
         return merging(defaults, uniquingKeysWith: valueMerger)
-    }
-}
-
-public extension Array where Element == Bundle {
-    /// Search through the resource bundles looking for an image of the given name.
-    ///
-    /// If no image is found in any of the `resourceBundles`, then the `nil` is returned.
-    func getImage(named name: String) -> UIImage? {
-        for bundle in self {
-            if let image = UIImage(named: name, in: bundle, compatibleWith: nil) {
-                return image
-            }
-        }
-        return nil
-    }
-
-    /// Search through the resource bundles looking for an image of the given name.
-    ///
-    /// If no image is found in any of the `resourceBundles`, then a fatal error is
-    /// thrown. This method is only intended for use with hard coded default images
-    /// when other images have been omitted or are missing.
-    ///
-    /// The two ways of fixing this would be to provide the image as its named in the `.fml.yaml`
-    /// file or to change the name of the image in the FML file.
-    func getImageNotNull(named name: String) -> UIImage {
-        guard let image = getImage(named: name) else {
-            fatalError(
-                "An image named \"\(name)\" has been named in a `.fml.yaml` file, but is missing from the asset bundle")
-        }
-        return image
-    }
-
-    /// Search through the resource bundles looking for localized strings with the given name.
-    /// If the `name` contains exactly one slash, it is split up and the first part of the string is used
-    /// as the `tableName` and the second the `key` in localized string lookup.
-    /// If no string is found in any of the `resourceBundles`, then the `name` is passed back unmodified.
-    func getString(named name: String) -> String? {
-        let parts = name.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: true).map { String($0) }
-        let key: String
-        let tableName: String?
-        switch parts.count {
-        case 2:
-            tableName = parts[0]
-            key = parts[1]
-        default:
-            tableName = nil
-            key = name
-        }
-
-        for bundle in self {
-            let value = bundle.localizedString(forKey: key, value: nil, table: tableName)
-            if value != key {
-                return value
-            }
-        }
-        return nil
     }
 }
 

--- a/components/nimbus/ios/Nimbus/NimbusBuilder.swift
+++ b/components/nimbus/ios/Nimbus/NimbusBuilder.swift
@@ -20,7 +20,7 @@ public class NimbusBuilder {
      * This will only be null or empty in development or testing, or in any build variant of a
      * non-Mozilla fork.
      */
-    func withUrl(_ url: String?) {
+    func with(url: String?) {
         self.url = url
     }
 
@@ -30,7 +30,7 @@ public class NimbusBuilder {
      * A closure for reporting errors from Rust.
      */
     @discardableResult
-    func withErrorReporter(_ reporter: @escaping NimbusErrorReporter) -> NimbusBuilder {
+    func with(errorReporter reporter: @escaping NimbusErrorReporter) -> NimbusBuilder {
         errorReporter = reporter
         return self
     }
@@ -41,7 +41,7 @@ public class NimbusBuilder {
      * A flag to select the main or preview collection of remote settings. Defaults to `false`.
      */
     @discardableResult
-    func usingPreviewCollection(_ flag: Bool) -> NimbusBuilder {
+    func using(previewCollection flag: Bool) -> NimbusBuilder {
         usePreviewCollection = flag
         return self
     }
@@ -64,7 +64,7 @@ public class NimbusBuilder {
      * A optional raw resource of a file downloaded at or near build time from Remote Settings.
      */
     @discardableResult
-    func withInitialExperiments(fileURL: URL?) -> NimbusBuilder {
+    func with(initialExperiments fileURL: URL?) -> NimbusBuilder {
         initialExperiments = fileURL
         return self
     }
@@ -75,7 +75,7 @@ public class NimbusBuilder {
      * The timeout used to wait for the loading of the `initial_experiments
      */
     @discardableResult
-    func withTimeoutForLoadingInitialExperiments(_ seconds: TimeInterval) -> NimbusBuilder {
+    func with(timeoutForLoadingInitialExperiments seconds: TimeInterval) -> NimbusBuilder {
         timeoutLoadingExperiment = seconds
         return self
     }
@@ -107,7 +107,7 @@ public class NimbusBuilder {
     var onApplyCallback: ((NimbusInterface) -> Void)?
 
     @discardableResult
-    func withResourceBundles(_ bundles: [Bundle]) -> NimbusBuilder {
+    func with(bundles: [Bundle]) -> NimbusBuilder {
         resourceBundles = bundles
         return self
     }

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -60,6 +60,7 @@
 		1BF50F1A27B1E19800A9C8A5 /* FxAccountMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAC53C27AE065300DAFEF2 /* FxAccountMocks.swift */; };
 		1BFC469827C99F250034E0A5 /* Metrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BFC469627C99F250034E0A5 /* Metrics.swift */; };
 		39083AAB29561E2400FDD302 /* OperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39083AAA29561E2400FDD302 /* OperationTests.swift */; };
+		395EFD6E2966EB6D00D24B97 /* Bundle+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 395EFD6D2966EB6D00D24B97 /* Bundle+.swift */; };
 		3963A5862919A541001ED4C3 /* Dictionary+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3963A5852919A541001ED4C3 /* Dictionary+.swift */; };
 		39F5D7642956161E004E2384 /* Operation+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F5D7632956161E004E2384 /* Operation+.swift */; };
 		39F5D766295616E3004E2384 /* NimbusBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F5D765295616E3004E2384 /* NimbusBuilder.swift */; };
@@ -176,6 +177,7 @@
 		1BF50F2B27B1EB7D00A9C8A5 /* sdk_generator.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; name = sdk_generator.sh; path = "../../../../../components/external/glean/glean-core/ios/sdk_generator.sh"; sourceTree = SOURCE_ROOT; };
 		1BFC469627C99F250034E0A5 /* Metrics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Metrics.swift; path = MozillaTestServices/Generated/Metrics.swift; sourceTree = SOURCE_ROOT; };
 		39083AAA29561E2400FDD302 /* OperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationTests.swift; sourceTree = "<group>"; };
+		395EFD6D2966EB6D00D24B97 /* Bundle+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Bundle+.swift"; path = "Nimbus/Bundle+.swift"; sourceTree = "<group>"; };
 		3963A5852919A541001ED4C3 /* Dictionary+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Dictionary+.swift"; path = "Nimbus/Dictionary+.swift"; sourceTree = "<group>"; };
 		39F5D7632956161E004E2384 /* Operation+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "Operation+.swift"; path = "Nimbus/Operation+.swift"; sourceTree = "<group>"; };
 		39F5D765295616E3004E2384 /* NimbusBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = NimbusBuilder.swift; path = Nimbus/NimbusBuilder.swift; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 				1BF50F2327B1E53E00A9C8A5 /* metrics.yaml */,
 				1BF50EF327B1DD7D00A9C8A5 /* Generated */,
 				1B3BC98E27B1D9D600229CF6 /* nimbus.udl */,
+				395EFD6D2966EB6D00D24B97 /* Bundle+.swift */,
 				1B3BC97527B1D9B700229CF6 /* Collections+.swift */,
 				3963A5852919A541001ED4C3 /* Dictionary+.swift */,
 				39F5D7632956161E004E2384 /* Operation+.swift */,
@@ -668,6 +671,7 @@
 				1B3BC94627B1D6A500229CF6 /* ResultError.swift in Sources */,
 				1B3BC98327B1D9B700229CF6 /* FeatureHolder.swift in Sources */,
 				1B3BC98527B1D9B800229CF6 /* GleanPlumbHelpers.swift in Sources */,
+				395EFD6E2966EB6D00D24B97 /* Bundle+.swift in Sources */,
 				1BF50F1427B1E17B00A9C8A5 /* PersistedFirefoxAccount.swift in Sources */,
 				1BF50F1027B1E17B00A9C8A5 /* FxAccountStorage.swift in Sources */,
 				1BF50F0E27B1E17B00A9C8A5 /* FxAccountLogging.swift in Sources */,


### PR DESCRIPTION
Related to [EXP-3042](https://mozilla-hub.atlassian.net/browse/EXP-3042).

The functional part of this is the adding a fallback translation bundle lookup method.

It's actually quite difficult to test, given that there are no strings in the ios megazord, so there exists a duplicate method in Firefox for iOS. We include it here since we want to use it in Focus.

Because Nimbus doesn't know the internal structure of the bundle it can only provide this `fallbackTranslationBundle()` method— it will be up to the app to provide the list of bundles themselves.

The **old** way of doing this was to call `Nimbus.create(… resourceBundles: [Bundle.main, Strings.bundle] )`. The **new** way of doing this will be:

```swift
let bundles = [
   Bundle.main,
   Strings.bundle,
   Strings.bundle.fallbackTranslationBundle(),
].compactMap { $0 }

NimbusBuilder(…)
    .with(resourceBundles: bundles)
    …
    .build()
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
