### PR TITLE
Renaming Sync metrics to prevent name collision

### DIFF
--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -1,10 +1,27 @@
+plugins {
+    id "com.jetbrains.python.envs" version "0.0.26"
+}
 
 apply from: "$rootDir/build-scripts/component-common.gradle"
 apply from: "$rootDir/publish.gradle"
 
+// Needs to happen before `dependencies` in order for the variables
+// exposed by the plugin to be available for this project.
+ext.gleanYamlFiles = ["${project.projectDir}/../metrics.yaml", "${project.projectDir}/../pings.yaml"]
+ext.gleanNamespace = "mozilla.telemetry.glean"
+apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"
+
 dependencies {
     // Part of the public API.
     api project(':sync15')
+
+    implementation "org.mozilla.telemetry:glean:$glean_version"
+    implementation "androidx.core:core-ktx:$androidx_core_version"
+
+    testImplementation "androidx.test:core-ktx:$androidx_test_version"
+    testImplementation "androidx.test.ext:junit-ktx:$androidx_test_junit_version"
+    testImplementation "androidx.work:work-testing:$androidx_work_testing_version"
+    testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:$glean_version"
 }
 
 ext.configureUniFFIBindgen("../src/syncmanager.udl")

--- a/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/BaseGleanSyncPing.kt
+++ b/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/BaseGleanSyncPing.kt
@@ -1,0 +1,57 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.syncmanager
+
+import mozilla.appservices.sync15.EngineInfo
+import mozilla.appservices.sync15.FailureReason
+import java.util.Date
+
+/**
+ * Holds fields common to all Glean sync engine pings.
+ */
+internal data class BaseGleanSyncPing(
+    val uid: String,
+    val startedAt: Date,
+    val finishedAt: Date,
+    val applied: Int,
+    val failedToApply: Int,
+    val reconciled: Int,
+    val uploaded: Int,
+    val failedToUpload: Int,
+    val outgoingBatches: Int,
+    val failureReason: FailureReason?,
+) {
+    companion object {
+        const val MILLIS_PER_SEC = 1000L
+
+        fun fromEngineInfo(uid: String, info: EngineInfo): BaseGleanSyncPing {
+            val failedToApply = info.incoming?.let {
+                it.failed + it.newFailed
+            } ?: 0
+            val (uploaded, failedToUpload) = info.outgoing.fold(Pair(0, 0)) { totals, batch ->
+                val (uploaded, failedToUpload) = totals
+                Pair(uploaded + batch.sent, failedToUpload + batch.failed)
+            }
+            return BaseGleanSyncPing(
+                uid = uid,
+                startedAt = Date(info.at * MILLIS_PER_SEC),
+                // Glean intentionally doesn't support recording arbitrary
+                // durations in timespans, and we can't use the timespan
+                // measurement API because everything is measured in Rust
+                // code. Instead, we record absolute start and end times.
+                // The Sync ping records both `at` _and_ `took`, so this doesn't
+                // leak additional info.
+                finishedAt = Date(info.at * MILLIS_PER_SEC + info.took),
+                applied = info.incoming?.applied ?: 0,
+                failedToApply = failedToApply,
+                reconciled = info.incoming?.reconciled ?: 0,
+                uploaded = uploaded,
+                failedToUpload = failedToUpload,
+                outgoingBatches = info.outgoing.size,
+                failureReason = info.failureReason,
+            )
+        }
+    }
+}

