### PR TITLE
Update the build-summary alert slack channel

### DIFF
--- a/taskcluster/ci/build-summary/kind.yml
+++ b/taskcluster/ci/build-summary/kind.yml
@@ -27,4 +27,4 @@ tasks:
       buildconfig:
         name: all
     alerts:
-      slack-channel: CKL0LGV9B
+      slack-channel: C0559DDDPQF


### PR DESCRIPTION
This updates the channel we send an alert to when a nightly or release build fails.  The old value was `#app-services`, which we're not using anymore.  I changed it to `#applicaiton-services-eng` which has a bunch of relman/releng members in it.

The other possibility is `#sync-bots`, but I'm thinking we can reserve that one for things like Sentry errors that happen fairly frequently. This one should be very low volume.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
