### PR TITLE
Upgrades openssl-src after cargo audit [ci full]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,9 +2277,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.25.0+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
Our dependency check CI started failing because of an openssl-src cargo audit. This PR updates openssl-src to the version suggested by the advisory.