### PR TITLE
Update ktlint to version 0.50.0 and fix new warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         espresso_core_version = '3.5.1'
 
         detekt_version = '1.23.0'
-        ktlint_version = '0.49.1'
+        ktlint_version = '0.50.0'
         gradle_download_task_version = '5.2.1'
         junit_version = '4.13.2'
         mockito_core_version = '5.3.1'
@@ -42,7 +42,6 @@ buildscript {
     repositories {
         mavenCentral()
         google()
-        jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"
         }

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Job+.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Job+.kt
@@ -1,7 +1,8 @@
-// ktlint-disable filename
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("ktlint:standard:filename")
 
 package org.mozilla.experiments.nimbus
 

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/Collection+.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/Collection+.kt
@@ -1,7 +1,8 @@
-// ktlint-disable filename
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@file:Suppress("ktlint:standard:filename")
 
 package org.mozilla.experiments.nimbus.internal
 

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/FeatureVariablesTest.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/FeatureVariablesTest.kt
@@ -249,8 +249,7 @@ class FeatureVariablesTest {
     }
 }
 
-// ktlint-disable enum-entry-name-case
-@Suppress("EnumNaming")
+@Suppress("EnumNaming", "ktlint:standard:enum-entry-name-case")
 enum class MenuItemId {
     settings,
     bookmarks,
@@ -260,8 +259,7 @@ enum class MenuItemId {
 
 data class MenuItem(val deepLink: String, val label: String)
 
-// ktlint-disable enum-entry-name-case
-@Suppress("EnumNaming")
+@Suppress("EnumNaming", "ktlint:standard:enum-entry-name-case")
 enum class NumKey {
     one,
     two,

--- a/components/support/nimbus-fml/fixtures/android/runtime/AppR.kt
+++ b/components/support/nimbus-fml/fixtures/android/runtime/AppR.kt
@@ -1,9 +1,8 @@
-// ktlint-disable filename
 /* This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("ClassName", "InvalidPackageDeclaration", "MatchingDeclarationName")
+@file:Suppress("ClassName", "InvalidPackageDeclaration", "ktlint:standard:filename", "MatchingDeclarationName")
 
 package com.example.app
 /**

--- a/components/support/nimbus-fml/fixtures/android/runtime/LibR.kt
+++ b/components/support/nimbus-fml/fixtures/android/runtime/LibR.kt
@@ -1,9 +1,8 @@
-// ktlint-disable filename
 /* This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("ClassName", "InvalidPackageDeclaration", "MatchingDeclarationName")
+@file:Suppress("ClassName", "InvalidPackageDeclaration", "ktlint:standard:filename", "MatchingDeclarationName")
 
 package com.example.lib
 /**

--- a/components/support/nimbus-fml/fixtures/android/runtime/SubLibR.kt
+++ b/components/support/nimbus-fml/fixtures/android/runtime/SubLibR.kt
@@ -1,9 +1,8 @@
-// ktlint-disable filename
 /* This Source Code Form is subject to the terms of the Mozilla Public
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-@file:Suppress("ClassName", "InvalidPackageDeclaration", "MatchingDeclarationName")
+@file:Suppress("ClassName", "InvalidPackageDeclaration", "ktlint:standard:filename", "MatchingDeclarationName")
 
 package com.example.sublib
 /**


### PR DESCRIPTION
Changelog: https://github.com/pinterest/ktlint/releases/tag/0.50.0

Nothing super interesting in this update other than getting more strict about how suppressions are declared.