### PR TITLE
Uniffi library mode [ci full]

### DIFF
--- a/components/autofill/android/build.gradle
+++ b/components/autofill/android/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     testImplementation project(":syncmanager")
 }
 
-ext.configureUniFFIBindgen("../src/autofill.udl")
+ext.configureUniFFIBindgen("autofill")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/autofill/uniffi.toml
+++ b/components/autofill/uniffi.toml
@@ -1,6 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.autofill"
-cdylib_name = "megazord"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/crashtest/android/build.gradle
+++ b/components/crashtest/android/build.gradle
@@ -2,6 +2,6 @@
 apply from: "$rootDir/build-scripts/component-common.gradle"
 apply from: "$rootDir/publish.gradle"
 
-ext.configureUniFFIBindgen("../src/crashtest.udl")
+ext.configureUniFFIBindgen("crashtest")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/crashtest/uniffi.toml
+++ b/components/crashtest/uniffi.toml
@@ -1,7 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.crashtest"
-cdylib_name = "megazord"
-
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     api project(':sync15')
 }
 
-ext.configureUniFFIBindgen("../src/fxa_client.udl")
+ext.configureUniFFIBindgen("fxa_client")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/fxa-client/uniffi.toml
+++ b/components/fxa-client/uniffi.toml
@@ -1,10 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.fxaclient"
-cdylib_name = "megazord"
-
-[bindings.kotlin.external_packages]
-# Map from [External={crate-name}] into Kotlin package names
-sync15 = "mozilla.appservices.sync15"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -22,6 +22,6 @@ dependencies {
     testImplementation project(":syncmanager")
 }
 
-ext.configureUniFFIBindgen("../src/logins.udl")
+ext.configureUniFFIBindgen("logins")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/logins/uniffi.toml
+++ b/components/logins/uniffi.toml
@@ -1,6 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.logins"
-cdylib_name = "megazord"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -24,6 +24,6 @@ dependencies {
     testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:$glean_version"
 }
 
-ext.configureUniFFIBindgen("../src/nimbus.udl")
+ext.configureUniFFIBindgen("nimbus")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/nimbus/uniffi.toml
+++ b/components/nimbus/uniffi.toml
@@ -1,6 +1,5 @@
 [bindings.kotlin]
 package_name = "org.mozilla.experiments.nimbus.internal"
-cdylib = "megazord"
 
 [bindings.kotlin.custom_types.JsonObject]
 # Name of the type in the Kotlin code
@@ -11,14 +10,7 @@ imports = [ "org.json.JSONObject" ]
 into_custom = "JSONObject({})"
 from_custom = "{}.toString()"
 
-[bindings.kotlin.external_packages]
-# Map from [External={crate-name}] into Kotlin package names
-remote_settings = "mozilla.appservices.remotesettings"
-
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"
 ffi_module_filename = "nimbusFFI"
 generate_module_map = false
-
-[bindings.python]
-cdylib_name = "cirrus"

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -22,6 +22,6 @@ dependencies {
     testImplementation project(':syncmanager')
 }
 
-ext.configureUniFFIBindgen("../src/places.udl")
+ext.configureUniFFIBindgen("places")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/places/uniffi.toml
+++ b/components/places/uniffi.toml
@@ -2,7 +2,6 @@
 # Typically there'd be no `.uniffi` tail, but without it we see obscure
 # kotlin errors about being unable to resolve which `rustCall` to use.
 package_name = "mozilla.appservices.places.uniffi"
-cdylib_name = "megazord"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -2,6 +2,6 @@
 apply from: "$rootDir/build-scripts/component-common.gradle"
 apply from: "$rootDir/publish.gradle"
 
-ext.configureUniFFIBindgen("../src/push.udl")
+ext.configureUniFFIBindgen("push")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/push/uniffi.toml
+++ b/components/push/uniffi.toml
@@ -1,6 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.push"
-cdylib_name = "megazord"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -1,7 +1,7 @@
 apply from: "$rootDir/build-scripts/component-common.gradle"
 apply from: "$rootDir/publish.gradle"
 
-ext.configureUniFFIBindgen("../src/remote_settings.udl")
+ext.configureUniFFIBindgen("remote_settings")
 ext.dependsOnTheMegazord()
 ext.configurePublish()
 

--- a/components/remote_settings/uniffi.toml
+++ b/components/remote_settings/uniffi.toml
@@ -1,6 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.remotesettings"
-cdylib_name = "megazord"
 
 [bindings.kotlin.custom_types.RsJsonObject]
 # Name of the type in the Kotlin code

--- a/components/suggest/android/build.gradle
+++ b/components/suggest/android/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     api project(":remotesettings")
 }
 
