### PR TITLE
Clean up Nimbus test dependencies and cover all parsing paths.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,6 @@ dependencies = [
  "hex",
  "jexl-eval",
  "log",
- "mockito",
  "once_cell",
  "rkv",
  "rs_client",

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -43,7 +43,6 @@ glean-build = { path = "../external/glean/glean-core/build" }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
-mockito = "0.31"
 env_logger = "0.7"
 clap = "2.33.3"
 tempfile = "3"


### PR DESCRIPTION
This was intended to address https://github.com/mozilla/application-services/issues/5394 and the conversation that was started in [this comment thread](https://github.com/mozilla/application-services/pull/5369#discussion_r1103084587) but during implementation I discovered a couple things:

1. Turning `rs_client::Client` into a trait seemed non-trivial and I ran into difficulties updating the design accordingly. I think the best way to achieve it would probably be to add a trait, like `rs_client::ioHandler`, as a struct member of `Client` which could then be replaced under test. However, I felt it would be prudent to move forward with implementing the top-level Remote Settings client _first_ and see if that helps inform a design change like that. Otherwise, I am not sure complicating the design for test-only purposes is necessarily worth it given that `parse_experiments` is directly testable and `fetch_experiments` is 2 lines. 

2. In @jeddai's [comment here](https://github.com/mozilla/application-services/pull/5369#discussion_r1103251594) it was mentioned that the existing Nimbus test only covered the `Ok` path. I took this to mean that the test didn't cover any "unhappy paths", but when I read closer I saw that the test actually hides quite a bit of it. The malformed experiment case and the non-matching schema version case are both covered. Since I had to read closely to discover that, I added a couple comments. I also added a test to cover the `Error` case.

All that said, I thought it would be best for now to remove the unnecessary test dependencies, add the new test, and move on to the Remote Settings client. If any refactoring of the design of `rs_client` happens I will of course revisit that in Nimbus as well.  

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
