### PR TITLE
Update uniffi to 0.22/0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,6 @@ dependencies = [
  "thiserror",
  "types",
  "uniffi",
- "uniffi_build",
  "url",
 ]
 
@@ -595,8 +594,6 @@ dependencies = [
  "log",
  "thiserror",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
 ]
 
 [[package]]
@@ -826,7 +823,7 @@ name = "embedded-uniffi-bindgen"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "uniffi_bindgen",
+ "uniffi",
 ]
 
 [[package]]
@@ -878,8 +875,6 @@ dependencies = [
  "log",
  "parking_lot",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
 ]
 
 [[package]]
@@ -1190,8 +1185,6 @@ dependencies = [
  "sync15",
  "thiserror",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "url",
  "viaduct",
  "viaduct-reqwest",
@@ -1743,8 +1736,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "url",
 ]
 
@@ -2000,7 +1991,6 @@ dependencies = [
  "thiserror",
  "unicode-segmentation",
  "uniffi",
- "uniffi_build",
  "url",
  "uuid",
  "viaduct",
@@ -2400,8 +2390,6 @@ dependencies = [
  "thiserror",
  "types",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "url",
 ]
 
@@ -2619,8 +2607,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "url",
  "viaduct",
  "viaduct-reqwest",
@@ -3267,8 +3253,6 @@ dependencies = [
  "sync-guid",
  "thiserror",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "url",
  "viaduct",
 ]
@@ -3294,8 +3278,6 @@ dependencies = [
  "tabs",
  "thiserror",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "url",
 ]
 
@@ -3328,8 +3310,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "uniffi",
- "uniffi_build",
- "uniffi_macros",
  "url",
 ]
 
@@ -3671,30 +3651,26 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 [[package]]
 name = "uniffi"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7057bad60ea5f6e2c2df43dbc8143880d19daca2d9bb0ef81131b37ef42cc9"
+source = "git+https://github.com/mhammond/uniffi-rs?rev=e74ad9c20eb3371999ae59a453e80633f683aaac#e74ad9c20eb3371999ae59a453e80633f683aaac"
 dependencies = [
  "anyhow",
- "bytes",
  "camino",
- "log",
- "once_cell",
- "paste",
- "static_assertions",
+ "clap 3.2.8",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
  "uniffi_macros",
 ]
 
 [[package]]
 name = "uniffi_bindgen"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d84dea610e893f4043354c71e4361386475365e6e2834aded4c8cebf940311"
