### PR TITLE
Remove obsolete tooling-nimbus-gradle AC project

### DIFF
--- a/taskcluster/android-components-projects.json
+++ b/taskcluster/android-components-projects.json
@@ -112,6 +112,5 @@
     "samples-sync",
     "samples-sync-logins",
     "samples-toolbar",
-    "samples-dataprotect",
-    "tooling-nimbus-gradle"
+    "samples-dataprotect"
 ]


### PR DESCRIPTION
This was removed in https://github.com/mozilla-mobile/firefox-android/pull/1041