### PR TITLE
Make all tasks run for `github-release` events

### DIFF
--- a/taskcluster/app_services_taskgraph/__init__.py
+++ b/taskcluster/app_services_taskgraph/__init__.py
@@ -57,6 +57,7 @@ def get_decision_parameters(graph_config, parameters):
                 "Cannot run github-release if tag {} is different than in-tree "
                 "{version} from buildconfig.yml".format(head_tag[1:], version)
             )
+        parameters["target_tasks_method"] = "full"
     elif parameters["tasks_for"] == "github-pull-request":
         pr_title = os.environ.get("APPSERVICES_PULL_REQUEST_TITLE", "")
         preview_match = PREVIEW_RE.search(pr_title)


### PR DESCRIPTION
Somewhere along the line, we changed it so the module-build, beetmover, and other tasks don't run unless `target_tasks=full`.  This fixes things so we set that value on github releases.

(This one was already merged on the release-v115 branch, cherry-picking it back to main).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
