### PR TITLE
Add update-informer to nimbus-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 ### 🦊 What's Changed 🦊
 
-- [`nimbus-cli`](./components/support/nimbus-cli) now has commands: `capture-logs`, `tail-logs`, `test-feature`, `fetch` and `apply-files`. ([#5517](https://github.com/mozilla/application-services/pull/5517))
-- [`nimbus-cli`](./components/support/nimbus-cli) also adds the ability to open deeplinks with the app. ([#5590](https://github.com/mozilla/application-services/pull/5590)).
 - Add additional Cirrus SDK helper methods and add Python testing for the generated Cirrus Python code ([#5478](https://github.com/mozilla/application-services/pull/5478)).
 - Add `user_id` RandomizationUnit (for Cirrus) ([#5564](https://github.com/mozilla/application-services/pull/5564)).
 - Fixed up a bug in `get_experiment_branch` and `get_active_experiments` ([(#5584)](https://github.com/mozilla/application-services/pull/5584)).
 - Renamed `GleanPlumb` classes and protocols to `NimbusMessaging` in Swift. Added more protocols to make it more mockable in application code ([#5604](https://github.com/mozilla/application-services/pull/5604)).
+
+## Nimbus CLI [⛅️🔬🔭👾](./components/support/nimbus-cli)
+
+### ✨ What's New ✨
+
+- Extra commands: `capture-logs`, `tail-logs`, `test-feature`, `fetch` and `apply-files`. ([#5517](https://github.com/mozilla/application-services/pull/5517))
+- Extra commands and options to open deeplinks with the app. ([#5590](https://github.com/mozilla/application-services/pull/5590)).
+- An update checker to keep you and your installation fresh ([#5618](https://github.com/mozilla/application-services/pull/5618)).
 
 ## Nimbus FML ⛅️🔬🔭🔧
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0122885821398cc923ece939e24d1056a2384ee719432397fa9db87230ff11"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,7 +293,7 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.5.3",
  "object",
  "rustc-demangle",
 ]
@@ -302,6 +315,12 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bincode"
@@ -709,6 +728,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "criterion"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +941,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
 name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,7 +967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
  "cfg-if 0.1.10",
- "dirs-sys",
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -942,6 +979,18 @@ dependencies = [
  "libc",
  "redox_users 0.4.3",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.3",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1272,6 +1321,16 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.7.1",
+]
 
 [[package]]
 name = "fnv"
@@ -2132,6 +2191,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,10 +2306,12 @@ dependencies = [
  "glob",
  "heck 0.4.1",
  "remote_settings",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",
  "unicode-segmentation",
+ "update-informer",
  "viaduct-reqwest",
  "whoami",
 ]
@@ -2546,6 +2616,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -3082,11 +3158,12 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.13.0",
+ "async-compression",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3109,6 +3186,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3477,9 +3555,9 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3837,19 +3915,18 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "0aa32867d44e6f2ce3385e89dceb990188b8bb0fb25b0cf576647a6f98ac5105"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4123,6 +4200,18 @@ dependencies = [
  "cargo_metadata",
  "fs-err",
  "once_cell",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "update-informer"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d952f24d9cd8b7564d22c7b2cde3429c48b50c6f4e72b07b382ae4ee5f21b3"
+dependencies = [
+ "directories",
+ "semver 1.0.12",
  "serde",
  "serde_json",
 ]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -28,8 +28,9 @@ the details of which are reproduced below.
 * [MIT License: scroll](#mit-license-scroll)
 * [MIT License: scroll_derive](#mit-license-scroll_derive)
 * [MIT License: slab](#mit-license-slab)
-* [MIT License: tokio, tokio-util](#mit-license-tokio-tokio-util)
+* [MIT License: tokio](#mit-license-tokio)
 * [MIT License: tokio-native-tls, tracing, tracing-core](#mit-license-tokio-native-tls-tracing-tracing-core)
+* [MIT License: tokio-util](#mit-license-tokio-util)
 * [MIT License: tower-service](#mit-license-tower-service)
 * [MIT License: try-lock](#mit-license-try-lock)
 * [MIT License: want](#mit-license-want)
@@ -578,6 +579,7 @@ The following text applies to code linked from these dependencies:
 [winapi-x86_64-pc-windows-gnu](https://github.com/retep998/winapi-rs),
 [winapi](https://github.com/retep998/winapi-rs),
 [windows-sys](https://github.com/microsoft/windows-rs),
+[windows-targets](https://github.com/microsoft/windows-rs),
 [windows_x86_64_gnu](https://github.com/microsoft/windows-rs),
 [windows_x86_64_msvc](https://github.com/microsoft/windows-rs),
 [xshell-macros](https://github.com/matklad/xshell),
@@ -1462,14 +1464,13 @@ DEALINGS IN THE SOFTWARE.
 
 ```
 -------------
-## MIT License: tokio, tokio-util
+## MIT License: tokio
 
 The following text applies to code linked from these dependencies:
-[tokio-util](https://github.com/tokio-rs/tokio),
 [tokio](https://github.com/tokio-rs/tokio)
 
 ```
-Copyright (c) 2022 Tokio Contributors
+Copyright (c) 2023 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -1506,6 +1507,40 @@ The following text applies to code linked from these dependencies:
 
 ```
 Copyright (c) 2019 Tokio Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+```
+-------------
+## MIT License: tokio-util
+
+The following text applies to code linked from these dependencies:
+[tokio-util](https://github.com/tokio-rs/tokio)
+
+```
+Copyright (c) 2022 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/components/support/nimbus-cli/Cargo.toml
+++ b/components/support/nimbus-cli/Cargo.toml
@@ -19,3 +19,5 @@ console = "0.15.5"
 glob = "0.3.1"
 heck = "0.4.1"
 whoami = "1.4.0"
+update-informer = { version = "1.0.0", default_features = false }
+reqwest = { version = "0.11.18", default_features = false, features = ["blocking", "native-tls-vendored", "gzip", "json"] }

--- a/components/support/nimbus-cli/src/main.rs
+++ b/components/support/nimbus-cli/src/main.rs
@@ -5,6 +5,7 @@
 mod cli;
 mod cmd;
 mod feature_utils;
+mod updater;
 mod value_utils;
 
 use anyhow::{bail, Result};
@@ -23,6 +24,7 @@ fn main() -> Result<()> {
             bail!("Failed");
         }
     }
+    updater::check_for_update();
     Ok(())
 }
 

--- a/components/support/nimbus-cli/src/updater/mod.rs
+++ b/components/support/nimbus-cli/src/updater/mod.rs
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+mod taskcluster;
+
+use console::Term;
+
+pub(crate) fn check_for_update() {
+    if std::env::var("NIMBUS_CLI_SUPPRESS_UPDATE_CHECK").is_ok() {
+        return;
+    }
+    taskcluster::check_taskcluster_for_update(|curr, next| {
+        let term = Term::stderr();
+        let txt_style = term.style().green();
+        let cmd_style = term.style().yellow();
+
+        _ = term.write_line(&format!(
+            "{}",
+            txt_style.apply_to(format!("An update is available: {} --> {}", curr, next))
+        ));
+
+        _ = if std::env::consts::OS != "windows" {
+            term.write_line(&format!("{}\n{}",
+                txt_style.apply_to("To update, run this command:"),
+                cmd_style.apply_to("  curl https://raw.githubusercontent.com/mozilla/application-services/main/install-nimbus-cli.sh | bash")
+            ))
+        } else {
+            term.write_line(&format!("{}",
+                txt_style.apply_to("To update follow the instructions at https://experimenter.info/nimbus-cli/install")
+            ))
+        };
+    });
+}

--- a/components/support/nimbus-cli/src/updater/taskcluster.rs
+++ b/components/support/nimbus-cli/src/updater/taskcluster.rs
@@ -1,0 +1,76 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use serde::de::DeserializeOwned;
+use std::time::Duration;
+use update_informer::{
+    http_client::{GenericHttpClient, HeaderMap, HttpClient},
+    Check, Package, Registry, Result,
+};
+
+#[derive(serde::Deserialize)]
+struct Response {
+    version: String,
+}
+
+struct TaskClusterRegistry;
+
+impl Registry for TaskClusterRegistry {
+    const NAME: &'static str = "taskcluster";
+
+    fn get_latest_version<T: HttpClient>(
+        http_client: GenericHttpClient<T>,
+        pkg: &Package,
+    ) -> Result<Option<String>> {
+        let name = pkg.to_string();
+        let url = format!("https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/project.application-services.v2.{name}.latest/artifacts/public%2Fbuild%2F{name}.json");
+        let resp = http_client.get::<Response>(&url)?;
+        Ok(Some(resp.version))
+    }
+}
+pub struct ReqwestGunzippingHttpClient;
+
+impl HttpClient for ReqwestGunzippingHttpClient {
+    fn get<T: DeserializeOwned>(url: &str, timeout: Duration, headers: HeaderMap) -> Result<T> {
+        let mut req = reqwest::blocking::Client::builder()
+            .timeout(timeout)
+            // We couldn't use the out-the-box HttpClient
+            // because task-cluster uses gzip.
+            .gzip(true)
+            .build()?
+            .get(url);
+
+        for (key, value) in headers {
+            req = req.header(key, value);
+        }
+
+        let json = req.send()?.json()?;
+
+        Ok(json)
+    }
+}
+
+/// Check the specifically crafted JSON file for this package to see if there has been a change in version.
+/// This is done every hour.
+pub(crate) fn check_taskcluster_for_update<F>(message: F)
+where
+    F: Fn(&str, &str),
+{
+    let name = env!("CARGO_PKG_NAME");
+    let version = env!("CARGO_PKG_VERSION");
+    let interval = Duration::from_secs(60 * 60);
+
+    #[cfg(not(test))]
+    let informer = update_informer::new(TaskClusterRegistry, name, version)
+        .http_client(ReqwestGunzippingHttpClient)
+        .interval(interval);
+
+    #[cfg(test)]
+    let informer =
+        update_informer::fake(TaskClusterRegistry, name, version, "1.0.0").interval(interval);
+
+    if let Ok(Some(new_version)) = informer.check_version() {
+        message(&format!("v{version}"), &new_version.to_string());
+    }
+}

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -354,6 +354,15 @@ PACKAGE_METADATA_FIXUPS = {
             "fixup": "https://raw.githubusercontent.com/microsoft/windows-rs/master/license-mit",
         },
     },
+    "windows-targets": {
+        "repository": {
+            "check": "https://github.com/microsoft/windows-rs",
+        },
+        "license_file": {
+            "check": None,
+            "fixup": "https://raw.githubusercontent.com/microsoft/windows-rs/master/license-mit",
+        },
+    },
     "windows_x86_64_msvc": {
         "repository": {
             "check": "https://github.com/microsoft/windows-rs",


### PR DESCRIPTION
Fixes [EXP-3476](https://mozilla-hub.atlassian.net/browse/EXP-3476).

This is very difficult to test, and relies largely on the effigacy and quality of the [update-informer](https://crates.io/crates/update-informer) crate.

The instructions on update also don't exist at the moment.

```sh
curl https://raw.githubusercontent.com/mozilla/application-services/main/install-nimbus-cli.sh | bash
```

For windows:  https://experimenter.info/nimbus-cli/install 

These are the subjects of other issues.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
