### PR TITLE
Don't try and link with sha-x86_c_lib for Android x86 targets

### DIFF
--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -120,7 +120,6 @@ fn get_nss_libs(kind: LinkingKind) -> Vec<&'static str> {
             }
             if target_arch == "x86_64" || target_arch == "x86" {
                 static_libs.push("gcm-aes-x86_c_lib");
-                static_libs.push("sha-x86_c_lib");
             }
             if target_arch == "arm" {
                 static_libs.push("gcm-aes-arm32-neon_c_lib")


### PR DESCRIPTION
Fixes gradle on Windows for me.
