### PR TITLE
Expose sync manager component to iOS

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -24,3 +24,11 @@ Use the template below to make assigning a version number during the release cut
 ### 🦊 What's Changed 🦊
 
 - The Tabs engine now trims the payload to be under the max the server will accept ([#5376](https://github.com/mozilla/application-services/pull/5376))
+
+
+## Sync Manager
+
+### 🦊 What's Changed 🦊
+
+- Exposing the Sync Manager component to iOS by addressing the existing naming collisions, adding logic to process the telemetry
+  data returned in the component's `sync` function, and adding the component to the iOS megazord ([#5359](https://github.com/mozilla/application-services/pull/5359)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,6 +1824,7 @@ dependencies = [
  "rc_log_ffi",
  "rust-log-forwarder",
  "sync15",
+ "sync_manager",
  "tabs",
  "viaduct",
  "viaduct-reqwest",

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -98,7 +98,7 @@ open class LoginsStorage {
     }
 
     /// Register with the sync manager
-    open func registerWithSyncManager() throws {
+    open func registerWithSyncManager() {
         return queue.sync {
             return self.store.registerWithSyncManager()
         }

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -168,6 +168,12 @@ public class PlacesAPI {
             return try self.api.bookmarksReset()
         }
     }
+
+    open func registerWithSyncManager() {
+        queue.sync {
+            self.api.registerWithSyncManager()
+        }
+    }
 }
 
 /**

--- a/components/sync15/ios/RustSyncTelemetryPing.swift
+++ b/components/sync15/ios/RustSyncTelemetryPing.swift
@@ -1,0 +1,435 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Foundation
+
+public class RustSyncTelemetryPing {
+    public let version: Int
+    public let uid: String
+    public let events: [EventInfo]
+    public let syncs: [SyncInfo]
+
+    private static let EMPTY_UID = String(repeating: "0", count: 32)
+
+    init(version: Int, uid: String, events: [EventInfo], syncs: [SyncInfo]) {
+        self.version = version
+        self.uid = uid
+        self.events = events
+        self.syncs = syncs
+    }
+
+    static func empty() -> RustSyncTelemetryPing {
+        return RustSyncTelemetryPing(version: 1,
+                                     uid: EMPTY_UID,
+                                     events: [EventInfo](),
+                                     syncs: [SyncInfo]())
+    }
+
+    static func fromJSON(jsonObject: [String: Any]) throws -> RustSyncTelemetryPing {
+        guard let version = jsonObject["version"] as? Int else {
+            throw TelemetryJSONError.intValueNotFound(
+                message: "RustSyncTelemetryPing `version` property not found")
+        }
+
+        let events = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            try EventInfo.fromJSONArray(
+                jsonArray: obj["events"] as? [[String: Any]] ?? [[String: Any]]())
+        } ?? [EventInfo]()
+
+        let syncs = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            try SyncInfo.fromJSONArray(
+                jsonArray: obj["syncs"] as? [[String: Any]] ?? [[String: Any]]())
+        } ?? [SyncInfo]()
+
+        return RustSyncTelemetryPing(version: version,
+                                     uid: try stringOrNull(jsonObject: jsonObject,
+                                                           key: "uid") ?? EMPTY_UID,
+                                     events: events, syncs: syncs)
+    }
+
+    public static func fromJSONString(jsonObjectText: String) throws -> RustSyncTelemetryPing {
+        guard let data = jsonObjectText.data(using: .utf8) else {
+            throw TelemetryJSONError.invalidJSONString
+        }
+
+        let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [String: Any]()
+        return try fromJSON(jsonObject: jsonObject)
+    }
+}
+
+public class SyncInfo {
+    public let at: Int64
+    public let took: Int64
+    public let engines: [EngineInfo]
+    public let failureReason: FailureReason?
+
+    init(at: Int64, took: Int64, engines: [EngineInfo], failureReason: FailureReason?) {
+        self.at = at
+        self.took = took
+        self.engines = engines
+        self.failureReason = failureReason
+    }
+
+    static func fromJSON(jsonObject: [String: Any]) throws -> SyncInfo {
+        guard let at = jsonObject["when"] as? Int64 else {
+            throw TelemetryJSONError.intValueNotFound(
+                message: "SyncInfo `when` property not found")
+        }
+
+        let engines = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            try EngineInfo.fromJSONArray(
+                jsonArray: obj["engines"] as? [[String: Any]] ?? [[String: Any]]())
+        } ?? [EngineInfo]()
+
+        let failureReason = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            FailureReason.fromJSON(
+                jsonObject: obj["failureReason"] as? [String: Any] ?? [String: Any]())
+        } as? FailureReason
+
+        return SyncInfo(at: at,
+                        took: int64OrZero(jsonObject: jsonObject, key: "took"),
+                        engines: engines,
+                        failureReason: failureReason)
+    }
+
+    static func fromJSONArray(jsonArray: [[String: Any]]) throws -> [SyncInfo] {
+        var result = [SyncInfo]()
+
+        for item in jsonArray {
+            result.append(try fromJSON(jsonObject: item))
+        }
+
+        return result
+    }
+}
+
+public class EngineInfo {
+    public let name: String
+    public let at: Int64
+    public let took: Int64
+    public let incoming: IncomingInfo?
+    public let outgoing: [OutgoingInfo]
+    public let failureReason: FailureReason?
+    public let validation: ValidationInfo?
+
+    init(
+        name: String,
+        at: Int64,
+        took: Int64,
+        incoming: IncomingInfo?,
+        outgoing: [OutgoingInfo],
+        failureReason: FailureReason?,
+        validation: ValidationInfo?
+    ) {
+        self.name = name
+        self.at = at
+        self.took = took
+        self.incoming = incoming
+        self.outgoing = outgoing
+        self.failureReason = failureReason
+        self.validation = validation
+    }
+
+    static func fromJSON(jsonObject: [String: Any]) throws -> EngineInfo {
+        guard let name = jsonObject["name"] as? String else {
+            throw TelemetryJSONError.stringValueNotFound
+        }
+
+        guard let at = jsonObject["when"] as? Int64 else {
+            throw TelemetryJSONError.intValueNotFound(
+                message: "EngineInfo `at` property not found")
+        }
+
+        guard let took = jsonObject["took"] as? Int64 else {
+            throw TelemetryJSONError.intValueNotFound(
+                message: "EngineInfo `took` property not found")
+        }
+
+        let incoming = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            IncomingInfo.fromJSON(
+                jsonObject: obj["incoming"] as? [String: Any] ?? [String: Any]())
+        }
+
+        let outgoing = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            OutgoingInfo.fromJSONArray(
+                jsonArray: obj["outgoing"] as? [[String: Any]] ?? [[String: Any]]())
+        } ?? [OutgoingInfo]()
+
+        let failureReason = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            FailureReason.fromJSON(
+                jsonObject: obj["failureReason"] as? [String: Any] ?? [String: Any]())
+        } as? FailureReason
+
+        let validation = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            try ValidationInfo.fromJSON(
+                jsonObject: obj["validation"] as? [String: Any] ?? [String: Any]())
+        }
+
+        return EngineInfo(name: name,
+                          at: at,
+                          took: took,
+                          incoming: incoming,
+                          outgoing: outgoing,
+                          failureReason: failureReason,
+                          validation: validation)
+    }
+
+    static func fromJSONArray(jsonArray: [[String: Any]]) throws -> [EngineInfo] {
+        var result = [EngineInfo]()
+
+        for item in jsonArray {
+            result.append(try fromJSON(jsonObject: item))
+        }
+
+        return result
+    }
+}
+
+public class IncomingInfo {
+    public let applied: Int
+    public let failed: Int
+    public let newFailed: Int
+    public let reconciled: Int
+
+    init(applied: Int, failed: Int, newFailed: Int, reconciled: Int) {
+        self.applied = applied
+        self.failed = failed
+        self.newFailed = newFailed
+        self.reconciled = reconciled
+    }
+
+    static func fromJSON(jsonObject: [String: Any]) -> IncomingInfo {
+        return IncomingInfo(applied: intOrZero(jsonObject: jsonObject, key: "applied"),
+                            failed: intOrZero(jsonObject: jsonObject, key: "failed"),
+                            newFailed: intOrZero(jsonObject: jsonObject, key: "newFailed"),
+                            reconciled: intOrZero(jsonObject: jsonObject, key: "reconciled"))
+    }
+}
+
+public class OutgoingInfo {
+    public let sent: Int
+    public let failed: Int
+
+    init(sent: Int, failed: Int) {
+        self.sent = sent
+        self.failed = failed
+    }
+
+    static func fromJSON(jsonObject: [String: Any]) -> OutgoingInfo {
+        return OutgoingInfo(sent: intOrZero(jsonObject: jsonObject, key: "sent"),
+                            failed: intOrZero(jsonObject: jsonObject, key: "failed"))
+    }
+
+    static func fromJSONArray(jsonArray: [[String: Any]]) -> [OutgoingInfo] {
+        var result = [OutgoingInfo]()
+
+        for (_, item) in jsonArray.enumerated() {
+            result.append(fromJSON(jsonObject: item))
+        }
+
+        return result
+    }
+}
+
+public class ValidationInfo {
+    public let version: Int
+    public let problems: [ProblemInfo]
+    public let failureReason: FailureReason?
+
+    init(version: Int, problems: [ProblemInfo], failureReason: FailureReason?) {
+        self.version = version
+        self.problems = problems
+        self.failureReason = failureReason
+    }
+
+    static func fromJSON(jsonObject: [String: Any]) throws -> ValidationInfo {
+        guard let version = jsonObject["version"] as? Int else {
+            throw TelemetryJSONError.intValueNotFound(
+                message: "ValidationInfo `version` property not found")
+        }
+
+        let problems = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            guard let problemJSON = obj["outgoing"] as? [[String: Any]] else {
+                return [ProblemInfo]()
+            }
+
+            return try ProblemInfo.fromJSONArray(jsonArray: problemJSON)
+        } ?? [ProblemInfo]()
+
+        let failureReason = unwrapFromJSON(jsonObject: jsonObject) { obj in
+            FailureReason.fromJSON(
+                jsonObject: obj["failureReason"] as? [String: Any] ?? [String: Any]())
+        } as? FailureReason
+
+        return ValidationInfo(version: version,
+                              problems: problems,
+                              failureReason: failureReason)
+    }
+}
+
+public class ProblemInfo {
+    public let name: String
+    public let count: Int
+
+    public init(name: String, count: Int) {
+        self.name = name
+        self.count = count
+    }
+
+    static func fromJSON(jsonObject: [String: Any]) throws -> ProblemInfo {
+        guard let name = jsonObject["name"] as? String else {
+            throw TelemetryJSONError.stringValueNotFound
+        }
+        return ProblemInfo(name: name,
+                           count: intOrZero(jsonObject: jsonObject, key: "count"))
+    }
+
+    static func fromJSONArray(jsonArray: [[String: Any]]) throws -> [ProblemInfo] {
+        var result = [ProblemInfo]()
+
+        for (_, item) in jsonArray.enumerated() {
+            result.append(try fromJSON(jsonObject: item))
+        }
+
+        return result
+    }
+}
+
+public enum FailureName {
+    case shutdown
+    case other
+    case unexpected
+    case auth
+    case http
+    case unknown
+}
+
+public struct FailureReason {
+    public let name: FailureName
+    public let message: String?
+    public let code: Int
+
+    public init(name: FailureName, message: String? = nil, code: Int = -1) {
+        self.name = name
+        self.message = message
+        self.code = code
+    }
+
+    static func fromJSON(jsonObject: [String: Any]) -> FailureReason? {
+        guard let name = jsonObject["name"] as? String else {
+            return nil
+        }
+
+        switch name {
+        case "shutdownerror":
+            return FailureReason(name: FailureName.shutdown)
+        case "othererror":
+            return FailureReason(name: FailureName.other,
+                                 message: jsonObject["error"] as? String)
+        case "unexpectederror":
+            return FailureReason(name: FailureName.unexpected,
+                                 message: jsonObject["error"] as? String)
+        case "autherror":
+            return FailureReason(name: FailureName.auth,
+                                 message: jsonObject["from"] as? String)
+        case "httperror":
+            return FailureReason(name: FailureName.http,
+                                 code: jsonObject["code"] as? Int ?? -1)
+        default:
+            return FailureReason(name: FailureName.unknown)
+        }
+    }
+}
+
+public class EventInfo {
+    public let obj: String
+    public let method: String
+    public let value: String?
+    public let extra: [String: String]
+
+    public init(obj: String, method: String, value: String?, extra: [String: String]) {
+        self.obj = obj
+        self.method = method
+        self.value = value
+        self.extra = extra
+    }
+
+    static func fromJSON(jsonObject: [String: Any]) throws -> EventInfo {
+        let extra = unwrapFromJSON(jsonObject: jsonObject) { (json: [String: Any]) -> [String: String] in
+            if json["extra"] as? [String: Any] == nil {
+                return [String: String]()
+            } else {
+                var extraValues = [String: String]()
+
+                for key in json.keys {
+                    extraValues[key] = extraValues[key]
+                }
+
+                return extraValues
+            }
+        }
+
+        return EventInfo(obj: jsonObject["object"] as? String ?? "",
+                         method: jsonObject["method"] as? String ?? "",
+                         value: try stringOrNull(jsonObject: jsonObject, key: "value"),
+                         extra: extra ?? [String: String]())
+    }
+
+    static func fromJSONArray(jsonArray: [[String: Any]]) throws -> [EventInfo] {
+        var result = [EventInfo]()
+
+        for (_, item) in jsonArray.enumerated() {
+            result.append(try fromJSON(jsonObject: item))
+        }
+
+        return result
+    }
+}
+
+func unwrapFromJSON<T>(
+    jsonObject: [String: Any],
+    f: @escaping ([String: Any]) throws -> T
+) -> T? {
+    do {
+        return try f(jsonObject)
+    } catch {
+        return nil
+    }
+}
+
+enum TelemetryJSONError: Error {
+    case stringValueNotFound
+    case intValueNotFound(message: String)
+    case invalidJSONString
+}
+
+func stringOrNull(jsonObject: [String: Any], key: String) throws -> String? {
+    return unwrapFromJSON(jsonObject: jsonObject) { data in
+        guard let value = data[key] as? String else {
+            throw TelemetryJSONError.stringValueNotFound
+        }
+
+        return value
+    }
+}
+
+func int64OrZero(jsonObject: [String: Any], key: String) -> Int64 {
+    return unwrapFromJSON(jsonObject: jsonObject) { data in
+        guard let value = data[key] as? Int64 else {
+            return 0
+        }
+
+        return value
+    } ?? 0
+}
+
+func intOrZero(jsonObject: [String: Any], key: String) -> Int {
+    return unwrapFromJSON(jsonObject: jsonObject) { data in
+        guard let value = data[key] as? Int else {
+            return 0
+        }
+
+        return value
+    } ?? 0
+}

--- a/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/DeviceType.kt
+++ b/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/DeviceType.kt
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("InvalidPackageDeclaration")
+package mozilla.appservices.syncmanager
+
+// We needed to rename the tabs `DeviceType` as it conflicts with the `DeviceType` we are exposing for FxA
+// in iOS. However renaming `DeviceType` to `SyncManagerDeviceType` creates a breaking change for the Android code.
+// So we are aliasing `SyncManagerDeviceType` back to `DeviceType` in order to prevent the breaking change.
+typealias DeviceType = SyncManagerDeviceType

--- a/components/sync_manager/src/lib.rs
+++ b/components/sync_manager/src/lib.rs
@@ -10,7 +10,7 @@ pub mod manager;
 mod types;
 
 pub use error::{Result, SyncManagerError};
-use sync15::DeviceType;
+use sync15::DeviceType as SyncManagerDeviceType;
 pub use types::*;
 
 use manager::SyncManager;

--- a/components/sync_manager/src/syncmanager.udl
+++ b/components/sync_manager/src/syncmanager.udl
@@ -54,6 +54,7 @@ enum SyncReason {
     "PreSleep",
     "Startup",
     "EnabledChange",
+    "Backgrounded",
 };
 
 dictionary SyncAuthInfo {
@@ -66,10 +67,10 @@ dictionary SyncAuthInfo {
 dictionary DeviceSettings {
     string fxa_device_id;
     string name;
-    DeviceType kind;
+    SyncManagerDeviceType kind;
 };
 
-enum DeviceType {
+enum SyncManagerDeviceType {
     "Desktop",
     "Mobile",
     "Tablet",

--- a/components/sync_manager/src/types.rs
+++ b/components/sync_manager/src/types.rs
@@ -35,6 +35,7 @@ pub enum SyncReason {
     PreSleep,
     Startup,
     EnabledChange,
+    Backgrounded,
 }
 
 #[derive(Debug)]

--- a/components/tabs/ios/Tabs/Tabs.swift
+++ b/components/tabs/ios/Tabs/Tabs.swift
@@ -32,6 +32,12 @@ open class TabsStorage {
         }
     }
 
+    open func registerWithSyncManager() {
+        queue.sync {
+            self.store.registerWithSyncManager()
+        }
+    }
+
     open func sync(unlockInfo: SyncUnlockInfo) throws -> String {
         guard let tabsLocalId = unlockInfo.tabsLocalId else {
             throw TabsApiError.UnexpectedTabsError(reason: "tabs local ID was not provided")

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -23,3 +23,4 @@ tabs = { path = "../../components/tabs", features = ["full-sync"] }
 places = {path = "../../components/places" }
 sync15 = {path = "../../components/sync15"}
 error-support = { path = "../../components/support/error" }
+sync_manager = { path = "../../components/sync_manager" }

--- a/megazords/ios-rust/MozillaRustComponents.h
+++ b/megazords/ios-rust/MozillaRustComponents.h
@@ -16,3 +16,4 @@
 #import "pushFFI.h"
 #import "tabsFFI.h"
 #import "errorFFI.h"
+#import "syncmanagerFFI.h"

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -66,6 +66,9 @@
 		39F5D7642956161E004E2384 /* Operation+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F5D7632956161E004E2384 /* Operation+.swift */; };
 		39F5D766295616E3004E2384 /* NimbusBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F5D765295616E3004E2384 /* NimbusBuilder.swift */; };
 		45CC574A28AD9C86006D55AA /* errorsupport.udl in Sources */ = {isa = PBXBuildFile; fileRef = 45CC574828AD9C31006D55AA /* errorsupport.udl */; };
