### PR TITLE
Fixing the objcopy path when building the megazord

### DIFF
--- a/CHANGES_UNRELEASED.md
+++ b/CHANGES_UNRELEASED.md
@@ -18,3 +18,8 @@ Use the template below to make assigning a version number during the release cut
   - Description of the change with a link to the pull request ([#0000](https://github.com/mozilla/application-services/pull/0000))
 
 -->
+
+## General
+
+### ✨ What's New ✨
+  - Fixing the objcopy path when building the megazord ([#5154](https://github.com/mozilla/application-services/pull/5154)).

--- a/automation/upload_android_symbols.sh
+++ b/automation/upload_android_symbols.sh
@@ -35,14 +35,13 @@ fi
 # Keep the 3 in sync.
 TARGET_ARCHS=("x86_64" "x86" "arm64" "arm")
 JNI_LIBS_TARGETS=("x86_64" "x86" "arm64-v8a" "armeabi-v7a")
-OBJCOPY_BINS=("x86_64-linux-android-objcopy" "i686-linux-android-objcopy" "aarch64-linux-android-objcopy" "arm-linux-androideabi-objcopy")
 
 rm -rf "${OUTPUT_FOLDER}"
 mkdir -p "${OUTPUT_FOLDER}"
 
 # 1. Generate the symbols.
 for i in "${!TARGET_ARCHS[@]}"; do
-  export OBJCOPY="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${NDK_HOST_TAG}/bin/${OBJCOPY_BINS[${i}]}"
+  export OBJCOPY="${ANDROID_NDK_ROOT}/toolchains/llvm/prebuilt/${NDK_HOST_TAG}/bin/llvm-objcopy"
   JNI_SO_PATH="${PROJECT_PATH}/build/rustJniLibs/android/${JNI_LIBS_TARGETS[${i}]}"
   for sofile in "${JNI_SO_PATH}"/*.so; do
     python3 automation/symbols-generation/symbolstore.py -c -s . --vcs-info "${DUMP_SYMS_DIR}"/dump_syms "${OUTPUT_FOLDER}" "${sofile}"


### PR DESCRIPTION
### Pull Request checklist ###

This PR includes commit [aad2c89](https://github.com/mozilla/application-services/commit/aad2c898283583503309dc301a74161cd1e9bde4) which was cherry-picked to address the `module-build-full-megazord` build issue (see [here](https://firefox-ci-tc.services.mozilla.com/tasks/M8e2ZHatSVyIcFryNBQJJg/runs/0/logs/live/public/logs/live.log) for details).

<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGES_UNRELEASED.md](../CHANGES_UNRELEASED.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
