### PR TITLE
Write trailing newlines when updating the changelog

### DIFF
--- a/automation/prepare-release.py
+++ b/automation/prepare-release.py
@@ -70,6 +70,7 @@ else:
 changelog[0] = f"# v{major_version_number}.0 (_{today_date}_)"
 with open(CHANGELOG_FILE, "w") as stream:
     stream.write("\n".join(changelog))
+    stream.write("\n")
 
 step_msg(f"Creating a commit with the changes")
 run_cmd_checked(["git", "add", CHANGELOG_FILE])
@@ -93,6 +94,7 @@ changelog[0:0] = [
 ]
 with open(CHANGELOG_FILE, "w") as stream:
     stream.write("\n".join(changelog))
+    stream.write("\n")
 
 step_msg(f"Creating a commit with the changes")
 run_cmd_checked(["git", "add", CHANGELOG_FILE])


### PR DESCRIPTION
Minor tweak that should make the PRs cleaner.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
