### PR TITLE
Added compatability methods to `FxaConfig` and related types

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/Config.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/Config.kt
@@ -20,6 +20,9 @@ class Config constructor(
         STAGE(FxaServer.Stage),
         CHINA(FxaServer.China),
         LOCALDEV(FxaServer.LocalDev),
+        ;
+
+        val contentUrl get() = this.rustServer.contentUrl
     }
 
     constructor(
@@ -29,8 +32,27 @@ class Config constructor(
         tokenServerUrlOverride: String? = null,
     ) : this(server.rustServer, clientId, redirectUri, tokenServerUrlOverride)
 
+    constructor(
+        contentUrl: String,
+        clientId: String,
+        redirectUri: String,
+        tokenServerUrlOverride: String? = null,
+    ) : this(FxaServer.Custom(contentUrl), clientId, redirectUri, tokenServerUrlOverride)
+
+    val contentUrl get() = this.server.contentUrl
+
     // Rust defines a config and server class that's virtually identically to these.  We should
     // remove the wrapper soon, but let's wait until we have a batch of breaking changes and do them
     // all at once.
     fun intoRustConfig() = FxaConfig(server, clientId, redirectUri, tokenServerUrlOverride)
 }
+
+val FxaServer.contentUrl: String
+    get() = when (this) {
+        is FxaServer.Release -> "https://accounts.firefox.com"
+        is FxaServer.Stable -> "https://stable.dev.lcip.org"
+        is FxaServer.Stage -> "https://accounts.stage.mozaws.net"
+        is FxaServer.China -> "https://accounts.firefox.com.cn"
+        is FxaServer.LocalDev -> "http://127.0.0.1:3030"
+        is FxaServer.Custom -> this.url
+    }


### PR DESCRIPTION
The latest Fenix nightly is failing because it was using the Rust versions of FxaConfig and FxaServer.  Adding some methods to prevent the breakage

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
