### PR TITLE
Trim the title of tabs and length of list before trying to upload

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,9 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Tabs
+
+### 🦊 What's Changed 🦊
+
+- The Tabs engine now trims the payload to be under the max the server will accept ([#5376](https://github.com/mozilla/application-services/pull/5376))

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -175,7 +175,8 @@ impl TabsStorage {
                     // to incate that we've truncated
                     if tab.title.len() > MAX_TITLE_CHAR_LENGTH {
                         tab.title.truncate(MAX_TITLE_CHAR_LENGTH - 3);
-                        tab.title.push_str("...");
+                        // Append ellipsis char for any client displaying the full title
+                        tab.title.push('\u{2026}');
                     }
                     Some(tab)
                 })
@@ -553,7 +554,7 @@ mod tests {
             last_used: 0,
         }]);
         let mut truncated_title = "a".repeat(MAX_TITLE_CHAR_LENGTH - 3);
-        truncated_title.push_str("...");
+        truncated_title.push('\u{2026}');
         assert_eq!(
             storage.prepare_local_tabs_for_upload(),
             Some(vec![

--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -279,7 +279,7 @@ mod tests {
                 title: "my first tab".to_string(),
                 url_history: vec!["http://1.com".to_string()],
                 icon: None,
-                last_used: 0,
+                last_used: 2,
             },
             RemoteTab {
                 title: "my second tab".to_string(),


### PR DESCRIPTION
Fixes #4986 


1. Sets the maximum upload amount to 1MB
2. Trims any tab titles above 512 characters (and adds ellipsis)
3. Sorts the tab list by last_used

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