+		F85ED649299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85ED648299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift */; };
+		F8BEFFDA299C4F1100776186 /* RustSyncTelemetryPing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BEFFD9299C4F1100776186 /* RustSyncTelemetryPing.swift */; };
+		F8C88393298B4BF80006E9E9 /* syncmanager.udl in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1CC298B41FC000BCDEC /* syncmanager.udl */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -186,6 +189,11 @@
 		45CC574528AD9C0B006D55AA /* errorFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = errorFFI.h; path = ../../../../components/support/error/ios/Generated/errorFFI.h; sourceTree = "<group>"; };
 		45CC574628AD9C0B006D55AA /* errorsupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = errorsupport.swift; path = ../../../../components/support/error/ios/Generated/errorsupport.swift; sourceTree = "<group>"; };
 		45CC574828AD9C31006D55AA /* errorsupport.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = errorsupport.udl; path = ../../../../components/support/error/src/errorsupport.udl; sourceTree = "<group>"; };
+		F85ED648299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustSyncTelemetryPingTests.swift; sourceTree = "<group>"; };
+		F8AAC1CC298B41FC000BCDEC /* syncmanager.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = syncmanager.udl; path = ../../../components/sync_manager/src/syncmanager.udl; sourceTree = SOURCE_ROOT; };
+		F8BEFFD9299C4F1100776186 /* RustSyncTelemetryPing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RustSyncTelemetryPing.swift; path = ../../../components/sync15/ios/RustSyncTelemetryPing.swift; sourceTree = SOURCE_ROOT; };
+		F8C88394298B4EC00006E9E9 /* syncmanagerFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = syncmanagerFFI.h; path = ../../../components/sync_manager/ios/Generated/syncmanagerFFI.h; sourceTree = SOURCE_ROOT; };
+		F8C88395298B4EC00006E9E9 /* syncmanager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = syncmanager.swift; path = ../../../components/sync_manager/ios/Generated/syncmanager.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -307,6 +315,7 @@
 		1BBAC4FA27AE049500DAFEF2 /* MozillaTestServices */ = {
 			isa = PBXGroup;
 			children = (
+				F8AAC1CB298B40B8000BCDEC /* SyncManager */,
 				15DAE2082944142000DB06FE /* Autofill */,
 				45CC574328AD9BC8006D55AA /* ErrorSupport */,
 				1BFC469427C99F250034E0A5 /* Generated */,
@@ -336,6 +345,7 @@
 				1BBAC53E27AE065300DAFEF2 /* NimbusTests.swift */,
 				39083AAA29561E2400FDD302 /* OperationTests.swift */,
 				1BBAC54027AE065300DAFEF2 /* PlacesTests.swift */,
+				F85ED648299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift */,
 			);
 			path = MozillaTestServicesTests;
 			sourceTree = SOURCE_ROOT;
@@ -427,6 +437,7 @@
 		1BBAC5AF27AE112D00DAFEF2 /* Sync15 */ = {
 			isa = PBXGroup;
 			children = (
+				F8BEFFD9299C4F1100776186 /* RustSyncTelemetryPing.swift */,
 				1BBAC5B127AE11AA00DAFEF2 /* ResultError.swift */,
 				1BBAC5B027AE11AA00DAFEF2 /* SyncUnlockInfo.swift */,
 			);
@@ -518,6 +529,26 @@
 			);
 			name = Generated;
 			sourceTree = "<group>";
+		};
+		F8AAC1CB298B40B8000BCDEC /* SyncManager */ = {
+			isa = PBXGroup;
+			children = (
+				F8AAC1CF298B43F0000BCDEC /* Generated */,
+				F8AAC1CC298B41FC000BCDEC /* syncmanager.udl */,
+			);
+			name = SyncManager;
+			path = ../../../components/sync_manager/ios;
+			sourceTree = "<group>";
+		};
+		F8AAC1CF298B43F0000BCDEC /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				F8C88395298B4EC00006E9E9 /* syncmanager.swift */,
+				F8C88394298B4EC00006E9E9 /* syncmanagerFFI.h */,
+			);
+			name = Generated;
+			path = ../../../components/sync_manager/ios/Generated;
+			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */
 
