### PR TITLE
Add info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@
 
 ### 🦊 What's Changed 🦊
 
+- Added isRollout and bucketing info to the `list` command ([#5672](https://github.com/mozilla/application-services/pull/5672)).
 - Fixed several paper cut usability issues ([#5654](https://github.com/mozilla/application-services/pull/5654)):
   - Experiments by default are fetched from the API v6, eliminating latency between making changes on experimenter and syncing with remote settings.
   - Separated `fetch` and `fetch-list`: experiment lists, by default still come from Remote Settings, but the slower API v6 `/api/v6/experiments` can be queried.
 
 ### ✨ What's New ✨
 
+- Added an `info` command ([#5672](https://github.com/mozilla/application-services/pull/5672)).
 - Fixed several paper cut usability issues ([#5654](https://github.com/mozilla/application-services/pull/5654)):
   - Added a `defaults` command to output the feature configuration from the manifest.
   - Added a `features` command to output the experiment branch features and optionally merged with the manifest defaults.

--- a/components/support/nimbus-cli/src/cli.rs
+++ b/components/support/nimbus-cli/src/cli.rs
@@ -172,6 +172,16 @@ pub(crate) enum CliCommand {
         list: ExperimentListArgs,
     },
 
+    /// Displays information about an experiment
+    Info {
+        #[command(flatten)]
+        experiment: ExperimentArgs,
+
+        /// An optional file to print the output.
+        #[arg(short, long, value_name = "OUTPUT_FILE")]
+        output: Option<PathBuf>,
+    },
+
     /// List the experiments from a server
     List {
         #[command(flatten)]

--- a/components/support/nimbus-cli/src/cli.rs
+++ b/components/support/nimbus-cli/src/cli.rs
@@ -147,7 +147,7 @@ pub(crate) enum CliCommand {
     Fetch {
         /// The file to download the recipes to.
         #[arg(short, long, value_name = "OUTPUT_FILE")]
-        output: PathBuf,
+        output: Option<PathBuf>,
 
         #[command(flatten)]
         experiment: ExperimentArgs,
@@ -166,7 +166,7 @@ pub(crate) enum CliCommand {
     FetchList {
         /// The file to download the recipes to.
         #[arg(short, long, value_name = "OUTPUT_FILE")]
-        output: PathBuf,
+        output: Option<PathBuf>,
 
         #[command(flatten)]
         list: ExperimentListArgs,

--- a/components/support/nimbus-cli/src/cmd.rs
+++ b/components/support/nimbus-cli/src/cmd.rs
@@ -28,11 +28,10 @@ pub(crate) fn process_cmd(cmd: &AppCommand) -> Result<bool> {
         } => app.apply_list(list, preserve_nimbus_db)?,
         AppCommand::CaptureLogs { app, file } => app.capture_logs(file)?,
         AppCommand::Defaults {
-            params,
             manifest,
             feature_id,
             output,
-        } => params.print_defaults(manifest, feature_id.as_ref(), output.as_ref())?,
+        } => manifest.print_defaults(feature_id.as_ref(), output.as_ref())?,
         AppCommand::Enroll {
             app,
             params,
@@ -55,7 +54,6 @@ pub(crate) fn process_cmd(cmd: &AppCommand) -> Result<bool> {
             open,
         )?,
         AppCommand::ExtractFeatures {
-            params,
             experiment,
             branch,
             manifest,
@@ -63,8 +61,7 @@ pub(crate) fn process_cmd(cmd: &AppCommand) -> Result<bool> {
             validate,
             multi,
             output,
-        } => params.print_experiment_features(
-            experiment,
+        } => experiment.print_features(
             branch,
             manifest,
             feature_id.as_ref(),
@@ -653,130 +650,5 @@ impl NimbusApp {
             bail!("At least one error detected");
         }
         Ok(true)
-    }
-
-    fn print_defaults(
-        &self,
-        manifest_source: &ManifestSource,
-        feature_id: Option<&String>,
-        output: Option<&PathBuf>,
-    ) -> Result<bool> {
-        let manifest: FeatureManifest = manifest_source.try_into()?;
-        let json = self.get_defaults_json(&manifest, feature_id)?;
-        value_utils::write_to_file_or_print(output.map(|f| f.as_path()), &json)?;
-        Ok(true)
-    }
-
-    fn get_defaults_json(
-        &self,
-        fm: &FeatureManifest,
-        feature_id: Option<&String>,
-    ) -> Result<Value> {
-        Ok(match feature_id {
-            Some(id) => {
-                let (_, feature) = fm.find_feature(id).ok_or_else(|| {
-                    anyhow::Error::msg(format!("Feature '{id}' does not exist in this manifest"))
-                })?;
-                feature.default_json()
-            }
-            _ => fm.default_json(),
-        })
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn print_experiment_features(
-        &self,
-        experiment: &ExperimentSource,
-        branch: &String,
-        manifest_source: &ManifestSource,
-        feature_id: Option<&String>,
-        validate: bool,
-        multi: bool,
-        output: Option<&PathBuf>,
-    ) -> Result<bool> {
-        let json = self.get_experimental_json(
-            manifest_source,
-            feature_id,
-            experiment,
-            branch,
-            validate,
-            multi,
-        )?;
-        value_utils::write_to_file_or_print(output.map(|f| f.as_path()), &json)?;
-        Ok(true)
-    }
-
-    fn get_experimental_json(
-        &self,
-        manifest_source: &ManifestSource,
-        feature_id: Option<&String>,
-        experiment: &ExperimentSource,
-        branch: &String,
-        validate: bool,
-        multi: bool,
-    ) -> Result<Value> {
-        let value = experiment.try_into()?;
-
-        // Find the named branch.
-        let branches = try_find_branches(&value)?;
-        let b = branches
-            .iter()
-            .find(|b| b.get_str("slug").unwrap() == branch)
-            .ok_or_else(|| anyhow::format_err!("Branch '{branch}' does not exist"))?;
-
-        // Find the features for this branch: there may be more than one.
-        let feature_values = try_find_features(b)?;
-
-        // Now extract the relevant features out of the branches.
-        let mut result = serde_json::value::Map::new();
-        for f in feature_values {
-            let id = f.get_str("featureId")?;
-            let value = f
-                .get("value")
-                .ok_or_else(|| anyhow::format_err!("Branch {branch} feature {id} has no value"))?;
-            match feature_id {
-                None => {
-                    // If the user hasn't specified a feature, then just add it.
-                    result.insert(id.to_string(), value.clone());
-                }
-                Some(feature_id) if feature_id == id => {
-                    // If the user has specified a feature, and this is it, then also add it.
-                    result.insert(id.to_string(), value.clone());
-                }
-                // Otherwise, the user has specified a feature, and this wasn't it.
-                _ => continue,
-            }
-        }
-
-        // By now: we have all the features that we need, and no more.
-
-        // If validating, then we should merge with the defaults from the manifest.
-        // If not, then nothing more is needed to be done: we're delivering the partial feature configuration.
-        if validate {
-            let fm: FeatureManifest = manifest_source.try_into()?;
-            let mut new = serde_json::value::Map::new();
-            for (id, value) in result {
-                let def = fm.validate_feature_config(&id, value)?;
-                new.insert(id.to_owned(), def.default_json());
-            }
-            result = new;
-        }
-
-        Ok(if !multi && result.len() == 1 {
-            // By default, if only a single feature is being displayed,
-            // we can output just the feature config.
-            match (result.values().find(|_| true), feature_id) {
-                (Some(v), _) => v.to_owned(),
-                (_, Some(id)) => anyhow::bail!(
-                    "The '{id}' feature is not involved in '{branch}' branch of '{experiment}'"
-                ),
-                (_, _) => {
-                    anyhow::bail!("No features available in '{branch}' branch of '{experiment}'")
-                }
-            }
-        } else {
-            // Otherwise, we can output the `{ featureId: featureValue }` in its entirety.
-            Value::Object(result)
-        })
     }
 }

--- a/components/support/nimbus-cli/src/main.rs
+++ b/components/support/nimbus-cli/src/main.rs
@@ -6,6 +6,7 @@ mod cli;
 mod cmd;
 mod config;
 mod feature_utils;
+mod output;
 mod sources;
 mod updater;
 mod value_utils;
@@ -139,6 +140,11 @@ enum AppCommand {
         params: NimbusApp,
         recipes: Vec<ExperimentSource>,
         file: PathBuf,
+    },
+
+    Info {
+        experiment: ExperimentSource,
+        output: Option<PathBuf>,
     },
 
     Kill {
@@ -334,6 +340,10 @@ impl TryFrom<&Cli> for AppCommand {
                     params,
                 }
             }
+            CliCommand::Info { experiment, output } => AppCommand::Info {
+                experiment: ExperimentSource::try_from(&experiment)?,
+                output,
+            },
             CliCommand::List { .. } => {
                 let list = ExperimentListSource::try_from(cli)?;
                 AppCommand::List { params, list }

--- a/components/support/nimbus-cli/src/main.rs
+++ b/components/support/nimbus-cli/src/main.rs
@@ -99,7 +99,6 @@ enum AppCommand {
     },
 
     Defaults {
-        params: NimbusApp,
         manifest: ManifestSource,
         feature_id: Option<String>,
         output: Option<PathBuf>,
@@ -118,7 +117,6 @@ enum AppCommand {
     },
 
     ExtractFeatures {
-        params: NimbusApp,
         experiment: ExperimentSource,
         branch: String,
         manifest: ManifestSource,
@@ -249,7 +247,6 @@ impl TryFrom<&Cli> for AppCommand {
             } => {
                 let manifest = ManifestSource::try_from(&params, &manifest)?;
                 AppCommand::Defaults {
-                    params,
                     manifest,
                     feature_id,
                     output,
@@ -301,7 +298,6 @@ impl TryFrom<&Cli> for AppCommand {
                 let manifest = ManifestSource::try_from(&params, &manifest)?;
                 let experiment = ExperimentSource::try_from(cli)?;
                 AppCommand::ExtractFeatures {
-                    params,
                     experiment,
                     branch,
                     manifest,

--- a/components/support/nimbus-cli/src/main.rs
+++ b/components/support/nimbus-cli/src/main.rs
@@ -131,13 +131,13 @@ enum AppCommand {
     FetchList {
         params: NimbusApp,
         list: ExperimentListSource,
-        file: PathBuf,
+        file: Option<PathBuf>,
     },
 
     FetchRecipes {
         params: NimbusApp,
         recipes: Vec<ExperimentSource>,
-        file: PathBuf,
+        file: Option<PathBuf>,
     },
 
     Info {
@@ -1244,7 +1244,7 @@ mod unit_tests {
 
     #[test]
     fn test_fetch() -> Result<()> {
-        let file = PathBuf::from("./archived.json");
+        let file = Some(PathBuf::from("./archived.json"));
         let observed = get_commands_from_cli([
             "nimbus-cli",
             "--app",
@@ -1294,7 +1294,7 @@ mod unit_tests {
 
     #[test]
     fn test_fetch_list() -> Result<()> {
-        let file = PathBuf::from("./archived.json");
+        let file = Some(PathBuf::from("./archived.json"));
         let observed = get_commands_from_cli([
             "nimbus-cli",
             "--app",

--- a/components/support/nimbus-cli/src/output/features.rs
+++ b/components/support/nimbus-cli/src/output/features.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::path::PathBuf;
+use std::path::Path;
 
 use anyhow::Result;
 use nimbus_fml::intermediate_representation::FeatureManifest;
@@ -14,14 +14,17 @@ use crate::{
 };
 
 impl ManifestSource {
-    pub(crate) fn print_defaults(
+    pub(crate) fn print_defaults<P>(
         &self,
         feature_id: Option<&String>,
-        output: Option<&PathBuf>,
-    ) -> Result<bool> {
+        output: Option<P>,
+    ) -> Result<bool>
+    where
+        P: AsRef<Path>,
+    {
         let manifest: FeatureManifest = self.try_into()?;
         let json = self.get_defaults_json(&manifest, feature_id)?;
-        value_utils::write_to_file_or_print(output.map(|f| f.as_path()), &json)?;
+        value_utils::write_to_file_or_print(output, &json)?;
         Ok(true)
     }
 
@@ -44,17 +47,20 @@ impl ManifestSource {
 
 impl ExperimentSource {
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn print_features(
+    pub(crate) fn print_features<P>(
         &self,
         branch: &String,
         manifest_source: &ManifestSource,
         feature_id: Option<&String>,
         validate: bool,
         multi: bool,
-        output: Option<&PathBuf>,
-    ) -> Result<bool> {
+        output: Option<P>,
+    ) -> Result<bool>
+    where
+        P: AsRef<Path>,
+    {
         let json = self.get_features_json(manifest_source, feature_id, branch, validate, multi)?;
-        value_utils::write_to_file_or_print(output.map(|f| f.as_path()), &json)?;
+        value_utils::write_to_file_or_print(output, &json)?;
         Ok(true)
     }
 

--- a/components/support/nimbus-cli/src/output/features.rs
+++ b/components/support/nimbus-cli/src/output/features.rs
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use nimbus_fml::intermediate_representation::FeatureManifest;
+use serde_json::Value;
+
+use crate::{
+    sources::{ExperimentSource, ManifestSource},
+    value_utils::{self, CliUtils},
+};
+
+impl ManifestSource {
+    pub(crate) fn print_defaults(
+        &self,
+        feature_id: Option<&String>,
+        output: Option<&PathBuf>,
+    ) -> Result<bool> {
+        let manifest: FeatureManifest = self.try_into()?;
+        let json = self.get_defaults_json(&manifest, feature_id)?;
+        value_utils::write_to_file_or_print(output.map(|f| f.as_path()), &json)?;
+        Ok(true)
+    }
+
+    fn get_defaults_json(
+        &self,
+        fm: &FeatureManifest,
+        feature_id: Option<&String>,
+    ) -> Result<Value> {
+        Ok(match feature_id {
+            Some(id) => {
+                let (_, feature) = fm.find_feature(id).ok_or_else(|| {
+                    anyhow::Error::msg(format!("Feature '{id}' does not exist in this manifest"))
+                })?;
+                feature.default_json()
+            }
+            _ => fm.default_json(),
+        })
+    }
+}
+
+impl ExperimentSource {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn print_features(
+        &self,
+        branch: &String,
+        manifest_source: &ManifestSource,
+        feature_id: Option<&String>,
+        validate: bool,
+        multi: bool,
+        output: Option<&PathBuf>,
+    ) -> Result<bool> {
+        let json = self.get_features_json(manifest_source, feature_id, branch, validate, multi)?;
+        value_utils::write_to_file_or_print(output.map(|f| f.as_path()), &json)?;
+        Ok(true)
+    }
+
+    fn get_features_json(
+        &self,
+        manifest_source: &ManifestSource,
+        feature_id: Option<&String>,
+        branch: &String,
+        validate: bool,
+        multi: bool,
+    ) -> Result<Value> {
+        let value = self.try_into()?;
+
+        // Find the named branch.
+        let branches = value_utils::try_find_branches(&value)?;
+        let b = branches
+            .iter()
+            .find(|b| b.get_str("slug").unwrap() == branch)
+            .ok_or_else(|| anyhow::format_err!("Branch '{branch}' does not exist"))?;
+
+        // Find the features for this branch: there may be more than one.
+        let feature_values = value_utils::try_find_features(b)?;
+
+        // Now extract the relevant features out of the branches.
+        let mut result = serde_json::value::Map::new();
+        for f in feature_values {
+            let id = f.get_str("featureId")?;
+            let value = f
+                .get("value")
+                .ok_or_else(|| anyhow::format_err!("Branch {branch} feature {id} has no value"))?;
+            match feature_id {
+                None => {
+                    // If the user hasn't specified a feature, then just add it.
+                    result.insert(id.to_string(), value.clone());
+                }
+                Some(feature_id) if feature_id == id => {
+                    // If the user has specified a feature, and this is it, then also add it.
+                    result.insert(id.to_string(), value.clone());
+                }
+                // Otherwise, the user has specified a feature, and this wasn't it.
+                _ => continue,
+            }
+        }
+
+        // By now: we have all the features that we need, and no more.
+
+        // If validating, then we should merge with the defaults from the manifest.
+        // If not, then nothing more is needed to be done: we're delivering the partial feature configuration.
+        if validate {
+            let fm: FeatureManifest = manifest_source.try_into()?;
+            let mut new = serde_json::value::Map::new();
+            for (id, value) in result {
+                let def = fm.validate_feature_config(&id, value)?;
+                new.insert(id.to_owned(), def.default_json());
+            }
+            result = new;
+        }
+
+        Ok(if !multi && result.len() == 1 {
+            // By default, if only a single feature is being displayed,
+            // we can output just the feature config.
+            match (result.values().find(|_| true), feature_id) {
+                (Some(v), _) => v.to_owned(),
+                (_, Some(id)) => anyhow::bail!(
+                    "The '{id}' feature is not involved in '{branch}' branch of '{self}'"
+                ),
+                (_, _) => {
+                    anyhow::bail!("No features available in '{branch}' branch of '{self}'")
+                }
+            }
+        } else {
+            // Otherwise, we can output the `{ featureId: featureValue }` in its entirety.
+            Value::Object(result)
+        })
+    }
+}

--- a/components/support/nimbus-cli/src/output/fetch.rs
+++ b/components/support/nimbus-cli/src/output/fetch.rs
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::path::Path;
+
+use anyhow::Result;
+use serde_json::Value;
+
+use crate::{
+    sources::{ExperimentListSource, ExperimentSource},
+    value_utils::{self, CliUtils},
+    NimbusApp,
+};
+
+impl NimbusApp {
+    pub(crate) fn fetch_list<P>(&self, list: &ExperimentListSource, file: Option<P>) -> Result<bool>
+    where
+        P: AsRef<Path>,
+    {
+        let value: Value = list.try_into()?;
+        let array = value_utils::try_extract_data_list(&value)?;
+        let mut data = Vec::new();
+
+        for exp in array {
+            let app_name = exp.get_str("appName")?;
+            if app_name != self.app_name {
+                continue;
+            }
+
+            data.push(exp);
+        }
+        write_experiments_to_file(&data, file)?;
+        Ok(true)
+    }
+}
+
+impl NimbusApp {
+    pub(crate) fn fetch_recipes<P>(
+        &self,
+        recipes: &Vec<ExperimentSource>,
+        file: Option<P>,
+    ) -> Result<bool>
+    where
+        P: AsRef<Path>,
+    {
+        let mut data = Vec::new();
+
+        for exp in recipes {
+            let exp: Value = exp.try_into()?;
+            let app_name = exp.get_str("appName")?;
+            if app_name != self.app_name {
+                continue;
+            }
+
+            data.push(exp);
+        }
+
+        write_experiments_to_file(&data, file)?;
+        Ok(true)
+    }
+}
+
+fn write_experiments_to_file<P>(data: &Vec<Value>, file: Option<P>) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let contents = serde_json::json!({
+        "data": data,
+    });
+    value_utils::write_to_file_or_print(file, &contents)?;
+    Ok(())
+}

--- a/components/support/nimbus-cli/src/output/info.rs
+++ b/components/support/nimbus-cli/src/output/info.rs
@@ -162,7 +162,10 @@ impl ExperimentListSource {
 }
 
 impl ExperimentSource {
-    pub(crate) fn print_info(&self, output: Option<&Path>) -> Result<bool> {
+    pub(crate) fn print_info<P>(&self, output: Option<P>) -> Result<bool>
+    where
+        P: AsRef<Path>,
+    {
         let value = self.try_into()?;
         let info: ExperimentInfo = ExperimentInfo::try_from(&value)?;
         if output.is_some() {

--- a/components/support/nimbus-cli/src/output/info.rs
+++ b/components/support/nimbus-cli/src/output/info.rs
@@ -172,6 +172,10 @@ impl ExperimentSource {
             value_utils::write_to_file_or_print(output, &info)?;
             return Ok(true);
         }
+        let url = match self {
+            Self::FromApiV6 { slug, endpoint } => Some(format!("{endpoint}/nimbus/{slug}/summary")),
+            _ => None,
+        };
         let term = Term::stdout();
         let t_style = term.style().italic();
         let d_style = term.style().bold().cyan();
@@ -208,6 +212,9 @@ impl ExperimentSource {
         line("Slug", info.slug);
         line("Name", info.user_facing_name);
         line("Description", info.user_facing_description);
+        if let Some(url) = url {
+            line("URL", &url);
+        }
         line("App", info.app_name);
         line("Channel", info.channel);
         line("E/R", &is_rollout);

--- a/components/support/nimbus-cli/src/output/info.rs
+++ b/components/support/nimbus-cli/src/output/info.rs
@@ -1,0 +1,220 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::{fmt::Display, path::Path};
+
+use anyhow::Result;
+use console::Term;
+use serde_json::Value;
+
+use crate::{
+    sources::{ExperimentListSource, ExperimentSource},
+    value_utils::{self, CliUtils},
+    NimbusApp,
+};
+
+#[derive(serde::Serialize, Debug)]
+struct ExperimentInfo<'a> {
+    slug: &'a str,
+    app_name: &'a str,
+    channel: &'a str,
+    branches: Vec<&'a str>,
+    features: Vec<&'a str>,
+    targeting: &'a str,
+    bucketing: u64,
+    is_rollout: bool,
+    user_facing_name: &'a str,
+    user_facing_description: &'a str,
+    enrollment: DateRange<'a>,
+    is_enrollment_paused: bool,
+    duration: DateRange<'a>,
+}
+
+impl ExperimentInfo<'_> {
+    fn bucketing_percent(&self) -> String {
+        format!("{: >3.0} %", self.bucketing / 100)
+    }
+}
+
+#[derive(serde::Serialize, Debug)]
+struct DateRange<'a> {
+    start: Option<&'a str>,
+    end: Option<&'a str>,
+    proposed: Option<i64>,
+}
+
+impl<'a> DateRange<'a> {
+    fn new(start: Option<&'a Value>, end: Option<&'a Value>, duration: Option<&'a Value>) -> Self {
+        let start = start.map(Value::as_str).unwrap_or_default();
+        let end = end.map(Value::as_str).unwrap_or_default();
+        let proposed = duration.map(Value::as_i64).unwrap_or_default();
+        Self {
+            start,
+            end,
+            proposed,
+        }
+    }
+}
+
+impl Display for DateRange<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.start, self.end, self.proposed) {
+            (Some(s), Some(e), _) => f.write_str(&format!("{s} ➞ {e}")),
+            (Some(s), _, Some(d)) => f.write_str(&format!("{s}, proposed ending after {d} days")),
+            (Some(s), _, _) => f.write_str(&format!("{s} ➞ ?")),
+            (None, Some(e), Some(d)) => {
+                f.write_str(&format!("ending {e}, started {d} days before"))
+            }
+            (None, Some(e), _) => f.write_str(&format!("ending {e}")),
+            _ => f.write_str("unknown"),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Value> for ExperimentInfo<'a> {
+    type Error = anyhow::Error;
+
+    fn try_from(exp: &'a Value) -> Result<Self> {
+        let features: Vec<_> = exp
+            .get_array("featureIds")?
+            .iter()
+            .flat_map(|f| f.as_str())
+            .collect();
+        let branches: Vec<_> = exp
+            .get_array("branches")?
+            .iter()
+            .flat_map(|b| {
+                b.get("slug")
+                    .expect("Expecting a branch with a slug")
+                    .as_str()
+            })
+            .collect();
+
+        let config = exp.get_object("bucketConfig")?;
+
+        Ok(Self {
+            slug: exp.get_str("slug")?,
+            app_name: exp.get_str("appName")?,
+            channel: exp.get_str("channel")?,
+            branches,
+            features,
+            targeting: exp.get_str("targeting")?,
+            bucketing: config.get_u64("count")?,
+            is_rollout: exp.get_bool("isRollout")?,
+            user_facing_name: exp.get_str("userFacingName")?,
+            user_facing_description: exp.get_str("userFacingDescription")?,
+            enrollment: DateRange::new(
+                exp.get("startDate"),
+                exp.get("enrollmentEndDate"),
+                exp.get("proposedEnrollment"),
+            ),
+            is_enrollment_paused: exp.get_bool("isEnrollmentPaused")?,
+            duration: DateRange::new(
+                exp.get("startDate"),
+                exp.get("endDate"),
+                exp.get("proposedDuration"),
+            ),
+        })
+    }
+}
+
+impl ExperimentListSource {
+    pub(crate) fn print_list(&self, params: &NimbusApp) -> Result<bool> {
+        let value: Value = self.try_into()?;
+        let array = value_utils::try_extract_data_list(&value)?;
+
+        let term = Term::stdout();
+        let style = term.style().italic().underlined();
+        term.write_line(&format!(
+            "{slug: <66}|{channel: <9}|{bucketing: >7}|{features: <31}|{is_rollout}|{branches: <20}",
+            slug = style.apply_to("Experiment slug"),
+            channel = style.apply_to(" Channel"),
+            bucketing = style.apply_to(" % "),
+            features = style.apply_to(" Features"),
+            is_rollout = style.apply_to("   "),
+            branches = style.apply_to(" Branches"),
+        ))?;
+        for exp in array {
+            let app_name = exp.get_str("appName").ok().unwrap_or_default();
+            if app_name != params.app_name {
+                continue;
+            }
+
+            let info = match ExperimentInfo::try_from(&exp) {
+                Ok(e) => e,
+                _ => continue,
+            };
+
+            let is_rollout = if info.is_rollout { "R" } else { "" };
+
+            term.write_line(&format!(
+                " {slug: <65}| {channel: <8}| {bucketing: >5} | {features: <30}| {is_rollout: <1} | {branches}",
+                slug = info.slug,
+                channel = info.channel,
+                bucketing = info.bucketing_percent(),
+                features = info.features.join(", "),
+                branches = info.branches.join(", ")
+            ))?;
+        }
+        Ok(true)
+    }
+}
+
+impl ExperimentSource {
+    pub(crate) fn print_info(&self, output: Option<&Path>) -> Result<bool> {
+        let value = self.try_into()?;
+        let info: ExperimentInfo = ExperimentInfo::try_from(&value)?;
+        if output.is_some() {
+            value_utils::write_to_file_or_print(output, &info)?;
+            return Ok(true);
+        }
+        let term = Term::stdout();
+        let t_style = term.style().italic();
+        let d_style = term.style().bold().cyan();
+        let line = |title: &str, detail: &str| {
+            _ = term.write_line(&format!(
+                "{: <11} {}",
+                t_style.apply_to(title),
+                d_style.apply_to(detail)
+            ));
+        };
+
+        let enrollment = format!(
+            "{} ({})",
+            info.enrollment,
+            if info.is_enrollment_paused {
+                "paused"
+            } else {
+                "enrolling"
+            }
+        );
+
+        let is_rollout = if info.is_rollout {
+            "Rollout".to_string()
+        } else {
+            let n = info.branches.len();
+            let b = if n == 1 {
+                "1 branch".to_string()
+            } else {
+                format!("{n} branches")
+            };
+            format!("Experiment with {b}")
+        };
+
+        line("Slug", info.slug);
+        line("Name", info.user_facing_name);
+        line("Description", info.user_facing_description);
+        line("App", info.app_name);
+        line("Channel", info.channel);
+        line("E/R", &is_rollout);
+        line("Enrollment", &enrollment);
+        line("Observing", &info.duration.to_string());
+        line("Targeting", &format!("\"{}\"", info.targeting));
+        line("Bucketing", &info.bucketing_percent());
+        line("Branches", &info.branches.join(", "));
+        line("Features", &info.features.join(", "));
+
+        Ok(true)
+    }
+}

--- a/components/support/nimbus-cli/src/output/mod.rs
+++ b/components/support/nimbus-cli/src/output/mod.rs
@@ -2,4 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+mod features;
 mod info;

--- a/components/support/nimbus-cli/src/output/mod.rs
+++ b/components/support/nimbus-cli/src/output/mod.rs
@@ -1,0 +1,5 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+mod info;

--- a/components/support/nimbus-cli/src/output/mod.rs
+++ b/components/support/nimbus-cli/src/output/mod.rs
@@ -3,4 +3,5 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 mod features;
+mod fetch;
 mod info;

--- a/components/support/nimbus-cli/src/value_utils.rs
+++ b/components/support/nimbus-cli/src/value_utils.rs
@@ -1,11 +1,11 @@
-use std::path::Path;
-
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::path::Path;
 
 use crate::NimbusApp;
 
@@ -230,30 +230,35 @@ pub(crate) fn prepare_experiment(
     Ok(experiment)
 }
 
-fn is_yaml(file: &Path) -> bool {
-    let ext = file.extension().unwrap_or_default();
+fn is_yaml<P>(file: P) -> bool
+where
+    P: AsRef<Path>,
+{
+    let ext = file.as_ref().extension().unwrap_or_default();
     ext == "yaml" || ext == "yml"
 }
 
-pub(crate) fn read_from_file<T>(file: &Path) -> Result<T>
+pub(crate) fn read_from_file<P, T>(file: P) -> Result<T>
 where
+    P: AsRef<Path>,
     for<'a> T: Deserialize<'a>,
 {
-    let s = std::fs::read_to_string(file)?;
-    Ok(if is_yaml(file) {
+    let s = std::fs::read_to_string(&file)?;
+    Ok(if is_yaml(&file) {
         serde_yaml::from_str(&s)?
     } else {
         serde_json::from_str(&s)?
     })
 }
 
-pub(crate) fn write_to_file_or_print<T>(file: Option<&Path>, contents: &T) -> Result<()>
+pub(crate) fn write_to_file_or_print<P, T>(file: Option<P>, contents: &T) -> Result<()>
 where
+    P: AsRef<Path>,
     T: Serialize,
 {
     match file {
         Some(file) => {
-            let s = if is_yaml(file) {
+            let s = if is_yaml(&file) {
                 serde_yaml::to_string(&contents)?
             } else {
                 serde_json::to_string_pretty(&contents)?

--- a/components/support/nimbus-cli/src/value_utils.rs
+++ b/components/support/nimbus-cli/src/value_utils.rs
@@ -15,6 +15,8 @@ pub(crate) trait CliUtils {
     fn get_array<'a>(&'a self, key: &str) -> Result<&'a Vec<Value>>;
     fn get_mut_array<'a>(&'a mut self, key: &str) -> Result<&'a mut Vec<Value>>;
     fn get_mut_object<'a>(&'a mut self, key: &str) -> Result<&'a mut Value>;
+    fn get_object<'a>(&'a self, key: &str) -> Result<&'a Value>;
+    fn get_u64(&self, key: &str) -> Result<u64>;
 
     fn set<V>(&mut self, key: &str, value: V) -> Result<()>
     where
@@ -76,12 +78,34 @@ impl CliUtils for Value {
         Ok(v)
     }
 
+    fn get_object<'a>(&'a self, key: &str) -> Result<&'a Value> {
+        let v = self.get(key).ok_or_else(|| {
+            anyhow::Error::msg(format!(
+                "Expected an object with key '{key}' in the JSONObject"
+            ))
+        })?;
+        Ok(v)
+    }
+
     fn get_mut_object<'a>(&'a mut self, key: &str) -> Result<&'a mut Value> {
         let v = self.get_mut(key).ok_or_else(|| {
             anyhow::Error::msg(format!(
                 "Expected an object with key '{key}' in the JSONObject"
             ))
         })?;
+        Ok(v)
+    }
+
+    fn get_u64(&self, key: &str) -> Result<u64> {
+        let v = self
+            .get(key)
+            .ok_or_else(|| {
+                anyhow::Error::msg(format!(
+                    "Expected an array with key '{key}' in the JSONObject"
+                ))
+            })?
+            .as_u64()
+            .ok_or_else(|| anyhow::Error::msg("value is not a array"))?;
         Ok(v)
     }
 

--- a/components/support/nimbus-cli/test/fixtures/fenix-nimbus-validation-v3.json
+++ b/components/support/nimbus-cli/test/fixtures/fenix-nimbus-validation-v3.json
@@ -1,0 +1,56 @@
+{
+  "appId": "org.mozilla.fenix",
+  "appName": "fenix",
+  "application": "org.mozilla.fenix",
+  "arguments": {},
+  "branches": [
+    {
+      "feature": {
+        "enabled": true,
+        "featureId": "no-feature-fenix",
+        "value": {}
+      },
+      "ratio": 3,
+      "slug": "a1"
+    },
+    {
+      "feature": {
+        "enabled": true,
+        "featureId": "no-feature-fenix",
+        "value": {}
+      },
+      "ratio": 2,
+      "slug": "a2"
+    }
+  ],
+  "bucketConfig": {
+    "count": 8000,
+    "namespace": "fenix-nimbus-validation-v3-1",
+    "randomizationUnit": "nimbus_id",
+    "start": 0,
+    "total": 10000
+  },
+  "channel": "nightly",
+  "endDate": "2021-02-11",
+  "enrollmentEndDate": "2021-02-11",
+  "featureIds": [
+    "no-feature-fenix"
+  ],
+  "featureValidationOptOut": false,
+  "id": "fenix-nimbus-validation-v3",
+  "isEnrollmentPaused": false,
+  "isRollout": false,
+  "locales": null,
+  "localizations": null,
+  "outcomes": [],
+  "probeSets": [],
+  "proposedDuration": 7,
+  "proposedEnrollment": 7,
+  "referenceBranch": "a1",
+  "schemaVersion": "1.12.0",
+  "slug": "fenix-nimbus-validation-v3",
+  "startDate": "2021-02-05",
+  "targeting": "true",
+  "userFacingDescription": "Verify we can run A/A experiments and bucket.",
+  "userFacingName": "Fenix Nimbus Validation v3"
+}


### PR DESCRIPTION
Fixes [EXP-3587](https://mozilla-hub.atlassian.net/browse/EXP-3587).

This adds an `info` command.

```sh
Slug        lifestyles-images-onboarding-experiment-v3
Name        Lifestyles images onboarding experiment v3
Description This experiment tests different sets of images for the same onboarding card messages to see if one is preferred.
App         fenix
Channel     release
E/R         Experiment with 2 branches
Enrollment  2023-06-09 ➞ 2023-06-23 (enrolling)
Observing   2023-06-09, proposed ending after 35 days
Targeting   "((is_already_enrolled) || ((isFirstRun == 'true') && (app_version|versionCompare('114.!') >= 0) && (language in ['en'])))"
Bucketing   100 %
Branches    control, treatment-a
Features    juno-onboarding
```

and adds info to the `list` command:

```sh
Experiment slug                                                   | Channel |     % | Features                      |   | Branches           
----------------------------------------------------------------------------------------------------------------------------------------------
 viewpoint-rolling-week-4-expansion-android                       | release |   3 % | messaging                     |   | treatment
 mobile-default-browser-cta-copy-test                             | release |  90 % | messaging                     |   | control, treatment
 lifestyles-images-onboarding-experiment-v3                       | release | 100 % | juno-onboarding               |   | control, treatment-a
 android-research-surface-validation                              | release |  10 % | messaging                     |   | control, treatment
 release-android-onboarding-redesign                              | release | 100 % | juno-onboarding               |   | control, treatment-a
 fx-release-android-re-engagement-notifications-114-rollout       | release | 100 % | re-engagement-notification    | R | control
 notification-worker-validation-experiment                        | nightly | 100 % | messaging                     |   | control, treatment-a
```

#### Note to reviewers:

The first commit is the meat of the info and list commands.

These lead to a slightly larger refactor of the some of the other commands: the code in the other commits are just moving around what was already there before.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
