### PR TITLE
Update rust version to 1.68

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,12 +295,7 @@ jobs:
       - setup-rust-min-version
       # tests.py doesn't support skipping tests, and we need to skip the systests on this rust version.
       # It's not in the default workspace members, so just `cargo test` is OK.
-      #
-      # Note "-j" here and below - we saw OOM errors which this tries to workaround and is
-      # hopefully a cheaper workaround than an "resource_class: xlarge".
-      # Probably https://github.com/rust-lang/rust/issues/97549 which is a 1.61 issue.
-      # We should revert this once we move past 1.61
-      - run: RUST_LOG=trace cargo test -j2
+      - run: RUST_LOG=trace cargo test
       - save-sccache-cache
   # These run periodically (driven by cron).
   Rust tests - beta:

--- a/components/nimbus/src/dbcache.rs
+++ b/components/nimbus/src/dbcache.rs
@@ -148,7 +148,6 @@ impl DatabaseCache {
         self.get_data(|data| {
             data.experiments_by_slug
                 .values()
-                .into_iter()
                 .map(|e| e.to_owned())
                 .collect::<Vec<EnrolledExperiment>>()
         })

--- a/components/places/src/bookmark_sync/engine.rs
+++ b/components/places/src/bookmark_sync/engine.rs
@@ -132,11 +132,11 @@ fn db_has_changes(db: &PlacesDb) -> Result<bool> {
 /// Conceptually, we examine the merge state of each item, and either leave the
 /// item unchanged, upload the local side, apply the remote side, or apply and
 /// then reupload the remote side with a new structure.
-fn update_local_items_in_places<'t>(
+fn update_local_items_in_places(
     db: &PlacesDb,
     scope: &SqlInterruptScope,
     now: Timestamp,
-    ops: &CompletionOps<'t>,
+    ops: &CompletionOps<'_>,
 ) -> Result<()> {
     // Build a table of new and updated items.
     log::debug!("Staging apply remote item ops");

--- a/components/places/src/bookmark_sync/tests/payload_evolution.rs
+++ b/components/places/src/bookmark_sync/tests/payload_evolution.rs
@@ -155,7 +155,6 @@ impl RoundtripTest {
             .collect();
         let mut correct_outgoing_keys = correct_outgoing_unknown_fields
             .keys()
-            .into_iter()
             .cloned()
             .collect::<Vec<_>>();
         // For each outgoing item, check that the unknown fields match what we expect

--- a/components/places/src/bookmark_sync/tests/synced_item.rs
+++ b/components/places/src/bookmark_sync/tests/synced_item.rs
@@ -30,6 +30,9 @@ pub enum SyncedBookmarkValue<T> {
     Specified(T),
 }
 
+// 1.65 gets upset if we derive default here due to the <T>
+// We should move to a derived default once the MSR is 1.68+
+#[allow(clippy::derivable_impls)]
 impl<T> Default for SyncedBookmarkValue<T> {
     fn default() -> Self {
         SyncedBookmarkValue::Unspecified

--- a/components/places/src/match_impl.rs
+++ b/components/places/src/match_impl.rs
@@ -445,7 +445,7 @@ mod test {
         for c in 0u8..=255u8 {
             assert_eq!(
                 is_ascii_lower_alpha(c),
-                (b'a'..=b'z').contains(&c),
+                c.is_ascii_lowercase(),
                 "is_lower_ascii_alpha is wrong for {}",
                 c
             );

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -457,8 +457,9 @@ fn delete_bookmark_in_tx(db: &PlacesDb, guid: &SyncGuid) -> Result<bool> {
 /// the tree.
 
 // Used to specify how the location of the item in the tree should be updated.
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub enum UpdateTreeLocation {
+    #[default]
     None, // no change
     Position {
         pos: BookmarkPosition,
@@ -467,12 +468,6 @@ pub enum UpdateTreeLocation {
         guid: SyncGuid,
         pos: BookmarkPosition,
     }, // new parent
-}
-
-impl Default for UpdateTreeLocation {
-    fn default() -> Self {
-        UpdateTreeLocation::None
-    }
 }
 
 /// Structures which can be used to update a bookmark, folder or separator.

--- a/components/places/src/storage/history/actions.rs
+++ b/components/places/src/storage/history/actions.rs
@@ -179,7 +179,6 @@ mod tests {
             .unwrap()
             .query_map(params, |row| row.get(0))
             .unwrap()
-            .into_iter()
             .collect::<rusqlite::Result<Vec<T>>>()
             .unwrap()
     }
@@ -193,7 +192,6 @@ mod tests {
             .unwrap()
             .query_map(params, |row| Ok((row.get(0)?, row.get(1)?)))
             .unwrap()
-            .into_iter()
             .collect::<rusqlite::Result<Vec<(T, V)>>>()
             .unwrap()
     }

--- a/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
@@ -43,7 +43,6 @@ impl TryFrom<FeatureManifest> for ExperimenterManifest {
     fn try_from(fm: FeatureManifest) -> Result<Self> {
         fm.all_imports
             .values()
-            .into_iter()
             .chain(vec![&fm])
             .flat_map(|fm| {
                 fm.feature_defs

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
@@ -38,7 +38,6 @@ impl<'a> FeatureManifestDeclaration<'a> {
         let fm = self.fm;
 
         fm.iter_feature_defs()
-            .into_iter()
             .map(|inner| {
                 Box::new(feature::FeatureCodeDeclaration::new(fm, inner))
                     as Box<dyn CodeDeclaration>
@@ -46,7 +45,7 @@ impl<'a> FeatureManifestDeclaration<'a> {
             .chain(fm.iter_enum_defs().map(|inner| {
                 Box::new(enum_::EnumCodeDeclaration::new(fm, inner)) as Box<dyn CodeDeclaration>
             }))
-            .chain(fm.iter_object_defs().into_iter().map(|inner| {
+            .chain(fm.iter_object_defs().map(|inner| {
                 Box::new(object::ObjectCodeDeclaration::new(fm, inner)) as Box<dyn CodeDeclaration>
             }))
             .chain(fm.iter_imported_files().into_iter().map(|inner| {

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
@@ -41,7 +41,6 @@ impl<'a> FeatureManifestDeclaration<'a> {
         let fm = self.fm;
 
         fm.iter_feature_defs()
-            .into_iter()
             .map(|inner| {
                 Box::new(feature::FeatureCodeDeclaration::new(fm, inner))
                     as Box<dyn CodeDeclaration>
@@ -49,7 +48,7 @@ impl<'a> FeatureManifestDeclaration<'a> {
             .chain(fm.iter_enum_defs().map(|inner| {
                 Box::new(enum_::EnumCodeDeclaration::new(fm, inner)) as Box<dyn CodeDeclaration>
             }))
-            .chain(fm.iter_object_defs().into_iter().map(|inner| {
+            .chain(fm.iter_object_defs().map(|inner| {
                 Box::new(object::ObjectCodeDeclaration::new(fm, inner)) as Box<dyn CodeDeclaration>
             }))
             .chain(fm.iter_imported_files().iter().map(|inner| {

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -229,7 +229,6 @@ impl ManifestFrontEnd {
                 merger.merge_feature_defaults(&mut def, &body.default)?;
                 Ok(def)
             })
-            .into_iter()
             .collect()
     }
 

--- a/components/sync15/src/device_type.rs
+++ b/components/sync15/src/device_type.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 ///   upload records with *this* device's type, not the type of other devices, and it's reasonable
 ///   to assume that this module knows about all valid device types for the device type it is
 ///   deployed on.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub enum DeviceType {
     Desktop,
     Mobile,
@@ -40,13 +40,8 @@ pub enum DeviceType {
     VR,
     TV,
     // See docstrings above re how Unknown is serialized and deserialized.
+    #[default]
     Unknown,
-}
-
-impl Default for DeviceType {
-    fn default() -> Self {
-        DeviceType::Unknown
-    }
 }
 
 impl<'de> Deserialize<'de> for DeviceType {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,7 +7,7 @@
 #   supported and used in CI.
 
 [toolchain]
-channel = "1.66.0"
+channel = "1.68.0"
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",


### PR DESCRIPTION
Now m-c is on 1.68 I thought I'd see that the fallout is. Fixes #5435, but blocked by #5436.

Most changes mage by clippy. 