### PR TITLE
#[handle_error] macro now requires the internal error type be specified

### DIFF
--- a/components/autofill/src/db/store.rs
+++ b/components/autofill/src/db/store.rs
@@ -49,7 +49,7 @@ pub struct Store {
 }
 
 impl Store {
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn new(db_path: impl AsRef<Path>) -> ApiResult<Self> {
         Ok(Self {
             db: Mutex::new(AutofillDb::new(db_path)?),
@@ -65,27 +65,27 @@ impl Store {
     }
 
     /// Creates a store backed by an in-memory database that shares its memory API (required for autofill sync tests).
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn new_shared_memory(db_name: &str) -> ApiResult<Self> {
         Ok(Self {
             db: Mutex::new(AutofillDb::new_memory(db_name)?),
         })
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn add_credit_card(&self, fields: UpdatableCreditCardFields) -> ApiResult<CreditCard> {
         let credit_card = credit_cards::add_credit_card(&self.db.lock().unwrap().writer, fields)?;
         Ok(credit_card.into())
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn get_credit_card(&self, guid: String) -> ApiResult<CreditCard> {
         let credit_card =
             credit_cards::get_credit_card(&self.db.lock().unwrap().writer, &Guid::new(&guid))?;
         Ok(credit_card.into())
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn get_all_credit_cards(&self) -> ApiResult<Vec<CreditCard>> {
         let credit_cards = credit_cards::get_all_credit_cards(&self.db.lock().unwrap().writer)?
             .into_iter()
@@ -94,7 +94,7 @@ impl Store {
         Ok(credit_cards)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn update_credit_card(
         &self,
         guid: String,
@@ -107,27 +107,27 @@ impl Store {
         )
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn delete_credit_card(&self, guid: String) -> ApiResult<bool> {
         credit_cards::delete_credit_card(&self.db.lock().unwrap().writer, &Guid::new(&guid))
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn touch_credit_card(&self, guid: String) -> ApiResult<()> {
         credit_cards::touch(&self.db.lock().unwrap().writer, &Guid::new(&guid))
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn add_address(&self, new_address: UpdatableAddressFields) -> ApiResult<Address> {
         Ok(addresses::add_address(&self.db.lock().unwrap().writer, new_address)?.into())
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn get_address(&self, guid: String) -> ApiResult<Address> {
         Ok(addresses::get_address(&self.db.lock().unwrap().writer, &Guid::new(&guid))?.into())
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn get_all_addresses(&self) -> ApiResult<Vec<Address>> {
         let addresses = addresses::get_all_addresses(&self.db.lock().unwrap().writer)?
             .into_iter()
@@ -136,22 +136,22 @@ impl Store {
         Ok(addresses)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn update_address(&self, guid: String, address: UpdatableAddressFields) -> ApiResult<()> {
         addresses::update_address(&self.db.lock().unwrap().writer, &Guid::new(&guid), &address)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn delete_address(&self, guid: String) -> ApiResult<bool> {
         addresses::delete_address(&self.db.lock().unwrap().writer, &Guid::new(&guid))
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn touch_address(&self, guid: String) -> ApiResult<()> {
         addresses::touch(&self.db.lock().unwrap().writer, &Guid::new(&guid))
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn scrub_encrypted_data(self: Arc<Self>) -> ApiResult<()> {
         // scrub the data on disk
         // Currently only credit cards have encrypted data

--- a/components/autofill/src/encryption.rs
+++ b/components/autofill/src/encryption.rs
@@ -76,17 +76,17 @@ impl EncryptorDecryptor {
 
 // public functions we expose over the FFI (which is why they take `String`
 // rather than the `&str` you'd otherwise expect)
-#[handle_error]
+#[handle_error(Error)]
 pub fn encrypt_string(key: String, cleartext: String) -> ApiResult<String> {
     EncryptorDecryptor::new(&key)?.encrypt(&cleartext)
 }
 
-#[handle_error]
+#[handle_error(Error)]
 pub fn decrypt_string(key: String, ciphertext: String) -> ApiResult<String> {
     EncryptorDecryptor::new(&key)?.decrypt(&ciphertext)
 }
 
-#[handle_error]
+#[handle_error(Error)]
 pub fn create_autofill_key() -> ApiResult<String> {
     let key = jwcrypto::Jwk::new_direct_key(None)?;
     Ok(serde_json::to_string(&key)?)

--- a/components/logins/src/encryption.rs
+++ b/components/logins/src/encryption.rs
@@ -83,17 +83,17 @@ impl EncryptorDecryptor {
 //     - If it returns true, then it's safe to assume the key can decrypt the DB data
 //     - If it returns false, then the key is no longer valid.  It should be regenerated and the DB
 //       data should be wiped since we can no longer read it properly
-#[handle_error]
+#[handle_error(Error)]
 pub fn create_canary(text: &str, key: &str) -> ApiResult<String> {
     EncryptorDecryptor::new(key)?.encrypt(text)
 }
 
-#[handle_error]
+#[handle_error(Error)]
 pub fn check_canary(canary: &str, text: &str, key: &str) -> ApiResult<bool> {
     Ok(EncryptorDecryptor::new(key)?.decrypt(canary)? == text)
 }
 
-#[handle_error]
+#[handle_error(Error)]
 pub fn create_key() -> ApiResult<String> {
     let key = jwcrypto::Jwk::new_direct_key(None)?;
     Ok(serde_json::to_string(&key)?)

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -29,25 +29,25 @@ pub use crate::sync::LoginsSyncEngine;
 
 // Public encryption functions.  We publish these as top-level functions to expose them across
 // UniFFI
-#[handle_error]
+#[handle_error(Error)]
 fn encrypt_login(login: Login, enc_key: &str) -> ApiResult<EncryptedLogin> {
     let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
     login.encrypt(&encdec)
 }
 
-#[handle_error]
+#[handle_error(Error)]
 fn decrypt_login(login: EncryptedLogin, enc_key: &str) -> ApiResult<Login> {
     let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
     login.decrypt(&encdec)
 }
 
-#[handle_error]
+#[handle_error(Error)]
 fn encrypt_fields(sec_fields: SecureLoginFields, enc_key: &str) -> ApiResult<String> {
     let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
     sec_fields.encrypt(&encdec)
 }
 
-#[handle_error]
+#[handle_error(Error)]
 fn decrypt_fields(sec_fields: String, enc_key: &str) -> ApiResult<SecureLoginFields> {
     let encdec = encryption::EncryptorDecryptor::new(enc_key)?;
     encdec.decrypt_struct(&sec_fields)

--- a/components/logins/src/migrate_sqlcipher_db.rs
+++ b/components/logins/src/migrate_sqlcipher_db.rs
@@ -50,7 +50,7 @@ enum MigrationOp {
 }
 
 // migration for consumers to migrate from their SQLCipher DB
-#[handle_error]
+#[handle_error(Error)]
 pub fn migrate_logins(
     path: impl AsRef<Path>,
     new_encryption_key: &str,

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -52,7 +52,7 @@ pub struct LoginStore {
 }
 
 impl LoginStore {
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn new(path: impl AsRef<Path>) -> ApiResult<Self> {
         let db = Mutex::new(LoginDb::open(path)?);
         Ok(Self { db })
@@ -62,28 +62,28 @@ impl LoginStore {
         Self { db: Mutex::new(db) }
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn new_in_memory() -> ApiResult<Self> {
         let db = Mutex::new(LoginDb::open_in_memory()?);
         Ok(Self { db })
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn list(&self) -> ApiResult<Vec<EncryptedLogin>> {
         self.db.lock().get_all()
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn get(&self, id: &str) -> ApiResult<Option<EncryptedLogin>> {
         self.db.lock().get_by_id(id)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn get_by_base_domain(&self, base_domain: &str) -> ApiResult<Vec<EncryptedLogin>> {
         self.db.lock().get_by_base_domain(base_domain)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn find_login_to_update(
         &self,
         entry: LoginEntry,
@@ -93,17 +93,17 @@ impl LoginStore {
         self.db.lock().find_login_to_update(entry, &encdec)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn touch(&self, id: &str) -> ApiResult<()> {
         self.db.lock().touch(id)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn delete(&self, id: &str) -> ApiResult<bool> {
         self.db.lock().delete(id)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn wipe(&self) -> ApiResult<()> {
         // This should not be exposed - it wipes the server too and there's
         // no good reason to expose that to consumers. wipe_local makes some
@@ -116,13 +116,13 @@ impl LoginStore {
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn wipe_local(&self) -> ApiResult<()> {
         self.db.lock().wipe_local()?;
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn reset(self: Arc<Self>) -> ApiResult<()> {
         // Reset should not exist here - all resets should be done via the
         // sync manager. It seems that actual consumers don't use this, but
@@ -132,19 +132,19 @@ impl LoginStore {
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn update(&self, id: &str, entry: LoginEntry, enc_key: &str) -> ApiResult<EncryptedLogin> {
         let encdec = EncryptorDecryptor::new(enc_key)?;
         self.db.lock().update(id, entry, &encdec)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn add(&self, entry: LoginEntry, enc_key: &str) -> ApiResult<EncryptedLogin> {
         let encdec = EncryptorDecryptor::new(enc_key)?;
         self.db.lock().add(entry, &encdec)
     }
 
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn add_or_update(&self, entry: LoginEntry, enc_key: &str) -> ApiResult<EncryptedLogin> {
         let encdec = EncryptorDecryptor::new(enc_key)?;
         self.db.lock().add_or_update(entry, &encdec)
@@ -155,7 +155,7 @@ impl LoginStore {
     // This can almost die later - consumers should never call it (they should
     // use the sync manager) and any of our examples probably can too!
     // Once this dies, `mem_cached_state` can die too.
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn sync(
         self: Arc<Self>,
         key_id: String,
@@ -223,7 +223,7 @@ impl LoginStore {
     // We could probably make the example work with the sync manager - but then
     // our example would link with places and logins etc, and it's not a big
     // deal really.
-    #[handle_error]
+    #[handle_error(Error)]
     pub fn create_logins_sync_engine(self: Arc<Self>) -> ApiResult<Box<dyn SyncEngine>> {
         Ok(Box::new(LoginsSyncEngine::new(self)?) as Box<dyn SyncEngine>)
     }

--- a/components/places/src/api/places_api.rs
+++ b/components/places/src/api/places_api.rs
@@ -130,7 +130,7 @@ pub struct SyncState {
 /// For uniffi we need to expose our `Arc` returning constructor as a global function :(
 /// https://github.com/mozilla/uniffi-rs/pull/1063 would fix this, but got some pushback
 /// meaning we are forced into this unfortunate workaround.
-#[handle_error]
+#[handle_error(crate::Error)]
 pub fn places_api_new(db_name: impl AsRef<Path>) -> ApiResult<Arc<PlacesApi>> {
     PlacesApi::new(db_name)
 }
@@ -457,7 +457,7 @@ impl PlacesApi {
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn reset_history(&self) -> ApiResult<()> {
         // Take the lock to prevent syncing while we're doing this.
         let _guard = self.sync_state.lock();

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -117,7 +117,7 @@ lazy_static::lazy_static! {
 }
 
 impl PlacesApi {
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn new_connection(&self, conn_type: ConnectionType) -> ApiResult<Arc<PlacesConnection>> {
         let db = self.open_connection(conn_type)?;
         let connection = Arc::new(PlacesConnection::new(db));
@@ -128,7 +128,7 @@ impl PlacesApi {
     // NOTE: These methods are unused on Android but will remain needed for
     // iOS until we can move them to the sync manager and replace their existing
     // sync engines with ours
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn history_sync(
         &self,
         key_id: String,
@@ -148,7 +148,7 @@ impl PlacesApi {
         Ok(serde_json::to_string(&ping).unwrap())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_sync(
         &self,
         key_id: String,
@@ -168,7 +168,7 @@ impl PlacesApi {
         Ok(serde_json::to_string(&ping).unwrap())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_reset(&self) -> ApiResult<()> {
         self.reset_bookmarks()?;
         Ok(())
@@ -202,7 +202,7 @@ impl PlacesConnection {
         Arc::clone(&self.interrupt_handle)
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_latest_history_metadata_for_url(
         &self,
         url: Url,
@@ -210,7 +210,7 @@ impl PlacesConnection {
         self.with_conn(|conn| history_metadata::get_latest_for_url(conn, &url))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_history_metadata_between(
         &self,
         start: PlacesTimestamp,
@@ -221,7 +221,7 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_history_metadata_since(
         &self,
         start: PlacesTimestamp,
@@ -229,7 +229,7 @@ impl PlacesConnection {
         self.with_conn(|conn| history_metadata::get_since(conn, start.as_millis_i64()))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn query_history_metadata(
         &self,
         query: String,
@@ -238,7 +238,7 @@ impl PlacesConnection {
         self.with_conn(|conn| history_metadata::query(conn, query.as_str(), limit))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_history_highlights(
         &self,
         weights: HistoryHighlightWeights,
@@ -247,7 +247,7 @@ impl PlacesConnection {
         self.with_conn(|conn| history_metadata::get_highlights(conn, weights, limit))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn note_history_metadata_observation(
         &self,
         data: HistoryMetadataObservation,
@@ -256,12 +256,12 @@ impl PlacesConnection {
         self.with_conn(|conn| history_metadata::apply_metadata_observation(conn, data))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn metadata_delete_older_than(&self, older_than: PlacesTimestamp) -> ApiResult<()> {
         self.with_conn(|conn| history_metadata::delete_older_than(conn, older_than.as_millis_i64()))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn metadata_delete(
         &self,
         url: Url,
@@ -279,13 +279,13 @@ impl PlacesConnection {
     }
 
     /// Add an observation to the database.
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn apply_observation(&self, visit: VisitObservation) -> ApiResult<()> {
         self.with_conn(|conn| history::apply_observation(conn, visit))?;
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_visited_urls_in_range(
         &self,
         start: PlacesTimestamp,
@@ -302,7 +302,7 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_visit_infos(
         &self,
         start_date: PlacesTimestamp,
@@ -312,12 +312,12 @@ impl PlacesConnection {
         self.with_conn(|conn| history::get_visit_infos(conn, start_date, end_date, exclude_types))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_visit_count(&self, exclude_types: VisitTransitionSet) -> ApiResult<i64> {
         self.with_conn(|conn| history::get_visit_count(conn, exclude_types))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_visit_page(
         &self,
         offset: i64,
@@ -327,7 +327,7 @@ impl PlacesConnection {
         self.with_conn(|conn| history::get_visit_page(conn, offset, count, exclude_types))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_visit_page_with_bound(
         &self,
         bound: i64,
@@ -343,7 +343,7 @@ impl PlacesConnection {
     // This is identical to get_visited in history.rs but takes a list of strings instead of urls
     // This is necessary b/c we still need to return 'false' for bad URLs which prevents us from
     // parsing/filtering them before reaching the history layer
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_visited(&self, urls: Vec<String>) -> ApiResult<Vec<bool>> {
         let iter = urls.into_iter();
         let mut result = vec![false; iter.len()];
@@ -355,7 +355,7 @@ impl PlacesConnection {
         Ok(result)
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn delete_visits_for(&self, url: String) -> ApiResult<()> {
         self.with_conn(|conn| {
             let guid = match Url::parse(&url) {
@@ -372,7 +372,7 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn delete_visits_between(
         &self,
         start: PlacesTimestamp,
@@ -381,7 +381,7 @@ impl PlacesConnection {
         self.with_conn(|conn| history::delete_visits_between(conn, start, end))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn delete_visit(&self, url: String, timestamp: PlacesTimestamp) -> ApiResult<()> {
         self.with_conn(|conn| {
             match Url::parse(&url) {
@@ -397,7 +397,7 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn get_top_frecent_site_infos(
         &self,
         num_items: i32,
@@ -414,7 +414,7 @@ impl PlacesConnection {
 
     // XXX - We probably need to document/name this a little better as it's specifically for
     // history and NOT bookmarks...
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn wipe_local_history(&self) -> ApiResult<()> {
         self.with_conn(history::wipe_local)
     }
@@ -422,39 +422,39 @@ impl PlacesConnection {
     // Calls wipe_local_history but also updates the
     // sync metadata to only sync after most recent visit to prevent
     // further syncing of older data
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn delete_everything_history(&self) -> ApiResult<()> {
         history::delete_everything(&self.db.lock())
     }
 
     // XXX - This just calls wipe_local under the hood...
     // should probably have this go away?
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn prune_destructively(&self) -> ApiResult<()> {
         self.with_conn(history::prune_destructively)
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn run_maintenance_prune(&self, db_size_limit: u32) -> ApiResult<RunMaintenanceMetrics> {
         self.with_conn(|conn| storage::run_maintenance_prune(conn, db_size_limit))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn run_maintenance_vacuum(&self) -> ApiResult<()> {
         self.with_conn(storage::run_maintenance_vacuum)
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn run_maintenance_optimize(&self) -> ApiResult<()> {
         self.with_conn(storage::run_maintenance_optimize)
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn run_maintenance_checkpoint(&self) -> ApiResult<()> {
         self.with_conn(storage::run_maintenance_checkpoint)
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn query_autocomplete(&self, search: String, limit: i32) -> ApiResult<Vec<SearchResult>> {
         self.with_conn(|conn| {
             search_frecent(
@@ -468,7 +468,7 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn accept_result(&self, search_string: String, url: String) -> ApiResult<()> {
         self.with_conn(|conn| {
             match Url::parse(&url) {
@@ -484,17 +484,17 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn match_url(&self, query: String) -> ApiResult<Option<Url>> {
         self.with_conn(|conn| matcher::match_url(conn, query))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_get_tree(&self, item_guid: &Guid) -> ApiResult<Option<BookmarkItem>> {
         self.with_conn(|conn| bookmarks::fetch::fetch_tree(conn, item_guid))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_get_by_guid(
         &self,
         guid: &Guid,
@@ -506,7 +506,7 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_get_all_with_url(&self, url: String) -> ApiResult<Vec<BookmarkItem>> {
         self.with_conn(|conn| {
             // XXX - We should return the exact type - ie, BookmarkData rather than BookmarkItem.
@@ -524,7 +524,7 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_search(&self, query: String, limit: i32) -> ApiResult<Vec<BookmarkItem>> {
         self.with_conn(|conn| {
             // XXX - We should return the exact type - ie, BookmarkData rather than BookmarkItem.
@@ -537,7 +537,7 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_get_recent(&self, limit: i32) -> ApiResult<Vec<BookmarkItem>> {
         self.with_conn(|conn| {
             // XXX - We should return the exact type - ie, BookmarkData rather than BookmarkItem.
@@ -548,32 +548,32 @@ impl PlacesConnection {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_delete(&self, id: Guid) -> ApiResult<bool> {
         self.with_conn(|conn| bookmarks::delete_bookmark(conn, &id))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_delete_everything(&self) -> ApiResult<()> {
         self.with_conn(bookmarks::delete_everything)
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_get_url_for_keyword(&self, keyword: String) -> ApiResult<Option<Url>> {
         self.with_conn(|conn| bookmarks::bookmarks_get_url_for_keyword(conn, keyword.as_str()))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_insert(&self, data: InsertableBookmarkItem) -> ApiResult<Guid> {
         self.with_conn(|conn| bookmarks::insert_bookmark(conn, data))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn bookmarks_update(&self, item: BookmarkUpdateInfo) -> ApiResult<()> {
         self.with_conn(|conn| bookmarks::update_bookmark_from_info(conn, item))
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn places_history_import_from_ios(
         &self,
         db_path: String,

--- a/components/support/error/macros/src/lib.rs
+++ b/components/support/error/macros/src/lib.rs
@@ -48,9 +48,11 @@ mod argument;
 ///    }
 /// }
 ///
+/// // The `handle_error` macro maps from the error supplied in the mandatory argument
+/// // (ie, `Error` in this example) to the error returned by the function (`ExternalError`
+/// // in this example)
 /// #[handle_error(Error)]
 /// fn do_something() -> std::result::Result<String, ExternalError> {
-///    // The `handle_error` macro maps from `Error` to `ExternalError`
 ///    Err(Error{})
 /// }
 ///

--- a/components/support/error/macros/src/lib.rs
+++ b/components/support/error/macros/src/lib.rs
@@ -48,7 +48,7 @@ mod argument;
 ///    }
 /// }
 ///
-/// #[handle_error]
+/// #[handle_error(Error)]
 /// fn do_something() -> std::result::Result<String, ExternalError> {
 ///    // The `handle_error` macro maps from `Error` to `ExternalError`
 ///    Err(Error{})
@@ -72,18 +72,13 @@ fn impl_handle_error(
     arguments: &syn::AttributeArgs,
 ) -> syn::Result<proc_macro2::TokenStream> {
     if let syn::Item::Fn(item_fn) = input {
-        argument::validate(arguments)?;
+        let err_path = argument::validate(arguments)?;
         let original_body = &item_fn.block;
 
         let mut new_fn = item_fn.clone();
         new_fn.block = parse_quote! {
             {
-                // Note: the `Result` here is a smell
-                // because the macro is **assuming** a `Result` exists
-                // that reflects the return value of the block
-                // An improvement would include the error of the `original_block`
-                // as an attribute to the macro itself.
-                (|| -> Result<_> {
+                (|| -> ::std::result::Result<_, #err_path> {
                     #original_body
                 })().map_err(::error_support::convert_log_report_error)
             }
@@ -95,7 +90,7 @@ fn impl_handle_error(
     } else {
         Err(syn::Error::new(
             input.span(),
-            "#[handle_error] can only be used on functions",
+            "#[handle_error(..)] can only be used on functions",
         ))
     }
 }

--- a/components/support/error/tests/handle_error_on_non_functions.rs
+++ b/components/support/error/tests/handle_error_on_non_functions.rs
@@ -8,7 +8,6 @@
  
  #[derive(Debug, thiserror::Error)]
  enum Error {}
- type Result<T, E = Error> = std::result::Result<T, E>;
 
  
  #[derive(Debug, thiserror::Error)]
@@ -29,20 +28,20 @@
  }
 
  // This is OK
- #[handle_error]
+ #[handle_error(Error)]
  fn func() -> ::std::result::Result<String, ExternalError> {
      Ok("".to_string())
  }
 
 
  // handle error only works on functions! this will fail to compile
- #[handle_error]
+ #[handle_error(Error)]
  struct SomeType {}
 
- #[handle_error]
+ #[handle_error(Error)]
  const A: u32 = 0;
 
- #[handle_error]
+ #[handle_error(Error)]
  impl SomeType {}
 
  fn main() {}

--- a/components/support/error/tests/handle_error_on_non_functions.stderr
+++ b/components/support/error/tests/handle_error_on_non_functions.stderr
@@ -1,17 +1,17 @@
-error: #[handle_error] can only be used on functions
-  --> handle_error_on_non_functions.rs:40:2
+error: #[handle_error(..)] can only be used on functions
+  --> handle_error_on_non_functions.rs:39:2
    |
-40 |  struct SomeType {}
+39 |  struct SomeType {}
    |  ^^^^^^
 
-error: #[handle_error] can only be used on functions
-  --> handle_error_on_non_functions.rs:43:2
+error: #[handle_error(..)] can only be used on functions
+  --> handle_error_on_non_functions.rs:42:2
    |
-43 |  const A: u32 = 0;
+42 |  const A: u32 = 0;
    |  ^^^^^
 
-error: #[handle_error] can only be used on functions
-  --> handle_error_on_non_functions.rs:46:2
+error: #[handle_error(..)] can only be used on functions
+  --> handle_error_on_non_functions.rs:45:2
    |
-46 |  impl SomeType {}
+45 |  impl SomeType {}
    |  ^^^^

--- a/components/support/error/tests/macro_arguments.rs
+++ b/components/support/error/tests/macro_arguments.rs
@@ -34,10 +34,35 @@
      }
  }
 
- #[handle_error(String)]
- fn func() -> ::std::result::Result<String, ExternalError> {
-     Err(Error{})
- }
+#[handle_error(Error)] // Works.
+fn func() -> ::std::result::Result<String, ExternalError> {
+    Err(Error{})
+}
 
- fn main(){}
- 
+#[handle_error("Error")] // Quoted string instead of a path
+fn func() -> ::std::result::Result<String, ExternalError> {
+    Err(Error{})
+}
+
+#[handle_error(2)] // bad type.
+fn func() -> ::std::result::Result<String, ExternalError> {
+    Err(Error{})
+}
+
+#[handle_error] // No args.
+fn func() -> ::std::result::Result<String, ExternalError> {
+    Err(Error{})
+}
+
+#[handle_error()] // empty args.
+fn func() -> ::std::result::Result<String, ExternalError> {
+    Err(Error{})
+}
+
+#[handle_error(Key="Value")] // unknown args.
+fn func() -> ::std::result::Result<String, ExternalError> {
+    Err(Error{})
+}
+
+
+fn main(){}

--- a/components/support/error/tests/macro_arguments.stderr
+++ b/components/support/error/tests/macro_arguments.stderr
@@ -1,0 +1,33 @@
+error: Expected #[handle_error(path::to::Error)]
+  --> macro_arguments.rs:42:16
+   |
+42 | #[handle_error("Error")] // Quoted string instead of a path
+   |                ^^^^^^^
+
+error: Expected #[handle_error(path::to::Error)]
+  --> macro_arguments.rs:47:16
+   |
+47 | #[handle_error(2)] // bad type.
+   |                ^
+
+error: Expected #[handle_error(path::to::Error)]
+  --> macro_arguments.rs:52:1
+   |
+52 | #[handle_error] // No args.
+   | ^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Expected #[handle_error(path::to::Error)]
+  --> macro_arguments.rs:57:1
+   |
+57 | #[handle_error()] // empty args.
+   | ^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Expected #[handle_error(path::to::Error)]
+  --> macro_arguments.rs:62:16
+   |
+62 | #[handle_error(Key="Value")] // unknown args.
+   |                ^^^

--- a/components/support/error/tests/macro_arguments.stderr
+++ b/components/support/error/tests/macro_arguments.stderr
@@ -31,3 +31,45 @@ error: Expected #[handle_error(path::to::Error)]
    |
 62 | #[handle_error(Key="Value")] // unknown args.
    |                ^^^
+
+error[E0277]: the trait bound `String: std::error::Error` is not satisfied
+  --> macro_arguments.rs:88:1
+   |
+88 | #[handle_error(Error2)] // Must implement `std::error::Error`
+   | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `String`
+   |
+note: required by a bound in `convert_log_report_error`
+  --> $WORKSPACE/components/support/error/src/handling.rs
+   |
+   |     EE: std::error::Error,
+   |         ^^^^^^^^^^^^^^^^^ required by this bound in `convert_log_report_error`
+   = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `String: GetErrorHandling` is not satisfied
+   --> macro_arguments.rs:107:1
+    |
+107 | #[handle_error(String)] // Must implement `std::error::Error`
+    | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `GetErrorHandling` is not implemented for `String`
+    |
+    = help: the following other types implement trait `GetErrorHandling`:
+              Error
+              Error2
+note: required by a bound in `convert_log_report_error`
+   --> $WORKSPACE/components/support/error/src/handling.rs
+    |
+    |     IE: GetErrorHandling<ExternalError = EE> + std::error::Error,
+    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `convert_log_report_error`
+    = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0277]: the trait bound `String: std::error::Error` is not satisfied
+   --> macro_arguments.rs:107:1
+    |
+107 | #[handle_error(String)] // Must implement `std::error::Error`
+    | ^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `String`
+    |
+note: required by a bound in `convert_log_report_error`
+   --> $WORKSPACE/components/support/error/src/handling.rs
+    |
+    |     IE: GetErrorHandling<ExternalError = EE> + std::error::Error,
+    |                                                ^^^^^^^^^^^^^^^^^ required by this bound in `convert_log_report_error`
+    = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/components/support/error/tests/macro_used_with_argument.stderr
+++ b/components/support/error/tests/macro_used_with_argument.stderr
@@ -1,7 +1,0 @@
-error: Expected #[handle_error] with no arguments
-  --> macro_used_with_argument.rs:37:2
-   |
-37 |  #[handle_error(String)]
-   |  ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/components/support/error/tests/parse.rs
+++ b/components/support/error/tests/parse.rs
@@ -8,15 +8,12 @@ use error_support::{handle_error, ErrorHandling, GetErrorHandling};
 
 #[derive(Debug, thiserror::Error)]
 struct Error {}
-type Result<T, E = Error> = std::result::Result<T, E>;
 
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Internal Error!")
     }
 }
-
-
 
 #[derive(Debug, thiserror::Error)]
 struct ExternalError {}
@@ -35,32 +32,36 @@ impl GetErrorHandling for Error {
     }
 }
 
-#[handle_error]
+#[handle_error(Error)]
 fn func() -> ::std::result::Result<String, ExternalError> {
     Err(Error{})
 }
 
-#[handle_error]
+#[handle_error(Error)]
 fn func2() -> Result<String, ExternalError> {
     Err(Error{})
 }
 
 type MyResult<T, E = ExternalError> = std::result::Result<T, E>;
 
-
-
-#[handle_error]
+#[handle_error(Error)]
 fn func3() -> MyResult<String> {
     Err(Error{})
 }
 
 type FullyAliasedResult<T = String, E = ExternalError> = std::result::Result<T, E>;
 
-#[handle_error]
+#[handle_error(Error)]
 fn func4() -> FullyAliasedResult {
     Err(Error{})
 }
 
+mod submodule {
+    #[super::handle_error(super::Error)]
+    fn func() -> ::std::result::Result<String, super::ExternalError> {
+        Err(super::Error{})
+    }
+}
 
 fn main() {
     // We verify that all functions now return Result<T, ExternalError>

--- a/components/support/error/tests/parse.rs
+++ b/components/support/error/tests/parse.rs
@@ -58,7 +58,7 @@ fn func4() -> FullyAliasedResult {
 
 mod submodule {
     #[super::handle_error(super::Error)]
-    fn func() -> ::std::result::Result<String, super::ExternalError> {
+    pub(super) fn func() -> ::std::result::Result<String, super::ExternalError> {
         Err(super::Error{})
     }
 }
@@ -69,6 +69,7 @@ fn main() {
         func().unwrap_err(),
         func2().unwrap_err(),
         func3().unwrap_err(),
-        func4().unwrap_err()
+        func4().unwrap_err(),
+        submodule::func().unwrap_err(),
     ];
 }

--- a/components/support/error/tests/returns_not_result.rs
+++ b/components/support/error/tests/returns_not_result.rs
@@ -14,8 +14,6 @@
     }
 }
 
- type Result<T, E = Error> = std::result::Result<T, E>;
-
  #[derive(Debug, thiserror::Error)]
  struct ExternalError {}
  
@@ -38,7 +36,7 @@
  // using the macro
  // however, the compiler will error because the return type is still a String
  // and the function after the macro returns `Result<String,ExternalError>`
- #[handle_error]
+ #[handle_error(Error)]
  fn func() -> String {
      Ok("".to_string())
  }

--- a/components/support/error/tests/returns_not_result.stderr
+++ b/components/support/error/tests/returns_not_result.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> returns_not_result.rs:41:2
+  --> returns_not_result.rs:39:2
    |
-41 |  #[handle_error]
-   |  ^^^^^^^^^^^^^^^ expected struct `String`, found enum `std::result::Result`
-42 |  fn func() -> String {
+39 |  #[handle_error(Error)]
+   |  ^^^^^^^^^^^^^^^^^^^^^^ expected struct `String`, found enum `Result`
+40 |  fn func() -> String {
    |               ------ expected `String` because of return type
    |
    = note: expected struct `String`
-                found enum `std::result::Result<String, ExternalError>`
+                found enum `Result<String, ExternalError>`
    = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/components/support/error/tests/returns_result_but_incorrect_error.rs
+++ b/components/support/error/tests/returns_result_but_incorrect_error.rs
@@ -47,7 +47,7 @@
 
  // handle_error expects that `Error` implements GetErrorHandling<E = ExternalError>
  // instead, it implements GetErrorHandling<E = OtherExternalError>
- #[handle_error]
+ #[handle_error(Error)]
  fn func() -> Result<String, ExternalError> {
      Err(Error{})
  }

--- a/components/support/error/tests/returns_result_but_incorrect_error.stderr
+++ b/components/support/error/tests/returns_result_but_incorrect_error.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
   --> returns_result_but_incorrect_error.rs:50:2
    |
-50 |  #[handle_error]
-   |  ^^^^^^^^^^^^^^^ expected struct `ExternalError`, found struct `OtherExternalError`
+50 |  #[handle_error(Error)]
+   |  ^^^^^^^^^^^^^^^^^^^^^^ expected struct `ExternalError`, found struct `OtherExternalError`
 51 |  fn func() -> Result<String, ExternalError> {
    |               ----------------------------- expected `std::result::Result<String, ExternalError>` because of return type
    |

--- a/components/support/error/tests/returns_result_but_not_error.rs
+++ b/components/support/error/tests/returns_result_but_not_error.rs
@@ -8,8 +8,6 @@
  
  #[derive(Debug, thiserror::Error)]
  enum Error {}
- type Result<T, E = Error> = std::result::Result<T, E>;
-
  
  #[derive(Debug, thiserror::Error)]
  struct ExternalError {}
@@ -28,7 +26,7 @@
      }
  }
 
- #[handle_error]
+ #[handle_error(Error)]
  fn func() -> Result<String, String> {
      Ok("".to_string())
  }

--- a/components/support/error/tests/returns_result_but_not_error.stderr
+++ b/components/support/error/tests/returns_result_but_not_error.stderr
@@ -1,11 +1,11 @@
 error[E0308]: mismatched types
-  --> returns_result_but_not_error.rs:31:2
+  --> returns_result_but_not_error.rs:29:2
    |
-31 |  #[handle_error]
-   |  ^^^^^^^^^^^^^^^ expected struct `String`, found struct `ExternalError`
-32 |  fn func() -> Result<String, String> {
-   |               ---------------------- expected `std::result::Result<String, String>` because of return type
+29 |  #[handle_error(Error)]
+   |  ^^^^^^^^^^^^^^^^^^^^^^ expected struct `String`, found struct `ExternalError`
+30 |  fn func() -> Result<String, String> {
+   |               ---------------------- expected `Result<String, String>` because of return type
    |
-   = note: expected enum `std::result::Result<_, String>`
-              found enum `std::result::Result<_, ExternalError>`
+   = note: expected enum `Result<_, String>`
+              found enum `Result<_, ExternalError>`
    = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/components/support/error/tests/tests.rs
+++ b/components/support/error/tests/tests.rs
@@ -10,5 +10,5 @@ fn tests() {
     t.compile_fail("returns_result_but_not_error.rs");
     t.compile_fail("returns_result_but_incorrect_error.rs");
     t.compile_fail("handle_error_on_non_functions.rs");
-    t.compile_fail("macro_used_with_argument.rs");
+    t.compile_fail("macro_arguments.rs");
 }

--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -4,7 +4,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use crate::error::{ApiResult, Result, TabsApiError};
+use crate::error::{ApiResult, TabsApiError};
 use crate::sync::engine::TabsSyncImpl;
 use crate::TabsStore;
 use error_support::handle_error;
@@ -47,7 +47,7 @@ impl BridgedEngineImpl {
 impl BridgedEngine for BridgedEngineImpl {
     type Error = TabsApiError;
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn last_sync(&self) -> ApiResult<i64> {
         Ok(self
             .sync_impl
@@ -58,7 +58,7 @@ impl BridgedEngine for BridgedEngineImpl {
             .as_millis())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn set_last_sync(&self, last_sync_millis: i64) -> ApiResult<()> {
         self.sync_impl
             .lock()
@@ -67,7 +67,7 @@ impl BridgedEngine for BridgedEngineImpl {
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn sync_id(&self) -> ApiResult<Option<String>> {
         Ok(match self.sync_impl.lock().unwrap().get_sync_assoc()? {
             EngineSyncAssociation::Connected(id) => Some(id.coll.to_string()),
@@ -75,7 +75,7 @@ impl BridgedEngine for BridgedEngineImpl {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn reset_sync_id(&self) -> ApiResult<String> {
         let new_id = SyncGuid::random().to_string();
         let new_coll_ids = CollSyncIds {
@@ -89,7 +89,7 @@ impl BridgedEngine for BridgedEngineImpl {
         Ok(new_id)
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn ensure_current_sync_id(&self, sync_id: &str) -> ApiResult<String> {
         let mut sync_impl = self.sync_impl.lock().unwrap();
         let assoc = sync_impl.get_sync_assoc()?;
@@ -105,7 +105,7 @@ impl BridgedEngine for BridgedEngineImpl {
         Ok(sync_id.to_string()) // this is a bit odd, why the result?
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn prepare_for_sync(&self, client_data: &str) -> ApiResult<()> {
         let data: ClientData = serde_json::from_str(client_data)?;
         self.sync_impl.lock().unwrap().prepare_for_sync(data)
@@ -116,14 +116,14 @@ impl BridgedEngine for BridgedEngineImpl {
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn store_incoming(&self, incoming: Vec<IncomingBso>) -> ApiResult<()> {
         // Store the incoming payload in memory so we can use it in apply
         *(self.incoming.lock().unwrap()) = incoming;
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn apply(&self) -> ApiResult<ApplyResults> {
         let mut incoming = self.incoming.lock().unwrap();
         // We've a reference to a Vec<> but it's owned by the mutex - swap the mutex owned
@@ -141,7 +141,7 @@ impl BridgedEngine for BridgedEngineImpl {
         })
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn set_uploaded(&self, server_modified_millis: i64, ids: &[SyncGuid]) -> ApiResult<()> {
         self.sync_impl
             .lock()
@@ -149,13 +149,13 @@ impl BridgedEngine for BridgedEngineImpl {
             .sync_finished(ServerTimestamp::from_millis(server_modified_millis), ids)
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn sync_finished(&self) -> ApiResult<()> {
         *(self.incoming.lock().unwrap()) = Vec::default();
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn reset(&self) -> ApiResult<()> {
         self.sync_impl
             .lock()
@@ -164,7 +164,7 @@ impl BridgedEngine for BridgedEngineImpl {
         Ok(())
     }
 
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn wipe(&self) -> ApiResult<()> {
         self.sync_impl.lock().unwrap().wipe()?;
         Ok(())
@@ -210,7 +210,7 @@ impl TabsBridgedEngine {
     }
 
     // Decode the JSON-encoded IncomingBso's that UniFFI passes to us
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn convert_incoming_bsos(&self, incoming: Vec<String>) -> ApiResult<Vec<IncomingBso>> {
         let mut bsos = Vec::with_capacity(incoming.len());
         for inc in incoming {
@@ -220,7 +220,7 @@ impl TabsBridgedEngine {
     }
 
     // Encode OutgoingBso's into JSON for UniFFI
-    #[handle_error]
+    #[handle_error(crate::Error)]
     fn convert_outgoing_bsos(&self, outgoing: Vec<OutgoingBso>) -> ApiResult<Vec<String>> {
         let mut bsos = Vec::with_capacity(outgoing.len());
         for e in outgoing {

--- a/components/tabs/src/sync/full_sync.rs
+++ b/components/tabs/src/sync/full_sync.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{sync::engine::TabsSyncImpl, ApiResult, Result, TabsEngine, TabsStore};
+use crate::{sync::engine::TabsSyncImpl, ApiResult, TabsEngine, TabsStore};
 use error_support::handle_error;
 use interrupt_support::NeverInterrupts;
 use std::sync::Arc;
@@ -11,7 +11,7 @@ use sync15::engine::EngineSyncAssociation;
 use sync15::KeyBundle;
 
 impl TabsStore {
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn reset(self: Arc<Self>) -> ApiResult<()> {
         let mut sync_impl = TabsSyncImpl::new(Arc::clone(&self));
         sync_impl.reset(&EngineSyncAssociation::Disconnected)?;
@@ -19,7 +19,7 @@ impl TabsStore {
     }
 
     /// A convenience wrapper around sync_multiple.
-    #[handle_error]
+    #[handle_error(crate::Error)]
     pub fn sync(
         self: Arc<Self>,
         key_id: String,


### PR DESCRIPTION
The fact that `#[handle_error]` assumed a `Result<>` was in scope and defined the internal error type just bit me as I was working on something else, and I saw it was described as a but of a smell, so I thought I'd look at fixing it.

This now requires every use of that macro to specify the internal error like `#[handle_error(E="path::to::Error")`. I've only converted tabs and places so far, but thought I'd put it up now for general comment and bikeshedding on the `E="..."` arg I came up with before converting the others.