### PR TITLE
Remove the schemaVersion check

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -24,3 +24,7 @@ Use the template below to make assigning a version number during the release cut
 ### ✨ What's New ✨
 
   - Added `recordPastEvent` for iOS and Android for testing of event store triggers. ([#5431](https://github.com/mozilla/application-services/pull/5431))
+
+### 🦊 What's Changed 🦊
+
+  - Removed the check for major `schemaVersion` in Experiment recipes. ([#5433](https://github.com/mozilla/application-services/pull/5433))

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -623,12 +623,6 @@ pub struct EnrolledExperiment {
     pub enrollment_id: String,
 }
 
-/// This is the currently supported major schema version.
-pub const SCHEMA_VERSION: u32 = 1;
-// XXX: In the future it would be nice if this lived in its own versioned crate so that
-// the schema could be decoupled from the sdk so that it can be iterated on while the
-// sdk depends on a particular version of the schema through the cargo.toml.
-
 // ⚠️ Attention : Changes to this type should be accompanied by a new test  ⚠️
 // ⚠️ in `test_lib_bw_compat.rs`, and may require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq, Eq)]

--- a/components/nimbus/src/tests/client/test_http_client.rs
+++ b/components/nimbus/src/tests/client/test_http_client.rs
@@ -3,9 +3,7 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::parse_experiments;
-use crate::{
-    Branch, BucketConfig, Experiment, FeatureConfig, NimbusError, RandomizationUnit, SCHEMA_VERSION,
-};
+use crate::{Branch, BucketConfig, Experiment, FeatureConfig, NimbusError, RandomizationUnit};
 
 #[test]
 fn test_fetch_experiments_from_schema() {
@@ -14,12 +12,12 @@ fn test_fetch_experiments_from_schema() {
     // should parse correctly.
     let result = parse_experiments(&response_body()).unwrap();
 
-    assert_eq!(result.len(), 1);
+    assert_eq!(result.len(), 2);
     let exp = &result[0];
     assert_eq!(
         exp.clone(),
         Experiment {
-            schema_version: format!("{}.0.0", SCHEMA_VERSION),
+            schema_version: "1.0.0".to_string(),
             slug: "mobile-a-a-example".to_string(),
             app_name: Some("reference-browser".to_string()),
             channel: Some("nightly".to_string()),
@@ -64,7 +62,7 @@ fn test_fetch_experiments_from_schema() {
 #[test]
 fn test_malformed_payload() {
     let payload = r#"
-        {{ "datar" : [} ]]
+        { "datar" : [} ]]
     "#;
 
     let result = parse_experiments(payload).unwrap_err();
@@ -74,24 +72,22 @@ fn test_malformed_payload() {
 // This response body includes a matching schema version, a non-matching schema version,
 // and a malformed experiment.
 fn response_body() -> String {
-    format!(
-        r#"
-    {{ "data": [
-        {{
-            "schemaVersion": "{current_version}.0.0",
+    r#"{ "data": [
+        {
+            "schemaVersion": "1.0.0",
             "slug": "mobile-a-a-example",
             "appName": "reference-browser",
             "channel": "nightly",
             "userFacingName": "Mobile A/A Example",
             "userFacingDescription": "An A/A Test to validate the Rust SDK",
             "isEnrollmentPaused": false,
-            "bucketConfig": {{
+            "bucketConfig": {
                 "randomizationUnit": "nimbus_id",
                 "namespace": "mobile-a-a-example",
                 "start": 0,
                 "count": 5000,
                 "total": 10000
-            }},
+            },
             "startDate": null,
             "endDate": null,
             "proposedEnrollment": 7,
@@ -99,39 +95,39 @@ fn response_body() -> String {
             "probeSets": [],
             "featureIds": ["first_switch"],
             "branches": [
-                {{
+                {
                 "slug": "control",
                 "ratio": 1,
-                "feature": {{
+                "feature": {
                     "featureId": "first_switch",
                     "enabled": false
-                    }}
-                }},
-                {{
+                    }
+                },
+                {
                 "slug": "treatment-variation-b",
                 "ratio": 1,
-                "feature": {{
+                "feature": {
                     "featureId": "first_switch",
                     "enabled": true
-                    }}
-                }}
+                    }
+                }
             ]
-        }},
-        {{
-            "schemaVersion": "{newer_version}.0.0",
+        },
+        {
+            "schemaVersion": "2.0.0",
             "slug": "mobile-a-a-example",
             "appName": "reference-browser",
             "channel": "nightly",
             "userFacingName": "Mobile A/A Example",
             "userFacingDescription": "An A/A Test to validate the Rust SDK",
             "isEnrollmentPaused": false,
-            "bucketConfig": {{
+            "bucketConfig": {
                 "randomizationUnit": "nimbus_id",
                 "namespace": "mobile-a-a-example",
                 "start": 0,
                 "count": 5000,
                 "total": 10000
-            }},
+            },
             "startDate": null,
             "endDate": null,
             "proposedEnrollment": 7,
@@ -139,25 +135,23 @@ fn response_body() -> String {
             "probeSets": [],
             "featureIds": ["some_switch"],
             "branches": [
-                {{
+                {
                 "slug": "control",
                 "ratio": 1
-                }},
-                {{
+                },
+                {
                 "slug": "treatment-variation-b",
                 "ratio": 1
-                }}
+                }
             ]
-        }},
-        {{
+        },
+        {
             "slug": "schema-version-missing",
             "appName": "reference-browser",
             "userFacingName": "Schema Version Missing",
             "userFacingDescription": "This should be completely ignored",
             "isEnrollmentPaused": false
-        }}
-    ]}}"#,
-        current_version = SCHEMA_VERSION,
-        newer_version = SCHEMA_VERSION + 1
-    )
+        }
+    ]}"#
+    .to_string()
 }


### PR DESCRIPTION
Fixes [EXP-3273](https://mozilla-hub.atlassian.net/browse/EXP-3273).

Removes the schemaVersion check for future versions of the SDK.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
