### PR TITLE
Add iOS sync telemetry reporting logic

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -37,3 +37,8 @@ Use the template below to make assigning a version number during the release cut
 
 - Added more testing tools for the `NimbusEventStore`, for iOS and Android ([#5477](https://github.com/mozilla/application-services/pull/5477))
   - `events.advanceEventTime(by: time)` lets you queue up a sequence of events to test JEXL queries.
+
+## Sync Manager
+
+### 🦊 What's Changed 🦊
+  - Added the sync telemetry reporting logic to replace the temp metrics in iOS. ([#5479](https://github.com/mozilla/application-services/pull/5479))

--- a/components/sync_manager/ios/SyncManager/SyncManagerComponent.swift
+++ b/components/sync_manager/ios/SyncManager/SyncManagerComponent.swift
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+open class SyncManagerComponent {
+    private var api: SyncManager
+
+    public init() {
+        api = SyncManager()
+    }
+
+    public func disconnect() {
+        api.disconnect()
+    }
+
+    public func sync(params: SyncParams) throws -> SyncResult {
+        return try api.sync(params: params)
+    }
+
+    public func getAvailableEngines() -> [String] {
+        return api.getAvailableEngines()
+    }
+
+    public static func reportSyncTelemetry(syncResult: SyncResult) throws {
+        if let json = syncResult.telemetryJson {
+            let telemetry = try RustSyncTelemetryPing.fromJSONString(jsonObjectText: json)
+            try processSyncTelemetry(syncTelemetry: telemetry)
+        }
+    }
+}

--- a/components/sync_manager/ios/SyncManager/SyncManagerTelemetry.swift
+++ b/components/sync_manager/ios/SyncManager/SyncManagerTelemetry.swift
@@ -1,0 +1,357 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import Glean
+
+enum SupportedEngines: String {
+    case History = "history"
+    case Bookmarks = "bookmarks"
+    case Logins = "passwords"
+    case CreditCards = "creditcards"
+    case Tabs = "tabs"
+}
+
+enum TelemetryReportingError: Error {
+    case InvalidEngine(message: String)
+    case UnsupportedEngine(message: String)
+}
+
+func processSyncTelemetry(syncTelemetry: RustSyncTelemetryPing,
+                          submitGlobalPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.sync.submit,
+                          submitHistoryPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.historySync.submit,
+                          submitBookmarksPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.bookmarksSync.submit,
+                          submitLoginsPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.loginsSync.submit,
+                          submitCreditCardsPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.creditcardsSync.submit,
+                          submitTabsPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.tabsSync.submit) throws
+{
+    for syncInfo in syncTelemetry.syncs {
+        _ = GleanMetrics.Sync.syncUuid.generateAndSet()
+
+        if let failureReason = syncInfo.failureReason {
+            recordFailureReason(reason: failureReason,
+                                failureReasonMetric: GleanMetrics.Sync.failureReason)
+        }
+
+        try syncInfo.engines.forEach { engineInfo in
+            switch engineInfo.name {
+            case SupportedEngines.Bookmarks.rawValue:
+                try individualBookmarksSync(hashedFxaUid: syncTelemetry.uid,
+                                            engineInfo: engineInfo)
+                submitBookmarksPing(nil)
+            case SupportedEngines.History.rawValue:
+                try individualHistorySync(hashedFxaUid: syncTelemetry.uid,
+                                          engineInfo: engineInfo)
+                submitHistoryPing(nil)
+            case SupportedEngines.Logins.rawValue:
+                try individualLoginsSync(hashedFxaUid: syncTelemetry.uid,
+                                         engineInfo: engineInfo)
+                submitLoginsPing(nil)
+            case SupportedEngines.CreditCards.rawValue:
+                try individualCreditCardsSync(hashedFxaUid: syncTelemetry.uid,
+                                              engineInfo: engineInfo)
+                submitCreditCardsPing(nil)
+            case SupportedEngines.Tabs.rawValue:
+                try individualTabsSync(hashedFxaUid: syncTelemetry.uid,
+                                       engineInfo: engineInfo)
+                submitTabsPing(nil)
+            default:
+                let message = "Ignoring telemetry for engine \(engineInfo.name)"
+                throw TelemetryReportingError.UnsupportedEngine(message: message)
+            }
+        }
+        submitGlobalPing(nil)
+    }
+}
+
+private func individualLoginsSync(hashedFxaUid: String, engineInfo: EngineInfo) throws {
+    guard engineInfo.name == SupportedEngines.Logins.rawValue else {
+        let message = "Expected 'passwords', got \(engineInfo.name)"
+        throw TelemetryReportingError.InvalidEngine(message: message)
+    }
+
+    let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
+    GleanMetrics.LoginsSync.uid.set(base.uid)
+    GleanMetrics.LoginsSync.startedAt.set(base.startedAt)
+    GleanMetrics.LoginsSync.finishedAt.set(base.finishedAt)
+
+    if base.applied > 0 {
+        GleanMetrics.LoginsSync.incoming["applied"].add(base.applied)
+    }
+
+    if base.failedToApply > 0 {
+        GleanMetrics.LoginsSync.incoming["failed_to_apply"].add(base.failedToApply)
+    }
+
+    if base.reconciled > 0 {
+        GleanMetrics.LoginsSync.incoming["reconciled"].add(base.reconciled)
+    }
+
+    if base.uploaded > 0 {
+        GleanMetrics.LoginsSync.outgoing["uploaded"].add(base.uploaded)
+    }
+
+    if base.failedToUpload > 0 {
+        GleanMetrics.LoginsSync.outgoing["failed_to_upload"].add(base.failedToUpload)
+    }
+
+    if base.outgoingBatches > 0 {
+        GleanMetrics.LoginsSync.outgoingBatches.add(base.outgoingBatches)
+    }
+
+    if let reason = base.failureReason {
+        recordFailureReason(reason: reason,
+                            failureReasonMetric: GleanMetrics.LoginsSync.failureReason)
+    }
+}
+
+private func individualBookmarksSync(hashedFxaUid: String, engineInfo: EngineInfo) throws {
+    guard engineInfo.name == SupportedEngines.Bookmarks.rawValue else {
+        let message = "Expected 'bookmarks', got \(engineInfo.name)"
+        throw TelemetryReportingError.InvalidEngine(message: message)
+    }
+
+    let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
+    GleanMetrics.BookmarksSync.uid.set(base.uid)
+    GleanMetrics.BookmarksSync.startedAt.set(base.startedAt)
+    GleanMetrics.BookmarksSync.finishedAt.set(base.finishedAt)
+
+    if base.applied > 0 {
+        GleanMetrics.BookmarksSync.incoming["applied"].add(base.applied)
+    }
+
+    if base.failedToApply > 0 {
+        GleanMetrics.BookmarksSync.incoming["failed_to_apply"].add(base.failedToApply)
+    }
+
+    if base.reconciled > 0 {
+        GleanMetrics.BookmarksSync.incoming["reconciled"].add(base.reconciled)
+    }
+
+    if base.uploaded > 0 {
+        GleanMetrics.BookmarksSync.outgoing["uploaded"].add(base.uploaded)
+    }
+
+    if base.failedToUpload > 0 {
+        GleanMetrics.BookmarksSync.outgoing["failed_to_upload"].add(base.failedToUpload)
+    }
+
+    if base.outgoingBatches > 0 {
+        GleanMetrics.BookmarksSync.outgoingBatches.add(base.outgoingBatches)
+    }
+
+    if let reason = base.failureReason {
+        recordFailureReason(reason: reason,
+                            failureReasonMetric: GleanMetrics.BookmarksSync.failureReason)
+    }
+
+    if let validation = engineInfo.validation {
+        validation.problems.forEach { problemInfo in
+            GleanMetrics.BookmarksSync.remoteTreeProblems[problemInfo.name].add(Int32(problemInfo.count))
+        }
+    }
+}
+
+private func individualHistorySync(hashedFxaUid: String, engineInfo: EngineInfo) throws {
+    guard engineInfo.name == SupportedEngines.History.rawValue else {
+        let message = "Expected 'history', got \(engineInfo.name)"
+        throw TelemetryReportingError.InvalidEngine(message: message)
+    }
+
+    let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
+    GleanMetrics.HistorySync.uid.set(base.uid)
+    GleanMetrics.HistorySync.startedAt.set(base.startedAt)
+    GleanMetrics.HistorySync.finishedAt.set(base.finishedAt)
+
+    if base.applied > 0 {
+        GleanMetrics.HistorySync.incoming["applied"].add(base.applied)
+    }
+
+    if base.failedToApply > 0 {
+        GleanMetrics.HistorySync.incoming["failed_to_apply"].add(base.failedToApply)
+    }
+
+    if base.reconciled > 0 {
+        GleanMetrics.HistorySync.incoming["reconciled"].add(base.reconciled)
+    }
+
+    if base.uploaded > 0 {
+        GleanMetrics.HistorySync.outgoing["uploaded"].add(base.uploaded)
+    }
+
+    if base.failedToUpload > 0 {
+        GleanMetrics.HistorySync.outgoing["failed_to_upload"].add(base.failedToUpload)
+    }
+
+    if base.outgoingBatches > 0 {
+        GleanMetrics.HistorySync.outgoingBatches.add(base.outgoingBatches)
+    }
+
+    if let reason = base.failureReason {
+        recordFailureReason(reason: reason,
+                            failureReasonMetric: GleanMetrics.HistorySync.failureReason)
+    }
+}
+
+private func individualCreditCardsSync(hashedFxaUid: String, engineInfo: EngineInfo) throws {
+    guard engineInfo.name == SupportedEngines.CreditCards.rawValue else {
+        let message = "Expected 'creditcards', got \(engineInfo.name)"
+        throw TelemetryReportingError.InvalidEngine(message: message)
+    }
+
+    let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
+    GleanMetrics.CreditcardsSync.uid.set(base.uid)
+    GleanMetrics.CreditcardsSync.startedAt.set(base.startedAt)
+    GleanMetrics.CreditcardsSync.finishedAt.set(base.finishedAt)
+
+    if base.applied > 0 {
+        GleanMetrics.CreditcardsSync.incoming["applied"].add(base.applied)
+    }
+
+    if base.failedToApply > 0 {
+        GleanMetrics.CreditcardsSync.incoming["failed_to_apply"].add(base.failedToApply)
+    }
+
+    if base.reconciled > 0 {
+        GleanMetrics.CreditcardsSync.incoming["reconciled"].add(base.reconciled)
+    }
+
+    if base.uploaded > 0 {
+        GleanMetrics.CreditcardsSync.outgoing["uploaded"].add(base.uploaded)
+    }
+
+    if base.failedToUpload > 0 {
+        GleanMetrics.CreditcardsSync.outgoing["failed_to_upload"].add(base.failedToUpload)
+    }
+
+    if base.outgoingBatches > 0 {
+        GleanMetrics.CreditcardsSync.outgoingBatches.add(base.outgoingBatches)
+    }
+
+    if let reason = base.failureReason {
+        recordFailureReason(reason: reason,
+                            failureReasonMetric: GleanMetrics.CreditcardsSync.failureReason)
+    }
+}
+
+private func individualTabsSync(hashedFxaUid: String, engineInfo: EngineInfo) throws {
+    guard engineInfo.name == SupportedEngines.Tabs.rawValue else {
+        let message = "Expected 'tabs', got \(engineInfo.name)"
+        throw TelemetryReportingError.InvalidEngine(message: message)
+    }
+
+    let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
+    GleanMetrics.TabsSync.uid.set(base.uid)
+    GleanMetrics.TabsSync.startedAt.set(base.startedAt)
+    GleanMetrics.TabsSync.finishedAt.set(base.finishedAt)
+
+    if base.applied > 0 {
+        GleanMetrics.TabsSync.incoming["applied"].add(base.applied)
+    }
+
+    if base.failedToApply > 0 {
+        GleanMetrics.TabsSync.incoming["failed_to_apply"].add(base.failedToApply)
+    }
+
+    if base.reconciled > 0 {
+        GleanMetrics.TabsSync.incoming["reconciled"].add(base.reconciled)
+    }
+
+    if base.uploaded > 0 {
+        GleanMetrics.TabsSync.outgoing["uploaded"].add(base.uploaded)
+    }
+
+    if base.failedToUpload > 0 {
+        GleanMetrics.TabsSync.outgoing["failed_to_upload"].add(base.failedToUpload)
+    }
+
+    if base.outgoingBatches > 0 {
+        GleanMetrics.TabsSync.outgoingBatches.add(base.outgoingBatches)
+    }
+
+    if let reason = base.failureReason {
+        recordFailureReason(reason: reason,
+                            failureReasonMetric: GleanMetrics.TabsSync.failureReason)
+    }
+}
+
+private func recordFailureReason(reason: FailureReason,
+                                 failureReasonMetric: LabeledMetricType<StringMetricType>)
+{
+    let metric: StringMetricType? = {
+        switch reason.name {
+        case .other, .unknown:
+            return failureReasonMetric["other"]
+        case .unexpected, .http:
+            return failureReasonMetric["unexpected"]
+        case .auth:
+            return failureReasonMetric["auth"]
+        case .shutdown:
+            return nil
+        }
+    }()
+
+    let MAX_FAILURE_REASON_LENGTH = 100 // Maximum length for Glean labeled strings
+    let message = reason.message ?? "Unexpected error: \(reason.code)"
+    metric?.set(String(message.prefix(MAX_FAILURE_REASON_LENGTH)))
+}
+
+class BaseGleanSyncPing {
+    public static let MILLIS_PER_SEC: Int64 = 1000
+
+    var uid: String
+    var startedAt: Date
+    var finishedAt: Date
+    var applied: Int32
+    var failedToApply: Int32
+    var reconciled: Int32
+    var uploaded: Int32
+    var failedToUpload: Int32
+    var outgoingBatches: Int32
+    var failureReason: FailureReason?
+
+    init(uid: String,
+         startedAt: Date,
+         finishedAt: Date,
+         applied: Int32,
+         failedToApply: Int32,
+         reconciled: Int32,
+         uploaded: Int32,
+         failedToUpload: Int32,
+         outgoingBatches: Int32,
+         failureReason: FailureReason? = nil)
+    {
+        self.uid = uid
+        self.startedAt = startedAt
+        self.finishedAt = finishedAt
+        self.applied = applied
+        self.failedToApply = failedToApply
+        self.reconciled = reconciled
+        self.uploaded = uploaded
+        self.failedToUpload = failedToUpload
+        self.outgoingBatches = outgoingBatches
+        self.failureReason = failureReason
+    }
+
+    static func fromEngineInfo(uid: String, info: EngineInfo) -> BaseGleanSyncPing {
+        let failedToApply = (info.incoming?.failed ?? 0) + (info.incoming?.newFailed ?? 0)
+        let (uploaded, failedToUpload) = info.outgoing.reduce((0, 0)) { totals, batch in
+            let (totalSent, totalFailed) = totals
+            return (totalSent + batch.sent, totalFailed + batch.failed)
+        }
+        let startedAt = info.at * MILLIS_PER_SEC
+        let ping = BaseGleanSyncPing(uid: uid,
+                                     startedAt: Date(timeIntervalSince1970: TimeInterval(startedAt)),
+                                     finishedAt: Date(timeIntervalSince1970: TimeInterval(startedAt + info.took)),
+                                     applied: Int32(info.incoming?.applied ?? 0),
+                                     failedToApply: Int32(failedToApply),
+                                     reconciled: Int32(info.incoming?.reconciled ?? 0),
+                                     uploaded: Int32(uploaded),
+                                     failedToUpload: Int32(failedToUpload),
+                                     outgoingBatches: Int32(info.outgoing.count),
+                                     failureReason: info.failureReason)
+
+        return ping
+    }
+}

--- a/components/sync_manager/metrics.yaml
+++ b/components/sync_manager/metrics.yaml
@@ -1,0 +1,911 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+
+sync:
+  sync_uuid:
+    type: uuid
+    description: >
+      Unique identifier for this sync, used to correlate together
+      individual pings for data types that were synchronized together
+      (history, bookmarks, logins).
+      If a data type is synchronized by itself via the legacy 'sync' API
+      (as opposed to the Sync Manager),
+      then this field will not be set on the corresponding ping.
+    send_in_pings:
+      - sync
+      - history-sync
+      - bookmarks-sync
+      - logins-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/5371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/5386#pullrequestreview-392363687
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  failure_reason:
+    type: labeled_string
+    labels:
+      - other
+      - unexpected
+      - auth
+    description: >
+      Records a global sync failure: either due to an authentication error,
+      unexpected exception, or other error that caused the sync to fail.
+      Error strings are truncated and sanitized to omit
+      PII, like URLs and file system paths.
+    send_in_pings:
+      - sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+
+# `history-sync`, `logins-sync`, `bookmarks-sync`, `creditcards-sync`,
+# `addresses-sync` and `tabs-sync` metrics
+# mostly use the same structure, with some minor variability,
+# but must be specified individually. We can't define them once and use
+# `send_in_pings` because the stores might be synced in parallel, and we can't
+# guarantee that a ping for one store would be sent before the others.
+history_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - history-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  started_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the history sync started.
+    send_in_pings:
+      - history-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  finished_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the history sync finished. This includes the time to
+      download, apply, and upload all records.
+    send_in_pings:
+      - history-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming history record counts. `applied` is the number of
+      incoming history pages that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of pages that were
+      ignored due to errors. `reconciled` is the number of pages with new visits
+      locally and remotely, and had their visits merged.
+    send_in_pings:
+      - history-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing history record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - history-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing_batches:
+    type: counter
+    description: >
+      Records the number of batches needed to upload all outgoing records. The
+      Sync server has a hard limit on the number of records (and request body
+      bytes) on the number of records that can fit into a single batch, and
+      large syncs may require multiple batches.
+    send_in_pings:
+      - history-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  failure_reason:
+    type: labeled_string
+    labels:
+      - other
+      - unexpected
+      - auth
+    description: >
+      Records why the history sync failed: either due to an authentication
+      error, unexpected exception, or other error. The error strings are
+      truncated and sanitized to omit PII, like URLs and file system paths.
+    send_in_pings:
+      - history-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+
+logins_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - logins-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/4556
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/5294
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  started_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the passwords sync started.
+    send_in_pings:
+      - logins-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/4556
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/5294
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  finished_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the passwords sync finished. This includes the time to
+      download, apply, and upload all records.
+    send_in_pings:
+      - logins-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/4556
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/5294
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming passwords record counts. `applied` is the number of
+      incoming passwords entries that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of entries that were
+      ignored due to errors. `reconciled` is the number of entries with changes
+      both locally and remotely that were merged.
+    send_in_pings:
+      - logins-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/4556
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/5294
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing passwords record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - logins-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/4556
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/5294
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing_batches:
+    type: counter
+    description: >
+      Records the number of batches needed to upload all outgoing records. The
+      Sync server has a hard limit on the number of records (and request body
+      bytes) on the number of records that can fit into a single batch, and
+      large syncs may require multiple batches.
+    send_in_pings:
+      - logins-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/4556
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/5294
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  failure_reason:
+    type: labeled_string
+    labels:
+      - other
+      - unexpected
+      - auth
+    description: >
+      Records why the passwords sync failed: either due to an authentication
+      error, unexpected exception, or other error. The error strings are
+      truncated and sanitized to omit PII, like usernames and passwords.
+    send_in_pings:
+      - logins-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/4556
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/5294
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+
+bookmarks_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - bookmarks-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  started_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the bookmark sync started.
+    send_in_pings:
+      - bookmarks-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  finished_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the bookmark sync finished.
+    send_in_pings:
+      - bookmarks-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming bookmark record counts.
+    send_in_pings:
+      - bookmarks-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing bookmark record counts.
+    send_in_pings:
+      - bookmarks-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing_batches:
+    type: counter
+    description: >
+      Records the number of batches needed to upload all outgoing records.
+    send_in_pings:
+      - bookmarks-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  failure_reason:
+    type: labeled_string
+    labels:
+      - other
+      - unexpected
+      - auth
+    description: >
+      Records bookmark sync failure reasons.
+    send_in_pings:
+      - bookmarks-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  remote_tree_problems:
+    type: labeled_counter
+    labels:
+      - orphans
+      - misparented_roots
+      - multiple_parents_by_children
+      - missing_parent_guids
+      - non_folder_parent_guids
+      - parent_child_disagreements
+      - missing_children
+    description: >
+      Records counts for structure problems and divergences in the remote
+      bookmarks tree. These are documented in
+      https://github.com/mozilla/dogear/blob/fbade15f2a4f11215e30b8f428a0a8df3defeaec/src/tree.rs#L1273-L1294.
+    send_in_pings:
+      - bookmarks-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/3092
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+
+creditcards_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - creditcards-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  started_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the credit cards sync started.
+    send_in_pings:
+      - creditcards-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  finished_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the credit cards sync finished. This includes the time to
+      download, apply, and upload all records.
+    send_in_pings:
+      - creditcards-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming credit cards record counts. `applied` is the number of
+      incoming records that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of records that were
+      ignored due to errors. `reconciled` is the number of merged records.
+    send_in_pings:
+      - creditcards-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing credit cards record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - creditcards-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing_batches:
+    type: counter
+    description: >
+      Records the number of batches needed to upload all outgoing records. The
+      Sync server has a hard limit on the number of records (and request body
+      bytes) on the number of records that can fit into a single batch, and
+      large syncs may require multiple batches.
+    send_in_pings:
+      - creditcards-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  failure_reason:
+    type: labeled_string
+    labels:
+      - other
+      - unexpected
+      - auth
+    description: >
+      Records why the credit cards sync failed: either due to an authentication
+      error, unexpected exception, or other error. The error strings are
+      truncated and sanitized to omit PII, like URLs and file system paths.
+    send_in_pings:
+      - creditcards-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+
+addresses_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - addresses-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  started_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the addresses sync started.
+    send_in_pings:
+      - addresses-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  finished_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the addresses sync finished. This includes the time to
+      download, apply, and upload all records.
+    send_in_pings:
+      - addresses-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming addresses record counts. `applied` is the number of
+      incoming records that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of records that were
+      ignored due to errors. `reconciled` is the number of merged records.
+    send_in_pings:
+      - addresses-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing addresses record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - addresses-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing_batches:
+    type: counter
+    description: >
+      Records the number of batches needed to upload all outgoing records. The
+      Sync server has a hard limit on the number of records (and request body
+      bytes) on the number of records that can fit into a single batch, and
+      large syncs may require multiple batches.
+    send_in_pings:
+      - addresses-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  failure_reason:
+    type: labeled_string
+    labels:
+      - other
+      - unexpected
+      - auth
+    description: >
+      Records why the addresses sync failed: either due to an authentication
+      error, unexpected exception, or other error. The error strings are
+      truncated and sanitized to omit PII, like URLs and file system paths.
+    send_in_pings:
+      - addresses-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+
+tabs_sync:
+  uid:
+    type: string
+    description: >
+      The user's hashed Firefox Account ID.
+    send_in_pings:
+      - tabs-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  started_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the tabs sync started.
+    send_in_pings:
+      - tabs-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  finished_at:
+    type: datetime
+    time_unit: millisecond
+    description: >
+      Records when the tabs sync finished. This includes the time to
+      download, apply, and upload all records.
+    send_in_pings:
+      - tabs-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  incoming:
+    type: labeled_counter
+    labels:
+      - applied
+      - failed_to_apply
+      - reconciled
+    description: >
+      Records incoming tabs record counts. `applied` is the number of
+      incoming records that were successfully stored or updated in the
+      local database. `failed_to_apply` is the number of records that were
+      ignored due to errors. `reconciled` is the number of merged records.
+    send_in_pings:
+      - tabs-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing:
+    type: labeled_counter
+    labels:
+      - uploaded
+      - failed_to_upload
+    description: >
+      Records outgoing tabs record counts. `uploaded` is the number of
+      records that were successfully sent to the server. `failed_to_upload`
+      is the number of records that weren't uploaded, and will be retried
+      on the next sync.
+    send_in_pings:
+      - tabs-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  outgoing_batches:
+    type: counter
+    description: >
+      Records the number of batches needed to upload all outgoing records. The
+      Sync server has a hard limit on the number of records (and request body
+      bytes) on the number of records that can fit into a single batch, and
+      large syncs may require multiple batches.
+    send_in_pings:
+      - tabs-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping
+  failure_reason:
+    type: labeled_string
+    labels:
+      - other
+      - unexpected
+      - auth
+    description: >
+      Records why the tabs sync failed: either due to an authentication
+      error, unexpected exception, or other error. The error strings are
+      truncated and sanitized to omit PII, like URLs and file system paths.
+    send_in_pings:
+      - tabs-sync
+    bugs:
+      - https://github.com/mozilla-mobile/android-components/issues/10371
+    data_reviews:
+      - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+    expires: never
+    lifetime: ping

--- a/components/sync_manager/pings.yaml
+++ b/components/sync_manager/pings.yaml
@@ -1,0 +1,101 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+$schema: moz://mozilla.org/schemas/glean/pings/2-0-0
+
+sync:
+  description: >
+    A summary ping, sent every time a sync is performed.
+    During each Sync one or more data types could be synchronized,
+    depending on which data types user configured to sync.
+    Alongside with 'sync' ping one or more individual data type specific
+    pings will be sent.
+    For example, if history and bookmarks data types
+    are configured to be synchronized, the following pings will be sent:
+    'sync', 'history-sync' and 'bookmarks-sync'.
+    Alternatively, if only history is configured to be synchronized
+    then 'sync' and 'history-sync' pings will be sent.
+    In case of a "global failure" where none of the data type syncs
+    could even start, e.g. device is offline,
+    only the 'sync' ping will be sent.
+    This ping doesn't include the `client_id`
+    because it reports a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://github.com/mozilla-mobile/android-components/issues/5371
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - https://github.com/mozilla-mobile/android-components/pull/5386#pullrequestreview-392363687
+history-sync:
+  description: >
+    A ping sent for every history sync. It doesn't include the `client_id`
+    because it reports a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://github.com/mozilla-mobile/android-components/pull/3092
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - https://github.com/mozilla-mobile/android-components/pull/3092
+bookmarks-sync:
+  description: >
+    A ping sent for every bookmarks sync. It doesn't include the `client_id`
+    because it reports a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://github.com/mozilla-mobile/android-components/pull/3092
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - https://github.com/mozilla-mobile/android-components/pull/3092
+logins-sync:
+  description: >
+    A ping sent for every logins/passwords sync.
+    It doesn't include the `client_id` because it reports
+    a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://github.com/mozilla-mobile/android-components/issues/4556
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - https://github.com/mozilla-mobile/android-components/pull/5294
+creditcards-sync:
+  description: >
+    A ping sent for every Credit Cards engine sync.
+    It doesn't include the `client_id` because it reports
+    a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://github.com/mozilla-mobile/android-components/issues/10371
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+addresses-sync:
+  description: >
+    A ping sent for every Addresses engine sync.
+    It doesn't include the `client_id` because it reports
+    a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://github.com/mozilla-mobile/android-components/issues/10371
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
+tabs-sync:
+  description: >
+    A ping sent for every Tabs engine sync.
+    It doesn't include the `client_id` because it reports
+    a hashed version of the user's Firefox Account ID.
+  include_client_id: false
+  bugs:
+    - https://github.com/mozilla-mobile/android-components/issues/10371
+  notification_emails:
+    - sync-core@mozilla.com
+  data_reviews:
+    - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -68,6 +68,9 @@
 		39F5D7642956161E004E2384 /* Operation+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F5D7632956161E004E2384 /* Operation+.swift */; };
 		39F5D766295616E3004E2384 /* NimbusBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F5D765295616E3004E2384 /* NimbusBuilder.swift */; };
 		45CC574A28AD9C86006D55AA /* errorsupport.udl in Sources */ = {isa = PBXBuildFile; fileRef = 45CC574828AD9C31006D55AA /* errorsupport.udl */; };
+		F814DE8029DF762800FD26F5 /* SyncManagerTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F814DE7F29DF762800FD26F5 /* SyncManagerTelemetryTests.swift */; };
+		F81C7B9829DE305C00FAF8F9 /* SyncManagerTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81C7B9729DE305C00FAF8F9 /* SyncManagerTelemetry.swift */; };
+		F81C7B9A29DE309C00FAF8F9 /* SyncManagerComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81C7B9929DE309C00FAF8F9 /* SyncManagerComponent.swift */; };
 		F85ED649299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85ED648299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift */; };
 		F8BEFFDA299C4F1100776186 /* RustSyncTelemetryPing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BEFFD9299C4F1100776186 /* RustSyncTelemetryPing.swift */; };
 		F8C88393298B4BF80006E9E9 /* syncmanager.udl in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1CC298B41FC000BCDEC /* syncmanager.udl */; };
