### PR TITLE
Fix for the swift-build task artifacts

### DIFF
--- a/taskcluster/ci/swift/kind.yml
+++ b/taskcluster/ci/swift/kind.yml
@@ -32,24 +32,12 @@ tasks:
     worker-type: b-osx
     worker:
       max-run-time: 1800
-      artifacts:
-        - name: "public/build/swift-components.tar.xz"
-          path: "checkouts/vcs/build/swift-components.tar.xz"
-          type: "file"
-        - name: "public/build/MozillaRustComponents.xcframework.zip"
-          path: "checkouts/vcs/build/MozillaRustComponents.xcframework.zip"
-          type: "file"
-        - name: "public/build/FocusRustComponents.xcframework.zip"
-          path: "checkouts/vcs/build/FocusRustComponents.xcframework.zip"
-          type: "file"
-        # TODO: re-enable once we get tests working
-        # - name: "public/build/raw_xcodetest.log"
-        #   path: "checkouts/vcs/logs/raw_xcodetest.log"
-        #   type: "file"
     release-artifacts:
       - swift-components.tar.xz
       - MozillaRustComponents.xcframework.zip
       - FocusRustComponents.xcframework.zip
+      # TODO: re-enable once we get tests working
+      # - raw_xcodetest.log
     run:
       pre-commands:
         - ["source", "taskcluster/scripts/setup-mac-worker.sh"]


### PR DESCRIPTION
Don't include the same files as both artifacts and release-artifacts, that resulted in an error in today's nightly.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