--- a/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncTelemetry.kt
+++ b/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncTelemetry.kt
@@ -1,0 +1,468 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.syncmanager
+
+import mozilla.appservices.sync15.EngineInfo
+import mozilla.appservices.sync15.FailureName
+import mozilla.appservices.sync15.FailureReason
+import mozilla.appservices.sync15.SyncTelemetryPing
+import mozilla.telemetry.glean.private.LabeledMetricType
+import mozilla.telemetry.glean.private.StringMetricType
+import org.json.JSONException
+import org.json.JSONObject
+import org.mozilla.appservices.syncmanager.GleanMetrics.Pings
+import org.mozilla.appservices.syncmanager.GleanMetrics.AddressesSyncV2 as AddressesSync
+import org.mozilla.appservices.syncmanager.GleanMetrics.BookmarksSyncV2 as BookmarksSync
+import org.mozilla.appservices.syncmanager.GleanMetrics.CreditcardsSyncV2 as CreditcardsSync
+import org.mozilla.appservices.syncmanager.GleanMetrics.FxaTabV2 as FxaTab
+import org.mozilla.appservices.syncmanager.GleanMetrics.HistorySyncV2 as HistorySync
+import org.mozilla.appservices.syncmanager.GleanMetrics.LoginsSyncV2 as LoginsSync
+import org.mozilla.appservices.syncmanager.GleanMetrics.SyncV2 as Sync
+import org.mozilla.appservices.syncmanager.GleanMetrics.TabsSyncV2 as TabsSync
+
+const val MAX_FAILURE_REASON_LENGTH = 100
+
+// The exceptions we report to the crash reporter, but otherwise don't escape this module.
+sealed class InvalidTelemetryException(cause: Exception) : Exception(cause) {
+    // The top-level data passed in is invalid.
+    class InvalidData(cause: JSONException) : InvalidTelemetryException(cause)
+
+    // The sent or received tabs data is invalid.
+    class InvalidEvents(cause: JSONException) : InvalidTelemetryException(cause)
+}
+
+/**
+ * Contains functionality necessary to process instances of [SyncTelemetryPing].
+ */
+@Suppress("LargeClass")
+object SyncTelemetry {
+    // TODO: Swap this with a local version if we need it
+    // private val logger = Logger("SyncTelemetry")
+
+    /**
+     * Process [SyncTelemetryPing] as returned from [mozilla.appservices.syncmanager.SyncManager].
+     */
+    @Suppress("LongParameterList")
+    fun processSyncTelemetry(
+        syncTelemetry: SyncTelemetryPing,
+
+        // The following are present to make this function testable. In tests, we need to "intercept"
+        // values set in singleton ping objects before they're reset by a 'submit' call.
+        submitGlobalPing: () -> Unit = { Pings.sync.submit() },
+        submitHistoryPing: () -> Unit = { Pings.historySync.submit() },
+        submitBookmarksPing: () -> Unit = { Pings.bookmarksSync.submit() },
+        submitLoginsPing: () -> Unit = { Pings.loginsSync.submit() },
+        submitCreditCardsPing: () -> Unit = { Pings.creditcardsSync.submit() },
+        submitAddressesPing: () -> Unit = { Pings.addressesSync.submit() },
+        submitTabsPing: () -> Unit = { Pings.tabsSync.submit() },
+    ) {
+        syncTelemetry.syncs.forEach { syncInfo ->
+            // Note that `syncUuid` is configured to be submitted in all of the sync pings (it's set
+            // once, and will be attached by glean to history-sync, bookmarks-sync, and logins-sync pings).
+            // However, this only happens if sync telemetry is being submitted via [processSyncTelemetry].
+            // That is, if different data types were synchronized together, as happens when using a sync manager.
+            // We can then use 'syncUuid' to associate together all of the individual syncs that happened together.
+            // If a data type is synchronized individually via the legacy 'sync' API on specific storage layers,
+            // then the corresponding ping will not have 'syncUuid' set.
+            Sync.syncUuid.generateAndSet()
+
+            // It's possible for us to sync some engines, and then get a hard error that fails the
+            // entire sync. Examples of such errors are an HTTP server error, token authentication
+            // error, or other kind of network error.
+            // We can have some engines that succeed (and others that fail, with different reasons)
+            // and still have a global failure_reason.
+            syncInfo.failureReason?.let { failureReason ->
+                recordFailureReason(failureReason, Sync.failureReason)
+            }
+
+            syncInfo.engines.forEach { engineInfo ->
+                when (engineInfo.name) {
+                    "bookmarks" -> {
+                        individualBookmarksSync(syncTelemetry.uid, engineInfo)
+                        submitBookmarksPing()
+                    }
+                    "history" -> {
+                        individualHistorySync(syncTelemetry.uid, engineInfo)
+                        submitHistoryPing()
+                    }
+                    "passwords" -> {
+                        individualLoginsSync(syncTelemetry.uid, engineInfo)
+                        submitLoginsPing()
+                    }
+                    "creditcards" -> {
+                        individualCreditCardsSync(syncTelemetry.uid, engineInfo)
+                        submitCreditCardsPing()
+                    }
+                    "addresses" -> {
+                        individualAddressesSync(syncTelemetry.uid, engineInfo)
+                        submitAddressesPing()
+                    }
+                    "tabs" -> {
+                        individualTabsSync(syncTelemetry.uid, engineInfo)
+                        submitTabsPing()
+                    }
+                    // TODO: fix
+                    // else -> logger.warn("Ignoring telemetry for engine ${engineInfo.name}")
+                }
+            }
+
+            submitGlobalPing()
+        }
+    }
+
+    /**
+     * Processes a history-related ping information from the [ping].
+     * @return 'false' if global error was encountered, 'true' otherwise.
+     */
+    @Suppress("ComplexMethod", "NestedBlockDepth", "ReturnCount")
+    fun processHistoryPing(
+        ping: SyncTelemetryPing,
+        sendPing: () -> Unit = { Pings.historySync.submit() },
+    ): Boolean {
+        ping.syncs.forEach eachSync@{ sync ->
+            sync.failureReason?.let {
+                recordFailureReason(it, HistorySync.failureReason)
+                sendPing()
+                return false
+            }
+            sync.engines.forEach eachEngine@{ engine ->
+                if (engine.name != "history") {
+                    return@eachEngine
+                }
+                individualHistorySync(ping.uid, engine)
+                sendPing()
+            }
+        }
+        return true
+    }
+
+    /**
+     * Processes a passwords-related ping information from the [ping].
+     * @return 'false' if global error was encountered, 'true' otherwise.
+     */
+    @Suppress("ComplexMethod", "NestedBlockDepth", "ReturnCount")
+    fun processLoginsPing(
+        ping: SyncTelemetryPing,
+        sendPing: () -> Unit = { Pings.loginsSync.submit() },
+    ): Boolean {
+        ping.syncs.forEach eachSync@{ sync ->
+            sync.failureReason?.let {
+                recordFailureReason(it, LoginsSync.failureReason)
+                sendPing()
+                return false
+            }
+            sync.engines.forEach eachEngine@{ engine ->
+                if (engine.name != "passwords") {
+                    return@eachEngine
+                }
+                individualLoginsSync(ping.uid, engine)
+                sendPing()
+            }
+        }
+        return true
+    }
+
+    /**
+     * Processes a bookmarks-related ping information from the [ping].
+     * @return 'false' if global error was encountered, 'true' otherwise.
+     */
+    @Suppress("ComplexMethod", "NestedBlockDepth", "ReturnCount")
+    fun processBookmarksPing(
+        ping: SyncTelemetryPing,
+        sendPing: () -> Unit = { Pings.bookmarksSync.submit() },
+    ): Boolean {
+        // This function is almost identical to `recordHistoryPing`, with additional
+        // reporting for validation problems. Unfortunately, since the
+        // `BookmarksSync` and `HistorySync` metrics are two separate objects, we
+        // can't factor this out into a generic function.
+        ping.syncs.forEach eachSync@{ sync ->
+            sync.failureReason?.let {
+                // If the entire sync fails, don't try to unpack the ping; just
+                // report the error and bail.
+                recordFailureReason(it, BookmarksSync.failureReason)
+                sendPing()
+                return false
+            }
+            sync.engines.forEach eachEngine@{ engine ->
+                if (engine.name != "bookmarks") {
+                    return@eachEngine
+                }
+                individualBookmarksSync(ping.uid, engine)
+                sendPing()
+            }
+        }
+        return true
+    }
+
+    @Suppress("ComplexMethod")
+    private fun individualLoginsSync(hashedFxaUid: String, engineInfo: EngineInfo) {
+        require(engineInfo.name == "passwords") { "Expected 'passwords', got ${engineInfo.name}" }
+
+        LoginsSync.apply {
+            val base = BaseGleanSyncPing.fromEngineInfo(hashedFxaUid, engineInfo)
+            uid.set(base.uid)
+            startedAt.set(base.startedAt)
+            finishedAt.set(base.finishedAt)
+            if (base.applied > 0) {
+                // Since all Sync ping counters have `lifetime: ping`, and
+                // we send the ping immediately after, we don't need to
+                // reset the counters before calling `add`.
+                incoming["applied"].add(base.applied)
+            }
+            if (base.failedToApply > 0) {
+                incoming["failed_to_apply"].add(base.failedToApply)
+            }
+            if (base.reconciled > 0) {
+                incoming["reconciled"].add(base.reconciled)
+            }
+            if (base.uploaded > 0) {
+                outgoing["uploaded"].add(base.uploaded)
+            }
+            if (base.failedToUpload > 0) {
+                outgoing["failed_to_upload"].add(base.failedToUpload)
+            }
+            if (base.outgoingBatches > 0) {
+                outgoingBatches.add(base.outgoingBatches)
+            }
+            base.failureReason?.let {
+                recordFailureReason(it, failureReason)
+            }
+        }
+    }
+
+    @Suppress("ComplexMethod")
+    private fun individualBookmarksSync(hashedFxaUid: String, engineInfo: EngineInfo) {
+        require(engineInfo.name == "bookmarks") { "Expected 'bookmarks', got ${engineInfo.name}" }
+
+        BookmarksSync.apply {
+            val base = BaseGleanSyncPing.fromEngineInfo(hashedFxaUid, engineInfo)
+            uid.set(base.uid)
+            startedAt.set(base.startedAt)
+            finishedAt.set(base.finishedAt)
+            if (base.applied > 0) {
+                incoming["applied"].add(base.applied)
+            }
+            if (base.failedToApply > 0) {
+                incoming["failed_to_apply"].add(base.failedToApply)
+            }
+            if (base.reconciled > 0) {
+                incoming["reconciled"].add(base.reconciled)
+            }
+            if (base.uploaded > 0) {
+                outgoing["uploaded"].add(base.uploaded)
+            }
+            if (base.failedToUpload > 0) {
+                outgoing["failed_to_upload"].add(base.failedToUpload)
+            }
+            if (base.outgoingBatches > 0) {
+                outgoingBatches.add(base.outgoingBatches)
+            }
+            base.failureReason?.let {
+                recordFailureReason(it, failureReason)
+            }
+            engineInfo.validation?.let {
+                it.problems.forEach { problemInfo ->
+                    remoteTreeProblems[problemInfo.name].add(problemInfo.count)
+                }
+            }
+        }
+    }
+
+    @Suppress("ComplexMethod")
+    private fun individualHistorySync(hashedFxaUid: String, engineInfo: EngineInfo) {
+        require(engineInfo.name == "history") { "Expected 'history', got ${engineInfo.name}" }
+
+        HistorySync.apply {
+            val base = BaseGleanSyncPing.fromEngineInfo(hashedFxaUid, engineInfo)
+            uid.set(base.uid)
+            startedAt.set(base.startedAt)
+            finishedAt.set(base.finishedAt)
+            if (base.applied > 0) {
+                // Since all Sync ping counters have `lifetime: ping`, and
+                // we send the ping immediately after, we don't need to
+                // reset the counters before calling `add`.
+                incoming["applied"].add(base.applied)
+            }
+            if (base.failedToApply > 0) {
+                incoming["failed_to_apply"].add(base.failedToApply)
+            }
+            if (base.reconciled > 0) {
+                incoming["reconciled"].add(base.reconciled)
+            }
+            if (base.uploaded > 0) {
+                outgoing["uploaded"].add(base.uploaded)
+            }
+            if (base.failedToUpload > 0) {
+                outgoing["failed_to_upload"].add(base.failedToUpload)
+            }
+            if (base.outgoingBatches > 0) {
+                outgoingBatches.add(base.outgoingBatches)
+            }
+            base.failureReason?.let {
+                recordFailureReason(it, failureReason)
+            }
+        }
+    }
+
+    @Suppress("ComplexMethod")
+    private fun individualCreditCardsSync(hashedFxaUid: String, engineInfo: EngineInfo) {
+        require(engineInfo.name == "creditcards") { "Expected 'creditcards', got ${engineInfo.name}" }
+
+        CreditcardsSync.apply {
+            val base = BaseGleanSyncPing.fromEngineInfo(hashedFxaUid, engineInfo)
+            uid.set(base.uid)
+            startedAt.set(base.startedAt)
+            finishedAt.set(base.finishedAt)
+            if (base.applied > 0) {
+                // Since all Sync ping counters have `lifetime: ping`, and
+                // we send the ping immediately after, we don't need to
+                // reset the counters before calling `add`.
+                incoming["applied"].add(base.applied)
+            }
+            if (base.failedToApply > 0) {
+                incoming["failed_to_apply"].add(base.failedToApply)
+            }
+            if (base.reconciled > 0) {
+                incoming["reconciled"].add(base.reconciled)
+            }
+            if (base.uploaded > 0) {
+                outgoing["uploaded"].add(base.uploaded)
+            }
+            if (base.failedToUpload > 0) {
+                outgoing["failed_to_upload"].add(base.failedToUpload)
+            }
+            if (base.outgoingBatches > 0) {
+                outgoingBatches.add(base.outgoingBatches)
+            }
+            base.failureReason?.let {
+                recordFailureReason(it, failureReason)
+            }
+        }
+    }
+
+    @Suppress("ComplexMethod")
+    private fun individualAddressesSync(hashedFxaUid: String, engineInfo: EngineInfo) {
+        require(engineInfo.name == "addresses") { "Expected 'addresses', got ${engineInfo.name}" }
+
+        AddressesSync.apply {
+            val base = BaseGleanSyncPing.fromEngineInfo(hashedFxaUid, engineInfo)
+            uid.set(base.uid)
+            startedAt.set(base.startedAt)
+            finishedAt.set(base.finishedAt)
+            if (base.applied > 0) {
+                // Since all Sync ping counters have `lifetime: ping`, and
+                // we send the ping immediately after, we don't need to
+                // reset the counters before calling `add`.
+                incoming["applied"].add(base.applied)
+            }
+            if (base.failedToApply > 0) {
+                incoming["failed_to_apply"].add(base.failedToApply)
+            }
+            if (base.reconciled > 0) {
+                incoming["reconciled"].add(base.reconciled)
+            }
+            if (base.uploaded > 0) {
+                outgoing["uploaded"].add(base.uploaded)
+            }
+            if (base.failedToUpload > 0) {
+                outgoing["failed_to_upload"].add(base.failedToUpload)
+            }
+            if (base.outgoingBatches > 0) {
+                outgoingBatches.add(base.outgoingBatches)
+            }
+            base.failureReason?.let {
+                recordFailureReason(it, failureReason)
+            }
+        }
+    }
+
+    @Suppress("ComplexMethod")
+    private fun individualTabsSync(hashedFxaUid: String, engineInfo: EngineInfo) {
+        require(engineInfo.name == "tabs") { "Expected 'tabs', got ${engineInfo.name}" }
+
+        TabsSync.apply {
+            val base = BaseGleanSyncPing.fromEngineInfo(hashedFxaUid, engineInfo)
+            uid.set(base.uid)
+            startedAt.set(base.startedAt)
+            finishedAt.set(base.finishedAt)
+            if (base.applied > 0) {
+                // Since all Sync ping counters have `lifetime: ping`, and
+                // we send the ping immediately after, we don't need to
+                // reset the counters before calling `add`.
+                incoming["applied"].add(base.applied)
+            }
+            if (base.failedToApply > 0) {
+                incoming["failed_to_apply"].add(base.failedToApply)
+            }
+            if (base.reconciled > 0) {
+                incoming["reconciled"].add(base.reconciled)
+            }
+            if (base.uploaded > 0) {
+                outgoing["uploaded"].add(base.uploaded)
+            }
+            if (base.failedToUpload > 0) {
+                outgoing["failed_to_upload"].add(base.failedToUpload)
+            }
+            if (base.outgoingBatches > 0) {
+                outgoingBatches.add(base.outgoingBatches)
+            }
+            base.failureReason?.let {
+                recordFailureReason(it, failureReason)
+            }
+        }
+    }
+
+    private fun recordFailureReason(reason: FailureReason, failureReasonMetric: LabeledMetricType<StringMetricType>) {
+        val metric = when (reason.name) {
+            FailureName.Other, FailureName.Unknown -> failureReasonMetric["other"]
+            FailureName.Unexpected, FailureName.Http -> failureReasonMetric["unexpected"]
+            FailureName.Auth -> failureReasonMetric["auth"]
+            FailureName.Shutdown -> return
+        }
+        val message = reason.message ?: "Unexpected error: ${reason.code}"
+        metric.set(message.take(MAX_FAILURE_REASON_LENGTH))
+    }
+
+    @Throws(Throwable::class)
+    fun processFxaTelemetry(jsonStr: String): List<Throwable> {
+        val errors = mutableListOf<Throwable>()
+        val json = try {
+            JSONObject(jsonStr)
+        } catch (e: JSONException) {
+            // top level failures return immediately
+            return listOf(InvalidTelemetryException.InvalidData(e))
+        }
+        try {
+            val sent = json.getJSONArray("commands_sent")
+            for (i in 0..sent.length() - 1) {
+                val one = sent.getJSONObject(i)
+                val extras = FxaTab.SentExtra(
+                    flowId = one.getString("flow_id"),
+                    streamId = one.getString("stream_id"),
+                )
+                FxaTab.sent.record(extras)
+            }
+            // logger.info("Reported telemetry for ${sent.length()} sent commands")
+        } catch (e: JSONException) {
+            errors.add(InvalidTelemetryException.InvalidEvents(e))
+        }
+        try {
+            val recd = json.getJSONArray("commands_received")
+            for (i in 0..recd.length() - 1) {
+                val one = recd.getJSONObject(i)
+                val extras = FxaTab.ReceivedExtra(
+                    flowId = one.getString("flow_id"),
+                    streamId = one.getString("stream_id"),
+                    reason = one.getString("reason"),
+                )
+                FxaTab.received.record(extras)
+            }
+            // logger.info("Reported telemetry for ${recd.length()} received commands")
+        } catch (e: JSONException) {
+            errors.add(InvalidTelemetryException.InvalidEvents(e))
+        }
+        return errors
+    }
+}

