### PR TITLE
Don't use workspace dependencies for UniFFI.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,11 +106,6 @@ default-members = [
     "testing/separated/*/",
 ]
 
-[workspace.dependencies]
-# Use the following line to test local changes to UniFFI (and comment out the main one):
-# uniffi = { path = "../uniffi-rs/uniffi" }
-uniffi = "0.23"
-
 [profile.release]
 opt-level = "s"
 debug = true
@@ -121,3 +116,9 @@ lto = "thin"
 [patch."https://github.com/mozilla/application-services"]
 viaduct = { path = "components/viaduct" }
 
+# If you need to test some local changes to UniFFI, uncomment the following line
+# for a convenient way to use a local checkout rather than the published version.
+# You just have to make sure that the version number in your local checkout
+# matches the one used in the `Cargo.toml` files in this workspace.
+#[patch.crates-io]
+#uniffi = { path = "../uniffi-rs/uniffi" }

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -22,7 +22,7 @@ sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
 types = { path = "../support/types" }
-uniffi = { workspace = true }
+uniffi = "0.23"
 url = { version = "2.2", features = ["serde"] }
 
 [dependencies.rusqlite]
@@ -35,4 +35,4 @@ libsqlite3-sys = "0.25.2"
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { version = "0.23", features = ["build"] }

--- a/components/crashtest/Cargo.toml
+++ b/components/crashtest/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["/android", "/ios"]
 [dependencies]
 log = "0.4"
 thiserror = "1.0"
-uniffi = { workspace = true }
+uniffi = "0.23"
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { version = "0.23", features = ["build"] }

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -24,10 +24,10 @@ error-support = { path = "../support/error" }
 thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
-uniffi = { workspace = true }
+uniffi = "0.23"
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { version = "0.23", features = ["build"] }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -27,14 +27,14 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = { workspace = true }
+uniffi = "0.23"
 
 [dependencies.rusqlite]
 version = "0.28.0"
 features = ["sqlcipher", "limits", "unlock_notify"]
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { version = "0.23", features = ["build"] }
 
 [dev-dependencies]
 more-asserts = "0.2"

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -32,13 +32,13 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { workspace = true, optional = true }
+uniffi = { version = "0.23", optional = true }
 chrono = { version = "0.4", features = ["serde"]}
 unicode-segmentation = "1.8.0"
 error-support = { path = "../support/error" }
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"], optional = true }
+uniffi = { version = "0.23", features = ["build"], optional = true }
 glean-build = { path = "../external/glean/glean-core/build" }
 
 [dev-dependencies]

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -33,7 +33,7 @@ error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
 thiserror = "1.0"
 anyhow = "1.0"
-uniffi = { workspace = true }
+uniffi = "0.23"
 
 [dependencies.rusqlite]
 version = "0.28.0"
@@ -45,4 +45,4 @@ tempfile = "3.1"
 env_logger = {version = "0.7", default-features = false}
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { version = "0.23", features = ["build"] }

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -21,10 +21,10 @@ error-support = { path = "../support/error" }
 sql-support = { path = "../support/sql" }
 rc_crypto = { path = "../support/rc_crypto", features = ["ece"] }
 thiserror = "1.0"
-uniffi = { workspace = true }
+uniffi = "0.23"
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { version = "0.23", features = ["build"] }
 
 [dev-dependencies]
 env_logger = { version = "0.8", default-features = false, features = ["termcolor", "atty", "humantime"] }

--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -10,7 +10,7 @@ autotests = false
 log = "0.4"
 lazy_static = { version = "1.4" }
 parking_lot = { version = ">=0.11,<=0.12" }
-uniffi = { workspace = true }
+uniffi = "0.23"
 error-support-macros = { path = "macros" }
 
 [dependencies.backtrace]
@@ -18,4 +18,4 @@ optional = true
 version = "0.3"
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { version = "0.23", features = ["build"] }

--- a/components/sync_manager/Cargo.toml
+++ b/components/sync_manager/Cargo.toml
@@ -24,7 +24,7 @@ serde_derive = "1"
 serde_json = "1"
 parking_lot = ">=0.11,<=0.12"
 interrupt-support = { path = "../support/interrupt" }
-uniffi = { workspace = true }
+uniffi = "0.23"
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { version = "0.23", features = ["build"] }

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -33,7 +33,7 @@ sql-support = { path = "../support/sql" }
 sync-guid = { path = "../support/guid", features = ["random"] }
 sync15 = { path = "../sync15", features = ["sync-engine"] }
 thiserror = "1.0"
-uniffi = { workspace = true }
+uniffi = "0.23"
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [dev-dependencies]
@@ -41,4 +41,4 @@ env_logger = { version = "0.8.0", default-features = false, features = ["termcol
 tempfile = "3.1"
 
 [build-dependencies]
-uniffi = { workspace = true, features = ["build"] }
+uniffi = { version = "0.23", features = ["build"] }

--- a/tools/embedded-uniffi-bindgen/Cargo.toml
+++ b/tools/embedded-uniffi-bindgen/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 license = "MPL-2.0"
 
 [dependencies]
-uniffi = { workspace = true, features = ["cli"] }
+uniffi = { version = "0.23", features = ["cli"] }


### PR DESCRIPTION
This was really nice, but it breaks when we get vendored in to moz-central.  So we have to go back to the dark ages.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
