### PR TITLE
Pass ${cron.quoted_args} to taskgraph

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -241,26 +241,30 @@ tasks:
                               - '--'
                               - bash
                               - -cx
-                              - $if: 'tasks_for == "action"'
-                                then: >
-                                  ln -s /builds/worker/artifacts artifacts &&
-                                  ~/.local/bin/taskgraph action-callback
-                                else: >
-                                  ln -s /builds/worker/artifacts artifacts &&
-                                  ~/.local/bin/taskgraph decision
-                                  --pushlog-id='0'
-                                  --pushdate='0'
-                                  --project='${project}'
-                                  --message=""
-                                  --owner='${ownerEmail}'
-                                  --level='${level}'
-                                  --base-repository="$APPSERVICES_BASE_REPOSITORY"
-                                  --head-repository="$APPSERVICES_HEAD_REPOSITORY"
-                                  --head-ref="$APPSERVICES_HEAD_REF"
-                                  --head-rev="$APPSERVICES_HEAD_REV"
-                                  --head-tag="$APPSERVICES_HEAD_TAG"
-                                  --repository-type="$APPSERVICES_REPOSITORY_TYPE"
-                                  --tasks-for='${tasks_for}'
+                              - $let:
+                                  extraArgs: {$if: 'tasks_for == "cron"', then: '${cron.quoted_args}', else: ''}
+                                in:
+                                  $if: 'tasks_for == "action"'
+                                  then: >
+                                    ln -s /builds/worker/artifacts artifacts &&
+                                    ~/.local/bin/taskgraph action-callback
+                                  else: >
+                                    ln -s /builds/worker/artifacts artifacts &&
+                                    ~/.local/bin/taskgraph decision
+                                    --pushlog-id='0'
+                                    --pushdate='0'
+                                    --project='${project}'
+                                    --message=""
+                                    --owner='${ownerEmail}'
+                                    --level='${level}'
+                                    --base-repository="$APPSERVICES_BASE_REPOSITORY"
+                                    --head-repository="$APPSERVICES_HEAD_REPOSITORY"
+                                    --head-ref="$APPSERVICES_HEAD_REF"
+                                    --head-rev="$APPSERVICES_HEAD_REV"
+                                    --head-tag="$APPSERVICES_HEAD_TAG"
+                                    --repository-type="$APPSERVICES_REPOSITORY_TYPE"
+                                    --tasks-for='${tasks_for}'
+                                    ${extraArgs}
                           artifacts:
                               'public':
                                   type: 'directory'


### PR DESCRIPTION
The nightly cron job needs to be able to pass a target-tasks-method to taskgraph, so .taskcluster.yml needs to pass that along.

Fixes a regression from commit 21be4e2508c72b93e20b89287051fac0f741d6ab.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
