### PR TITLE
Ensure syncing history sees the most recent 5000 records

### DIFF
--- a/components/places/src/history_sync/engine.rs
+++ b/components/places/src/history_sync/engine.rs
@@ -10,7 +10,7 @@ use interrupt_support::SqlInterruptScope;
 use std::sync::Arc;
 use sync15::engine::{
     CollSyncIds, CollectionRequest, EngineSyncAssociation, IncomingChangeset, OutgoingChangeset,
-    SyncEngine,
+    RequestOrder, SyncEngine,
 };
 use sync15::{telemetry, Guid, ServerTimestamp};
 
@@ -116,7 +116,7 @@ impl SyncEngine for HistorySyncEngine {
             vec![CollectionRequest::new("history".into())
                 .full()
                 .newer_than(since)
-                .limit(MAX_INCOMING_PLACES)]
+                .limit(MAX_INCOMING_PLACES, RequestOrder::Newest)]
         })
     }
 

--- a/components/sync15/src/client/coll_update.rs
+++ b/components/sync15/src/client/coll_update.rs
@@ -24,7 +24,7 @@ pub fn encrypt_outgoing(
 pub fn fetch_incoming(
     client: &Sync15StorageClient,
     state: &CollState,
-    collection_request: &CollectionRequest,
+    collection_request: CollectionRequest,
 ) -> Result<IncomingChangeset> {
     let collection = collection_request.collection.clone();
     let (records, timestamp) = match client.get_encrypted_records(collection_request)? {

--- a/components/sync15/src/client/storage_client.rs
+++ b/components/sync15/src/client/storage_client.rs
@@ -7,7 +7,7 @@ use super::request::{
 };
 use super::token;
 use crate::bso::{IncomingBso, IncomingEncryptedBso, OutgoingBso, OutgoingEncryptedBso};
-use crate::engine::CollectionRequest;
+use crate::engine::{CollectionPost, CollectionRequest};
 use crate::error::{self, Error, ErrorResponse};
 use crate::record_types::MetaGlobalRecord;
 use crate::{CollectionName, Guid, ServerTimestamp};
@@ -293,7 +293,7 @@ impl Sync15StorageClient {
 
     pub fn get_encrypted_records(
         &self,
-        collection_request: &CollectionRequest,
+        collection_request: CollectionRequest,
     ) -> error::Result<Sync15ClientResponse<Vec<IncomingEncryptedBso>>> {
         self.collection_request(Method::Get, collection_request)
     }
@@ -356,7 +356,7 @@ impl Sync15StorageClient {
     fn collection_request<T>(
         &self,
         method: Method,
-        r: &CollectionRequest,
+        r: CollectionRequest,
     ) -> error::Result<Sync15ClientResponse<T>>
     where
         for<'a> T: serde::de::Deserialize<'a>,
@@ -435,10 +435,10 @@ impl<'a> BatchPoster for PostWrapper<'a> {
         commit: bool,
         _: &PostQueue<T, O>,
     ) -> error::Result<PostResponse> {
-        let r = CollectionRequest::new(self.coll.clone())
+        let r = CollectionPost::new(self.coll.clone())
             .batch(batch)
             .commit(commit);
-        let url = build_collection_request_url(Url::parse(&self.client.tsc.api_endpoint()?)?, &r)?;
+        let url = build_collection_post_url(Url::parse(&self.client.tsc.api_endpoint()?)?, r)?;
 
         let req = self
             .client
@@ -450,18 +450,26 @@ impl<'a> BatchPoster for PostWrapper<'a> {
     }
 }
 
-fn build_collection_request_url(mut base_url: Url, r: &CollectionRequest) -> error::Result<Url> {
+fn build_collection_url(mut base_url: Url, collection: CollectionName) -> error::Result<Url> {
     base_url
         .path_segments_mut()
         .map_err(|_| Error::UnacceptableUrl("Storage server URL is not a base".to_string()))?
-        .extend(&["storage", &r.collection]);
+        .extend(&["storage", &collection]);
 
+    // This is strange but just accessing query_pairs_mut makes you have
+    // a trailing question mark on your url. I don't think anything bad
+    // would happen here, but I don't know, and also, it looks dumb so
+    // I'd rather not have it.
+    if base_url.query() == Some("") {
+        base_url.set_query(None);
+    }
+    Ok(base_url)
+}
+
+fn build_collection_request_url(mut base_url: Url, r: CollectionRequest) -> error::Result<Url> {
     let mut pairs = base_url.query_pairs_mut();
     if r.full {
         pairs.append_pair("full", "1");
-    }
-    if r.limit > 0 {
-        pairs.append_pair("limit", &r.limit.to_string());
     }
     if let Some(ids) = &r.ids {
         // Most ids are 12 characters, and we comma separate them, so 13.
@@ -474,32 +482,33 @@ fn build_collection_request_url(mut base_url: Url, r: &CollectionRequest) -> err
         }
         pairs.append_pair("ids", &buf);
     }
-    if let Some(batch) = &r.batch {
-        pairs.append_pair("batch", batch);
-    }
-    if r.commit {
-        pairs.append_pair("commit", "true");
-    }
     if let Some(ts) = r.older {
         pairs.append_pair("older", &ts.to_string());
     }
     if let Some(ts) = r.newer {
         pairs.append_pair("newer", &ts.to_string());
     }
-    if let Some(o) = r.order {
-        pairs.append_pair("sort", o.as_str());
+    if let Some(l) = r.limit {
+        pairs.append_pair("sort", l.order.as_str());
+        pairs.append_pair("limit", &l.num.to_string());
     }
     pairs.finish();
     drop(pairs);
+    build_collection_url(base_url, r.collection)
+}
 
-    // This is strange but just accessing query_pairs_mut makes you have
-    // a trailing question mark on your url. I don't think anything bad
-    // would happen here, but I don't know, and also, it looks dumb so
-    // I'd rather not have it.
-    if base_url.query() == Some("") {
-        base_url.set_query(None);
+#[cfg(feature = "sync-client")]
+fn build_collection_post_url(mut base_url: Url, r: CollectionPost) -> error::Result<Url> {
+    let mut pairs = base_url.query_pairs_mut();
+    if let Some(batch) = &r.batch {
+        pairs.append_pair("batch", batch);
     }
-    Ok(base_url)
+    if r.commit {
+        pairs.append_pair("commit", "true");
+    }
+    pairs.finish();
+    drop(pairs);
+    build_collection_url(base_url, r.collection)
 }
 
 #[cfg(test)]
@@ -533,35 +542,13 @@ mod test {
         let base = Url::parse("https://example.com/sync").unwrap();
 
         let empty =
-            build_collection_request_url(base.clone(), &CollectionRequest::new("foo".into()))
+            build_collection_request_url(base.clone(), CollectionRequest::new("foo".into()))
                 .unwrap();
         assert_eq!(empty.as_str(), "https://example.com/sync/storage/foo");
-        let batch_start = build_collection_request_url(
-            base.clone(),
-            &CollectionRequest::new("bar".into())
-                .batch(Some("true".into()))
-                .commit(false),
-        )
-        .unwrap();
-        assert_eq!(
-            batch_start.as_str(),
-            "https://example.com/sync/storage/bar?batch=true"
-        );
-        let batch_commit = build_collection_request_url(
-            base.clone(),
-            &CollectionRequest::new("asdf".into())
-                .batch(Some("1234abc".into()))
-                .commit(true),
-        )
-        .unwrap();
-        assert_eq!(
-            batch_commit.as_str(),
-            "https://example.com/sync/storage/asdf?batch=1234abc&commit=true"
-        );
 
         let idreq = build_collection_request_url(
             base.clone(),
-            &CollectionRequest::new("wutang".into())
+            CollectionRequest::new("wutang".into())
                 .full()
                 .ids(&["rza", "gza"]),
         )
@@ -573,15 +560,46 @@ mod test {
 
         let complex = build_collection_request_url(
             base,
-            &CollectionRequest::new("specific".into())
+            CollectionRequest::new("specific".into())
                 .full()
-                .limit(10)
-                .sort_by(RequestOrder::Oldest)
+                .limit(10, RequestOrder::Oldest)
                 .older_than(ServerTimestamp(9_876_540))
                 .newer_than(ServerTimestamp(1_234_560)),
         )
         .unwrap();
         assert_eq!(complex.as_str(),
-            "https://example.com/sync/storage/specific?full=1&limit=10&older=9876.54&newer=1234.56&sort=oldest");
+            "https://example.com/sync/storage/specific?full=1&older=9876.54&newer=1234.56&sort=oldest&limit=10");
+    }
+
+    #[cfg(feature = "sync-client")]
+    #[test]
+    fn test_post_query_building() {
+        let base = Url::parse("https://example.com/sync").unwrap();
+
+        let empty =
+            build_collection_post_url(base.clone(), CollectionPost::new("foo".into())).unwrap();
+        assert_eq!(empty.as_str(), "https://example.com/sync/storage/foo");
+        let batch_start = build_collection_post_url(
+            base.clone(),
+            CollectionPost::new("bar".into())
+                .batch(Some("true".into()))
+                .commit(false),
+        )
+        .unwrap();
+        assert_eq!(
+            batch_start.as_str(),
+            "https://example.com/sync/storage/bar?batch=true"
+        );
+        let batch_commit = build_collection_post_url(
+            base,
+            CollectionPost::new("asdf".into())
+                .batch(Some("1234abc".into()))
+                .commit(true),
+        )
+        .unwrap();
+        assert_eq!(
+            batch_commit.as_str(),
+            "https://example.com/sync/storage/asdf?batch=1234abc&commit=true"
+        );
     }
 }

--- a/components/sync15/src/client/sync.rs
+++ b/components/sync15/src/client/sync.rs
@@ -55,7 +55,7 @@ pub fn synchronize_with_clients_engine(
             .map(|(idx, collection_request)| {
                 interruptee.err_if_interrupted()?;
                 let incoming_changes =
-                    super::fetch_incoming(client, &coll_state, &collection_request)?;
+                    super::fetch_incoming(client, &coll_state, collection_request)?;
 
                 log::info!(
                     "Downloaded {} remote changes (request {} of {})",

--- a/components/sync15/src/clients_engine/engine.rs
+++ b/components/sync15/src/clients_engine/engine.rs
@@ -330,7 +330,7 @@ impl<'a> Engine<'a> {
         let coll_request = CollectionRequest::new(COLLECTION_NAME.into()).full();
 
         self.interruptee.err_if_interrupted()?;
-        let inbound = crate::client::fetch_incoming(storage_client, coll_state, &coll_request)?;
+        let inbound = crate::client::fetch_incoming(storage_client, coll_state, coll_request)?;
 
         Ok(inbound)
     }

--- a/components/sync15/src/engine/mod.rs
+++ b/components/sync15/src/engine/mod.rs
@@ -32,5 +32,7 @@ mod sync_engine;
 
 pub use bridged_engine::{ApplyResults, BridgedEngine};
 pub use changeset::{IncomingChangeset, OutgoingChangeset};
+#[cfg(feature = "sync-client")]
+pub(crate) use request::CollectionPost;
 pub use request::{CollectionRequest, RequestOrder};
 pub use sync_engine::{CollSyncIds, EngineSyncAssociation, SyncEngine, SyncEngineId};

--- a/components/sync15/src/engine/request.rs
+++ b/components/sync15/src/engine/request.rs
@@ -2,17 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 use crate::{CollectionName, Guid, ServerTimestamp};
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct CollectionRequest {
     pub collection: CollectionName,
     pub full: bool,
     pub ids: Option<Vec<Guid>>,
-    pub limit: usize,
+
+    pub limit: Option<RequestLimit>,
     pub older: Option<ServerTimestamp>,
     pub newer: Option<ServerTimestamp>,
-    pub order: Option<RequestOrder>,
-    pub commit: bool,
-    pub batch: Option<String>,
 }
 
 impl CollectionRequest {
@@ -20,14 +18,7 @@ impl CollectionRequest {
     pub fn new(collection: CollectionName) -> CollectionRequest {
         CollectionRequest {
             collection,
-            full: false,
-            ids: None,
-            limit: 0,
-            older: None,
-            newer: None,
-            order: None,
-            commit: false,
-            batch: None,
+            ..Default::default()
         }
     }
 
@@ -60,30 +51,47 @@ impl CollectionRequest {
     }
 
     #[inline]
-    pub fn sort_by(mut self, order: RequestOrder) -> CollectionRequest {
-        self.order = Some(order);
+    pub fn limit(mut self, num: usize, order: RequestOrder) -> CollectionRequest {
+        self.limit = Some(RequestLimit { num, order });
         self
+    }
+}
+
+// This is just used interally - consumers just provide the content, not request params.
+#[cfg(feature = "sync-client")]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct CollectionPost {
+    pub collection: CollectionName,
+    pub commit: bool,
+    pub batch: Option<String>,
+}
+
+#[cfg(feature = "sync-client")]
+impl CollectionPost {
+    #[inline]
+    pub fn new(collection: CollectionName) -> Self {
+        Self {
+            collection,
+            ..Default::default()
+        }
     }
 
     #[inline]
-    pub fn limit(mut self, num: usize) -> CollectionRequest {
-        self.limit = num;
-        self
-    }
-
-    #[inline]
-    pub fn batch(mut self, batch: Option<String>) -> CollectionRequest {
+    pub fn batch(mut self, batch: Option<String>) -> Self {
         self.batch = batch;
         self
     }
 
     #[inline]
-    pub fn commit(mut self, v: bool) -> CollectionRequest {
+    pub fn commit(mut self, v: bool) -> Self {
         self.commit = v;
         self
     }
 }
 
+// Asking for the order of records only makes sense if you are limiting them
+// in some way - consumers don't care about the order otherwise as everything
+// is processed as a set.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum RequestOrder {
     Oldest,
@@ -106,4 +114,12 @@ impl std::fmt::Display for RequestOrder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
+}
+
+// If you specify a numerical limit you must provide the order so backfilling
+// is possible (ie, so you know which ones you got!)
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct RequestLimit {
+    pub(crate) num: usize,
+    pub(crate) order: RequestOrder,
 }


### PR DESCRIPTION
The [docs](https://mozilla-services.readthedocs.io/en/latest/storage/apis-1.1.html#url-semantics) don't specify what the default value is. I asked in slack whether the default is `newest`, but regardless, it makes sense for us to specify it - [desktop does](https://searchfox.org/mozilla-central/rev/66aa740e65a343659a7446b890145781f1b6a344/services/sync/modules/engines.sys.mjs#1221)
