### PR TITLE
gh-5465 -- Add extra checks for the places 15-16 migration

### DIFF
--- a/components/support/sql/src/conn_ext.rs
+++ b/components/support/sql/src/conn_ext.rs
@@ -76,6 +76,14 @@ pub trait ConnExt {
         Ok(res)
     }
 
+    /// Return true if a query returns any rows
+    fn exists<P: Params>(&self, sql: &str, params: P) -> SqlResult<bool> {
+        let conn = self.conn();
+        let mut stmt = conn.prepare(sql)?;
+        let exists = stmt.query(params)?.next()?.is_some();
+        Ok(exists)
+    }
+
     /// Execute a query that returns 0 or 1 result columns, returning None
     /// if there were no rows, or if the only result was NULL.
     fn try_query_one<T: FromSql, P: Params>(


### PR DESCRIPTION
The rollout of this migration was unfortunate, since the new code was before the DB schema version was bumped.  This means that:

- Some users installed a nightly which had the v16 schema, but had the schema version set to 15.
- dce0f34 fixed the code so the version was correctly listed as 16
- This caused those users to run the 15 -> 16 migration, which fails since the `unknownFields` column is already present.

Updated the 15 -> 16 migration to handle this case.  Refactored the places schema code a bit so follows the new pattern we're using for schema upgrades with `open_database()`.  The new pattern gives us more flexibility which simplifies the fix.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
