### PR TITLE
Add recordPastEvent to EventStore for iOS and Android.

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,9 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## Nimbus ⛅️🔬🔭
+
+### ✨ What's New ✨
+
+  - Added `recordPastEvent` for iOS and Android for testing of event store triggers. ([#5431](https://github.com/mozilla/application-services/pull/5431))

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -358,12 +358,15 @@ open class Nimbus(
         recordExposure(featureId)
     }
 
-    @WorkerThread
-    override fun recordEvent(eventId: String) {
+    @AnyThread
+    override fun recordEvent(count: Long, eventId: String) {
         dbScope.launch {
-            nimbusClient.recordEvent(eventId)
+            nimbusClient.recordEvent(count, eventId)
         }
     }
+
+    override fun recordPastEvent(count: Long, eventId: String, secondsAgo: Long) =
+        nimbusClient.recordPastEvent(count, eventId, secondsAgo)
 
     @WorkerThread
     override fun clearEvents() {

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -71,11 +71,23 @@ extension Nimbus: NimbusQueues {
     }
 }
 
-extension Nimbus: NimbusEvents {
+extension Nimbus: NimbusEventStore {
+    public var events: NimbusEventStore {
+        self
+    }
+
     public func recordEvent(_ eventId: String) {
+        recordEvent(1, eventId)
+    }
+
+    public func recordEvent(_ count: Int, _ eventId: String) {
         _ = catchAll(dbQueue) { _ in
-            try self.nimbusClient.recordEvent(eventId: eventId)
+            try self.nimbusClient.recordEvent(count: Int64(count), eventId: eventId)
         }
+    }
+
+    public func recordPastEvent(_ count: Int, _ eventId: String, _ timeAgo: TimeInterval) throws {
+        try nimbusClient.recordPastEvent(count: Int64(count), eventId: eventId, secondsAgo: Int64(timeAgo))
     }
 
     public func clearEvents() {
@@ -438,7 +450,11 @@ public extension NimbusDisabled {
 
     func recordExposureEvent(featureId _: String) {}
 
+    func recordEvent(_: Int, _: String) {}
+
     func recordEvent(_: String) {}
+
+    func recordPastEvent(_: Int, _: String, _: TimeInterval) {}
 
     func clearEvents() {}
 

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -371,7 +371,7 @@ fn query_event_store(
     let (event, interval, num_buckets, starting_bucket) = query_type.validate_arguments(args)?;
 
     Ok(json!(event_store.lock().unwrap().query(
-        event,
+        &event,
         interval,
         num_buckets,
         starting_bucket,

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -576,9 +576,20 @@ impl NimbusClient {
     ///
     /// This function is used to record and persist data used for the behavioral
     /// targeting such as "core-active" user targeting.
-    pub fn record_event(&self, event_id: String) -> Result<()> {
+    pub fn record_event(&self, count: i64, event_id: String) -> Result<()> {
         let mut event_store = self.event_store.lock().unwrap();
-        event_store.record_event(event_id, None)?;
+        event_store.record_event(count as u64, &event_id, None)?;
+        event_store.persist_data(self.db()?)?;
+        Ok(())
+    }
+
+    /// Records an event for the purposes of behavioral targeting.
+    ///
+    /// This differs from the `record_event` method in that the event is recorded as if it were
+    /// recorded `seconds_ago` in the past. This makes it very useful for testing.
+    pub fn record_past_event(&self, count: i64, event_id: String, seconds_ago: i64) -> Result<()> {
+        let mut event_store = self.event_store.lock().unwrap();
+        event_store.record_past_event(count as u64, &event_id, None, chrono::Duration::seconds(seconds_ago))?;
         event_store.persist_data(self.db()?)?;
         Ok(())
     }

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -589,7 +589,12 @@ impl NimbusClient {
     /// recorded `seconds_ago` in the past. This makes it very useful for testing.
     pub fn record_past_event(&self, count: i64, event_id: String, seconds_ago: i64) -> Result<()> {
         let mut event_store = self.event_store.lock().unwrap();
-        event_store.record_past_event(count as u64, &event_id, None, chrono::Duration::seconds(seconds_ago))?;
+        event_store.record_past_event(
+            count as u64,
+            &event_id,
+            None,
+            chrono::Duration::seconds(seconds_ago),
+        )?;
         event_store.persist_data(self.db()?)?;
         Ok(())
     }

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -205,7 +205,10 @@ interface NimbusClient {
     // This function is used to record and persist data used for the behavioral
     // targeting such as "core-active" user targeting.
     [Throws=NimbusError]
-    void record_event(string event_id);
+    void record_event(optional i64 count = 1, string event_id);
+
+    [Throws=NimbusError]
+    void record_past_event(optional i64 count = 1, string event_id, i64 seconds_ago);
 
     [Throws=NimbusError]
     void clear_events();

--- a/components/nimbus/src/tests/test_behavior.rs
+++ b/components/nimbus/src/tests/test_behavior.rs
@@ -832,7 +832,7 @@ mod event_store_tests {
         let tmp_dir = tempfile::tempdir()?;
         let db = Database::new(&tmp_dir)?;
 
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(2)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(2)))?;
         store.persist_data(&db)?;
 
         // Rebuild the EventStore from persisted data in order to test persistence
@@ -946,7 +946,7 @@ mod event_store_tests {
     #[test]
     fn record_event_should_create_events_where_applicable() -> Result<()> {
         let mut store = EventStore::new();
-        store.record_event("test".to_string(), None)?;
+        store.record_event(1, "test", None)?;
 
         assert_eq!(
             store
@@ -1041,13 +1041,13 @@ mod event_store_tests {
             ("event-2".to_string(), counter2),
         ]);
 
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(2)))?;
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(3)))?;
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(3)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(2)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(3)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(3)))?;
 
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 7,
                 0,
@@ -1057,7 +1057,7 @@ mod event_store_tests {
         );
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 0,
                 0,
@@ -1067,7 +1067,7 @@ mod event_store_tests {
         );
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 7,
                 7,
@@ -1096,13 +1096,13 @@ mod event_store_tests {
             ("event-2".to_string(), counter2),
         ]);
 
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(2)))?;
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(3)))?;
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(3)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(2)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(3)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(3)))?;
 
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 7,
                 0,
@@ -1112,7 +1112,7 @@ mod event_store_tests {
         );
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 7,
                 2,
@@ -1141,13 +1141,13 @@ mod event_store_tests {
             ("event-2".to_string(), counter2),
         ]);
 
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(2)))?;
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(3)))?;
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(3)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(2)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(3)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(3)))?;
 
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 7,
                 0,
