### PR TITLE
Add a debug-tools feature to sql-support.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
  "once_cell",
  "serde",
  "version_check",
@@ -365,17 +365,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,39 +648,16 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size",
- "termios",
- "unicode-width",
- "winapi",
- "winapi-util",
-]
-
-[[package]]
-name = "console"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
 dependencies = [
- "encode_unicode",
+ "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
  "unicode-width",
  "windows-sys 0.42.0",
 ]
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -916,13 +882,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.6.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aa86af7b19b40ef9cbef761ed411a49f0afa06b7b6dcd3dfe2f96a3c546138"
+checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
 dependencies = [
- "console 0.11.3",
- "lazy_static",
+ "console",
+ "shell-words",
  "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -957,17 +924,6 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
-dependencies = [
- "libc",
- "redox_users 0.3.5",
- "winapi",
-]
-
-[[package]]
-name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
@@ -977,13 +933,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users 0.4.3",
+ "redox_users",
  "winapi",
 ]
 
@@ -995,8 +961,19 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.4.3",
+ "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -1053,6 +1030,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1325,7 +1308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1594bf39a5c2a21fb4ea7fd6f6cfeeeba9ece09012d9c6081349c5de1c441076"
 dependencies = [
  "anyhow",
- "dirs 2.0.2",
+ "dirs",
  "log",
 ]
 
@@ -1533,17 +1516,6 @@ checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2357,7 +2329,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap 4.2.2",
- "console 0.15.5",
+ "console",
  "glob",
  "heck 0.4.1",
  "nimbus-fml",
@@ -2727,7 +2699,7 @@ checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.13",
+ "redox_syscall",
  "smallvec",
  "windows-sys 0.36.1",
 ]
@@ -2930,15 +2902,15 @@ dependencies = [
 
 [[package]]
 name = "prettytable-rs"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
+checksum = "eea25e07510aa6ab6547308ebe3c036016d162b8da920dbb079e3ba8acf3d95a"
 dependencies = [
- "atty",
  "csv",
- "encode_unicode",
+ "encode_unicode 1.0.0",
+ "is-terminal",
  "lazy_static",
- "term 0.5.2",
+ "term 0.7.0",
  "unicode-width",
 ]
 
@@ -3115,7 +3087,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
 ]
 
 [[package]]
@@ -3180,12 +3152,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
@@ -3199,18 +3165,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440d8acb4fd3d277125b4bd01a6f38aee8d814b3b5fc09b3f2b825d37d3fe8f"
 dependencies = [
- "redox_syscall 0.2.13",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3219,8 +3174,8 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.7",
- "redox_syscall 0.2.13",
+ "getrandom",
+ "redox_syscall",
  "thiserror",
 ]
 
