### PR TITLE
Update Android Components and related Gradle dependencies to v110

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,16 +7,16 @@ buildscript {
         kotlin_coroutines_version = '1.6.4'
         jna_version = '5.12.1'
         android_gradle_plugin_version = '7.3.0'
-        android_components_version = '108.0.8'
+        android_components_version = '110.0.1'
         glean_version = '52.0.0'
 
         // NOTE: AndroidX libraries should be synced with AC to avoid compatibility issues
         androidx_annotation_version = '1.5.0'
         androidx_core_version = '1.8.0'
         androidx_test_version = '1.5.0'
-        androidx_test_junit_version = '1.1.4'
+        androidx_test_junit_version = '1.1.5'
         androidx_work_testing_version = '2.7.1'
-        espresso_core_version = '3.5.0'
+        espresso_core_version = '3.5.1'
 
         detekt_version = '1.21.0'
         gradle_download_task_version = '5.2.1'


### PR DESCRIPTION
Nothing earth-shattering here, just updating AC to the recently-released 110.0.1 release and updating common Gradle dependencies to the same versions it's using.