### PR TITLE
Upgrades glean to 52.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glean-build"
-version = "6.4.0"
+version = "7.0.0"
 dependencies = [
  "xshell-venv",
 ]

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jna_version = '5.12.1'
         android_gradle_plugin_version = '7.3.0'
         android_components_version = '110.0.1'
-        glean_version = '52.0.0'
+        glean_version = '52.2.0'
 
         // NOTE: AndroidX libraries should be synced with AC to avoid compatibility issues
         androidx_annotation_version = '1.5.0'

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -988,7 +988,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 52.0.0;
+				minimumVersion = 52.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,16 +1,14 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Glean",
-        "repositoryURL": "https://github.com/mozilla/glean-swift",
-        "state": {
-          "branch": null,
-          "revision": "b850864b945621c0ce9d16c380137fe410a3593f",
-          "version": "52.0.0"
-        }
+  "pins" : [
+    {
+      "identity" : "glean-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mozilla/glean-swift",
+      "state" : {
+        "revision" : "a65127dedd442b682e1eaaae6533c525def78394",
+        "version" : "52.2.0"
       }
-    ]
-  },
-  "version": 1
+    }
+  ],
+  "version" : 2
 }


### PR DESCRIPTION
Upgrades glean to 52.2.0

This is to unblock iOS from upgrading, see https://github.com/mozilla-mobile/firefox-ios/pull/13323#issuecomment-1440415294

Jan-Erik is on PTO and Travis is out sick, but this should be a safe upgrade to land.


I already tested locally that Firefox-iOS builds OK once they take a release with this patch

cc @lmarceau 
