### PR TITLE
Clean gradle autopublish

### DIFF
--- a/tools/clean-gradle-autopublish.py
+++ b/tools/clean-gradle-autopublish.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python3
+
+from configparser import RawConfigParser
+from pathlib import Path
+import io
+import shutil
+import subprocess
+import sys
+
+def main(args):
+    if len(args) != 1:
+        print("usage clean-gradle-autopublish.py [path-to-firefox-android]")
+        sys.exit(1)
+    ff_android_path = Path(args[0])
+    if not path_looks_like_firefox_android(ff_android_path):
+        print(f"{ff_android_path} does not look like a firefox-android repo")
+        sys.exit(1)
+    appservices_path = Path(__file__).parent.parent
+    check_rust_targets(appservices_path)
+    # Delete lastAutoPublishContentsHash to force gradle to rebuild/republish our maven packages
+    delete_if_exists(appservices_path / '.lastAutoPublishContentsHash')
+    # Delete the packages in our local maven repository as well
+    delete_if_exists(Path.home().joinpath('.m2', 'repository', 'org', 'mozilla', 'appservices'))
+    subprocess.run(["cargo", "clean"], cwd=appservices_path)
+    subprocess.run(["./gradlew", "clean"], cwd=appservices_path)
+    subprocess.run(["./gradlew", "clean"], cwd=ff_android_path / 'android-components')
+    subprocess.run(["./gradlew", "clean"], cwd=ff_android_path / 'fenix')
+
+def path_looks_like_firefox_android(path):
+    return path.joinpath('android-components').exists() and path.joinpath("fenix").exists()
+
+def check_rust_targets(appservices_path):
+    # config parser expects a header, but properties files don't have them.  So add one manually:
+    f = io.StringIO()
+    f.write("[main]\n")
+    f.write((appservices_path / 'local.properties').open().read())
+    f.seek(0)
+    config = RawConfigParser()
+    config.read_file(f)
+    rust_targets = config['main'].get('rust.targets')
+    if rust_targets is not None:
+        if "linux-x86-64" not in rust_targets.split(','):
+            print("rust.targets set in local.properties, but linux-x86-64 is not included.")
+            print("This will cause builds to fail, please fix this before running clean-gradle-autopublish.py")
+            sys.exit(1)
+        print(f"rust targets set to: {rust_targets}")
+        print("Note: this means that only APKs for those targets will work")
+        input("\nPress enter to continue")
+
+def delete_if_exists(path):
+    if path.exists():
+        if path.is_file():
+            path.unlink()
+        else:
+            shutil.rmtree(path)
+
+if __name__ == '__main__':
+    main(sys.argv[1:])


### PR DESCRIPTION
While investigating the ndk-25 issue, I had to frequently clean things
while going back and forth between ndk-25 and ndk-21.  It was very easy
to forgot a step and have to rebuild fenix an extra time.

I believe this script should fully clean things out and can help with
linker errors from stale builds.  It's somewhat of a half-measure -- a
real solution would fix the gradle code to properly detect changes.
However, this is an improvement over the status quo at least.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
