### PR TITLE
Fixes sync15 not referencing the megazord

### DIFF
--- a/components/sync15/uniffi.toml
+++ b/components/sync15/uniffi.toml
@@ -1,5 +1,6 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.sync15"
+cdylib_name = "megazord"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1830793

the new sync15 DeviceType type can't be accessed from Fenix because it's attempting to be loaded through it's own shared object.

Exposing it through the megazord 
