### PR TITLE
Mac taskcluster improvements [ci full]

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -15,7 +15,8 @@ targets = [
     "x86_64-linux-android",
     "aarch64-apple-ios",
     "x86_64-apple-ios",
-    "aarch64-apple-ios-sim"
+    "aarch64-apple-ios-sim",
+    "aarch64-apple-darwin",
 ]
 # The "rust-src" component is currently required for building for the M1 iOS simulator.
 components = ["clippy", "rustfmt", "rust-src"]

--- a/taskcluster/app_services_taskgraph/transforms/appservices.py
+++ b/taskcluster/app_services_taskgraph/transforms/appservices.py
@@ -13,7 +13,7 @@ transforms = TransformSequence()
 def add_release_routes(config, tasks):
     for task in tasks:
         # Add routes listed in `release-routes` if we're building for a release
-        release_routes = task['attributes'].get('release-routes')
+        release_routes = task.get('attributes', {}).get('release-routes')
         release_type = config.params.get('release-type')
         if release_type and release_routes:
             task.setdefault('routes', []).extend(release_routes)

--- a/taskcluster/app_services_taskgraph/transforms/nimbus.py
+++ b/taskcluster/app_services_taskgraph/transforms/nimbus.py
@@ -69,12 +69,17 @@ def setup_mac_build_task(task, target, binary):
         'using': 'run-commands',
         'run-task-command': ["/usr/local/bin/python3", "run-task"],
         'pre-commands': [
-            ["taskcluster/scripts/toolchain/build-rust-toolchain-macosx.sh"],
-            ["taskcluster/scripts/toolchain/libs-ios.sh"],
+            ["source", "taskcluster/scripts/setup-mac-worker.sh"],
+            ["source", "taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh"],
         ],
         'commands': [
             [ "taskcluster/scripts/nimbus-build-osx.sh", "build/", binary, target ]
         ],
+    }
+    task['fetches'] = {
+        'toolchain': [
+            'rust-osx',
+        ]
     }
 
 # Transform for the nimbus-assemble task

--- a/taskcluster/app_services_taskgraph/transforms/worker.py
+++ b/taskcluster/app_services_taskgraph/transforms/worker.py
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+@transforms.add
+def setup_worker(_, tasks):
+    for task in tasks:
+        task_name = task['name']
+        try:
+            worker_type = task['worker-type']
+        except KeyError:
+            raise ValueError(f"worker-type not set for {task_name}")
+        if worker_type == 'b-linux':
+            worker = task.setdefault('worker', {})
+            worker['docker-image'] = {'in-tree': 'linux'}
+        else:
+            raise ValueError(f"Unknown worker type for {task_name} ({worker_type})")
+        yield task

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -7,6 +7,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+  - app_services_taskgraph.transforms.worker:transforms
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.task:transforms
 
@@ -25,7 +26,6 @@ tasks:
       - project:releng:services/tooltool/api/download/internal
     worker-type: b-linux
     worker:
-      docker-image: { in-tree: linux }
       max-run-time: 1800
       env: {}
     run:

--- a/taskcluster/ci/lint/kind.yml
+++ b/taskcluster/ci/lint/kind.yml
@@ -7,13 +7,13 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+  - app_services_taskgraph.transforms.worker:transforms
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.task:transforms
 
 task-defaults:
   worker-type: b-linux
   worker:
-    docker-image: { in-tree: linux }
     max-run-time: 1800
   run:
     using: gradlew

--- a/taskcluster/ci/module-build/kind.yml
+++ b/taskcluster/ci/module-build/kind.yml
@@ -7,6 +7,7 @@
 loader: app_services_taskgraph.loader.build_config:loader
 
 transforms:
+  - app_services_taskgraph.transforms.worker:transforms
   - app_services_taskgraph.transforms.secrets:transforms
   - app_services_taskgraph.transforms.module_build:transforms
   - taskgraph.transforms.job:transforms
@@ -26,7 +27,6 @@ task-defaults:
   worker-type: b-linux
   worker:
     chain-of-trust: true
-    docker-image: { in-tree: linux }
     max-run-time: 1800
     env: {}
   run:

--- a/taskcluster/ci/nimbus-binaries-assemble/kind.yml
+++ b/taskcluster/ci/nimbus-binaries-assemble/kind.yml
@@ -16,6 +16,7 @@ kind-dependencies:
   - nimbus-build
 
 transforms:
