### PR TITLE
Updating buildconfig for release cycle 116

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -1,4 +1,4 @@
-libraryVersion: 115.0a1
+libraryVersion: 116.0a1
 groupId: org.mozilla.appservices
 projects:
   autofill:

--- a/automation/prepare-release.py
+++ b/automation/prepare-release.py
@@ -25,6 +25,7 @@ with open(BUILDCONFIG_FILE, "r") as stream:
 
 cur_version = build_config[BUILDCONFIG_VERSION_FIELD]
 major_version_number = int(cur_version.split('.')[0])
+next_version_number = major_version_number + 1
 release_version = f"{major_version_number}.0"
 refs = RefNames(major_version_number, 0)
 
@@ -86,14 +87,14 @@ run_cmd_checked(["git", "checkout", refs.main])
 run_cmd_checked(["git", "checkout", "-b", refs.start_release_pr])
 
 step_msg(f"Bumping version in {BUILDCONFIG_FILE}")
-build_config[BUILDCONFIG_VERSION_FIELD] = f"{major_version_number}.0a1"
+build_config[BUILDCONFIG_VERSION_FIELD] = f"{next_version_number}.0a1"
 
 with open(BUILDCONFIG_FILE, "w") as stream:
     yaml.dump(build_config, stream, sort_keys=False)
 
 step_msg(f"UPDATING {CHANGELOG_FILE}")
 changelog[0:0] = [
-    f"# v{major_version_number+1}.0 (In progress)",
+    f"# v{next_version_number}.0 (In progress)",
     "",
     "[Full Changelog](In progress)",
     ""
@@ -104,7 +105,7 @@ with open(CHANGELOG_FILE, "w") as stream:
 
 step_msg(f"Creating a commit with the changes")
 run_cmd_checked(["git", "add", CHANGELOG_FILE])
-run_cmd_checked(["git", "commit", "-m", f"Start release v{major_version_number+1}"])
+run_cmd_checked(["git", "commit", "-m", f"Start release v{next_version_number}"])
 
 print()
 response = input("Great! Would you like to push and open the two pull-requests? ([Y]/N)").lower()


### PR DESCRIPTION
Bumped the version in `.buildconfig-android.yml` and also fixed the `prepare-release.py` script to properly bump the version next time.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
