### PR TITLE
Add receiver for a command line to drive experiments

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,10 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+## Nimbus ⛅️🔬🔭
+
+### ✨ What's New ✨
+
+- Added processing of command line arguments (or intent extras) to be driven by a command line tool. ([#5482](https://github.com/mozilla/application-services/pull/5482))
+  - Requires passing `CommandLine.arguments` to `NimbusBuilder` in iOS.
+  - Requires passing `intent` to `NimbusInterface` in Android.

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/ArgumentProcessor.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/ArgumentProcessor.kt
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.experiments.nimbus
+
+import android.content.Context
+import android.content.Intent
+import kotlinx.coroutines.runBlocking
+import org.json.JSONException
+import org.json.JSONObject
+
+private const val NIMBUS_FLAG = "nimbus-cli"
+private const val EXPERIMENTS_KEY = "experiments"
+private const val VERSION_KEY = "version"
+private const val DATA_KEY = "data"
+
+/**
+ * This method allows QA tooling to launch the app via an adb command-line,
+ * and set up experiments at or just before first run.
+ */
+@Suppress("UNUSED_PARAMETER", "ReturnCount")
+fun NimbusInterface.initializeTooling(context: Context, intent: Intent) {
+    if (!intent.hasExtra(NIMBUS_FLAG)) {
+        return
+    }
+
+    if (intent.getIntExtra(VERSION_KEY, 0) != 1) {
+        return
+    }
+
+    val experiments = intent.getStringExtra(EXPERIMENTS_KEY) ?: return
+
+    // We do some rudimentary taint checking of the string:
+    // we make sure it looks like a JSON object, with a `data` key
+    // and an array value.
+    try {
+        val jsonObject = JSONObject(experiments)
+        jsonObject.optJSONArray(DATA_KEY) ?: return
+    } catch (e: JSONException) {
+        return
+    }
+
+    setExperimentsLocally(experiments)
+    val job = applyPendingExperiments()
+    runBlocking {
+        job.join()
+    }
+
+    setFetchEnabled(false)
+}

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -200,6 +200,18 @@ open class Nimbus(
         }
     }
 
+    override fun setFetchEnabled(enabled: Boolean) {
+        fetchScope.launch {
+            withCatchAll("setFetchEnabled") {
+                nimbusClient.setFetchEnabled(enabled)
+            }
+        }
+    }
+
+    override fun isFetchEnabled() = withCatchAll("isFetchEnabled") {
+        nimbusClient.isFetchEnabled()
+    } ?: true
+
     @WorkerThread
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun fetchExperimentsOnThisThread() = withCatchAll("fetchExperiments") {

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
@@ -94,6 +94,26 @@ interface NimbusInterface : FeaturesInterface, GleanPlumbInterface, NimbusEventS
     fun fetchExperiments() = Unit
 
     /**
+     * Enable or disable fetching of experiments.
+     *
+     * This is performed on a background thread.
+     *
+     * This is only used during QA of the app, and not meant for application developers.
+     * Application developers should allow users to opt out with [globalUserParticipation]
+     * instead.
+     */
+    fun setFetchEnabled(enabled: Boolean) = Unit
+
+    /**
+     * The complement for [setFetchEnabled].
+     *
+     * This is only used during QA of the app, and not meant for application developers.
+     * Application developers should allow users to opt out with [globalUserParticipation]
+     * instead.
+     */
+    fun isFetchEnabled(): Boolean = true
+
+    /**
      * Calculates the experiment enrolment from experiments from the last `fetchExperiments` or
      * `setExperimentsLocally`, and then informs Glean of new experiment enrolment.
      *

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -354,6 +354,18 @@ extension Nimbus: NimbusStartup {
         }
     }
 
+    public func setFetchEnabled(_ enabled: Bool) {
+        _ = catchAll(fetchQueue) { _ in
+            try self.nimbusClient.setFetchEnabled(flag: enabled)
+        }
+    }
+
+    public func isFetchEnabled() -> Bool {
+        return catchAll {
+            try self.nimbusClient.isFetchEnabled()
+        } ?? true
+    }
+
     public func applyPendingExperiments() -> Operation {
         catchAll(dbQueue) { _ in
             try self.applyPendingExperimentsOnThisThread()
@@ -451,6 +463,12 @@ public extension NimbusDisabled {
     func initialize() {}
 
     func fetchExperiments() {}
+
+    func setFetchEnabled(_: Bool) {}
+
+    func isFetchEnabled() -> Bool {
+        false
+    }
 
     func applyPendingExperiments() -> Operation {
         BlockOperation()

--- a/components/nimbus/ios/Nimbus/NimbusApi.swift
+++ b/components/nimbus/ios/Nimbus/NimbusApi.swift
@@ -99,6 +99,24 @@ public protocol NimbusStartup {
     /// - Parameter fileURL the URL of a JSON document in the app `Bundle`.
     ///
     func setExperimentsLocally(_ fileURL: URL)
+
+    /// Enable or disable fetching of experiments.
+    ///
+    /// This is performed on a background thread.
+    ///
+    /// This is only used during QA of the app, and not meant for application developers.
+    /// Application developers should allow users to opt out with `setGlobalUserParticipation`
+    /// instead.
+    ///
+    /// - Parameter enabled
+    func setFetchEnabled(_ enabled: Bool)
+
+    /// The complement for [setFetchEnabled].
+    ///
+    /// This is only used during QA of the app, and not meant for application developers.
+    ///
+    /// - Returns true if fetch is allowed
+    func isFetchEnabled() -> Bool
 }
 
 public protocol NimbusUserConfiguration {

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -146,17 +146,21 @@ interface NimbusClient {
     [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> set_global_user_participation(boolean opt_in);
 
-    // Updates the list of experiments from the server.
-    // This method is deprecated, in favour of calling `fetch_experiments()` and then
-    // `apply_pending_updates()`.
-    [Throws=NimbusError]
-    sequence<EnrollmentChangeEvent> update_experiments();
-
     // Fetches the list of experiments from the server. This does not affect the list
     // of active experiments or experiment enrolment.
     // Fetched experiments are not applied until `apply_pending_updates()` is called.
     [Throws=NimbusError]
     void fetch_experiments();
+
+    // Toggles the enablement of the fetch. If `false`, then calling `fetch_experiments`
+    // returns immediately, having not done any fetching from remote settings.
+    // This is only useful for QA, and should not be used in production: use
+    // `set_global_user_participation` instead.
+    [Throws=NimbusError]
+    void set_fetch_enabled(boolean flag);
+
+    [Throws=NimbusError]
+    boolean is_fetch_enabled();
 
     // Apply the updated experiments from the last fetch.
     // After calling this, the list of active experiments might change


### PR DESCRIPTION
Adds receivers for command line options coming from a future command line tool.

Landing this now, with a minimal option set to allow development of a `nimbus-cli`.

Current options are:

 - `nimbus-cli` - must be present, or continue with a normal startup.
 - `version` - only `1` is supported.
 - `experiments` – a string containing a JSON object. The object must be of the form `{"data": []}`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
