### PR TITLE
Ensure places/origins are removed when a bookmark with no visits etc is removed.

### DIFF
--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -43,6 +43,7 @@ features = ["functions", "window", "bundled", "unlock_notify"]
 pretty_assertions = "0.6"
 tempfile = "3.1"
 env_logger = {version = "0.7", default-features = false}
+sql-support = { path = "../support/sql" }
 
 [build-dependencies]
 uniffi = { version = "0.23", features = ["build"] }

--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -268,6 +268,20 @@ BEGIN
     WHERE id = OLD.placeId;
 END;
 
+-- Similar to cleanup_pages, if the origin/place remains with no foreign references
+-- and no visits it should be deleted.
+-- This approach may not be suitable for desktop but seems to be for us - see
+-- https://bugzilla.mozilla.org/show_bug.cgi?id=1650511#c41 for more discussion.
+CREATE TEMP TRIGGER moz_cleanup_origin_bookmark_deleted_trigger
+AFTER DELETE ON moz_bookmarks
+BEGIN
+    DELETE FROM moz_places
+        WHERE id = OLD.fk
+        AND foreign_count = 0
+        AND last_visit_date_local = 0
+        AND last_visit_date_remote = 0;
+END;
+
 -- These triggers adjust the foreign count for tagged URLs, and bump the
 -- tag's last modified time when a URL is tagged or untagged. These are
 -- split out from the main connection's tag triggers because we also want

--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -4,13 +4,20 @@
 
 -- This file defines triggers shared between the main and Sync connections.
 
+-- markh doesn't understand why this trigger is needed. It seems to be doing roughly
+-- the same work as moz_updateoriginsinsert_afterdelete_trigger and so we have 2 very
+-- similar triggers for the same insert. A difference between them though is some
+-- frecency stuff - and if you remove this filter, all tests pass except one obscure
+-- one in matcher.rs, where a test site ends up with a frecency of zero rather than the
+-- expected 1999. Both triggers exist in desktop too.
+-- So if anyone can explain this, please update this comment :)
 CREATE TEMP TRIGGER moz_places_afterinsert_trigger
 AFTER INSERT ON moz_places FOR EACH ROW
 BEGIN
     INSERT OR IGNORE INTO moz_origins(prefix, host, rev_host, frecency)
     VALUES(get_prefix(NEW.url), get_host_and_port(NEW.url), reverse_host(get_host_and_port(NEW.url)), NEW.frecency);
 
-    -- This is temporary.
+    -- This is temporary (well, given that was written in 2018, as of 2023 I think we can declate it's not :)
     UPDATE moz_places SET
       origin_id = (SELECT id FROM moz_origins
                    WHERE prefix = get_prefix(NEW.url) AND

--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -4,28 +4,6 @@
 
 -- This file defines triggers shared between the main and Sync connections.
 
--- markh doesn't understand why this trigger is needed. It seems to be doing roughly
--- the same work as moz_updateoriginsinsert_afterdelete_trigger and so we have 2 very
--- similar triggers for the same insert. A difference between them though is some
--- frecency stuff - and if you remove this filter, all tests pass except one obscure
--- one in matcher.rs, where a test site ends up with a frecency of zero rather than the
--- expected 1999. Both triggers exist in desktop too.
--- So if anyone can explain this, please update this comment :)
-CREATE TEMP TRIGGER moz_places_afterinsert_trigger
-AFTER INSERT ON moz_places FOR EACH ROW
-BEGIN
-    INSERT OR IGNORE INTO moz_origins(prefix, host, rev_host, frecency)
-    VALUES(get_prefix(NEW.url), get_host_and_port(NEW.url), reverse_host(get_host_and_port(NEW.url)), NEW.frecency);
-
-    -- This is temporary (well, given that was written in 2018, as of 2023 I think we can declate it's not :)
-    UPDATE moz_places SET
-      origin_id = (SELECT id FROM moz_origins
-                   WHERE prefix = get_prefix(NEW.url) AND
-                         host = get_host_and_port(NEW.url) AND
-                         rev_host = reverse_host(get_host_and_port(NEW.url)))
-    WHERE id = NEW.id;
-END;
-
 -- Note that while we create tombstones manually, we rely on this trigger to
 -- delete any which might exist when a new record is written to moz_places.
 CREATE TEMP TRIGGER moz_places_afterinsert_trigger_tombstone

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -745,7 +745,7 @@ mod tests {
                 url: Url::parse("http://example.com/").unwrap(),
                 title: "example.com/".into(),
                 icon_url: None,
-                frecency: 1999,
+                frecency: 2000,
                 reasons: vec![MatchReason::Origin],
             }]
         );

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -827,6 +827,7 @@ mod tests {
             [],
         )
         .expect("should insert");
