### PR TITLE
nimbus-gradle-plugin arch fix

### DIFF
--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -234,7 +234,7 @@ class NimbusPlugin implements Plugin<Project> {
         if (os.contains("win")) {
             osPart = "pc-windows-gnu"
         } else if (os.contains("nix") || os.contains("nux") || os.contains("aix")) {
-            osPart = "unknown-linux-musl"
+            osPart = "unknown-linux"
         } else if (os.contains("mac")) {
             osPart = "apple-darwin"
         } else {


### PR DESCRIPTION
PR#5543 changed things so we use the `-gnu` version instead of the `-musl` version.  This updates the plugin to match.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
