### PR TITLE
When bucketing decreasing in a rollout, then end enrollment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🦊 What's Changed 🦊
 
+- When a rollout audience size decreases, the enrollment is re-evaluated and the client is unenrolled if no longer in the bucket. ([#5687](https://github.com/mozilla/application-services/pull/5687)).
+  - The record of enrollment will be available in the new `enrollments` targeting attribute.
 - Add `enrollments` value to `TargetingAttributes` — it is a set of strings containing all enrollments, past and present ([#5685](https://github.com/mozilla/application-services/pull/5685)).
   - _Note: This change only applies to stateful uses of the Nimbus SDK, e.g. mobile_
 - Add ability to enroll selected features multiple times (coenrollment) ([#5684](https://github.com/mozilla/application-services/pull/5684)).

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -237,6 +237,14 @@ impl ExperimentEnrollment {
                             out_enrollment_events.push(updated_enrollment.get_change_event());
                             updated_enrollment
                         }
+                        EnrollmentStatus::NotEnrolled {
+                            reason: NotEnrolledReason::NotSelected,
+                        } => {
+                            // In the case of a rollout being scaled back, we should end with WasEnrolled.
+                            //
+                            self.on_experiment_ended(out_enrollment_events)
+                                .ok_or_else(|| NimbusError::InternalError("An unexpected None happened while ending an experiment prematurely"))?
+                        }
                         EnrollmentStatus::NotEnrolled { .. }
                         | EnrollmentStatus::Enrolled { .. }
                         | EnrollmentStatus::Disqualified { .. }

--- a/components/nimbus/src/tests/helpers.rs
+++ b/components/nimbus/src/tests/helpers.rs
@@ -266,14 +266,55 @@ pub fn get_single_feature_experiment(slug: &str, feature_id: &str, config: Value
         "featureIds": [feature_id],
         "channel": "nightly",
         "probeSets":[],
-        "startDate":null,
-        "appName":"fenix",
+        "startDate":null,"appName":"fenix",
         "appId":"org.mozilla.fenix",
         "bucketConfig":{
             // Also enroll everyone.
             "count":10_000,
             "start":0,
             "total":10_000,
+            "namespace":"secure-silver",
+            "randomizationUnit":"nimbus_id"
+        },
+        "userFacingName":"",
+        "referenceBranch":"control",
+        "isEnrollmentPaused":false,
+        "proposedEnrollment":7,
+        "userFacingDescription":"",
+    }
+    ))
+    .unwrap()
+}
+
+pub fn get_bucketed_rollout(slug: &str, count: i64) -> Experiment {
+    let feature_id = "a-feature";
+    serde_json::from_value(json!(
+        {
+        "schemaVersion": "1.0.0",
+        "slug": slug,
+        "endDate": null,
+        "branches":[
+            {
+                "slug": "control",
+                "ratio": 1,
+                "feature": {
+                    "featureId": feature_id,
+                    "enabled": true,
+                    "value": {},
+                }
+            },
+        ],
+        "isRollout": true,
+        "featureIds": [feature_id],
+        "channel": "nightly",
+        "probeSets": [],
+        "startDate": null,
+        "appName":"fenix",
+        "appId":"org.mozilla.fenix",
+        "bucketConfig":{
+            "count": count,
+            "start": 0,
+            "total": 10_000,
             "namespace":"secure-silver",
             "randomizationUnit":"nimbus_id"
         },


### PR DESCRIPTION
Fixes [EXP-3450](https://mozilla-hub.atlassian.net/browse/EXP-3450), [ EXP-3451](https://mozilla-hub.atlassian.net/browse/EXP-3451).

Discussion: when an audience size reduces, we now move into status `WasEnrolled`. This has two effects:

- we will still be accessible via the new `enrollments` targeting
- the client will not be able to enroll if the bucketing goes back up again.

We should note that:
- `Disqualified` as a status exists (so the client can drop out of targeting), but in this case the `enrollments` is not sensitive to this.

Alternatives considered: 
- adding a `DisqualifiedReason::NotSelected`, and then at some later time translating this to a `WasEnrolled`
- Making the `enrollments` targeting sensitive to `Disqualified` enrollments. -- both rejected on too many moving parts.
- Adding extra edges to the DFA to get from Disqualified or WasEnrolled back to Enrolled— rejected because of this may affect data quality.

/cc @jaredlockhart

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
