### PR TITLE
Move sync-test to the fxa cli helper.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "fxa-client",
  "log",
  "sync15",
+ "sync_manager",
  "url",
  "webbrowser",
 ]

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -116,6 +116,13 @@ impl FirefoxAccount {
             )),
         }
     }
+
+    /// A temporary helper while we convert some of our test utilities from using the internal account.
+    pub fn with_internal(internal: internal::FirefoxAccount) -> FirefoxAccount {
+        FirefoxAccount {
+            internal: Mutex::new(internal),
+        }
+    }
 }
 
 uniffi::include_scaffolding!("fxa_client");

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -396,7 +396,7 @@ fn run_sync(
             &mut global_state,
             &mut mem_cached_state,
             &cli_fxa.client_init.clone(),
-            &cli_fxa.root_sync_key,
+            &cli_fxa.as_key_bundle()?,
             &NeverInterrupts,
             None,
         );

--- a/examples/cli-support/Cargo.toml
+++ b/examples/cli-support/Cargo.toml
@@ -8,12 +8,14 @@ license = "MPL-2.0"
 [dependencies]
 anyhow = "1.0"
 fxa-client = { path = "../../components/fxa-client" }
+sync_manager = { path = "../../components/sync_manager" }
 log = "0.4"
 sync15 = { path = "../../components/sync15", features=["sync-client"] }
 url = "2.2"
 webbrowser = "0.5"
 # disable regex feature, as it's very costly for compile time and very rarely
 # used.
+
 [dependencies.env_logger]
 version = "0.7"
 default-features = false

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -233,7 +233,7 @@ fn sync(
             &mut global_state,
             &mut mem_cached_state,
             &cli_fxa.client_init.clone(),
-            &cli_fxa.root_sync_key,
+            &cli_fxa.as_key_bundle()?,
             &interrupt_support::ShutdownInterruptee,
             None,
         );

--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
         base64::URL_SAFE_NO_PAD,
     );
 
-    let mut cli_fxa = get_cli_fxa(get_default_fxa_config(), &opts.creds_file)?;
+    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &opts.creds_file)?;
     let device_id = cli_fxa.account.get_current_device_id()?;
 
     let store = Arc::new(TabsStore::new(Path::new(&opts.db_path)));

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -28,3 +28,4 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 base64 = "0.13"
+cli-support = { path = "../../examples/cli-support" }

--- a/testing/sync-test/src/auth.rs
+++ b/testing/sync-test/src/auth.rs
@@ -1,233 +1,30 @@
 /* Any copyright is dedicated to the Public Domain.
 http://creativecommons.org/publicdomain/zero/1.0/ */
 
-use crate::Opts;
 use anyhow::Result;
 use autofill::db::store::Store as AutofillStore;
-use fxa_client::internal::{auth, config::Config as FxaConfig, FirefoxAccount};
+use cli_support::fxa_creds::CliFxa;
+use fxa_client::internal::{config::Config as FxaConfig};
+use fxa_client::Device;
 use logins::LoginStore;
-use serde_json::json;
 use std::collections::HashMap;
 use std::sync::Arc;
-use sync15::DeviceType;
+use sync15::{client::{SetupStorageClient, Sync15StorageClient}, DeviceType};
 use sync_manager::{
-    manager::SyncManager, DeviceSettings, SyncAuthInfo, SyncEngineSelection, SyncParams, SyncReason,
+    manager::SyncManager, SyncEngineSelection, SyncParams, SyncReason, DeviceSettings
 };
 use tabs::TabsStore;
-use url::Url;
-use viaduct::Request;
 
-pub const CLIENT_ID: &str = "3c49430b43dfba77"; // Hrm...
-pub const SYNC_SCOPE: &str = "https://identity.mozilla.com/apps/oldsync";
+// Note that in revision ba9cc53710243c357e5bf125636bb94a7c6a4a48 or so, this had support for
+// username/password authentication and for "temporary" accounts using restmail etc.
+// It has since been refactored to use only oauth and to use the "cli-support" crate to help
+// manage the account, but you can use that revision if you ever want to revive username/password
+// support.
 
