### PR TITLE
add user_id randomization unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### 🦊 What's Changed 🦊
 
- - [`nimbus-cli`](./components/support/nimbus-cli) now has commands: `capture-logs`, `tail-logs`, `test-feature`, `fetch` and `apply-files`. ([#5517](https://github.com/mozilla/application-services/pull/5517)))
- - Add additional Cirrus SDK helper methods and add Python testing for the generated Cirrus Python code [#5478](https://github.com/mozilla/application-services/pull/5478)).
- - Add `user_id` RandomizationUnit (for Cirrus) ([#<id>](https://github.com/mozilla/application-services/pull/<id>)).
+ - [`nimbus-cli`](./components/support/nimbus-cli) now has commands: `capture-logs`, `tail-logs`, `test-feature`, `fetch` and `apply-files`. ([#5517](https://github.com/mozilla/application-services/pull/5517))
+ - Add additional Cirrus SDK helper methods and add Python testing for the generated Cirrus Python code ([#5478](https://github.com/mozilla/application-services/pull/5478)).
+ - Add `user_id` RandomizationUnit (for Cirrus) ([#5564](https://github.com/mozilla/application-services/pull/5564)).
 
 [Full Changelog](In progress)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  - [`nimbus-cli`](./components/support/nimbus-cli) now has commands: `capture-logs`, `tail-logs`, `test-feature`, `fetch` and `apply-files`. ([#5517](https://github.com/mozilla/application-services/pull/5517)))
  - Add additional Cirrus SDK helper methods and add Python testing for the generated Cirrus Python code [#5478](https://github.com/mozilla/application-services/pull/5478)).
+ - Add `user_id` RandomizationUnit (for Cirrus) ([#<id>](https://github.com/mozilla/application-services/pull/<id>)).
 
 [Full Changelog](In progress)
 

--- a/automation/python-tests/conftest.py
+++ b/automation/python-tests/conftest.py
@@ -6,7 +6,7 @@ from components.nimbus.cirrus import CirrusClient
 @pytest.fixture
 def bucket_config():
     return {
-        "randomizationUnit": "client_id",
+        "randomizationUnit": "user_id",
         "count": 100,
         "namespace": '',
         "start": 1,

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -115,7 +115,7 @@ open class Nimbus(
             remoteSettingsConfig,
             // The "dummy" field here is required for obscure reasons when generating code on desktop,
             // so we just automatically set it to a dummy value.
-            AvailableRandomizationUnits(clientId = null, dummy = 0)
+            AvailableRandomizationUnits(clientId = null, userId = null, dummy = 0)
         )
     }
 
@@ -355,7 +355,7 @@ open class Nimbus(
     override fun resetTelemetryIdentifiers() {
         // The "dummy" field here is required for obscure reasons when generating code on desktop,
         // so we just automatically set it to a dummy value.
-        val aru = AvailableRandomizationUnits(clientId = null, dummy = 0)
+        val aru = AvailableRandomizationUnits(clientId = null, userId = null, dummy = 0)
         dbScope.launch {
             withCatchAll("resetTelemetryIdentifiers") {
                 nimbusClient.resetTelemetryIdentifiers(aru).also { enrollmentChangeEvents ->

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -335,7 +335,7 @@ extension Nimbus: NimbusUserConfiguration {
         _ = catchAll(dbQueue) { _ in
             // The "dummy" field here is required for obscure reasons when generating code on desktop,
             // so we just automatically set it to a dummy value.
-            let aru = AvailableRandomizationUnits(clientId: nil, dummy: 0)
+            let aru = AvailableRandomizationUnits(clientId: nil, userId: nil, dummy: 0)
             try self.resetTelemetryIdentifiersOnThisThread(aru)
         }
     }

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -56,7 +56,7 @@ public extension Nimbus {
             remoteSettingsConfig: remoteSettings,
             // The "dummy" field here is required for obscure reasons when generating code on desktop,
             // so we just automatically set it to a dummy value.
-            availableRandomizationUnits: AvailableRandomizationUnits(clientId: nil, dummy: 0)
+            availableRandomizationUnits: AvailableRandomizationUnits(clientId: nil, userId: nil, dummy: 0)
         )
 
         return Nimbus(nimbusClient: nimbusClient, resourceBundles: resourceBundles, errorReporter: errorReporter)

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -55,6 +55,7 @@ dictionary RemoteSettingsConfig {
 
 dictionary AvailableRandomizationUnits {
     string? client_id;
+    string? user_id;
     // work around uniffi-rs #331 by including a non-optional value. We'll
     // try and hide this in the bindings used by clients and eventually remove
     // it entirely.

--- a/components/nimbus/src/schema.rs
+++ b/components/nimbus/src/schema.rs
@@ -246,6 +246,7 @@ impl From<Branch> for ExperimentBranch {
 pub enum RandomizationUnit {
     NimbusId,
     ClientId,
+    UserId,
 }
 
 impl Default for RandomizationUnit {
@@ -257,6 +258,7 @@ impl Default for RandomizationUnit {
 #[derive(Default)]
 pub struct AvailableRandomizationUnits {
     pub client_id: Option<String>,
+    pub user_id: Option<String>,
     #[allow(dead_code)]
     pub(crate) dummy: i8, // See comments in nimbus.udl for why this hacky item exists.
 }
@@ -267,6 +269,17 @@ impl AvailableRandomizationUnits {
     pub fn with_client_id(client_id: &str) -> Self {
         Self {
             client_id: Some(client_id.to_string()),
+            user_id: None,
+            dummy: 0,
+        }
+    }
+
+    // Use ::with_user_id when you want to specify one, or use
+    // Default::default if you don't!
+    pub fn with_user_id(user_id: &str) -> Self {
+        Self {
+            client_id: None,
+            user_id: Some(user_id.to_string()),
             dummy: 0,
         }
     }
@@ -279,6 +292,7 @@ impl AvailableRandomizationUnits {
         match wanted {
             RandomizationUnit::NimbusId => Some(nimbus_id),
             RandomizationUnit::ClientId => self.client_id.as_deref(),
+            RandomizationUnit::UserId => self.user_id.as_deref(),
         }
     }
 }

--- a/components/nimbus/src/stateless/cirrus_client.rs
+++ b/components/nimbus/src/stateless/cirrus_client.rs
@@ -124,7 +124,7 @@ impl CirrusClient {
 
     pub(crate) fn enroll(
         &self,
-        client_id: String,
+        user_id: String,
         request_context: Map<String, Value>,
         is_user_participating: bool,
         prev_enrollments: &[ExperimentEnrollment],
@@ -134,7 +134,7 @@ impl CirrusClient {
         // part of https://mozilla-hub.atlassian.net/browse/EXP-3401
         let nimbus_id = Uuid::new_v4();
         let available_randomization_units =
-            AvailableRandomizationUnits::with_client_id(client_id.as_str());
+            AvailableRandomizationUnits::with_user_id(user_id.as_str());
         let ta = TargetingAttributes::new(self.app_context.clone(), request_context);
         let th = NimbusTargetingHelper::new(ta);
         let enrollments_evolver =

--- a/components/nimbus/src/tests/stateless/test_cirrus_client.rs
+++ b/components/nimbus/src/tests/stateless/test_cirrus_client.rs
@@ -180,7 +180,7 @@ mod helpers {
                 "start":0,
                 "total":10_000,
                 "namespace":"secure-silver",
-                "randomizationUnit":"client_id"
+                "randomizationUnit":"user_id"
             },
             "isEnrollmentPaused":false,
             "proposedEnrollment":7,
@@ -226,7 +226,7 @@ mod helpers {
                 "start":0,
                 "total":10_000,
                 "namespace":"secure-silver",
-                "randomizationUnit":"client_id"
+                "randomizationUnit":"user_id"
             },
             "isEnrollmentPaused":false,
             "proposedEnrollment":7,


### PR DESCRIPTION
This PR adds a UserId randomization unit. It's mainly required for Cirrus, but I feel as though since it is a part of the overall schema it should not be behind conditional compilation.

There are no _direct_ tests for this change, but the adjustments to the Cirrus client tests cover the changes.

https://mozilla-hub.atlassian.net/browse/EXP-3399

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
