### PR TITLE
Fix the taskcluster code that handles GitHub releases

### DIFF
--- a/taskcluster/app_services_taskgraph/__init__.py
+++ b/taskcluster/app_services_taskgraph/__init__.py
@@ -10,7 +10,7 @@ import re
 
 from taskgraph.parameters import extend_parameters_schema
 from . import branch_builds
-from .build_config import get_version
+from .build_config import get_version_from_build_config
 
 PREVIEW_RE = re.compile(r'\[preview ([\w-]+)\]')
 
@@ -49,7 +49,7 @@ def get_decision_parameters(graph_config, parameters):
                     head_tag
                 )
             )
-        version = get_version(graph_config.params)
+        version = get_version_from_build_config()
         # XXX: tags are in the format of `v<semver>`
         if head_tag[1:] != version:
             raise ValueError(

--- a/taskcluster/app_services_taskgraph/build_config.py
+++ b/taskcluster/app_services_taskgraph/build_config.py
@@ -32,7 +32,7 @@ def get_components():
 
 
 def get_version(params):
-    version = _read_build_config()["libraryVersion"]
+    version = get_version_from_build_config()
     preview_build = params.get('preview-build')
     if preview_build == 'nightly':
         components = version.split('.')
@@ -43,6 +43,9 @@ def get_version(params):
         raise NotImplemented("Only nightly preview builds are currently supported")
     else:
         return version
+
+def get_version_from_build_config():
+    return _read_build_config()["libraryVersion"]
 
 def get_extensions(module_name):
     publications = _read_build_config()["projects"][module_name]['publications']


### PR DESCRIPTION
In order to enable the nightly builds, we made `get_version()` input the decision parameters.  However, this clearly isn't going to work in the `get_decision_parameters()` function.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
