### PR TITLE
New versioning system [preview nightly]

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 97.5.1
+libraryVersion: 114.0a1
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/build-scripts/substitute-local-appservices.gradle
+++ b/build-scripts/substitute-local-appservices.gradle
@@ -37,7 +37,7 @@ configurations.all { config ->
                     }
 
                     def group = dependency.requested.group
-                    if (group == 'org.mozilla.appservices') {
+                    if (group == 'org.mozilla.appservices' || group == 'org.mozilla.appservices.nightly') {
                         def name = dependency.requested.module
                         dependency.useTarget([group: group, name: name, version: version])
                     }

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -58,8 +58,8 @@ fi
 # https://github.com/mozilla/application-services/issues/962
 if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   #https://treeherder.mozilla.org/jobs?repo=nss&revision=3ab9260101b1a0d5c3d709ba45975f7e4a9d0077
-  curl -sfSL --retry 5 --retry-delay 10 -O "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/uGFsaHyNS4Oj-HFcOyR6eg/runs/0/artifacts/public/dist.tar.bz2"
-  SHA256="0d36171f6f0815fd0e90fe78d106b7e62e606b9655bf64851debeeaa8a1cb767"
+  curl -sfSL --retry 5 --retry-delay 10 -O "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/XiuUZWgyQIyhTkcBj9GN4A/runs/0/artifacts/public/dist.tar.bz2"
+  SHA256="690302e9c15d49d3d25a9d2fb0de4f80559a880b9555ed311aea4e8cdb28597b"
   echo "${SHA256}  dist.tar.bz2" | shasum -a 256 -c - || exit 2
   tar xvjf dist.tar.bz2 && rm -rf dist.tar.bz2
   NSS_DIST_DIR=$(abspath "dist")

--- a/settings.gradle
+++ b/settings.gradle
@@ -66,7 +66,10 @@ if (file('local.properties').canRead()) {
 
 def calcVersion(buildconfig) {
     def local = gradle.rootProject.findProperty("local")
-    if (gradle.hasProperty("localProperties.branchBuild.application-services.version")) {
+
+    if (gradle.rootProject.hasProperty("nightlyVersion")) {
+        return gradle.rootProject.nightlyVersion
+    } else if (gradle.hasProperty("localProperties.branchBuild.application-services.version")) {
         def branchBuildVersion = gradle.getProperty("localProperties.branchBuild.application-services.version")
         logger.lifecycle("Branch build: forcing all versions to ${branchBuildVersion}")
         return branchBuildVersion

--- a/settings.gradle
+++ b/settings.gradle
@@ -80,6 +80,15 @@ def calcVersion(buildconfig) {
     }
 }
 
+def calcGroupId(buildconfig) {
+    if (gradle.rootProject.hasProperty("nightlyVersion")) {
+        return buildconfig.groupId + ".nightly"
+    } else {
+        return buildconfig.groupId
+    }
+}
+
+
 gradle.projectsLoaded { ->
     // Wait until root project is "loaded" before we set "config"
     // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
@@ -90,6 +99,6 @@ gradle.projectsLoaded { ->
         // which can be depended on specifically by the ./build-scripts/substitute-local-appservices.gradle
         // but which is unlikely to be depended on by accident otherwise.
         version: calcVersion(buildconfig),
-        groupId: buildconfig.groupId,
+        groupId: calcGroupId(buildconfig),
     ]
 }

--- a/taskcluster/app_services_taskgraph/__init__.py
+++ b/taskcluster/app_services_taskgraph/__init__.py
@@ -6,11 +6,14 @@
 from importlib import import_module
 from voluptuous import Optional
 import os
+import re
 
 from taskgraph.parameters import extend_parameters_schema
 from . import branch_builds
 from . import nightly_builds
 from .build_config import get_version
+
+PREVIEW_RE = re.compile(r'\[preview ([\w-]+)\]')
 
 def register(graph_config):
     # Import modules to register decorated functions
@@ -26,7 +29,10 @@ def register(graph_config):
             Optional('firefox-android-owner'): str,
             Optional('firefox-android-branch'): str,
         },
-        'nightly-build': bool,
+        # Publish a "preview build" for a future version.  This is set to
+        # "nightly" for the nightly builds.  Other strings indicate making a
+        # preview build for a particular application-services branch.
+        'preview-build': str,
     })
 
 def _import_modules(modules):
@@ -51,7 +57,14 @@ def get_decision_parameters(graph_config, parameters):
             )
     elif parameters["tasks_for"] == "github-pull-request":
         pr_title = os.environ.get("APPSERVICES_PULL_REQUEST_TITLE", "")
-        if "[ci full]" in pr_title:
+        preview_match = PREVIEW_RE.search(pr_title)
+        if preview_match is not None:
+            if preview_match.group(1) == 'nightly':
+                parameters["preview-build"] = "nightly"
+                parameters["target_tasks_method"] = "preview"
+            else:
+                raise NotImplemented("Only nightly preview builds are currently supported")
+        elif "[ci full]" in pr_title:
             parameters["target_tasks_method"] = "pr-full"
         elif "[ci skip]" in pr_title:
             parameters["target_tasks_method"] = "pr-skip"
@@ -60,7 +73,7 @@ def get_decision_parameters(graph_config, parameters):
     elif parameters["tasks_for"] == "cron":
         # We don't have a great way of determining if something is a nightly or
         # not.  But for now, we can assume all cron-based builds are nightlies.
-        parameters["nightly-build"] = True
+        parameters["preview-build"] = "nightly"
 
     parameters['branch-build'] = branch_builds.calc_branch_build_param(parameters)
     parameters['filters'].extend([

--- a/taskcluster/app_services_taskgraph/__init__.py
+++ b/taskcluster/app_services_taskgraph/__init__.py
@@ -42,7 +42,7 @@ def get_decision_parameters(graph_config, parameters):
                     head_tag
                 )
             )
