### PR TITLE
Include path to errors when deserializing BSOs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3188,6 +3188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_test"
 version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3375,6 +3384,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_path_to_error",
  "sync-guid",
  "thiserror",
  "url",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -549,6 +549,7 @@ The following text applies to code linked from these dependencies:
 [serde](https://github.com/serde-rs/serde),
 [serde_derive](https://github.com/serde-rs/serde),
 [serde_json](https://github.com/serde-rs/json),
+[serde_path_to_error](https://github.com/dtolnay/path-to-error),
 [serde_urlencoded](https://github.com/nox/serde_urlencoded),
 [sha2](https://github.com/RustCrypto/hashes),
 [siphasher](https://github.com/jedisct1/rust-siphash),

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -57,6 +57,7 @@ rc_crypto = { path = "../support/rc_crypto", features = ["hawk"], optional = tru
 serde = { version = "1", features = ["derive"] }
 serde_derive = "1"
 serde_json = "1"
+serde_path_to_error = "0.1"
 sync-guid = { path = "../support/guid", features = ["random"] }
 thiserror = "1.0"
 url = { version = "2.1", optional = true } # mozilla-central can't yet take 2.2 (see bug 1734538)

--- a/components/sync15/src/bso/content.rs
+++ b/components/sync15/src/bso/content.rs
@@ -181,10 +181,10 @@ where
             }
         }
     };
-    match serde_json::from_value(json) {
+    match serde_path_to_error::deserialize(json) {
         Ok(v) => IncomingKind::Content(v),
         Err(e) => {
-            report_error!("invalid-incoming-content", "Invalid incoming T: {}", e);
+            report_error!("invalid-incoming-content", "{}: {}", e.path(), e.inner());
             IncomingKind::Malformed
         }
     }

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -506,6 +506,7 @@ The following text applies to code linked from these dependencies:
 [serde](https://github.com/serde-rs/serde),
 [serde_derive](https://github.com/serde-rs/serde),
 [serde_json](https://github.com/serde-rs/json),
+[serde_path_to_error](https://github.com/dtolnay/path-to-error),
 [sha2](https://github.com/RustCrypto/hashes),
 [siphasher](https://github.com/jedisct1/rust-siphash),
 [smallbitvec](https://github.com/servo/smallbitvec),

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -385,6 +385,10 @@ the details of which are reproduced below.
     <url>https://github.com/serde-rs/json/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: serde_path_to_error</name>
+    <url>https://github.com/dtolnay/path-to-error/blob/master/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>Apache License 2.0: sha2</name>
     <url>https://github.com/RustCrypto/hashes/blob/master/sha2/LICENSE-APACHE</url>
   </license>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -535,6 +535,7 @@ The following text applies to code linked from these dependencies:
 [serde](https://github.com/serde-rs/serde),
 [serde_derive](https://github.com/serde-rs/serde),
 [serde_json](https://github.com/serde-rs/json),
+[serde_path_to_error](https://github.com/dtolnay/path-to-error),
 [serde_urlencoded](https://github.com/nox/serde_urlencoded),
 [sha2](https://github.com/RustCrypto/hashes),
 [siphasher](https://github.com/jedisct1/rust-siphash),

--- a/megazords/ios-rust/focus/DEPENDENCIES.md
+++ b/megazords/ios-rust/focus/DEPENDENCIES.md
@@ -468,6 +468,7 @@ The following text applies to code linked from these dependencies:
 [httparse](https://github.com/seanmonstar/httparse),
 [httpdate](https://github.com/pyfisch/httpdate),
 [hyper-tls](https://github.com/hyperium/hyper-tls),
+[iana-time-zone](https://github.com/strawlab/iana-time-zone),
 [id-arena](https://github.com/fitzgen/id-arena),
 [idna](https://github.com/servo/rust-url/),
 [indexmap](https://github.com/bluss/indexmap),


### PR DESCRIPTION
Use the serde_path_to_error crate to get the path where an error occured when deserializing BSOs.  I hope this will help with things like `Invalid incoming T: invalid type: null, expected a string` (#5457).  I also think the error path is just generally useful.

I couldn't figure out a good test for this, but I did some manually checking and the paths seem correct to me.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