+  - app_services_taskgraph.transforms.worker:transforms
   - app_services_taskgraph.transforms.nimbus:assemble
   - app_services_taskgraph.transforms.release_artifacts
   - app_services_taskgraph.transforms.appservices
@@ -28,7 +29,6 @@ task-defaults:
   worker-type: b-linux
   worker:
     chain-of-trust: true
-    docker-image: { in-tree: linux }
     max-run-time: 1800
 
 tasks:

--- a/taskcluster/ci/release-publish/kind.yml
+++ b/taskcluster/ci/release-publish/kind.yml
@@ -16,6 +16,7 @@ kind-dependencies:
   - build-summary
 
 transforms:
+  - app_services_taskgraph.transforms.worker:transforms
   - app_services_taskgraph.transforms.release_publish:transforms
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.task:transforms
@@ -30,7 +31,6 @@ tasks:
     worker-type: b-linux
     worker:
       chain-of-trust: true
-      docker-image: { in-tree: linux }
       max-run-time: 1800
       env: {}
     run:

--- a/taskcluster/ci/swift/kind.yml
+++ b/taskcluster/ci/swift/kind.yml
@@ -7,6 +7,7 @@
 loader: taskgraph.loader.transform:loader
 
 transforms:
+  - app_services_taskgraph.transforms.worker:transforms
   - app_services_taskgraph.transforms.appservices:transforms
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.task:transforms
@@ -46,8 +47,9 @@ tasks:
         #   type: "file"
     run:
       pre-commands:
-        - ["taskcluster/scripts/toolchain/build-rust-toolchain-macosx.sh"]
-        - ["taskcluster/scripts/toolchain/libs-ios.sh"]
+        - ["source", "taskcluster/scripts/setup-mac-worker.sh"]
+        - ["source", "taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh"]
+        - ["source", "taskcluster/scripts/toolchain/setup-libs-ios.sh"]
       commands:
         - ["taskcluster/scripts/build-and-test-swift.sh"]
         - [ "cd", "build/" ]
@@ -56,5 +58,8 @@ tasks:
       run-task-command: ["/usr/local/bin/python3", "run-task"]
       use-caches: true
     fetches:
-        fetch:
-            - swiftformat
+      toolchain:
+        - rust-osx
+        - libs-ios
+      fetch:
+          - swiftformat

--- a/taskcluster/ci/toolchain/ios.yml
+++ b/taskcluster/ci/toolchain/ios.yml
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+libs-ios:
+    description: 'Build NSS/SQLCipher for iOS'
+    run:
+        resources:
+            - libs
+        script: libs-ios.sh
+        toolchain-alias: libs-ios
+        toolchain-artifact: public/build/ios.tar.gz
+        run-task-command: ["/usr/local/bin/python3", "run-task"]
+    worker-type: b-osx

--- a/taskcluster/ci/toolchain/kind.yml
+++ b/taskcluster/ci/toolchain/kind.yml
@@ -8,6 +8,7 @@ kind-dependencies:
   - fetch
 
 transforms:
+  - app_services_taskgraph.transforms.worker:transforms
   - app_services_taskgraph.transforms.toolchain:transforms
   - taskgraph.transforms.job:transforms
   - taskgraph.transforms.cached_tasks:transforms
@@ -24,12 +25,12 @@ task-defaults:
   worker-type: b-linux
   worker:
     env: {}
-    docker-image: {in-tree: linux}
     max-run-time: 7200
 
 tasks-from:
     - android.yml
     - desktop.yml
+    - ios.yml
     - resourcemonitor.yml
     - robolectric.yml
     - rust.yml

--- a/taskcluster/ci/toolchain/rust.yml
+++ b/taskcluster/ci/toolchain/rust.yml
@@ -10,3 +10,14 @@ rust:
         script: build-rust-toolchain.sh
         toolchain-alias: rust
         toolchain-artifact: public/build/rust.tar.gz
+
+rust-osx:
+    description: 'Build the OSX Rust toolchain'
+    run:
+        resources:
+            - rust-toolchain.toml
+        script: build-rust-toolchain-macosx.sh
+        toolchain-alias: rust-osx
+        toolchain-artifact: public/build/rust-osx.tar.gz
+        run-task-command: ["/usr/local/bin/python3", "run-task"]
+    worker-type: b-osx

