### PR TITLE
ci: use level appropriate worker for b-osx [full]

### DIFF
--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -23,7 +23,7 @@ workers:
       provisioner: releng-hardware
       implementation: generic-worker
       os: macosx
-      worker-type: applicationservices-b-1-osx1015
+      worker-type: applicationservices-b-{level}-osx1015
     images:
       provisioner: 'app-services-{level}'
       implementation: docker-worker


### PR DESCRIPTION
Hardcoding this to level 1 was a security issue as tasks from PRs were running on the same worker as tasks used in releases.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