-        version = get_version()
+        version = get_version(graph_config)
         # XXX: tags are in the format of `v<semver>`
         if head_tag[1:] != version:
             raise ValueError(
@@ -57,10 +57,12 @@ def get_decision_parameters(graph_config, parameters):
             parameters["target_tasks_method"] = "pr-skip"
         else:
             parameters["target_tasks_method"] = "pr-normal"
+    elif parameters["tasks_for"] == "cron":
+        # We don't have a great way of determining if something is a nightly or
+        # not.  But for now, we can assume all cron-based builds are nightlies.
+        parameters["nightly-build"] = True
+        parameters["target_tasks_method"] = "nightly"
 
-    # We don't have a great way of determining if something is a nightly or
-    # not.  But for now, we can assume all cron-based builds are nightlies.
-    parameters["nightly-build"] = (parameters["tasks_for"] == "cron")
     parameters['branch-build'] = branch_builds.calc_branch_build_param(parameters)
     parameters['filters'].extend([
         'branch-build',

--- a/taskcluster/app_services_taskgraph/__init__.py
+++ b/taskcluster/app_services_taskgraph/__init__.py
@@ -42,7 +42,7 @@ def get_decision_parameters(graph_config, parameters):
                     head_tag
                 )
             )
-        version = get_version(graph_config)
+        version = get_version(graph_config.params)
         # XXX: tags are in the format of `v<semver>`
         if head_tag[1:] != version:
             raise ValueError(
@@ -61,7 +61,6 @@ def get_decision_parameters(graph_config, parameters):
         # We don't have a great way of determining if something is a nightly or
         # not.  But for now, we can assume all cron-based builds are nightlies.
         parameters["nightly-build"] = True
-        parameters["target_tasks_method"] = "nightly"
 
     parameters['branch-build'] = branch_builds.calc_branch_build_param(parameters)
     parameters['filters'].extend([

--- a/taskcluster/app_services_taskgraph/beetmover.py
+++ b/taskcluster/app_services_taskgraph/beetmover.py
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+def get_maven_bucket(params):
+    if params['level'] == '3':
+        return "maven-production"
+    else:
+        return "maven-staging"

--- a/taskcluster/app_services_taskgraph/branch_builds.py
+++ b/taskcluster/app_services_taskgraph/branch_builds.py
@@ -14,10 +14,6 @@ def update_decision_parameters(parameters):
     parameters['branch-build'] = calc_branch_build_param(parameters)
 
 def calc_branch_build_param(parameters):
-    if parameters.get('nightly-build'):
-        return {
-            'firefox-android-branch': 'main',
-        }
     title = os.environ.get("APPSERVICES_PULL_REQUEST_TITLE", "")
     branch_build = {}
 

--- a/taskcluster/app_services_taskgraph/build_config.py
+++ b/taskcluster/app_services_taskgraph/build_config.py
@@ -31,18 +31,15 @@ def get_components():
     } for (name, project) in build_config['projects'].items()]
 
 
-def get_version(config):
+def get_version(params):
     version = _read_build_config()["libraryVersion"]
-    if config.params.get('nightly-build', False):
-        return make_nightly_version(version, config.params['moz_build_date'])
+    if params.get('nightly-build', False):
+        components = version.split('.')
+        assert len(components) == 2
+        components[1] = params['moz_build_date']
+        return '.'.join(components)
     else:
         return version
-
-def make_nightly_version(version, moz_build_date):
-    components = version.split('.')
-    assert len(components) == 2
-    components[1] = moz_build_date
-    return '.'.join(components)
 
 def get_extensions(module_name):
     publications = _read_build_config()["projects"][module_name]['publications']

--- a/taskcluster/app_services_taskgraph/build_config.py
+++ b/taskcluster/app_services_taskgraph/build_config.py
@@ -31,9 +31,18 @@ def get_components():
     } for (name, project) in build_config['projects'].items()]
 
 
-def get_version():
-    return _read_build_config()["libraryVersion"]
+def get_version(config):
+    version = _read_build_config()["libraryVersion"]
+    if config.params.get('nightly-build', False):
+        return make_nightly_version(version, config.params['moz_build_date'])
+    else:
+        return version
 
+def make_nightly_version(version, moz_build_date):
+    components = version.split('.')
+    assert len(components) == 3
+    components[2] = moz_build_date
+    return '.'.join(components)
 
 def get_extensions(module_name):
     publications = _read_build_config()["projects"][module_name]['publications']

--- a/taskcluster/app_services_taskgraph/build_config.py
+++ b/taskcluster/app_services_taskgraph/build_config.py
@@ -40,8 +40,8 @@ def get_version(config):
 
 def make_nightly_version(version, moz_build_date):
     components = version.split('.')
-    assert len(components) == 3
-    components[2] = moz_build_date
+    assert len(components) == 2
+    components[1] = moz_build_date
     return '.'.join(components)
 
 def get_extensions(module_name):

--- a/taskcluster/app_services_taskgraph/build_config.py
+++ b/taskcluster/app_services_taskgraph/build_config.py
@@ -33,11 +33,14 @@ def get_components():
 
 def get_version(params):
     version = _read_build_config()["libraryVersion"]
-    if params.get('nightly-build', False):
+    preview_build = params.get('preview-build')
+    if preview_build == 'nightly':
         components = version.split('.')
         assert len(components) == 2
         components[1] = params['moz_build_date']
         return '.'.join(components)
+    elif preview_build is not None:
+        raise NotImplemented("Only nightly preview builds are currently supported")
     else:
         return version
 

--- a/taskcluster/app_services_taskgraph/nightly_builds.py
+++ b/taskcluster/app_services_taskgraph/nightly_builds.py
@@ -6,7 +6,7 @@ from taskgraph.filter_tasks import filter_task
 
 @filter_task("nightly-build")
 def filter_nightly_tasks(full_task_graph, parameters, graph_config):
-    if parameters.get('nightly-build'):
+    if parameters.get('nightly-build', False):
         # Nothing to filter for nightly builds
         return full_task_graph.tasks.keys()
     else:

--- a/taskcluster/app_services_taskgraph/nightly_builds.py
+++ b/taskcluster/app_services_taskgraph/nightly_builds.py
@@ -6,7 +6,7 @@ from taskgraph.filter_tasks import filter_task
 
 @filter_task("nightly-build")
 def filter_nightly_tasks(full_task_graph, parameters, graph_config):
-    if parameters.get('nightly-build', False):
+    if parameters.get('preview-build') == 'nightly':
         # Nothing to filter for nightly builds
         return full_task_graph.tasks.keys()
     else:

--- a/taskcluster/app_services_taskgraph/target_tasks.py
+++ b/taskcluster/app_services_taskgraph/target_tasks.py
@@ -10,10 +10,10 @@ from taskgraph.target_tasks import _target_task, filter_for_tasks_for
 def target_tasks_pr_skip(full_task_graph, parameters, graph_config):
     return []
 
-@_target_task('nightly')
-def target_tasks_nightly(full_task_graph, parameters, graph_config):
-    # Nightly builds should do a full-ci build
-    return target_tasks_all(full_task_graph, parameters, graph_config)
+@_target_task('preview')
+def target_tasks_preview(full_task_graph, parameters, graph_config):
+    # Run all tasks for preview builds
+    return full_task_graph.tasks
 
 @_target_task('pr-full')
 def target_tasks_all(full_task_graph, parameters, graph_config):

--- a/taskcluster/app_services_taskgraph/target_tasks.py
+++ b/taskcluster/app_services_taskgraph/target_tasks.py
@@ -10,8 +10,9 @@ from taskgraph.target_tasks import _target_task, filter_for_tasks_for
 def target_tasks_pr_skip(full_task_graph, parameters, graph_config):
     return []
 
+@_target_task('nightly')
 @_target_task('pr-full')
-def target_tasks_default(full_task_graph, parameters, graph_config):
+def target_tasks_all(full_task_graph, parameters, graph_config):
     """Target the tasks which have indicated they should be run on this project
     via the `run_on_projects` attributes."""
     def filter(task):

--- a/taskcluster/app_services_taskgraph/target_tasks.py
+++ b/taskcluster/app_services_taskgraph/target_tasks.py
@@ -11,6 +11,10 @@ def target_tasks_pr_skip(full_task_graph, parameters, graph_config):
     return []
 
 @_target_task('nightly')
