### PR TITLE
Adding a script to vendor in a new app-services version into moz-central

### DIFF
--- a/docs/howtos/vendoring-into-mozilla-central.md
+++ b/docs/howtos/vendoring-into-mozilla-central.md
@@ -7,6 +7,17 @@ The general process for [vendoring rust code into mozilla-central has its own
 documentation](https://firefox-source-docs.mozilla.org/build/buildsystem/rust.html) -
 please make sure you read that before continuing.
 
+### When to vendor
+
+We want to keep our versions in moz-central relatively up-to-date, but it takes some manual effort
+to do.  The main possibility of breakage is from a dependency mismatch, so our current vendoring
+policy is:
+
+  - Whenever a 3rd-party dependency is added or updated, the dev who made the change is responsible
+    for vendoring.
+  - At the start of the [release cycle](https://wiki.mozilla.org/Release_Management/Calendar) the
+    triage owner is response for vendoring.
+
 ### Updating existing components.
 
 To update components which are already in mozilla-central, follow these steps:
@@ -15,20 +26,15 @@ To update components which are already in mozilla-central, follow these steps:
    "non-artifact" builds - check you can get a full working build before
    starting this process.
 
-1. The exact version of each component is specified [in the top-level Cargo.toml
-  ](https://searchfox.org/mozilla-central/search?q=application-services+overrides&path=Cargo.toml) -
-  just edit these lines.
+1. Run `./tools/update-moz-central-vendoring.py [path-to-moz-central]` from the application-services
+   root directory.
 
-1. From the root of the mozilla-central tree, execute `./mach vendor rust`.
-   If this generates errors regarding duplicate crates, you will enter a world
+1. If this generates errors regarding duplicate crates, you will enter a world
    of pain, and probably need to ask for advice from the application-services
    team, and/or the [`#build` channel on matrix](https://matrix.to/#/#build:mozilla.org).
 
-1. Verify that `git status` shows the crates you are trying to update have
-   matching changes in the `third_party/rust` directory - that directory will
-   should exactly match the application-services changes you are making. If
-   that directory shows no changes, the `./mach vendor rust` command probably
-   failed, so check its output.
+1. Run `./mach cargo vet` to check if there any any new dependencies that need to be vetted.  If
+   there are ask for advice from the application-services team.
 
 1. Build and test your tree. Ideally make a try run.
 
@@ -39,22 +45,6 @@ To update components which are already in mozilla-central, follow these steps:
    most recent update and ask the same reviewer in that patch.
 
 1. Profit!
-
-Notes:
-
-* While not strictly required, it is best-practice to ensure all
-  application-services components are on the same revision. This makes it
-  easier to rationalize dependencies etc.
-
-* The specified revision you vendor generally doesn't correspond to a specific
-  release - we tend to not make releases just to update the vendored version.
-
-* If the current `main` branch of application-services can't be taken due to
-  breaking changes, but `mozilla-central` requires a new version for reasons
-  internal to that repo (eg, maybe a tweak to dependencies, or because of
-  the Rust version requirements etc), you will probably need to make a new
-  branch on application-services and vendor from that - but even in that
-  scenario, you specify the hash of the revision rather than the branch name.
 
 ### Adding a new component
 

--- a/tools/update-moz-central-vendoring.py
+++ b/tools/update-moz-central-vendoring.py
@@ -22,6 +22,8 @@ def main():
           "follow the listed steps to resolve that issue")
     print(" - Run `./mach cargo vet` to manually vet any new dependencies")
     print(" - Commit any changes and submit a phabricator patch")
+    print()
+    print("Details here: https://github.com/mozilla/application-services/blob/main/docs/howtos/vendoring-into-mozilla-central.md")
 
 def parse_args():
     parser = argparse.ArgumentParser()

--- a/tools/update-moz-central-vendoring.py
+++ b/tools/update-moz-central-vendoring.py
@@ -1,0 +1,53 @@
+#!/usr/bin/python
+
+import argparse
+import pathlib
+import re
+import subprocess
+
+APP_SERVICES_DEPENDENCY_RE = re.compile(
+    r'([\w-]+).*{\s*git\s*=\s*"https://github.com/mozilla/application-services"'
+)
+APP_SERVICES_ROOT = pathlib.Path(__file__).parent.parent
+
+def main():
+    args = parse_args()
+    moz_central_root = pathlib.Path(args.moz_central_dir)
+    app_services_rev = get_app_services_rev()
+    update_cargo_toml(moz_central_root / "Cargo.toml", app_services_rev)
+    subprocess.run(["./mach", "vendor", "rust"], cwd=moz_central_root)
+
+    print("The vendoring was successful")
+    print(" - If you saw a warning saying `There are 2 different versions of crate X`, then "
+          "follow the listed steps to resolve that issue")
+    print(" - Run `./mach cargo vet` to manually vet any new dependencies")
+    print(" - Commit any changes and submit a phabricator patch")
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("moz_central_dir")
+    return parser.parse_args()
+
+def get_app_services_rev():
+    return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            encoding="utf-8",
+            cwd=APP_SERVICES_ROOT,
+        ).strip()
+
+def update_cargo_toml(cargo_toml_path, app_services_rev):
+    print(f"Updating application-services revision to {app_services_rev}")
+    with open(cargo_toml_path, "r") as f:
+        lines = f.readlines()
+        for i in range(len(lines)):
+            line = lines[i]
+            m = APP_SERVICES_DEPENDENCY_RE.match(line)
+            if m:
+                crate = m.group(1)
+                lines[i] = f'{crate} = {{ git = "https://github.com/mozilla/application-services", rev = "{app_services_rev}" }}\n'
+
+    with open(cargo_toml_path, "w") as f:
+        f.write("".join(lines))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I wish this script could do more, but a couple steps can't really be automated:
  - Fixing duplicate crates
  - Running `cargo vet`

I tested this out with the current main branches from both repos and ran into some issues that would prevent vendoring a new version.  I'll make a separate issue to resolve those.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