@@ -193,6 +196,9 @@
 		45CC574528AD9C0B006D55AA /* errorFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = errorFFI.h; path = ../../../../components/support/error/ios/Generated/errorFFI.h; sourceTree = "<group>"; };
 		45CC574628AD9C0B006D55AA /* errorsupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = errorsupport.swift; path = ../../../../components/support/error/ios/Generated/errorsupport.swift; sourceTree = "<group>"; };
 		45CC574828AD9C31006D55AA /* errorsupport.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = errorsupport.udl; path = ../../../../components/support/error/src/errorsupport.udl; sourceTree = "<group>"; };
+		F814DE7F29DF762800FD26F5 /* SyncManagerTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManagerTelemetryTests.swift; sourceTree = "<group>"; };
+		F81C7B9729DE305C00FAF8F9 /* SyncManagerTelemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SyncManagerTelemetry.swift; path = ../../../components/sync_manager/ios/SyncManager/SyncManagerTelemetry.swift; sourceTree = SOURCE_ROOT; };
+		F81C7B9929DE309C00FAF8F9 /* SyncManagerComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SyncManagerComponent.swift; path = ../../../components/sync_manager/ios/SyncManager/SyncManagerComponent.swift; sourceTree = SOURCE_ROOT; };
 		F85ED648299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustSyncTelemetryPingTests.swift; sourceTree = "<group>"; };
 		F8AAC1CC298B41FC000BCDEC /* syncmanager.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = syncmanager.udl; path = ../../../components/sync_manager/src/syncmanager.udl; sourceTree = SOURCE_ROOT; };
 		F8BEFFD9299C4F1100776186 /* RustSyncTelemetryPing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RustSyncTelemetryPing.swift; path = ../../../components/sync15/ios/RustSyncTelemetryPing.swift; sourceTree = SOURCE_ROOT; };
@@ -352,6 +358,7 @@
 				39083AAA29561E2400FDD302 /* OperationTests.swift */,
 				1BBAC54027AE065300DAFEF2 /* PlacesTests.swift */,
 				F85ED648299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift */,
