### PR TITLE
ci: add checkout dir as a Taskcluster cache in Decision task

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -214,6 +214,7 @@ tasks:
                                     REPOSITORIES: {$json: {appservices: "Application Services"}}
                                     ANDROID_SDK_ROOT: /builds/worker/android-sdk
                                     MOZ_FETCHES_DIR: /builds/worker/fetches
+                                    TASKCLUSTER_CACHES: /builds/worker/checkouts
                                   - $if: 'tasks_for in ["github-pull-request"]'
                                     then:
                                         APPSERVICES_PULL_REQUEST_TITLE: '${event.pull_request.title}'
@@ -224,6 +225,8 @@ tasks:
                                       ACTION_TASK_ID: {$json: {$eval: 'taskId'}}
                                       ACTION_INPUT: {$json: {$eval: 'input'}}
                                       ACTION_CALLBACK: '${action.cb_name}'
+                          cache:
+                              "${trustDomain}-level-${level}-checkouts-v1": /builds/worker/checkouts
 
                           features:
                               taskclusterProxy: true


### PR DESCRIPTION
I noticed that the decision tasks often spend a long time cloning glean. Adding the `/build/worker/checkouts` dir as a TC cache means we'll only incur this penalty on the first task a worker claims.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
