### PR TITLE
Fix Nimbus gradle plugin issues [firefox-android: gabrielluong:1818826]

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -27,5 +27,8 @@ Use the template below to make assigning a version number during the release cut
 
 ## Nimbus ⛅️🔬🔭
 
+### 🦊 What's Changed 🦊
+  - Fix Nimbus gradle plugin source file and task dependency issues ([#5421](https://github.com/mozilla/application-services/pull/5421))
+
 ### ✨ What's New ✨
-  - Added new testing tooling `HardcodeNimbusFeatures` to aid UI and integration tests ([#5393](https://github.com/mozilla/application-services/pull/5393).
+  - Added new testing tooling `HardcodeNimbusFeatures` to aid UI and integration tests ([#5393](https://github.com/mozilla/application-services/pull/5393))

--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -363,7 +363,7 @@ class NimbusPlugin implements Plugin<Project> {
             println args
         }
 
-        if(variant.hasProperty('registerJavaGeneratingTask')) {
+        if(variant.metaClass.respondsTo(variant, 'registerJavaGeneratingTask', Task, File)) {
             variant.registerJavaGeneratingTask(generateTask, new File(outputDir))
         }
 
@@ -371,9 +371,11 @@ class NimbusPlugin implements Plugin<Project> {
         if (generateSourcesTask != null) {
             generateSourcesTask.dependsOn(generateTask)
         } else {
-            project.tasks.findAll().stream().filter({ task ->
-                task.name.startsWith("compile")
-            }).forEach({ task ->
+            project.tasks.findAll().stream()
+            .filter({ task ->
+                return task.name.contains("compile")
+            })
+            .forEach({ task ->
                 task.dependsOn(generateTask)
             })
         }


### PR DESCRIPTION
This resolves two issues:
1. The Nimbus gradle plugin will now include the generated files in the sources by default
2. It will now ensure all compilation tasks depend on the nimbus task

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
