### PR TITLE
Move the EventStore into the TargetingHelper

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -31,3 +31,4 @@ Use the template below to make assigning a version number during the release cut
 
 - Changed the ordering around for optional arguments for Python compatibility ([#5460](https://github.com/mozilla/application-services/pull/5460)).
   - This does not change Kotlin or Swift APIs, but affects code that uses the uniffi generated FFI for `record_event` and `record_past_event` directly.
+- Refactor the `EnrollmentEvolver` in preparation for a larger refactor to split out a `stateful` feature. ([#5374](https://github.com/mozilla/application-services/pull/5374)).

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -1,17 +1,17 @@
-use crate::behavior::EventStore;
-use crate::defaults::Defaults;
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use crate::defaults::Defaults;
 use crate::error::{NimbusError, Result};
-use crate::evaluator::TargetingAttributes;
 use crate::persistence::{Database, StoreId, Writer};
 use crate::{evaluator::evaluate_enrollment, persistence::Readable};
-use crate::{AvailableRandomizationUnits, EnrolledExperiment, Experiment, FeatureConfig};
+use crate::{
+    AvailableRandomizationUnits, EnrolledExperiment, Experiment, FeatureConfig,
+    NimbusTargetingHelper,
+};
 
 use ::uuid::Uuid;
 use serde_derive::*;
-use std::sync::{Arc, Mutex};
 use std::{
     collections::{HashMap, HashSet},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -81,9 +81,8 @@ impl ExperimentEnrollment {
         is_user_participating: bool,
         nimbus_id: &Uuid,
         available_randomization_units: &AvailableRandomizationUnits,
-        targeting_attributes: &TargetingAttributes,
         experiment: &Experiment,
-        event_store: Arc<Mutex<EventStore>>,
+        targeting_helper: &NimbusTargetingHelper,
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,
     ) -> Result<Self> {
         Ok(if !is_user_participating {
@@ -104,9 +103,8 @@ impl ExperimentEnrollment {
             let enrollment = evaluate_enrollment(
                 nimbus_id,
                 available_randomization_units,
-                targeting_attributes,
                 experiment,
-                event_store,
+                targeting_helper,
             )?;
             log::debug!(
                 "Experiment '{}' is new - enrollment status is {:?}",
@@ -155,9 +153,8 @@ impl ExperimentEnrollment {
         is_user_participating: bool,
         nimbus_id: &Uuid,
         available_randomization_units: &AvailableRandomizationUnits,
-        targeting_attributes: &TargetingAttributes,
         updated_experiment: &Experiment,
-        event_store: Arc<Mutex<EventStore>>,
+        targeting_helper: &NimbusTargetingHelper,
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,
     ) -> Result<Self> {
         Ok(match self.status {
@@ -168,9 +165,8 @@ impl ExperimentEnrollment {
                     let updated_enrollment = evaluate_enrollment(
                         nimbus_id,
                         available_randomization_units,
-                        targeting_attributes,
                         updated_experiment,
-                        event_store,
+                        targeting_helper,
                     )?;
                     log::debug!(
                         "Experiment '{}' with enrollment {:?} is now {:?}",
@@ -212,9 +208,8 @@ impl ExperimentEnrollment {
                     let evaluated_enrollment = evaluate_enrollment(
                         nimbus_id,
                         available_randomization_units,
-                        targeting_attributes,
                         updated_experiment,
-                        event_store,
+                        targeting_helper,
                     )?;
                     match evaluated_enrollment.status {
                         EnrollmentStatus::Error { .. } => {
@@ -567,19 +562,19 @@ pub fn get_enrollments<'r>(
 pub(crate) struct EnrollmentsEvolver<'a> {
     nimbus_id: &'a Uuid,
     available_randomization_units: &'a AvailableRandomizationUnits,
-    targeting_attributes: &'a TargetingAttributes,
+    targeting_helper: &'a NimbusTargetingHelper,
 }
 
 impl<'a> EnrollmentsEvolver<'a> {
     pub(crate) fn new(
         nimbus_id: &'a Uuid,
         available_randomization_units: &'a AvailableRandomizationUnits,
-        targeting_attributes: &'a TargetingAttributes,
+        targeting_helper: &'a NimbusTargetingHelper,
     ) -> Self {
         Self {
             nimbus_id,
             available_randomization_units,
-            targeting_attributes,
+            targeting_helper,
         }
     }
 
@@ -590,7 +585,6 @@ impl<'a> EnrollmentsEvolver<'a> {
         db: &Database,
         writer: &mut Writer,
         next_experiments: &[Experiment],
-        event_store: Arc<Mutex<EventStore>>,
     ) -> Result<Vec<EnrollmentChangeEvent>> {
         // Get the state from the db.
         let is_user_participating = get_global_user_participation(db, writer)?;
@@ -604,7 +598,6 @@ impl<'a> EnrollmentsEvolver<'a> {
             &prev_experiments,
             next_experiments,
             &prev_enrollments,
-            event_store,
         )?;
         let next_enrollments = map_enrollments(&next_enrollments);
         // Write the changes to the Database.
@@ -630,7 +623,6 @@ impl<'a> EnrollmentsEvolver<'a> {
         prev_experiments: &[Experiment],
         next_experiments: &[Experiment],
         prev_enrollments: &[ExperimentEnrollment],
-        event_store: Arc<Mutex<EventStore>>,
     ) -> Result<(Vec<ExperimentEnrollment>, Vec<EnrollmentChangeEvent>)> {
         let mut enrollments: Vec<ExperimentEnrollment> = Default::default();
         let mut events: Vec<EnrollmentChangeEvent> = Default::default();
@@ -649,7 +641,6 @@ impl<'a> EnrollmentsEvolver<'a> {
             &prev_rollouts,
             &next_rollouts,
             &ro_enrollments,
-            event_store.clone(),
         )?;
 
         enrollments.extend(next_ro_enrollments.into_iter());
@@ -675,7 +666,6 @@ impl<'a> EnrollmentsEvolver<'a> {
             &prev_experiments,
             &next_experiments,
             &prev_enrollments,
-            event_store,
         )?;
 
         enrollments.extend(next_exp_enrollments.into_iter());
@@ -692,7 +682,6 @@ impl<'a> EnrollmentsEvolver<'a> {
         prev_experiments: &[Experiment],
         next_experiments: &[Experiment],
         prev_enrollments: &[ExperimentEnrollment],
-        event_store: Arc<Mutex<EventStore>>,
     ) -> Result<(Vec<ExperimentEnrollment>, Vec<EnrollmentChangeEvent>)> {
         let mut enrollment_events = vec![];
         let prev_experiments = map_experiments(prev_experiments);
@@ -727,7 +716,6 @@ impl<'a> EnrollmentsEvolver<'a> {
                 prev_experiments.get(slug).copied(),
                 next_experiments.get(slug).copied(),
                 Some(prev_enrollment),
-                event_store.clone(),
                 &mut enrollment_events,
             ) {
                 Ok(enrollment) => enrollment,
@@ -819,7 +807,6 @@ impl<'a> EnrollmentsEvolver<'a> {
                     prev_experiments.get(slug).copied(),
                     Some(next_experiment),
                     prev_enrollment,
-                    event_store.clone(),
                     &mut enrollment_events,
                 ) {
                     Ok(enrollment) => enrollment,
@@ -891,7 +878,6 @@ impl<'a> EnrollmentsEvolver<'a> {
         prev_experiment: Option<&Experiment>,
         next_experiment: Option<&Experiment>,
         prev_enrollment: Option<&ExperimentEnrollment>,
-        event_store: Arc<Mutex<EventStore>>,
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>, // out param containing the events we'd like to emit to glean.
     ) -> Result<Option<ExperimentEnrollment>> {
         let is_already_enrolled = if let Some(enrollment) = prev_enrollment {
@@ -900,8 +886,13 @@ impl<'a> EnrollmentsEvolver<'a> {
             false
         };
 
-        let mut targeting_attributes = self.targeting_attributes.clone();
-        targeting_attributes.is_already_enrolled = is_already_enrolled;
+        // XXX This is not pretty, however, we need to re-write the way sticky targeting strings are generated in
+        // experimenter. Once https://github.com/mozilla/experimenter/issues/8661 is fixed, we can remove the calculation
+        // for `is_already_enrolled` above, the `put` call here and the `put` method declaration, and replace it with
+        // let th = self.targeting_helper;
+        let th = self
+            .targeting_helper
+            .put("is_already_enrolled", is_already_enrolled);
 
         Ok(match (prev_experiment, next_experiment, prev_enrollment) {
             // New experiment.
@@ -909,9 +900,8 @@ impl<'a> EnrollmentsEvolver<'a> {
                 is_user_participating,
                 self.nimbus_id,
                 self.available_randomization_units,
-                &targeting_attributes,
                 experiment,
-                event_store,
+                &th,
                 out_enrollment_events,
             )?),
             // Experiment deleted remotely.
@@ -924,9 +914,8 @@ impl<'a> EnrollmentsEvolver<'a> {
                     is_user_participating,
                     self.nimbus_id,
                     self.available_randomization_units,
-                    &targeting_attributes,
                     experiment,
-                    event_store,
+                    &th,
                     out_enrollment_events,
                 )?)
             }

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -12,7 +12,7 @@ use crate::{
     AvailableRandomizationUnits,
 };
 use crate::{matcher::AppContext, sampling};
-use crate::{Branch, Experiment};
+use crate::{Branch, Experiment, NimbusTargetingHelper};
 use jexl_eval::Evaluator;
 use serde_derive::*;
 use serde_json::{json, Value};
@@ -100,11 +100,10 @@ fn split_locale(locale: String) -> (Option<String>, Option<String>) {
 pub fn evaluate_enrollment(
     nimbus_id: &Uuid,
     available_randomization_units: &AvailableRandomizationUnits,
-    targeting_attributes: &TargetingAttributes,
     exp: &Experiment,
-    event_store: Arc<Mutex<EventStore>>,
+    th: &NimbusTargetingHelper,
 ) -> Result<ExperimentEnrollment> {
-    if !is_experiment_available(&targeting_attributes.app_context, exp, true) {
+    if !is_experiment_available(th, exp, true) {
         return Ok(ExperimentEnrollment {
             slug: exp.slug.clone(),
             status: EnrollmentStatus::NotEnrolled {
@@ -116,7 +115,7 @@ pub fn evaluate_enrollment(
     // Get targeting out of the way - "if let chains" are experimental,
     // otherwise we could improve this.
     if let Some(expr) = &exp.targeting {
-        if let Some(status) = targeting(expr, targeting_attributes, event_store) {
+        if let Some(status) = targeting(expr, th) {
             return Ok(ExperimentEnrollment {
                 slug: exp.slug.clone(),
                 status,
@@ -175,19 +174,19 @@ pub fn evaluate_enrollment(
 /// # Returns:
 /// Returns `true` if the experiment matches the targeting
 pub fn is_experiment_available(
-    app_context: &AppContext,
+    th: &NimbusTargetingHelper,
     exp: &Experiment,
     is_release: bool,
 ) -> bool {
     // Verify the app_name matches the application being targeted
     // by the experiment.
-    match &exp.app_name {
-        Some(app_name) => {
-            if !app_name.eq(&app_context.app_name) {
+    match (&exp.app_name, th.context.get("app_name".to_string())) {
+        (Some(exp), Some(Value::String(mine))) => {
+            if !exp.eq(mine) {
                 return false;
             }
         }
-        None => log::debug!("Experiment missing app_name, skipping it as a targeting parameter"),
+        (_, _) => log::debug!("Experiment missing app_name, skipping it as a targeting parameter"),
     }
 
     if !is_release {
@@ -197,16 +196,13 @@ pub fn is_experiment_available(
     // Verify the channel matches the application being targeted
     // by the experiment.  Note, we are intentionally comparing in a case-insensitive way.
     // See https://jira.mozilla.com/browse/SDK-246 for more info.
-    match &exp.channel {
-        Some(channel) => {
-            if !channel
-                .to_lowercase()
-                .eq(&app_context.channel.to_lowercase())
-            {
+    match (&exp.channel, th.context.get("channel".to_string())) {
+        (Some(exp), Some(Value::String(mine))) => {
+            if !exp.to_lowercase().eq(&mine.to_lowercase()) {
                 return false;
             }
         }
-        None => log::debug!("Experiment missing channel, skipping it as a targeting parameter"),
+        (_, _) => log::debug!("Experiment missing channel, skipping it as a targeting parameter"),
     }
     true
 }
@@ -267,10 +263,9 @@ pub(crate) fn choose_branch<'a>(
 /// - jexl-rs returned an error
 pub(crate) fn targeting(
     expression_statement: &str,
-    targeting_attributes: &TargetingAttributes,
-    event_store: Arc<Mutex<EventStore>>,
+    targeting_helper: &NimbusTargetingHelper,
 ) -> Option<EnrollmentStatus> {
-    match jexl_eval(expression_statement, targeting_attributes, event_store) {
+    match targeting_helper.eval_jexl(expression_statement.to_string()) {
         Ok(res) => match res {
             true => None,
             false => Some(EnrollmentStatus::NotEnrolled {


### PR DESCRIPTION
This started off as a fix for [EXP-2943](https://mozilla-hub.atlassian.net/browse/EXP-2943).

This is not ready for that, it is a pre-requisite for that work: however, it is also very useful for the Cirrus work of separating out the event store from the enrollment evolution path.

This work is to unify all calls into the `EnrollmentEvolver` so that we're not passing an `EventStore` around, but a `NimbusTargetingHelper`.

Thus: bringing this out of Draft, so it may be landed and become useful to the Cirrus work.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
