### PR TITLE
BridgedEngine now uses no generic types and is `Send+Sync`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,6 +4069,7 @@ dependencies = [
 name = "webext-storage"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "env_logger 0.7.1",
  "error-support",
  "ffi-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,6 +4078,7 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "nss_build_common",
+ "parking_lot",
  "prettytable-rs",
  "rusqlite",
  "serde",

--- a/components/sync15/src/engine/bridged_engine.rs
+++ b/components/sync15/src/engine/bridged_engine.rs
@@ -2,8 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::bso::{IncomingBso, OutgoingBso};
+use anyhow::Result;
 
+use crate::bso::{IncomingBso, OutgoingBso};
 use crate::Guid;
 
 /// A BridgedEngine acts as a bridge between application-services, rust
@@ -16,27 +17,24 @@ use crate::Guid;
 /// [SyncEngine](crate::SyncEngine) trait), so this BridgedEngine trait adapts
 /// between the 2.
 pub trait BridgedEngine {
-    /// The type returned for errors.
-    type Error;
-
     /// Returns the last sync time, in milliseconds, for this engine's
     /// collection. This is called before each sync, to determine the lower
     /// bound for new records to fetch from the server.
-    fn last_sync(&self) -> Result<i64, Self::Error>;
+    fn last_sync(&self) -> Result<i64>;
 
     /// Sets the last sync time, in milliseconds. This is called throughout
     /// the sync, to fast-forward the stored last sync time to match the
     /// timestamp on the uploaded records.
-    fn set_last_sync(&self, last_sync_millis: i64) -> Result<(), Self::Error>;
+    fn set_last_sync(&self, last_sync_millis: i64) -> Result<()>;
 
     /// Returns the sync ID for this engine's collection. This is only used in
     /// tests.
-    fn sync_id(&self) -> Result<Option<String>, Self::Error>;
+    fn sync_id(&self) -> Result<Option<String>>;
 
     /// Resets the sync ID for this engine's collection, returning the new ID.
     /// As a side effect, implementations should reset all local Sync state,
     /// as in `reset`.
-    fn reset_sync_id(&self) -> Result<String, Self::Error>;
+    fn reset_sync_id(&self) -> Result<String>;
 
     /// Ensures that the locally stored sync ID for this engine's collection
     /// matches the `new_sync_id` from the server. If the two don't match,
@@ -45,48 +43,48 @@ pub trait BridgedEngine {
     /// `new_sync_id`, or a different one if the engine wants to force other
     /// devices to reset their Sync state for this collection the next time they
     /// sync.
-    fn ensure_current_sync_id(&self, new_sync_id: &str) -> Result<String, Self::Error>;
+    fn ensure_current_sync_id(&self, new_sync_id: &str) -> Result<String>;
 
     /// Tells the tabs engine about recent FxA devices. A bit of a leaky abstration as it only
     /// makes sense for tabs.
     /// The arg is a json serialized `ClientData` struct.
-    fn prepare_for_sync(&self, _client_data: &str) -> Result<(), Self::Error> {
+    fn prepare_for_sync(&self, _client_data: &str) -> Result<()> {
         Ok(())
     }
 
     /// Indicates that the engine is about to start syncing. This is called
     /// once per sync, and always before `store_incoming`.
-    fn sync_started(&self) -> Result<(), Self::Error>;
+    fn sync_started(&self) -> Result<()>;
 
     /// Stages a batch of incoming Sync records. This is called multiple
     /// times per sync, once for each batch. Implementations can use the
     /// signal to check if the operation was aborted, and cancel any
     /// pending work.
-    fn store_incoming(&self, incoming_records: Vec<IncomingBso>) -> Result<(), Self::Error>;
+    fn store_incoming(&self, incoming_records: Vec<IncomingBso>) -> Result<()>;
 
     /// Applies all staged records, reconciling changes on both sides and
     /// resolving conflicts. Returns a list of records to upload.
-    fn apply(&self) -> Result<ApplyResults, Self::Error>;
+    fn apply(&self) -> Result<ApplyResults>;
 
     /// Indicates that the given record IDs were uploaded successfully to the
     /// server. This is called multiple times per sync, once for each batch
     /// upload.
-    fn set_uploaded(&self, server_modified_millis: i64, ids: &[Guid]) -> Result<(), Self::Error>;
+    fn set_uploaded(&self, server_modified_millis: i64, ids: &[Guid]) -> Result<()>;
 
     /// Indicates that all records have been uploaded. At this point, any record
     /// IDs marked for upload that haven't been passed to `set_uploaded`, can be
     /// assumed to have failed: for example, because the server rejected a record
     /// with an invalid TTL or sort index.
-    fn sync_finished(&self) -> Result<(), Self::Error>;
+    fn sync_finished(&self) -> Result<()>;
 
     /// Resets all local Sync state, including any change flags, mirrors, and
     /// the last sync time, such that the next sync is treated as a first sync
     /// with all new local data. Does not erase any local user data.
-    fn reset(&self) -> Result<(), Self::Error>;
+    fn reset(&self) -> Result<()>;
 
     /// Erases all local user data for this collection, and any Sync metadata.
     /// This method is destructive, and unused for most collections.
-    fn wipe(&self) -> Result<(), Self::Error>;
+    fn wipe(&self) -> Result<()>;
 }
 
 // TODO: We should replace this with OutgoingChangeset to reduce the number

--- a/components/sync15/src/engine/bridged_engine.rs
+++ b/components/sync15/src/engine/bridged_engine.rs
@@ -16,7 +16,7 @@ use crate::Guid;
 /// implemented in Rust use a different shape (specifically, the
 /// [SyncEngine](crate::SyncEngine) trait), so this BridgedEngine trait adapts
 /// between the 2.
-pub trait BridgedEngine {
+pub trait BridgedEngine: Send + Sync {
     /// Returns the last sync time, in milliseconds, for this engine's
     /// collection. This is called before each sync, to determine the lower
     /// bound for new records to fetch from the server.

--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -94,7 +94,7 @@ impl BridgedEngine for BridgedEngineImpl {
             };
             sync_impl.reset(&EngineSyncAssociation::Connected(new_coll_ids))?;
         }
-        Ok(sync_id.to_string()) // this is a bit odd, why the result?
+        Ok(sync_id.to_string())
     }
 
     fn prepare_for_sync(&self, client_data: &str) -> Result<()> {

--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -2,12 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::sync::{Arc, Mutex};
-
-use crate::error::{ApiResult, TabsApiError};
+use crate::error::TabsApiError;
 use crate::sync::engine::TabsSyncImpl;
 use crate::TabsStore;
-use error_support::handle_error;
+use anyhow::Result;
+use std::sync::{Arc, Mutex};
 use sync15::bso::{IncomingBso, OutgoingBso};
 use sync15::engine::{ApplyResults, BridgedEngine, CollSyncIds, EngineSyncAssociation};
 use sync15::{ClientData, ServerTimestamp};
@@ -45,10 +44,7 @@ impl BridgedEngineImpl {
 }
 
 impl BridgedEngine for BridgedEngineImpl {
-    type Error = TabsApiError;
-
-    #[handle_error(crate::Error)]
-    fn last_sync(&self) -> ApiResult<i64> {
+    fn last_sync(&self) -> Result<i64> {
         Ok(self
             .sync_impl
             .lock()
@@ -58,8 +54,7 @@ impl BridgedEngine for BridgedEngineImpl {
             .as_millis())
     }
 
-    #[handle_error(crate::Error)]
-    fn set_last_sync(&self, last_sync_millis: i64) -> ApiResult<()> {
+    fn set_last_sync(&self, last_sync_millis: i64) -> Result<()> {
         self.sync_impl
             .lock()
             .unwrap()
@@ -67,16 +62,14 @@ impl BridgedEngine for BridgedEngineImpl {
         Ok(())
     }
 
-    #[handle_error(crate::Error)]
-    fn sync_id(&self) -> ApiResult<Option<String>> {
+    fn sync_id(&self) -> Result<Option<String>> {
         Ok(match self.sync_impl.lock().unwrap().get_sync_assoc()? {
             EngineSyncAssociation::Connected(id) => Some(id.coll.to_string()),
             EngineSyncAssociation::Disconnected => None,
         })
     }
 
-    #[handle_error(crate::Error)]
-    fn reset_sync_id(&self) -> ApiResult<String> {
+    fn reset_sync_id(&self) -> Result<String> {
         let new_id = SyncGuid::random().to_string();
         let new_coll_ids = CollSyncIds {
             global: SyncGuid::empty(),
@@ -89,8 +82,7 @@ impl BridgedEngine for BridgedEngineImpl {
         Ok(new_id)
     }
 
-    #[handle_error(crate::Error)]
-    fn ensure_current_sync_id(&self, sync_id: &str) -> ApiResult<String> {
+    fn ensure_current_sync_id(&self, sync_id: &str) -> Result<String> {
         let mut sync_impl = self.sync_impl.lock().unwrap();
         let assoc = sync_impl.get_sync_assoc()?;
         if matches!(assoc, EngineSyncAssociation::Connected(c) if c.coll == sync_id) {
@@ -105,26 +97,23 @@ impl BridgedEngine for BridgedEngineImpl {
         Ok(sync_id.to_string()) // this is a bit odd, why the result?
     }
 
-    #[handle_error(crate::Error)]
-    fn prepare_for_sync(&self, client_data: &str) -> ApiResult<()> {
+    fn prepare_for_sync(&self, client_data: &str) -> Result<()> {
         let data: ClientData = serde_json::from_str(client_data)?;
-        self.sync_impl.lock().unwrap().prepare_for_sync(data)
+        Ok(self.sync_impl.lock().unwrap().prepare_for_sync(data)?)
     }
 
-    fn sync_started(&self) -> ApiResult<()> {
+    fn sync_started(&self) -> Result<()> {
         // This is a no-op for the Tabs Engine
         Ok(())
     }
 
-    #[handle_error(crate::Error)]
-    fn store_incoming(&self, incoming: Vec<IncomingBso>) -> ApiResult<()> {
+    fn store_incoming(&self, incoming: Vec<IncomingBso>) -> Result<()> {
         // Store the incoming payload in memory so we can use it in apply
         *(self.incoming.lock().unwrap()) = incoming;
         Ok(())
     }
 
-    #[handle_error(crate::Error)]
-    fn apply(&self) -> ApiResult<ApplyResults> {
+    fn apply(&self) -> Result<ApplyResults> {
         let mut incoming = self.incoming.lock().unwrap();
         // We've a reference to a Vec<> but it's owned by the mutex - swap the mutex owned
         // value for an empty vec so we can consume the original.
@@ -141,22 +130,20 @@ impl BridgedEngine for BridgedEngineImpl {
         })
     }
 
-    #[handle_error(crate::Error)]
-    fn set_uploaded(&self, server_modified_millis: i64, ids: &[SyncGuid]) -> ApiResult<()> {
-        self.sync_impl
+    fn set_uploaded(&self, server_modified_millis: i64, ids: &[SyncGuid]) -> Result<()> {
+        Ok(self
+            .sync_impl
             .lock()
             .unwrap()
-            .sync_finished(ServerTimestamp::from_millis(server_modified_millis), ids)
+            .sync_finished(ServerTimestamp::from_millis(server_modified_millis), ids)?)
     }
 
-    #[handle_error(crate::Error)]
-    fn sync_finished(&self) -> ApiResult<()> {
+    fn sync_finished(&self) -> Result<()> {
         *(self.incoming.lock().unwrap()) = Vec::default();
         Ok(())
     }
 
-    #[handle_error(crate::Error)]
-    fn reset(&self) -> ApiResult<()> {
+    fn reset(&self) -> Result<()> {
         self.sync_impl
             .lock()
             .unwrap()
@@ -164,8 +151,7 @@ impl BridgedEngine for BridgedEngineImpl {
         Ok(())
     }
 
-    #[handle_error(crate::Error)]
-    fn wipe(&self) -> ApiResult<()> {
+    fn wipe(&self) -> Result<()> {
         self.sync_impl.lock().unwrap().wipe()?;
         Ok(())
     }
@@ -181,37 +167,36 @@ impl TabsBridgedEngine {
         Self { bridge_impl }
     }
 
-    pub fn last_sync(&self) -> ApiResult<i64> {
+    pub fn last_sync(&self) -> Result<i64> {
         self.bridge_impl.last_sync()
     }
 
-    pub fn set_last_sync(&self, last_sync: i64) -> ApiResult<()> {
+    pub fn set_last_sync(&self, last_sync: i64) -> Result<()> {
         self.bridge_impl.set_last_sync(last_sync)
     }
 
-    pub fn sync_id(&self) -> ApiResult<Option<String>> {
+    pub fn sync_id(&self) -> Result<Option<String>> {
         self.bridge_impl.sync_id()
     }
 
-    pub fn reset_sync_id(&self) -> ApiResult<String> {
+    pub fn reset_sync_id(&self) -> Result<String> {
         self.bridge_impl.reset_sync_id()
     }
 
-    pub fn ensure_current_sync_id(&self, sync_id: &str) -> ApiResult<String> {
+    pub fn ensure_current_sync_id(&self, sync_id: &str) -> Result<String> {
         self.bridge_impl.ensure_current_sync_id(sync_id)
     }
 
-    pub fn prepare_for_sync(&self, client_data: &str) -> ApiResult<()> {
+    pub fn prepare_for_sync(&self, client_data: &str) -> Result<()> {
         self.bridge_impl.prepare_for_sync(client_data)
     }
 
-    pub fn sync_started(&self) -> ApiResult<()> {
+    pub fn sync_started(&self) -> Result<()> {
         self.bridge_impl.sync_started()
     }
 
     // Decode the JSON-encoded IncomingBso's that UniFFI passes to us
-    #[handle_error(crate::Error)]
-    fn convert_incoming_bsos(&self, incoming: Vec<String>) -> ApiResult<Vec<IncomingBso>> {
+    fn convert_incoming_bsos(&self, incoming: Vec<String>) -> Result<Vec<IncomingBso>> {
         let mut bsos = Vec::with_capacity(incoming.len());
         for inc in incoming {
             bsos.push(serde_json::from_str::<IncomingBso>(&inc)?);
@@ -220,8 +205,7 @@ impl TabsBridgedEngine {
     }
 
     // Encode OutgoingBso's into JSON for UniFFI
-    #[handle_error(crate::Error)]
-    fn convert_outgoing_bsos(&self, outgoing: Vec<OutgoingBso>) -> ApiResult<Vec<String>> {
+    fn convert_outgoing_bsos(&self, outgoing: Vec<OutgoingBso>) -> Result<Vec<String>> {
         let mut bsos = Vec::with_capacity(outgoing.len());
         for e in outgoing {
             bsos.push(serde_json::to_string(&e)?);
@@ -229,31 +213,39 @@ impl TabsBridgedEngine {
         Ok(bsos)
     }
 
-    pub fn store_incoming(&self, incoming: Vec<String>) -> ApiResult<()> {
+    pub fn store_incoming(&self, incoming: Vec<String>) -> Result<()> {
         self.bridge_impl
             .store_incoming(self.convert_incoming_bsos(incoming)?)
     }
 
-    pub fn apply(&self) -> ApiResult<Vec<String>> {
+    pub fn apply(&self) -> Result<Vec<String>> {
         let apply_results = self.bridge_impl.apply()?;
         self.convert_outgoing_bsos(apply_results.records)
     }
 
-    pub fn set_uploaded(&self, server_modified_millis: i64, guids: Vec<SyncGuid>) -> ApiResult<()> {
+    pub fn set_uploaded(&self, server_modified_millis: i64, guids: Vec<SyncGuid>) -> Result<()> {
         self.bridge_impl
             .set_uploaded(server_modified_millis, &guids)
     }
 
-    pub fn sync_finished(&self) -> ApiResult<()> {
+    pub fn sync_finished(&self) -> Result<()> {
         self.bridge_impl.sync_finished()
     }
 
-    pub fn reset(&self) -> ApiResult<()> {
+    pub fn reset(&self) -> Result<()> {
         self.bridge_impl.reset()
     }
 
-    pub fn wipe(&self) -> ApiResult<()> {
+    pub fn wipe(&self) -> Result<()> {
         self.bridge_impl.wipe()
+    }
+}
+
+impl From<anyhow::Error> for TabsApiError {
+    fn from(value: anyhow::Error) -> Self {
+        TabsApiError::UnexpectedTabsError {
+            reason: value.to_string(),
+        }
     }
 }
 

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -9,6 +9,7 @@ license = "MPL-2.0"
 default = []
 
 [dependencies]
+anyhow = "1.0"
 error-support = { path = "../support/error" }
 thiserror = "1.0"
 ffi-support = "0.4"

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -16,6 +16,7 @@ ffi-support = "0.4"
 interrupt-support = { path = "../support/interrupt" }
 lazy_static = "1.4"
 log = "0.4"
+parking_lot = ">=0.11,<=0.12"
 serde = "1"
 serde_json = "1"
 serde_derive = "1"

--- a/components/webext-storage/src/db.rs
+++ b/components/webext-storage/src/db.rs
@@ -5,6 +5,7 @@
 use crate::error::*;
 use crate::schema;
 use interrupt_support::{SqlInterruptHandle, SqlInterruptScope};
+use parking_lot::Mutex;
 use rusqlite::types::{FromSql, ToSql};
 use rusqlite::Connection;
 use rusqlite::OpenFlags;
@@ -12,7 +13,6 @@ use sql_support::open_database::open_database_with_flags;
 use sql_support::ConnExt;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
-use std::result;
 use std::sync::Arc;
 use url::Url;
 
@@ -69,24 +69,16 @@ impl StorageDb {
 
     /// Closes the database connection. If there are any unfinalized prepared
     /// statements on the connection, `close` will fail and the `StorageDb` will
-    /// be returned to the caller so that it can retry, drop (via `mem::drop`)
-    // or leak (`mem::forget`) the connection.
-    ///
-    /// Keep in mind that dropping the connection tries to close it again, and
-    /// panics on error.
-    pub fn close(self) -> result::Result<(), (StorageDb, Error)> {
-        let StorageDb {
-            writer,
-            interrupt_handle,
-        } = self;
-        writer.close().map_err(|(writer, err)| {
-            (
-                StorageDb {
-                    writer,
-                    interrupt_handle,
-                },
-                err.into(),
-            )
+    /// remain open and the connection will be leaked - we used to return the
+    /// underlying connection so the caller can retry but (a) that's very tricky
+    /// in an Arc<Mutex<>> world and (b) we never actually took advantage of
+    /// that retry capability.
+    pub fn close(self) -> Result<()> {
+        self.writer.close().map_err(|(writer, err)| {
+            // If we just let `writer` drop, the close would panic on failure.
+            // (Actually, not sure that's true? Regardless, this seems fine)
+            std::mem::forget(writer);
+            err.into()
         })
     }
 }
@@ -102,6 +94,53 @@ impl Deref for StorageDb {
 impl DerefMut for StorageDb {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.writer
+    }
+}
+
+// We almost exclusively use this SharedStorageDb
+pub struct SharedStorageDb {
+    db: Mutex<StorageDb>,
+    // This "outer" interrupt_handle not protected by the mutex means
+    // consumers can interrupt us when the mutex is held - which it always will
+    // be if we are doing anything interruptable!
+    interrupt_handle: Arc<SqlInterruptHandle>,
+}
+
+impl SharedStorageDb {
+    pub fn new(db: StorageDb) -> Self {
+        Self {
+            interrupt_handle: db.interrupt_handle(),
+            db: Mutex::new(db),
+        }
+    }
+
+    pub fn interrupt_handle(&self) -> Arc<SqlInterruptHandle> {
+        Arc::clone(&self.interrupt_handle)
+    }
+
+    pub fn begin_interrupt_scope(&self) -> Result<SqlInterruptScope> {
+        Ok(self.interrupt_handle.begin_interrupt_scope()?)
+    }
+
+    pub fn into_inner(self) -> StorageDb {
+        self.db.into_inner()
+    }
+}
+
+// Deref to a Mutex<StorageDb>, which is how we will use SharedStorageDb most of the time
+impl Deref for SharedStorageDb {
+    type Target = Mutex<StorageDb>;
+
+    #[inline]
+    fn deref(&self) -> &Mutex<StorageDb> {
+        &self.db
+    }
+}
+
+// Also implement AsRef<SqlInterruptHandle> so that we can interrupt this at shutdown
+impl AsRef<SqlInterruptHandle> for SharedStorageDb {
+    fn as_ref(&self) -> &SqlInterruptHandle {
+        &self.interrupt_handle
     }
 }
 
@@ -226,6 +265,10 @@ pub mod test {
         let _ = env_logger::try_init();
         let counter = ATOMIC_COUNTER.fetch_add(1, Ordering::Relaxed);
         StorageDb::new_memory(&format!("test-api-{}", counter)).expect("should get an API")
+    }
+
+    pub fn new_shared_mem_db() -> Arc<SharedStorageDb> {
+        Arc::new(SharedStorageDb::new(new_mem_db()))
     }
 }
 

--- a/components/webext-storage/src/db.rs
+++ b/components/webext-storage/src/db.rs
@@ -110,8 +110,8 @@ impl Drop for StorageDb {
 }
 */
 
-// We almost exclusively use this SharedStorageDb
-pub struct SharedStorageDb {
+// We almost exclusively use this ThreadSafeStorageDb
+pub struct ThreadSafeStorageDb {
     db: Mutex<StorageDb>,
     // This "outer" interrupt_handle not protected by the mutex means
     // consumers can interrupt us when the mutex is held - which it always will
@@ -119,7 +119,7 @@ pub struct SharedStorageDb {
     interrupt_handle: Arc<SqlInterruptHandle>,
 }
 
-impl SharedStorageDb {
+impl ThreadSafeStorageDb {
     pub fn new(db: StorageDb) -> Self {
         Self {
             interrupt_handle: db.interrupt_handle(),
@@ -140,8 +140,8 @@ impl SharedStorageDb {
     }
 }
 
-// Deref to a Mutex<StorageDb>, which is how we will use SharedStorageDb most of the time
-impl Deref for SharedStorageDb {
+// Deref to a Mutex<StorageDb>, which is how we will use ThreadSafeStorageDb most of the time
+impl Deref for ThreadSafeStorageDb {
     type Target = Mutex<StorageDb>;
 
     #[inline]
@@ -151,7 +151,7 @@ impl Deref for SharedStorageDb {
 }
 
 // Also implement AsRef<SqlInterruptHandle> so that we can interrupt this at shutdown
-impl AsRef<SqlInterruptHandle> for SharedStorageDb {
+impl AsRef<SqlInterruptHandle> for ThreadSafeStorageDb {
     fn as_ref(&self) -> &SqlInterruptHandle {
         &self.interrupt_handle
     }
@@ -280,8 +280,8 @@ pub mod test {
         StorageDb::new_memory(&format!("test-api-{}", counter)).expect("should get an API")
     }
 
-    pub fn new_shared_mem_db() -> Arc<SharedStorageDb> {
-        Arc::new(SharedStorageDb::new(new_mem_db()))
+    pub fn new_shared_mem_db() -> Arc<ThreadSafeStorageDb> {
+        Arc::new(ThreadSafeStorageDb::new(new_mem_db()))
     }
 }
 

--- a/components/webext-storage/src/db.rs
+++ b/components/webext-storage/src/db.rs
@@ -269,7 +269,7 @@ pub mod test {
         StorageDb::new_memory(&format!("test-api-{}", counter)).expect("should get an API")
     }
 
-    pub fn new_shared_mem_db() -> Arc<ThreadSafeStorageDb> {
+    pub fn new_mem_thread_safe_storage_db() -> Arc<ThreadSafeStorageDb> {
         Arc::new(ThreadSafeStorageDb::new(new_mem_db()))
     }
 }

--- a/components/webext-storage/src/db.rs
+++ b/components/webext-storage/src/db.rs
@@ -76,7 +76,6 @@ impl StorageDb {
     pub fn close(self) -> Result<()> {
         self.writer.close().map_err(|(writer, err)| {
             // If we just let `writer` drop, the close would panic on failure.
-            // (Actually, not sure that's true? Regardless, this seems fine)
             std::mem::forget(writer);
             err.into()
         })
@@ -96,6 +95,20 @@ impl DerefMut for StorageDb {
         &mut self.writer
     }
 }
+
+/* ugh - can't call writer.close() as it consumes self
+impl Drop for StorageDb {
+    // Although we do this same dance in `StorageDb::close()` above, the semantics of the Arc and
+    // Mutex unwrapping in the store means it might not always be possible for `Store::close()`
+    // to actually call `close()` above - and as noted, if `writer` is just dropped and the
+    // close fails at that time, we panic, which is an abort on Desktop.
+    fn drop(&mut self) {
+        self.writer.close().map_err(|(writer, err)| {
+            std::mem::forget(writer);
+        });
+    }
+}
+*/
 
 // We almost exclusively use this SharedStorageDb
 pub struct SharedStorageDb {

--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -49,8 +49,8 @@ pub enum ErrorKind {
     #[error("Error opening database: {0}")]
     OpenDatabaseError(#[from] sql_support::open_database::Error),
 
-    #[error("Sync Payload Error: {0}")]
-    IncomingPayloadError(#[from] sync15::Error),
+    #[error("Sync Error: {0}")]
+    SyncError(String),
 }
 
 error_support::define_error! {
@@ -60,7 +60,6 @@ error_support::define_error! {
         (IoError, std::io::Error),
         (InterruptedError, Interrupted),
         (Utf8Error, std::str::Utf8Error),
-        (IncomingPayloadError, sync15::Error),
         (OpenDatabaseError, sql_support::open_database::Error),
     }
 }

--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -49,6 +49,14 @@ pub enum ErrorKind {
     #[error("Error opening database: {0}")]
     OpenDatabaseError(#[from] sql_support::open_database::Error),
 
+    // When trying to close a connection but we aren't the exclusive owner of the containing Arc<>
+    #[error("Other shared references to this connection are alive")]
+    OtherConnectionReferencesExist,
+
+    // When `Weak::upgrade()` returns None.
+    #[error("The storage database has been closed")]
+    WeakReferenceDropped,
+
     #[error("Sync Error: {0}")]
     SyncError(String),
 }

--- a/components/webext-storage/src/error.rs
+++ b/components/webext-storage/src/error.rs
@@ -53,9 +53,8 @@ pub enum ErrorKind {
     #[error("Other shared references to this connection are alive")]
     OtherConnectionReferencesExist,
 
-    // When `Weak::upgrade()` returns None.
     #[error("The storage database has been closed")]
-    WeakReferenceDropped,
+    DatabaseConnectionClosed,
 
     #[error("Sync Error: {0}")]
     SyncError(String),

--- a/components/webext-storage/src/sync/bridge.rs
+++ b/components/webext-storage/src/sync/bridge.rs
@@ -48,10 +48,9 @@ impl BridgedEngine {
     }
 
     fn get_shared_db(&self) -> Result<Arc<SharedStorageDb>> {
-        match self.db.upgrade() {
-            Some(db) => Ok(db),
-            None => Err(crate::error::ErrorKind::WeakReferenceDropped.into()),
-        }
+        self.db
+            .upgrade()
+            .ok_or_else(|| crate::error::ErrorKind::DatabaseConnectionClosed.into())
     }
 }
 

--- a/components/webext-storage/src/sync/bridge.rs
+++ b/components/webext-storage/src/sync/bridge.rs
@@ -9,7 +9,7 @@ use sync15::bso::IncomingBso;
 use sync15::engine::ApplyResults;
 use sync_guid::Guid as SyncGuid;
 
-use crate::db::{delete_meta, get_meta, put_meta, SharedStorageDb};
+use crate::db::{delete_meta, get_meta, put_meta, ThreadSafeStorageDb};
 use crate::schema;
 use crate::sync::incoming::{apply_actions, get_incoming, plan_incoming, stage_incoming};
 use crate::sync::outgoing::{get_outgoing, record_uploaded, stage_outgoing};
@@ -27,12 +27,12 @@ const SYNC_ID_META_KEY: &str = "sync_id";
 /// the desktop semantics as close as possible to what they were when the
 /// engines all took lifetime params to ensure they don't outlive the store.
 pub struct BridgedEngine {
-    db: Weak<SharedStorageDb>,
+    db: Weak<ThreadSafeStorageDb>,
 }
 
 impl BridgedEngine {
     /// Creates a bridged engine for syncing.
-    pub fn new(db: &Arc<SharedStorageDb>) -> Self {
+    pub fn new(db: &Arc<ThreadSafeStorageDb>) -> Self {
         BridgedEngine {
             db: Arc::downgrade(db),
         }
@@ -47,7 +47,7 @@ impl BridgedEngine {
         Ok(())
     }
 
-    fn get_shared_db(&self) -> Result<Arc<SharedStorageDb>> {
+    fn get_shared_db(&self) -> Result<Arc<ThreadSafeStorageDb>> {
         self.db
             .upgrade()
             .ok_or_else(|| crate::error::ErrorKind::DatabaseConnectionClosed.into())

--- a/components/webext-storage/src/sync/bridge.rs
+++ b/components/webext-storage/src/sync/bridge.rs
@@ -4,11 +4,12 @@
 
 use anyhow::Result;
 use rusqlite::Transaction;
+use std::sync::{Arc, Weak};
 use sync15::bso::IncomingBso;
 use sync15::engine::ApplyResults;
 use sync_guid::Guid as SyncGuid;
 
-use crate::db::{delete_meta, get_meta, put_meta, StorageDb};
+use crate::db::{delete_meta, get_meta, put_meta, SharedStorageDb};
 use crate::schema;
 use crate::sync::incoming::{apply_actions, get_incoming, plan_incoming, stage_incoming};
 use crate::sync::outgoing::{get_outgoing, record_uploaded, stage_outgoing};
@@ -20,14 +21,21 @@ const SYNC_ID_META_KEY: &str = "sync_id";
 /// `storage.sync` store work with Desktop's Sync implementation.
 /// Conceptually, it's similar to `sync15::Store`, which we
 /// should eventually rename and unify with this trait (#2841).
-pub struct BridgedEngine<'a> {
-    db: &'a StorageDb,
+///
+/// Unlike most of our other implementation which hold a strong reference
+/// to the store, this engine keeps a weak reference in an attempt to keep
+/// the desktop semantics as close as possible to what they were when the
+/// engines all took lifetime params to ensure they don't outlive the store.
+pub struct BridgedEngine {
+    db: Weak<SharedStorageDb>,
 }
 
-impl<'a> BridgedEngine<'a> {
+impl BridgedEngine {
     /// Creates a bridged engine for syncing.
-    pub fn new(db: &'a StorageDb) -> Self {
-        BridgedEngine { db }
+    pub fn new(db: &Arc<SharedStorageDb>) -> Self {
+        BridgedEngine {
+            db: Arc::downgrade(db),
+        }
     }
 
     fn do_reset(&self, tx: &Transaction<'_>) -> Result<()> {
@@ -38,40 +46,57 @@ impl<'a> BridgedEngine<'a> {
         delete_meta(tx, LAST_SYNC_META_KEY)?;
         Ok(())
     }
+
+    fn get_shared_db(&self) -> Result<Arc<SharedStorageDb>> {
+        match self.db.upgrade() {
+            Some(db) => Ok(db),
+            None => Err(crate::error::ErrorKind::WeakReferenceDropped.into()),
+        }
+    }
 }
 
-impl<'a> sync15::engine::BridgedEngine for BridgedEngine<'a> {
+impl sync15::engine::BridgedEngine for BridgedEngine {
     fn last_sync(&self) -> Result<i64> {
-        Ok(get_meta(self.db, LAST_SYNC_META_KEY)?.unwrap_or(0))
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        Ok(get_meta(&db, LAST_SYNC_META_KEY)?.unwrap_or(0))
     }
 
     fn set_last_sync(&self, last_sync_millis: i64) -> Result<()> {
-        put_meta(self.db, LAST_SYNC_META_KEY, &last_sync_millis)?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        put_meta(&db, LAST_SYNC_META_KEY, &last_sync_millis)?;
         Ok(())
     }
 
     fn sync_id(&self) -> Result<Option<String>> {
-        Ok(get_meta(self.db, SYNC_ID_META_KEY)?)
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        Ok(get_meta(&db, SYNC_ID_META_KEY)?)
     }
 
     fn reset_sync_id(&self) -> Result<String> {
-        let tx = self.db.unchecked_transaction()?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        let tx = db.unchecked_transaction()?;
         let new_id = SyncGuid::random().to_string();
         self.do_reset(&tx)?;
-        put_meta(self.db, SYNC_ID_META_KEY, &new_id)?;
+        put_meta(&tx, SYNC_ID_META_KEY, &new_id)?;
         tx.commit()?;
         Ok(new_id)
     }
 
     fn ensure_current_sync_id(&self, sync_id: &str) -> Result<String> {
-        let current: Option<String> = get_meta(self.db, SYNC_ID_META_KEY)?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        let current: Option<String> = get_meta(&db, SYNC_ID_META_KEY)?;
         Ok(match current {
             Some(current) if current == sync_id => current,
             _ => {
-                let tx = self.db.unchecked_transaction()?;
+                let tx = db.unchecked_transaction()?;
                 self.do_reset(&tx)?;
                 let result = sync_id.to_string();
-                put_meta(self.db, SYNC_ID_META_KEY, &result)?;
+                put_meta(&tx, SYNC_ID_META_KEY, &result)?;
                 tx.commit()?;
                 result
             }
@@ -79,13 +104,17 @@ impl<'a> sync15::engine::BridgedEngine for BridgedEngine<'a> {
     }
 
     fn sync_started(&self) -> Result<()> {
-        schema::create_empty_sync_temp_tables(self.db)?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        schema::create_empty_sync_temp_tables(&db)?;
         Ok(())
     }
 
     fn store_incoming(&self, incoming_bsos: Vec<IncomingBso>) -> Result<()> {
-        let signal = self.db.begin_interrupt_scope()?;
-        let tx = self.db.unchecked_transaction()?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        let signal = db.begin_interrupt_scope()?;
+        let tx = db.unchecked_transaction()?;
         let incoming_content: Vec<_> = incoming_bsos
             .into_iter()
             .map(IncomingBso::into_content::<super::WebextRecord>)
@@ -96,9 +125,11 @@ impl<'a> sync15::engine::BridgedEngine for BridgedEngine<'a> {
     }
 
     fn apply(&self) -> Result<ApplyResults> {
-        let signal = self.db.begin_interrupt_scope()?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        let signal = db.begin_interrupt_scope()?;
 
-        let tx = self.db.unchecked_transaction()?;
+        let tx = db.unchecked_transaction()?;
         let incoming = get_incoming(&tx)?;
         let actions = incoming
             .into_iter()
@@ -108,12 +139,14 @@ impl<'a> sync15::engine::BridgedEngine for BridgedEngine<'a> {
         stage_outgoing(&tx)?;
         tx.commit()?;
 
-        Ok(get_outgoing(self.db, &signal)?.into())
+        Ok(get_outgoing(&db, &signal)?.into())
     }
 
     fn set_uploaded(&self, _server_modified_millis: i64, ids: &[SyncGuid]) -> Result<()> {
-        let signal = self.db.begin_interrupt_scope()?;
-        let tx = self.db.unchecked_transaction()?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        let signal = db.begin_interrupt_scope()?;
+        let tx = db.unchecked_transaction()?;
         record_uploaded(&tx, ids, &signal)?;
         tx.commit()?;
 
@@ -121,12 +154,16 @@ impl<'a> sync15::engine::BridgedEngine for BridgedEngine<'a> {
     }
 
     fn sync_finished(&self) -> Result<()> {
-        schema::create_empty_sync_temp_tables(self.db)?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        schema::create_empty_sync_temp_tables(&db)?;
         Ok(())
     }
 
     fn reset(&self) -> Result<()> {
-        let tx = self.db.unchecked_transaction()?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        let tx = db.unchecked_transaction()?;
         self.do_reset(&tx)?;
         delete_meta(&tx, SYNC_ID_META_KEY)?;
         tx.commit()?;
@@ -134,7 +171,9 @@ impl<'a> sync15::engine::BridgedEngine for BridgedEngine<'a> {
     }
 
     fn wipe(&self) -> Result<()> {
-        let tx = self.db.unchecked_transaction()?;
+        let shared_db = self.get_shared_db()?;
+        let db = shared_db.lock();
+        let tx = db.unchecked_transaction()?;
         // We assume the meta table is only used by sync.
         tx.execute_batch(
             "DELETE FROM storage_sync_data; DELETE FROM storage_sync_mirror; DELETE FROM meta;",
@@ -153,7 +192,8 @@ impl From<anyhow::Error> for crate::error::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::test::new_mem_db;
+    use crate::db::test::new_shared_mem_db;
+    use crate::db::StorageDb;
     use sync15::engine::BridgedEngine;
 
     fn query_count(conn: &StorageDb, table: &str) -> u32 {
@@ -164,94 +204,115 @@ mod tests {
     }
 
     // Sets up mock data for the tests here.
-    fn setup_mock_data(engine: &super::BridgedEngine<'_>) -> Result<()> {
-        engine.db.execute(
-            "INSERT INTO storage_sync_data (ext_id, data, sync_change_counter)
-                 VALUES ('ext-a', 'invalid-json', 2)",
-            [],
-        )?;
-        engine.db.execute(
-            "INSERT INTO storage_sync_mirror (guid, ext_id, data)
-                 VALUES ('guid', 'ext-a', '3')",
-            [],
-        )?;
+    fn setup_mock_data(engine: &super::BridgedEngine) -> Result<()> {
+        {
+            let shared = engine.get_shared_db()?;
+            let db = shared.lock();
+            db.execute(
+                "INSERT INTO storage_sync_data (ext_id, data, sync_change_counter)
+                    VALUES ('ext-a', 'invalid-json', 2)",
+                [],
+            )?;
+            db.execute(
+                "INSERT INTO storage_sync_mirror (guid, ext_id, data)
+                    VALUES ('guid', 'ext-a', '3')",
+                [],
+            )?;
+        }
         engine.set_last_sync(1)?;
 
+        let shared = engine.get_shared_db()?;
+        let db = shared.lock();
         // and assert we wrote what we think we did.
-        assert_eq!(query_count(engine.db, "storage_sync_data"), 1);
-        assert_eq!(query_count(engine.db, "storage_sync_mirror"), 1);
-        assert_eq!(query_count(engine.db, "meta"), 1);
+        assert_eq!(query_count(&db, "storage_sync_data"), 1);
+        assert_eq!(query_count(&db, "storage_sync_mirror"), 1);
+        assert_eq!(query_count(&db, "meta"), 1);
         Ok(())
     }
 
     // Assuming a DB setup with setup_mock_data, assert it was correctly reset.
-    fn assert_reset(engine: &super::BridgedEngine<'_>) -> Result<()> {
+    fn assert_reset(engine: &super::BridgedEngine) -> Result<()> {
         // A reset never wipes data...
-        assert_eq!(query_count(engine.db, "storage_sync_data"), 1);
+        let shared = engine.get_shared_db()?;
+        let db = shared.lock();
+        assert_eq!(query_count(&db, "storage_sync_data"), 1);
 
         // But did reset the change counter.
-        let cc = engine.db.query_row_and_then(
+        let cc = db.query_row_and_then(
             "SELECT sync_change_counter FROM storage_sync_data WHERE ext_id = 'ext-a';",
             [],
             |row| row.get::<_, u32>(0),
         )?;
         assert_eq!(cc, 1);
         // But did wipe the mirror...
-        assert_eq!(query_count(engine.db, "storage_sync_mirror"), 0);
+        assert_eq!(query_count(&db, "storage_sync_mirror"), 0);
         // And the last_sync should have been wiped.
-        assert!(get_meta::<i64>(engine.db, LAST_SYNC_META_KEY)?.is_none());
+        assert!(get_meta::<i64>(&db, LAST_SYNC_META_KEY)?.is_none());
         Ok(())
     }
 
     // Assuming a DB setup with setup_mock_data, assert it has not been reset.
-    fn assert_not_reset(engine: &super::BridgedEngine<'_>) -> Result<()> {
-        assert_eq!(query_count(engine.db, "storage_sync_data"), 1);
-        let cc = engine.db.query_row_and_then(
+    fn assert_not_reset(engine: &super::BridgedEngine) -> Result<()> {
+        let shared = engine.get_shared_db()?;
+        let db = shared.lock();
+        assert_eq!(query_count(&db, "storage_sync_data"), 1);
+        let cc = db.query_row_and_then(
             "SELECT sync_change_counter FROM storage_sync_data WHERE ext_id = 'ext-a';",
             [],
             |row| row.get::<_, u32>(0),
         )?;
         assert_eq!(cc, 2);
-        assert_eq!(query_count(engine.db, "storage_sync_mirror"), 1);
+        assert_eq!(query_count(&db, "storage_sync_mirror"), 1);
         // And the last_sync should remain.
-        assert!(get_meta::<i64>(engine.db, LAST_SYNC_META_KEY)?.is_some());
+        assert!(get_meta::<i64>(&db, LAST_SYNC_META_KEY)?.is_some());
         Ok(())
     }
 
     #[test]
     fn test_wipe() -> Result<()> {
-        let db = new_mem_db();
-        let engine = super::BridgedEngine::new(&db);
+        let strong = new_shared_mem_db();
+        let engine = super::BridgedEngine::new(&strong);
 
         setup_mock_data(&engine)?;
 
         engine.wipe()?;
-        assert_eq!(query_count(engine.db, "storage_sync_data"), 0);
-        assert_eq!(query_count(engine.db, "storage_sync_mirror"), 0);
-        assert_eq!(query_count(engine.db, "meta"), 0);
+
+        let shared = engine.get_shared_db()?;
+        let db = shared.lock();
+
+        assert_eq!(query_count(&db, "storage_sync_data"), 0);
+        assert_eq!(query_count(&db, "storage_sync_mirror"), 0);
+        assert_eq!(query_count(&db, "meta"), 0);
         Ok(())
     }
 
     #[test]
     fn test_reset() -> Result<()> {
-        let db = new_mem_db();
-        let engine = super::BridgedEngine::new(&db);
+        let strong = new_shared_mem_db();
+        let engine = super::BridgedEngine::new(&strong);
 
         setup_mock_data(&engine)?;
-        put_meta(engine.db, SYNC_ID_META_KEY, &"sync-id".to_string())?;
+        put_meta(
+            &engine.get_shared_db()?.lock(),
+            SYNC_ID_META_KEY,
+            &"sync-id".to_string(),
+        )?;
 
         engine.reset()?;
         assert_reset(&engine)?;
         // Only an explicit reset kills the sync-id, so check that here.
-        assert_eq!(get_meta::<String>(engine.db, SYNC_ID_META_KEY)?, None);
+        assert_eq!(
+            get_meta::<String>(&engine.get_shared_db()?.lock(), SYNC_ID_META_KEY)?,
+            None
+        );
 
         Ok(())
     }
 
     #[test]
     fn test_ensure_missing_sync_id() -> Result<()> {
-        let db = new_mem_db();
-        let engine = super::BridgedEngine::new(&db);
+        let strong = new_shared_mem_db();
+        let engine = super::BridgedEngine::new(&strong);
 
         setup_mock_data(&engine)?;
 
@@ -265,12 +326,16 @@ mod tests {
 
     #[test]
     fn test_ensure_new_sync_id() -> Result<()> {
-        let db = new_mem_db();
-        let engine = super::BridgedEngine::new(&db);
+        let strong = new_shared_mem_db();
+        let engine = super::BridgedEngine::new(&strong);
 
         setup_mock_data(&engine)?;
 
-        put_meta(engine.db, SYNC_ID_META_KEY, &"old-id".to_string())?;
+        put_meta(
+            &engine.get_shared_db()?.lock(),
+            SYNC_ID_META_KEY,
+            &"old-id".to_string(),
+        )?;
         assert_not_reset(&engine)?;
         assert_eq!(engine.sync_id()?, Some("old-id".to_string()));
 
@@ -284,13 +349,17 @@ mod tests {
 
     #[test]
     fn test_ensure_same_sync_id() -> Result<()> {
-        let db = new_mem_db();
-        let engine = super::BridgedEngine::new(&db);
+        let strong = new_shared_mem_db();
+        let engine = super::BridgedEngine::new(&strong);
 
         setup_mock_data(&engine)?;
         assert_not_reset(&engine)?;
 
-        put_meta(engine.db, SYNC_ID_META_KEY, &"sync-id".to_string())?;
+        put_meta(
+            &engine.get_shared_db()?.lock(),
+            SYNC_ID_META_KEY,
+            &"sync-id".to_string(),
+        )?;
 
         engine.ensure_current_sync_id("sync-id")?;
         // should not have reset.
@@ -300,11 +369,15 @@ mod tests {
 
     #[test]
     fn test_reset_sync_id() -> Result<()> {
-        let db = new_mem_db();
-        let engine = super::BridgedEngine::new(&db);
+        let strong = new_shared_mem_db();
+        let engine = super::BridgedEngine::new(&strong);
 
         setup_mock_data(&engine)?;
-        put_meta(engine.db, SYNC_ID_META_KEY, &"sync-id".to_string())?;
+        put_meta(
+            &engine.get_shared_db()?.lock(),
+            SYNC_ID_META_KEY,
+            &"sync-id".to_string(),
+        )?;
 
         assert_eq!(engine.sync_id()?, Some("sync-id".to_string()));
         let new_id = engine.reset_sync_id()?;


### PR DESCRIPTION
* A key, fundamental difference between `SyncEngine` and `BridgedEngine`
  is the latter's use of a generic `Error` type. This isn't necessary
  in practice and makes the uniffication of this trait more difficult,
  so this patch uses `anyhow::Error` instead.

* While adjusting `golden_gate` for this change, I noticed alot of
  additional complexity around the lifetime and the fact the trait
  is not `Send+Sync` - which will be a requirement if we want to
  expose this via UniFFI, so thought I'd do this at the same time.
  Tabs was already Send+Sync, but for webext-storage we now use
  a similar pattern used in all other engines - although here,
  inspired by `golden_gate`'s teardown code, we use a `Weak<Store>`
  instead of an `Arc<>` - which is probably what all engines should
  also do!

I'll put up a phabricator patch for the m-c side of this.