+def target_tasks_nightly(full_task_graph, parameters, graph_config):
+    # Nightly builds should do a full-ci build
+    return target_tasks_all(full_task_graph, parameters, graph_config)
+
 @_target_task('pr-full')
 def target_tasks_all(full_task_graph, parameters, graph_config):
     """Target the tasks which have indicated they should be run on this project

--- a/taskcluster/app_services_taskgraph/transforms/__init__.py
+++ b/taskcluster/app_services_taskgraph/transforms/__init__.py
@@ -24,13 +24,14 @@ def publications_to_artifact_paths(name, version, publications, secondary_extens
     return paths
 
 
-def publications_to_artifact_map_paths(name, version, publications, nightly_build, secondary_extensions):
+def publications_to_artifact_map_paths(name, version, publications, preview_build, secondary_extensions):
     build_map_paths = {}
     for publication in publications:
         for extension in _extensions(publication["type"], secondary_extensions):
             publication_name = publication['name']
             artifact_filename = _artifact_filename(publication_name, version, extension)
-            if nightly_build:
+            if preview_build is not None:
+                # Both nightly and other preview builds are places in separate directory
                 destination = "maven2/org/mozilla/appservices/nightlies/{}/{}/{}".format(publication_name, version, artifact_filename)
             else:
                 destination = "maven2/org/mozilla/appservices/{}/{}/{}".format(publication_name, version, artifact_filename)

--- a/taskcluster/app_services_taskgraph/transforms/__init__.py
+++ b/taskcluster/app_services_taskgraph/transforms/__init__.py
@@ -32,7 +32,7 @@ def publications_to_artifact_map_paths(name, version, publications, preview_buil
             artifact_filename = _artifact_filename(publication_name, version, extension)
             if preview_build is not None:
                 # Both nightly and other preview builds are places in separate directory
-                destination = "maven2/org/mozilla/appservices/nightlies/{}/{}/{}".format(publication_name, version, artifact_filename)
+                destination = "maven2/org/mozilla/appservices/nightly/{}/{}/{}".format(publication_name, version, artifact_filename)
             else:
                 destination = "maven2/org/mozilla/appservices/{}/{}/{}".format(publication_name, version, artifact_filename)
             build_map_paths[f"public/build/{artifact_filename}"] = {

--- a/taskcluster/app_services_taskgraph/transforms/__init__.py
+++ b/taskcluster/app_services_taskgraph/transforms/__init__.py
@@ -24,14 +24,19 @@ def publications_to_artifact_paths(name, version, publications, secondary_extens
     return paths
 
 
-def publications_to_artifact_map_paths(name, version, publications, secondary_extensions):
+def publications_to_artifact_map_paths(name, version, publications, nightly_build, secondary_extensions):
     build_map_paths = {}
     for publication in publications:
         for extension in _extensions(publication["type"], secondary_extensions):
-            artifact_filename = _artifact_filename(publication['name'], version, extension)
+            publication_name = publication['name']
+            artifact_filename = _artifact_filename(publication_name, version, extension)
+            if nightly_build:
+                destination = "maven2/org/mozilla/appservices/nightlies/{}/{}/{}".format(publication_name, version, artifact_filename)
+            else:
+                destination = "maven2/org/mozilla/appservices/{}/{}/{}".format(publication_name, version, artifact_filename)
             build_map_paths[f"public/build/{artifact_filename}"] = {
                 "checksums_path": "",  # XXX beetmover marks this as required, but it's not needed
-                "destinations": ["maven2/org/mozilla/appservices/{}/{}/{}".format(publication['name'], version, artifact_filename)]
+                "destinations": [destination]
             }
 
     return build_map_paths

--- a/taskcluster/app_services_taskgraph/transforms/appservices.py
+++ b/taskcluster/app_services_taskgraph/transforms/appservices.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from taskgraph.transforms.base import TransformSequence
+
+from ..build_config import get_version
+
+transforms = TransformSequence()
+
+@transforms.add
+def transform_routes(config, tasks):
+    version = get_version(config.params)
+    for task in tasks:
+        task["routes"] = [
+            route.replace("{appservices_version}", version)
+            for route in task.get("routes", [])
+        ]
+        yield task
+

--- a/taskcluster/app_services_taskgraph/transforms/beetmover.py
+++ b/taskcluster/app_services_taskgraph/transforms/beetmover.py
@@ -19,7 +19,7 @@ def build_upstream_artifacts(config, tasks):
     for task in tasks:
         module_info = task["attributes"]["buildconfig"]
         name = module_info["name"]
-        version = get_version(config)
+        version = get_version(config.params)
         publications = module_info["publications"]
 
         worker_definition = {"upstream-artifacts": [{
@@ -43,7 +43,7 @@ def build_artifact_map(config, tasks):
     for task in tasks:
         module_info = task["attributes"]["buildconfig"]
         name = module_info["name"]
-        version = get_version(config)
+        version = get_version(config.params)
 
         publications = module_info["publications"]
 
@@ -69,7 +69,7 @@ def build_artifact_map(config, tasks):
 def beetmover_task(config, tasks):
     for task in tasks:
         task["worker"]["max-run-time"] = 600
-        task["worker"]["version"] = get_version(config)
+        task["worker"]["version"] = get_version(config.params)
         task["description"] = task["description"].format(task["attributes"]["buildconfig"]["name"])
         resolve_keyed_by(task, "worker.bucket", item_name=task["name"], **{
             "level": config.params["level"],

--- a/taskcluster/app_services_taskgraph/transforms/beetmover.py
+++ b/taskcluster/app_services_taskgraph/transforms/beetmover.py
@@ -19,7 +19,7 @@ def build_upstream_artifacts(config, tasks):
     for task in tasks:
         module_info = task["attributes"]["buildconfig"]
         name = module_info["name"]
-        version = get_version()
+        version = get_version(config)
         publications = module_info["publications"]
 
         worker_definition = {"upstream-artifacts": [{
@@ -43,7 +43,7 @@ def build_artifact_map(config, tasks):
     for task in tasks:
         module_info = task["attributes"]["buildconfig"]
         name = module_info["name"]
-        version = get_version()
+        version = get_version(config)
 
         publications = module_info["publications"]
 
@@ -51,11 +51,14 @@ def build_artifact_map(config, tasks):
             "locale": "en-US",
             "task-id": {"task-reference": "<module-build>"},
             "paths": (publications_to_artifact_map_paths(name, version, publications,
+                                                         config.params.get("nightly-build", False),
                                                          ("", ".sha1", ".md5")))
         }, {
             "locale": "en-US",
             "task-id": {"task-reference": "<signing>"},
-            "paths": publications_to_artifact_map_paths(name, version, publications, (".asc",))
+            "paths": publications_to_artifact_map_paths(name, version, publications,
+                                                        config.params.get("nightly-build", False),
+                                                        (".asc",))
         }]
 
         task["worker"]["artifact-map"] = artifact_map
@@ -66,7 +69,7 @@ def build_artifact_map(config, tasks):
 def beetmover_task(config, tasks):
     for task in tasks:
         task["worker"]["max-run-time"] = 600
-        task["worker"]["version"] = get_version()
+        task["worker"]["version"] = get_version(config)
         task["description"] = task["description"].format(task["attributes"]["buildconfig"]["name"])
         resolve_keyed_by(task, "worker.bucket", item_name=task["name"], **{
             "level": config.params["level"],

--- a/taskcluster/app_services_taskgraph/transforms/beetmover.py
+++ b/taskcluster/app_services_taskgraph/transforms/beetmover.py
@@ -10,6 +10,7 @@ from . import (
     publications_to_artifact_paths, publications_to_artifact_map_paths
 )
 from ..build_config import get_version
+from ..beetmover import get_maven_bucket
 
 transforms = TransformSequence()
 
@@ -71,20 +72,7 @@ def beetmover_task(config, tasks):
         task["worker"]["max-run-time"] = 600
         task["worker"]["version"] = get_version(config.params)
         task["description"] = task["description"].format(task["attributes"]["buildconfig"]["name"])
-        if config.params['level'] == '3':
-            if config.params.get('preview-build') is None:
-                task["worker"]["bucket"] = "maven-production"
-            else:
-                # Once we setup access, these should be published to the nightly maven repos
-                # task["worker"]["bucket"] = "maven-nightly-production"
-                task["worker"]["bucket"] = "maven-production"
-        else:
-            if config.params.get('preview-build') is None:
-                task["worker"]["bucket"] = "maven-staging"
-            else:
-                # Once we setup access, these should be published to the nightly maven repos
-                # task["worker"]["bucket"] = "maven-nightly-staging"
-                task["worker"]["bucket"] = "maven-staging"
+        task["worker"]["bucket"] = get_maven_bucket(config.params)
         yield task
 
 

--- a/taskcluster/app_services_taskgraph/transforms/beetmover.py
+++ b/taskcluster/app_services_taskgraph/transforms/beetmover.py
@@ -51,13 +51,13 @@ def build_artifact_map(config, tasks):
             "locale": "en-US",
             "task-id": {"task-reference": "<module-build>"},
             "paths": (publications_to_artifact_map_paths(name, version, publications,
-                                                         config.params.get("nightly-build", False),
+                                                         config.params.get("preview-build"),
                                                          ("", ".sha1", ".md5")))
         }, {
             "locale": "en-US",
             "task-id": {"task-reference": "<signing>"},
             "paths": publications_to_artifact_map_paths(name, version, publications,
-                                                        config.params.get("nightly-build", False),
+                                                        config.params.get("preview-build"),
                                                         (".asc",))
         }]
 
@@ -71,9 +71,20 @@ def beetmover_task(config, tasks):
         task["worker"]["max-run-time"] = 600
         task["worker"]["version"] = get_version(config.params)
         task["description"] = task["description"].format(task["attributes"]["buildconfig"]["name"])
-        resolve_keyed_by(task, "worker.bucket", item_name=task["name"], **{
-            "level": config.params["level"],
-        })
+        if config.params['level'] == '3':
+            if config.params.get('preview-build') is None:
+                task["worker"]["bucket"] = "maven-production"
+            else:
+                # Once we setup access, these should be published to the nightly maven repos
+                # task["worker"]["bucket"] = "maven-nightly-production"
+                task["worker"]["bucket"] = "maven-production"
+        else:
+            if config.params.get('preview-build') is None:
+                task["worker"]["bucket"] = "maven-staging"
+            else:
+                # Once we setup access, these should be published to the nightly maven repos
+                # task["worker"]["bucket"] = "maven-nightly-staging"
+                task["worker"]["bucket"] = "maven-staging"
         yield task
 
 

--- a/taskcluster/app_services_taskgraph/transforms/module_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/module_build.py
@@ -43,6 +43,11 @@ def release_upload_symbols(config, tasks):
 
 @transforms.add
 def build_task(config, tasks):
+    if config.params.get("preview-build") is None:
+        path_prefix = "/builds/worker/checkouts/vcs/build/maven/org/mozilla/appservices/"
+    else:
+        path_prefix = "/builds/worker/checkouts/vcs/build/maven/org/mozilla/appservices/nightly"
+
     for task in tasks:
         module_info = task["attributes"]["buildconfig"]
         name = module_info["name"]
@@ -61,7 +66,7 @@ def build_task(config, tasks):
                 artifact_filename = f"{publication_name}-{version}{extension}"
                 artifacts.append({
                     "name": f"public/build/{artifact_filename}",
-                    "path": f"/builds/worker/checkouts/vcs/build/maven/org/mozilla/appservices/{publication_name}/{version}/{artifact_filename}",
+                    "path": f"{path_prefix}/{publication_name}/{version}/{artifact_filename}",
                     "type": "file",
                 })
 

--- a/taskcluster/app_services_taskgraph/transforms/module_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/module_build.py
@@ -46,10 +46,13 @@ def build_task(config, tasks):
     for task in tasks:
         module_info = task["attributes"]["buildconfig"]
         name = module_info["name"]
-        version = get_version()
+        version = get_version(config)
 
         for i,item in enumerate(task["run"]["gradlew"]):
             task["run"]["gradlew"][i] = task["run"]["gradlew"][i].format(module_name=name)
+        if config.params.get('nightly-build', False):
+            for i,item in enumerate(task["run"]["gradlew"]):
+                task["run"]["gradlew"][i] = f"{item} -PnightlyVersion={version}"
         task["description"] = task["description"].format(module_name=name)
         task["worker"]["artifacts"] = artifacts = []
 

--- a/taskcluster/app_services_taskgraph/transforms/module_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/module_build.py
@@ -46,7 +46,7 @@ def build_task(config, tasks):
     for task in tasks:
         module_info = task["attributes"]["buildconfig"]
         name = module_info["name"]
-        version = get_version(config)
+        version = get_version(config.params)
 
         for i,item in enumerate(task["run"]["gradlew"]):
             task["run"]["gradlew"][i] = task["run"]["gradlew"][i].format(module_name=name)

--- a/taskcluster/app_services_taskgraph/transforms/module_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/module_build.py
@@ -50,9 +50,8 @@ def build_task(config, tasks):
 
         for i,item in enumerate(task["run"]["gradlew"]):
             task["run"]["gradlew"][i] = task["run"]["gradlew"][i].format(module_name=name)
-        if config.params.get('nightly-build', False):
-            for i,item in enumerate(task["run"]["gradlew"]):
-                task["run"]["gradlew"][i] = f"{item} -PnightlyVersion={version}"
+        if config.params.get('preview-build') is not None:
+            task["run"]["gradlew"].append(f"-PnightlyVersion={version}")
         task["description"] = task["description"].format(module_name=name)
         task["worker"]["artifacts"] = artifacts = []
 

--- a/taskcluster/app_services_taskgraph/transforms/nightly_publish.py
+++ b/taskcluster/app_services_taskgraph/transforms/nightly_publish.py
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+from taskgraph.transforms.base import TransformSequence
+
+from ..build_config import get_version
+from ..beetmover import get_maven_bucket
+
+transforms = TransformSequence()
+
+@transforms.add
+def setup_command(config, tasks):
+    version = get_version(config.params)
+    if config.params['level'] == '3':
+        if config.params.get('preview-build') is None:
+            maven_channel = "maven-production"
+        else:
+            maven_channel = "maven-nightly-production"
+    else:
+        if config.params.get('preview-build') is None:
+            maven_channel = "maven-staging"
+        else:
+            maven_channel = "maven-nightly-staging"
+
+    for task in tasks:
+        task["run"]["commands"] = [
+           [
+               "/builds/worker/checkouts/vcs/taskcluster/scripts/generate-nightly-json.py",
+               "/builds/worker/checkouts/vcs/build/nightly.json",
+               "--version", version,
+               "--maven-channel", maven_channel,
+           ]
+       ]
+        task["routes"] = [
+            "index.project.application-services.v2.nightly.latest",
+            f"index.project.application-services.v2.nightly.{version}",
+        ]
+        yield task

--- a/taskcluster/app_services_taskgraph/transforms/signing.py
+++ b/taskcluster/app_services_taskgraph/transforms/signing.py
@@ -18,7 +18,7 @@ def build_upstream_artifacts(config, tasks):
         dep = task.pop("primary-dependency")
         module_info = task["attributes"]["buildconfig"]
         name = module_info["name"]
-        version = get_version()
+        version = get_version(config)
 
         worker_definition = {"upstream-artifacts": [{
             "taskId": {"task-reference": f"<{dep.kind}>"},

--- a/taskcluster/app_services_taskgraph/transforms/signing.py
+++ b/taskcluster/app_services_taskgraph/transforms/signing.py
@@ -18,7 +18,7 @@ def build_upstream_artifacts(config, tasks):
         dep = task.pop("primary-dependency")
         module_info = task["attributes"]["buildconfig"]
         name = module_info["name"]
-        version = get_version(config)
+        version = get_version(config.params)
 
         worker_definition = {"upstream-artifacts": [{
             "taskId": {"task-reference": f"<{dep.kind}>"},

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -19,7 +19,7 @@ tasks:
       run-on-pr-type: all
       resource-monitor: true
     needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
-    run-on-tasks-for: [github-pull-request, github-release]
+    run-on-tasks-for: [github-pull-request, github-release, cron]
     description: Build and test (Android - linux-x86-64)
     scopes:
       - project:releng:services/tooltool/api/download/internal

--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -22,12 +22,6 @@ task-template:
   worker-type: beetmover
   worker:
     app-name: appservices
-    bucket:
-      by-level:
-        "3":
-          maven-production
-        default:
-          maven-staging
   routes:
     - notify.email.a-s-ci-failures@mozilla.com.on-failed
 

--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -17,7 +17,7 @@ primary-dependency: module-build
 group-by: component
 
 task-template:
-  run-on-tasks-for: [github-release]
+  run-on-tasks-for: [github-release, cron]
   description: 'Publish release module {}'
   worker-type: beetmover
   worker:

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -20,6 +20,11 @@ workers:
       implementation: docker-worker
       os: linux
       worker-type: 'b-linux-gcp'
+    b-osx:
+      provisioner: releng-hardware
+      implementation: generic-worker
+      os: macosx
+      worker-type: applicationservices-b-1-osx1015
     images:
       provisioner: 'app-services-{level}'
       implementation: docker-worker

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -19,7 +19,7 @@ task-defaults:
   attributes:
     run-on-pr-type: full-ci
     resource-monitor: true
-  run-on-tasks-for: [github-pull-request, github-push]
+  run-on-tasks-for: [github-pull-request, github-push, cron]
   description: "{module_name} - Build and test"
   scopes:
     - project:releng:services/tooltool/api/download/internal

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -33,7 +33,7 @@ task-defaults:
     pre-gradlew:
       - [source, taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh]
       - [source, taskcluster/scripts/toolchain/cross-compile-setup.sh]
-      - [rsync, '-a', /builds/worker/fetches/libs/, /builds/worker/checkouts/vcs/libs/]
+      - [source, taskcluster/scripts/toolchain/copy-libs-dir.sh, libs]
       - [bash, '-c', 'echo "rust.targets=arm,arm64,x86_64,x86,darwin,linux-x86-64\n" > local.properties']
     gradlew:
       - ':{module_name}:assembleRelease'

--- a/taskcluster/ci/nightly-publish/kind.yml
+++ b/taskcluster/ci/nightly-publish/kind.yml
@@ -1,0 +1,41 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+# nightly-publish: publish artifacts for successful nightly builds
+#
+# This task publishes the nightly.json file for the nightly builds.
+# nightly.json is used by consumer apps for their nightly app-services version
+# bump.
+#
+# This task only runs if nightly-summary succeeds, which implies that all other
+# tasks suceeded.  This task should not fail, since that could leave the
+# nightly artifacts in an inconsistent state.
+loader: taskgraph.loader.transform:loader
+
+kind-dependencies:
+  - nightly-summary
+
+transforms:
+  - app_services_taskgraph.transforms.nightly_publish:transforms
+  - taskgraph.transforms.job:transforms
+  - taskgraph.transforms.task:transforms
+
+tasks:
+  nightly_publish:
+    attributes:
+      nightly: nightly-only
+    label: "Nightly build publish task"
+    description: "Publish nightly artifacts"
+    worker-type: b-linux
+    worker:
+      chain-of-trust: true
+      docker-image: { in-tree: linux }
+      max-run-time: 1800
+      env: {}
+      artifacts:
+        - name: "public/build/nightly.json"
+          path: "/builds/worker/checkouts/vcs/build/nightly.json"
+          type: "file"
+    run:
+        using: run-commands

--- a/taskcluster/ci/nightly-summary/kind.yml
+++ b/taskcluster/ci/nightly-summary/kind.yml
@@ -5,9 +5,11 @@
 loader: taskgraph.loader.transform:loader
 
 kind-dependencies:
-  - branch-build-as
-  - branch-build-firefox-android
-  - branch-build-fenix
+  - module-build
+  - signing
+  - beetmover
+  - swift
+  - nimbus-fml
 
 transforms:
   - app_services_taskgraph.transforms.deps_complete:transforms

--- a/taskcluster/ci/nimbus-fml/kind.yml
+++ b/taskcluster/ci/nimbus-fml/kind.yml
@@ -7,6 +7,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+  - app_services_taskgraph.transforms.appservices:transforms
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.task:transforms
 
@@ -14,36 +15,41 @@ kind-dependencies:
   - toolchain
 
 tasks:
-  pr:
+  build:
     attributes:
       run-on-pr-type: all
       resource-monitor: true
     needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
     run-on-tasks-for: [github-pull-request, github-release, cron]
-    description: Build and test (Android - linux-x86-64)
+    description: Build and test (Swift)
     scopes:
       - project:releng:services/tooltool/api/download/internal
     worker-type: b-linux
     worker:
       docker-image: { in-tree: linux }
       max-run-time: 1800
-      env: {}
+      artifacts:
+        - name: "public/build/nimbus-fml.zip"
+          path: "/builds/worker/checkouts/vcs/build/nimbus-fml.zip"
+          type: "file"
+        - name: "public/build/nimbus-fml.sha256"
+          path: "/builds/worker/checkouts/vcs/build/nimbus-fml.sha256"
+          type: "file"
     run:
-      pre-gradlew:
+      pre-commands:
         - [git, submodule, update, --init]
         - [source, taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh]
-        - [source, taskcluster/scripts/toolchain/cross-compile-setup.sh]
-        - [source, taskcluster/scripts/toolchain/copy-libs-dir.sh, libs]
-        - [bash, '-c', 'echo "rust.targets=linux-x86-64\n" > local.properties']
-      gradlew:
-        - 'clean'
-        - 'assembleDebug'
-        - 'testDebug'
-      using: gradlew
+        - [rsync, '-a', /builds/worker/fetches/libs/, /builds/worker/checkouts/vcs/libs/]
+      commands:
+        - [
+            "/builds/worker/checkouts/vcs/taskcluster/scripts/build-nimbus-fml.py",
+            "/builds/worker/checkouts/vcs/build/",
+          ]
+      using: run-commands
       use-caches: true
-
     fetches:
       toolchain:
-        - android-libs
         - desktop-linux-libs
         - rust
+    routes:
+      - index.project.application-services.v2.nimbus-fml.{appservices_version}

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -16,7 +16,7 @@ primary-dependency: module-build
 group-by: component
 
 task-template:
-  run-on-tasks-for: [github-release]
+  run-on-tasks-for: [github-release, cron]
   description: 'Sign release module {}'
   worker-type: signing
   worker:

--- a/taskcluster/ci/swift/kind.yml
+++ b/taskcluster/ci/swift/kind.yml
@@ -1,0 +1,56 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# ⚠️ If you add, rename or delete a task here, please also update .mergify.yml! ⚠️
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+  - app_services_taskgraph.transforms.appservices:transforms
+  - taskgraph.transforms.job:transforms
+  - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+  - toolchain
+
+tasks:
+  build:
+    attributes:
+      run-on-pr-type: all
+      resource-monitor: true
+    needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
+    run-on-tasks-for: [github-pull-request, github-release, cron]
+    description: Build and test (Swift)
+    scopes:
+      - project:releng:services/tooltool/api/download/internal
+    worker-type: b-osx
+    worker:
+      max-run-time: 1800
+      artifacts:
+        - name: "public/build/swift-components.tar.xz"
+          path: "checkouts/vcs/build/swift-components.tar.xz"
+          type: "file"
+        - name: "public/build/MozillaRustComponents.xcframework.zip"
+          path: "checkouts/vcs/build/MozillaRustComponents.xcframework.zip"
+          type: "file"
+        - name: "public/build/FocusRustComponents.xcframework.zip"
+          path: "checkouts/vcs/build/FocusRustComponents.xcframework.zip"
+          type: "file"
+        # TODO: re-enable once we get tests working
+        # - name: "public/build/raw_xcodetest.log"
+        #   path: "checkouts/vcs/logs/raw_xcodetest.log"
+        #   type: "file"
+    run:
+      pre-commands:
+        - ["taskcluster/scripts/toolchain/build-rust-toolchain-macosx.sh"]
+        - ["taskcluster/scripts/toolchain/libs-ios.sh"]
+      commands:
+        - ["taskcluster/scripts/build-and-test-swift.sh"]
+        - [ "cd", "build/" ]
+        - [ "tar", "acf", "swift-components.tar.xz", "swift-components" ]
+      using: run-commands
+      run-task-command: ["/usr/local/bin/python3", "run-task"]
+      use-caches: true
+    routes:
+      - index.project.application-services.v2.swift.{appservices_version}

--- a/taskcluster/ci/toolchain/resourcemonitor.yml
+++ b/taskcluster/ci/toolchain/resourcemonitor.yml
@@ -16,3 +16,8 @@ linux64-resource-monitor:
     description: "linux64 resourcemonitor toolchain build"
     run:
         arguments: ['linux64']
+
+macosx64-resource-monitor:
+    description: "macos64 resourcemonitor toolchain build"
+    run:
+        arguments: ['macos64']

--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -1,0 +1,162 @@
+#!/usr/bin/python3
+
+from collections import namedtuple
+import argparse
+import shutil
+import subprocess
+import pathlib
+import os
+
+# Repository root dir
+ROOT_DIR = pathlib.Path(__file__).parent.parent.parent
+# List of udl_paths to generate bindings for
+BINDINGS_UDL_PATHS = [
+    "components/autofill/src/autofill.udl",
+    "components/crashtest/src/crashtest.udl",
+    "components/fxa-client/src/fxa_client.udl",
+    "components/logins/src/logins.udl",
+    "components/nimbus/src/nimbus.udl",
+    "components/places/src/places.udl",
+    "components/push/src/push.udl",
+    "components/support/error/src/errorsupport.udl",
+    "components/sync_manager/src/syncmanager.udl",
+]
+# List of globs to copy the sources from
+SOURCE_TO_COPY = [
+    "components/nimbus/ios/Nimbus",
+    "components/fxa-client/ios/FxAClient",
+    "components/logins/ios/Logins",
+    "components/tabs/ios/Tabs",
+    "components/places/ios/Places",
+    "components/sync15/ios/*",
+    "components/rc_log/ios/*",
+    "components/viaduct/ios/*",
+]
+
+def main():
+    args = parse_args()
+    ensure_dir(args.out_dir)
+    run_tests(args)
+    xcframework_build(args, "MozillaRustComponents.xcframework.zip")
+    xcframework_build(args, "FocusRustComponents.xcframework.zip")
+    generate_nimbus_metrics(args)
+    generate_uniffi_bindings(args)
+    copy_source_dirs(args)
+    log("build complete")
+
+def parse_args():
+    parser = argparse.ArgumentParser(prog='build-and-test-swift.py')
+    parser.add_argument('out_dir', type=pathlib.Path)
+    parser.add_argument('xcframework_dir', type=pathlib.Path)
+    parser.add_argument('glean_work_dir', type=pathlib.Path)
+    return parser.parse_args()
+
+def run_tests(args):
+    # FIXME: this is currently failing with `Package.resolved file is corrupted or malformed; fix or
+    # delete the file to continue`
+    # subprocess.check_call([
+    #     "automation/tests.py", "ios-tests"
+    # ])
+    pass
+
+XCFrameworkBuildInfo = namedtuple("XCFrameworkBuildInfo", "filename out_path build_command")
+XCFRAMEWORK_BUILDS = [
+    XCFrameworkBuildInfo(
+        'MozillaRustComponents.xcframework.zip',
+        'megazords/ios-rust/MozillaRustComponents.xcframework.zip',
+        [
+            'megazords/ios-rust/build-xcframework.sh',
+            '--build-profile',
+            'release',
+        ],
+    ),
+    XCFrameworkBuildInfo(
+        'FocusRustComponents.xcframework.zip',
+        'megazords/ios-rust/focus/FocusRustComponents.xcframework.zip',
+        [
+            'megazords/ios-rust/build-xcframework.sh',
+            '--build-profile',
+            'release',
+            '--focus',
+        ],
+    ),
+]
+
+def xcframework_build(args, filename):
+    for build_info in XCFRAMEWORK_BUILDS:
+        if build_info.filename == filename:
+            break
+    else:
+        raise LookupError(f"No XCFrameworkBuildInfo for {filename}")
+
+    # Build the XCFramework if it hasn't already been built (for example the `tests.py ios-tests`)
+    if not os.path.exists(build_info.out_path):
+        subprocess.check_call(build_info.build_command)
+
+    # Copy the XCFramework to our output directory
+    subprocess.check_call(['cp', '-a', build_info.out_path, args.xcframework_dir])
+
+"""Generate Glean metrics.
+
+Run this first, because it appears to delete any other .swift files in the output directory.
+"""
+def generate_nimbus_metrics(args):
+    # Make sure there's a python venv for glean to use
+    venv_dir = args.glean_work_dir / '.venv'
+    if not venv_dir.exists():
+        log("setting up Glean venv")
+        subprocess.check_call(['python3', '-m', 'venv', str(venv_dir)])
+
+    log("Running Glean for nimbus")
+    # sdk_generator wants to be run from inside Xcode, so we set some env vars to fake it out.
+    env = {
+        'SOURCE_ROOT': str(args.glean_work_dir),
+        'PROJECT': "MozillaAppServices",
+        'GLEAN_PYTHON': '/usr/bin/python3',
+        'LC_ALL': 'C.UTF-8',
+        'LANG': 'C.UTF-8',
+    }
+    glean_script = ROOT_DIR / "components/external/glean/glean-core/ios/sdk_generator.sh"
+    out_dir = args.out_dir / "glean-metrics"
+    metrics_yaml = ROOT_DIR / "components/nimbus/metrics.yaml"
+    ensure_dir(out_dir)
+    subprocess.check_call([
+        str(glean_script),
+        "-o", str(out_dir),
+        str(metrics_yaml)
+    ], env=env)
+
+def generate_uniffi_bindings(args):
+    out_dir = args.out_dir / 'generated-swift-sources'
+    ensure_dir(out_dir)
+
+    for udl_path in BINDINGS_UDL_PATHS:
+        log(f"generating sources for {udl_path}")
+        run_uniffi_bindgen(['generate', '-l', 'swift', '--no-format', '-o', out_dir, ROOT_DIR / udl_path])
+
+def run_uniffi_bindgen(bindgen_args):
+    all_args = [
+        'cargo', 'run', '-p', 'embedded-uniffi-bindgen',
+    ]
+    all_args.extend(bindgen_args)
+    subprocess.check_call(all_args, cwd=ROOT_DIR)
+
+def copy_source_dirs(args):
+    out_dir = args.out_dir / 'swift-sources'
+    ensure_dir(out_dir)
+
+    for source in SOURCE_TO_COPY:
+        log(f"copying {source}")
+        for path in ROOT_DIR.glob(source):
+            subprocess.check_call(['cp', '-r', path, out_dir])
+
+def ensure_dir(path):
+    if not path.exists():
+        os.makedirs(path)
+
+def log(message):
+    print()
+    print(f'* {message}', flush=True)
+
+if __name__ == '__main__':
+    main()

--- a/taskcluster/scripts/build-and-test-swift.sh
+++ b/taskcluster/scripts/build-and-test-swift.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -ex
+
+# This runs in front of `build-and-test-swift.py`  The only reason it exists is that it's easier to
+# setup the enviroment in a script.
+
+# shellcheck source=/dev/null
+source "$HOME/.cargo/env"
+export PATH="$HOME/bin:$HOME/Library/Python/3.7/bin:$PATH"
+taskcluster/scripts/build-and-test-swift.py build/swift-components build/ build/glean-workdir

--- a/taskcluster/scripts/build-nimbus-fml.py
+++ b/taskcluster/scripts/build-nimbus-fml.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+import argparse
+import subprocess
+import pathlib
+import os
+
+# Repository root dir
+ROOT_DIR = pathlib.Path(__file__).parent.parent.parent
+
+def main():
+    args = parse_args()
+    if not args.out_dir.exists():
+        os.makedirs(args.out_dir)
+    # TODO: implement this for real once we have access to a Mac worker on taskcluster
+    subprocess.check_call([
+        'curl', '-LsS',
+        '-o', str(args.out_dir / 'nimbus-fml.zip'),
+        'https://github.com/mozilla/application-services/releases/download/v97.2.0/nimbus-fml.zip',
+    ])
+    subprocess.check_call([
+        'curl', '-LsS',
+        '-o', str(args.out_dir / 'nimbus-fml.sha256'),
+        'https://github.com/mozilla/application-services/releases/download/v97.2.0/nimbus-fml.sha256',
+    ])
+
+def parse_args():
+    parser = argparse.ArgumentParser(prog='build-and-test-swift.py')
+    parser.add_argument('out_dir', type=pathlib.Path)
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    main()

--- a/taskcluster/scripts/generate-nightly-json.py
+++ b/taskcluster/scripts/generate-nightly-json.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+import argparse
+import json
+import os
+
+def main():
+    args = parse_args()
+    dump_json(args)
+
+def dump_json(args):
+    data = {
+        'version': args.version,
+        'channel': args.maven_channel,
+        'commit': os.environ['APPSERVICES_HEAD_REV'],
+    }
+    dir = os.path.dirname(args.path)
+    if not os.path.exists(dir):
+        os.makedirs(dir)
+    with open(args.path, "wt") as f:
+        json.dump(data, f)
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Publish information about the nightly build')
+    parser.add_argument('path')
+    parser.add_argument('--version', help='version string', required=True)
+    parser.add_argument('--maven-channel', help='channel the maven packages were uploaded to', required=True)
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    main()

--- a/taskcluster/scripts/toolchain/build-rust-toolchain-macosx.sh
+++ b/taskcluster/scripts/toolchain/build-rust-toolchain-macosx.sh
@@ -10,24 +10,23 @@
 
 set -ex
 
+# Clear out any existing Rust files
+rm -fr ~/.cargo ~/.rustup
 # Install rustup
-RUSTUP_PLATFORM='x86_64-unknown-linux-gnu'
-RUSTUP_VERSION='1.24.1'
-RUSTUP_SHA256='fb3a7425e3f10d51f0480ac3cdb3e725977955b2ba21c9bdac35309563b115e8'
+RUSTUP_PLATFORM=x86_64-apple-darwin
+RUSTUP_VERSION=1.24.1
+RUSTUP_SHA256=d53e8000c8663e1704a2071f7042be917bc90cbc89c11e11c5dfdcb35b84c00e
 curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"
-echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -
+echo "${RUSTUP_SHA256} *rustup-init" | shasum -a 256 -c -
 chmod +x rustup-init
-./rustup-init -y --no-modify-path --default-toolchain none
-
-# cd to the app-services directory, so that rustup will see our `rust-toolchain.toml` file
-cd "$VCS_PATH"
-# `rustup --version` causes the compilers and components from `rust-toolchain.toml` to be installed
-rustup --version
-# cross-compilation targets
-rustup target add x86_64-apple-darwin
-rustup target add x86_64-pc-windows-gnu
-
-# Tar everything into UPLOAD_DIR
-cd "$HOME"
-mkdir -p "$UPLOAD_DIR"
-tar -czf "$UPLOAD_DIR"/rust.tar.gz .rustup .cargo
+./rustup-init -y --no-modify-path
+rm rustup-init
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+# So long as this is executed after the checkout it will use the version specified in rust-toolchain.yaml
+rustup update
+# TODO: re-enable this once we split out the toolchain tasks from swift-build
+# # Tar everything into UPLOAD_DIR
+# cd "$HOME"
+# mkdir -p "$UPLOAD_DIR"
+# tar -czf "$UPLOAD_DIR"/rust.tar.gz .rustup .cargo

--- a/taskcluster/scripts/toolchain/copy-libs-dir.sh
+++ b/taskcluster/scripts/toolchain/copy-libs-dir.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -ex
+
+rsync -av "$(realpath "$MOZ_FETCHES_DIR"/libs)/" "$(realpath "$1")/"

--- a/taskcluster/scripts/toolchain/libs-ios.sh
+++ b/taskcluster/scripts/toolchain/libs-ios.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -ex
+
+# Clean out files from the previous run
+rm -fr ../gyp "$HOME/Library/Python/" "${HOME:?}/bin"
+
+# Add cargo/rust to PATH
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
+
+# Install ninja, gyp, and xcpretty
+NINJA_DOWNLOAD_URL=https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip
+NINJA_SHA256=482ecb23c59ae3d4f158029112de172dd96bb0e97549c4b1ca32d8fad11f873e
+curl -OL "$NINJA_DOWNLOAD_URL"
+echo "${NINJA_SHA256}  ninja-mac.zip" | shasum -a 256 -c -
+unzip ninja-mac.zip -d "$HOME/bin"
+rm ninja-mac.zip
+gem install --user-install --bindir "$HOME"/bin xcpretty
+pushd ..
+git clone https://chromium.googlesource.com/external/gyp.git
+pip3 install -v --user ./gyp six
+popd
+export PATH="$HOME/bin:$HOME/Library/Python/3.7/bin:$PATH"
+
+# Build the libs
+pushd libs
+./build-all.sh ios
+popd
+
+# TODO: re-enable this once we split out the toolchain tasks from swift-build
+# mkdir -p "$UPLOAD_DIR"
+# tar -czf "$UPLOAD_DIR"/ios.tar.gz libs/ios

--- a/taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh
+++ b/taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh
@@ -7,5 +7,5 @@ set -ex
 # By the time this script runs, `build-rust-toolchain.sh` has completed and all
 # the artifacts it's built have been downloaded and unpacked into the fetches
 # directory.  We just need to copy them out.
-rsync -a /builds/worker/fetches/.cargo /builds/worker/
-rsync -a /builds/worker/fetches/.rustup /builds/worker/
+rsync -a "${MOZ_FETCHES_DIR}"/.cargo "${HOME}"
+rsync -a "${MOZ_FETCHES_DIR}"/.rustup "${HOME}"

--- a/taskcluster/test/params/cron-nightly.yml
+++ b/taskcluster/test/params/cron-nightly.yml
@@ -1,6 +1,4 @@
 base_repository: https://github.com/mozilla/application-services
-branch-build:
-  firefox-android-branch: main
 build_date: 1651554220
 do_not_optimize: []
 existing_tasks: {}
@@ -20,6 +18,6 @@ project: application-services
 pushdate: 0
 pushlog_id: '0'
 repository_type: git
-target_tasks_method: default
+target_tasks_method: nightly
 tasks_for: cron
 nightly-build: true

--- a/taskcluster/test/params/nightly-from-pr.yml
+++ b/taskcluster/test/params/nightly-from-pr.yml
@@ -10,7 +10,7 @@ head_ref: main
 head_repository: https://github.com/mozilla/application-services
 head_rev: 5ad5931c2d91c9f00e9984131925c76136822ab5
 head_tag: ''
-level: '3'
+level: '1'
 moz_build_date: '20220503050340'
 optimize_target_tasks: true
 owner: cron@noreply.mozilla.org

--- a/tools/nimbus-gradle-plugin/settings.gradle
+++ b/tools/nimbus-gradle-plugin/settings.gradle
@@ -17,7 +17,10 @@ def buildconfig = yaml.load(new File(rootDir, '../../.buildconfig-android.yml').
 
 def calcVersion(buildconfig) {
     def local = gradle.rootProject.findProperty("local")
-    if (gradle.hasProperty("localProperties.branchBuild.application-services.version")) {
+
+    if (gradle.rootProject.hasProperty("nightlyVersion")) {
+        return gradle.rootProject.nightlyVersion
+    } else if (gradle.hasProperty("localProperties.branchBuild.application-services.version")) {
         def branchBuildVersion = gradle.getProperty("localProperties.branchBuild.application-services.version")
         logger.lifecycle("Branch build: forcing all versions to ${branchBuildVersion}")
         return branchBuildVersion


### PR DESCRIPTION
**Merge note:** Most of these changes are approved, but we can't merge it because of blockers from other repos.  In fact, almost all of these PRs need to be approved and merged at the same time.  We don't want to update the firefox-android/firefox-ios code to expect the new versioning system without also merging this PR.  Here's a summary of the work:

- [x] Add taskcluster task to build the swift code (this is the one remaining code task for this repo)
  - [x] blocked by **relops 1821390**  [Add darwin worker for application-services](https://bugzilla.mozilla.org/show_bug.cgi?id=1821390)
- [ ] **firefox-android 1823462** [New application-services release system](https://github.com/mozilla-mobile/firefox-android/pull/1325)
- [x] **relbot#105** [Work with the new application-services release process](https://github.com/mozilla-mobile/relbot/pull/105)
- [x] **rust-components-swift#98** [New app services release process](https://github.com/mozilla/rust-components-swift/pull/98)
- [x] **firefox-ios #13806:** [Refactor app-services update code](https://github.com/mozilla-mobile/firefox-ios/pull/13806)
---

- Update the version number to `112.0.a1`.  It now matches the firefox version as discussed in ADR-0006.
- Update the nightly build task to replace the last component of that version number with a timestamp.
- Place nightly builds in a different directory in the Maven repository, like how geckoview uses a different directory for the nightly channel.

I think this is how we're going to want to handle our nightlies going forward, but I would love feedback from releng/relman.

We're hoping to move to using ship-it for cutting releases at the end of the nightly cycle and uplifts.  Should we be using ship-it for nightlies as well, or can we just continue to use the taskcluster cron task?  Is there anything that should change to be more compatible with ship-it?

Is there any way to test running the nightly taskcluster task from this branch?
 
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[ff-android: firefox-android-branch-name]` and/or `[fenix: fenix-branch-name]` to the PR title.