-ext.configureUniFFIBindgen("../src/suggest.udl")
+ext.configureUniFFIBindgen("suggest")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/suggest/uniffi.toml
+++ b/components/suggest/uniffi.toml
@@ -1,6 +1,2 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.suggest"
-cdylib_name = "megazord"
-
-[bindings.kotlin.external_packages]
-remote_settings = "mozilla.appservices.remotesettings"

--- a/components/support/error/android/build.gradle
+++ b/components/support/error/android/build.gradle
@@ -2,6 +2,6 @@
 apply from: "$rootDir/build-scripts/component-common.gradle"
 apply from: "$rootDir/publish.gradle"
 
-ext.configureUniFFIBindgen("../src/errorsupport.udl")
+ext.configureUniFFIBindgen("error_support")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/support/error/uniffi.toml
+++ b/components/support/error/uniffi.toml
@@ -1,6 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.errorsupport"
-cdylib_name = "megazord"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/support/rust-log-forwarder/android/build.gradle
+++ b/components/support/rust-log-forwarder/android/build.gradle
@@ -2,6 +2,6 @@
 apply from: "$rootDir/build-scripts/component-common.gradle"
 apply from: "$rootDir/publish.gradle"
 
-ext.configureUniFFIBindgen("../src/rust_log_forwarder.udl")
+ext.configureUniFFIBindgen("rust_log_forwarder")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/support/rust-log-forwarder/uniffi.toml
+++ b/components/support/rust-log-forwarder/uniffi.toml
@@ -1,6 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.rust_log_forwarder"
-cdylib_name = "megazord"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/sync15/android/build.gradle
+++ b/components/sync15/android/build.gradle
@@ -2,6 +2,6 @@
 apply from: "$rootDir/build-scripts/component-common.gradle"
 apply from: "$rootDir/publish.gradle"
 
-ext.configureUniFFIBindgen("../src/sync15.udl")
+ext.configureUniFFIBindgen("sync15")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/sync15/uniffi.toml
+++ b/components/sync15/uniffi.toml
@@ -1,6 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.sync15"
-cdylib_name = "megazord"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -24,6 +24,6 @@ dependencies {
     testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:$glean_version"
 }
 
-ext.configureUniFFIBindgen("../src/syncmanager.udl")
+ext.configureUniFFIBindgen("sync_manager")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/sync_manager/uniffi.toml
+++ b/components/sync_manager/uniffi.toml
@@ -1,10 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.syncmanager"
-cdylib_name = "megazord"
-
-[bindings.kotlin.external_packages]
-# Map from [External={crate-name}] into Kotlin package names
-sync15 = "mozilla.appservices.sync15"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/components/tabs/android/build.gradle
+++ b/components/tabs/android/build.gradle
@@ -8,6 +8,6 @@ dependencies {
     testImplementation project(':syncmanager')
 }
 
-ext.configureUniFFIBindgen("../src/tabs.udl")
+ext.configureUniFFIBindgen("tabs")
 ext.dependsOnTheMegazord()
 ext.configurePublish()

--- a/components/tabs/uniffi.toml
+++ b/components/tabs/uniffi.toml
@@ -1,10 +1,5 @@
 [bindings.kotlin]
 package_name = "mozilla.appservices.remotetabs"
-cdylib_name = "megazord"
-
-[bindings.kotlin.external_packages]
-# Map from [External={crate-name}] into Kotlin package names
-sync15 = "mozilla.appservices.sync15"
 
 [bindings.swift]
 ffi_module_name = "MozillaRustComponents"

--- a/megazords/cirrus/tests/run_python_tests.sh
+++ b/megazords/cirrus/tests/run_python_tests.sh
@@ -5,14 +5,16 @@
 
 set -e
 
-cargo uniffi-bindgen generate components/nimbus/src/cirrus.udl --language python -o .
-cargo uniffi-bindgen generate components/support/nimbus-fml/src/fml.udl --language python -o .
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  LIBCIRRUS_PATH=target/release/libcirrus.dylib
+else
+  LIBCIRRUS_PATH=target/release/libcirrus.so
+fi
+
 cargo build --manifest-path megazords/cirrus/Cargo.toml --release
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  mv target/release/libcirrus.dylib ./
-else
-  mv target/release/libcirrus.so ./
-fi
+cargo uniffi-bindgen generate --library $LIBCIRRUS_PATH --language python -o .
+
+cp $LIBCIRRUS_PATH ./
 
 PYTHONPATH=$PYTHONPATH:$(pwd) pytest -s megazords/cirrus/tests/python-tests

--- a/megazords/ios-rust/build-xcframework.sh
+++ b/megazords/ios-rust/build-xcframework.sh
@@ -140,36 +140,23 @@ cp "$WORKING_DIR/DEPENDENCIES.md" "$COMMON/DEPENDENCIES.md"
 
 mkdir -p "$COMMON/Headers"
 
