### PR TITLE
Removes Rust beta runs from circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,17 +297,6 @@ jobs:
       # It's not in the default workspace members, so just `cargo test` is OK.
       - run: RUST_LOG=trace cargo test
       - save-sccache-cache
-  # These run periodically (driven by cron).
-  Rust tests - beta:
-    executor: docker
-    resource_class: large
-    steps:
-      - full-checkout
-      - restore-sccache-cache
-      - test-setup
-      - run: rustup override set beta
-      - run-tests
-      - save-sccache-cache
 
   Focus build XCFramework:
     executor: macos
@@ -451,16 +440,6 @@ workflows:
   bash-lint:
     jobs:
       - Lint Bash scripts
-  run-beta-tests-periodically:
-    jobs:
-      - Rust tests - beta
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only:
-                - main
   run-tests:
     jobs:
       - Rust tests


### PR DESCRIPTION
Fixes #5357 

Beta build has been failing on main for a while now, let's get rid of it. I can't think of a time when they were actionable.

For context, they were failing on error formatting, for testing proc-macros, we use `trybuild` which tests that compilation errors produce an exact error, but Rust doesn't guarantee compilation errors stay the same across upgrades