--- a/taskcluster/docker/linux/Dockerfile
+++ b/taskcluster/docker/linux/Dockerfile
@@ -166,7 +166,7 @@ RUN \
 
 ENV SHELL=/bin/bash \
     HOME=/builds/worker \
-    PATH=/builds/worker/.local/bin:/builds/worker/.cargo/bin:$PATH
+    PATH=/builds/worker/.local/bin:$PATH
 
 VOLUME /builds/worker/checkouts
 VOLUME /builds/worker/.cache

--- a/taskcluster/scripts/build-and-test-swift.sh
+++ b/taskcluster/scripts/build-and-test-swift.sh
@@ -5,9 +5,5 @@ set -ex
 # This runs in front of `build-and-test-swift.py`  The only reason it exists is that it's easier to
 # setup the enviroment in a script.
 
-# shellcheck source=/dev/null
-source "$HOME/.cargo/env"
-export PATH="$HOME/bin:$HOME/Library/Python/3.7/bin:$PATH"
 mv "$MOZ_FETCHES_DIR/swiftformat" "$HOME/bin/swiftformat"
-
 taskcluster/scripts/build-and-test-swift.py build/swift-components build/ build/glean-workdir

--- a/taskcluster/scripts/nimbus-build-osx.sh
+++ b/taskcluster/scripts/nimbus-build-osx.sh
@@ -5,9 +5,6 @@ set -ex
 # This runs in front of `build-nimbus-fml.py`  The only reason it exists is that it's easier to
 # setup the enviroment in a script.
 
-# shellcheck source=/dev/null
-source "$HOME/.cargo/env"
-export PATH="$HOME/bin:$HOME/Library/Python/3.7/bin:$PATH"
 SDK=macosx11.0
 xcodebuild -showsdks
 SDKROOT=$(xcrun -sdk $SDK --show-sdk-path)

--- a/taskcluster/scripts/setup-mac-worker.sh
+++ b/taskcluster/scripts/setup-mac-worker.sh
@@ -1,0 +1,12 @@
+# Script to setup the mac workers
+#
+# This is intended to be sourced in `pre-commands`
+#
+# shellcheck shell=bash
+
+mkdir -p "$HOME/bin"
+export PATH="$HOME/bin:$HOME/Library/Python/3.7/bin:$PATH"
+
+# UPLOAD_DIR is not set for the generic worker, so we need to set it ourselves
+# FIXME: what's the right way to get this value?
+export UPLOAD_DIR="${PWD}/../public/build"

--- a/taskcluster/scripts/toolchain/android.sh
+++ b/taskcluster/scripts/toolchain/android.sh
@@ -2,7 +2,7 @@
 set -ex
 cd vcs
 git submodule update --init
-./taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh
+source ./taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh
 ./libs/verify-android-ci-environment.sh
 pushd libs
 ./build-all.sh android

--- a/taskcluster/scripts/toolchain/build-rust-toolchain-macosx.sh
+++ b/taskcluster/scripts/toolchain/build-rust-toolchain-macosx.sh
@@ -10,6 +10,9 @@
 
 set -ex
 
+# UPLOAD_DIR is not set for the generic worker, so we need to set it ourselves
+# FIXME: what's the right way to get this value?
+UPLOAD_DIR="${PWD}/../public/build"
 # Clear out any existing Rust files
 rm -fr ~/.cargo ~/.rustup
 # Install rustup
@@ -26,8 +29,8 @@ source "$HOME"/.cargo/env
 # So long as this is executed after the checkout it will use the version specified in rust-toolchain.yaml
 rustup update
 rustup target add aarch64-apple-darwin
-# TODO: re-enable this once we split out the toolchain tasks from swift-build
-# # Tar everything into UPLOAD_DIR
-# cd "$HOME"
-# mkdir -p "$UPLOAD_DIR"
-# tar -czf "$UPLOAD_DIR"/rust.tar.gz .rustup .cargo
+
+# Tar everything into UPLOAD_DIR
+cd "$HOME"
+mkdir -p "$UPLOAD_DIR"
+tar -czf "$UPLOAD_DIR"/rust-osx.tar.gz .rustup .cargo

