### PR TITLE
Renaming `Record` to `RemoteSettingsRecord` [ci full]

### DIFF
--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -178,19 +178,19 @@ impl Client {
 /// Data structure representing the top-level response from the Remote Settings.
 /// [last_modified] will be extracted from the etag header of the response.
 pub struct RemoteSettingsResponse {
-    pub records: Vec<Record>,
+    pub records: Vec<RemoteSettingsRecord>,
     pub last_modified: u64,
 }
 
 #[derive(Deserialize)]
 struct RecordsResponse {
-    data: Vec<Record>,
+    data: Vec<RemoteSettingsRecord>,
 }
 
 /// A parsed Remote Settings record. Records can contain arbitrary fields, so clients
 /// are required to further extract expected values from the [fields] member.
 #[derive(Deserialize, PartialEq)]
-pub struct Record {
+pub struct RemoteSettingsRecord {
     pub id: String,
     pub last_modified: u64,
     pub attachment: Option<Attachment>,

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -6,7 +6,7 @@ pub mod error;
 pub use error::{RemoteSettingsError, Result};
 use std::{fs::File, io::prelude::Write};
 pub mod client;
-pub use client::{Attachment, Client, Record, RemoteSettingsResponse, RsJsonObject};
+pub use client::{Attachment, Client, RemoteSettingsRecord, RemoteSettingsResponse, RsJsonObject};
 pub mod config;
 pub use config::RemoteSettingsConfig;
 
@@ -50,7 +50,7 @@ impl RemoteSettings {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Record;
+    use crate::RemoteSettingsRecord;
     use mockito::mock;
 
     #[test]
@@ -103,8 +103,8 @@ mod test {
             .unwrap();
     }
 
-    fn are_equal_json(str: &str, rec: &Record) -> bool {
-        let r1: Record = serde_json::from_str(str).unwrap();
+    fn are_equal_json(str: &str, rec: &RemoteSettingsRecord) -> bool {
+        let r1: RemoteSettingsRecord = serde_json::from_str(str).unwrap();
         &r1 == rec
     }
 

--- a/components/remote_settings/src/remote_settings.udl
+++ b/components/remote_settings/src/remote_settings.udl
@@ -14,11 +14,11 @@ dictionary RemoteSettingsConfig {
 };
 
 dictionary RemoteSettingsResponse {
-    sequence<Record> records;
+    sequence<RemoteSettingsRecord> records;
     u64 last_modified;
 };
 
-dictionary Record {
+dictionary RemoteSettingsRecord {
     string id;
     u64 last_modified;
     Attachment? attachment;


### PR DESCRIPTION
This prevents a name conflict on Swift.

Technically this is a breaking change, but hopefully we can sneak this in under the radar. the remote settings client refactor was recent and I don't believe anyone is using the API yet.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
