### PR TITLE
Don't write duplicate entries to dependency-licenses.xml

### DIFF
--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -97,10 +97,6 @@ the details of which are reproduced below.
     <url>https://github.com/marshallpierce/rust-base64/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
-    <name>Apache License 2.0: base64</name>
-    <url>https://github.com/marshallpierce/rust-base64/blob/master/LICENSE-APACHE</url>
-  </license>
-  <license>
     <name>Apache License 2.0: bitflags</name>
     <url>https://github.com/bitflags/bitflags/blob/main/LICENSE-APACHE</url>
   </license>
@@ -119,10 +115,6 @@ the details of which are reproduced below.
   <license>
     <name>Apache License 2.0: cc</name>
     <url>https://github.com/alexcrichton/cc-rs/blob/main/LICENSE-APACHE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: cfg-if</name>
-    <url>https://github.com/alexcrichton/cfg-if/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: cfg-if</name>
@@ -493,19 +485,7 @@ the details of which are reproduced below.
     <url>https://github.com/microsoft/windows-rs/blob/master/license-mit</url>
   </license>
   <license>
-    <name>Apache License 2.0: windows-sys</name>
-    <url>https://github.com/microsoft/windows-rs/blob/master/license-mit</url>
-  </license>
-  <license>
     <name>Apache License 2.0: windows_x86_64_gnu</name>
-    <url>https://github.com/microsoft/windows-rs/blob/master/license-mit</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: windows_x86_64_gnu</name>
-    <url>https://github.com/microsoft/windows-rs/blob/master/license-mit</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: windows_x86_64_msvc</name>
     <url>https://github.com/microsoft/windows-rs/blob/master/license-mit</url>
   </license>
   <license>

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -1402,8 +1402,12 @@ def print_dependency_summary_pom(deps, file=sys.stdout):
     sections = group_dependencies_for_printing(deps)
 
     for section in sections:
-        # For the .pom file we want to list each dependency separately.
-        for dep in section["dependencies"]:
+        # For the .pom file we want to list each dependency separately unless the name/license/url are identical.
+        # First collapse to a tuple as that's hashable, and put it in a set
+        deps = sorted(set(map(lambda d: (d["name"], d["license"], d["license_url"]), section["dependencies"])))
+
+        for (name, license, license_url) in deps:
+            dep = {"name": name, "license": license, "license_url": license_url}
             pf("  <license>")
             pf("    <name>{}</name>", saxutils.escape(make_license_title(dep["license"], [dep])))
             pf("    <url>{}</url>", saxutils.escape(dep["license_url"]))


### PR DESCRIPTION
This no longer tries to add the dupe `syn` but there are a few other dupes this removes