### PR TITLE
Include the type name when we get the `invalid-incoming-content` error

### DIFF
--- a/components/sync15/src/bso/content.rs
+++ b/components/sync15/src/bso/content.rs
@@ -184,7 +184,13 @@ where
     match serde_path_to_error::deserialize(json) {
         Ok(v) => IncomingKind::Content(v),
         Err(e) => {
-            report_error!("invalid-incoming-content", "{}: {}", e.path(), e.inner());
+            report_error!(
+                "invalid-incoming-content",
+                "{}.{}: {}",
+                std::any::type_name::<T>(),
+                e.path(),
+                e.inner()
+            );
             IncomingKind::Malformed
         }
     }


### PR DESCRIPTION
This can help disambiguate which record has the invalid incoming content.  (See PR 5473).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
