### PR TITLE
Introduces an API to set sync IDs for history engine before first sync

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -23,3 +23,8 @@ Use the template below to make assigning a version number during the release cut
 
 ### 🦊 What's Changed 🦊
 - Updated the Nimbus Gradle Plugin to fix a number of issues after migrating it to this repository ([#5348](https://github.com/mozilla/application-services/pull/5348))
+## Places
+### What's New
+ - We Expose an API to set the Sync IDs for the history engine.
+   This is to be used by iOS to supplement the migration and ensure that
+   the history engine does not re-upload any already uploaded records.

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -912,4 +912,11 @@ public class PlacesWriteConnection: PlacesReadConnection {
             return try self.conn.placesHistoryImportFromIos(dbPath: path, lastSyncTimestamp: lastSyncTimestamp)
         }
     }
+
+    open func setSyncIds(globalSyncId: String, collectionSyncId: String) throws {
+        return try queue.sync {
+            try self.checkApi()
+            return try self.conn.setHistorySyncIds(globalSyncId: globalSyncId, collectionSyncId: collectionSyncId)
+        }
+    }
 }

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -616,6 +616,17 @@ impl PlacesConnection {
     ) -> ApiResult<HistoryMigrationResult> {
         self.with_conn(|conn| import_ios_history(conn, &db_path, last_sync_timestamp))
     }
+
+    #[handle_error]
+    fn set_history_sync_ids(
+        &self,
+        global_sync_id: String,
+        collection_sync_id: String,
+    ) -> ApiResult<()> {
+        self.with_conn(|conn| {
+            history::history_sync::set_sync_ids(conn, global_sync_id, collection_sync_id)
+        })
+    }
 }
 
 impl AsRef<SqlInterruptHandle> for PlacesConnection {

--- a/components/places/src/history_sync/engine.rs
+++ b/components/places/src/history_sync/engine.rs
@@ -141,3 +141,8 @@ impl SyncEngine for HistorySyncEngine {
         Ok(())
     }
 }
+
+pub fn set_sync_ids(conn: &PlacesDb, global: String, collection_id: String) -> Result<()> {
+    put_meta(conn, GLOBAL_SYNCID_META_KEY, &global)?;
+    put_meta(conn, COLLECTION_SYNCID_META_KEY, &collection_id)
+}

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -206,6 +206,9 @@ interface PlacesConnection {
 
     [Throws=PlacesApiError]
     HistoryMigrationResult places_history_import_from_ios(string db_path, i64 last_sync_timestamp);
+
+    [Throws=PlacesApiError]
+    void set_history_sync_ids(string global_sync_id, string collection_sync_id);
 };
 
 /**

--- a/components/places/src/storage/history.rs
+++ b/components/places/src/storage/history.rs
@@ -806,6 +806,7 @@ pub mod history_sync {
     use sync15::bso::OutgoingEnvelope;
 
     use super::*;
+    pub use crate::history_sync::engine::set_sync_ids;
     use crate::history_sync::record::{HistoryRecord, HistoryRecordVisit};
     use crate::history_sync::HISTORY_TTL;
     use std::collections::HashSet;

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -358,7 +358,8 @@ pub(crate) fn put_meta(db: &PlacesDb, key: &str, value: &dyn ToSql) -> Result<()
     Ok(())
 }
 
-pub(crate) fn get_meta<T: FromSql>(db: &PlacesDb, key: &str) -> Result<Option<T>> {
+// Public because integration tests for iOS migration uses it
+pub fn get_meta<T: FromSql>(db: &PlacesDb, key: &str) -> Result<Option<T>> {
     let res = db.try_query_one(
         "SELECT value FROM moz_meta WHERE key = :key",
         &[(":key", &key)],


### PR DESCRIPTION
Introduces an API to allow iOS to set the sync IDs for the history engine. Tested against iOS and verified that with https://github.com/mozilla-mobile/firefox-ios/compare/main...tarikeshaq:firefox-ios:fixes-sync-always-syncs-everything-first-time iOS will now only uploaded dirty records that have changed

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
