### PR TITLE
Fixes broken doc builds

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -36,7 +36,7 @@
   - [Metrics - (Glean Telemetry)](design/metrics.md)
   - [Rust Version Policy](design/rust-versions.md)
   - [Sqlite Database Pragma Usage](design/db-pragmas.md)
-- [How to cut a new release](howtos/cut-a-new-release.md)
+- [Releases](howtos/releases.md)
   - [CI Publishing tools and flow](build-and-publish-pipeline.md)
   - [How to upgrade NSS](howtos/upgrading-nss-guide.md)
 - [Rustdocs for components](rust-docs/fxa_client/index.html)

--- a/docs/build-and-publish-pipeline.md
+++ b/docs/build-and-publish-pipeline.md
@@ -21,14 +21,7 @@ The key points:
   tests via gradle.
 * [CircleCI](../.circleci/config.yml) runs on every branch, pull-request (including forks), and release,
   to execute lint checks and automated tests at the Rust and Swift level.
-* Releases are made by [manually creating a new release](./howtos/cut-a-new-release.md) via github,
-  which triggers various CI jobs:
-    * [CircleCI](../.circleci/config.yml) is used to build an iOS binary release on every release,
-      and publish it as GitHub release artifacts.
-    * [TaskCluster](../automation/taskcluster/README.md) is used to:
-        * Build an Android binary release.
-        * Upload Android library symbols to [Socorro](https://wiki.mozilla.org/Socorro).
-        * Publish it to the [maven.mozilla.org](https://maven.mozilla.org).
+* Releases align with the Firefox Releases schedules, and nightly releases are automated to run daily see the [releases](./howtos/releases.md) for more information
 * Notifications about build failures are sent to a mailing list at
   [a-s-ci-failures@mozilla.com](https://groups.google.com/a/mozilla.com/forum/#!forum/a-s-ci-failures)
 * Our Taskcluster implementation is almost entirely maintained by the Release Engineering team.


### PR DESCRIPTION
Noticed that our docs haven't built in a month or so, looks like an orphan link to a doc we killed


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
