### PR TITLE
Don't generate module map for remote settings

### DIFF
--- a/components/remote_settings/uniffi.toml
+++ b/components/remote_settings/uniffi.toml
@@ -14,4 +14,5 @@ from_custom = "{}.toString()"
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"
 ffi_module_filename = "remote_settingsFFI"
+generate_module_map = false
 


### PR DESCRIPTION
I don't think having the module map will break anything, but I noticed it generated when I locally run the taskcluster script and it's unneeded