-// TODO: This is wrong for dev?
-pub const REDIRECT_URI: &str = "https://stable.dev.lcip.org/oauth/success/3c49430b43dfba77";
-
-// It's important that this doesn't implement Clone! (It destroys it's temporary fxaccount on drop)
-#[derive(Debug)]
-pub struct TestAccount {
-    pub email: String,
-    pub pass: String,
-    pub cfg: FxaConfig,
-    pub no_delete: bool,
-    pub session_token: String,
-    pub k_sync: Vec<u8>,
-    pub xcs: Vec<u8>,
-}
-
-impl TestAccount {
-    fn new(
-        email: String,
-        pass: String,
-        cfg: FxaConfig,
-        no_delete: bool,
-    ) -> Result<Arc<TestAccount>> {
-        log::info!("Creating temporary fx account");
-
-        restmail_client::clear_mailbox(&email).unwrap();
-
-        let create_endpoint = cfg.auth_url_path("v1/account/create?keys=true").unwrap();
-        let body = json!({
-            "email": &email,
-            "authPW": auth::auth_pwd(&email, &pass)?,
-            "service": &cfg.client_id,
-        });
-        let req = Request::post(create_endpoint).json(&body).send()?;
-        let resp: serde_json::Value = req.json()?;
-        let uid = resp["uid"]
-            .as_str()
-            .ok_or_else(|| anyhow::Error::msg("No Uid"))?;
-        let session_token = resp["sessionToken"]
-            .as_str()
-            .ok_or_else(|| anyhow::Error::msg("No session Token"))?;
-        let key_fetch_token = resp["keyFetchToken"]
-            .as_str()
-            .ok_or_else(|| anyhow::Error::msg("No Key fetch token"))?;
-        log::info!("POST /v1/account/create succeeded");
-
-        log::info!("Autoverifying account on restmail... uid = {}", uid);
-        Self::verify_account(&email, &cfg, uid)?;
-        let (sync_key, xcs_key) = auth::get_sync_keys(&cfg, key_fetch_token, &email, &pass)?;
-        log::info!("Account created and verified!");
-
-        Ok(Arc::new(TestAccount {
-            email,
-            pass,
-            cfg,
-            no_delete,
-            session_token: session_token.to_string(),
-            k_sync: sync_key,
-            xcs: xcs_key,
-        }))
-    }
-
-    pub fn new_random(opts: &Opts) -> Result<Arc<TestAccount>> {
-        use rand::prelude::*;
-        let rng = thread_rng();
-        let name = opts.force_username.clone().unwrap_or_else(|| {
-            format!(
-                "rust-login-sql-test--{}",
-                std::str::from_utf8(
-                    &rng.sample_iter(&rand::distributions::Alphanumeric)
-                        .take(5)
-                        .collect::<Vec<u8>>()
-                )
-                .unwrap()
-            )
-        });
-        // We should probably check this some other time, but whatever.
-        assert!(
-            !name.contains('@'),
-            "--force-username passed an illegal username"
-        );
-        // Just use the username for the password in case we need to clean these
-        // up easily later because of some issue.
-        let password = name.clone();
-        let email = format!("{}@restmail.net", name);
-        Self::new(
-            email,
-            password,
-            opts.fxa_stack.to_config(CLIENT_ID, REDIRECT_URI),
-            opts.no_delete_account,
-        )
-    }
-
-    fn verify_account(email_in: &str, config: &FxaConfig, uid: &str) -> Result<()> {
-        let verification_email = restmail_client::find_email(
-            email_in,
-            |email| {
-                email["headers"]["x-uid"] == uid && email["headers"]["x-template-name"] == "verify"
-            },
-            10,
-        )
-        .unwrap();
-        let code = verification_email["headers"]["x-verify-code"]
-            .as_str()
-            .unwrap();
-        log::info!("Code is: {}", code);
-        let body = json!({
-            "uid": uid,
-            "code": verification_email["headers"]["x-verify-code"].as_str().unwrap(),
-        });
-        let resp = auth::send_verification(config, body).unwrap();
-        if !resp.is_success() {
-            log::warn!(
-                "Error verifying account: {}",
-                resp.json::<serde_json::Value>().unwrap()
-            );
-            anyhow::bail!("Unable to verify account!");
-        }
-        Ok(())
-    }
-
-    pub fn execute_oauth_flow(&self, oauth_url: &str) -> Result<String> {
-        let url = Url::parse(oauth_url)?;
-        let auth_key = auth::derive_auth_key_from_session_token(&self.session_token)?;
-        let query_map: HashMap<String, String> = url.query_pairs().into_owned().collect();
-        let jwk_base_64 = query_map.get("keys_jwk").unwrap();
-        let decoded = base64::decode(jwk_base_64).unwrap();
-        let jwk = std::str::from_utf8(&decoded)?;
-        let scope = query_map.get("scope").unwrap();
-        let client_id = query_map.get("client_id").unwrap();
-        let state = query_map.get("state").unwrap();
-        let code_challenge = query_map.get("code_challenge").unwrap();
-        let code_challenge_method = query_map.get("code_challenge_method").unwrap();
-        let keys_jwe = auth::create_keys_jwe(
-            client_id,
-            scope,
-            jwk,
-            &auth_key,
-            &self.cfg,
-            (&self.k_sync, &self.xcs),
-        )?;
-        let auth_params = auth::AuthorizationRequestParameters {
-            client_id: client_id.clone(),
-            code_challenge: Some(code_challenge.clone()),
-            code_challenge_method: Some(code_challenge_method.clone()),
-            scope: scope.clone(),
-            keys_jwe: Some(keys_jwe),
-            state: state.clone(),
-            access_type: "offline".to_string(),
-        };
-        auth::send_authorization_request(&self.cfg, auth_params, &auth_key)
-    }
-
-    fn execute_oauth_pair_flow(&self, oauth_uri: &str) -> Result<(String, String)> {
-        let url = Url::parse(oauth_uri)?;
-        let auth_params = auth::AuthorizationParameters::try_from(url)?;
-        let scoped_keys = auth::get_scoped_keys(
-            &auth_params.scope.join(" "),
-            &auth_params.client_id,
-            &auth::derive_auth_key_from_session_token(&self.session_token)?,
-            &self.cfg,
-            (&self.k_sync, &self.xcs),
-        )?;
-        // Setup authority account that is logged in and has the appropriate scoped keys
-        let fxa = FirefoxAccount::new_logged_in(self.cfg.clone(), &self.session_token, scoped_keys);
-
-        let state = auth_params.state.clone();
-        // Use the logged in client to generate the oauth code for
-        // a different client
-        let code = fxa.authorize_code_using_session_token(auth_params)?;
-        Ok((code, state))
-    }
-}
-
-impl Drop for TestAccount {
-    fn drop(&mut self) {
-        if self.no_delete {
-            log::info!("Cleanup was explicitly disabled, not deleting account");
-            return;
-        }
-        log::info!("Cleaning up temporary firefox account");
-        let destroy_endpoint = self.cfg.auth_url_path("v1/account/destroy").unwrap();
-        let body = json!({
-            "email": self.email,
-            "authPW": auth::auth_pwd(&self.email, &self.pass).unwrap()
-        });
-        let req = Request::post(destroy_endpoint).json(&body).send();
-        match req {
-            Ok(resp) => {
-                if resp.is_success() {
-                    log::info!("Account destroyed successfully!");
-                    return;
-                } else {
-                    log::warn!("   Error: {}", resp.text());
-                }
-            }
-            Err(e) => log::warn!("   Error: {}", e),
-        }
-        log::warn!(
-            "Failed to destroy fxacct {} with pass {}!",
-            self.email,
-            self.pass
-        );
-    }
-}
-
+// Many of these tests simulate multiple devices (aka clients).
 pub struct TestClient {
-    pub fxa: fxa_client::internal::FirefoxAccount,
-    pub test_acct: Arc<TestAccount>,
+    pub cli: Arc<CliFxa>,
+    pub device: Device,
     // XXX do this more generically...
     pub autofill_store: Arc<AutofillStore>,
     pub logins_store: Arc<LoginStore>,
@@ -237,76 +34,26 @@ pub struct TestClient {
 }
 
 impl TestClient {
-    pub fn new(acct: Arc<TestAccount>) -> Result<Self> {
-        log::info!("Doing oauth flow!");
-        let mut fxa = FirefoxAccount::with_config(acct.cfg.clone());
-        // We either authenticate using the normal oauth_flow
-        // Or we use a pairing flow with a logged in account
-        // Both should work fine in executing the oauth flow
-        let (code, state) = if rand::random() {
-            let pairing_url = acct.cfg.authorization_endpoint().unwrap();
-            let pairing_url = fxa.begin_pairing_flow(
-                pairing_url.as_str(),
-                &[SYNC_SCOPE],
-                "integration_test",
-                None,
-            )?;
-            acct.execute_oauth_pair_flow(&pairing_url)?
-        } else {
-            let oauth_uri = fxa.begin_oauth_flow(&[SYNC_SCOPE], "integration_test", None)?;
-            let redirect_uri = acct.execute_oauth_flow(&oauth_uri)?;
-            let redirect_uri = Url::parse(&redirect_uri)?;
-            let query_params = redirect_uri
-                .query_pairs()
-                .into_owned()
-                .collect::<HashMap<String, String>>();
-            (query_params["code"].clone(), query_params["state"].clone())
+    pub fn new(cli: Arc<CliFxa>, device_name: &str) -> Result<Self> {
+        // XXX - not clear if/how this device gets cleaned up - we never disconnect from the account!
+        // And this is messy - I think it reflects that the public device api should be improved?
+        let device = match cli.account.get_devices(false)?.into_iter().find(|d| d.is_current_device) {
+            Some(d) => d,
+            None => {
+                cli.account.initialize_device(device_name, DeviceType::Desktop, vec![])?;
+                cli.account.get_devices(true)?.into_iter().find(|d| d.is_current_device).ok_or_else(|| anyhow::Error::msg("can't find new device"))?
+            }
         };
-        // should we be using the OAuthInfo this returns?
-        fxa.complete_oauth_flow(&code, &state)?;
-        log::info!("OAuth flow finished");
-
-        fxa.initialize_device("Testing Device", DeviceType::Desktop, &[])?;
 
         Ok(Self {
-            fxa,
-            test_acct: acct,
+            cli,
+            device,
             autofill_store: Arc::new(AutofillStore::new_shared_memory("sync-test")?),
             logins_store: Arc::new(LoginStore::new_in_memory()?),
             tabs_store: Arc::new(TabsStore::new_with_mem_path("sync-test-tabs")),
             sync_manager: SyncManager::new(),
             persisted_state: None,
         })
-    }
-
-    pub fn get_sync_data(&mut self) -> Result<(SyncAuthInfo, DeviceSettings)> {
-        // Allow overriding it via environment
-        let tokenserver_url = option_env!("TOKENSERVER_URL")
-            .map(|env_var| {
-                // We hard error here even though we want to return a Result to provide a clearer
-                // error for misconfiguration
-                Ok(Url::parse(env_var)
-                    .expect("Failed to parse TOKENSERVER_URL environment variable!"))
-            })
-            .unwrap_or_else(|| self.test_acct.cfg.token_server_endpoint_url())?;
-        let token = self.fxa.get_access_token(SYNC_SCOPE, None)?;
-
-        let key = token.key.as_ref().unwrap();
-
-        let auth_info = SyncAuthInfo {
-            kid: key.kid.clone(),
-            fxa_access_token: token.token,
-            sync_key: key.k.clone(),
-            tokenserver_url: tokenserver_url.to_string(),
-        };
-
-        let device_settings = DeviceSettings {
-            fxa_device_id: self.fxa.get_current_device_id()?,
-            name: "sync-test".to_string(),
-            kind: DeviceType::Desktop,
-        };
-
-        Ok((auth_info, device_settings))
     }
 
     pub fn sync(
@@ -318,7 +65,6 @@ impl TestClient {
         self.autofill_store.clone().register_with_sync_manager();
         self.tabs_store.clone().register_with_sync_manager();
         self.logins_store.clone().register_with_sync_manager();
-        let (auth_info, device_settings) = self.get_sync_data()?;
         let params = SyncParams {
             reason: SyncReason::User,
             engines: SyncEngineSelection::Some {
@@ -326,9 +72,13 @@ impl TestClient {
             },
             enabled_changes: HashMap::new(),
             local_encryption_keys,
-            auth_info,
+            auth_info: self.cli.as_auth_info(),
             persisted_state: self.persisted_state.take(),
-            device_settings,
+            device_settings: DeviceSettings {
+                fxa_device_id: self.device.id.clone(),
+                name: self.device.display_name.clone(),
+                kind: self.device.device_type,
+            },
         };
         let result = self.sync_manager.sync(params)?;
         // We expect all syncs in these tests to pass, so let's catch that here
@@ -348,18 +98,7 @@ impl TestClient {
     }
 
     pub fn fully_wipe_server(&mut self) -> Result<()> {
-        let (auth_info, _device_settings) = self
-            .get_sync_data()
-            .expect("Should have data for syncing first client");
-
-        use sync15::client::{SetupStorageClient, Sync15StorageClient, Sync15StorageClientInit};
-        let storage_init = Sync15StorageClientInit {
-            key_id: auth_info.kid,
-            access_token: auth_info.fxa_access_token,
-            tokenserver_url: url::Url::parse(auth_info.tokenserver_url.as_str()).unwrap(),
-        };
-
-        Sync15StorageClient::new(storage_init)?.wipe_all_remote()?;
+        Sync15StorageClient::new(self.cli.client_init.clone())?.wipe_all_remote()?;
         Ok(())
     }
 
@@ -392,66 +131,20 @@ pub fn cleanup_server(clients: Vec<&mut TestClient>) -> Result<()> {
 }
 
 pub struct TestUser {
-    pub account: Arc<TestAccount>,
     pub clients: Vec<TestClient>,
 }
 
 impl TestUser {
-    fn new_random(opts: &Opts, client_count: usize) -> Result<Self> {
-        log::info!("Creating test account with {} clients", client_count);
-
-        let account = TestAccount::new_random(opts)?;
-        let mut clients = Vec::with_capacity(client_count);
-
-        for c in 0..client_count {
-            log::info!("Creating test client {}", c);
-            clients.push(TestClient::new(account.clone())?);
-        }
-        Ok(Self { account, clients })
-    }
-
-    pub fn new(opts: &Opts, client_count: usize) -> Result<TestUser> {
-        if opts.oauth_retries > 0 && opts.no_delete_account {
-            anyhow::bail!(
-                "Illegal option combination: oauth-retries is nonzero \
-                 and no-delete-account is specified."
-            );
-        }
-        if opts.helper_debug {
-            std::env::set_var("DEBUG", "nightmare");
-            std::env::set_var("HELPER_SHOW_BROWSER", "1");
-        }
-        for attempt in 0..=opts.oauth_retries {
-            log::info!("Creating test user (attempt {})", attempt);
-            match TestUser::new_random(opts, client_count) {
-                Ok(user) => {
-                    log::info!("Created test user (attempt {})", attempt);
-                    return Ok(user);
-                }
-                Err(e) => {
-                    if attempt == opts.oauth_retries {
-                        log::error!("Failed to create test user (attempt {}): {:?}", attempt, e);
-                        return Err(e);
-                    }
-                    log::warn!("Failed to create test user (attempt {}): {}", attempt, e);
-                    if opts.oauth_delay_time > 0 {
-                        let delay = opts.oauth_delay_time + attempt * opts.oauth_retry_backoff;
-                        log::info!(
-                            "Retrying after {} ms (attempt {} => {})",
-                            delay,
-                            attempt,
-                            attempt + 1
-                        );
-                        std::thread::sleep(std::time::Duration::from_millis(delay));
-                    }
-                }
-            }
-        }
-        // Above loop always either hits the `return Err(e)` or `return Ok(user);` cases
-        unreachable!();
+    pub fn new(cli: Arc<CliFxa>, client_count: usize) -> Result<Self> {
+        let clients = (0..client_count).map(|client_num| {
+            let name = format!("Testing Device {client_num}");
+            TestClient::new(cli.clone(), &name)
+        }).collect::<Result<_>>()?;
+        Ok(Self { clients })
     }
 }
 
+// Should move this into the cli helper?
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum FxaConfigUrl {
     StableDev,
@@ -466,7 +159,8 @@ impl FxaConfigUrl {
             FxaConfigUrl::StableDev => FxaConfig::stable_dev(client_id, redirect),
             FxaConfigUrl::Stage => FxaConfig::stage_dev(client_id, redirect),
             FxaConfigUrl::Release => FxaConfig::release(client_id, redirect),
-            FxaConfigUrl::Custom(url) => FxaConfig::new(url.as_str(), client_id, redirect),
+            //FxaConfigUrl::Custom(url) => FxaConfig::new(url.as_str(), client_id, redirect),
+            _ => todo!(),
         }
     }
 }

--- a/testing/sync-test/src/sync15.rs
+++ b/testing/sync-test/src/sync15.rs
@@ -15,7 +15,7 @@ use serde_derive::*;
 use std::cell::{Cell, RefCell};
 use std::mem;
 use sync15::bso::{IncomingBso, OutgoingBso};
-use sync15::client::{sync_multiple, MemoryCachedState, Sync15StorageClientInit};
+use sync15::client::{sync_multiple, MemoryCachedState};
 use sync15::engine::{
     CollectionRequest, EngineSyncAssociation, SyncEngine,
 };
@@ -144,17 +144,6 @@ impl SyncEngine for TestEngine {
 }
 
 fn sync_client(c: &mut TestClient, desc: &str, engine: &dyn SyncEngine) {
-    let (auth_info, _device_settings) = c
-        .get_sync_data()
-        .expect("Should have data for syncing first client");
-
-    let storage_init = &Sync15StorageClientInit {
-        key_id: auth_info.kid,
-        access_token: auth_info.fxa_access_token,
-        tokenserver_url: url::Url::parse(auth_info.tokenserver_url.as_str()).unwrap(),
-    };
-    let root_sync_key = &sync15::KeyBundle::from_ksync_base64(auth_info.sync_key.as_str()).unwrap();
-
     let mut persisted_global_state = None;
     let mut mem_cached_state = MemoryCachedState::default();
 
@@ -162,8 +151,8 @@ fn sync_client(c: &mut TestClient, desc: &str, engine: &dyn SyncEngine) {
         &[engine],
         &mut persisted_global_state,
         &mut mem_cached_state,
-        storage_init,
-        root_sync_key,
+        &c.cli.client_init,
+        &c.cli.as_key_bundle().unwrap(),
         &NeverInterrupts,
         None,
     );

--- a/testing/sync-test/src/tabs.rs
+++ b/testing/sync-test/src/tabs.rs
@@ -5,7 +5,6 @@ use crate::auth::TestClient;
 use crate::testing::TestGroup;
 use anyhow::Result;
 use std::collections::HashMap;
-use sync15::DeviceType;
 use tabs::{ClientRemoteTabs, RemoteTabRecord, TabsStore};
 // helpers...
 
@@ -61,9 +60,9 @@ fn test_tabs(c0: &mut TestClient, c1: &mut TestClient) {
     verify_tabs(
         &c1.tabs_store,
         &ClientRemoteTabs {
-            client_id: c0.fxa.get_current_device_id().unwrap(),
-            client_name: String::new(),
-            device_type: DeviceType::Mobile,
+            client_id: c0.device.id.clone(),
+            client_name: c0.device.display_name.clone(),
+            device_type: c0.device.device_type,
             remote_tabs: vec![t0],
             last_modified: 0,
         },
@@ -90,9 +89,9 @@ fn test_tabs(c0: &mut TestClient, c1: &mut TestClient) {
     verify_tabs(
         &c0.tabs_store,
         &ClientRemoteTabs {
-            client_id: c1.fxa.get_current_device_id().unwrap(),
-            client_name: String::new(),
-            device_type: DeviceType::Mobile,
+            client_id: c1.device.id.clone(),
+            client_name: c1.device.display_name.clone(),
+            device_type: c1.device.device_type,
             remote_tabs: vec![t1, t2],
             last_modified: 0,
         },


### PR DESCRIPTION
I initially did this on @bendk's FxA branch, but given it's so large I thought I'd put it in main first, then @bendk can rebase and make alot of this go away (although I do still have a version for that branch)

Not that happy with the new `with_internal` for FxA, but that's obviously not needed on Ben's branch, but am I missing something?