### PR TITLE
Another swift-build artifact fix [ci full]

### DIFF
--- a/taskcluster/ci/swift/kind.yml
+++ b/taskcluster/ci/swift/kind.yml
@@ -45,8 +45,12 @@ tasks:
         - ["source", "taskcluster/scripts/toolchain/setup-libs-ios.sh"]
       commands:
         - ["taskcluster/scripts/build-and-test-swift.sh"]
-        - [ "cd", "build/" ]
+        - [ "pushd", "build/" ]
         - [ "tar", "acf", "swift-components.tar.xz", "swift-components" ]
+        - [ "popd"]
+        - [ "mv", "build/swift-components.tar.xz", "artifacts/"]
+        - [ "pwd"]
+        - [ "mv", "artifacts", "../../"]
       using: run-commands
       run-task-command: ["/usr/local/bin/python3", "run-task"]
       use-caches: true

--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -54,6 +54,7 @@ FOCUS_SOURCE_TO_COPY = [
 def main():
     args = parse_args()
     ensure_dir(args.out_dir)
+    ensure_dir(args.xcframework_dir)
     run_tests(args)
     xcframework_build(args, "MozillaRustComponents.xcframework.zip")
     xcframework_build(args, "FocusRustComponents.xcframework.zip")

--- a/taskcluster/scripts/build-and-test-swift.sh
+++ b/taskcluster/scripts/build-and-test-swift.sh
@@ -6,4 +6,4 @@ set -ex
 # setup the enviroment in a script.
 
 mv "$MOZ_FETCHES_DIR/swiftformat" "$HOME/bin/swiftformat"
-taskcluster/scripts/build-and-test-swift.py build/swift-components build/ build/glean-workdir
+taskcluster/scripts/build-and-test-swift.py build/swift-components artifacts/ build/glean-workdir


### PR DESCRIPTION
Put the artifacts in the place where taskcluster expects them.  This changed when we switched to using release-artifacts

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