-# First we move the files that are common between both
-# firefox-ios and Focus
+# Library to generate the UniFFI bindings with.  We use an arbitrary target, since that doesn't
+# affect the bindings.
+UNIFFI_BINDGEN_LIBRARY="$TARGET_DIR/aarch64-apple-ios/$BUILD_PROFILE/$LIB_NAME"
+
+# First move the non-generated headers (these are all common between both firefox-ios and Focus)
 cp "$WORKING_DIR/$FRAMEWORK_NAME.h" "$COMMON/Headers"
 cp "$REPO_ROOT/components/rc_log/ios/RustLogFFI.h" "$COMMON/Headers"
 cp "$REPO_ROOT/components/viaduct/ios/RustViaductFFI.h" "$COMMON/Headers"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/remote_settings/src/remote_settings.udl" -l swift -o "$COMMON/Headers"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l swift -o "$COMMON/Headers"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/error/src/errorsupport.udl" -l swift -o "$COMMON/Headers"
 
+# Next, move the generated headers.
+#
+# TODO: https://github.com/mozilla/uniffi-rs/issues/1060
+#
+# It would be neat if there was a single UniFFI command that would generate headers-only, but for
+# now we generate both the `.h` and `.swift` files, then delete the `.swift`.  Bleh.
 
-
-# We now only move/generate the rest of the headers if we are generating a full
-# iOS megazord
-if [ -z $IS_FOCUS ]; then
-  # TODO: https://github.com/mozilla/uniffi-rs/issues/1060
-  # it would be neat if there was a single UniFFI command that would spit out
-  # all of the generated headers for all UniFFIed dependencies of a given crate.
-  # For now we generate the Swift bindings to get the headers as a side effect,
-  # then delete the generated Swift code. Bleh.
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/crashtest/src/crashtest.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/fxa-client/src/fxa_client.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/logins/src/logins.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/autofill/src/autofill.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/push/src/push.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/tabs/src/tabs.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/places/src/places.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync_manager/src/syncmanager.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync15/src/sync15.udl" -l swift -o "$COMMON/Headers"
-  $CARGO uniffi-bindgen generate "$REPO_ROOT/components/as-ohttp-client/src/as_ohttp_client.udl" -l swift -o "$COMMON/Headers"
-fi
+$CARGO uniffi-bindgen generate --library "$UNIFFI_BINDGEN_LIBRARY" -l swift -o "$COMMON/Headers"
 rm -rf "$COMMON"/Headers/*.swift
 
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -207,21 +207,44 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
 // with appropriate dependency info. This fill call `uniffi-bindgen`
 // on the provided `.udl` file in order to generate Kotlin language
 // bindings and include them in the source set for the project.
-ext.configureUniFFIBindgen = { udlFilePath ->
+ext.configureUniFFIBindgen = { crateName ->
     android.libraryVariants.all { variant ->
         def uniffiGeneratedPath = "generated/source/uniffi/${variant.name}/java"
-        def t = tasks.register("generate${variant.name.capitalize()}UniFFIBindings", Exec) {
-            workingDir project.rootDir
-            commandLine '/usr/bin/env', 'cargo', 'uniffi-bindgen', 'generate', "${project.projectDir}/${udlFilePath}", '--language', 'kotlin', '--out-dir', "${buildDir}/${uniffiGeneratedPath}"
+        def megazordPathCandidates = [
+            "${project.rootDir}/target/release/libmegazord.so",
+            "${project.rootDir}/target/release/libmegazord.dylib",
+            "${project.rootDir}/target/release/libmegazord.dll"
+        ]
+        def taskName = "generate${variant.name.capitalize()}UniFFIBindings";
+        def t = tasks.register(taskName) {
+            doLast {
+                def megazordPath = null
+                for (path in megazordPathCandidates) {
+                    def file = new File(path)
+                    if (file.exists()) {
+                        megazordPath = path
+                        break
+                    }
+                }
+                if (megazordPath == null) {
+                    throw new GradleException("libmegazord dynamic library path not found")
+                }
+                exec {
+                    workingDir project.rootDir
+                    commandLine '/usr/bin/env', 'cargo', 'uniffi-bindgen', 'generate', '--library', megazordPath, "--crate", crateName, '--language', 'kotlin', '--out-dir', "${buildDir}/${uniffiGeneratedPath}"
+                }
+            }
             outputs.dir "${buildDir}/${uniffiGeneratedPath}"
-            // Re-generate if the interface definition changes.
-            inputs.file "${project.projectDir}/${udlFilePath}"
+            // Re-generate when the megazord is rebuilt, which should happen if any components
+            // change
+            it.inputs.files megazordPathCandidates
             // Re-generate if our uniffi-bindgen tooling changes.
             inputs.dir "${project.rootDir}/tools/embedded-uniffi-bindgen/"
             // Re-generate if our uniffi-bindgen version changes.
             inputs.file "${project.rootDir}/Cargo.lock"
         }
         variant.registerJavaGeneratingTask(t.get(), new File(buildDir, uniffiGeneratedPath))
+        tasks[taskName].dependsOn(":full-megazord:assembleRelease")
     }
 }
 

--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -8,28 +8,6 @@ import os
 
 # Repository root dir
 ROOT_DIR = pathlib.Path(__file__).parent.parent.parent
-# List of udl_paths to generate bindings for
-BINDINGS_UDL_PATHS = [
-    "components/as-ohttp-client/src/as_ohttp_client.udl",
-    "components/autofill/src/autofill.udl",
-    "components/fxa-client/src/fxa_client.udl",
-    "components/logins/src/logins.udl",
-    "components/nimbus/src/nimbus.udl",
-    "components/places/src/places.udl",
-    "components/push/src/push.udl",
-    "components/remote_settings/src/remote_settings.udl",
-    "components/support/error/src/errorsupport.udl",
-    "components/sync15/src/sync15.udl",
-    "components/sync_manager/src/syncmanager.udl",
-    "components/tabs/src/tabs.udl",
-]
-
-# List of udl_paths to generate bindings for
-FOCUS_UDL_PATHS = [
-    "components/nimbus/src/nimbus.udl",
-    "components/remote_settings/src/remote_settings.udl",
-    "components/support/error/src/errorsupport.udl",
-]
 
 # List of globs to copy the sources from
 SOURCE_TO_COPY = [
@@ -160,13 +138,20 @@ def generate_uniffi_bindings(args):
 
     ensure_dir(out_dir)
 
-    generate_uniffi_bindings_for_target(out_dir, BINDINGS_UDL_PATHS)
-    generate_uniffi_bindings_for_target(focus_out_dir, FOCUS_UDL_PATHS)
+    # Generate sources for Firefox
+    generate_uniffi_bindings_for_target(out_dir, "megazord_ios")
 
-def generate_uniffi_bindings_for_target(out_dir, bindings_path):
-    for udl_path in bindings_path:
-        log(f"generating sources for {udl_path}")
-        run_uniffi_bindgen(['generate', '-l', 'swift', '-o', out_dir, ROOT_DIR / udl_path])
+    # Generate sources for Focus
+    generate_uniffi_bindings_for_target(focus_out_dir, "megazord_focus")
+
+def generate_uniffi_bindings_for_target(out_dir, library_name):
+    log(f"generating sources for {library_name}")
+    # Use a megazord library that was built for the XCFramework.  Pick an arbitrary target, since
+    # the target doesn't affect the UniFFI bindings.
+    lib_path = f'target/aarch64-apple-ios/release/lib{library_name}.a'
+
+    cmdline = ['generate', '--library', lib_path, '-l', 'swift', '-o', out_dir]
+    run_uniffi_bindgen(cmdline)
 
 def run_uniffi_bindgen(bindgen_args):
     all_args = [


### PR DESCRIPTION
This branch is testing out the new UniFFI library mode system and the results seem pretty good:

- The `uniffi.toml` files get simpler (although I'm not totally sure about the swift removal, since there's still some more work to do)
- It facilitates the transition from UDL -> proc-macros
- I think it makes it easier to use different megazords for focus vs firefox

There's still some work TODO:
- [x] The swift code needs some more work.  I ran the parts of `taskcluster/scripts/build-and-test-swift.py` that I could and the results were identical.  But there are some parts that need an Mac box, for example `megazords/ios-rust/build-xcframework.sh`).  I'm running full CI now, it'll be interesting to see what errors come back.
- [x] We need to land a few PRs on UniFFI and maybe do a release.
- [x] The gradle dependencies aren't totally right.  I was trying to run `test` and it failed because it depends on the release build of the megazord.

This part is speculative, but I think this could be taken further in the future.  We could remove the wrapper code from each component making them closer to vanilla Rust crates, no need for the `android` and `swift` directories.  The android/swift parts could be all in a single place that ran UniFFI library mode for a megazord and generated bindings for all crates that it depended on.  Removing the wrapper code means refactoring the Glean metrics, removing a backward compatibility layer, and adding UniFFI features like async callbacks so that we can express the API we want to export without needing an extra wrapper.  That's a lot of work, but many of those things come with their own motivation.  I know @tarikeshaq has a plan for reworking the Glean code, maybe it could be compatible with this dream.  The other changes would be nice for our documentation story -- as long as there's a wrapper layer, our Rust documentation won't accurately describe the consumer API.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