@@ -652,6 +683,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				39AD326F2988468B00E42E13 /* FeatureManifestInterface.swift in Sources */,
+				F8C88393298B4BF80006E9E9 /* syncmanager.udl in Sources */,
 				15DAE213294418F600DB06FE /* autofill.udl in Sources */,
 				45CC574A28AD9C86006D55AA /* errorsupport.udl in Sources */,
 				1BE9B60D27C9CD770029D11A /* crashtest.udl in Sources */,
@@ -693,6 +725,7 @@
 				1BF50F0C27B1E17B00A9C8A5 /* KeychainWrapper+.swift in Sources */,
 				1BF50F0D27B1E17B00A9C8A5 /* FxAccountMigration.swift in Sources */,
 				1B3BC94527B1D6A500229CF6 /* SyncUnlockInfo.swift in Sources */,
+				F8BEFFDA299C4F1100776186 /* RustSyncTelemetryPing.swift in Sources */,
 				1B3BC94B27B1D79B00229CF6 /* LoginsStorage.swift in Sources */,
 				1B3BC98927B1D9B800229CF6 /* Unreachable.swift in Sources */,
 				1BF50F1727B1E18000A9C8A5 /* KeychainItemAccessibility.swift in Sources */,
@@ -710,6 +743,7 @@
 				1BF50F1A27B1E19800A9C8A5 /* FxAccountMocks.swift in Sources */,
 				1B3BC95127B1D93100229CF6 /* CrashTestTests.swift in Sources */,
 				1B3BC94727B1D73500229CF6 /* LogTest.swift in Sources */,
