### PR TITLE
Add arm64 artifact to branch builds.

### DIFF
--- a/taskcluster/app_services_taskgraph/transforms/branch_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/branch_build.py
@@ -196,6 +196,11 @@ def get_fenix_build_tasks(task):
             'name': 'public/branch-build/app-x86-debug.apk',
             'path': '/builds/worker/checkouts/vcs/firefox-android/fenix/app/build/outputs/apk/fenix/debug/app-fenix-x86-debug.apk',
             'type': 'file',
+        },
+        {
+            'name': 'public/branch-build/app-arm64-debug.apk',
+            'path': '/builds/worker/checkouts/vcs/firefox-android/fenix/app/build/outputs/apk/fenix/debug/app-fenix-arm64-v8a-debug.apk',
+            'type': 'file',
         }
     ]
     yield task


### PR DESCRIPTION
This _should_ add an arm64 apk artifact to branch builds. Currently, only x86 is made available which is a rare physical device type and can't really be emulated on Apple silicon easily.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