+source = "git+https://github.com/mhammond/uniffi-rs?rev=e74ad9c20eb3371999ae59a453e80633f683aaac#e74ad9c20eb3371999ae59a453e80633f683aaac"
 dependencies = [
  "anyhow",
  "askama 0.11.1",
  "bincode",
  "camino",
- "clap 3.2.8",
  "fs-err",
  "glob",
  "goblin",
@@ -3712,8 +3688,7 @@ dependencies = [
 [[package]]
 name = "uniffi_build"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db116cd55ae857fd40d5780d47c76d3f6aa68c242458fb57bc24cb130a3e920"
+source = "git+https://github.com/mhammond/uniffi-rs?rev=e74ad9c20eb3371999ae59a453e80633f683aaac#e74ad9c20eb3371999ae59a453e80633f683aaac"
 dependencies = [
  "anyhow",
  "camino",
@@ -3723,18 +3698,31 @@ dependencies = [
 [[package]]
 name = "uniffi_checksum_derive"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55105cc7e1ac83ca1eb29587e3b7f65737f9142dc65d54b63502c2589c9d6a5"
+source = "git+https://github.com/mhammond/uniffi-rs?rev=e74ad9c20eb3371999ae59a453e80633f683aaac#e74ad9c20eb3371999ae59a453e80633f683aaac"
 dependencies = [
  "quote",
  "syn",
 ]
 
 [[package]]
+name = "uniffi_core"
+version = "0.22.0"
+source = "git+https://github.com/mhammond/uniffi-rs?rev=e74ad9c20eb3371999ae59a453e80633f683aaac#e74ad9c20eb3371999ae59a453e80633f683aaac"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "camino",
+ "cargo_metadata",
+ "log",
+ "once_cell",
+ "paste",
+ "static_assertions",
+]
+
+[[package]]
 name = "uniffi_macros"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed72d962296f794d962888484c8a2129174976fb2d7c566eca52892d373e0234"
+source = "git+https://github.com/mhammond/uniffi-rs?rev=e74ad9c20eb3371999ae59a453e80633f683aaac#e74ad9c20eb3371999ae59a453e80633f683aaac"
 dependencies = [
  "bincode",
  "camino",
@@ -3752,8 +3740,7 @@ dependencies = [
 [[package]]
 name = "uniffi_meta"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f819a2d6f98e2e9758604f3f541c8200166868525d0329e232ce188f19eeeb4"
+source = "git+https://github.com/mhammond/uniffi-rs?rev=e74ad9c20eb3371999ae59a453e80633f683aaac#e74ad9c20eb3371999ae59a453e80633f683aaac"
 dependencies = [
  "serde",
  "siphasher",
@@ -3763,8 +3750,7 @@ dependencies = [
 [[package]]
 name = "uniffi_testing"
 version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd68c90ec2ab35abc868eae85eedd92b7cede34d38a57e356fce96b8f99d4ef"
+source = "git+https://github.com/mhammond/uniffi-rs?rev=e74ad9c20eb3371999ae59a453e80633f683aaac#e74ad9c20eb3371999ae59a453e80633f683aaac"
 dependencies = [
  "anyhow",
  "camino",
@@ -4008,8 +3994,7 @@ dependencies = [
 [[package]]
 name = "weedle2"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
+source = "git+https://github.com/mhammond/uniffi-rs?rev=e74ad9c20eb3371999ae59a453e80633f683aaac#e74ad9c20eb3371999ae59a453e80633f683aaac"
 dependencies = [
  "nom 7.1.1",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,15 +370,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.12",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1286,9 +1287,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
+checksum = "572564d6cba7d09775202c8e7eebc4d534d5ae36578ab402fb21e182a0ac9505"
 dependencies = [
  "log",
  "plain",
@@ -1594,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877e398ffb23c1c311c417ef5e72e8699c3822dbf835468f009c6ce91b6c206b"
 dependencies = [
  "ahash",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bytecount",
  "fancy-regex",
  "fraction",
@@ -3128,6 +3129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3259,6 +3266,9 @@ dependencies = [
  "serde_json",
  "sync-guid",
  "thiserror",
+ "uniffi",
+ "uniffi_build",
+ "uniffi_macros",
  "url",
  "viaduct",
 ]
@@ -3660,14 +3670,13 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uniffi"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54af5ada67d1173457a99a7bb44a7917f63e7466764cb4714865c7a6678b830"
+checksum = "8e7057bad60ea5f6e2c2df43dbc8143880d19daca2d9bb0ef81131b37ef42cc9"
 dependencies = [
  "anyhow",
  "bytes",
  "camino",
- "cargo_metadata",
  "log",
  "once_cell",
  "paste",
@@ -3677,9 +3686,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc4af3c0180c7e86c4a3acf2b6587af04ba2567b1e948993df10f421796621"
+checksum = "19d84dea610e893f4043354c71e4361386475365e6e2834aded4c8cebf940311"
 dependencies = [
  "anyhow",
  "askama 0.11.1",
@@ -3687,6 +3696,7 @@ dependencies = [
  "camino",
  "clap 3.2.8",
  "fs-err",
+ "glob",
  "goblin",
  "heck 0.4.0",
  "once_cell",
@@ -3695,14 +3705,15 @@ dependencies = [
  "serde_json",
  "toml",
  "uniffi_meta",
+ "uniffi_testing",
  "weedle2",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510287c368a9386eb731ebe824a6fc6c82a105e20d020af1aa20519c1c1561db"
+checksum = "6db116cd55ae857fd40d5780d47c76d3f6aa68c242458fb57bc24cb130a3e920"
 dependencies = [
  "anyhow",
  "camino",
@@ -3710,10 +3721,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_macros"
-version = "0.21.0"
+name = "uniffi_checksum_derive"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8604503caa2cbcf271578dc51ca236d40e3b22e1514ffa2e638e2c39f6ad10"
+checksum = "f55105cc7e1ac83ca1eb29587e3b7f65737f9142dc65d54b63502c2589c9d6a5"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed72d962296f794d962888484c8a2129174976fb2d7c566eca52892d373e0234"
 dependencies = [
  "bincode",
  "camino",
@@ -3730,11 +3751,28 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9417cc653937681436b93838d8c5f97a5b8c58697813982ee8810bd1dc3b57"
+checksum = "9f819a2d6f98e2e9758604f3f541c8200166868525d0329e232ce188f19eeeb4"
 dependencies = [
  "serde",
+ "siphasher",
+ "uniffi_checksum_derive",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd68c90ec2ab35abc868eae85eedd92b7cede34d38a57e356fce96b8f99d4ef"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,8 +117,5 @@ viaduct = { path = "components/viaduct" }
 # for a convenient way to use a local checkout rather than the published version.
 # You just have to make sure that the version number in your local checkout
 # matches the one used in the `Cargo.toml` files in this workspace.
-#[patch.crates-io]
-#uniffi = { path = "../uniffi-rs/uniffi" }
-#uniffi_bindgen = { path = "../uniffi-rs/uniffi_bindgen" }
-#uniffi_build = { path = "../uniffi-rs/uniffi_build" }
-#uniffi_macros = { path = "../uniffi-rs/uniffi_macros" }
+[patch.crates-io]
+uniffi = { git = "https://github.com/mhammond/uniffi-rs", rev = "e74ad9c20eb3371999ae59a453e80633f683aaac" }

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -7,8 +7,7 @@ the details of which are reproduced below.
 * [Mozilla Public License 2.0](#mozilla-public-license-20)
 * [Apache License 2.0](#apache-license-20)
 * [MIT License: SwiftKeychainWrapper](#mit-license-swiftkeychainwrapper)
-* [MIT License: aho-corasick, byteorder, memchr, termcolor](#mit-license-aho-corasick-byteorder-memchr-termcolor)
-* [MIT License: atty](#mit-license-atty)
+* [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata](#mit-license-cargo_metadata)
@@ -29,8 +28,6 @@ the details of which are reproduced below.
 * [MIT License: scroll](#mit-license-scroll)
 * [MIT License: scroll_derive](#mit-license-scroll_derive)
 * [MIT License: slab](#mit-license-slab)
-* [MIT License: strsim](#mit-license-strsim)
-* [MIT License: textwrap](#mit-license-textwrap)
 * [MIT License: tokio, tokio-util](#mit-license-tokio-tokio-util)
 * [MIT License: tokio-native-tls, tracing, tracing-core](#mit-license-tokio-native-tls-tracing-tracing-core)
 * [MIT License: tower-service](#mit-license-tower-service)
@@ -60,8 +57,10 @@ The following text applies to code linked from these dependencies:
 [uniffi](https://github.com/mozilla/uniffi-rs),
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
+[uniffi_checksum_derive](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
-[uniffi_meta](https://github.com/mozilla/uniffi-rs)
+[uniffi_meta](https://github.com/mozilla/uniffi-rs),
+[uniffi_testing](https://github.com/mozilla/uniffi-rs)
 
 ```
 Mozilla Public License Version 2.0
@@ -458,9 +457,6 @@ The following text applies to code linked from these dependencies:
 [cc](https://github.com/alexcrichton/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
-[clap](https://github.com/clap-rs/clap),
-[clap_derive](https://github.com/clap-rs/clap/tree/master/clap_derive),
-[clap_lex](https://github.com/clap-rs/clap/tree/master/clap_lex),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
 [core-foundation](https://github.com/servo/core-foundation-rs),
 [cpufeatures](https://github.com/RustCrypto/utils),
@@ -483,6 +479,7 @@ The following text applies to code linked from these dependencies:
 [futures-task](https://github.com/rust-lang/futures-rs),
 [futures-util](https://github.com/rust-lang/futures-rs),
 [getrandom](https://github.com/rust-random/getrandom),
+[glob](https://github.com/rust-lang/glob),
 [hashbrown](https://github.com/rust-lang/hashbrown),
 [hashlink](https://github.com/kyren/hashlink),
 [heck](https://github.com/withoutboats/heck),
@@ -517,7 +514,6 @@ The following text applies to code linked from these dependencies:
 [openssl-probe](https://github.com/alexcrichton/openssl-probe),
 [openssl-src](https://github.com/alexcrichton/openssl-src-rs),
 [openssl](https://github.com/sfackler/rust-openssl),
-[os_str_bytes](https://github.com/dylni/os_str_bytes),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste](https://github.com/dtolnay/paste),
@@ -527,8 +523,6 @@ The following text applies to code linked from these dependencies:
 [pkg-config](https://github.com/rust-lang/pkg-config-rs),
 [plain](https://github.com/randomites/plain),
 [ppv-lite86](https://github.com/cryptocorrosion/cryptocorrosion),
-[proc-macro-error-attr](https://gitlab.com/CreepySkeleton/proc-macro-error),
-[proc-macro-error](https://gitlab.com/CreepySkeleton/proc-macro-error),
 [proc-macro2](https://github.com/dtolnay/proc-macro2),
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
@@ -551,6 +545,7 @@ The following text applies to code linked from these dependencies:
 [serde_json](https://github.com/serde-rs/json),
 [serde_urlencoded](https://github.com/nox/serde_urlencoded),
 [sha2](https://github.com/RustCrypto/hashes),
+[siphasher](https://github.com/jedisct1/rust-siphash),
 [smallbitvec](https://github.com/servo/smallbitvec),
 [smallvec](https://github.com/servo/rust-smallvec),
 [socket2](https://github.com/rust-lang/socket2),
@@ -817,13 +812,12 @@ SOFTWARE.
 
 ```
 -------------
-## MIT License: aho-corasick, byteorder, memchr, termcolor
+## MIT License: aho-corasick, byteorder, memchr
 
 The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
-[memchr](https://github.com/BurntSushi/memchr),
-[termcolor](https://github.com/BurntSushi/termcolor)
+[memchr](https://github.com/BurntSushi/memchr)
 
 ```
 The MIT License (MIT)
@@ -847,35 +841,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: atty
-
-The following text applies to code linked from these dependencies:
-[atty](https://github.com/softprops/atty)
-
-```
-Copyright (c) 2015-2019 Doug Tangren
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
@@ -1487,68 +1452,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: strsim
-
-The following text applies to code linked from these dependencies:
-[strsim](https://github.com/dguo/strsim-rs)
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2015 Danny Guo
-Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
-Copyright (c) 2018 Akash Kurdekar
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
-## MIT License: textwrap
-
-The following text applies to code linked from these dependencies:
-[textwrap](https://github.com/mgeisler/textwrap)
-
-```
-MIT License
-
-Copyright (c) 2016 Martin Geisler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ```
 -------------

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -7,7 +7,8 @@ the details of which are reproduced below.
 * [Mozilla Public License 2.0](#mozilla-public-license-20)
 * [Apache License 2.0](#apache-license-20)
 * [MIT License: SwiftKeychainWrapper](#mit-license-swiftkeychainwrapper)
-* [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
+* [MIT License: aho-corasick, byteorder, memchr, termcolor](#mit-license-aho-corasick-byteorder-memchr-termcolor)
+* [MIT License: atty](#mit-license-atty)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata](#mit-license-cargo_metadata)
@@ -28,12 +29,15 @@ the details of which are reproduced below.
 * [MIT License: scroll](#mit-license-scroll)
 * [MIT License: scroll_derive](#mit-license-scroll_derive)
 * [MIT License: slab](#mit-license-slab)
+* [MIT License: strsim](#mit-license-strsim)
+* [MIT License: textwrap](#mit-license-textwrap)
 * [MIT License: tokio, tokio-util](#mit-license-tokio-tokio-util)
 * [MIT License: tokio-native-tls, tracing, tracing-core](#mit-license-tokio-native-tls-tracing-tracing-core)
 * [MIT License: tower-service](#mit-license-tower-service)
 * [MIT License: try-lock](#mit-license-try-lock)
 * [MIT License: want](#mit-license-want)
 * [MIT License: weedle2](#mit-license-weedle2)
+* [MIT License: winapi-util](#mit-license-winapi-util)
 * [MIT License: winreg](#mit-license-winreg)
 * [MIT License: xshell-venv](#mit-license-xshell-venv)
 * [CC0-1.0 License: base16](#cc0-10-license-base16)
@@ -58,6 +62,7 @@ The following text applies to code linked from these dependencies:
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
 [uniffi_checksum_derive](https://github.com/mozilla/uniffi-rs),
+[uniffi_core](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_meta](https://github.com/mozilla/uniffi-rs),
 [uniffi_testing](https://github.com/mozilla/uniffi-rs)
@@ -457,6 +462,9 @@ The following text applies to code linked from these dependencies:
 [cc](https://github.com/alexcrichton/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
+[clap](https://github.com/clap-rs/clap),
+[clap_derive](https://github.com/clap-rs/clap/tree/master/clap_derive),
+[clap_lex](https://github.com/clap-rs/clap/tree/master/clap_lex),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
 [core-foundation](https://github.com/servo/core-foundation-rs),
 [cpufeatures](https://github.com/RustCrypto/utils),
@@ -514,6 +522,7 @@ The following text applies to code linked from these dependencies:
 [openssl-probe](https://github.com/alexcrichton/openssl-probe),
 [openssl-src](https://github.com/alexcrichton/openssl-src-rs),
 [openssl](https://github.com/sfackler/rust-openssl),
+[os_str_bytes](https://github.com/dylni/os_str_bytes),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste](https://github.com/dtolnay/paste),
@@ -523,6 +532,8 @@ The following text applies to code linked from these dependencies:
 [pkg-config](https://github.com/rust-lang/pkg-config-rs),
 [plain](https://github.com/randomites/plain),
 [ppv-lite86](https://github.com/cryptocorrosion/cryptocorrosion),
+[proc-macro-error-attr](https://gitlab.com/CreepySkeleton/proc-macro-error),
+[proc-macro-error](https://gitlab.com/CreepySkeleton/proc-macro-error),
 [proc-macro2](https://github.com/dtolnay/proc-macro2),
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
@@ -812,12 +823,13 @@ SOFTWARE.
 
 ```
 -------------
-## MIT License: aho-corasick, byteorder, memchr
+## MIT License: aho-corasick, byteorder, memchr, termcolor
 
 The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
-[memchr](https://github.com/BurntSushi/memchr)
+[memchr](https://github.com/BurntSushi/memchr),
+[termcolor](https://github.com/BurntSushi/termcolor)
 
 ```
 The MIT License (MIT)
@@ -841,6 +853,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+```
+-------------
+## MIT License: atty
+
+The following text applies to code linked from these dependencies:
+[atty](https://github.com/softprops/atty)
+
+```
+Copyright (c) 2015-2019 Doug Tangren
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
@@ -1455,6 +1496,68 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
+## MIT License: strsim
+
+The following text applies to code linked from these dependencies:
+[strsim](https://github.com/dguo/strsim-rs)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Danny Guo
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
+Copyright (c) 2018 Akash Kurdekar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: textwrap
+
+The following text applies to code linked from these dependencies:
+[textwrap](https://github.com/mgeisler/textwrap)
+
+```
+MIT License
+
+Copyright (c) 2016 Martin Geisler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
 ## MIT License: tokio, tokio-util
 
 The following text applies to code linked from these dependencies:
@@ -1641,6 +1744,36 @@ TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONIN
 THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
 CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: winapi-util
+
+The following text applies to code linked from these dependencies:
+[winapi-util](https://github.com/BurntSushi/winapi-util)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2017 Andrew Gallant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ```
 -------------

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -22,7 +22,7 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.21"
+uniffi = "^0.22"
 url = { version = "2.2", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -35,4 +35,4 @@ libsqlite3-sys = "0.25.2"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.21", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.22", features = [ "builtin-bindgen" ]}

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -35,4 +35,4 @@ libsqlite3-sys = "0.25.2"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.22", features = [ "builtin-bindgen" ]}
+uniffi = { version = "^0.22" }

--- a/components/autofill/build.rs
+++ b/components/autofill/build.rs
@@ -8,7 +8,7 @@
 //! gross hack).
 
 fn main() {
-    uniffi_build::generate_scaffolding("./src/autofill.udl").unwrap();
+    uniffi::generate_scaffolding("./src/autofill.udl").unwrap();
 
     println!("cargo:rerun-if-changed=build.rs");
 

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -10,7 +10,6 @@ exclude = ["/android", "/ios"]
 log = "0.4"
 thiserror = "1.0"
 uniffi = "^0.22"
-uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
+uniffi = { version = "^0.22" }

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,8 +9,8 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }

--- a/components/crashtest/build.rs
+++ b/components/crashtest/build.rs
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 fn main() {
-    uniffi_build::generate_scaffolding("./src/crashtest.udl").unwrap();
+    uniffi::generate_scaffolding("./src/crashtest.udl").unwrap();
 }

--- a/components/crashtest/src/lib.rs
+++ b/components/crashtest/src/lib.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 #[cfg(test)]
 mod tests;
 
-uniffi_macros::include_scaffolding!("crashtest");
+uniffi::include_scaffolding!("crashtest");
 
 /// Trigger a hard abort inside the Rust code.
 ///

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -25,10 +25,9 @@ thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
 uniffi = "^0.22"
-uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
+uniffi = { version = "^0.22" }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,11 +24,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/fxa-client/build.rs
+++ b/components/fxa-client/build.rs
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 fn main() {
-    uniffi_build::generate_scaffolding("./src/fxa_client.udl").unwrap();
+    uniffi::generate_scaffolding("./src/fxa_client.udl").unwrap();
 }

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -51,7 +51,7 @@ use thiserror::Error;
 // not currently expose to consumers. But we should figure out how to expose them!
 pub mod internal;
 
-uniffi_macros::include_scaffolding!("fxa_client");
+uniffi::include_scaffolding!("fxa_client");
 
 /// Generic error type thrown by many [`FirefoxAccount`] operations.
 ///

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -27,15 +27,15 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [dependencies.rusqlite]
 version = "0.28.0"
 features = ["sqlcipher", "limits", "unlock_notify"]
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 more-asserts = "0.2"

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -28,14 +28,13 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 thiserror = "1.0"
 anyhow = "1.0"
 uniffi = "^0.22"
-uniffi_macros = "^0.22"
 
 [dependencies.rusqlite]
 version = "0.28.0"
 features = ["sqlcipher", "limits", "unlock_notify"]
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
+uniffi = { version = "^0.22" }
 
 [dev-dependencies]
 more-asserts = "0.2"

--- a/components/logins/build.rs
+++ b/components/logins/build.rs
@@ -4,5 +4,5 @@
  */
 
 fn main() {
-    uniffi_build::generate_scaffolding("./src/logins.udl").unwrap();
+    uniffi::generate_scaffolding("./src/logins.udl").unwrap();
 }

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -17,7 +17,7 @@ mod store;
 mod sync;
 mod util;
 
-uniffi_macros::include_scaffolding!("logins");
+uniffi::include_scaffolding!("logins");
 
 pub use crate::db::LoginDb;
 use crate::encryption::{check_canary, create_canary, create_key};

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -32,13 +32,13 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "^0.21", optional = true }
+uniffi = { version = "^0.22", optional = true }
 chrono = { version = "0.4", features = ["serde"]}
 unicode-segmentation = "1.8.0"
 error-support = { path = "../support/error" }
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.22", features = [ "builtin-bindgen" ], optional = true }
 glean-build = { path = "../external/glean/glean-core/build" }
 
 [dev-dependencies]

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -15,7 +15,7 @@ name = "nimbus"
 # `rkv-safe-mode` is the same name as used by glean. For us though, it's the default.
 default=["rkv-safe-mode", "uniffi-bindings"]
 rkv-safe-mode = []
-uniffi-bindings = ["uniffi", "uniffi_build"]
+uniffi-bindings = ["uniffi"]
 
 [dependencies]
 anyhow = "1"
@@ -38,7 +38,7 @@ unicode-segmentation = "1.8.0"
 error-support = { path = "../support/error" }
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features = [ "builtin-bindgen" ], optional = true }
+uniffi = { version = "^0.22", optional = true }
 glean-build = { path = "../external/glean/glean-core/build" }
 
 [dev-dependencies]

--- a/components/nimbus/build.rs
+++ b/components/nimbus/build.rs
@@ -6,7 +6,7 @@ use glean_build::Builder;
 
 pub fn main() {
     #[cfg(feature = "uniffi-bindings")]
-    uniffi_build::generate_scaffolding("./src/nimbus.udl").unwrap();
+    uniffi::generate_scaffolding("./src/nimbus.udl").unwrap();
 
     Builder::default()
         .file("./metrics.yaml")

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -34,7 +34,6 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 thiserror = "1.0"
 anyhow = "1.0"
 uniffi = "^0.22"
-uniffi_macros = "^0.22"
 
 [dependencies.rusqlite]
 version = "0.28.0"
@@ -46,4 +45,4 @@ tempfile = "3.1"
 env_logger = {version = "0.7", default-features = false}
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
+uniffi = { version = "^0.22" }

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -33,8 +33,8 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [dependencies.rusqlite]
 version = "0.28.0"
@@ -46,4 +46,4 @@ tempfile = "3.1"
 env_logger = {version = "0.7", default-features = false}
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }

--- a/components/places/build.rs
+++ b/components/places/build.rs
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 fn main() {
-    uniffi_build::generate_scaffolding("./src/places.udl").unwrap();
+    uniffi::generate_scaffolding("./src/places.udl").unwrap();
 }

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -728,7 +728,7 @@ pub enum MatchReason {
     Tags,
 }
 
-uniffi_macros::include_scaffolding!("places");
+uniffi::include_scaffolding!("places");
 // Exists just to convince uniffi to generate `liftSequence*` helpers!
 pub struct Dummy {
     md: Option<Vec<HistoryMetadata>>,

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -21,11 +21,11 @@ error-support = { path = "../support/error" }
 sql-support = { path = "../support/sql" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }
 thiserror = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
 
 
 [dev-dependencies]

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -22,10 +22,9 @@ sql-support = { path = "../support/sql" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }
 thiserror = "1.0"
 uniffi = "^0.22"
-uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
+uniffi = { version = "^0.22" }
 
 
 [dev-dependencies]

--- a/components/push/build.rs
+++ b/components/push/build.rs
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 fn main() {
-    uniffi_build::generate_scaffolding("./src/push.udl").unwrap();
+    uniffi::generate_scaffolding("./src/push.udl").unwrap();
 }

--- a/components/push/src/lib.rs
+++ b/components/push/src/lib.rs
@@ -180,7 +180,7 @@
 //!     return result.toString(Charset.forName("UTF-8"))
 //!```
 
-uniffi_macros::include_scaffolding!("push");
+uniffi::include_scaffolding!("push");
 // All implementation detail lives in the `internal` module
 mod internal;
 use std::sync::Mutex;

--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -9,12 +9,12 @@ license = "MPL-2.0"
 log = "0.4"
 lazy_static = { version = "1.4" }
 parking_lot = { version = ">=0.11,<=0.12" }
-uniffi = { version = "^0.21" }
-uniffi_macros = { version = "^0.21" }
+uniffi = { version = "^0.22" }
+uniffi_macros = { version = "^0.22" }
 
 [dependencies.backtrace]
 optional = true
 version = "0.3"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }

--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -10,11 +10,10 @@ log = "0.4"
 lazy_static = { version = "1.4" }
 parking_lot = { version = ">=0.11,<=0.12" }
 uniffi = { version = "^0.22" }
-uniffi_macros = { version = "^0.22" }
 
 [dependencies.backtrace]
 optional = true
 version = "0.3"
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
+uniffi = { version = "^0.22" }

--- a/components/support/error/build.rs
+++ b/components/support/error/build.rs
@@ -4,5 +4,5 @@
  */
 
 fn main() {
-    uniffi_build::generate_scaffolding("./src/errorsupport.udl").unwrap();
+    uniffi::generate_scaffolding("./src/errorsupport.udl").unwrap();
 }

--- a/components/support/error/src/lib.rs
+++ b/components/support/error/src/lib.rs
@@ -157,4 +157,4 @@ macro_rules! define_error {
     };
 }
 
-uniffi_macros::include_scaffolding!("errorsupport");
+uniffi::include_scaffolding!("errorsupport");

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -59,8 +59,13 @@ serde_derive = "1"
 serde_json = "1"
 sync-guid = { path = "../support/guid", features = ["random"] }
 thiserror = "1.0"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 url = { version = "2.1", optional = true } # mozilla-central can't yet take 2.2 (see bug 1734538)
 viaduct = { path = "../viaduct", optional = true }
+
+[build-dependencies]
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -60,12 +60,11 @@ serde_json = "1"
 sync-guid = { path = "../support/guid", features = ["random"] }
 thiserror = "1.0"
 uniffi = "^0.22"
-uniffi_macros = "^0.22"
 url = { version = "2.1", optional = true } # mozilla-central can't yet take 2.2 (see bug 1734538)
 viaduct = { path = "../viaduct", optional = true }
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
+uniffi = { version = "^0.22" }
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -24,8 +24,8 @@ serde_derive = "1"
 serde_json = "1"
 parking_lot = ">=0.11,<=0.12"
 interrupt-support = { path = "../support/interrupt" }
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -25,7 +25,6 @@ serde_json = "1"
 parking_lot = ">=0.11,<=0.12"
 interrupt-support = { path = "../support/interrupt" }
 uniffi = "^0.22"
-uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
+uniffi = { version = "^0.22" }

--- a/components/sync_manager/build.rs
+++ b/components/sync_manager/build.rs
@@ -4,5 +4,5 @@
  */
 
 fn main() {
-    uniffi_build::generate_scaffolding("./src/syncmanager.udl").unwrap();
+    uniffi::generate_scaffolding("./src/syncmanager.udl").unwrap();
 }

--- a/components/sync_manager/src/lib.rs
+++ b/components/sync_manager/src/lib.rs
@@ -45,4 +45,4 @@ pub fn sync(params: SyncParams) -> Result<SyncResult> {
     manager.sync(params)
 }
 
-uniffi_macros::include_scaffolding!("syncmanager");
+uniffi::include_scaffolding!("syncmanager");

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -33,8 +33,8 @@ sql-support = { path = "../support/sql" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [dev-dependencies]
@@ -42,4 +42,4 @@ env_logger = { version = "0.8.0", default-features = false, features = ["termcol
 tempfile = "3.1"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.22", features = [ "builtin-bindgen" ]}

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -34,7 +34,6 @@ sync-guid = { path = "../support/guid", features = ["random"] }
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
 uniffi = "^0.22"
-uniffi_macros = "^0.22"
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [dev-dependencies]
@@ -42,4 +41,4 @@ env_logger = { version = "0.8.0", default-features = false, features = ["termcol
 tempfile = "3.1"
 
 [build-dependencies]
-uniffi_build = { version = "^0.22", features = [ "builtin-bindgen" ]}
+uniffi = { version = "^0.22" }

--- a/components/tabs/build.rs
+++ b/components/tabs/build.rs
@@ -3,5 +3,5 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 fn main() {
-    uniffi_build::generate_scaffolding("./src/tabs.udl").unwrap();
+    uniffi::generate_scaffolding("./src/tabs.udl").unwrap();
 }

--- a/components/tabs/src/lib.rs
+++ b/components/tabs/src/lib.rs
@@ -12,7 +12,7 @@ mod storage;
 mod store;
 mod sync;
 
-uniffi_macros::include_scaffolding!("tabs");
+uniffi::include_scaffolding!("tabs");
 
 // Our UDL uses a `Guid` type.
 use sync_guid::Guid as TabsGuid;

--- a/docs/howtos/adding-a-new-component.md
+++ b/docs/howtos/adding-a-new-component.md
@@ -18,13 +18,12 @@ introduces any new dependencies.
 
 Use [UniFFI](https://mozilla.github.io/uniffi-rs/) to define how your crate's
 API will get exposed to foreign-language bindings. By convention, put the interface
-definition file at `./components/<your_crate_name>/<your_crate_name>.udl`. Use
-the `builtin-bindgen` feature of UniFFI to simplify the build process, by
-putting the following in your `Cargo.toml`:
+definition file at `./components/<your_crate_name>/<your_crate_name>.udl`.
+Put the following in your `Cargo.toml`:
 
 ```
 [build-dependencies]
-uniffi_build = { version = "<latest version here>", features=["builtin-bindgen"] }
+uniffi = { version = "<latest version here>" }
 ```
 
 Include your new crate in the `application-services` workspace, by adding

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -6,7 +6,8 @@ the details of which are reproduced below.
 
 * [Mozilla Public License 2.0](#mozilla-public-license-20)
 * [Apache License 2.0](#apache-license-20)
-* [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
+* [MIT License: aho-corasick, byteorder, memchr, termcolor](#mit-license-aho-corasick-byteorder-memchr-termcolor)
+* [MIT License: atty](#mit-license-atty)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata](#mit-license-cargo_metadata)
@@ -20,7 +21,10 @@ the details of which are reproduced below.
 * [MIT License: ordered-float](#mit-license-ordered-float)
 * [MIT License: scroll](#mit-license-scroll)
 * [MIT License: scroll_derive](#mit-license-scroll_derive)
+* [MIT License: strsim](#mit-license-strsim)
+* [MIT License: textwrap](#mit-license-textwrap)
 * [MIT License: weedle2](#mit-license-weedle2)
+* [MIT License: winapi-util](#mit-license-winapi-util)
 * [MIT License: xshell-venv](#mit-license-xshell-venv)
 * [CC0-1.0 License: base16](#cc0-10-license-base16)
 * [ISC License: ring](#isc-license-ring)
@@ -42,6 +46,7 @@ The following text applies to code linked from these dependencies:
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
 [uniffi_checksum_derive](https://github.com/mozilla/uniffi-rs),
+[uniffi_core](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_meta](https://github.com/mozilla/uniffi-rs),
 [uniffi_testing](https://github.com/mozilla/uniffi-rs)
@@ -441,6 +446,9 @@ The following text applies to code linked from these dependencies:
 [cc](https://github.com/alexcrichton/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
+[clap](https://github.com/clap-rs/clap),
+[clap_derive](https://github.com/clap-rs/clap/tree/master/clap_derive),
+[clap_lex](https://github.com/clap-rs/clap/tree/master/clap_lex),
 [cpufeatures](https://github.com/RustCrypto/utils),
 [digest](https://github.com/RustCrypto/traits),
 [dogear](https://github.com/mozilla/dogear),
@@ -459,6 +467,7 @@ The following text applies to code linked from these dependencies:
 [hex](https://github.com/KokaKiwi/rust-hex),
 [id-arena](https://github.com/fitzgen/id-arena),
 [idna](https://github.com/servo/rust-url/),
+[indexmap](https://github.com/bluss/indexmap),
 [itertools](https://github.com/rust-itertools/itertools),
 [itoa](https://github.com/dtolnay/itoa),
 [jna](https://github.com/java-native-access/jna),
@@ -475,6 +484,7 @@ The following text applies to code linked from these dependencies:
 [num-traits](https://github.com/rust-num/num-traits),
 [once_cell](https://github.com/matklad/once_cell),
 [opaque-debug](https://github.com/RustCrypto/utils),
+[os_str_bytes](https://github.com/dylni/os_str_bytes),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste](https://github.com/dtolnay/paste),
@@ -482,6 +492,8 @@ The following text applies to code linked from these dependencies:
 [pkg-config](https://github.com/rust-lang/pkg-config-rs),
 [plain](https://github.com/randomites/plain),
 [ppv-lite86](https://github.com/cryptocorrosion/cryptocorrosion),
+[proc-macro-error-attr](https://gitlab.com/CreepySkeleton/proc-macro-error),
+[proc-macro-error](https://gitlab.com/CreepySkeleton/proc-macro-error),
 [proc-macro2](https://github.com/dtolnay/proc-macro2),
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
@@ -735,12 +747,13 @@ limitations under the License.
 
 ```
 -------------
-## MIT License: aho-corasick, byteorder, memchr
+## MIT License: aho-corasick, byteorder, memchr, termcolor
 
 The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
-[memchr](https://github.com/BurntSushi/memchr)
+[memchr](https://github.com/BurntSushi/memchr),
+[termcolor](https://github.com/BurntSushi/termcolor)
 
 ```
 The MIT License (MIT)
@@ -764,6 +777,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+```
+-------------
+## MIT License: atty
+
+The following text applies to code linked from these dependencies:
+[atty](https://github.com/softprops/atty)
+
+```
+Copyright (c) 2015-2019 Doug Tangren
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
@@ -1170,6 +1212,68 @@ SOFTWARE.
 
 ```
 -------------
+## MIT License: strsim
+
+The following text applies to code linked from these dependencies:
+[strsim](https://github.com/dguo/strsim-rs)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Danny Guo
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
+Copyright (c) 2018 Akash Kurdekar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: textwrap
+
+The following text applies to code linked from these dependencies:
+[textwrap](https://github.com/mgeisler/textwrap)
+
+```
+MIT License
+
+Copyright (c) 2016 Martin Geisler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
 ## MIT License: weedle2
 
 The following text applies to code linked from these dependencies:
@@ -1192,6 +1296,36 @@ TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONIN
 THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
 CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: winapi-util
+
+The following text applies to code linked from these dependencies:
+[winapi-util](https://github.com/BurntSushi/winapi-util)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2017 Andrew Gallant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ```
 -------------

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -6,8 +6,7 @@ the details of which are reproduced below.
 
 * [Mozilla Public License 2.0](#mozilla-public-license-20)
 * [Apache License 2.0](#apache-license-20)
-* [MIT License: aho-corasick, byteorder, memchr, termcolor](#mit-license-aho-corasick-byteorder-memchr-termcolor)
-* [MIT License: atty](#mit-license-atty)
+* [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata](#mit-license-cargo_metadata)
@@ -21,8 +20,6 @@ the details of which are reproduced below.
 * [MIT License: ordered-float](#mit-license-ordered-float)
 * [MIT License: scroll](#mit-license-scroll)
 * [MIT License: scroll_derive](#mit-license-scroll_derive)
-* [MIT License: strsim](#mit-license-strsim)
-* [MIT License: textwrap](#mit-license-textwrap)
 * [MIT License: weedle2](#mit-license-weedle2)
 * [MIT License: xshell-venv](#mit-license-xshell-venv)
 * [CC0-1.0 License: base16](#cc0-10-license-base16)
@@ -44,8 +41,10 @@ The following text applies to code linked from these dependencies:
 [uniffi](https://github.com/mozilla/uniffi-rs),
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
+[uniffi_checksum_derive](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
-[uniffi_meta](https://github.com/mozilla/uniffi-rs)
+[uniffi_meta](https://github.com/mozilla/uniffi-rs),
+[uniffi_testing](https://github.com/mozilla/uniffi-rs)
 
 ```
 Mozilla Public License Version 2.0
@@ -442,9 +441,6 @@ The following text applies to code linked from these dependencies:
 [cc](https://github.com/alexcrichton/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
-[clap](https://github.com/clap-rs/clap),
-[clap_derive](https://github.com/clap-rs/clap/tree/master/clap_derive),
-[clap_lex](https://github.com/clap-rs/clap/tree/master/clap_lex),
 [cpufeatures](https://github.com/RustCrypto/utils),
 [digest](https://github.com/RustCrypto/traits),
 [dogear](https://github.com/mozilla/dogear),
@@ -456,13 +452,13 @@ The following text applies to code linked from these dependencies:
 [form_urlencoded](https://github.com/servo/rust-url),
 [fs-err](https://github.com/andrewhickman/fs-err),
 [getrandom](https://github.com/rust-random/getrandom),
+[glob](https://github.com/rust-lang/glob),
 [hashbrown](https://github.com/rust-lang/hashbrown),
 [hashlink](https://github.com/kyren/hashlink),
 [heck](https://github.com/withoutboats/heck),
 [hex](https://github.com/KokaKiwi/rust-hex),
 [id-arena](https://github.com/fitzgen/id-arena),
 [idna](https://github.com/servo/rust-url/),
-[indexmap](https://github.com/bluss/indexmap),
 [itertools](https://github.com/rust-itertools/itertools),
 [itoa](https://github.com/dtolnay/itoa),
 [jna](https://github.com/java-native-access/jna),
@@ -479,7 +475,6 @@ The following text applies to code linked from these dependencies:
 [num-traits](https://github.com/rust-num/num-traits),
 [once_cell](https://github.com/matklad/once_cell),
 [opaque-debug](https://github.com/RustCrypto/utils),
-[os_str_bytes](https://github.com/dylni/os_str_bytes),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste](https://github.com/dtolnay/paste),
@@ -487,8 +482,6 @@ The following text applies to code linked from these dependencies:
 [pkg-config](https://github.com/rust-lang/pkg-config-rs),
 [plain](https://github.com/randomites/plain),
 [ppv-lite86](https://github.com/cryptocorrosion/cryptocorrosion),
-[proc-macro-error-attr](https://gitlab.com/CreepySkeleton/proc-macro-error),
-[proc-macro-error](https://gitlab.com/CreepySkeleton/proc-macro-error),
 [proc-macro2](https://github.com/dtolnay/proc-macro2),
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
@@ -507,6 +500,7 @@ The following text applies to code linked from these dependencies:
 [serde_derive](https://github.com/serde-rs/serde),
 [serde_json](https://github.com/serde-rs/json),
 [sha2](https://github.com/RustCrypto/hashes),
+[siphasher](https://github.com/jedisct1/rust-siphash),
 [smallbitvec](https://github.com/servo/smallbitvec),
 [smallvec](https://github.com/servo/rust-smallvec),
 [static_assertions](https://github.com/nvzqz/static-assertions-rs),
@@ -741,13 +735,12 @@ limitations under the License.
 
 ```
 -------------
-## MIT License: aho-corasick, byteorder, memchr, termcolor
+## MIT License: aho-corasick, byteorder, memchr
 
 The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
-[memchr](https://github.com/BurntSushi/memchr),
-[termcolor](https://github.com/BurntSushi/termcolor)
+[memchr](https://github.com/BurntSushi/memchr)
 
 ```
 The MIT License (MIT)
@@ -771,35 +764,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: atty
-
-The following text applies to code linked from these dependencies:
-[atty](https://github.com/softprops/atty)
-
-```
-Copyright (c) 2015-2019 Doug Tangren
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
@@ -1185,68 +1149,6 @@ The following text applies to code linked from these dependencies:
 MIT License
 
 Copyright (c) 2017 
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
-## MIT License: strsim
-
-The following text applies to code linked from these dependencies:
-[strsim](https://github.com/dguo/strsim-rs)
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2015 Danny Guo
-Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
-Copyright (c) 2018 Akash Kurdekar
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
-## MIT License: textwrap
-
-The following text applies to code linked from these dependencies:
-[textwrap](https://github.com/mgeisler/textwrap)
-
-```
-MIT License
-
-Copyright (c) 2016 Martin Geisler
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -41,11 +41,19 @@ the details of which are reproduced below.
     <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
   </license>
   <license>
+    <name>Mozilla Public License 2.0: uniffi_checksum_derive</name>
+    <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
+  </license>
+  <license>
     <name>Mozilla Public License 2.0: uniffi_macros</name>
     <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
   </license>
   <license>
     <name>Mozilla Public License 2.0: uniffi_meta</name>
+    <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
+  </license>
+  <license>
+    <name>Mozilla Public License 2.0: uniffi_testing</name>
     <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
   </license>
   <license>
@@ -117,18 +125,6 @@ the details of which are reproduced below.
     <url>https://github.com/chronotope/chrono/blob/main/LICENSE.txt</url>
   </license>
   <license>
-    <name>Apache License 2.0: clap</name>
-    <url>https://github.com/clap-rs/clap/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: clap_derive</name>
-    <url>https://github.com/clap-rs/clap/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: clap_lex</name>
-    <url>https://github.com/clap-rs/clap/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
     <name>Apache License 2.0: cpufeatures</name>
     <url>https://github.com/RustCrypto/utils/blob/master/cpufeatures/LICENSE-APACHE</url>
   </license>
@@ -173,6 +169,10 @@ the details of which are reproduced below.
     <url>https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: glob</name>
+    <url>https://github.com/rust-lang/glob/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: hashbrown</name>
     <url>https://github.com/rust-lang/hashbrown/blob/master/LICENSE-APACHE</url>
   </license>
@@ -195,10 +195,6 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: idna</name>
     <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: indexmap</name>
-    <url>https://github.com/bluss/indexmap/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: itertools</name>
@@ -265,10 +261,6 @@ the details of which are reproduced below.
     <url>https://github.com/RustCrypto/utils/blob/master/opaque-debug/LICENSE-APACHE</url>
   </license>
   <license>
-    <name>Apache License 2.0: os_str_bytes</name>
-    <url>https://github.com/dylni/os_str_bytes/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
     <name>Apache License 2.0: parking_lot</name>
     <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
   </license>
@@ -295,14 +287,6 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: ppv-lite86</name>
     <url>https://github.com/cryptocorrosion/cryptocorrosion/blob/master/utils-simd/ppv-lite86/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: proc-macro-error</name>
-    <url>https://gitlab.com/CreepySkeleton/proc-macro-error/-/raw/master/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: proc-macro-error-attr</name>
-    <url>https://gitlab.com/CreepySkeleton/proc-macro-error/-/raw/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: proc-macro2</name>
@@ -375,6 +359,10 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: sha2</name>
     <url>https://github.com/RustCrypto/hashes/blob/master/sha2/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: siphasher</name>
+    <url>https://github.com/jedisct1/rust-siphash/blob/master/COPYING</url>
   </license>
   <license>
     <name>Apache License 2.0: smallbitvec</name>
@@ -501,14 +489,6 @@ the details of which are reproduced below.
     <url>https://github.com/BurntSushi/memchr/blob/master/LICENSE-MIT</url>
   </license>
   <license>
-    <name>MIT License: termcolor</name>
-    <url>https://github.com/BurntSushi/termcolor/blob/master/LICENSE-MIT</url>
-  </license>
-  <license>
-    <name>MIT License: atty</name>
-    <url>https://github.com/softprops/atty/blob/master/LICENSE</url>
-  </license>
-  <license>
     <name>MIT License: bincode</name>
     <url>https://github.com/servo/bincode/blob/master/LICENSE.md</url>
   </license>
@@ -563,14 +543,6 @@ the details of which are reproduced below.
   <license>
     <name>MIT License: scroll_derive</name>
     <url>https://github.com/m4b/scroll/blob/master/LICENSE</url>
-  </license>
-  <license>
-    <name>MIT License: strsim</name>
-    <url>https://github.com/dguo/strsim-rs/blob/master/LICENSE</url>
-  </license>
-  <license>
-    <name>MIT License: textwrap</name>
-    <url>https://github.com/mgeisler/textwrap/blob/master/LICENSE</url>
   </license>
   <license>
     <name>MIT License: weedle2</name>

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -45,6 +45,10 @@ the details of which are reproduced below.
     <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
   </license>
   <license>
+    <name>Mozilla Public License 2.0: uniffi_core</name>
+    <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
+  </license>
+  <license>
     <name>Mozilla Public License 2.0: uniffi_macros</name>
     <url>https://github.com/mozilla/uniffi-rs/blob/main/LICENSE</url>
   </license>
@@ -125,6 +129,18 @@ the details of which are reproduced below.
     <url>https://github.com/chronotope/chrono/blob/main/LICENSE.txt</url>
   </license>
   <license>
+    <name>Apache License 2.0: clap</name>
+    <url>https://github.com/clap-rs/clap/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: clap_derive</name>
+    <url>https://github.com/clap-rs/clap/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: clap_lex</name>
+    <url>https://github.com/clap-rs/clap/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: cpufeatures</name>
     <url>https://github.com/RustCrypto/utils/blob/master/cpufeatures/LICENSE-APACHE</url>
   </license>
@@ -197,6 +213,10 @@ the details of which are reproduced below.
     <url>https://github.com/servo/rust-url/blob//master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: indexmap</name>
+    <url>https://github.com/bluss/indexmap/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: itertools</name>
     <url>https://github.com/rust-itertools/itertools/blob/master/LICENSE-APACHE</url>
   </license>
@@ -261,6 +281,10 @@ the details of which are reproduced below.
     <url>https://github.com/RustCrypto/utils/blob/master/opaque-debug/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: os_str_bytes</name>
+    <url>https://github.com/dylni/os_str_bytes/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: parking_lot</name>
     <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
   </license>
@@ -287,6 +311,14 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: ppv-lite86</name>
     <url>https://github.com/cryptocorrosion/cryptocorrosion/blob/master/utils-simd/ppv-lite86/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: proc-macro-error</name>
+    <url>https://gitlab.com/CreepySkeleton/proc-macro-error/-/raw/master/LICENSE-APACHE</url>
+  </license>
+  <license>
+    <name>Apache License 2.0: proc-macro-error-attr</name>
+    <url>https://gitlab.com/CreepySkeleton/proc-macro-error/-/raw/master/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: proc-macro2</name>
@@ -489,6 +521,14 @@ the details of which are reproduced below.
     <url>https://github.com/BurntSushi/memchr/blob/master/LICENSE-MIT</url>
   </license>
   <license>
+    <name>MIT License: termcolor</name>
+    <url>https://github.com/BurntSushi/termcolor/blob/master/LICENSE-MIT</url>
+  </license>
+  <license>
+    <name>MIT License: atty</name>
+    <url>https://github.com/softprops/atty/blob/master/LICENSE</url>
+  </license>
+  <license>
     <name>MIT License: bincode</name>
     <url>https://github.com/servo/bincode/blob/master/LICENSE.md</url>
   </license>
@@ -545,8 +585,20 @@ the details of which are reproduced below.
     <url>https://github.com/m4b/scroll/blob/master/LICENSE</url>
   </license>
   <license>
+    <name>MIT License: strsim</name>
+    <url>https://github.com/dguo/strsim-rs/blob/master/LICENSE</url>
+  </license>
+  <license>
+    <name>MIT License: textwrap</name>
+    <url>https://github.com/mgeisler/textwrap/blob/master/LICENSE</url>
+  </license>
+  <license>
     <name>MIT License: weedle2</name>
     <url>https://github.com/mozilla/uniffi-rs/blob/main/weedle2/LICENSE.md</url>
+  </license>
+  <license>
+    <name>MIT License: winapi-util</name>
+    <url>https://github.com/BurntSushi/winapi-util/blob/master/LICENSE-MIT</url>
   </license>
   <license>
     <name>MIT License: xshell-venv</name>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -7,8 +7,7 @@ the details of which are reproduced below.
 * [Mozilla Public License 2.0](#mozilla-public-license-20)
 * [Apache License 2.0](#apache-license-20)
 * [MIT License: SwiftKeychainWrapper](#mit-license-swiftkeychainwrapper)
-* [MIT License: aho-corasick, byteorder, memchr, termcolor](#mit-license-aho-corasick-byteorder-memchr-termcolor)
-* [MIT License: atty](#mit-license-atty)
+* [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata](#mit-license-cargo_metadata)
@@ -27,8 +26,6 @@ the details of which are reproduced below.
 * [MIT License: scroll](#mit-license-scroll)
 * [MIT License: scroll_derive](#mit-license-scroll_derive)
 * [MIT License: slab](#mit-license-slab)
-* [MIT License: strsim](#mit-license-strsim)
-* [MIT License: textwrap](#mit-license-textwrap)
 * [MIT License: tokio, tokio-util](#mit-license-tokio-tokio-util)
 * [MIT License: tokio-native-tls, tracing, tracing-core](#mit-license-tokio-native-tls-tracing-tracing-core)
 * [MIT License: tower-service](#mit-license-tower-service)
@@ -55,8 +52,10 @@ The following text applies to code linked from these dependencies:
 [uniffi](https://github.com/mozilla/uniffi-rs),
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
+[uniffi_checksum_derive](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
-[uniffi_meta](https://github.com/mozilla/uniffi-rs)
+[uniffi_meta](https://github.com/mozilla/uniffi-rs),
+[uniffi_testing](https://github.com/mozilla/uniffi-rs)
 
 ```
 Mozilla Public License Version 2.0
@@ -453,9 +452,6 @@ The following text applies to code linked from these dependencies:
 [cc](https://github.com/alexcrichton/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
-[clap](https://github.com/clap-rs/clap),
-[clap_derive](https://github.com/clap-rs/clap/tree/master/clap_derive),
-[clap_lex](https://github.com/clap-rs/clap/tree/master/clap_lex),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
 [core-foundation](https://github.com/servo/core-foundation-rs),
 [cpufeatures](https://github.com/RustCrypto/utils),
@@ -476,6 +472,7 @@ The following text applies to code linked from these dependencies:
 [futures-task](https://github.com/rust-lang/futures-rs),
 [futures-util](https://github.com/rust-lang/futures-rs),
 [getrandom](https://github.com/rust-random/getrandom),
+[glob](https://github.com/rust-lang/glob),
 [hashbrown](https://github.com/rust-lang/hashbrown),
 [hashlink](https://github.com/kyren/hashlink),
 [heck](https://github.com/withoutboats/heck),
@@ -505,7 +502,6 @@ The following text applies to code linked from these dependencies:
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
 [opaque-debug](https://github.com/RustCrypto/utils),
-[os_str_bytes](https://github.com/dylni/os_str_bytes),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste](https://github.com/dtolnay/paste),
@@ -515,8 +511,6 @@ The following text applies to code linked from these dependencies:
 [pkg-config](https://github.com/rust-lang/pkg-config-rs),
 [plain](https://github.com/randomites/plain),
 [ppv-lite86](https://github.com/cryptocorrosion/cryptocorrosion),
-[proc-macro-error-attr](https://gitlab.com/CreepySkeleton/proc-macro-error),
-[proc-macro-error](https://gitlab.com/CreepySkeleton/proc-macro-error),
 [proc-macro2](https://github.com/dtolnay/proc-macro2),
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
@@ -539,6 +533,7 @@ The following text applies to code linked from these dependencies:
 [serde_json](https://github.com/serde-rs/json),
 [serde_urlencoded](https://github.com/nox/serde_urlencoded),
 [sha2](https://github.com/RustCrypto/hashes),
+[siphasher](https://github.com/jedisct1/rust-siphash),
 [smallbitvec](https://github.com/servo/smallbitvec),
 [smallvec](https://github.com/servo/rust-smallvec),
 [socket2](https://github.com/rust-lang/socket2),
@@ -800,13 +795,12 @@ SOFTWARE.
 
 ```
 -------------
-## MIT License: aho-corasick, byteorder, memchr, termcolor
+## MIT License: aho-corasick, byteorder, memchr
 
 The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
-[memchr](https://github.com/BurntSushi/memchr),
-[termcolor](https://github.com/BurntSushi/termcolor)
+[memchr](https://github.com/BurntSushi/memchr)
 
 ```
 The MIT License (MIT)
@@ -830,35 +824,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: atty
-
-The following text applies to code linked from these dependencies:
-[atty](https://github.com/softprops/atty)
-
-```
-Copyright (c) 2015-2019 Doug Tangren
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
@@ -1420,68 +1385,6 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-```
--------------
-## MIT License: strsim
-
-The following text applies to code linked from these dependencies:
-[strsim](https://github.com/dguo/strsim-rs)
-
-```
-The MIT License (MIT)
-
-Copyright (c) 2015 Danny Guo
-Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
-Copyright (c) 2018 Akash Kurdekar
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
--------------
-## MIT License: textwrap
-
-The following text applies to code linked from these dependencies:
-[textwrap](https://github.com/mgeisler/textwrap)
-
-```
-MIT License
-
-Copyright (c) 2016 Martin Geisler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 ```
 -------------

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -7,7 +7,8 @@ the details of which are reproduced below.
 * [Mozilla Public License 2.0](#mozilla-public-license-20)
 * [Apache License 2.0](#apache-license-20)
 * [MIT License: SwiftKeychainWrapper](#mit-license-swiftkeychainwrapper)
-* [MIT License: aho-corasick, byteorder, memchr](#mit-license-aho-corasick-byteorder-memchr)
+* [MIT License: aho-corasick, byteorder, memchr, termcolor](#mit-license-aho-corasick-byteorder-memchr-termcolor)
+* [MIT License: atty](#mit-license-atty)
 * [MIT License: bincode](#mit-license-bincode)
 * [MIT License: bytes](#mit-license-bytes)
 * [MIT License: cargo_metadata](#mit-license-cargo_metadata)
@@ -26,6 +27,8 @@ the details of which are reproduced below.
 * [MIT License: scroll](#mit-license-scroll)
 * [MIT License: scroll_derive](#mit-license-scroll_derive)
 * [MIT License: slab](#mit-license-slab)
+* [MIT License: strsim](#mit-license-strsim)
+* [MIT License: textwrap](#mit-license-textwrap)
 * [MIT License: tokio, tokio-util](#mit-license-tokio-tokio-util)
 * [MIT License: tokio-native-tls, tracing, tracing-core](#mit-license-tokio-native-tls-tracing-tracing-core)
 * [MIT License: tower-service](#mit-license-tower-service)
@@ -53,6 +56,7 @@ The following text applies to code linked from these dependencies:
 [uniffi_bindgen](https://github.com/mozilla/uniffi-rs),
 [uniffi_build](https://github.com/mozilla/uniffi-rs),
 [uniffi_checksum_derive](https://github.com/mozilla/uniffi-rs),
+[uniffi_core](https://github.com/mozilla/uniffi-rs),
 [uniffi_macros](https://github.com/mozilla/uniffi-rs),
 [uniffi_meta](https://github.com/mozilla/uniffi-rs),
 [uniffi_testing](https://github.com/mozilla/uniffi-rs)
@@ -452,6 +456,9 @@ The following text applies to code linked from these dependencies:
 [cc](https://github.com/alexcrichton/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
+[clap](https://github.com/clap-rs/clap),
+[clap_derive](https://github.com/clap-rs/clap/tree/master/clap_derive),
+[clap_lex](https://github.com/clap-rs/clap/tree/master/clap_lex),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
 [core-foundation](https://github.com/servo/core-foundation-rs),
 [cpufeatures](https://github.com/RustCrypto/utils),
@@ -502,6 +509,7 @@ The following text applies to code linked from these dependencies:
 [num_cpus](https://github.com/seanmonstar/num_cpus),
 [once_cell](https://github.com/matklad/once_cell),
 [opaque-debug](https://github.com/RustCrypto/utils),
+[os_str_bytes](https://github.com/dylni/os_str_bytes),
 [parking_lot](https://github.com/Amanieu/parking_lot),
 [parking_lot_core](https://github.com/Amanieu/parking_lot),
 [paste](https://github.com/dtolnay/paste),
@@ -511,6 +519,8 @@ The following text applies to code linked from these dependencies:
 [pkg-config](https://github.com/rust-lang/pkg-config-rs),
 [plain](https://github.com/randomites/plain),
 [ppv-lite86](https://github.com/cryptocorrosion/cryptocorrosion),
+[proc-macro-error-attr](https://gitlab.com/CreepySkeleton/proc-macro-error),
+[proc-macro-error](https://gitlab.com/CreepySkeleton/proc-macro-error),
 [proc-macro2](https://github.com/dtolnay/proc-macro2),
 [prost-derive](https://github.com/tokio-rs/prost),
 [prost](https://github.com/tokio-rs/prost),
@@ -795,12 +805,13 @@ SOFTWARE.
 
 ```
 -------------
-## MIT License: aho-corasick, byteorder, memchr
+## MIT License: aho-corasick, byteorder, memchr, termcolor
 
 The following text applies to code linked from these dependencies:
 [aho-corasick](https://github.com/BurntSushi/aho-corasick),
 [byteorder](https://github.com/BurntSushi/byteorder),
-[memchr](https://github.com/BurntSushi/memchr)
+[memchr](https://github.com/BurntSushi/memchr),
+[termcolor](https://github.com/BurntSushi/termcolor)
 
 ```
 The MIT License (MIT)
@@ -824,6 +835,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+```
+-------------
+## MIT License: atty
+
+The following text applies to code linked from these dependencies:
+[atty](https://github.com/softprops/atty)
+
+```
+Copyright (c) 2015-2019 Doug Tangren
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
@@ -1385,6 +1425,68 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: strsim
+
+The following text applies to code linked from these dependencies:
+[strsim](https://github.com/dguo/strsim-rs)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2015 Danny Guo
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
+Copyright (c) 2018 Akash Kurdekar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+-------------
+## MIT License: textwrap
+
+The following text applies to code linked from these dependencies:
+[textwrap](https://github.com/mgeisler/textwrap)
+
+```
+MIT License
+
+Copyright (c) 2016 Martin Geisler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ```
 -------------

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -28,3 +28,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 base64 = "0.13"
+
+[patch.crates-io]
+uniffi = { git = "https://github.com/mhammond/uniffi-rs", rev = "e74ad9c20eb3371999ae59a453e80633f683aaac" }

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -737,6 +737,16 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "https://raw.githubusercontent.com/mozilla/uniffi-rs/main/LICENSE",
         }
     },
+    "uniffi_checksum_derive": {
+        "license_url": {
+            "check": None,
+            "fixup": "https://github.com/mozilla/uniffi-rs/blob/main/LICENSE",
+        },
+        "license_file": {
+            "check": None,
+            "fixup": "https://raw.githubusercontent.com/mozilla/uniffi-rs/main/LICENSE",
+        }
+    },
     "uniffi_macros": {
         "license_url": {
             "check": None,
@@ -748,6 +758,16 @@ PACKAGE_METADATA_FIXUPS = {
         }
     },
     "uniffi_meta": {
+        "license_url": {
+            "check": None,
+            "fixup": "https://github.com/mozilla/uniffi-rs/blob/main/LICENSE",
+        },
+        "license_file": {
+            "check": None,
+            "fixup": "https://raw.githubusercontent.com/mozilla/uniffi-rs/main/LICENSE",
+        }
+    },
+    "uniffi_testing": {
         "license_url": {
             "check": None,
             "fixup": "https://github.com/mozilla/uniffi-rs/blob/main/LICENSE",

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -747,6 +747,16 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "https://raw.githubusercontent.com/mozilla/uniffi-rs/main/LICENSE",
         }
     },
+    "uniffi_core": {
+        "license_url": {
+            "check": None,
+            "fixup": "https://github.com/mozilla/uniffi-rs/blob/main/LICENSE",
+        },
+        "license_file": {
+            "check": None,
+            "fixup": "https://raw.githubusercontent.com/mozilla/uniffi-rs/main/LICENSE",
+        }
+    },
     "uniffi_macros": {
         "license_url": {
             "check": None,

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.22"
+uniffi = "^0.22"

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.21"
+uniffi_bindgen = "^0.22"

--- a/tools/embedded-uniffi-bindgen/README.md
+++ b/tools/embedded-uniffi-bindgen/README.md
@@ -1,38 +1,22 @@
 # Embedded uniffi-bindgen for this workspace
 
-This crate exists entirely to support running `cargo uniffi-bindgen` in the workspace
-root and having it correctly execute the `uniffi-bindgen` command provided by the
-version of `uniffi_bindgen` that's in use in the workspace.
+This crate exists entirely to support generating the uniffi bindings.
 
 Say what?
 
 OK, so exposing a crate to Kotlin or Swift via `uniffi` is done in two halves:
 
 * On the Rust side, the crate needs to depend on `uniffi` for runtime support code.
-* On the foreign-language side, we need to run `uniffi-bindgen` as part of the build
-  process to generate the language bindings.
+* On the foreign-language side, we need to also depend on `uniffi` to generate the language bindings.
 
 It's very important that both halves use the exact same version of UniFFI, and UniFFI
 will *try* to error out if it detects this. But if you *don't* detect it then using
 mismatched versions of UniFFI will lead to an inscrutable linker failure at runtime.
 
-The simple way to use UniFFI is for developers to `cargo install uniffi_bindgen`
-on their system and then use the `uniffi-bindgen` command-line tool during the build.
-But unfortunately, this makes it painful to bump the version of the `uniffi` crate
-used by the components, and it greatly complicates doing local development on UniFFI
-itself.
-
-This crate offers a more complicated way that is also more robust to UniFFI version
-changes.
-
-First, configure all UniFFI-using crates to use the `builtin-bindgen` feature
-of `uniffi_build`.
-
-Then, instead of running the system-installed `uniffi-bindgen`, run our handy
-`cargo uniffi-bindgen` alias, which delegates to this crate. This will execute
-the `uniffi-bindgen` command-line tool *provided by the version of UniFFI specified
-in this crate*, letting us avoid having to install and update `uniffi-bindgen` at
-the system level
+We do this by using the builtin capabilities of uniffi - we add that crate as
+a dev_dependency and run our handy
+`cargo uniffi-bindgen` alias, which delegates to this crate.
+XXX - update this?
 
 You'll still have to ensure that all crates in this workspace are using the
 same version of UniFFI, but that's much simpler than controlling what's installed

--- a/tools/embedded-uniffi-bindgen/src/main.rs
+++ b/tools/embedded-uniffi-bindgen/src/main.rs
@@ -3,5 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 fn main() -> anyhow::Result<()> {
-    uniffi_bindgen::run_main()
+    uniffi::uniffi_bindgen_main();
+    Ok(())
 }


### PR DESCRIPTION
Note sure when we should land this - we are hoping to do another vendor into desktop after the next merge - glean is already here but m-c isn't. Should we wait for @bendk 's  version-revamp? @badboy?