### PR TITLE
Adds remote-settings to taskcluster iOS releases [ci full]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,6 +2057,7 @@ dependencies = [
  "error-support",
  "nimbus-sdk",
  "rc_log_ffi",
+ "remote_settings",
  "viaduct",
  "viaduct-reqwest",
 ]

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -242,7 +242,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: libc</name>
-    <url>https://github.com/rust-lang/libc/blob/master/LICENSE-APACHE</url>
+    <url>https://github.com/rust-lang/libc/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: linux-raw-sys</name>

--- a/megazords/ios-rust/build-xcframework.sh
+++ b/megazords/ios-rust/build-xcframework.sh
@@ -145,8 +145,10 @@ mkdir -p "$COMMON/Headers"
 cp "$WORKING_DIR/$FRAMEWORK_NAME.h" "$COMMON/Headers"
 cp "$REPO_ROOT/components/rc_log/ios/RustLogFFI.h" "$COMMON/Headers"
 cp "$REPO_ROOT/components/viaduct/ios/RustViaductFFI.h" "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/remote_settings/src/remote_settings.udl" -l swift -o "$COMMON/Headers"
 $CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l swift -o "$COMMON/Headers"
 $CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/error/src/errorsupport.udl" -l swift -o "$COMMON/Headers"
+
 
 
 # We now only move/generate the rest of the headers if we are generating a full
@@ -164,7 +166,6 @@ if [ -z $IS_FOCUS ]; then
   $CARGO uniffi-bindgen generate "$REPO_ROOT/components/push/src/push.udl" -l swift -o "$COMMON/Headers"
   $CARGO uniffi-bindgen generate "$REPO_ROOT/components/tabs/src/tabs.udl" -l swift -o "$COMMON/Headers"
   $CARGO uniffi-bindgen generate "$REPO_ROOT/components/places/src/places.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/remote_settings/src/remote_settings.udl" -l swift -o "$COMMON/Headers"
   $CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync_manager/src/syncmanager.udl" -l swift -o "$COMMON/Headers"
   $CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync15/src/sync15.udl" -l swift -o "$COMMON/Headers"
 fi

--- a/megazords/ios-rust/focus/Cargo.toml
+++ b/megazords/ios-rust/focus/Cargo.toml
@@ -14,4 +14,4 @@ viaduct = { path = "../../../components/viaduct" }
 viaduct-reqwest = { path = "../../../components/support/viaduct-reqwest" }
 nimbus-sdk = { path = "../../../components/nimbus" }
 error-support = { path = "../../../components/support/error" }
-
+remote_settings = { path = "../../../components/remote_settings" }

--- a/megazords/ios-rust/focus/MozillaRustComponents.h
+++ b/megazords/ios-rust/focus/MozillaRustComponents.h
@@ -9,3 +9,4 @@
 #import "RustViaductFFI.h"
 #import "nimbusFFI.h"
 #import "errorFFI.h"
+#import "remote_settingsFFI.h"

--- a/megazords/ios-rust/focus/src/lib.rs
+++ b/megazords/ios-rust/focus/src/lib.rs
@@ -8,4 +8,5 @@
 pub use error_support;
 pub use nimbus;
 pub use rc_log_ffi;
+pub use remote_settings;
 pub use viaduct_reqwest;

--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -11,20 +11,22 @@ ROOT_DIR = pathlib.Path(__file__).parent.parent.parent
 # List of udl_paths to generate bindings for
 BINDINGS_UDL_PATHS = [
     "components/autofill/src/autofill.udl",
-    "components/support/error/src/errorsupport.udl",
     "components/fxa-client/src/fxa_client.udl",
     "components/logins/src/logins.udl",
     "components/nimbus/src/nimbus.udl",
     "components/places/src/places.udl",
     "components/push/src/push.udl",
+    "components/remote_settings/src/remote_settings.udl",
+    "components/support/error/src/errorsupport.udl",
+    "components/sync15/src/sync15.udl",
     "components/sync_manager/src/syncmanager.udl",
     "components/tabs/src/tabs.udl",
-    "components/sync15/src/sync15.udl",
 ]
 
 # List of udl_paths to generate bindings for
 FOCUS_UDL_PATHS = [
     "components/nimbus/src/nimbus.udl",
+    "components/remote_settings/src/remote_settings.udl",
     "components/support/error/src/errorsupport.udl",
 ]
 


### PR DESCRIPTION
When trying to build iOS with the latest nightly, I noticed breakage because the nimbus udl now depends on the remote settings udl, but the remote settings files were not being added to the taskcluster releases.


This PR adds the remote settings udl to the taskcluster releases for both Firefox and Focus iOS (since focus also uses nimbus)


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