--- a/components/sync_manager/android/src/test/java/mozilla/appservices/syncmanager/SyncTelemetryTest.kt
+++ b/components/sync_manager/android/src/test/java/mozilla/appservices/syncmanager/SyncTelemetryTest.kt
@@ -1,0 +1,1222 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package mozilla.appservices.syncmanager
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import mozilla.appservices.sync15.EngineInfo
+import mozilla.appservices.sync15.FailureName
+import mozilla.appservices.sync15.FailureReason
+import mozilla.appservices.sync15.IncomingInfo
+import mozilla.appservices.sync15.OutgoingInfo
+import mozilla.appservices.sync15.ProblemInfo
+import mozilla.appservices.sync15.SyncInfo
+import mozilla.appservices.sync15.SyncTelemetryPing
+import mozilla.appservices.sync15.ValidationInfo
+import mozilla.telemetry.glean.testing.GleanTestRule
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mozilla.appservices.syncmanager.GleanMetrics.Pings
+import java.util.Date
+import java.util.UUID
+import org.mozilla.appservices.syncmanager.GleanMetrics.BookmarksSyncV2 as BookmarksSync
+import org.mozilla.appservices.syncmanager.GleanMetrics.FxaTabV2 as FxaTab
+import org.mozilla.appservices.syncmanager.GleanMetrics.HistorySyncV2 as HistorySync
+import org.mozilla.appservices.syncmanager.GleanMetrics.LoginsSyncV2 as LoginsSync
+import org.mozilla.appservices.syncmanager.GleanMetrics.SyncV2 as Sync
+
+private fun Date.asSeconds() = time / BaseGleanSyncPing.MILLIS_PER_SEC
+
+@RunWith(AndroidJUnit4::class)
+@Suppress("LargeClass")
+class SyncTelemetryTest {
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+
+    private var now: Long = 0
+    private var pingCount = 0
+
+    @Before
+    fun setup() {
+        now = Date().asSeconds()
+        pingCount = 0
+    }
+
+    @Test
+    fun `sends history telemetry pings on success`() {
+        val noGlobalError = SyncTelemetry.processHistoryPing(
+            SyncTelemetryPing(
+                version = 1,
+                uid = "abc123",
+                syncs = listOf(
+                    SyncInfo(
+                        at = now,
+                        took = 10000,
+                        engines = listOf(
+                            EngineInfo(
+                                name = "logins",
+                                at = now + 5,
+                                took = 5000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = null,
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "history",
+                                at = now,
+                                took = 5000,
+                                incoming = IncomingInfo(
+                                    applied = 5,
+                                    failed = 4,
+                                    newFailed = 3,
+                                    reconciled = 2,
+                                ),
+                                outgoing = listOf(
+                                    OutgoingInfo(
+                                        sent = 10,
+                                        failed = 5,
+                                    ),
+                                    OutgoingInfo(
+                                        sent = 4,
+                                        failed = 2,
+                                    ),
+                                ),
+                                failureReason = null,
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                    SyncInfo(
+                        at = now + 10,
+                        took = 5000,
+                        engines = listOf(
+                            EngineInfo(
+                                name = "history",
+                                at = now + 10,
+                                took = 5000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = null,
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                ),
+                events = emptyList(),
+            ),
+        ) {
+            when (pingCount) {
+                0 -> {
+                    HistorySync.apply {
+                        assertEquals("abc123", uid.testGetValue())
+                        assertEquals(now, startedAt.testGetValue()!!.asSeconds())
+                        assertEquals(now + 5, finishedAt.testGetValue()!!.asSeconds())
+                        assertEquals(5, incoming["applied"].testGetValue())
+                        assertEquals(7, incoming["failed_to_apply"].testGetValue())
+                        assertEquals(2, incoming["reconciled"].testGetValue())
+                        assertEquals(14, outgoing["uploaded"].testGetValue())
+                        assertEquals(7, outgoing["failed_to_upload"].testGetValue())
+                        assertEquals(2, outgoingBatches.testGetValue())
+                        assertNull(Sync.syncUuid.testGetValue("history-sync"))
+                    }
+                }
+                1 -> {
+                    HistorySync.apply {
+                        assertEquals("abc123", uid.testGetValue())
+                        assertEquals(now + 10, startedAt.testGetValue()!!.asSeconds())
+                        assertEquals(now + 15, finishedAt.testGetValue()!!.asSeconds())
+                        assertTrue(
+                            listOf(
+                                incoming["applied"],
+                                incoming["failed_to_apply"],
+                                incoming["reconciled"],
+                                outgoing["uploaded"],
+                                outgoing["failed_to_upload"],
+                                outgoingBatches,
+                            ).none { it.testGetValue() != null },
+                        )
+                        assertNull(Sync.syncUuid.testGetValue("history-sync"))
+                    }
+                }
+                else -> fail()
+            }
+            // We still need to send the ping, so that the counters are
+            // cleared out between calls to `sendHistoryPing`.
+            Pings.historySync.submit()
+            pingCount++
+        }
+
+        assertEquals(2, pingCount)
+        assertTrue(noGlobalError)
+    }
+
+    @Test
+    fun `sends history telemetry pings on engine failure`() {
+        val noGlobalError = SyncTelemetry.processHistoryPing(
+            SyncTelemetryPing(
+                version = 1,
+                uid = "abc123",
+                syncs = listOf(
+                    SyncInfo(
+                        at = now,
+                        took = 5000,
+                        engines = listOf(
+                            // We should ignore any engines that aren't
+                            // history.
+                            EngineInfo(
+                                name = "bookmarks",
+                                at = now + 1,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Unknown, "Boxes not locked"),
+                                validation = null,
+                            ),
+                            // Multiple history engine syncs per sync isn't
+                            // expected, but it's easier to test the
+                            // different failure types this way, instead of
+                            // creating a top-level `SyncInfo` for each
+                            // one.
+                            EngineInfo(
+                                name = "history",
+                                at = now + 2,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Shutdown),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "history",
+                                at = now + 3,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Unknown, "Synergies not aligned"),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "history",
+                                at = now + 4,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Http, code = 418),
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                    // ...But, just in case, we also test multiple top-level
+                    // syncs.
+                    SyncInfo(
+                        at = now + 5,
+                        took = 4000,
+                        engines = listOf(
+                            EngineInfo(
+                                name = "history",
+                                at = now + 6,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Auth, "Splines not reticulated", 999),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "history",
+                                at = now + 7,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Unexpected, "Kaboom!"),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "history",
+                                at = now + 8,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Other, "Qualia unsynchronized"), // other
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                ),
+                events = emptyList(),
+            ),
+        ) {
+            when (pingCount) {
+                0 -> {
+                    // Shutdown errors shouldn't be reported at all.
+                    assertTrue(
+                        listOf(
+                            "other",
+                            "unexpected",
+                            "auth",
+                        ).none { HistorySync.failureReason[it].testGetValue() != null },
+                    )
+                }
+                1 -> HistorySync.apply {
+                    assertEquals("Synergies not aligned", failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("history-sync"))
+                }
+                2 -> HistorySync.apply {
+                    assertEquals("Unexpected error: 418", failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["other"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("history-sync"))
+                }
+                3 -> HistorySync.apply {
+                    assertEquals("Splines not reticulated", failureReason["auth"].testGetValue())
+                    assertNull(failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("history-sync"))
+                }
+                4 -> HistorySync.apply {
+                    assertEquals("Kaboom!", failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["other"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("history-sync"))
+                }
+                5 -> HistorySync.apply {
+                    assertEquals("Qualia unsynchronized", failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("history-sync"))
+                }
+                else -> fail()
+            }
+            // We still need to send the ping, so that the counters are
+            // cleared out between calls to `sendHistoryPing`.
+            Pings.historySync.submit()
+            pingCount++
+        }
+
+        assertEquals(6, pingCount)
+        assertTrue(noGlobalError)
+    }
+
+    @Test
+    fun `sends history telemetry pings on sync failure`() {
+        val noGlobalError = SyncTelemetry.processHistoryPing(
+            SyncTelemetryPing(
+                version = 1,
+                uid = "abc123",
+                syncs = listOf(
+                    SyncInfo(
+                        at = now,
+                        took = 5000,
+                        engines = emptyList(),
+                        failureReason = FailureReason(FailureName.Unknown, "Synergies not aligned"),
+                    ),
+                ),
+                events = emptyList(),
+            ),
+        ) {
+            when (pingCount) {
+                0 -> HistorySync.apply {
+                    assertEquals("Synergies not aligned", failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("history-sync"))
+                }
+                else -> fail()
+            }
+            // We still need to send the ping, so that the counters are
+            // cleared out between calls to `sendHistoryPing`.
+            Pings.historySync.submit()
+            pingCount++
+        }
+
+        assertEquals(1, pingCount)
+        assertFalse(noGlobalError)
+    }
+
+    @Test
+    fun `sends passwords telemetry pings on success`() {
+        val noGlobalError = SyncTelemetry.processLoginsPing(
+            SyncTelemetryPing(
+                version = 1,
+                uid = "abc123",
+                syncs = listOf(
+                    SyncInfo(
+                        at = now,
+                        took = 10000,
+                        engines = listOf(
+                            EngineInfo(
+                                name = "history",
+                                at = now + 5,
+                                took = 5000,
+                                incoming = IncomingInfo(
+                                    applied = 10,
+                                    failed = 2,
+                                    newFailed = 3,
+                                    reconciled = 2,
+                                ),
+                                outgoing = emptyList(),
+                                failureReason = null,
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "passwords",
+                                at = now,
+                                took = 5000,
+                                incoming = IncomingInfo(
+                                    applied = 5,
+                                    failed = 4,
+                                    newFailed = 3,
+                                    reconciled = 2,
+                                ),
+                                outgoing = listOf(
+                                    OutgoingInfo(
+                                        sent = 10,
+                                        failed = 5,
+                                    ),
+                                    OutgoingInfo(
+                                        sent = 4,
+                                        failed = 2,
+                                    ),
+                                ),
+                                failureReason = null,
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                    SyncInfo(
+                        at = now + 10,
+                        took = 5000,
+                        engines = listOf(
+                            EngineInfo(
+                                name = "passwords",
+                                at = now + 10,
+                                took = 5000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = null,
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                ),
+                events = emptyList(),
+            ),
+        ) {
+            when (pingCount) {
+                0 -> {
+                    LoginsSync.apply {
+                        assertEquals("abc123", uid.testGetValue())
+                        assertEquals(now, startedAt.testGetValue()!!.asSeconds())
+                        assertEquals(now + 5, finishedAt.testGetValue()!!.asSeconds())
+                        assertEquals(5, incoming["applied"].testGetValue())
+                        assertEquals(7, incoming["failed_to_apply"].testGetValue())
+                        assertEquals(2, incoming["reconciled"].testGetValue())
+                        assertEquals(14, outgoing["uploaded"].testGetValue())
+                        assertEquals(7, outgoing["failed_to_upload"].testGetValue())
+                        assertEquals(2, outgoingBatches.testGetValue())
+                        assertNull(Sync.syncUuid.testGetValue("logins-sync"))
+                    }
+                }
+                1 -> {
+                    LoginsSync.apply {
+                        assertEquals("abc123", uid.testGetValue())
+                        assertEquals(now + 10, startedAt.testGetValue()!!.asSeconds())
+                        assertEquals(now + 15, finishedAt.testGetValue()!!.asSeconds())
+                        assertTrue(
+                            listOf(
+                                incoming["applied"],
+                                incoming["failed_to_apply"],
+                                incoming["reconciled"],
+                                outgoing["uploaded"],
+                                outgoing["failed_to_upload"],
+                                outgoingBatches,
+                            ).none { it.testGetValue() != null },
+                        )
+                        assertNull(Sync.syncUuid.testGetValue("logins-sync"))
+                    }
+                }
+                else -> fail()
+            }
+            // We still need to send the ping, so that the counters are
+            // cleared out between calls to `sendPasswordsPing`.
+            Pings.loginsSync.submit()
+            pingCount++
+        }
+
+        assertEquals(2, pingCount)
+        assertTrue(noGlobalError)
+    }
+
+    @Test
+    fun `sends passwords telemetry pings on engine failure`() {
+        val noGlobalError = SyncTelemetry.processLoginsPing(
+            SyncTelemetryPing(
+                version = 1,
+                uid = "abc123",
+                syncs = listOf(
+                    SyncInfo(
+                        at = now,
+                        took = 5000,
+                        engines = listOf(
+                            // We should ignore any engines that aren't
+                            // passwords.
+                            EngineInfo(
+                                name = "bookmarks",
+                                at = now + 1,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Unknown, "Boxes not locked"),
+                                validation = null,
+                            ),
+                            // Multiple passwords engine syncs per sync isn't
+                            // expected, but it's easier to test the
+                            // different failure types this way, instead of
+                            // creating a top-level `SyncInfo` for each
+                            // one.
+                            EngineInfo(
+                                name = "passwords",
+                                at = now + 2,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Shutdown),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "passwords",
+                                at = now + 3,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Unknown, "Synergies not aligned"),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "passwords",
+                                at = now + 4,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Http, code = 418),
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                    // ...But, just in case, we also test multiple top-level
+                    // syncs.
+                    SyncInfo(
+                        at = now + 5,
+                        took = 4000,
+                        engines = listOf(
+                            EngineInfo(
+                                name = "passwords",
+                                at = now + 6,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Auth, "Splines not reticulated", 999),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "passwords",
+                                at = now + 7,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Unexpected, "Kaboom!"),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "passwords",
+                                at = now + 8,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Other, "Qualia unsynchronized"), // other
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                ),
+                events = emptyList(),
+            ),
+        ) {
+            when (pingCount) {
+                0 -> {
+                    // Shutdown errors shouldn't be reported at all.
+                    assertTrue(
+                        listOf(
+                            "other",
+                            "unexpected",
+                            "auth",
+                        ).none { LoginsSync.failureReason[it].testGetValue() != null },
+                    )
+                }
+                1 -> LoginsSync.apply {
+                    assertEquals("Synergies not aligned", failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("logins-sync"))
+                }
+                2 -> LoginsSync.apply {
+                    assertEquals("Unexpected error: 418", failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["other"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("logins-sync"))
+                }
+                3 -> LoginsSync.apply {
+                    assertEquals("Splines not reticulated", failureReason["auth"].testGetValue())
+                    assertNull(failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("logins-sync"))
+                }
+                4 -> LoginsSync.apply {
+                    assertEquals("Kaboom!", failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["other"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("logins-sync"))
+                }
+                5 -> LoginsSync.apply {
+                    assertEquals("Qualia unsynchronized", failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("logins-sync"))
+                }
+                else -> fail()
+            }
+            // We still need to send the ping, so that the counters are
+            // cleared out between calls to `sendPasswordsPing`.
+            Pings.loginsSync.submit()
+            pingCount++
+        }
+
+        assertEquals(6, pingCount)
+        assertTrue(noGlobalError)
+    }
+
+    @Test
+    fun `sends passwords telemetry pings on sync failure`() {
+        val noGlobalError = SyncTelemetry.processLoginsPing(
+            SyncTelemetryPing(
+                version = 1,
+                uid = "abc123",
+                syncs = listOf(
+                    SyncInfo(
+                        at = now,
+                        took = 5000,
+                        engines = emptyList(),
+                        failureReason = FailureReason(FailureName.Unknown, "Synergies not aligned"),
+                    ),
+                ),
+                events = emptyList(),
+            ),
+        ) {
+            when (pingCount) {
+                0 -> LoginsSync.apply {
+                    assertEquals("Synergies not aligned", failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("logins-sync"))
+                }
+                else -> fail()
+            }
+            // We still need to send the ping, so that the counters are
+            // cleared out between calls to `sendHistoryPing`.
+            Pings.loginsSync.submit()
+            pingCount++
+        }
+
+        assertEquals(1, pingCount)
+        assertFalse(noGlobalError)
+    }
+
+    @Test
+    fun `sends bookmarks telemetry pings on success`() {
+        val noGlobalError = SyncTelemetry.processBookmarksPing(
+            SyncTelemetryPing(
+                version = 1,
+                uid = "xyz789",
+                syncs = listOf(
+                    SyncInfo(
+                        at = now + 20,
+                        took = 8000,
+                        engines = listOf(
+                            EngineInfo(
+                                name = "bookmarks",
+                                at = now + 25,
+                                took = 6000,
+                                incoming = null,
+                                outgoing = listOf(
+                                    OutgoingInfo(
+                                        sent = 10,
+                                        failed = 5,
+                                    ),
+                                ),
+                                failureReason = null,
+                                validation = ValidationInfo(
+                                    version = 2,
+                                    problems = listOf(
+                                        ProblemInfo(
+                                            name = "missingParents",
+                                            count = 5,
+                                        ),
+                                        ProblemInfo(
+                                            name = "missingChildren",
+                                            count = 7,
+                                        ),
+                                    ),
+                                    failureReason = null,
+                                ),
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                ),
+                events = emptyList(),
+            ),
+        ) {
+            when (pingCount) {
+                0 -> {
+                    BookmarksSync.apply {
+                        assertEquals("xyz789", uid.testGetValue())
+                        assertEquals(now + 25, startedAt.testGetValue()!!.asSeconds())
+                        assertEquals(now + 31, finishedAt.testGetValue()!!.asSeconds())
+                        assertNull(incoming["applied"].testGetValue())
+                        assertNull(incoming["failed_to_apply"].testGetValue())
+                        assertNull(incoming["reconciled"].testGetValue())
+                        assertEquals(10, outgoing["uploaded"].testGetValue())
+                        assertEquals(5, outgoing["failed_to_upload"].testGetValue())
+                        assertEquals(1, outgoingBatches.testGetValue())
+                        assertNull(Sync.syncUuid.testGetValue("bookmarks-sync"))
+                    }
+                }
+                else -> fail()
+            }
+            Pings.bookmarksSync.submit()
+            pingCount++
+        }
+
+        assertEquals(pingCount, 1)
+        assertTrue(noGlobalError)
+    }
+
+    @Test
+    fun `sends bookmarks telemetry pings on engine failure`() {
+        val noGlobalError = SyncTelemetry.processBookmarksPing(
+            SyncTelemetryPing(
+                version = 1,
+                uid = "abc123",
+                syncs = listOf(
+                    SyncInfo(
+                        at = now,
+                        took = 5000,
+                        engines = listOf(
+                            EngineInfo(
+                                name = "history",
+                                at = now + 1,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Unknown, "Boxes not locked"),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "bookmarks",
+                                at = now + 2,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Shutdown),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "bookmarks",
+                                at = now + 3,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Unknown, "Synergies not aligned"),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "bookmarks",
+                                at = now + 4,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Http, code = 418),
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                    SyncInfo(
+                        at = now + 5,
+                        took = 4000,
+                        engines = listOf(
+                            EngineInfo(
+                                name = "bookmarks",
+                                at = now + 6,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Auth, "Splines not reticulated", 999),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "bookmarks",
+                                at = now + 7,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Unexpected, "Kaboom!"),
+                                validation = null,
+                            ),
+                            EngineInfo(
+                                name = "bookmarks",
+                                at = now + 8,
+                                took = 1000,
+                                incoming = null,
+                                outgoing = emptyList(),
+                                failureReason = FailureReason(FailureName.Other, "Qualia unsynchronized"), // other
+                                validation = null,
+                            ),
+                        ),
+                        failureReason = null,
+                    ),
+                ),
+                events = emptyList(),
+            ),
+        ) {
+            when (pingCount) {
+                0 -> {
+                    // Shutdown errors shouldn't be reported.
+                    assertTrue(
+                        listOf(
+                            "other",
+                            "unexpected",
+                            "auth",
+                        ).none { BookmarksSync.failureReason[it].testGetValue() != null },
+                    )
+                }
+                1 -> BookmarksSync.apply {
+                    assertEquals("Synergies not aligned", failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("bookmarks-sync"))
+                }
+                2 -> BookmarksSync.apply {
+                    assertEquals("Unexpected error: 418", failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["other"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("bookmarks-sync"))
+                }
+                3 -> BookmarksSync.apply {
+                    assertEquals("Splines not reticulated", failureReason["auth"].testGetValue())
+                    assertNull(failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("bookmarks-sync"))
+                }
+                4 -> BookmarksSync.apply {
+                    assertEquals("Kaboom!", failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["other"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("bookmarks-sync"))
+                }
+                5 -> BookmarksSync.apply {
+                    assertEquals("Qualia unsynchronized", failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("bookmarks-sync"))
+                }
+                else -> fail()
+            }
+            // We still need to send the ping, so that the counters are
+            // cleared out between calls to `sendBookmarksPing`.
+            Pings.bookmarksSync.submit()
+            pingCount++
+        }
+
+        assertEquals(6, pingCount)
+        assertTrue(noGlobalError)
+    }
+
+    @Test
+    fun `sends bookmarks telemetry pings on sync failure`() {
+        val noGlobalError = SyncTelemetry.processBookmarksPing(
+            SyncTelemetryPing(
+                version = 1,
+                uid = "abc123",
+                syncs = listOf(
+                    SyncInfo(
+                        at = now,
+                        took = 5000,
+                        engines = emptyList(),
+                        failureReason = FailureReason(FailureName.Unknown, "Synergies not aligned"),
+                    ),
+                ),
+                events = emptyList(),
+            ),
+        ) {
+            when (pingCount) {
+                0 -> BookmarksSync.apply {
+                    assertEquals("Synergies not aligned", failureReason["other"].testGetValue())
+                    assertNull(failureReason["unexpected"].testGetValue())
+                    assertNull(failureReason["auth"].testGetValue())
+                    assertNull(Sync.syncUuid.testGetValue("bookmarks-sync"))
+                }
+                else -> fail()
+            }
+            // We still need to send the ping, so that the counters are
+            // cleared out between calls to `sendHistoryPing`.
+            Pings.bookmarksSync.submit()
+            pingCount++
+        }
+
+        assertEquals(1, pingCount)
+        assertFalse(noGlobalError)
+    }
+
+    @Test
+    @Suppress("ComplexMethod")
+    fun `sends a global sync ping alongside individual data type pings`() {
+        val pings = mutableListOf<MutableMap<String, Int>>(HashMap())
+        var globalPingCount = 0
+        val globalSyncUuids = mutableListOf<UUID>()
+
+        val syncTelemetry = SyncTelemetryPing(
+            version = 1,
+            uid = "abc123",
+            syncs = listOf(
+                SyncInfo(
+                    at = now,
+                    took = 10000,
+                    engines = listOf(
+                        EngineInfo(
+                            name = "passwords",
+                            at = now,
+                            took = 5000,
+                            incoming = IncomingInfo(
+                                applied = 5,
+                                failed = 4,
+                                newFailed = 3,
+                                reconciled = 2,
+                            ),
+                            outgoing = listOf(
+                                OutgoingInfo(
+                                    sent = 10,
+                                    failed = 5,
+                                ),
+                                OutgoingInfo(
+                                    sent = 4,
+                                    failed = 2,
+                                ),
+                            ),
+                            failureReason = null,
+                            validation = null,
+                        ),
+                        EngineInfo(
+                            name = "history",
+                            at = now,
+                            took = 5000,
+                            incoming = IncomingInfo(
+                                applied = 5,
+                                failed = 4,
+                                newFailed = 3,
+                                reconciled = 2,
+                            ),
+                            outgoing = listOf(
+                                OutgoingInfo(
+                                    sent = 10,
+                                    failed = 5,
+                                ),
+                                OutgoingInfo(
+                                    sent = 4,
+                                    failed = 2,
+                                ),
+                            ),
+                            failureReason = null,
+                            validation = null,
+                        ),
+                    ),
+                    failureReason = FailureReason(FailureName.Unknown, "Synergies not aligned"),
+                ),
+                SyncInfo(
+                    at = now + 10,
+                    took = 5000,
+                    engines = listOf(
+                        EngineInfo(
+                            name = "history",
+                            at = now + 10,
+                            took = 5000,
+                            incoming = null,
+                            outgoing = emptyList(),
+                            failureReason = null,
+                            validation = null,
+                        ),
+                    ),
+                    failureReason = null,
+                ),
+                SyncInfo(
+                    at = now + 20,
+                    took = 8000,
+                    engines = listOf(
+                        EngineInfo(
+                            name = "bookmarks",
+                            at = now + 25,
+                            took = 6000,
+                            incoming = null,
+                            outgoing = listOf(
+                                OutgoingInfo(
+                                    sent = 10,
+                                    failed = 5,
+                                ),
+                            ),
+                            failureReason = null,
+                            validation = ValidationInfo(
+                                version = 2,
+                                problems = listOf(
+                                    ProblemInfo(
+                                        name = "missingParents",
+                                        count = 5,
+                                    ),
+                                    ProblemInfo(
+                                        name = "missingChildren",
+                                        count = 7,
+                                    ),
+                                ),
+                                failureReason = null,
+                            ),
+                        ),
+                    ),
+                    failureReason = null,
+                ),
+            ),
+            events = emptyList(),
+        )
+
+        fun setOrAssertGlobalSyncUuid(currentPingIndex: Int, pingName: String) {
+            if (globalSyncUuids.elementAtOrNull(currentPingIndex) == null) {
+                globalSyncUuids.add(Sync.syncUuid.testGetValue(pingName)!!)
+            } else {
+                assertEquals(globalSyncUuids[currentPingIndex], Sync.syncUuid.testGetValue(pingName))
+            }
+        }
+
+        fun setOrIncrementPingCount(currentPingIndex: Int, pingName: String) {
+            if (pings.elementAtOrNull(currentPingIndex) == null) {
+                pings.add(mutableMapOf(pingName to 1))
+            } else {
+                pings[currentPingIndex].incrementForKey(pingName)
+            }
+        }
+
+        SyncTelemetry.processSyncTelemetry(
+            syncTelemetry,
+            submitGlobalPing = {
+                assertNotNull(globalSyncUuids.elementAtOrNull(globalPingCount))
+                assertEquals(globalSyncUuids[globalPingCount], Sync.syncUuid.testGetValue("sync"))
+
+                // Assertions above already assert syncUuid; below, let's make sure that 'failureReason' is processed.
+                when (globalPingCount) {
+                    0 -> {
+                        assertEquals("Synergies not aligned", Sync.failureReason["other"].testGetValue())
+                    }
+                    1 -> {
+                        assertNull(Sync.failureReason["other"].testGetValue())
+                    }
+                    2 -> {
+                        assertNull(Sync.failureReason["other"].testGetValue())
+                    }
+                    else -> fail()
+                }
+
+                Pings.sync.submit()
+                globalPingCount++
+            },
+            submitHistoryPing = {
+                when (val currentPingIndex = globalPingCount) {
+                    0 -> {
+                        setOrAssertGlobalSyncUuid(currentPingIndex, "history-sync")
+                        setOrIncrementPingCount(currentPingIndex, "history")
+                        HistorySync.apply {
+                            assertEquals("abc123", uid.testGetValue())
+                            assertEquals(now, startedAt.testGetValue()!!.asSeconds())
+                            assertEquals(now + 5, finishedAt.testGetValue()!!.asSeconds())
+                            assertEquals(5, incoming["applied"].testGetValue())
+                            assertEquals(7, incoming["failed_to_apply"].testGetValue())
+                            assertEquals(2, incoming["reconciled"].testGetValue())
+                            assertEquals(14, outgoing["uploaded"].testGetValue())
+                            assertEquals(7, outgoing["failed_to_upload"].testGetValue())
+                            assertEquals(2, outgoingBatches.testGetValue())
+                        }
+                        Pings.historySync.submit()
+                    }
+                    1 -> {
+                        setOrAssertGlobalSyncUuid(currentPingIndex, "history-sync")
+                        setOrIncrementPingCount(currentPingIndex, "history")
+                        HistorySync.apply {
+                            assertEquals("abc123", uid.testGetValue())
+                            assertEquals(now + 10, startedAt.testGetValue()!!.asSeconds())
+                            assertEquals(now + 15, finishedAt.testGetValue()!!.asSeconds())
+                            assertTrue(
+                                listOf(
+                                    incoming["applied"],
+                                    incoming["failed_to_apply"],
+                                    incoming["reconciled"],
+                                    outgoing["uploaded"],
+                                    outgoing["failed_to_upload"],
+                                    outgoingBatches,
+                                ).none { it.testGetValue() != null },
+                            )
+                        }
+                        Pings.historySync.submit()
+                    }
+                    else -> fail()
+                }
+            },
+            submitLoginsPing = {
+                when (val currentPingIndex = globalPingCount) {
+                    0 -> {
+                        setOrAssertGlobalSyncUuid(currentPingIndex, "logins-sync")
+                        setOrIncrementPingCount(currentPingIndex, "passwords")
+                        LoginsSync.apply {
+                            assertEquals("abc123", uid.testGetValue())
+                            assertEquals(now, startedAt.testGetValue()!!.asSeconds())
+                            assertEquals(now + 5, finishedAt.testGetValue()!!.asSeconds())
+                            assertEquals(5, incoming["applied"].testGetValue())
+                            assertEquals(7, incoming["failed_to_apply"].testGetValue())
+                            assertEquals(2, incoming["reconciled"].testGetValue())
+                            assertEquals(14, outgoing["uploaded"].testGetValue())
+                            assertEquals(7, outgoing["failed_to_upload"].testGetValue())
+                            assertEquals(2, outgoingBatches.testGetValue())
+                        }
+                        Pings.loginsSync.submit()
+                    }
+                    else -> fail()
+                }
+            },
+            submitBookmarksPing = {
+                when (val currentPingIndex = globalPingCount) {
+                    2 -> {
+                        setOrAssertGlobalSyncUuid(currentPingIndex, "bookmarks-sync")
+                        setOrIncrementPingCount(currentPingIndex, "bookmarks")
+                        BookmarksSync.apply {
+                            assertEquals("abc123", uid.testGetValue())
+                            assertEquals(now + 25, startedAt.testGetValue()!!.asSeconds())
+                            assertEquals(now + 31, finishedAt.testGetValue()!!.asSeconds())
+                            assertNull(incoming["applied"].testGetValue())
+                            assertNull(incoming["failed_to_apply"].testGetValue())
+                            assertNull(incoming["reconciled"].testGetValue())
+                            assertEquals(10, outgoing["uploaded"].testGetValue())
+                            assertEquals(5, outgoing["failed_to_upload"].testGetValue())
+                            assertEquals(1, outgoingBatches.testGetValue())
+                        }
+                        Pings.bookmarksSync.submit()
+                    }
+                }
+            },
+        )
+
+        assertEquals(
+            listOf(
+                mapOf("history" to 1, "passwords" to 1),
+                mapOf("history" to 1),
+                mapOf("bookmarks" to 1),
+            ),
+            pings,
+        )
+    }
+
+    @Test
+    fun `checks sent tab telemetry records what it should`() {
+        val json = """
+            {
+                "commands_sent":[{
+                    "flow_id":"test-flow-id",
+                    "stream_id":"test-stream-id"
+                }],
+                "commands_received":[]
+            }
+        """
+        SyncTelemetry.processFxaTelemetry(json)
+        val events = FxaTab.sent.testGetValue()!!
+        assertEquals(1, events.size)
+        assertEquals("test-flow-id", events.elementAt(0).extra!!["flow_id"])
+        assertEquals("test-stream-id", events.elementAt(0).extra!!["stream_id"])
+
+        assertNull(FxaTab.received.testGetValue())
+    }
+
+    @Test
+    fun `checks received tab telemetry records what it should`() {
+        val json = """
+            {
+                "commands_received":[{
+                    "flow_id":"test-flow-id",
+                    "stream_id":"test-stream-id",
+                    "reason":"test-reason"
+                }]
+            }
+        """
+        SyncTelemetry.processFxaTelemetry(json)
+        val events = FxaTab.received.testGetValue()!!
+        assertEquals(1, events.size)
+        assertEquals("test-flow-id", events.elementAt(0).extra!!["flow_id"])
+        assertEquals("test-stream-id", events.elementAt(0).extra!!["stream_id"])
+        assertEquals("test-reason", events.elementAt(0).extra!!["reason"])
+
+        assertNull(FxaTab.sent.testGetValue())
+    }
+
+    @Test
+    fun `checks invalid tab telemetry doesn't record anything and doesn't crash`() {
+        // commands_sent is missing the stream_id, command_received is missing a reason
+        val json = """
+            {
+                "commands_sent":[{
+                    "flow_id":"test-flow-id"
+                }],
+                "commands_received":[{
+                    "flow_id":"test-flow-id",
+                    "stream_id":"test-stream-id"
+                }]
+            }
+        """
+        val sendRecieveExceptions: List<Throwable> = SyncTelemetry.processFxaTelemetry(json)
+        // one exception for each of 'send' and 'received'
+        assertEquals(sendRecieveExceptions.count(), 2)
+
+        // completely invalid json
+        val topLevelExceptions: List<Throwable> = SyncTelemetry.processFxaTelemetry(""" foo bar """)
+        assertNull(FxaTab.sent.testGetValue())
+        assertNull(FxaTab.received.testGetValue())
+        // processFxaTelemetry should report only one error
+        assertEquals(topLevelExceptions.count(), 1)
+    }
+
+    private fun MutableMap<String, Int>.incrementForKey(key: String) {
+        this[key] = 1 + this.getOrElse(key, { 0 })
+    }
+}

--- a/components/sync_manager/ios/SyncManager/SyncManagerTelemetry.swift
+++ b/components/sync_manager/ios/SyncManager/SyncManagerTelemetry.swift
@@ -5,6 +5,13 @@
 import Foundation
 import Glean
 
+typealias SyncMetrics = GleanMetrics.SyncV2
+typealias LoginsMetrics = GleanMetrics.LoginsSyncV2
+typealias BookmarksMetrics = GleanMetrics.BookmarksSyncV2
+typealias HistoryMetrics = GleanMetrics.HistorySyncV2
+typealias CreditcardsMetrics = GleanMetrics.CreditcardsSyncV2
+typealias TabsMetrics = GleanMetrics.TabsSyncV2
+
 enum SupportedEngines: String {
     case History = "history"
     case Bookmarks = "bookmarks"
@@ -27,11 +34,11 @@ func processSyncTelemetry(syncTelemetry: RustSyncTelemetryPing,
                           submitTabsPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.tabsSync.submit) throws
 {
     for syncInfo in syncTelemetry.syncs {
-        _ = GleanMetrics.Sync.syncUuid.generateAndSet()
+        _ = SyncMetrics.syncUuid.generateAndSet()
 
         if let failureReason = syncInfo.failureReason {
             recordFailureReason(reason: failureReason,
-                                failureReasonMetric: GleanMetrics.Sync.failureReason)
+                                failureReasonMetric: SyncMetrics.failureReason)
         }
 
         try syncInfo.engines.forEach { engineInfo in
@@ -72,37 +79,37 @@ private func individualLoginsSync(hashedFxaUid: String, engineInfo: EngineInfo) 
     }
 
     let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
-    GleanMetrics.LoginsSync.uid.set(base.uid)
-    GleanMetrics.LoginsSync.startedAt.set(base.startedAt)
-    GleanMetrics.LoginsSync.finishedAt.set(base.finishedAt)
+    LoginsMetrics.uid.set(base.uid)
+    LoginsMetrics.startedAt.set(base.startedAt)
+    LoginsMetrics.finishedAt.set(base.finishedAt)
 
     if base.applied > 0 {
-        GleanMetrics.LoginsSync.incoming["applied"].add(base.applied)
+        LoginsMetrics.incoming["applied"].add(base.applied)
     }
 
     if base.failedToApply > 0 {
-        GleanMetrics.LoginsSync.incoming["failed_to_apply"].add(base.failedToApply)
+        LoginsMetrics.incoming["failed_to_apply"].add(base.failedToApply)
     }
 
     if base.reconciled > 0 {
-        GleanMetrics.LoginsSync.incoming["reconciled"].add(base.reconciled)
+        LoginsMetrics.incoming["reconciled"].add(base.reconciled)
     }
 
     if base.uploaded > 0 {
-        GleanMetrics.LoginsSync.outgoing["uploaded"].add(base.uploaded)
+        LoginsMetrics.outgoing["uploaded"].add(base.uploaded)
     }
 
     if base.failedToUpload > 0 {
-        GleanMetrics.LoginsSync.outgoing["failed_to_upload"].add(base.failedToUpload)
+        LoginsMetrics.outgoing["failed_to_upload"].add(base.failedToUpload)
     }
 
     if base.outgoingBatches > 0 {
-        GleanMetrics.LoginsSync.outgoingBatches.add(base.outgoingBatches)
+        LoginsMetrics.outgoingBatches.add(base.outgoingBatches)
     }
 
     if let reason = base.failureReason {
         recordFailureReason(reason: reason,
-                            failureReasonMetric: GleanMetrics.LoginsSync.failureReason)
+                            failureReasonMetric: LoginsMetrics.failureReason)
     }
 }
 
@@ -113,42 +120,42 @@ private func individualBookmarksSync(hashedFxaUid: String, engineInfo: EngineInf
     }
 
     let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
-    GleanMetrics.BookmarksSync.uid.set(base.uid)
-    GleanMetrics.BookmarksSync.startedAt.set(base.startedAt)
-    GleanMetrics.BookmarksSync.finishedAt.set(base.finishedAt)
+    BookmarksMetrics.uid.set(base.uid)
+    BookmarksMetrics.startedAt.set(base.startedAt)
+    BookmarksMetrics.finishedAt.set(base.finishedAt)
 
     if base.applied > 0 {
-        GleanMetrics.BookmarksSync.incoming["applied"].add(base.applied)
+        BookmarksMetrics.incoming["applied"].add(base.applied)
     }
 
     if base.failedToApply > 0 {
-        GleanMetrics.BookmarksSync.incoming["failed_to_apply"].add(base.failedToApply)
+        BookmarksMetrics.incoming["failed_to_apply"].add(base.failedToApply)
     }
 
     if base.reconciled > 0 {
-        GleanMetrics.BookmarksSync.incoming["reconciled"].add(base.reconciled)
+        BookmarksMetrics.incoming["reconciled"].add(base.reconciled)
     }
 
     if base.uploaded > 0 {
-        GleanMetrics.BookmarksSync.outgoing["uploaded"].add(base.uploaded)
+        BookmarksMetrics.outgoing["uploaded"].add(base.uploaded)
     }
 
     if base.failedToUpload > 0 {
-        GleanMetrics.BookmarksSync.outgoing["failed_to_upload"].add(base.failedToUpload)
+        BookmarksMetrics.outgoing["failed_to_upload"].add(base.failedToUpload)
     }
 
     if base.outgoingBatches > 0 {
-        GleanMetrics.BookmarksSync.outgoingBatches.add(base.outgoingBatches)
+        BookmarksMetrics.outgoingBatches.add(base.outgoingBatches)
     }
 
     if let reason = base.failureReason {
         recordFailureReason(reason: reason,
-                            failureReasonMetric: GleanMetrics.BookmarksSync.failureReason)
+                            failureReasonMetric: BookmarksMetrics.failureReason)
     }
 
     if let validation = engineInfo.validation {
         validation.problems.forEach { problemInfo in
-            GleanMetrics.BookmarksSync.remoteTreeProblems[problemInfo.name].add(Int32(problemInfo.count))
+            BookmarksMetrics.remoteTreeProblems[problemInfo.name].add(Int32(problemInfo.count))
         }
     }
 }
@@ -160,37 +167,37 @@ private func individualHistorySync(hashedFxaUid: String, engineInfo: EngineInfo)
     }
 
     let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
-    GleanMetrics.HistorySync.uid.set(base.uid)
-    GleanMetrics.HistorySync.startedAt.set(base.startedAt)
-    GleanMetrics.HistorySync.finishedAt.set(base.finishedAt)
+    HistoryMetrics.uid.set(base.uid)
+    HistoryMetrics.startedAt.set(base.startedAt)
+    HistoryMetrics.finishedAt.set(base.finishedAt)
 
     if base.applied > 0 {
-        GleanMetrics.HistorySync.incoming["applied"].add(base.applied)
+        HistoryMetrics.incoming["applied"].add(base.applied)
     }
 
     if base.failedToApply > 0 {
-        GleanMetrics.HistorySync.incoming["failed_to_apply"].add(base.failedToApply)
+        HistoryMetrics.incoming["failed_to_apply"].add(base.failedToApply)
     }
 
     if base.reconciled > 0 {
-        GleanMetrics.HistorySync.incoming["reconciled"].add(base.reconciled)
+        HistoryMetrics.incoming["reconciled"].add(base.reconciled)
     }
 
     if base.uploaded > 0 {
-        GleanMetrics.HistorySync.outgoing["uploaded"].add(base.uploaded)
+        HistoryMetrics.outgoing["uploaded"].add(base.uploaded)
     }
 
     if base.failedToUpload > 0 {
-        GleanMetrics.HistorySync.outgoing["failed_to_upload"].add(base.failedToUpload)
+        HistoryMetrics.outgoing["failed_to_upload"].add(base.failedToUpload)
     }
 
     if base.outgoingBatches > 0 {
-        GleanMetrics.HistorySync.outgoingBatches.add(base.outgoingBatches)
+        HistoryMetrics.outgoingBatches.add(base.outgoingBatches)
     }
 
     if let reason = base.failureReason {
         recordFailureReason(reason: reason,
-                            failureReasonMetric: GleanMetrics.HistorySync.failureReason)
+                            failureReasonMetric: HistoryMetrics.failureReason)
     }
 }
 
@@ -201,37 +208,37 @@ private func individualCreditCardsSync(hashedFxaUid: String, engineInfo: EngineI
     }
 
     let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
-    GleanMetrics.CreditcardsSync.uid.set(base.uid)
-    GleanMetrics.CreditcardsSync.startedAt.set(base.startedAt)
-    GleanMetrics.CreditcardsSync.finishedAt.set(base.finishedAt)
+    CreditcardsMetrics.uid.set(base.uid)
+    CreditcardsMetrics.startedAt.set(base.startedAt)
+    CreditcardsMetrics.finishedAt.set(base.finishedAt)
 
     if base.applied > 0 {
-        GleanMetrics.CreditcardsSync.incoming["applied"].add(base.applied)
+        CreditcardsMetrics.incoming["applied"].add(base.applied)
     }
 
     if base.failedToApply > 0 {
-        GleanMetrics.CreditcardsSync.incoming["failed_to_apply"].add(base.failedToApply)
+        CreditcardsMetrics.incoming["failed_to_apply"].add(base.failedToApply)
     }
 
     if base.reconciled > 0 {
-        GleanMetrics.CreditcardsSync.incoming["reconciled"].add(base.reconciled)
+        CreditcardsMetrics.incoming["reconciled"].add(base.reconciled)
     }
 
     if base.uploaded > 0 {
-        GleanMetrics.CreditcardsSync.outgoing["uploaded"].add(base.uploaded)
+        CreditcardsMetrics.outgoing["uploaded"].add(base.uploaded)
     }
 
     if base.failedToUpload > 0 {
-        GleanMetrics.CreditcardsSync.outgoing["failed_to_upload"].add(base.failedToUpload)
+        CreditcardsMetrics.outgoing["failed_to_upload"].add(base.failedToUpload)
     }
 
     if base.outgoingBatches > 0 {
-        GleanMetrics.CreditcardsSync.outgoingBatches.add(base.outgoingBatches)
+        CreditcardsMetrics.outgoingBatches.add(base.outgoingBatches)
     }
 
     if let reason = base.failureReason {
         recordFailureReason(reason: reason,
-                            failureReasonMetric: GleanMetrics.CreditcardsSync.failureReason)
+                            failureReasonMetric: CreditcardsMetrics.failureReason)
     }
 }
 
@@ -242,37 +249,37 @@ private func individualTabsSync(hashedFxaUid: String, engineInfo: EngineInfo) th
     }
 
     let base = BaseGleanSyncPing.fromEngineInfo(uid: hashedFxaUid, info: engineInfo)
-    GleanMetrics.TabsSync.uid.set(base.uid)
-    GleanMetrics.TabsSync.startedAt.set(base.startedAt)
-    GleanMetrics.TabsSync.finishedAt.set(base.finishedAt)
+    TabsMetrics.uid.set(base.uid)
+    TabsMetrics.startedAt.set(base.startedAt)
+    TabsMetrics.finishedAt.set(base.finishedAt)
 
     if base.applied > 0 {
-        GleanMetrics.TabsSync.incoming["applied"].add(base.applied)
+        TabsMetrics.incoming["applied"].add(base.applied)
     }
 
     if base.failedToApply > 0 {
-        GleanMetrics.TabsSync.incoming["failed_to_apply"].add(base.failedToApply)
+        TabsMetrics.incoming["failed_to_apply"].add(base.failedToApply)
     }
 
     if base.reconciled > 0 {
-        GleanMetrics.TabsSync.incoming["reconciled"].add(base.reconciled)
+        TabsMetrics.incoming["reconciled"].add(base.reconciled)
     }
 
     if base.uploaded > 0 {
-        GleanMetrics.TabsSync.outgoing["uploaded"].add(base.uploaded)
+        TabsMetrics.outgoing["uploaded"].add(base.uploaded)
     }
 
     if base.failedToUpload > 0 {
-        GleanMetrics.TabsSync.outgoing["failed_to_upload"].add(base.failedToUpload)
+        TabsMetrics.outgoing["failed_to_upload"].add(base.failedToUpload)
     }
 
     if base.outgoingBatches > 0 {
-        GleanMetrics.TabsSync.outgoingBatches.add(base.outgoingBatches)
+        TabsMetrics.outgoingBatches.add(base.outgoingBatches)
     }
 
     if let reason = base.failureReason {
         recordFailureReason(reason: reason,
-                            failureReasonMetric: GleanMetrics.TabsSync.failureReason)
+                            failureReasonMetric: TabsMetrics.failureReason)
     }
 }
 

--- a/components/sync_manager/metrics.yaml
+++ b/components/sync_manager/metrics.yaml
@@ -5,7 +5,7 @@
 
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
-sync:
+sync_v2:
   sync_uuid:
     type: uuid
     description: >
@@ -28,6 +28,7 @@ sync:
       - technical
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   failure_reason:
@@ -51,6 +52,7 @@ sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
 
@@ -60,7 +62,7 @@ sync:
 # but must be specified individually. We can't define them once and use
 # `send_in_pings` because the stores might be synced in parallel, and we can't
 # guarantee that a ping for one store would be sent before the others.
-history_sync:
+history_sync_v2:
   uid:
     type: string
     description: >
@@ -75,6 +77,7 @@ history_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   started_at:
@@ -92,6 +95,7 @@ history_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   finished_at:
@@ -110,6 +114,7 @@ history_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   incoming:
@@ -134,6 +139,7 @@ history_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing:
@@ -156,6 +162,7 @@ history_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing_batches:
@@ -175,6 +182,7 @@ history_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   failure_reason:
@@ -197,10 +205,11 @@ history_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
 
-logins_sync:
+logins_sync_v2:
   uid:
     type: string
     description: >
@@ -215,6 +224,7 @@ logins_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   started_at:
@@ -232,6 +242,7 @@ logins_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   finished_at:
@@ -250,6 +261,7 @@ logins_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   incoming:
@@ -274,6 +286,7 @@ logins_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing:
@@ -296,6 +309,7 @@ logins_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing_batches:
@@ -315,6 +329,7 @@ logins_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   failure_reason:
@@ -337,10 +352,11 @@ logins_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
 
-bookmarks_sync:
+bookmarks_sync_v2:
   uid:
     type: string
     description: >
@@ -355,6 +371,7 @@ bookmarks_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   started_at:
@@ -372,6 +389,7 @@ bookmarks_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   finished_at:
@@ -389,6 +407,7 @@ bookmarks_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   incoming:
@@ -409,6 +428,7 @@ bookmarks_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing:
@@ -428,6 +448,7 @@ bookmarks_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing_batches:
@@ -444,6 +465,7 @@ bookmarks_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   failure_reason:
@@ -464,6 +486,7 @@ bookmarks_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   remote_tree_problems:
@@ -490,10 +513,11 @@ bookmarks_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
 
-creditcards_sync:
+creditcards_sync_v2:
   uid:
     type: string
     description: >
@@ -508,6 +532,7 @@ creditcards_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   started_at:
@@ -525,6 +550,7 @@ creditcards_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   finished_at:
@@ -543,6 +569,7 @@ creditcards_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   incoming:
@@ -566,6 +593,7 @@ creditcards_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing:
@@ -588,6 +616,7 @@ creditcards_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing_batches:
@@ -607,6 +636,7 @@ creditcards_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   failure_reason:
@@ -629,10 +659,11 @@ creditcards_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
 
-addresses_sync:
+addresses_sync_v2:
   uid:
     type: string
     description: >
@@ -647,6 +678,7 @@ addresses_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   started_at:
@@ -664,6 +696,7 @@ addresses_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   finished_at:
@@ -682,6 +715,7 @@ addresses_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   incoming:
@@ -705,6 +739,7 @@ addresses_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing:
@@ -727,6 +762,7 @@ addresses_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing_batches:
@@ -746,6 +782,7 @@ addresses_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   failure_reason:
@@ -768,10 +805,11 @@ addresses_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
 
-tabs_sync:
+tabs_sync_v2:
   uid:
     type: string
     description: >
@@ -786,6 +824,7 @@ tabs_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   started_at:
@@ -803,6 +842,7 @@ tabs_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   finished_at:
@@ -821,6 +861,7 @@ tabs_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   incoming:
@@ -844,6 +885,7 @@ tabs_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing:
@@ -866,6 +908,7 @@ tabs_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   outgoing_batches:
@@ -885,6 +928,7 @@ tabs_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
   failure_reason:
@@ -907,5 +951,69 @@ tabs_sync:
       - interaction
     notification_emails:
       - sync-team@mozilla.com
+      - skhamis@mozilla.com
     expires: never
     lifetime: ping
+
+fxa_tab_v2:
+  sent:
+    type: event
+    description: >
+      Recorded when a tab is sent. Also sent by desktop - see also the docs at
+      https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/sync-ping.html
+    send_in_pings:
+      - sync
+    extra_keys:
+      flow_id:
+        type: string
+        description: >
+          A guid, unique for the URL being sent but common for all target
+          devices. The value is randomly generated so can not identify details
+          about the user or tab.
+      stream_id:
+        type: string
+        description: >
+          A guid, unique for both the URL being sent and the target device. The
+          value is randomly generated so can not identify details about the
+          user or tab.
+    bugs:
+      - https://github.com/mozilla/application-services/pull/3308
+      - https://github.com/mozilla-mobile/android-components/pull/7618
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1652902
+    notification_emails:
+      - sync-team@mozilla.com
+      - skhamis@mozilla.com
+    expires: never
+  received:
+    type: event
+    description: >
+      Recorded when a tab is received.  Also sent by desktop - see also the
+      docs at
+      https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/sync-ping.html
+    send_in_pings:
+      - sync
+    extra_keys:
+      flow_id:
+        type: string
+        description: >
+          A guid, unique for the URL being sent but common for all target
+          devices.
+      stream_id:
+        type: string
+        description: >
+          A guid, unique for both the URL being sent and the target device.
+      reason:
+        type: string
+        description: >
+          The reason we discovered the tab. Will be one of 'push', 'push-missed'
+          or 'poll'.
+    bugs:
+      - https://github.com/mozilla/application-services/pull/3308
+      - https://github.com/mozilla-mobile/android-components/pull/7618
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1652902
+    notification_emails:
+      - sync-team@mozilla.com
+      - skhamis@mozilla.com
+    expires: never

--- a/components/sync_manager/pings.yaml
+++ b/components/sync_manager/pings.yaml
@@ -26,7 +26,8 @@ sync:
   bugs:
     - https://github.com/mozilla-mobile/android-components/issues/5371
   notification_emails:
-    - sync-core@mozilla.com
+    - sync-team@mozilla.com
+    - skhamis@mozilla.com
   data_reviews:
     - https://github.com/mozilla-mobile/android-components/pull/5386#pullrequestreview-392363687
 history-sync:
@@ -37,7 +38,8 @@ history-sync:
   bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
   notification_emails:
-    - sync-core@mozilla.com
+    - sync-team@mozilla.com
+    - skhamis@mozilla.com
   data_reviews:
     - https://github.com/mozilla-mobile/android-components/pull/3092
 bookmarks-sync:
@@ -48,7 +50,8 @@ bookmarks-sync:
   bugs:
     - https://github.com/mozilla-mobile/android-components/pull/3092
   notification_emails:
-    - sync-core@mozilla.com
+    - sync-team@mozilla.com
+    - skhamis@mozilla.com
   data_reviews:
     - https://github.com/mozilla-mobile/android-components/pull/3092
 logins-sync:
@@ -60,7 +63,8 @@ logins-sync:
   bugs:
     - https://github.com/mozilla-mobile/android-components/issues/4556
   notification_emails:
-    - sync-core@mozilla.com
+    - sync-team@mozilla.com
+    - skhamis@mozilla.com
   data_reviews:
     - https://github.com/mozilla-mobile/android-components/pull/5294
 creditcards-sync:
@@ -72,7 +76,8 @@ creditcards-sync:
   bugs:
     - https://github.com/mozilla-mobile/android-components/issues/10371
   notification_emails:
-    - sync-core@mozilla.com
+    - sync-team@mozilla.com
+    - skhamis@mozilla.com
   data_reviews:
     - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
 addresses-sync:
@@ -84,7 +89,8 @@ addresses-sync:
   bugs:
     - https://github.com/mozilla-mobile/android-components/issues/10371
   notification_emails:
-    - sync-core@mozilla.com
+    - sync-team@mozilla.com
+    - skhamis@mozilla.com
   data_reviews:
     - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481
 tabs-sync:
@@ -96,6 +102,7 @@ tabs-sync:
   bugs:
     - https://github.com/mozilla-mobile/android-components/issues/10371
   notification_emails:
-    - sync-core@mozilla.com
+    - sync-team@mozilla.com
+    - skhamis@mozilla.com
   data_reviews:
     - https://github.com/mozilla-mobile/android-components/pull/10372#issuecomment-850378481

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
@@ -54,43 +54,43 @@ class SyncManagerTelemetryTests: XCTestCase {
                                                                                                 message: "Synergies not aligned"))])
 
         func submitGlobalPing(_: NoReasonCodes?) {
-            XCTAssertEqual("Synergies not aligned", GleanMetrics.Sync.failureReason["other"].testGetValue())
+            XCTAssertEqual("Synergies not aligned", SyncMetrics.failureReason["other"].testGetValue())
             XCTAssertNotNil(globalSyncUuid)
-            XCTAssertEqual(globalSyncUuid, GleanMetrics.Sync.syncUuid.testGetValue("sync"))
+            XCTAssertEqual(globalSyncUuid, SyncMetrics.syncUuid.testGetValue("sync"))
         }
 
         func submitHistoryPing(_: NoReasonCodes?) {
-            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("history-sync")!
-            XCTAssertEqual("abc123", GleanMetrics.HistorySync.uid.testGetValue())
+            globalSyncUuid = SyncMetrics.syncUuid.testGetValue("history-sync")!
+            XCTAssertEqual("abc123", HistoryMetrics.uid.testGetValue())
 
-            XCTAssertNotNil(GleanMetrics.HistorySync.startedAt.testGetValue())
-            XCTAssertNotNil(GleanMetrics.HistorySync.finishedAt.testGetValue())
-            XCTAssertEqual(now, Int64(GleanMetrics.HistorySync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
-            XCTAssertEqual(now + 5, Int64(GleanMetrics.HistorySync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertNotNil(HistoryMetrics.startedAt.testGetValue())
+            XCTAssertNotNil(HistoryMetrics.finishedAt.testGetValue())
+            XCTAssertEqual(now, Int64(HistoryMetrics.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 5, Int64(HistoryMetrics.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
 
-            XCTAssertEqual(5, GleanMetrics.HistorySync.incoming["applied"].testGetValue())
-            XCTAssertEqual(7, GleanMetrics.HistorySync.incoming["failed_to_apply"].testGetValue())
-            XCTAssertEqual(2, GleanMetrics.HistorySync.incoming["reconciled"].testGetValue())
-            XCTAssertEqual(14, GleanMetrics.HistorySync.outgoing["uploaded"].testGetValue())
-            XCTAssertEqual(7, GleanMetrics.HistorySync.outgoing["failed_to_upload"].testGetValue())
-            XCTAssertEqual(2, GleanMetrics.HistorySync.outgoingBatches.testGetValue())
+            XCTAssertEqual(5, HistoryMetrics.incoming["applied"].testGetValue())
+            XCTAssertEqual(7, HistoryMetrics.incoming["failed_to_apply"].testGetValue())
+            XCTAssertEqual(2, HistoryMetrics.incoming["reconciled"].testGetValue())
+            XCTAssertEqual(14, HistoryMetrics.outgoing["uploaded"].testGetValue())
+            XCTAssertEqual(7, HistoryMetrics.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertEqual(2, HistoryMetrics.outgoingBatches.testGetValue())
         }
 
         func submitLoginsPing(_: NoReasonCodes?) {
-            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("logins-sync")!
-            XCTAssertEqual("abc123", GleanMetrics.LoginsSync.uid.testGetValue())
+            globalSyncUuid = SyncMetrics.syncUuid.testGetValue("logins-sync")!
+            XCTAssertEqual("abc123", LoginsMetrics.uid.testGetValue())
 
-            XCTAssertNotNil(GleanMetrics.LoginsSync.startedAt.testGetValue())
-            XCTAssertNotNil(GleanMetrics.LoginsSync.finishedAt.testGetValue())
-            XCTAssertEqual(now, Int64(GleanMetrics.LoginsSync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
-            XCTAssertEqual(now + 5, Int64(GleanMetrics.LoginsSync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertNotNil(LoginsMetrics.startedAt.testGetValue())
+            XCTAssertNotNil(LoginsMetrics.finishedAt.testGetValue())
+            XCTAssertEqual(now, Int64(LoginsMetrics.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 5, Int64(LoginsMetrics.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
 
-            XCTAssertEqual(5, GleanMetrics.LoginsSync.incoming["applied"].testGetValue())
-            XCTAssertEqual(7, GleanMetrics.LoginsSync.incoming["failed_to_apply"].testGetValue())
-            XCTAssertEqual(2, GleanMetrics.LoginsSync.incoming["reconciled"].testGetValue())
-            XCTAssertEqual(14, GleanMetrics.LoginsSync.outgoing["uploaded"].testGetValue())
-            XCTAssertEqual(7, GleanMetrics.LoginsSync.outgoing["failed_to_upload"].testGetValue())
-            XCTAssertEqual(2, GleanMetrics.LoginsSync.outgoingBatches.testGetValue())
+            XCTAssertEqual(5, LoginsMetrics.incoming["applied"].testGetValue())
+            XCTAssertEqual(7, LoginsMetrics.incoming["failed_to_apply"].testGetValue())
+            XCTAssertEqual(2, LoginsMetrics.incoming["reconciled"].testGetValue())
+            XCTAssertEqual(14, LoginsMetrics.outgoing["uploaded"].testGetValue())
+            XCTAssertEqual(7, LoginsMetrics.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertEqual(2, LoginsMetrics.outgoingBatches.testGetValue())
         }
 
         try! processSyncTelemetry(syncTelemetry: syncTelemetry,
@@ -116,26 +116,26 @@ class SyncManagerTelemetryTests: XCTestCase {
                                                                    failureReason: nil)])
 
         func submitGlobalPing(_: NoReasonCodes?) {
-            XCTAssertNil(GleanMetrics.Sync.failureReason["other"].testGetValue())
+            XCTAssertNil(SyncMetrics.failureReason["other"].testGetValue())
             XCTAssertNotNil(globalSyncUuid)
-            XCTAssertEqual(globalSyncUuid, GleanMetrics.Sync.syncUuid.testGetValue("sync"))
+            XCTAssertEqual(globalSyncUuid, SyncMetrics.syncUuid.testGetValue("sync"))
         }
 
         func submitHistoryPing(_: NoReasonCodes?) {
-            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("history-sync")!
-            XCTAssertEqual("abc123", GleanMetrics.HistorySync.uid.testGetValue())
+            globalSyncUuid = SyncMetrics.syncUuid.testGetValue("history-sync")!
+            XCTAssertEqual("abc123", HistoryMetrics.uid.testGetValue())
 
-            XCTAssertNotNil(GleanMetrics.HistorySync.startedAt.testGetValue())
-            XCTAssertNotNil(GleanMetrics.HistorySync.finishedAt.testGetValue())
-            XCTAssertEqual(now + 10, Int64(GleanMetrics.HistorySync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
-            XCTAssertEqual(now + 15, Int64(GleanMetrics.HistorySync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertNotNil(HistoryMetrics.startedAt.testGetValue())
+            XCTAssertNotNil(HistoryMetrics.finishedAt.testGetValue())
+            XCTAssertEqual(now + 10, Int64(HistoryMetrics.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 15, Int64(HistoryMetrics.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
 
-            XCTAssertNil(GleanMetrics.HistorySync.incoming["applied"].testGetValue())
-            XCTAssertNil(GleanMetrics.HistorySync.incoming["failed_to_apply"].testGetValue())
-            XCTAssertNil(GleanMetrics.HistorySync.incoming["reconciled"].testGetValue())
-            XCTAssertNil(GleanMetrics.HistorySync.outgoing["uploaded"].testGetValue())
-            XCTAssertNil(GleanMetrics.HistorySync.outgoing["failed_to_upload"].testGetValue())
-            XCTAssertNil(GleanMetrics.HistorySync.outgoingBatches.testGetValue())
+            XCTAssertNil(HistoryMetrics.incoming["applied"].testGetValue())
+            XCTAssertNil(HistoryMetrics.incoming["failed_to_apply"].testGetValue())
+            XCTAssertNil(HistoryMetrics.incoming["reconciled"].testGetValue())
+            XCTAssertNil(HistoryMetrics.outgoing["uploaded"].testGetValue())
+            XCTAssertNil(HistoryMetrics.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertNil(HistoryMetrics.outgoingBatches.testGetValue())
         }
 
         try! processSyncTelemetry(syncTelemetry: syncTelemetry,
@@ -165,26 +165,26 @@ class SyncManagerTelemetryTests: XCTestCase {
                                                                    failureReason: nil)])
 
         func submitGlobalPing(_: NoReasonCodes?) {
-            XCTAssertNil(GleanMetrics.Sync.failureReason["other"].testGetValue())
+            XCTAssertNil(SyncMetrics.failureReason["other"].testGetValue())
             XCTAssertNotNil(globalSyncUuid)
-            XCTAssertEqual(globalSyncUuid, GleanMetrics.Sync.syncUuid.testGetValue("sync"))
+            XCTAssertEqual(globalSyncUuid, SyncMetrics.syncUuid.testGetValue("sync"))
         }
 
         func submitBookmarksPing(_: NoReasonCodes?) {
-            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("bookmarks-sync")!
-            XCTAssertEqual("abc123", GleanMetrics.BookmarksSync.uid.testGetValue())
+            globalSyncUuid = SyncMetrics.syncUuid.testGetValue("bookmarks-sync")!
+            XCTAssertEqual("abc123", BookmarksMetrics.uid.testGetValue())
 
-            XCTAssertNotNil(GleanMetrics.BookmarksSync.startedAt.testGetValue())
-            XCTAssertNotNil(GleanMetrics.BookmarksSync.finishedAt.testGetValue())
-            XCTAssertEqual(now + 25, Int64(GleanMetrics.BookmarksSync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
-            XCTAssertEqual(now + 31, Int64(GleanMetrics.BookmarksSync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertNotNil(BookmarksMetrics.startedAt.testGetValue())
+            XCTAssertNotNil(BookmarksMetrics.finishedAt.testGetValue())
+            XCTAssertEqual(now + 25, Int64(BookmarksMetrics.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 31, Int64(BookmarksMetrics.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
 
-            XCTAssertNil(GleanMetrics.BookmarksSync.incoming["applied"].testGetValue())
-            XCTAssertNil(GleanMetrics.BookmarksSync.incoming["failed_to_apply"].testGetValue())
-            XCTAssertNil(GleanMetrics.BookmarksSync.incoming["reconciled"].testGetValue())
-            XCTAssertEqual(10, GleanMetrics.BookmarksSync.outgoing["uploaded"].testGetValue())
-            XCTAssertEqual(5, GleanMetrics.BookmarksSync.outgoing["failed_to_upload"].testGetValue())
-            XCTAssertEqual(1, GleanMetrics.BookmarksSync.outgoingBatches.testGetValue())
+            XCTAssertNil(BookmarksMetrics.incoming["applied"].testGetValue())
+            XCTAssertNil(BookmarksMetrics.incoming["failed_to_apply"].testGetValue())
+            XCTAssertNil(BookmarksMetrics.incoming["reconciled"].testGetValue())
+            XCTAssertEqual(10, BookmarksMetrics.outgoing["uploaded"].testGetValue())
+            XCTAssertEqual(5, BookmarksMetrics.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertEqual(1, BookmarksMetrics.outgoingBatches.testGetValue())
         }
 
         try! processSyncTelemetry(syncTelemetry: syncTelemetry,
@@ -219,42 +219,42 @@ class SyncManagerTelemetryTests: XCTestCase {
                                                                    failureReason: nil)])
 
         func submitGlobalPing(_: NoReasonCodes?) {
-            XCTAssertNil(GleanMetrics.Sync.failureReason["other"].testGetValue())
+            XCTAssertNil(SyncMetrics.failureReason["other"].testGetValue())
             XCTAssertNotNil(globalSyncUuid)
-            XCTAssertEqual(globalSyncUuid, GleanMetrics.Sync.syncUuid.testGetValue("sync"))
+            XCTAssertEqual(globalSyncUuid, SyncMetrics.syncUuid.testGetValue("sync"))
         }
 
         func submitCreditCardsPing(_: NoReasonCodes?) {
-            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("creditcards-sync")!
-            XCTAssertEqual("abc123", GleanMetrics.CreditcardsSync.uid.testGetValue())
+            globalSyncUuid = SyncMetrics.syncUuid.testGetValue("creditcards-sync")!
+            XCTAssertEqual("abc123", CreditcardsMetrics.uid.testGetValue())
 
-            XCTAssertNotNil(GleanMetrics.CreditcardsSync.startedAt.testGetValue())
-            XCTAssertNotNil(GleanMetrics.CreditcardsSync.finishedAt.testGetValue())
-            XCTAssertEqual(now + 15, Int64(GleanMetrics.CreditcardsSync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
-            XCTAssertEqual(now + 19, Int64(GleanMetrics.CreditcardsSync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertNotNil(CreditcardsMetrics.startedAt.testGetValue())
+            XCTAssertNotNil(CreditcardsMetrics.finishedAt.testGetValue())
+            XCTAssertEqual(now + 15, Int64(CreditcardsMetrics.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 19, Int64(CreditcardsMetrics.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
 
-            XCTAssertEqual(3, GleanMetrics.CreditcardsSync.incoming["applied"].testGetValue())
-            XCTAssertEqual(2, GleanMetrics.CreditcardsSync.incoming["failed_to_apply"].testGetValue())
-            XCTAssertNil(GleanMetrics.CreditcardsSync.incoming["reconciled"].testGetValue())
-            XCTAssertNil(GleanMetrics.HistorySync.outgoing["uploaded"].testGetValue())
-            XCTAssertNil(GleanMetrics.HistorySync.outgoing["failed_to_upload"].testGetValue())
-            XCTAssertNil(GleanMetrics.CreditcardsSync.outgoingBatches.testGetValue())
+            XCTAssertEqual(3, CreditcardsMetrics.incoming["applied"].testGetValue())
+            XCTAssertEqual(2, CreditcardsMetrics.incoming["failed_to_apply"].testGetValue())
+            XCTAssertNil(CreditcardsMetrics.incoming["reconciled"].testGetValue())
+            XCTAssertNil(HistoryMetrics.outgoing["uploaded"].testGetValue())
+            XCTAssertNil(HistoryMetrics.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertNil(CreditcardsMetrics.outgoingBatches.testGetValue())
         }
 
         func submitTabsPing(_: NoReasonCodes?) {
-            globalSyncUuid = GleanMetrics.Sync.syncUuid.testGetValue("tabs-sync")!
-            XCTAssertEqual("abc123", GleanMetrics.TabsSync.uid.testGetValue())
+            globalSyncUuid = SyncMetrics.syncUuid.testGetValue("tabs-sync")!
+            XCTAssertEqual("abc123", TabsMetrics.uid.testGetValue())
 
-            XCTAssertNotNil(GleanMetrics.TabsSync.startedAt.testGetValue())
-            XCTAssertNotNil(GleanMetrics.TabsSync.finishedAt.testGetValue())
-            XCTAssertEqual(now + 10, Int64(GleanMetrics.TabsSync.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
-            XCTAssertEqual(now + 16, Int64(GleanMetrics.TabsSync.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertNotNil(TabsMetrics.startedAt.testGetValue())
+            XCTAssertNotNil(TabsMetrics.finishedAt.testGetValue())
+            XCTAssertEqual(now + 10, Int64(TabsMetrics.startedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
+            XCTAssertEqual(now + 16, Int64(TabsMetrics.finishedAt.testGetValue()!.timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC)
 
-            XCTAssertNil(GleanMetrics.TabsSync.incoming["applied"].testGetValue())
-            XCTAssertNil(GleanMetrics.TabsSync.incoming["failed_to_apply"].testGetValue())
-            XCTAssertNil(GleanMetrics.TabsSync.incoming["reconciled"].testGetValue())
-            XCTAssertEqual(8, GleanMetrics.TabsSync.outgoing["uploaded"].testGetValue())
-            XCTAssertEqual(2, GleanMetrics.TabsSync.outgoing["failed_to_upload"].testGetValue())
+            XCTAssertNil(TabsMetrics.incoming["applied"].testGetValue())
+            XCTAssertNil(TabsMetrics.incoming["failed_to_apply"].testGetValue())
+            XCTAssertNil(TabsMetrics.incoming["reconciled"].testGetValue())
+            XCTAssertEqual(8, TabsMetrics.outgoing["uploaded"].testGetValue())
+            XCTAssertEqual(2, TabsMetrics.outgoing["failed_to_upload"].testGetValue())
         }
 
         try! processSyncTelemetry(syncTelemetry: syncTelemetry,

--- a/taskcluster/android-components-projects.json
+++ b/taskcluster/android-components-projects.json
@@ -86,7 +86,6 @@
     "support-rusterrors",
     "support-test-appservices",
     "support-utils",
-    "support-sync-telemetry",
     "support-rustlog",
     "support-rusthttp",
     "support-locale",


### PR DESCRIPTION
To solve the issues detailed in: https://bugzilla.mozilla.org/show_bug.cgi?id=1827949

In short:
Glean will run into name collisions with moving the metrics to application-services. So we're renaming the metrics in`metrics.yaml`  to `*_v2` to prevent this. Since we now control the wrappers there is surprisingly-little churn for the API since most of the renaming affects under-the-hood` but the top-level APIs might be relatively unchanged.


Part 2 of: https://github.com/mozilla/application-services/pull/5588 but didn't want to update it since it was already approved (also might be easier to split the changes

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
