### PR TITLE
Tabs storage should create DB when adding meta rows

### DIFF
--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -442,8 +442,9 @@ mod tests {
 
     #[test]
     fn test_tabs_meta() {
-        // Does not create the db on new
-        let mut db = TabsStorage::new("test.db");
+        let dir = tempfile::tempdir().unwrap();
+        let db_name = dir.path().join("test_tabs_meta.db");
+        let mut db = TabsStorage::new(db_name);
         let test_key = "TEST KEY A";
         let test_value = "TEST VALUE A";
         let test_key2 = "TEST KEY B";

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -346,12 +346,11 @@ impl TabsStorage {
     }
 
     pub(crate) fn put_meta(&mut self, key: &str, value: &dyn ToSql) -> Result<()> {
-        if let Some(db) = self.open_if_exists()? {
-            db.execute_cached(
-                "REPLACE INTO moz_meta (key, value) VALUES (:key, :value)",
-                &[(":key", &key as &dyn ToSql), (":value", value)],
-            )?;
-        }
+        let db = self.open_or_create()?;
+        db.execute_cached(
+            "REPLACE INTO moz_meta (key, value) VALUES (:key, :value)",
+            &[(":key", &key as &dyn ToSql), (":value", value)],
+        )?;
         Ok(())
     }
 
@@ -443,12 +442,14 @@ mod tests {
 
     #[test]
     fn test_tabs_meta() {
-        let mut db = TabsStorage::new_with_mem_path("test");
+        // Does not create the db on new
+        let mut db = TabsStorage::new("test.db");
         let test_key = "TEST KEY A";
         let test_value = "TEST VALUE A";
         let test_key2 = "TEST KEY B";
         let test_value2 = "TEST VALUE B";
 
+        // should automatically make the DB if one doesn't exist
         db.put_meta(test_key, &test_value).unwrap();
         db.put_meta(test_key2, &test_value2).unwrap();
 


### PR DESCRIPTION
Fixes #5404 

1. `put_meta` should create the DB if doesn't exists (see issue, new user first sync or TPS tests)
2. get/delete shouldn't create the DBs, those are unchanged
3. Updated tests to ensure this scenario works

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
