### PR TITLE
Increasing places connection timetout (#5237)

### DIFF
--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -94,7 +94,7 @@ impl ConnectionInitializer for PlacesInitializer {
 
             -- How long to wait for a lock before returning SQLITE_BUSY (in ms)
             -- See `doc/sql_concurrency.md` for details.
-            PRAGMA busy_timeout = 5000;
+            PRAGMA busy_timeout = 10000;
         ";
         conn.execute_batch(initial_pragmas)?;
         define_functions(conn, self.api_id)?;


### PR DESCRIPTION
This increases the places connection busy timeout to 10s from 5s.  The idea is to land this early in the nightly cycle and monitor if this changes the error rates we're seeing in Sentry.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
