### PR TITLE
Adds sync15.udl to nightly builds for iOS

### DIFF
--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -20,6 +20,8 @@ BINDINGS_UDL_PATHS = [
     "components/push/src/push.udl",
     "components/support/error/src/errorsupport.udl",
     "components/sync_manager/src/syncmanager.udl",
+    "components/sync15/src/sync15.udl",
+
 ]
 # List of globs to copy the sources from
 SOURCE_TO_COPY = [


### PR DESCRIPTION
While testing the nightly builds for iOS, came across the fact that our other components now depend on sync15, but it wasn't included in the nightly builds