+				F85ED649299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift in Sources */,
 				1B3BC94327B1D63B00229CF6 /* PlacesTests.swift in Sources */,
 				1B3BC94827B1D73700229CF6 /* LoginsTests.swift in Sources */,
 				1B3BC94F27B1D92800229CF6 /* NimbusTests.swift in Sources */,

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/RustSyncTelemetryPingTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/RustSyncTelemetryPingTests.swift
@@ -1,0 +1,108 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import MozillaTestServices
+
+import XCTest
+
+class RustSyncTelemetryPingTests: XCTestCase {
+    func testValidJSON() {
+        let json = """
+        {"version":1,"uid":"b01a6f3d11cbb0f2ae2c940ab458b30a","syncs":[ {"when":1676416271.0,"took":837,"engines":[{"name":"passwords","when":167641627.0,"took":116,"incoming":{"applied":1},"outgoing":[{}]}]}]}
+        """
+        let syncs = [
+            SyncInfo(at: Int64(1_676_416_271.0),
+                     took: Int64(837),
+                     engines: [EngineInfo(name: "passwords",
+                                          at: Int64(1_676_416_271),
+                                          took: Int64(116),
+                                          incoming: IncomingInfo(applied: 1,
+                                                                 failed: 0,
+                                                                 newFailed: 0,
+                                                                 reconciled: 0),
+                                          outgoing: [OutgoingInfo(sent: 0, failed: 0)],
+                                          failureReason: nil,
+                                          validation: ValidationInfo(version: 0,
+                                                                     problems: [ProblemInfo](),
+                                                                     failureReason: nil))],
+                     failureReason: nil),
+        ]
+
+        let expected = RustSyncTelemetryPing(version: 1,
+                                             uid: "b01a6f3d11cbb0f2ae2c940ab458b30a",
+                                             events: [EventInfo](),
+                                             syncs: syncs)
+
+        let actual = try! RustSyncTelemetryPing.fromJSONString(jsonObjectText: json)
+
+        XCTAssertEqual(actual.uid, expected.uid)
+        XCTAssertNotNil(actual.syncs[0].engines[0].incoming)
+        XCTAssertNotNil(expected.syncs[0].engines[0].incoming)
+        XCTAssertEqual(actual.syncs[0].engines[0].incoming!.applied,
+                       expected.syncs[0].engines[0].incoming!.applied)
+        XCTAssertEqual(actual.syncs[0].engines[0].outgoing[0].sent,
+                       expected.syncs[0].engines[0].outgoing[0].sent)
+        XCTAssertEqual(actual.syncs[0].engines[0].outgoing[0].failed,
+                       expected.syncs[0].engines[0].outgoing[0].failed)
+        XCTAssertTrue(actual.events.isEmpty)
+    }
+
+    func testHttpError() {
+        let json = """
+        {"version":1,"uid":"b01a6f3d11cbb0f2ae2c940ab458b30a","syncs":[{"when":1676416271.0,"took":134,"engines":[],"failureReason":{ "name":"httperror","code":500}}]}
+        """
+        let expected = RustSyncTelemetryPing(version: 1,
+                                             uid: "b01a6f3d11cbb0f2ae2c940ab458b30a",
+                                             events: [EventInfo](),
+                                             syncs: [SyncInfo(at: Int64(1_676_416_271.0),
+                                                              took: Int64(134),
+                                                              engines: [EngineInfo](),
+                                                              failureReason: FailureReason(name: FailureName.http,
+                                                                                           message: nil,
+                                                                                           code: 500))])
+        let actual = try! RustSyncTelemetryPing.fromJSONString(jsonObjectText: json)
+
+        XCTAssertEqual(actual.uid, expected.uid)
+        XCTAssertEqual(actual.version, expected.version)
+        XCTAssertEqual(actual.syncs[0].at, expected.syncs[0].at)
+        XCTAssertEqual(actual.syncs[0].took, expected.syncs[0].took)
+        XCTAssertTrue(actual.syncs[0].engines.isEmpty)
+        XCTAssertEqual(actual.syncs[0].failureReason?.name, expected.syncs[0].failureReason?.name)
+        XCTAssertNil(actual.syncs[0].failureReason?.message)
+        XCTAssertEqual(actual.syncs[0].failureReason?.code, expected.syncs[0].failureReason?.code)
+    }
+
+    func testOtherError() {
+        let json = """
+        {"version":1,"uid":"b01a6f3d11cbb0f2ae2c940ab458b30a","syncs":[{"when":1676416271.0,"took":68,"engines":[],"failureReason":{ "name":"othererror","error":"other error"}}]}
+        """
+        let expected = RustSyncTelemetryPing(version: 1,
+                                             uid: "b01a6f3d11cbb0f2ae2c940ab458b30a",
+                                             events: [EventInfo](),
+                                             syncs: [SyncInfo(at: Int64(1_676_416_271.0),
+                                                              took: Int64(68),
+                                                              engines: [EngineInfo](),
+                                                              failureReason: FailureReason(name: FailureName.other,
+                                                                                           message: "other error",
+                                                                                           code: -1))])
+        let actual = try! RustSyncTelemetryPing.fromJSONString(jsonObjectText: json)
+
+        XCTAssertEqual(actual.uid, expected.uid)
+        XCTAssertEqual(actual.version, expected.version)
+        XCTAssertEqual(actual.syncs[0].at, expected.syncs[0].at)
+        XCTAssertEqual(actual.syncs[0].took, expected.syncs[0].took)
+        XCTAssertTrue(actual.syncs[0].engines.isEmpty)
+        XCTAssertEqual(actual.syncs[0].failureReason?.name, expected.syncs[0].failureReason?.name)
+        XCTAssertEqual(actual.syncs[0].failureReason?.code, expected.syncs[0].failureReason?.code)
+        XCTAssertEqual(actual.syncs[0].failureReason?.message!, expected.syncs[0].failureReason?.message!)
+    }
+
+    func testInvalidJSON() {
+        let json = """
+        {"version";1}
+        """
+
+        XCTAssertThrowsError(try RustSyncTelemetryPing.fromJSONString(jsonObjectText: json))
+    }
+}