--- a/taskcluster/scripts/toolchain/build-rust-toolchain.sh
+++ b/taskcluster/scripts/toolchain/build-rust-toolchain.sh
@@ -18,6 +18,9 @@ curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/ar
 echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -
 chmod +x rustup-init
 ./rustup-init -y --no-modify-path --default-toolchain none
+rm rustup-init
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env
 
 # cd to the app-services directory, so that rustup will see our `rust-toolchain.toml` file
 cd "$VCS_PATH"

--- a/taskcluster/scripts/toolchain/desktop-linux.sh
+++ b/taskcluster/scripts/toolchain/desktop-linux.sh
@@ -2,7 +2,7 @@
 set -ex
 cd vcs
 git submodule update --init
-./taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh
+source ./taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh
 ./libs/verify-android-ci-environment.sh
 pushd libs
 ./build-all.sh desktop

--- a/taskcluster/scripts/toolchain/libs-ios.sh
+++ b/taskcluster/scripts/toolchain/libs-ios.sh
@@ -2,11 +2,10 @@
 set -ex
 
 # Clean out files from the previous run
-rm -fr ../gyp "$HOME/Library/Python/" "${HOME:?}/bin"
+rm -fr gyp "$HOME/Library/Python/" "${HOME:?}/bin"
 
-# Add cargo/rust to PATH
 # shellcheck source=/dev/null
-source "$HOME"/.cargo/env
+source vcs/taskcluster/scripts/setup-mac-worker.sh
 
 # Install ninja, gyp, and xcpretty
 NINJA_DOWNLOAD_URL=https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-mac.zip
@@ -16,17 +15,14 @@ echo "${NINJA_SHA256}  ninja-mac.zip" | shasum -a 256 -c -
 unzip ninja-mac.zip -d "$HOME/bin"
 rm ninja-mac.zip
 gem install --user-install --bindir "$HOME"/bin xcpretty
-pushd ..
 git clone https://chromium.googlesource.com/external/gyp.git
 pip3 install -v --user ./gyp six
-popd
 export PATH="$HOME/bin:$HOME/Library/Python/3.7/bin:$PATH"
 
 # Build the libs
-pushd libs
+cd vcs/libs
 ./build-all.sh ios
-popd
+cd ..
 
-# TODO: re-enable this once we split out the toolchain tasks from swift-build
-# mkdir -p "$UPLOAD_DIR"
-# tar -czf "$UPLOAD_DIR"/ios.tar.gz libs/ios
+mkdir -p "$UPLOAD_DIR"
+tar -czf "$UPLOAD_DIR"/ios.tar.gz libs/ios

--- a/taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh
+++ b/taskcluster/scripts/toolchain/setup-fetched-rust-toolchain.sh
@@ -1,11 +1,12 @@
-#!/bin/bash
-#
 # Setup the Rust toolchain built by the `build-rust-toolchain-sh` script.  See that script for details on this process.
+#
+# This is intended to be sourced in the `pre-commands`
+# shellcheck shell=bash
 
-set -ex
-
-# By the time this script runs, `build-rust-toolchain.sh` has completed and all
-# the artifacts it's built have been downloaded and unpacked into the fetches
-# directory.  We just need to copy them out.
+# The artifacts from `build-rust-toolchain.sh` have been fetched to MOZ_FETCHES_DIR.  Copy them out
+# to our home directory
 rsync -a "${MOZ_FETCHES_DIR}"/.cargo "${HOME}"
 rsync -a "${MOZ_FETCHES_DIR}"/.rustup "${HOME}"
+
+# shellcheck source=/dev/null
+source "$HOME"/.cargo/env

--- a/taskcluster/scripts/toolchain/setup-libs-ios.sh
+++ b/taskcluster/scripts/toolchain/setup-libs-ios.sh
@@ -1,0 +1,6 @@
+# Setup the ios libraries built by the `libs-ios.sh`` script.  See that script for details on this process.
+#
+# This is intended to be sourced in the `pre-commands`
+# shellcheck shell=bash
+
+rsync -av "${MOZ_FETCHES_DIR}"/libs/ios/ libs/ios/


### PR DESCRIPTION
Move OSX Rust setup and library building to toolchain tasks.  This way we can only build them once, rather than in each task that requires it.
    
- Updated `setup-fetched-rust-toolchain.sh` to work with both the docker worker and mac worker.
- Build the NSS/SQJCipher libraries as a toolchain task that other tasks can depend on.  Right now, we're building these libraries in each task.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
