### PR TITLE
nss_build_common: Search the correct NDK toolchain path on macOS.

### DIFF
--- a/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
+++ b/components/support/rc_crypto/nss/nss_build_common/src/lib.rs
@@ -93,6 +93,10 @@ fn link_nss_libs(kind: LinkingKind) {
     if target_arch == "x86_64" && target_os == "android" {
         let android_home = env::var("ANDROID_HOME").expect("ANDROID_HOME not set");
         const ANDROID_NDK_VERSION: &str = "25.2.9519653";
+        // One of these will exist, depending on the host platform.
+        const DARWIN_X86_64_LIB_DIR: &str =
+            "/toolchains/llvm/prebuilt/darwin-x86_64/lib64/clang/14.0.7/lib/linux/";
+        println!("cargo:rustc-link-search={android_home}/ndk/{ANDROID_NDK_VERSION}/{DARWIN_X86_64_LIB_DIR}");
         const LINUX_X86_64_LIB_DIR: &str =
             "/toolchains/llvm/prebuilt/linux-x86_64/lib64/clang/14.0.7/lib/linux/";
         println!("cargo:rustc-link-search={android_home}/ndk/{ANDROID_NDK_VERSION}/{LINUX_X86_64_LIB_DIR}");

--- a/docs/howtos/upgrades/android-ndk.md
+++ b/docs/howtos/upgrades/android-ndk.md
@@ -10,5 +10,5 @@ Here's how to upgrade the Android NDK version:
 * These may need updating if the directory structure changed between this version and the last
   * `libs/build-android-common.sh`: ensure the paths to the various binaries are correct.
   * `components/support/rc_crypto/nss/nss_build_common/src/lib.rs`: search for
-    `LINUX_X86_64_LIB_DIR` and ensure this correctly points to the correct lib directory containing
+    `DARWIN_X86_64_LIB_DIR` and `LINUX_X86_64_LIB_DIR`, and ensure that both point to the correct lib directory containing
     `libclang_rt.builtins-x86_64-android.a`.


### PR DESCRIPTION
On macOS, `clang_rt.builtins-x86_64-android` is in the `darwin-x86_64` subdirectory. According to
https://developer.android.com/ndk/guides/other_build_systems, these toolchain paths are "host tag"-specific, for Linux, macOS, and Windows.

I don't have a Windows machine handy, so I'm not sure what that path should be on Windows! Maybe @mhammond can double-check for us once he's back from PTO? But this fixes my macOS build! 😄

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
