### PR TITLE
[firefox-android: jhugman/bug-1841262-add-coenrolling-features-to-nimbus-builder] Add API to SDK populating EnrollmentsEvolver coenrolling feature ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,12 @@
   - The record of enrollment will be available in the new `enrollments` targeting attribute.
 - Add `enrollments` value to `TargetingAttributes` — it is a set of strings containing all enrollments, past and present ([#5685](https://github.com/mozilla/application-services/pull/5685)).
   - _Note: This change only applies to stateful uses of the Nimbus SDK, e.g. mobile_
-- Add ability to enroll selected features multiple times (coenrollment) ([#5684](https://github.com/mozilla/application-services/pull/5684)).
+- Add ability to enroll selected features multiple times (coenrollment) ([#5684](https://github.com/mozilla/application-services/pull/5684), [#5697](https://github.com/mozilla/application-services/pull/5697)).
+
+### ⚠️ Breaking Changes ⚠️
+
+- Several changes to the NimbusBuilder mean that this is a breaking change for Firefox for Android [#5697](https://github.com/mozilla/application-services/pull/5697).
+  - These changes are fixed by [firefox-android#2682](https://github.com/mozilla-mobile/firefox-android/pull/2682).
 
 ## Nimbus FML ⛅️🔬🔭🔧
 

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -111,6 +111,7 @@ open class Nimbus(
 
         nimbusClient = NimbusClient(
             experimentContext,
+            listOf(),
             dataDir.path,
             remoteSettingsConfig,
             // The "dummy" field here is required for obscure reasons when generating code on desktop,

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -59,6 +59,7 @@ data class NimbusServerSettings(
 open class Nimbus(
     override val context: Context,
     appInfo: NimbusAppInfo,
+    coenrollingFeatureIds: List<String>,
     server: NimbusServerSettings?,
     deviceInfo: NimbusDeviceInfo,
     private val observer: NimbusInterface.Observer? = null,
@@ -111,7 +112,7 @@ open class Nimbus(
 
         nimbusClient = NimbusClient(
             experimentContext,
-            listOf(),
+            coenrollingFeatureIds,
             dataDir.path,
             remoteSettingsConfig,
             // The "dummy" field here is required for obscure reasons when generating code on desktop,

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusBuilder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusBuilder.kt
@@ -9,7 +9,6 @@ import android.net.Uri
 import androidx.annotation.RawRes
 import kotlinx.coroutines.runBlocking
 import org.mozilla.experiments.nimbus.internal.FeatureManifestInterface
-import java.util.Locale
 
 private const val TIME_OUT_LOADING_EXPERIMENT_FROM_DISK_MS = 200L
 
@@ -58,6 +57,26 @@ abstract class AbstractNimbusBuilder<T : NimbusInterface>(val context: Context) 
      * to be used.
      */
     var onCreateCallback: (T) -> Unit = {}
+
+    /**
+     * Optional callback to be called everytime experiments have been applied.
+     *
+     * Experiment recipes are usually fetched shortly after startup, and those pending recipes are
+     * applied at the following startup.
+     *
+     * This is not usually needed.
+     */
+    var onApplyCallback: () -> Unit = {}
+
+    /**
+     * Optional callback to be called everytime experiments have been fetched.
+     *
+     * Experiment recipes are usually fetched shortly after startup, and those pending recipes are
+     * applied at the following startup.
+     *
+     * This is not usually needed.
+     */
+    var onFetchCallback: () -> Unit = {}
 
     /**
      * The `object` generated from the `nimbus.fml.yaml` file and the nimbus-gradle-plugin.
@@ -140,6 +159,51 @@ abstract class AbstractNimbusBuilder<T : NimbusInterface>(val context: Context) 
      * [NimbusInterface] object, then construct a dummy object.
      */
     protected abstract fun newNimbusDisabled(): T
+
+    /**
+     * Creates the [NimbusDeviceInfo] for each Nimbus object built.
+     */
+    protected open fun createDeviceInfo() = NimbusDeviceInfo.default()
+
+    /**
+     * Creates the [NimbusDelegate] for each Nimbus instance built.
+     *
+     * The delegate is the main low-level interface between the embedding apps and the SDK.
+     *
+     * Override this if you want to customize the threading, error reporting or logging used
+     * by the [NimbusInterface] instance.
+     */
+    protected open fun createDelegate() = NimbusDelegate.default()
+
+    /**
+     * Creates the observer used to tie together the feature manifest and the SDK. Implementers of
+     * [newNimbus] should use this to register this observer with the [NimbusInterface] object.
+     */
+    protected fun createObserver(): NimbusInterface.Observer =
+        Observer(featureManifest, onFetchCallback, onApplyCallback)
+
+    /**
+     * Returns a list of feature ids that support coenrollment. Implementers of [newNimbus] should
+     * use this to pass into the [NimbusInterface] instance.
+     */
+    protected fun getCoenrollingFeatureIds(): List<String> =
+        // This will be changed to use the feature manifest in EXP-3265
+        listOf()
+}
+
+private class Observer(
+    val featureManifest: FeatureManifestInterface<*>?,
+    val onFetchCallback: () -> Unit,
+    val onApplyCallback: () -> Unit,
+) : NimbusInterface.Observer {
+    override fun onExperimentsFetched() {
+        onFetchCallback.invoke()
+    }
+
+    override fun onUpdatesApplied(updated: List<EnrolledExperiment>) {
+        featureManifest?.invalidateCachedValues()
+        onApplyCallback.invoke()
+    }
 }
 
 class DefaultNimbusBuilder(context: Context) : AbstractNimbusBuilder<NimbusInterface>(context) {
@@ -147,9 +211,11 @@ class DefaultNimbusBuilder(context: Context) : AbstractNimbusBuilder<NimbusInter
         Nimbus(
             context,
             appInfo = appInfo,
+            coenrollingFeatureIds = getCoenrollingFeatureIds(),
             server = serverSettings,
-            deviceInfo = NimbusDeviceInfo(Locale.getDefault().toLanguageTag()),
-            delegate = NimbusDelegate.default(),
+            deviceInfo = createDeviceInfo(),
+            delegate = createDelegate(),
+            observer = createObserver(),
         )
 
     override fun newNimbusDisabled() = NullNimbus(context)

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusParams.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusParams.kt
@@ -5,6 +5,7 @@
 package org.mozilla.experiments.nimbus
 
 import org.json.JSONObject
+import java.util.Locale
 
 /**
  * This class represents the client application name and channel for filtering purposes
@@ -43,4 +44,8 @@ data class NimbusAppInfo(
  */
 data class NimbusDeviceInfo(
     val localeTag: String,
-)
+) {
+    companion object {
+        fun default() = NimbusDeviceInfo(Locale.getDefault().toLanguageTag())
+    }
+}

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/GleanPlumbTests.kt
@@ -47,6 +47,7 @@ class GleanPlumbTests {
         val nimbus = Nimbus(
             context = context,
             appInfo = developmentAppInfo,
+            coenrollingFeatureIds = listOf(),
             server = null,
             deviceInfo = deviceInfo,
             delegate = nimbusDelegate,
@@ -72,6 +73,7 @@ class GleanPlumbTests {
         val nimbus = Nimbus(
             context = context,
             appInfo = developmentAppInfo,
+            coenrollingFeatureIds = listOf(),
             server = null,
             deviceInfo = deviceInfo,
             delegate = nimbusDelegate,
@@ -107,6 +109,7 @@ class GleanPlumbTests {
         val nimbus = Nimbus(
             context = context,
             appInfo = developmentAppInfo,
+            coenrollingFeatureIds = listOf(),
             server = null,
             deviceInfo = deviceInfo,
             delegate = nimbusDelegate,

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -66,6 +66,7 @@ class NimbusTests {
     private val nimbus = Nimbus(
         context = context,
         appInfo = appInfo,
+        coenrollingFeatureIds = listOf(),
         server = null,
         deviceInfo = deviceInfo,
         observer = null,
@@ -435,6 +436,7 @@ class NimbusTests {
         val nimbus = Nimbus(
             context = context,
             appInfo = developmentAppInfo,
+            coenrollingFeatureIds = listOf(),
             server = null,
             deviceInfo = deviceInfo,
             delegate = nimbusDelegate,
@@ -455,6 +457,7 @@ class NimbusTests {
         val nimbus = Nimbus(
             context = context,
             appInfo = developmentAppInfo,
+            coenrollingFeatureIds = listOf(),
             server = null,
             deviceInfo = deviceInfo,
             delegate = nimbusDelegate,
@@ -545,6 +548,7 @@ class NimbusTests {
         val nimbus = Nimbus(
             context = context,
             appInfo = appInfo,
+            coenrollingFeatureIds = listOf(),
             server = null,
             deviceInfo = deviceInfo,
             observer = observer,
@@ -575,6 +579,7 @@ class NimbusTests {
         val nimbus = Nimbus(
             context = context,
             appInfo = appInfo,
+            coenrollingFeatureIds = listOf(),
             server = null,
             deviceInfo = deviceInfo,
             observer = observer,

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/util/TestNimbusBuilder.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/util/TestNimbusBuilder.kt
@@ -19,7 +19,7 @@ class TestNimbusBuilder(context: Context) : AbstractNimbusBuilder<NimbusInterfac
         appInfo: NimbusAppInfo,
         serverSettings: NimbusServerSettings?,
     ): NimbusInterface =
-        Nimbus(context, appInfo, serverSettings, NimbusDeviceInfo("en-US"), null, NimbusDelegate.default())
+        Nimbus(context, appInfo, listOf(), serverSettings, NimbusDeviceInfo("en-US"), null, NimbusDelegate.default())
 
     override fun newNimbusDisabled(): NimbusInterface =
         uninitialized()

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -202,7 +202,13 @@ fn main() -> Result<()> {
     let aru = AvailableRandomizationUnits::with_client_id(&client_id);
 
     // Here we initialize our main `NimbusClient` struct
-    let nimbus_client = NimbusClient::new(context.clone(), db_path, Some(config), aru)?;
+    let nimbus_client = NimbusClient::new(
+        context.clone(),
+        Default::default(),
+        db_path,
+        Some(config),
+        aru,
+    )?;
     log::info!("Nimbus ID is {}", nimbus_client.nimbus_id()?);
 
     // Explicitly update experiments at least once for init purposes

--- a/components/nimbus/ios/Nimbus/NimbusBuilder.swift
+++ b/components/nimbus/ios/Nimbus/NimbusBuilder.swift
@@ -114,7 +114,7 @@ public class NimbusBuilder {
      */
     @discardableResult
     public func onFetch(callback: @escaping (NimbusInterface) -> Void) -> NimbusBuilder {
-        onApplyCallback = callback
+        onFetchCallback = callback
         return self
     }
 

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -34,6 +34,7 @@ public extension Nimbus {
     static func create(
         _ server: NimbusServerSettings?,
         appSettings: NimbusAppSettings,
+        coenrollingFeatureIds: [String] = [],
         dbPath: String,
         resourceBundles: [Bundle] = [Bundle.main],
         enabled: Bool = true,
@@ -52,6 +53,7 @@ public extension Nimbus {
         }
         let nimbusClient = try NimbusClient(
             appCtx: context,
+            coenrollingFeatureIds: coenrollingFeatureIds,
             dbpath: dbPath,
             remoteSettingsConfig: remoteSettings,
             // The "dummy" field here is required for obscure reasons when generating code on desktop,

--- a/components/nimbus/src/cirrus.udl
+++ b/components/nimbus/src/cirrus.udl
@@ -13,7 +13,7 @@ enum NimbusError {
 
 interface CirrusClient {
     [Throws=NimbusError]
-    constructor(string app_context);
+    constructor(string app_context, optional sequence<string> coenrolling_feature_ids = []);
 
     // Handles an enrollment request string and returns an enrollment response string.
     [Throws=NimbusError]

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -91,6 +91,7 @@ interface NimbusClient {
     [Throws=NimbusError]
     constructor(
         AppContext app_ctx,
+        optional sequence<string> coenrolling_feature_ids = [],
         string dbpath,
         RemoteSettingsConfig? remote_settings_config,
         AvailableRandomizationUnits available_randomization_units

--- a/components/nimbus/src/nimbus_client.rs
+++ b/components/nimbus/src/nimbus_client.rs
@@ -69,6 +69,7 @@ impl NimbusClient {
     // thread in the gecko Javascript stack, hence the use of OnceCell for the db.
     pub fn new<P: Into<PathBuf>>(
         app_context: AppContext,
+        coenrolling_feature_ids: Vec<String>,
         db_path: P,
         config: Option<RemoteSettingsConfig>,
         available_randomization_units: AvailableRandomizationUnits,
@@ -86,10 +87,7 @@ impl NimbusClient {
             app_context,
             database_cache: Default::default(),
             db_path: db_path.into(),
-            // With this being default, i.e. empty, Nimbus doesn't support coenrolling ids.
-            // Once the API is connected with Swift/Kotlin it will.
-            // This is the subject of https://mozilla-hub.atlassian.net/browse/EXP-3623
-            coenrolling_feature_ids: Default::default(),
+            coenrolling_feature_ids,
             db: OnceCell::default(),
             event_store: Arc::default(),
         })

--- a/components/nimbus/src/stateless/cirrus_client.rs
+++ b/components/nimbus/src/stateless/cirrus_client.rs
@@ -85,14 +85,11 @@ pub struct CirrusClient {
 }
 
 impl CirrusClient {
-    pub fn new(app_context: String) -> Result<Self> {
+    pub fn new(app_context: String, coenrolling_feature_ids: Vec<String>) -> Result<Self> {
         let app_context: AppContext = serde_json::from_str(&app_context)?;
         Ok(Self {
             app_context,
-            // As it currently stands, with no coenrolling feature ids, cirrus cannot
-            // support coenrolling features.
-            // This is the subject of https://mozilla-hub.atlassian.net/browse/EXP-3623
-            coenrolling_feature_ids: Default::default(),
+            coenrolling_feature_ids,
             state: Default::default(),
         })
     }

--- a/components/nimbus/src/tests/stateful/client/test_null_client.rs
+++ b/components/nimbus/src/tests/stateful/client/test_null_client.rs
@@ -17,7 +17,13 @@ fn test_null_client() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
 
     let aru = Default::default();
-    let client = NimbusClient::new(Default::default(), tmp_dir.path(), None, aru)?;
+    let client = NimbusClient::new(
+        Default::default(),
+        Default::default(),
+        tmp_dir.path(),
+        None,
+        aru,
+    )?;
     client.fetch_experiments()?;
     client.apply_pending_experiments()?;
 

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -30,6 +30,7 @@ fn test_telemetry_reset() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     let client = NimbusClient::new(
         AppContext::default(),
+        Default::default(),
         tmp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -107,6 +108,7 @@ fn test_installation_date() -> Result<()> {
     };
     let client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         tmp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -143,6 +145,7 @@ fn test_installation_date() -> Result<()> {
     app_context.installation_date = None;
     let client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         tmp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -166,6 +169,7 @@ fn test_installation_date() -> Result<()> {
     // we wipe any non-persistent memory
     let client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         tmp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -197,6 +201,7 @@ fn test_installation_date() -> Result<()> {
     // Step 4: We test that if the storage is clear, we will fallback to the
     let client = NimbusClient::new(
         app_context,
+        Default::default(),
         tmp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -228,6 +233,7 @@ fn test_days_since_calculation_happens_at_startup() -> Result<()> {
     };
     let client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         tmp_dir.path(),
         None,
         Default::default(),
@@ -251,7 +257,13 @@ fn test_days_since_calculation_happens_at_startup() -> Result<()> {
     // 2. This is the new case: exactly one of initialize() or apply_pending_experiments()
     // is called during start up.
     // This case ensures that dates are available after apply_pending_experiments().
-    let client = NimbusClient::new(app_context, tmp_dir.path(), None, Default::default())?;
+    let client = NimbusClient::new(
+        app_context,
+        Default::default(),
+        tmp_dir.path(),
+        None,
+        Default::default(),
+    )?;
     client.apply_pending_experiments()?;
     let targeting_attributes = client.get_targeting_attributes();
     assert!(matches!(targeting_attributes.days_since_install, Some(3)));
@@ -266,6 +278,7 @@ fn test_days_since_update_changes_with_context() -> Result<()> {
     let tmp_dir = tempfile::tempdir()?;
     let client = NimbusClient::new(
         AppContext::default(),
+        Default::default(),
         tmp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -287,6 +300,7 @@ fn test_days_since_update_changes_with_context() -> Result<()> {
     };
     let client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         tmp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -315,6 +329,7 @@ fn test_days_since_update_changes_with_context() -> Result<()> {
     // the update_date should not change
     let client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         tmp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -349,6 +364,7 @@ fn test_days_since_update_changes_with_context() -> Result<()> {
     app_context.app_version = Some("v94.0.1".into()); // A different version
     let client = NimbusClient::new(
         app_context,
+        Default::default(),
         tmp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -391,6 +407,7 @@ fn test_days_since_install() -> Result<()> {
     };
     let mut client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         temp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -469,6 +486,7 @@ fn test_days_since_install_failed_targeting() -> Result<()> {
     };
     let mut client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         temp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -546,6 +564,7 @@ fn test_days_since_update() -> Result<()> {
     };
     let mut client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         temp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -624,6 +643,7 @@ fn test_days_since_update_failed_targeting() -> Result<()> {
     };
     let mut client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         temp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -714,6 +734,7 @@ fn event_store_exists_for_apply_pending_experiments() -> Result<()> {
     };
     let mut client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         temp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -836,6 +857,7 @@ fn event_store_on_targeting_attributes_is_updated_after_an_event_is_recorded() -
     };
     let mut client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         temp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -934,7 +956,7 @@ fn test_ios_rollout() -> Result<()> {
         ..Default::default()
     };
     let tmp_dir = TempDir::new()?;
-    let client = NimbusClient::new(ctx, tmp_dir.path(), None, aru)?;
+    let client = NimbusClient::new(ctx, Default::default(), tmp_dir.path(), None, aru)?;
 
     let exp = get_ios_rollout_experiment();
     let data = json!({
@@ -961,13 +983,25 @@ fn test_fetch_enabled() -> Result<()> {
         ..Default::default()
     };
     let tmp_dir = TempDir::new()?;
-    let client = NimbusClient::new(ctx.clone(), tmp_dir.path(), None, Default::default())?;
+    let client = NimbusClient::new(
+        ctx.clone(),
+        Default::default(),
+        tmp_dir.path(),
+        None,
+        Default::default(),
+    )?;
     client.set_fetch_enabled(false)?;
 
     assert!(!client.is_fetch_enabled()?);
     drop(client);
 
-    let client = NimbusClient::new(ctx, tmp_dir.path(), None, Default::default())?;
+    let client = NimbusClient::new(
+        ctx,
+        Default::default(),
+        tmp_dir.path(),
+        None,
+        Default::default(),
+    )?;
     assert!(!client.is_fetch_enabled()?);
     Ok(())
 }
@@ -1027,6 +1061,7 @@ fn test_active_enrollment_in_targeting() -> Result<()> {
     };
     let mut client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         temp_dir.path(),
         None,
         AvailableRandomizationUnits {
@@ -1083,6 +1118,7 @@ fn test_previous_enrollment_in_targeting() -> Result<()> {
     };
     let mut client = NimbusClient::new(
         app_context.clone(),
+        Default::default(),
         temp_dir.path(),
         None,
         AvailableRandomizationUnits {

--- a/components/nimbus/src/tests/stateless/test_cirrus_client.rs
+++ b/components/nimbus/src/tests/stateless/test_cirrus_client.rs
@@ -20,6 +20,7 @@ fn create_client() -> Result<CirrusClient> {
             custom_targeting_attributes: None,
         })
         .unwrap(),
+        Default::default(),
     )
 }
 

--- a/components/nimbus/tests/common/mod.rs
+++ b/components/nimbus/tests/common/mod.rs
@@ -43,7 +43,7 @@ fn new_test_client_internal(
         locale: Some("en-GB".to_string()),
         ..Default::default()
     };
-    NimbusClient::new(ctx, tmp_dir.path(), Some(config), aru)
+    NimbusClient::new(ctx, Default::default(), tmp_dir.path(), Some(config), aru)
 }
 
 use nimbus::persistence::{Database, SingleStore};

--- a/components/nimbus/tests/test_fs_client.rs
+++ b/components/nimbus/tests/test_fs_client.rs
@@ -31,7 +31,13 @@ fn test_simple() -> Result<()> {
 
     let tmp_dir = tempfile::tempdir()?;
     let aru = Default::default();
-    let client = NimbusClient::new(Default::default(), tmp_dir.path(), Some(config), aru)?;
+    let client = NimbusClient::new(
+        Default::default(),
+        Default::default(),
+        tmp_dir.path(),
+        Some(config),
+        aru,
+    )?;
     client.fetch_experiments()?;
     client.apply_pending_experiments()?;
 


### PR DESCRIPTION
Fixes [EXP-3623](https://mozilla-hub.atlassian.net/browse/EXP-3623).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
