### PR TITLE
Fixes intermittent test by reseting glean stores

### DIFF
--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -1094,7 +1094,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 52.4.1;
+				minimumVersion = 52.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "428f832d35e573e173087308c70274eed3a45db3",
-        "version" : "52.4.1"
+        "revision" : "dd626f0fb051ffc70179846a0b75a04f997b63b7",
+        "version" : "52.7.0"
       }
     }
   ],

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
@@ -10,28 +10,8 @@ import XCTest
 
 class NimbusTests: XCTestCase {
     override func setUp() {
-        // TODO(jan-erik): Figure out what is the right clearStores here.
-        Glean.shared.resetGlean(clearStores: false)
+        Glean.shared.resetGlean(clearStores: true)
         Glean.shared.enableTestingMode()
-        let buildDate = DateComponents(
-            calendar: Calendar.current,
-            timeZone: TimeZone(abbreviation: "UTC"),
-            year: 2019,
-            month: 10,
-            day: 23,
-            hour: 12,
-            minute: 52,
-            second: 8
-        )
-        let buildInfo = BuildInfo(buildDate: buildDate)
-        Glean.shared.initialize(
-            uploadEnabled: true,
-            configuration: Configuration(
-                channel: "test",
-                serverEndpoint: "https://example.com"
-            ),
-            buildInfo: buildInfo
-        )
     }
 
     func emptyExperimentJSON() -> String {


### PR DESCRIPTION
This should fix #5520 

The Glean stores weren't being reset in-between tests because of bug in Glean 52.2.0, but the bug was resolved since then so we can bring back the reset. The Android part of AS is already on glean `52.7.0` so this PR updates the iOS and submodule dependencies to match and fixes the test.

Depending on the order the tests run it was possible for the `testRecordDisqualificationOnGlobalOptOut` to error

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: ~~This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one~~ Changes to internal tests don't need a changelog
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