+				F814DE7F29DF762800FD26F5 /* SyncManagerTelemetryTests.swift */,
 			);
 			path = MozillaTestServicesTests;
 			sourceTree = SOURCE_ROOT;
@@ -539,6 +546,8 @@
 		F8AAC1CB298B40B8000BCDEC /* SyncManager */ = {
 			isa = PBXGroup;
 			children = (
+				F81C7B9929DE309C00FAF8F9 /* SyncManagerComponent.swift */,
+				F81C7B9729DE305C00FAF8F9 /* SyncManagerTelemetry.swift */,
 				F8AAC1CF298B43F0000BCDEC /* Generated */,
 				F8AAC1CC298B41FC000BCDEC /* syncmanager.udl */,
 			);
@@ -670,6 +679,8 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/../../../components/nimbus/metrics.yaml",
+				"$(SRCROOT)/../../../components/sync_manager/metrics.yaml",
+				"$(SRCROOT)/../../../components/sync_manager/pings.yaml",
 			);
 			name = "Generate Glean Metrics";
 			outputFileListPaths = (
@@ -692,6 +703,7 @@
 				F8C88393298B4BF80006E9E9 /* syncmanager.udl in Sources */,
 				15DAE213294418F600DB06FE /* autofill.udl in Sources */,
 				45CC574A28AD9C86006D55AA /* errorsupport.udl in Sources */,
+				F81C7B9A29DE309C00FAF8F9 /* SyncManagerComponent.swift in Sources */,
 				1BE9B60D27C9CD770029D11A /* crashtest.udl in Sources */,
 				1BE9B60E27C9CD770029D11A /* nimbus.udl in Sources */,
 				1BE9B60F27C9CD770029D11A /* places.udl in Sources */,
@@ -737,6 +749,7 @@
 				1B3BC98927B1D9B800229CF6 /* Unreachable.swift in Sources */,
 				1BF50F1727B1E18000A9C8A5 /* KeychainItemAccessibility.swift in Sources */,
 				1B3BC94027B1D62800229CF6 /* Places.swift in Sources */,
+				F81C7B9829DE305C00FAF8F9 /* SyncManagerTelemetry.swift in Sources */,
 				1BF50F1527B1E17B00A9C8A5 /* FxAccountState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -745,6 +758,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F814DE8029DF762800FD26F5 /* SyncManagerTelemetryTests.swift in Sources */,
 				1BB64C7A27B1FA0400A4247F /* GleanPlumbTests.swift in Sources */,
 				1B3BC95027B1D92A00229CF6 /* NimbusFeatureVariablesTests.swift in Sources */,
 				1BF50F1A27B1E19800A9C8A5 /* FxAccountMocks.swift in Sources */,

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
@@ -1,0 +1,265 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@testable import MozillaTestServices
+
+import Glean
+import XCTest
+
+class SyncManagerTelemetryTests: XCTestCase {
+    private var now: Int64 = 0
+
+    override func setUp() {
+        super.setUp()
+        Glean.shared.resetGlean(clearStores: true)
+        Glean.shared.enableTestingMode()
+        now = Int64(Date().timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC
+    }
+
+    func testSendsLoginsHistoryAndGlobalPings() {
+        var globalSyncUuid = UUID()
+        let syncTelemetry = RustSyncTelemetryPing(version: 1,
+                                                  uid: "abc123",
+                                                  events: [],
+                                                  syncs: [SyncInfo(at: now,
+                                                                   took: 10000,
+                                                                   engines: [EngineInfo(name: "passwords",
+                                                                                        at: now,
+                                                                                        took: 5000,
+                                                                                        incoming: IncomingInfo(applied: 5,
+                                                                                                               failed: 4,
+                                                                                                               newFailed: 3,
+                                                                                                               reconciled: 2),
+                                                                                        outgoing: [OutgoingInfo(sent: 10,
+                                                                                                                failed: 5),
+                                                                                                   OutgoingInfo(sent: 4,
+                                                                                                                failed: 2)],
+                                                                                        failureReason: nil,
+                                                                                        validation: nil),
+                                                                             EngineInfo(name: "history",
+                                                                                        at: now,
+                                                                                        took: 5000,
+                                                                                        incoming: IncomingInfo(applied: 5,
+                                                                                                               failed: 4,
+                                                                                                               newFailed: 3,
+                                                                                                               reconciled: 2),
+                                                                                        outgoing: [OutgoingInfo(sent: 10,
+                                                                                                                failed: 5),
+                                                                                                   OutgoingInfo(sent: 4,
+                                                                                                                failed: 2)],
+                                                                                        failureReason: nil,
+                                                                                        validation: nil)],
+                                                                   failureReason: FailureReason(name: FailureName.unknown,
+                                                                                                message: "Synergies not aligned"))])
+
+        func submitGlobalPing(_: NoReasonCodes?) {
+            XCTAssertEqual("Synergies not aligned", GleanMetrics.Sync.failureReason["other"].testGetValue())
+            XCTAssertNotNil(globalSyncUuid)
+            XCTAssertEqual(globalSyncUuid, GleanMetrics.Sync.syncUuid.testGetValue("sync"))
+        }
+
+        func submitHistoryPing(_: NoReasonCodes?) {
+            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("history-sync")!
+            XCTAssertEqual("abc123", GleanMetrics.HistorySync.uid.testGetValue())
+
+            XCTAssertNotNil(GleanMetrics.HistorySync.startedAt.testGetValue())
+            XCTAssertNotNil(GleanMetrics.HistorySync.finishedAt.testGetValue())
+            XCTAssertEqual(now, Int64(GleanMetrics.HistorySync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 5, Int64(GleanMetrics.HistorySync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+
+            XCTAssertEqual(5, GleanMetrics.HistorySync.incoming["applied"].testGetValue())
+            XCTAssertEqual(7, GleanMetrics.HistorySync.incoming["failed_to_apply"].testGetValue())
+            XCTAssertEqual(2, GleanMetrics.HistorySync.incoming["reconciled"].testGetValue())
+            XCTAssertEqual(14, GleanMetrics.HistorySync.outgoing["uploaded"].testGetValue())
+            XCTAssertEqual(7, GleanMetrics.HistorySync.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertEqual(2, GleanMetrics.HistorySync.outgoingBatches.testGetValue())
+        }
+
+        func submitLoginsPing(_: NoReasonCodes?) {
+            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("logins-sync")!
+            XCTAssertEqual("abc123", GleanMetrics.LoginsSync.uid.testGetValue())
+
+            XCTAssertNotNil(GleanMetrics.LoginsSync.startedAt.testGetValue())
+            XCTAssertNotNil(GleanMetrics.LoginsSync.finishedAt.testGetValue())
+            XCTAssertEqual(now, Int64(GleanMetrics.LoginsSync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 5, Int64(GleanMetrics.LoginsSync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+
+            XCTAssertEqual(5, GleanMetrics.LoginsSync.incoming["applied"].testGetValue())
+            XCTAssertEqual(7, GleanMetrics.LoginsSync.incoming["failed_to_apply"].testGetValue())
+            XCTAssertEqual(2, GleanMetrics.LoginsSync.incoming["reconciled"].testGetValue())
+            XCTAssertEqual(14, GleanMetrics.LoginsSync.outgoing["uploaded"].testGetValue())
+            XCTAssertEqual(7, GleanMetrics.LoginsSync.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertEqual(2, GleanMetrics.LoginsSync.outgoingBatches.testGetValue())
+        }
+
+        try! processSyncTelemetry(syncTelemetry: syncTelemetry,
+                                  submitGlobalPing: submitGlobalPing,
+                                  submitHistoryPing: submitHistoryPing,
+                                  submitLoginsPing: submitLoginsPing)
+    }
+
+    func testSendsHistoryAndGlobalPings() {
+        var globalSyncUuid = UUID()
+        let syncTelemetry = RustSyncTelemetryPing(version: 1,
+                                                  uid: "abc123",
+                                                  events: [],
+                                                  syncs: [SyncInfo(at: now + 10,
+                                                                   took: 5000,
+                                                                   engines: [EngineInfo(name: "history",
+                                                                                        at: now + 10,
+                                                                                        took: 5000,
+                                                                                        incoming: nil,
+                                                                                        outgoing: [],
+                                                                                        failureReason: nil,
+                                                                                        validation: nil)],
+                                                                   failureReason: nil)])
+
+        func submitGlobalPing(_: NoReasonCodes?) {
+            XCTAssertNil(GleanMetrics.Sync.failureReason["other"].testGetValue())
+            XCTAssertNotNil(globalSyncUuid)
+            XCTAssertEqual(globalSyncUuid, GleanMetrics.Sync.syncUuid.testGetValue("sync"))
+        }
+
+        func submitHistoryPing(_: NoReasonCodes?) {
+            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("history-sync")!
+            XCTAssertEqual("abc123", GleanMetrics.HistorySync.uid.testGetValue())
+
+            XCTAssertNotNil(GleanMetrics.HistorySync.startedAt.testGetValue())
+            XCTAssertNotNil(GleanMetrics.HistorySync.finishedAt.testGetValue())
+            XCTAssertEqual(now + 10, Int64(GleanMetrics.HistorySync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 15, Int64(GleanMetrics.HistorySync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+
+            XCTAssertNil(GleanMetrics.HistorySync.incoming["applied"].testGetValue())
+            XCTAssertNil(GleanMetrics.HistorySync.incoming["failed_to_apply"].testGetValue())
+            XCTAssertNil(GleanMetrics.HistorySync.incoming["reconciled"].testGetValue())
+            XCTAssertNil(GleanMetrics.HistorySync.outgoing["uploaded"].testGetValue())
+            XCTAssertNil(GleanMetrics.HistorySync.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertNil(GleanMetrics.HistorySync.outgoingBatches.testGetValue())
+        }
+
+        try! processSyncTelemetry(syncTelemetry: syncTelemetry,
+                                  submitGlobalPing: submitGlobalPing,
+                                  submitHistoryPing: submitHistoryPing)
+    }
+
+    func testSendsBookmarksAndGlobalPings() {
+        var globalSyncUuid = UUID()
+        let syncTelemetry = RustSyncTelemetryPing(version: 1,
+                                                  uid: "abc123",
+                                                  events: [],
+                                                  syncs: [SyncInfo(at: now + 20,
+                                                                   took: 8000,
+                                                                   engines: [EngineInfo(name: "bookmarks",
+                                                                                        at: now + 25,
+                                                                                        took: 6000,
+                                                                                        incoming: nil,
+                                                                                        outgoing: [OutgoingInfo(sent: 10, failed: 5)],
+                                                                                        failureReason: nil,
+                                                                                        validation: ValidationInfo(version: 2,
+                                                                                                                   problems: [ProblemInfo(name: "missingParents",
+                                                                                                                                          count: 5),
+                                                                                                                              ProblemInfo(name: "missingChildren",
+                                                                                                                                          count: 7)],
+                                                                                                                   failureReason: nil))],
+                                                                   failureReason: nil)])
+
+        func submitGlobalPing(_: NoReasonCodes?) {
+            XCTAssertNil(GleanMetrics.Sync.failureReason["other"].testGetValue())
+            XCTAssertNotNil(globalSyncUuid)
+            XCTAssertEqual(globalSyncUuid, GleanMetrics.Sync.syncUuid.testGetValue("sync"))
+        }
+
+        func submitBookmarksPing(_: NoReasonCodes?) {
+            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("bookmarks-sync")!
+            XCTAssertEqual("abc123", GleanMetrics.BookmarksSync.uid.testGetValue())
+
+            XCTAssertNotNil(GleanMetrics.BookmarksSync.startedAt.testGetValue())
+            XCTAssertNotNil(GleanMetrics.BookmarksSync.finishedAt.testGetValue())
+            XCTAssertEqual(now + 25, Int64(GleanMetrics.BookmarksSync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 31, Int64(GleanMetrics.BookmarksSync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+
+            XCTAssertNil(GleanMetrics.BookmarksSync.incoming["applied"].testGetValue())
+            XCTAssertNil(GleanMetrics.BookmarksSync.incoming["failed_to_apply"].testGetValue())
+            XCTAssertNil(GleanMetrics.BookmarksSync.incoming["reconciled"].testGetValue())
+            XCTAssertEqual(10, GleanMetrics.BookmarksSync.outgoing["uploaded"].testGetValue())
+            XCTAssertEqual(5, GleanMetrics.BookmarksSync.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertEqual(1, GleanMetrics.BookmarksSync.outgoingBatches.testGetValue())
+        }
+
+        try! processSyncTelemetry(syncTelemetry: syncTelemetry,
+                                  submitGlobalPing: submitGlobalPing,
+                                  submitBookmarksPing: submitBookmarksPing)
+    }
+
+    func testSendsTabsCreditCardsAndGlobalPings() {
+        var globalSyncUuid = UUID()
+        let syncTelemetry = RustSyncTelemetryPing(version: 1,
+                                                  uid: "abc123",
+                                                  events: [],
+                                                  syncs: [SyncInfo(at: now + 30,
+                                                                   took: 10000,
+                                                                   engines: [EngineInfo(name: "tabs",
+                                                                                        at: now + 10,
+                                                                                        took: 6000,
+                                                                                        incoming: nil,
+                                                                                        outgoing: [OutgoingInfo(sent: 8, failed: 2)],
+                                                                                        failureReason: nil,
+                                                                                        validation: nil),
+                                                                             EngineInfo(name: "creditcards",
+                                                                                        at: now + 15,
+                                                                                        took: 4000,
+                                                                                        incoming: IncomingInfo(applied: 3,
+                                                                                                               failed: 1,
+                                                                                                               newFailed: 1,
+                                                                                                               reconciled: 0),
+                                                                                        outgoing: [],
+                                                                                        failureReason: nil,
+                                                                                        validation: nil)],
+                                                                   failureReason: nil)])
+
+        func submitGlobalPing(_: NoReasonCodes?) {
+            XCTAssertNil(GleanMetrics.Sync.failureReason["other"].testGetValue())
+            XCTAssertNotNil(globalSyncUuid)
+            XCTAssertEqual(globalSyncUuid, GleanMetrics.Sync.syncUuid.testGetValue("sync"))
+        }
+
+        func submitCreditCardsPing(_: NoReasonCodes?) {
+            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("creditcards-sync")!
+            XCTAssertEqual("abc123", GleanMetrics.CreditcardsSync.uid.testGetValue())
+
+            XCTAssertNotNil(GleanMetrics.CreditcardsSync.startedAt.testGetValue())
+            XCTAssertNotNil(GleanMetrics.CreditcardsSync.finishedAt.testGetValue())
+            XCTAssertEqual(now + 15, Int64(GleanMetrics.CreditcardsSync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 19, Int64(GleanMetrics.CreditcardsSync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+
+            XCTAssertEqual(3, GleanMetrics.CreditcardsSync.incoming["applied"].testGetValue())
+            XCTAssertEqual(2, GleanMetrics.CreditcardsSync.incoming["failed_to_apply"].testGetValue())
+            XCTAssertNil(GleanMetrics.CreditcardsSync.incoming["reconciled"].testGetValue())
+            XCTAssertNil(GleanMetrics.HistorySync.outgoing["uploaded"].testGetValue())
+            XCTAssertNil(GleanMetrics.HistorySync.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertNil(GleanMetrics.CreditcardsSync.outgoingBatches.testGetValue())
+        }
+
+        func submitTabsPing(_: NoReasonCodes?) {
+            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("tabs-sync")!
+            XCTAssertEqual("abc123", GleanMetrics.TabsSync.uid.testGetValue())
+
+            XCTAssertNotNil(GleanMetrics.TabsSync.startedAt.testGetValue())
+            XCTAssertNotNil(GleanMetrics.TabsSync.finishedAt.testGetValue())
+            XCTAssertEqual(now + 10, Int64(GleanMetrics.TabsSync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 16, Int64(GleanMetrics.TabsSync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+
+            XCTAssertNil(GleanMetrics.TabsSync.incoming["applied"].testGetValue())
+            XCTAssertNil(GleanMetrics.TabsSync.incoming["failed_to_apply"].testGetValue())
+            XCTAssertNil(GleanMetrics.TabsSync.incoming["reconciled"].testGetValue())
+            XCTAssertEqual(8, GleanMetrics.TabsSync.outgoing["uploaded"].testGetValue())
+            XCTAssertEqual(2, GleanMetrics.TabsSync.outgoing["failed_to_upload"].testGetValue())
+        }
+
+        try! processSyncTelemetry(syncTelemetry: syncTelemetry,
+                                  submitGlobalPing: submitGlobalPing,
+                                  submitCreditCardsPing: submitCreditCardsPing,
+                                  submitTabsPing: submitTabsPing)
+    }
+}


### PR DESCRIPTION
### Pull Request checklist ###

This PR adds the telemetry that will replace the temp sync metrics in iOS. Much of the logic is duplicated from android components in preparation for consolidating our mobile sync telemetry logic. The following is included:
  - A `metrics.yaml` file similar to the sync [metrics.yaml](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/support/sync-telemetry/metrics.yaml) file in a-c
  - A `pings.yaml` file similar to the sync [pings.yaml](https://github.com/mozilla-mobile/firefox-android/blob/main/android-components/components/support/sync-telemetry/pings.yaml) file in a-c
  - The `SyncManagerTelemetry.swift` and `SyncManagerTelemetryTests.swift` files which duplicate the sync telemetry reporting logic found in the [SyncTelemetry.kt](https://github.com/mozilla-mobile/firefox-android/blob/9de5ab8cc098674aad5190ce8b00ae6be65e9bd0/android-components/components/support/sync-telemetry/src/main/java/mozilla/components/support/sync/telemetry/SyncTelemetry.kt), [BaseGleanSyncPing.kt](https://github.com/mozilla-mobile/firefox-android/blob/9de5ab8cc098674aad5190ce8b00ae6be65e9bd0/android-components/components/support/sync-telemetry/src/main/java/mozilla/components/support/sync/telemetry/BaseGleanSyncPing.kt), and [SyncTelemetryTest.kt](https://github.com/mozilla-mobile/firefox-android/blob/9de5ab8cc098674aad5190ce8b00ae6be65e9bd0/android-components/components/support/sync-telemetry/src/test/java/mozilla/components/support/sync/telemetry/SyncTelemetryTest.kt) files
  - The `SyncManagerComponent.swift` file which serves as a thin wrapper around the sync manager API to add the `reportSyncTelemetry` function which reports the sync telemetry to Glean


<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
