### PR TITLE
EXP-3458: add nimbus-fml validate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v116.0 (In progress)
 
+## Nimbus FML ⛅️🔬🔭🔧
+
+### ✨ What's New ✨
+
+- Add `validate` command to the FML CLI. This command validates a chosen manifest file, including all its imports, includes, and channels ([#5607](https://github.com/mozilla/application-services/pull/5607)).
+
 [Full Changelog](In progress)
 
 # v115.0 (_2023-06-05_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,6 +2380,7 @@ dependencies = [
  "askama 0.10.5",
  "cfg-if 1.0.0",
  "clap 2.34.0",
+ "console 0.15.5",
  "glob",
  "heck 0.3.3",
  "jsonschema",

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -29,6 +29,7 @@ reqwest = { version = "0.11", features = ["blocking", "native-tls-vendored"] }
 glob = "0.3.0"
 uniffi = { version = "0.23", optional = true }
 cfg-if = "1.0.0"
+console = "0.15.5"
 
 [build-dependencies]
 uniffi = { version = "0.23", features = ["build"], optional = true }

--- a/components/support/nimbus-fml/fixtures/fe/invalid/invalid_default_value_for_one_channel.fml.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/invalid/invalid_default_value_for_one_channel.fml.yaml
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
 version: 1.0
 about:
   description: The default value for `example-feature` on the `app-release` channel does not match its type.

--- a/components/support/nimbus-fml/fixtures/fe/invalid/invalid_default_value_for_one_channel.fml.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/invalid/invalid_default_value_for_one_channel.fml.yaml
@@ -17,11 +17,9 @@ features:
         type: Boolean
         default: false
     defaults:
-      - value: {
-          "enabled": true
-        }
+      - value:
+          enabled: true
         channel: app-debug
-      - value: {
-          "enabled": 1
-        }
+      - value:
+          enabled: 1
         channel: app-release

--- a/components/support/nimbus-fml/fixtures/fe/invalid/invalid_default_value_for_one_channel.fml.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/invalid/invalid_default_value_for_one_channel.fml.yaml
@@ -1,0 +1,23 @@
+version: 1.0
+about:
+  description: The default value for `example-feature` on the `app-release` channel does not match its type.
+channels:
+  - app-debug
+  - app-release
+features:
+  example-feature:
+    description: An example feature
+    variables:
+      enabled:
+        description: Whether the feature is enabled
+        type: Boolean
+        default: false
+    defaults:
+      - value: {
+          "enabled": true
+        }
+        channel: app-debug
+      - value: {
+          "enabled": 1
+        }
+        channel: app-release

--- a/components/support/nimbus-fml/fixtures/fe/no_about_no_channels.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/no_about_no_channels.yaml
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+version: 1.0
+features:
+  example-feature:
+    description: An example feature
+    variables:
+      enabled:
+        description: Whether the feature is enabled
+        type: Boolean
+        default: false

--- a/components/support/nimbus-fml/src/cli.yaml
+++ b/components/support/nimbus-fml/src/cli.yaml
@@ -124,6 +124,22 @@ subcommands:
                 long: repo-file
                 takes_value: true
                 multiple: true
+    - validate:
+          about: Validate an FML configuration and all of its channels.
+          args:
+              - INPUT:
+                    help: Sets the input file to use
+                    required: true
+                    index: 1
+              - cache-dir:
+                    help: The directory where downloaded files are cached
+                    long: cache-dir
+                    takes_value: true
+              - repo-file:
+                    help: The file containing the version/refs/locations for other repos
+                    long: repo-file
+                    takes_value: true
+                    multiple: true
 ######################################
 # Deprecated commands.
 ######################################

--- a/components/support/nimbus-fml/src/commands.rs
+++ b/components/support/nimbus-fml/src/commands.rs
@@ -15,6 +15,7 @@ pub(crate) enum CliCmd {
     GenerateExperimenter(GenerateExperimenterManifestCmd),
     GenerateIR(GenerateIRCmd),
     FetchFile(LoaderConfig, String),
+    Validate(ValidateCmd),
 }
 
 #[derive(Clone)]
@@ -41,6 +42,11 @@ pub(crate) struct GenerateIRCmd {
     pub(crate) output: PathBuf,
     pub(crate) load_from_ir: bool,
     pub(crate) channel: String,
+    pub(crate) loader: LoaderConfig,
+}
+
+pub(crate) struct ValidateCmd {
+    pub(crate) manifest: String,
     pub(crate) loader: LoaderConfig,
 }
 

--- a/components/support/nimbus-fml/src/main.rs
+++ b/components/support/nimbus-fml/src/main.rs
@@ -705,10 +705,7 @@ mod cli_tests {
         let cmd = get_command_from_cli([FML_BIN, "validate", TEST_FILE], &cwd)?;
 
         assert!(matches!(cmd, CliCmd::Validate(_)));
-
-        if let CliCmd::Validate(cmd) = cmd {
-            assert!(cmd.manifest.ends_with(TEST_FILE));
-        }
+        assert!(matches!(cmd, CliCmd::Validate(c) if c.manifest.ends_with(TEST_FILE)));
         Ok(())
     }
 }

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -145,7 +145,7 @@ pub struct ManifestFrontEnd {
     imports: Vec<ImportBlock>,
 
     #[serde(default)]
-    pub channels: Vec<String>,
+    channels: Vec<String>,
 
     // If a types attribute isn't explicitly expressed,
     // then we should assume that we use the flattened version.
@@ -155,6 +155,10 @@ pub struct ManifestFrontEnd {
 }
 
 impl ManifestFrontEnd {
+    pub fn channels(&self) -> Vec<String> {
+        self.channels.clone()
+    }
+
     /// Retrieves all the types represented in the Manifest
     ///
     /// # Returns
@@ -786,6 +790,7 @@ impl Parser {
         current: &FilePath,
         channel: &str,
         imports: &mut HashMap<ModuleId, FeatureManifest>,
+        // includes: &mut HashSet<ModuleId>,
     ) -> Result<ModuleId> {
         let id = current.try_into()?;
         if imports.contains_key(&id) {

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -122,7 +122,7 @@ pub(crate) struct FeatureBody {
 }
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct ManifestFrontEnd {
+pub struct ManifestFrontEnd {
     #[serde(default)]
     version: String,
     #[serde(default)]
@@ -145,7 +145,7 @@ pub(crate) struct ManifestFrontEnd {
     imports: Vec<ImportBlock>,
 
     #[serde(default)]
-    channels: Vec<String>,
+    pub channels: Vec<String>,
 
     // If a types attribute isn't explicitly expressed,
     // then we should assume that we use the flattened version.
@@ -693,7 +693,7 @@ impl Parser {
     // This method loads a manifest, including resolving the includes and merging the included files
     // into this top level one.
     // It recursively calls itself and then calls `merge_manifest`.
-    fn load_manifest(
+    pub fn load_manifest(
         &self,
         path: &FilePath,
         loading: &mut HashSet<ModuleId>,

--- a/components/support/nimbus-fml/src/workflows.rs
+++ b/components/support/nimbus-fml/src/workflows.rs
@@ -167,7 +167,7 @@ pub(crate) fn validate(cmd: &ValidateCmd) -> Result<()> {
     let file_path = files.file_path(filename)?;
     let parser: Parser = Parser::new(files, file_path.clone())?;
     let mut loading = HashSet::new();
-    let fe = parser.load_manifest(&file_path, &mut loading)?;
+    let manifest_front_end = parser.load_manifest(&file_path, &mut loading)?;
 
     println!(
         "Loaded modules: [\n\t{}\n]",
@@ -178,8 +178,8 @@ pub(crate) fn validate(cmd: &ValidateCmd) -> Result<()> {
             .join(",\n\t")
     );
 
-    for channel in fe.channels {
-        print!("Validating manifest for channel \"{}\".", &channel);
+    for channel in manifest_front_end.channels {
+        print!(r#"Validating manifest for channel "{}"."#, &channel);
         let ir = parser.get_intermediate_representation(&channel)?;
         print!(".");
         ir.validate_manifest()?;
@@ -767,11 +767,8 @@ mod test {
 
         match result.err().unwrap() {
             ValidationError(path, error) => {
-                assert_eq!(path, "features/example-feature.enabled".to_string());
-                assert_eq!(
-                    error,
-                    "Mismatch between type Boolean and default 1".to_string()
-                );
+                assert_eq!(path, "features/example-feature.enabled");
+                assert_eq!(error, "Mismatch between type Boolean and default 1");
             }
             _ => panic!("Error is not a ValidationError"),
         };

--- a/components/support/nimbus-fml/src/workflows.rs
+++ b/components/support/nimbus-fml/src/workflows.rs
@@ -210,7 +210,12 @@ pub(crate) fn validate(cmd: &ValidateCmd) -> Result<()> {
         ))?;
         return Ok(());
     }
-    let intermediate_representation = parser.get_intermediate_representation(&channels[0])?;
+    let intermediate_representation = parser
+        .get_intermediate_representation(&channels[0])
+        .map_err(|e| {
+            output_err(&term, "Manifest is invalid", &e.to_string()).unwrap();
+            e
+        })?;
 
     output_note(
         &term,


### PR DESCRIPTION
This PR adds a command to the `nimbus-fml` CLI that validates an FML file and all of its channels.

[EXP-3458](https://mozilla-hub.atlassian.net/browse/EXP-3458)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.
