### PR TITLE
Don't build nightlies if there isn't a new commit

### DIFF
--- a/taskcluster/app_services_taskgraph/__init__.py
+++ b/taskcluster/app_services_taskgraph/__init__.py
@@ -83,7 +83,6 @@ def get_decision_parameters(graph_config, parameters):
         # We don't have a great way of determining if something is a nightly or
         # not.  But for now, we can assume all cron-based builds are nightlies.
         parameters["preview-build"] = "nightly"
-        parameters["target_tasks_method"] = "full"
         parameters["release-type"] = "nightly"
 
     parameters['branch-build'] = branch_builds.calc_branch_build_param(parameters)

--- a/taskcluster/test/params/cron-nightly.yml
+++ b/taskcluster/test/params/cron-nightly.yml
@@ -26,6 +26,6 @@ pushdate: 0
 pushlog_id: '0'
 release-type: nightly
 repository_type: git
-target_tasks_method: full
+target_tasks_method: nightly
 tasks_for: cron
 version: null


### PR DESCRIPTION
Added a new `nightly` target tasks method.  That works like `full`, except it checks the `nightly.json` file to see if we're still on the same commit as the last nightly build.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
