### PR TITLE
Remove obsolete lib-crash-sentry-legacy and tooling-glean-gradle AC projects

### DIFF
--- a/taskcluster/android-components-projects.json
+++ b/taskcluster/android-components-projects.json
@@ -94,7 +94,6 @@
     "lib-auth",
     "lib-crash",
     "lib-crash-sentry",
-    "lib-crash-sentry-legacy",
     "lib-dataprotect",
     "lib-fetch-httpurlconnection",
     "lib-fetch-okhttp",
@@ -114,6 +113,5 @@
     "samples-sync-logins",
     "samples-toolbar",
     "samples-dataprotect",
-    "tooling-glean-gradle",
     "tooling-nimbus-gradle"
 ]


### PR DESCRIPTION
They were removed upstream in the below commits:
https://github.com/mozilla-mobile/firefox-android/commit/56432f8df809b1e5d6d6b8a6f9583dc44c3eb3e1
https://github.com/mozilla-mobile/firefox-android/commit/2c82e61071faccdc159c11cca42a61c7138818bc