--- a/megazords/ios-rust/build-xcframework.sh
+++ b/megazords/ios-rust/build-xcframework.sh
@@ -164,6 +164,7 @@ if [ -z $IS_FOCUS ]; then
   $CARGO uniffi-bindgen generate "$REPO_ROOT/components/push/src/push.udl" -l swift -o "$COMMON/Headers"
   $CARGO uniffi-bindgen generate "$REPO_ROOT/components/tabs/src/tabs.udl" -l swift -o "$COMMON/Headers"
   $CARGO uniffi-bindgen generate "$REPO_ROOT/components/places/src/places.udl" -l swift -o "$COMMON/Headers"
+  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync_manager/src/syncmanager.udl" -l swift -o "$COMMON/Headers"
 fi
 rm -rf "$COMMON"/Headers/*.swift
 

--- a/megazords/ios-rust/src/lib.rs
+++ b/megazords/ios-rust/src/lib.rs
@@ -18,5 +18,6 @@ pub use push;
 pub use rc_log_ffi;
 pub use rust_log_forwarder;
 pub use sync15;
+pub use sync_manager;
 pub use tabs;
 pub use viaduct_reqwest;


### PR DESCRIPTION
This PR, in addition to (PR #94)[https://github.com/mozilla/rust-components-swift/pull/94] in `rust-components-swift`, expose the sync manager component to iOS for the sync manager integration. In also adds the following:

- `RustSyncTelemetryPing.Swift` and tests, similar to `SyncTelemetryPing.kt` for deserializing the json telemetry data in `SyncResult`
- Renaming sync manager's `DeviceType` to avoid a naming collision with other a-s components and code to avoid the breaking change for android components

This PR should not be merged until a PR to add namespacing to iOS's `SyncReason`, `SyncResult`, and `SyncManager` types is merged.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