@@ -3351,18 +3306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "rust-log-forwarder"
 version = "0.1.0"
 dependencies = [
@@ -3422,6 +3365,12 @@ dependencies = [
  "linux-raw-sys 0.3.2",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
@@ -3624,6 +3573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
 name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,6 +3634,7 @@ dependencies = [
  "lazy_static",
  "log",
  "nss_build_common",
+ "prettytable-rs",
  "rusqlite",
  "tempfile",
  "thiserror",
@@ -3854,20 +3810,9 @@ checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
- "redox_syscall 0.2.13",
+ "redox_syscall",
  "rustix 0.36.7",
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "term"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
-dependencies = [
- "byteorder",
- "dirs 1.0.5",
- "winapi",
 ]
 
 [[package]]
@@ -3876,7 +3821,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
- "dirs 2.0.2",
+ "dirs",
+ "winapi",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
  "winapi",
 ]
 
@@ -3890,16 +3846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termion"
 version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3907,17 +3853,8 @@ checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
 dependencies = [
  "libc",
  "numtoa",
- "redox_syscall 0.2.13",
+ "redox_syscall",
  "redox_termios",
-]
-
-[[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -4353,7 +4290,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom 0.2.7",
+ "getrandom",
  "serde",
 ]
 
@@ -4421,12 +4358,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -4541,7 +4472,6 @@ dependencies = [
  "log",
  "nss_build_common",
  "parking_lot",
- "prettytable-rs",
  "rusqlite",
  "serde",
  "serde_derive",
@@ -4851,3 +4781,9 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -7,6 +7,8 @@ license = "MPL-2.0"
 
 [features]
 default = []
+### The debug-tools feature brings in utilities to help with debugging.
+debug-tools = ["dep:prettytable-rs", "rusqlite/column_decltype"]
 
 [dependencies]
 log = "0.4"
@@ -15,6 +17,7 @@ interrupt-support = { path = "../interrupt" }
 ffi-support = "0.4"
 thiserror = "1.0"
 tempfile = "3.1.0"
+prettytable-rs = { version = "0.10", optional = true }
 
 [dependencies.rusqlite]
 version = "0.28.0"

--- a/components/support/sql/src/conn_ext.rs
+++ b/components/support/sql/src/conn_ext.rs
@@ -126,7 +126,7 @@ pub trait ConnExt {
             .ok_or(rusqlite::Error::QueryReturnedNoRows)?)
     }
 
-    /// Helper for when you'd like to get a Vec<T> of all the rows returned by a
+    /// Helper for when you'd like to get a `Vec<T>` of all the rows returned by a
     /// query that takes named arguments. See also
     /// `query_rows_and_then_cached`.
     fn query_rows_and_then<T, E, P, F>(&self, sql: &str, params: P, mapper: F) -> Result<Vec<T>, E>
@@ -139,7 +139,7 @@ pub trait ConnExt {
         query_rows_and_then_cachable(self.conn(), sql, params, mapper, false)
     }
 
-    /// Helper for when you'd like to get a Vec<T> of all the rows returned by a
+    /// Helper for when you'd like to get a `Vec<T>` of all the rows returned by a
     /// query that takes named arguments.
     fn query_rows_and_then_cached<T, E, P, F>(
         &self,

--- a/components/support/sql/src/debug_tools.rs
+++ b/components/support/sql/src/debug_tools.rs
@@ -1,0 +1,123 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/// This module supplies utilities to help with debugging SQL in these components.
+///
+/// To take advantage of this module, you must enable the `debug-tools` feature for
+/// this crate.
+use rusqlite::{functions::Context, types::Value, Connection};
+
+/// Print the entire contents of an arbitrary query. A common usage would be to pass
+/// `SELECT * FROM table`
+#[cfg(feature = "debug-tools")]
+pub fn print_query(conn: &Connection, query: &str) -> rusqlite::Result<()> {
+    use prettytable::{Cell, Row};
+
+    let mut stmt = conn.prepare(query)?;
+    let mut rows = stmt.query([])?;
+    let mut table = prettytable::Table::new();
+    let mut titles = Row::empty();
+    for col in rows.as_ref().expect("must have statement").columns() {
+        titles.add_cell(Cell::new(col.name()));
+    }
+    table.set_titles(titles);
+    while let Some(sql_row) = rows.next()? {
+        let mut table_row = Row::empty();
+        for i in 0..sql_row.as_ref().column_count() {
+            let val = match sql_row.get::<_, Value>(i)? {
+                Value::Null => "null".to_string(),
+                Value::Integer(i) => i.to_string(),
+                Value::Real(f) => f.to_string(),
+                Value::Text(s) => s,
+                Value::Blob(b) => format!("<blob with {} bytes>", b.len()),
+            };
+            table_row.add_cell(Cell::new(&val));
+        }
+        table.add_row(table_row);
+    }
+    // printstd ends up on stdout - if we just println!() extra buffering seems to happen?
+    use std::io::Write;
+    std::io::stdout()
+        .write_all(format!("query: {query}\n").as_bytes())
+        .unwrap();
+    table.printstd();
+    Ok(())
+}
+
+#[cfg(feature = "debug-tools")]
+#[inline(never)]
+fn dbg(ctx: &Context<'_>) -> rusqlite::Result<Value> {
+    let mut s = Value::Null;
+    for i in 0..ctx.len() {
+        let raw = ctx.get_raw(i);
+        let str_repr = match raw {
+            rusqlite::types::ValueRef::Text(_) => raw.as_str().unwrap().to_owned(),
+            _ => format!("{:?}", raw),
+        };
+        eprint!("{} ", str_repr);
+        s = raw.into();
+    }
+    eprintln!();
+    Ok(s)
+}
+
+#[cfg(not(feature = "debug-tools"))]
+// It would be very bad if the `dbg()` function only existed when the `debug-tools` feature was
+// enabled - you could imagine some crate defining it as a `dev-dependency`, but then shipping
+// sql with an embedded `dbg()` call - tests and CI would pass, but it would fail in the real lib.
+fn dbg(ctx: &Context<'_>) -> rusqlite::Result<Value> {
+    Ok(if ctx.is_empty() {
+        Value::Null
+    } else {
+        ctx.get_raw(ctx.len() - 1).into()
+    })
+}
+
+/// You can call this function to add all sql functions provided by this module
+/// to your connection. The list of supported functions is described below.
+///
+/// *Note:* you must enable the `debug-tools` feature for these functions to perform
+/// as described. If this feature is not enabled, functions of the same name will still
+/// exist, but will be no-ops.
+///
+/// # dbg
+/// `dbg()` is a simple sql function that prints all args to stderr and returns the last argument.
+/// It's useful for instrumenting existing WHERE statements - eg, changing a statement
+/// ```sql
+/// WHERE a.bar = foo
+/// ```
+/// to
+/// ```sql
+/// WHERE dbg("a bar", a.bar) = foo
+/// ```
+/// will print the *literal* `a bar` followed by the *value* of `a.bar`, then return `a.bar`,
+/// so the semantics of the `WHERE` statement do not change.
+/// If you have a series of statements being executed (ie, statements separated by a `;`),
+/// adding a new statement like `SELECT dbg("hello");` is also possible.
+pub fn define_debug_functions(c: &Connection) -> rusqlite::Result<()> {
+    use rusqlite::functions::FunctionFlags;
+    c.create_scalar_function("dbg", -1, FunctionFlags::SQLITE_UTF8, dbg)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::conn_ext::ConnExt;
+
+    #[test]
+    fn test_dbg() {
+        let conn = Connection::open_with_flags(":memory:", rusqlite::OpenFlags::default()).unwrap();
+        define_debug_functions(&conn).unwrap();
+        assert_eq!(conn.query_one::<i64>("SELECT dbg('foo', 0);").unwrap(), 0);
+        assert_eq!(
+            conn.query_one::<String>("SELECT dbg('foo');").unwrap(),
+            "foo"
+        );
+        assert_eq!(
+            conn.query_one::<Option<String>>("SELECT dbg();").unwrap(),
+            None
+        );
+    }
+}

--- a/components/support/sql/src/lib.rs
+++ b/components/support/sql/src/lib.rs
@@ -5,7 +5,10 @@
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
+//! A crate with various sql/sqlcipher helpers.
+
 mod conn_ext;
+pub mod debug_tools;
 mod each_chunk;
 mod maybe_cached;
 pub mod open_database;
@@ -18,7 +21,7 @@ pub use crate::repeat::*;
 
 /// In PRAGMA foo='bar', `'bar'` must be a constant string (it cannot be a
 /// bound parameter), so we need to escape manually. According to
-/// https://www.sqlite.org/faq.html, the only character that must be escaped is
+/// <https://www.sqlite.org/faq.html>, the only character that must be escaped is
 /// the single quote, which is escaped by placing two single quotes in a row.
 pub fn escape_string_for_pragma(s: &str) -> String {
     s.replace('\'', "''")

--- a/components/support/sql/src/repeat.rs
+++ b/components/support/sql/src/repeat.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 
 /// Helper type for printing repeated strings more efficiently. You should use
-/// [`repeat_display`](sql_support::repeat_display), or one of the `repeat_sql_*` helpers to
+/// [`repeat_display`] or one of the `repeat_sql_*` helpers to
 /// construct it.
 #[derive(Debug, Clone)]
 pub struct RepeatDisplay<'a, F> {

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -27,16 +27,16 @@ url = { version = "2.1", features = ["serde"] }
 
 [dependencies.rusqlite]
 version = "0.28.0"
-features = ["functions", "bundled", "serde_json", "unlock_notify", "column_decltype"]
+features = ["functions", "bundled", "serde_json", "unlock_notify"]
 
 [dev-dependencies]
 env_logger = { version = "0.7", default-features = false }
-prettytable-rs = "0.8"
 tempfile = "3"
 # A *direct* dep on the -sys crate is required for our build.rs
 # to see the DEP_SQLITE3_LINK_TARGET env var that cargo sets
 # on its behalf.
 libsqlite3-sys = "0.25.2"
+sql-support = { path = "../support/sql" }
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }

--- a/components/webext-storage/src/schema.rs
+++ b/components/webext-storage/src/schema.rs
@@ -82,42 +82,6 @@ pub fn create_empty_sync_temp_tables(db: &Connection) -> Result<()> {
 }
 
 #[cfg(test)]
-pub mod test {
-    use prettytable::{Cell, Row};
-    use rusqlite::Result as RusqliteResult;
-    use rusqlite::{types::Value, Connection};
-
-    // To help debugging tests etc.
-    #[allow(unused)]
-    pub fn print_table(conn: &Connection, table_name: &str) -> RusqliteResult<()> {
-        let mut stmt = conn.prepare(&format!("SELECT * FROM {}", table_name))?;
-        let mut rows = stmt.query([])?;
-        let mut table = prettytable::Table::new();
-        let mut titles = Row::empty();
-        for col in rows.as_ref().expect("must have statement").columns() {
-            titles.add_cell(Cell::new(col.name()));
-        }
-        table.set_titles(titles);
-        while let Some(sql_row) = rows.next()? {
-            let mut table_row = Row::empty();
-            for i in 0..sql_row.as_ref().column_count() {
-                let val = match sql_row.get::<_, Value>(i)? {
-                    Value::Null => "null".to_string(),
-                    Value::Integer(i) => i.to_string(),
-                    Value::Real(f) => f.to_string(),
-                    Value::Text(s) => s,
-                    Value::Blob(b) => format!("<blob with {} bytes>", b.len()),
-                };
-                table_row.add_cell(Cell::new(&val));
-            }
-            table.add_row(table_row);
-        }
-        table.printstd();
-        Ok(())
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::db::test::new_mem_db;

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,6 +9,7 @@
   - [How to test Rust Components](howtos/testing-a-rust-component.md)
     - [How to integration (smoke) test application-services](howtos/smoke-testing-app-services.md)
     - [Writing efficient tests](design/test-faster.md)
+    - [How to debug SQL/sqlite](howtos/debug-sql.md)
   - [Dependency management](dependency-management.md)
   - [How to add a new component](howtos/adding-a-new-component.md)
     - [How to build a new syncable component](howtos/building-a-rust-component.md)

--- a/docs/howtos/debug-sql.md
+++ b/docs/howtos/debug-sql.md
@@ -1,0 +1,98 @@
+# Debugging Sql
+
+It can be quite tricky to debug what is going on with sql statement, especially
+once the sql gets complicated or many triggers are involved.
+
+The `sql_support` create provides some utilities to help. Note that
+these utilities are gated behind a `debug-tools` feature. [The module
+provides docstrings, so you should read them before you start](
+https://mozilla.github.io/application-services/book/rust-docs/sql_support/debug_tools/index.html).
+
+
+This document describes how to use these capabilities and we'll use `places`
+as an example.
+
+First, we must enable the feature:
+
+```diff
+--- a/components/places/Cargo.toml
++++ b/components/places/Cargo.toml
+@@ -22,7 +22,7 @@ lazy_static = "1.4"
+ url = { version = "2.1", features = ["serde"] }
+ percent-encoding = "2.1"
+ caseless = "0.2"
+-sql-support = { path = "../support/sql" }
++sql-support = { path = "../support/sql", features=["debug-tools"] }
+```
+
+and we probably need to make the debug functions available:
+```diff
+--- a/components/places/src/db/db.rs
++++ b/components/places/src/db/db.rs
+@@ -108,6 +108,7 @@ impl ConnectionInitializer for PlacesInitializer {
+         ";
+         conn.execute_batch(initial_pragmas)?;
+         define_functions(conn, self.api_id)?;
++        sql_support::debug_tools::define_debug_functions(conn)?;
+```
+
+We now have a Rust function `print_query()` and a SQL function `dbg()` available.
+
+Let's say we were trying to debug a test such as `test_bookmark_tombstone_auto_created`.
+We might want to print the entire contents of a table, then instrument a query to check
+what the value of a query is. We might end up with a patch something like:
+```diff
+index 28f19307..225dccbb 100644
+--- a/components/places/src/db/schema.rs
++++ b/components/places/src/db/schema.rs
+@@ -666,7 +666,8 @@ mod tests {
+             [],
+         )
+         .expect("should insert regular bookmark folder");
+-        conn.execute("DELETE FROM moz_bookmarks WHERE guid = 'bookmarkguid'", [])
++        sql_support::debug_tools::print_query(&conn, "select * from moz_bookmarks").unwrap();
++        conn.execute("DELETE FROM moz_bookmarks WHERE dbg('CHECKING GUID', guid) = 'bookmarkguid'", [])
+             .expect("should delete");
+         // should have a tombstone.
+         assert_eq!(
+```
+
+There are 2 things of note:
+* We used the `print_query` function to dump the entire `moz_bookmarks` table before executing the query.
+* We instrumented the query to print the `guid` every time sqlite reads a row and compares it against
+  a literal.
+
+The output of this test now looks something like:
+```
+running 1 test
+query: select * from moz_bookmarks
++----+------+------+--------+----------+---------+---------------+---------------+--------------+------------+-------------------+
+| id | fk   | type | parent | position | title   | dateAdded     | lastModified  | guid         | syncStatus | syncChangeCounter |
++====+======+======+========+==========+=========+===============+===============+==============+============+===================+
+| 1  | null | 2    | null   | 0        | root    | 1686248350470 | 1686248350470 | root________ | 1          | 1                 |
++----+------+------+--------+----------+---------+---------------+---------------+--------------+------------+-------------------+
+| 2  | null | 2    | 1      | 0        | menu    | 1686248350470 | 1686248350470 | menu________ | 1          | 1                 |
++----+------+------+--------+----------+---------+---------------+---------------+--------------+------------+-------------------+
+| 3  | null | 2    | 1      | 1        | toolbar | 1686248350470 | 1686248350470 | toolbar_____ | 1          | 1                 |
++----+------+------+--------+----------+---------+---------------+---------------+--------------+------------+-------------------+
+| 4  | null | 2    | 1      | 2        | unfiled | 1686248350470 | 1686248350470 | unfiled_____ | 1          | 1                 |
++----+------+------+--------+----------+---------+---------------+---------------+--------------+------------+-------------------+
+| 5  | null | 2    | 1      | 3        | mobile  | 1686248350470 | 1686248350470 | mobile______ | 1          | 1                 |
++----+------+------+--------+----------+---------+---------------+---------------+--------------+------------+-------------------+
+| 6  | null | 3    | 1      | 0        | null    | 1             | 1             | bookmarkguid | 2          | 1                 |
++----+------+------+--------+----------+---------+---------------+---------------+--------------+------------+-------------------+
+test db::schema::tests::test_bookmark_tombstone_auto_created ... FAILED
+
+failures:
+
+---- db::schema::tests::test_bookmark_tombstone_auto_created stdout ----
+CHECKING GUID root________
+CHECKING GUID menu________
+CHECKING GUID toolbar_____
+CHECKING GUID unfiled_____
+CHECKING GUID mobile______
+CHECKING GUID bookmarkguid
+```
+
+It's unfortunate that the output of `print_table()` goes to the tty while the output of `dbg` goes to `stderr`, so
+you might find the output isn't quite intermingled as you would expect, but it's better than nothing!

--- a/examples/fxa-client/Cargo.toml
+++ b/examples/fxa-client/Cargo.toml
@@ -24,7 +24,7 @@ viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
 cli-support = { path = "../cli-support" }
 fxa-client = { path = "../../components/fxa-client" }
 anyhow = "1.0"
-dialoguer = "0.6"
+dialoguer = "0.10"
 webbrowser = "0.5"
 url = "2.2"
 sync15 = { path = "../../components/sync15" }

--- a/examples/sync-pass/Cargo.toml
+++ b/examples/sync-pass/Cargo.toml
@@ -18,7 +18,7 @@ sync-guid = { path = "../../components/support/guid" }
 log = "0.4"
 sql-support = { path = "../../components/support/sql" }
 anyhow = "1.0"
-prettytable-rs = "0.8"
+prettytable-rs = "0.10"
 fxa-client = { path = "../../components/fxa-client" }
 chrono = "0.4"
 clap = "2.33"

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -13,7 +13,7 @@ use logins::{
     EncryptedLogin, LoginEntry, LoginFields, LoginStore, LoginsSyncEngine, SecureLoginFields,
     ValidateAndFixup,
 };
-use prettytable::{cell, row, Cell, Row, Table};
+use prettytable::{row, Cell, Row, Table};
 use rusqlite::OptionalExtension;
 use std::sync::Arc;
 use sync15::engine::{EngineSyncAssociation, SyncEngine};

--- a/tools/build-book.sh
+++ b/tools/build-book.sh
@@ -9,9 +9,10 @@
 
 set -xe
 
-# Genarate the Rust docs and
-# move them over to the book
-cargo doc --no-deps
+# Genarate the Rust docs and move them over to the book.
+# We document all features. Ideally we'd leverage https://docs.rs/document-features/latest/document_features/
+# so the features themselves are documented, but that's another dependency or another yak, so for another day.
+cargo doc --all-features --no-deps
 echo '<meta http-equiv=refresh content=0;url=fxa_client>' > target/doc/index.html
 mkdir -p docs/rust-docs
 cp -rf target/doc/* docs/rust-docs


### PR DESCRIPTION
It steals a cute function from webext-storage which can dump any arbitrary query.

It also allows for the use of a `dbg()` sql function which can be helpful trying to debug SQL as it is executing. The function is also available as a no-op when the feature is not available to prevent us accidently using it in released code.

Sadly this required updating the use of prettytable-rs as the old version crashed on Apple silicon, which had a bit of a blow-on effect on other dependencies.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
