### PR TITLE
Block all beetmover tasks on all signing tasks being completed

### DIFF
--- a/taskcluster/app_services_taskgraph/transforms/reverse_chunk_deps.py
+++ b/taskcluster/app_services_taskgraph/transforms/reverse_chunk_deps.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Adds dependencies on all tasks from a kind referenced in `kind-dependencies`
+
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+@transforms.add
+def add_dependencies(config, jobs):
+    for job in jobs:
+        job["dependencies"] = {}
+        for dep_task in config.kind_dependencies_tasks.values():
+            job["dependencies"][dep_task.label] = dep_task.label
+
+        yield job

--- a/taskcluster/ci/beetmover/kind.yml
+++ b/taskcluster/ci/beetmover/kind.yml
@@ -12,6 +12,9 @@ transforms:
 kind-dependencies:
   - module-build
   - signing
+  # Adding this means that we will not run _any_ beetmover task until
+  # _all_ signing has been completed.
+  - post-signing-dummy
 
 primary-dependency: module-build
 group-by: component
@@ -24,4 +27,3 @@ task-template:
     app-name: appservices
   routes:
     - notify.email.a-s-ci-failures@mozilla.com.on-failed
-

--- a/taskcluster/ci/post-signing-dummy/kind.yml
+++ b/taskcluster/ci/post-signing-dummy/kind.yml
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - app_services_taskgraph.transforms.reverse_chunk_deps:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - signing
+
+tasks:
+    post-signing-dummy:
+        label: post-signing-dummy
+        name: post-signing-dummy
+        description: Dummy task to make it easier to block beetmover on signing completion
+        attributes:
+            buildconfig:
+                name: all
+        run-on-tasks-for: [github-release, cron]
+        worker-type: succeed
+        worker:
+            implementation: succeed


