### PR TITLE
Don't run `nimbus-binaries-assemble` in normal CI

### DIFF
--- a/taskcluster/ci/nimbus-binaries-assemble/kind.yml
+++ b/taskcluster/ci/nimbus-binaries-assemble/kind.yml
@@ -23,8 +23,7 @@ transforms:
 
 task-defaults:
   attributes:
-    # TODO: uncomment when we're done testing
-    # run-on-pr-type: full-ci
+    run-on-pr-type: full-ci
   worker-type: b-linux
   worker:
     chain-of-trust: true


### PR DESCRIPTION
I forgot to uncomment this line before merging the PR

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
