### PR TITLE
Another fix for test_logging

### DIFF
--- a/components/support/rust-log-forwarder/src/lib.rs
+++ b/components/support/rust-log-forwarder/src/lib.rs
@@ -70,6 +70,7 @@ mod test {
         let _lock = TEST_LOCK.lock().unwrap();
         let logger = TestLogger::new();
         set_logger(Some(Box::new(logger.clone())));
+        set_max_level(Level::Debug);
         log::info!("Test message");
         log::warn!("Test message2");
         logger.check_records(vec![


### PR DESCRIPTION
It seems like the tests can intermittently fail based on which order they run, since some tests set the max logging level and `test_logging` depends on info-level logs being recorded.  Updated `test_logging` to manually set it's max level.  Hopefully this fixes the issue for good.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