### PR DESCRIPTION
This results in a new `post-signing-dummy` task, which depends on all signing tasks, and the existing `beetmover` tasks adding this new task as a dependency. Diff below:
```
--- target_task_graph@d0abca2b9ce1
+++ target_task_graph@post-signing-dummy
@@ -113,40 +113,41 @@
     always_target: false
     buildconfig:
       artifactId: autofill
       name: autofill
       path: components/autofill/android
       publications:
       - name: autofill
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-autofill
+    post-signing-dummy: post-signing-dummy
     signing: signing-autofill
   description: Publish release module autofill
   if_dependencies: []
   kind: beetmover
   label: beetmover-autofill
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module autofill
@@ -256,40 +257,41 @@
     always_target: false
     buildconfig:
       artifactId: crashtest
       name: crashtest
       path: components/crashtest/android
       publications:
       - name: crashtest
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-crashtest
+    post-signing-dummy: post-signing-dummy
     signing: signing-crashtest
   description: Publish release module crashtest
   if_dependencies: []
   kind: beetmover
   label: beetmover-crashtest
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module crashtest
@@ -399,40 +401,41 @@
     always_target: false
     buildconfig:
       artifactId: errorsupport
       name: errorsupport
       path: components/support/error/android
       publications:
       - name: errorsupport
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-errorsupport
+    post-signing-dummy: post-signing-dummy
     signing: signing-errorsupport
   description: Publish release module errorsupport
   if_dependencies: []
   kind: beetmover
   label: beetmover-errorsupport
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module errorsupport
@@ -544,40 +547,41 @@
       artifactId: full-megazord
       name: full-megazord
       path: megazords/full/android
       publications:
       - name: full-megazord
         type: aar
       - name: full-megazord-forUnitTests
         type: jar
       uploadSymbols: true
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-full-megazord
+    post-signing-dummy: post-signing-dummy
     signing: signing-full-megazord
   description: Publish release module full-megazord
   if_dependencies: []
   kind: beetmover
   label: beetmover-full-megazord
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module full-megazord
@@ -727,40 +731,41 @@
     always_target: false
     buildconfig:
       artifactId: fxaclient
       name: fxaclient
       path: components/fxa-client/android
       publications:
       - name: fxaclient
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-fxaclient
+    post-signing-dummy: post-signing-dummy
     signing: signing-fxaclient
   description: Publish release module fxaclient
   if_dependencies: []
   kind: beetmover
   label: beetmover-fxaclient
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module fxaclient
@@ -870,40 +875,41 @@
     always_target: false
     buildconfig:
       artifactId: httpconfig
       name: httpconfig
       path: components/viaduct/android
       publications:
       - name: httpconfig
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-httpconfig
+    post-signing-dummy: post-signing-dummy
     signing: signing-httpconfig
   description: Publish release module httpconfig
   if_dependencies: []
   kind: beetmover
   label: beetmover-httpconfig
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module httpconfig
@@ -1013,40 +1019,41 @@
     always_target: false
     buildconfig:
       artifactId: logins
       name: logins
       path: components/logins/android
       publications:
       - name: logins
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-logins
+    post-signing-dummy: post-signing-dummy
     signing: signing-logins
   description: Publish release module logins
   if_dependencies: []
   kind: beetmover
   label: beetmover-logins
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module logins
@@ -1156,40 +1163,41 @@
     always_target: false
     buildconfig:
       artifactId: native-support
       name: native-support
       path: components/support/android
       publications:
       - name: native-support
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-native-support
+    post-signing-dummy: post-signing-dummy
     signing: signing-native-support
   description: Publish release module native-support
   if_dependencies: []
   kind: beetmover
   label: beetmover-native-support
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module native-support
@@ -1299,40 +1307,41 @@
     always_target: false
     buildconfig:
       artifactId: nimbus
       name: nimbus
       path: components/nimbus/android
       publications:
       - name: nimbus
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-nimbus
+    post-signing-dummy: post-signing-dummy
     signing: signing-nimbus
   description: Publish release module nimbus
   if_dependencies: []
   kind: beetmover
   label: beetmover-nimbus
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module nimbus
@@ -1442,40 +1451,41 @@
     always_target: false
     buildconfig:
       artifactId: places
       name: places
       path: components/places/android
       publications:
       - name: places
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-places
+    post-signing-dummy: post-signing-dummy
     signing: signing-places
   description: Publish release module places
   if_dependencies: []
   kind: beetmover
   label: beetmover-places
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module places
@@ -1585,40 +1595,41 @@
     always_target: false
     buildconfig:
       artifactId: push
       name: push
       path: components/push/android
       publications:
       - name: push
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-push
+    post-signing-dummy: post-signing-dummy
     signing: signing-push
   description: Publish release module push
   if_dependencies: []
   kind: beetmover
   label: beetmover-push
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module push
@@ -1728,40 +1739,41 @@
     always_target: false
     buildconfig:
       artifactId: rust-log-forwarder
       name: rust-log-forwarder
       path: components/support/rust-log-forwarder/android
       publications:
       - name: rust-log-forwarder
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-rust-log-forwarder
+    post-signing-dummy: post-signing-dummy
     signing: signing-rust-log-forwarder
   description: Publish release module rust-log-forwarder
   if_dependencies: []
   kind: beetmover
   label: beetmover-rust-log-forwarder
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module rust-log-forwarder
@@ -1871,40 +1883,41 @@
     always_target: false
     buildconfig:
       artifactId: rustlog
       name: rustlog
       path: components/rc_log/android
       publications:
       - name: rustlog
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-rustlog
+    post-signing-dummy: post-signing-dummy
     signing: signing-rustlog
   description: Publish release module rustlog
   if_dependencies: []
   kind: beetmover
   label: beetmover-rustlog
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module rustlog
@@ -2014,40 +2027,41 @@
     always_target: false
     buildconfig:
       artifactId: sync15
       name: sync15
       path: components/sync15/android
       publications:
       - name: sync15
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-sync15
+    post-signing-dummy: post-signing-dummy
     signing: signing-sync15
   description: Publish release module sync15
   if_dependencies: []
   kind: beetmover
   label: beetmover-sync15
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module sync15
@@ -2157,40 +2171,41 @@
     always_target: false
     buildconfig:
       artifactId: syncmanager
       name: syncmanager
       path: components/sync_manager/android
       publications:
       - name: syncmanager
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-syncmanager
+    post-signing-dummy: post-signing-dummy
     signing: signing-syncmanager
   description: Publish release module syncmanager
   if_dependencies: []
   kind: beetmover
   label: beetmover-syncmanager
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module syncmanager
@@ -2300,40 +2315,41 @@
     always_target: false
     buildconfig:
       artifactId: tabs
       name: tabs
       path: components/tabs/android
       publications:
       - name: tabs
         type: aar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-tabs
+    post-signing-dummy: post-signing-dummy
     signing: signing-tabs
   description: Publish release module tabs
   if_dependencies: []
   kind: beetmover
   label: beetmover-tabs
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module tabs
@@ -2443,40 +2459,41 @@
     always_target: false
     buildconfig:
       artifactId: tooling-nimbus-gradle
       name: tooling-nimbus-gradle
       path: tools/nimbus-gradle-plugin
       publications:
       - name: tooling-nimbus-gradle
         type: jar
       uploadSymbols: null
     kind: beetmover
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
   dependencies:
     module-build: module-build-tooling-nimbus-gradle
+    post-signing-dummy: post-signing-dummy
     signing: signing-tooling-nimbus-gradle
   description: Publish release module tooling-nimbus-gradle
   if_dependencies: []
   kind: beetmover
   label: beetmover-tooling-nimbus-gradle
   optimization: null
   soft_dependencies: []
   task:
     created:
       relative-datestamp: 0 seconds
     deadline:
       relative-datestamp: 1 day
     expires:
       relative-datestamp: 1 year
     extra:
       index:
         rank: 0
       parent: ''
     metadata:
       description: Publish release module tooling-nimbus-gradle
@@ -5897,40 +5914,103 @@
       onExitStatus:
         purgeCaches:
         - 72
         retry:
         - 72
     priority: highest
     provisionerId: app-services-3
     routes:
     - index.project.application-services.v2.nimbus-fml.114.0a1
     - checks
     scopes:
     - project:releng:services/tooltool/api/download/internal
     - docker-worker:cache:app-services-level-3-checkouts-hg58-v3-2c30e788cdb1128174d0
     tags:
       createdForUser: lougeniaC64@users.noreply.github.com
       kind: nimbus-fml
       label: nimbus-fml-build
       os: linux
       worker-implementation: docker-worker
     workerType: b-linux-gcp
+post-signing-dummy:
+  attributes:
+    always_target: false
+    buildconfig:
+      name: all
+    kind: post-signing-dummy
+    run_on_projects:
+    - all
+    run_on_tasks_for:
+    - github-release
+    - cron
+    shipping_phase: null
+  dependencies:
+    signing-autofill: signing-autofill
+    signing-crashtest: signing-crashtest
+    signing-errorsupport: signing-errorsupport
+    signing-full-megazord: signing-full-megazord
+    signing-fxaclient: signing-fxaclient
+    signing-httpconfig: signing-httpconfig
+    signing-logins: signing-logins
+    signing-native-support: signing-native-support
+    signing-nimbus: signing-nimbus
+    signing-places: signing-places
+    signing-push: signing-push
+    signing-rust-log-forwarder: signing-rust-log-forwarder
+    signing-rustlog: signing-rustlog
+    signing-sync15: signing-sync15
+    signing-syncmanager: signing-syncmanager
+    signing-tabs: signing-tabs
+    signing-tooling-nimbus-gradle: signing-tooling-nimbus-gradle
+  description: Dummy task to make it easier to block beetmover on signing completion
+  if_dependencies: []
+  kind: post-signing-dummy
+  label: post-signing-dummy
+  optimization: null
+  soft_dependencies: []
+  task:
+    created:
+      relative-datestamp: 0 seconds
+    deadline:
+      relative-datestamp: 1 day
+    expires:
+      relative-datestamp: 1 year
+    extra:
+      index:
+        rank: 0
+      parent: ''
+    metadata:
+      description: Dummy task to make it easier to block beetmover on signing completion
+      name: post-signing-dummy
+      owner: lougeniaC64@users.noreply.github.com
+      source: https://github.com/mozilla/application-services/blob/29a50092f8134db5e4343a3c56e2fd236a83f498/taskcluster/ci/post-signing-dummy
+    payload: {}
+    priority: highest
+    provisionerId: built-in
+    routes:
+    - checks
+    scopes: []
+    tags:
+      createdForUser: lougeniaC64@users.noreply.github.com
+      kind: post-signing-dummy
+      label: post-signing-dummy
+    workerType: succeed
 signing-autofill:
   attributes:
     always_target: false
     buildconfig:
       artifactId: autofill
       name: autofill
       path: components/autofill/android
       publications:
       - name: autofill
         type: aar
       uploadSymbols: null
     kind: signing
     resource-monitor: true
     run-on-pr-type: full-ci
     run_on_projects:
     - all
     run_on_tasks_for:
     - github-release
     - cron
     shipping_phase: null
```