### PR TITLE
Cut release v97.0.0

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 96.4.0
+libraryVersion: 97.0.0
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v97.0.0 (_2023-02-22_)
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v96.4.0...v97.0.0)
+
+## Nimbus ⛅️🔬🔭
+### 🦊 What's Changed 🦊
+- Updated the Nimbus Gradle Plugin to fix a number of issues after migrating it to this repository ([#5348](https://github.com/mozilla/application-services/pull/5348))
+- Good fences: protected calls out to the error reporter with a `try`/`catch` ([#5366](https://github.com/mozilla/application-services/pull/5366))
+- Updated the Nimbus FML CLI to only import the R class if it will be used by a feature property ([#5361](https://github.com/mozilla/application-services/pull/5361))
+### ⚠️ Breaking Changes ⚠️
+  - Android and iOS: Several errors have been moved to an internal support library and will no longer be reported as top-level Nimbus errors. They should still be accessible through `NimbusError.ClientError`. They are: `RequestError`, `ResponseError`, and `BackoffError`. ([#5369](https://github.com/mozilla/application-services/pull/5369))
+
 # v96.4.0 (_2023-01-30_)
 
 [Full Changelog](https://github.com/mozilla/application-services/compare/v96.3.0...v96.4.0)

--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 # Unreleased Changes
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v96.4.0...main)
+[Full Changelog](https://github.com/mozilla/application-services/compare/v97.0.0...main)
 
 <!-- WARNING: New entries should be added below this comment to ensure the `./automation/prepare-release.py` script works as expected.
 
@@ -18,11 +18,3 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
-
-## Nimbus ⛅️🔬🔭
-### 🦊 What's Changed 🦊
-- Updated the Nimbus Gradle Plugin to fix a number of issues after migrating it to this repository ([#5348](https://github.com/mozilla/application-services/pull/5348))
-- Good fences: protected calls out to the error reporter with a `try`/`catch` ([#5366](https://github.com/mozilla/application-services/pull/5366))
-- Updated the Nimbus FML CLI to only import the R class if it will be used by a feature property ([#5361](https://github.com/mozilla/application-services/pull/5361))
-### ⚠️ Breaking Changes ⚠️
-  - Android and iOS: Several errors have been moved to an internal support library and will no longer be reported as top-level Nimbus errors. They should still be accessible through `NimbusError.ClientError`. They are: `RequestError`, `ResponseError`, and `BackoffError`. ([#5369](https://github.com/mozilla/application-services/pull/5369))


### PR DESCRIPTION
Cuts 97.0.0 mainly to unblock iOS from upgrading glean


Also includes refactoring of the HTTP layer of Nimbus and some other nimbus plugin clean ups.