@@ -1157,7 +1157,7 @@ mod event_store_tests {
         );
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 2,
                 0,
@@ -1186,13 +1186,13 @@ mod event_store_tests {
             ("event-2".to_string(), counter2),
         ]);
 
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(2)))?;
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(3)))?;
-        store.record_event("event-1".to_string(), Some(Utc::now() + Duration::days(3)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(2)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(3)))?;
+        store.record_event(1, "event-1", Some(Utc::now() + Duration::days(3)))?;
 
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 7,
                 0,
@@ -1202,7 +1202,7 @@ mod event_store_tests {
         );
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 7,
                 2,
@@ -1230,7 +1230,7 @@ mod event_store_tests {
 
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
                 usize::MAX,
                 0,
@@ -1240,9 +1240,9 @@ mod event_store_tests {
         );
         assert_eq!(
             store.query(
-                "event-1".to_string(),
+                "event-1",
                 Interval::Days,
-                usize::MAX,
+                365,
                 21,
                 EventQueryType::LastSeen
             )?,

--- a/components/nimbus/src/tests/test_lib.rs
+++ b/components/nimbus/src/tests/test_lib.rs
@@ -889,7 +889,7 @@ fn event_store_on_targeting_attributes_is_updated_after_an_event_is_recorded() -
     let active_experiments = client.get_active_experiments()?;
     assert_eq!(active_experiments.len(), 1);
 
-    client.record_event("app.foregrounded".to_string())?;
+    client.record_event(1, "app.foregrounded".to_string())?;
 
     client.set_global_user_participation(true)?;
 

--- a/components/nimbus/tests/test_message_helpers.rs
+++ b/components/nimbus/tests/test_message_helpers.rs
@@ -24,7 +24,7 @@ mod message_tests {
         let nimbus = common::new_test_client("jexl_test")?;
         nimbus.initialize()?;
 
-        nimbus.record_event("test".to_string())?;
+        nimbus.record_event(1, "test".to_string())?;
 
         let helper = nimbus.create_targeting_helper(None)?;
 


### PR DESCRIPTION
[EXP-2948](https://mozilla-hub.atlassian.net/browse/EXP-2948).

This PR implements `record_past_event` for the event store.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
