### PR TITLE
Fix the `test_logging` test

### DIFF
--- a/components/support/rust-log-forwarder/src/lib.rs
+++ b/components/support/rust-log-forwarder/src/lib.rs
@@ -61,8 +61,13 @@ mod test {
         }
     }
 
+    // Lock that we take for each test.  This prevents multiple threads from running these tests at
+    // the same time, which makes them flakey.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
     #[test]
     fn test_logging() {
+        let _lock = TEST_LOCK.lock().unwrap();
         let logger = TestLogger::new();
         set_logger(Some(Box::new(logger.clone())));
         log::info!("Test message");
@@ -88,6 +93,7 @@ mod test {
 
     #[test]
     fn test_max_level() {
+        let _lock = TEST_LOCK.lock().unwrap();
         set_max_level(Level::Debug);
         assert_eq!(log::max_level(), log::Level::Debug);
         set_max_level(Level::Warn);
@@ -96,6 +102,7 @@ mod test {
 
     #[test]
     fn test_max_level_default() {
+        let _lock = TEST_LOCK.lock().unwrap();
         HAVE_SET_MAX_LEVEL.store(false, Ordering::Relaxed);
         let logger = TestLogger::new();
         // Calling set_logger should set the level to `Debug' by default
@@ -105,6 +112,7 @@ mod test {
 
     #[test]
     fn test_max_level_default_ignored_if_set_manually() {
+        let _lock = TEST_LOCK.lock().unwrap();
         HAVE_SET_MAX_LEVEL.store(false, Ordering::Relaxed);
         set_max_level(Level::Warn);
         // Calling set_logger should not set the level if it was set manually.


### PR DESCRIPTION
We've been getting intermittent failures for the this one.  I'm pretty sure it's because cargo runs the tests in multiple threads, but the tests assume they are running in a single threaded environment.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
