### PR TITLE
[DontMerge] Uniffi proc macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,15 +370,16 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.14.2"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+checksum = "982a0cf6a99c350d7246035613882e376d58cebe571785abc5da4f648d53ac0a"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.12",
  "serde",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1286,9 +1287,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "goblin"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
+checksum = "572564d6cba7d09775202c8e7eebc4d534d5ae36578ab402fb21e182a0ac9505"
 dependencies = [
  "log",
  "plain",
@@ -1594,7 +1595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877e398ffb23c1c311c417ef5e72e8699c3822dbf835468f009c6ce91b6c206b"
 dependencies = [
  "ahash",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bytecount",
  "fancy-regex",
  "fraction",
@@ -3128,6 +3129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
+name = "siphasher"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
+
+[[package]]
 name = "slab"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,14 +3667,13 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uniffi"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54af5ada67d1173457a99a7bb44a7917f63e7466764cb4714865c7a6678b830"
+checksum = "8e7057bad60ea5f6e2c2df43dbc8143880d19daca2d9bb0ef81131b37ef42cc9"
 dependencies = [
  "anyhow",
  "bytes",
  "camino",
- "cargo_metadata",
  "log",
  "once_cell",
  "paste",
@@ -3677,9 +3683,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc4af3c0180c7e86c4a3acf2b6587af04ba2567b1e948993df10f421796621"
+checksum = "19d84dea610e893f4043354c71e4361386475365e6e2834aded4c8cebf940311"
 dependencies = [
  "anyhow",
  "askama 0.11.1",
@@ -3687,6 +3693,7 @@ dependencies = [
  "camino",
  "clap 3.2.8",
  "fs-err",
+ "glob",
  "goblin",
  "heck 0.4.0",
  "once_cell",
@@ -3695,14 +3702,15 @@ dependencies = [
  "serde_json",
  "toml",
  "uniffi_meta",
+ "uniffi_testing",
  "weedle2",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510287c368a9386eb731ebe824a6fc6c82a105e20d020af1aa20519c1c1561db"
+checksum = "6db116cd55ae857fd40d5780d47c76d3f6aa68c242458fb57bc24cb130a3e920"
 dependencies = [
  "anyhow",
  "camino",
@@ -3710,10 +3718,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniffi_macros"
-version = "0.21.0"
+name = "uniffi_checksum_derive"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8604503caa2cbcf271578dc51ca236d40e3b22e1514ffa2e638e2c39f6ad10"
+checksum = "f55105cc7e1ac83ca1eb29587e3b7f65737f9142dc65d54b63502c2589c9d6a5"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed72d962296f794d962888484c8a2129174976fb2d7c566eca52892d373e0234"
 dependencies = [
  "bincode",
  "camino",
@@ -3730,11 +3748,28 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9417cc653937681436b93838d8c5f97a5b8c58697813982ee8810bd1dc3b57"
+checksum = "9f819a2d6f98e2e9758604f3f541c8200166868525d0329e232ce188f19eeeb4"
 dependencies = [
  "serde",
+ "siphasher",
+ "uniffi_checksum_derive",
+]
+
+[[package]]
+name = "uniffi_testing"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd68c90ec2ab35abc868eae85eedd92b7cede34d38a57e356fce96b8f99d4ef"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "fs-err",
+ "once_cell",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -22,7 +22,7 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = "^0.21"
+uniffi = "^0.22"
 url = { version = "2.2", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -35,4 +35,4 @@ libsqlite3-sys = "0.25.2"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi_build = { version = "^0.21", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.22", features = [ "builtin-bindgen" ]}

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,8 +9,8 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,11 +24,11 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -27,15 +27,15 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [dependencies.rusqlite]
 version = "0.28.0"
 features = ["sqlcipher", "limits", "unlock_notify"]
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
 
 [dev-dependencies]
 more-asserts = "0.2"

--- a/components/logins/src/encryption.rs
+++ b/components/logins/src/encryption.rs
@@ -83,18 +83,21 @@ impl EncryptorDecryptor {
 //     - If it returns true, then it's safe to assume the key can decrypt the DB data
 //     - If it returns false, then the key is no longer valid.  It should be regenerated and the DB
 //       data should be wiped since we can no longer read it properly
+#[uniffi::export]
 pub fn create_canary(text: &str, key: &str) -> ApiResult<String> {
     handle_error! {
         EncryptorDecryptor::new(key)?.encrypt(text)
     }
 }
 
+#[uniffi::export]
 pub fn check_canary(canary: &str, text: &str, key: &str) -> ApiResult<bool> {
     handle_error! {
         Ok(EncryptorDecryptor::new(key)?.decrypt(canary)? == text)
     }
 }
 
+#[uniffi::export]
 pub fn create_key() -> ApiResult<String> {
     handle_error! {
         let key = jwcrypto::Jwk::new_direct_key(None)?;

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -29,6 +29,7 @@ pub use crate::sync::LoginsSyncEngine;
 
 // Public encryption functions.  We publish these as top-level functions to expose them across
 // UniFFI
+#[uniffi::export]
 fn encrypt_login(login: Login, enc_key: &str) -> ApiResult<EncryptedLogin> {
     handle_error! {
         let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
@@ -36,6 +37,7 @@ fn encrypt_login(login: Login, enc_key: &str) -> ApiResult<EncryptedLogin> {
     }
 }
 
+#[uniffi::export]
 fn decrypt_login(login: EncryptedLogin, enc_key: &str) -> ApiResult<Login> {
     handle_error! {
         let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
@@ -43,6 +45,7 @@ fn decrypt_login(login: EncryptedLogin, enc_key: &str) -> ApiResult<Login> {
     }
 }
 
+#[uniffi::export]
 fn encrypt_fields(sec_fields: SecureLoginFields, enc_key: &str) -> ApiResult<String> {
     handle_error! {
         let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
@@ -50,6 +53,7 @@ fn encrypt_fields(sec_fields: SecureLoginFields, enc_key: &str) -> ApiResult<Str
     }
 }
 
+#[uniffi::export]
 fn decrypt_fields(sec_fields: String, enc_key: &str) -> ApiResult<SecureLoginFields> {
     handle_error! {
         let encdec = encryption::EncryptorDecryptor::new(enc_key)?;

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -2,46 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-namespace logins {
-    // We expose the crypto primitives on the namespace
-
-    // Create a new, random, encryption key.
-    [Throws=LoginsApiError]
-    string create_key();
-
-    // Decrypt an `EncryptedLogin` to a `Login`
-    [Throws=LoginsApiError]
-    Login decrypt_login(EncryptedLogin login, [ByRef]string encryption_key);
-
-    // Encrypt a `Login` to an `EncryptedLogin`
-    [Throws=LoginsApiError]
-    EncryptedLogin encrypt_login(Login login, [ByRef]string encryption_key);
-
-    // Decrypt an encrypted `string` to `SecureLoginFields`
-    [Throws=LoginsApiError]
-    SecureLoginFields decrypt_fields(string sec_fields, [ByRef]string encryption_key);
-
-    // Encrypt `SecureLoginFields` to an encrypted `string`
-    [Throws=LoginsApiError]
-    string encrypt_fields(SecureLoginFields sec_fields, [ByRef]string encryption_key);
-
-    // Create a "canary" string, which can be used to test if the encryption key is still valid for the logins data
-    [Throws=LoginsApiError]
-    string create_canary([ByRef]string text, [ByRef]string encryption_key);
-
-    // Check that key is still valid using the output of `create_canary`.  `text` much match the text you initially passed to `create_canary()`
-    [Throws=LoginsApiError]
-    boolean check_canary([ByRef]string canary, [ByRef]string text, [ByRef]string encryption_key);
-
-    [Throws=LoginsApiError]
-    void migrate_logins(
-        [ByRef]string path,
-        [ByRef]string new_encryption_key,
-        [ByRef]string sqlcipher_path,
-        [ByRef]string sqlcipher_key,
-        string? salt
-    );
-};
+namespace logins { };
 
 // The fields you can add or update.
 dictionary LoginFields {

--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -50,6 +50,7 @@ enum MigrationOp {
 }
 
 // migration for consumers to migrate from their SQLCipher DB
+#[uniffi::export]
 pub fn migrate_logins(
     path: impl AsRef<Path>,
     new_encryption_key: &str,

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -32,13 +32,13 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "^0.21", optional = true }
+uniffi = { version = "^0.22", optional = true }
 chrono = { version = "0.4", features = ["serde"]}
 unicode-segmentation = "1.8.0"
 error-support = { path = "../support/error" }
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.22", features = [ "builtin-bindgen" ], optional = true }
 glean-build = { path = "../external/glean/glean-core/build" }
 
 [dev-dependencies]

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -33,8 +33,8 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [dependencies.rusqlite]
 version = "0.28.0"
@@ -46,4 +46,4 @@ tempfile = "3.1"
 env_logger = {version = "0.7", default-features = false}
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -21,11 +21,11 @@ error-support = { path = "../support/error" }
 sql-support = { path = "../support/sql" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }
 thiserror = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }
 
 
 [dev-dependencies]

--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -9,12 +9,12 @@ license = "MPL-2.0"
 log = "0.4"
 lazy_static = { version = "1.4" }
 parking_lot = { version = ">=0.11,<=0.12" }
-uniffi = { version = "^0.21" }
-uniffi_macros = { version = "^0.21" }
+uniffi = { version = "^0.22" }
+uniffi_macros = { version = "^0.22" }
 
 [dependencies.backtrace]
 optional = true
 version = "0.3"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -24,8 +24,8 @@ serde_derive = "1"
 serde_json = "1"
 parking_lot = ">=0.11,<=0.12"
 interrupt-support = { path = "../support/interrupt" }
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features=["builtin-bindgen"] }
+uniffi_build = { version = "^0.22", features=["builtin-bindgen"] }

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -33,8 +33,8 @@ sql-support = { path = "../support/sql" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
-uniffi = "^0.21"
-uniffi_macros = "^0.21"
+uniffi = "^0.22"
+uniffi_macros = "^0.22"
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [dev-dependencies]
@@ -42,4 +42,4 @@ env_logger = { version = "0.8.0", default-features = false, features = ["termcol
 tempfile = "3.1"
 
 [build-dependencies]
-uniffi_build = { version = "^0.21", features = [ "builtin-bindgen" ]}
+uniffi_build = { version = "^0.22", features = [ "builtin-bindgen" ]}

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -7,4 +7,4 @@ license = "MPL-2.0"
 
 [dependencies]
 anyhow = "1"
-uniffi_bindgen = "^0.21"
+uniffi_bindgen = "^0.22"


### PR DESCRIPTION
This PR is to just share the results of me trying to switch the app-services code to use the new UniFFI proc-macro setup.  The goal here is to track the current state as we fix things on the UniFFI side and/or refactor the app-services code.

Right now it's failing because the proc-macros expect results to always be spelled as `Result<R, E>`.  We rename our `Result` types and make the error half implicit, both of which break the macros.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