+        crate::storage::delete_pending_temp_tables(&conn).expect("should work");
 
         let _ = search_frecent(
             &conn,

--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -108,6 +108,7 @@ impl ConnectionInitializer for PlacesInitializer {
         ";
         conn.execute_batch(initial_pragmas)?;
         define_functions(conn, self.api_id)?;
+        sql_support::debug_tools::define_debug_functions(conn)?;
         conn.set_prepared_statement_cache_capacity(128);
         Ok(())
     }

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -1235,6 +1235,16 @@ mod tests {
         assert_eq!(get_pos(&conn, &guid3), 1);
         assert!(global_change_tracker.changed());
 
+        // Should be no moz_origin entries left for the deleted bookmarks.
+        // For better or worse, origins are only cleaned up after history is cleared.
+        crate::storage::history::delete_everything(&conn)?;
+        assert_eq!(
+            conn.query_one::<i64>(
+                "SELECT COUNT(*) FROM moz_origins WHERE host='www.example2.com';"
+            )?,
+            0
+        );
+
         Ok(())
     }
 

--- a/components/places/src/storage/bookmarks.rs
+++ b/components/places/src/storage/bookmarks.rs
@@ -1235,9 +1235,6 @@ mod tests {
         assert_eq!(get_pos(&conn, &guid3), 1);
         assert!(global_change_tracker.changed());
 
-        // Should be no moz_origin entries left for the deleted bookmarks.
-        // For better or worse, origins are only cleaned up after history is cleared.
-        crate::storage::history::delete_everything(&conn)?;
         assert_eq!(
             conn.query_one::<i64>(
                 "SELECT COUNT(*) FROM moz_origins WHERE host='www.example2.com';"

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -382,9 +382,9 @@ pub(crate) fn delete_meta(db: &PlacesDb, key: &str) -> Result<()> {
 /// Delete all items in the temp tables we use for staging changes.
 pub fn delete_pending_temp_tables(conn: &PlacesDb) -> Result<()> {
     conn.execute_batch(
-        "DELETE FROM moz_updateoriginsupdate_temp;
-         DELETE FROM moz_updateoriginsdelete_temp;
-         DELETE FROM moz_updateoriginsinsert_temp;",
+        "DELETE FROM moz_updateoriginsinsert_temp;
+         DELETE FROM moz_updateoriginsupdate_temp;
+         DELETE FROM moz_updateoriginsdelete_temp;",
     )?;
     Ok(())
 }

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -434,25 +434,21 @@ mod tests {
     #[test]
     fn test_removal_delete_visits_between() {
         do_test_removal_places_and_origins(|conn: &PlacesDb, _guid: &SyncGuid| {
-            Ok(history::delete_visits_between(
-                conn,
-                Timestamp::EARLIEST,
-                Timestamp::now(),
-            )?)
+            history::delete_visits_between(conn, Timestamp::EARLIEST, Timestamp::now())
         })
     }
 
     #[test]
     fn test_removal_delete_visits_for() {
         do_test_removal_places_and_origins(|conn: &PlacesDb, guid: &SyncGuid| {
-            Ok(history::delete_visits_for(conn, guid)?)
+            history::delete_visits_for(conn, guid)
         })
     }
 
     #[test]
     fn test_removal_prune() {
         do_test_removal_places_and_origins(|conn: &PlacesDb, _guid: &SyncGuid| {
-            Ok(history::prune_older_visits(conn)?)
+            history::prune_older_visits(conn)
         })
     }
 
@@ -461,14 +457,14 @@ mod tests {
         do_test_removal_places_and_origins(|conn: &PlacesDb, _guid: &SyncGuid| {
             let url = Url::parse("http://example.com/foo").unwrap();
             let visit = Timestamp::from(727_747_200_001);
-            Ok(history::delete_place_visit_at_time(conn, &url, visit)?)
+            history::delete_place_visit_at_time(conn, &url, visit)
         })
     }
 
     #[test]
     fn test_removal_everything() {
         do_test_removal_places_and_origins(|conn: &PlacesDb, _guid: &SyncGuid| {
-            Ok(history::delete_everything(conn)?)
+            history::delete_everything(conn)
         })
     }
 
@@ -564,7 +560,7 @@ mod tests {
                 date_added: None,
                 last_modified: None,
                 guid: None,
-                url: url.clone(),
+                url,
                 title: Some("the title".into()),
             },
         };
@@ -594,7 +590,7 @@ mod tests {
                 .unwrap(),
             5
         ); // our 5 roots
-        // should be gone from places and origins.
+           // should be gone from places and origins.
         assert_eq!(
             conn.query_one::<i64>("SELECT COUNT(*) FROM moz_places;")
                 .unwrap(),


### PR DESCRIPTION
Fixes a few reports we have on Fenix for this, such as [this one](https://bugzilla.mozilla.org/show_bug.cgi?id=1813898) and I'm sure other dupes exist.

Lina, sorry to do this to you, but you are probably the best reviewer for this :( I'll also ask Ben to help grow more knowledge about places. This is by no means urgent.