### PR TITLE
Fixing branch build APK output [firefox-android: main]

### DIFF
--- a/taskcluster/app_services_taskgraph/transforms/branch_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/branch_build.py
@@ -194,7 +194,7 @@ def get_fenix_build_tasks(task):
     task['worker']['artifacts'] = [
         {
             'name': 'public/branch-build/app-x86-debug.apk',
-            'path': '/builds/worker/checkouts/vcs/fenix/app/build/outputs/apk/debug/app-x86-debug.apk',
+            'path': '/builds/worker/checkouts/vcs/firefox-android/fenix/app/build/outputs/apk/fenix/debug/app-fenix-x86-debug.apk',
             'type': 'file',
         }
     ]


### PR DESCRIPTION
After the firefox-android monorepo move, the Fenix APK is in a different place and wasn't being picked up by taskcluster.  This fixes things, which can be verified by going to the [branch-build-fenix-build task](https://firefox-ci-tc.services.mozilla.com/tasks/Qba3yqnLTNyjK7jOZOrjlA) and clicking on the APK under the artifacts heading.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
