### PR TITLE
Revert "Remove support for migrating from pre-app-services fxaccount …

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/PersistedFirefoxAccount.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/PersistedFirefoxAccount.kt
@@ -6,6 +6,7 @@ package mozilla.appservices.fxaclient
 
 import android.util.Log
 import mozilla.appservices.sync15.DeviceType
+import org.json.JSONObject
 
 /**
  * PersistedFirefoxAccount represents the authentication state of a client.
@@ -286,6 +287,75 @@ class PersistedFirefoxAccount(inner: FirefoxAccount, persistCallback: PersistCal
      */
     fun clearAccessTokenCache() {
         this.inner.clearAccessTokenCache()
+    }
+
+    /**
+     * Migrate from a logged-in Firefox Account, takes ownership of the provided session token.
+     *
+     * Modifies the FirefoxAccount state.
+     * @param sessionToken 64 character string of hex-encoded bytes
+     * @param kSync 128 character string of hex-encoded bytes
+     * @param kXCS 32 character string of hex-encoded bytes
+     * @return JSONObject JSON object with the result of the migration
+     * This performs network requests, and should not be used on the main thread.
+     */
+    fun migrateFromSessionToken(sessionToken: String, kSync: String, kXCS: String): JSONObject {
+        try {
+            val res = this.inner.migrateFromSessionToken(sessionToken, kSync, kXCS, false)
+            return JSONObject(mapOf("total_duration" to res.totalDuration))
+        } finally {
+            // Even a failed migration might alter the persisted account state, if it's able to be retried.
+            // It's safe to call this unconditionally, as the underlying code will not leave partial states.
+            this.tryPersistState()
+        }
+    }
+
+    /**
+     * Migrate from a logged-in Firefox Account, takes ownership of the provided session token.
+     *
+     * @return bool Returns a boolean if we are in a migration state
+     */
+    fun isInMigrationState(): MigrationState {
+        return this.inner.isInMigrationState()
+    }
+
+    /**
+     * Copy a logged-in session of a Firefox Account, creates a new session token in the process.
+     *
+     * Modifies the FirefoxAccount state.
+     * @param sessionToken 64 character string of hex-encoded bytes
+     * @param kSync 128 character string of hex-encoded bytes
+     * @param kXCS 32 character string of hex-encoded bytes
+     * @return JSONObject JSON object with the result of the migration
+     * This performs network requests, and should not be used on the main thread.
+     */
+    fun copyFromSessionToken(sessionToken: String, kSync: String, kXCS: String): JSONObject {
+        try {
+            val res = this.inner.migrateFromSessionToken(sessionToken, kSync, kXCS, true)
+            return JSONObject(mapOf("total_duration" to res.totalDuration))
+        } finally {
+            // Even a failed migration might alter the persisted account state, if it's able to be retried.
+            // It's safe to call this unconditionally, as the underlying code will not leave partial states.
+            this.tryPersistState()
+        }
+    }
+
+    /**
+     * Retry migration from a logged-in Firefox Account.
+     *
+     * Modifies the FirefoxAccount state.
+     * @return JSONObject JSON object with the result of the migration
+     * This performs network requests, and should not be used on the main thread.
+     */
+    fun retryMigrateFromSessionToken(): JSONObject {
+        try {
+            val res = this.inner.retryMigrateFromSessionToken()
+            return JSONObject(mapOf("total_duration" to res.totalDuration))
+        } finally {
+            // A failure her might alter the persisted account state, if we discover a permanent migration failure.
+            // It's safe to call this unconditionally, as the underlying code will not leave partial states.
+            this.tryPersistState()
+        }
     }
 
     /**

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -9,11 +9,8 @@ public extension Notification.Name {
     static let accountAuthProblems = Notification.Name("accountAuthProblems")
     static let accountAuthenticated = Notification.Name("accountAuthenticated")
     static let accountProfileUpdate = Notification.Name("accountProfileUpdate")
+    static let accountMigrationFailed = Notification.Name("accountMigrationFailed")
 }
-
-// A place-holder for now removed migration support. This can be removed once
-// https://github.com/mozilla-mobile/firefox-ios/issues/15258 has been resolved.
-public enum MigrationResult {}
 
 // swiftlint:disable type_body_length
 open class FxAccountManager {
@@ -71,7 +68,8 @@ open class FxAccountManager {
     public func hasAccount() -> Bool {
         return state == .authenticatedWithProfile ||
             state == .authenticatedNoProfile ||
-            state == .authenticationProblem
+            state == .authenticationProblem ||
+            state == .canAutoretryMigration
     }
 
     /// Resets the inner Persisted Account based on the persisted state
@@ -88,6 +86,12 @@ open class FxAccountManager {
     /// Your app should present the option to start a new OAuth flow.
     public func accountNeedsReauth() -> Bool {
         return state == .authenticationProblem
+    }
+
+    /// Returns true if there is a migration in-flight.
+    /// The caller should then call `retryMigration`.
+    public func accountMigrationInFlight() -> Bool {
+        return state == .canAutoretryMigration
     }
 
     /// Begins a new authentication flow.
@@ -158,19 +162,36 @@ open class FxAccountManager {
         }
     }
 
-    // A no-op place-holder for now removed support for migrating from a pre-rust
-    // session token into a rust fxa-client. This stub remains to avoid causing
-    // a breaking change for iOS and can be removed after https://github.com/mozilla-mobile/firefox-ios/issues/15258
-    // has been resolved.
+    /// Use the provided user account information to sign-in without any user interaction.
     public func authenticateViaMigration(
-        sessionToken _: String,
-        kSync _: String,
-        kXCS _: String,
-        completionHandler _: @escaping (MigrationResult) -> Void
+        sessionToken: String,
+        kSync: String,
+        kXCS: String,
+        completionHandler: @escaping (MigrationResult) -> Void
     ) {
-        // This will almost certainly never be called in practice. If it is, I guess
-        // trying to force iOS into a "needs auth" state is the right thing to do...
-        processEvent(event: .authenticationError) {}
+        processEvent(event: .authenticateViaMigration(sessionToken: sessionToken, kSync: kSync, kXCS: kXCS)) {
+            if self.accountMigrationInFlight() {
+                completionHandler(.willRetry)
+            } else if self.hasAccount() {
+                completionHandler(.success)
+            } else {
+                completionHandler(.failure)
+            }
+        }
+    }
+
+    /// If `accountMigrationInFlight` returns true, this function should be called
+    /// on a regular basic by the caller.
+    public func retryMigration(completionHandler: @escaping (MigrationResult) -> Void) {
+        processEvent(event: .retryMigration) {
+            if self.accountMigrationInFlight() {
+                completionHandler(.willRetry)
+            } else if self.hasAccount() {
+                completionHandler(.success)
+            } else {
+                completionHandler(.failure)
+            }
+        }
     }
 
     /// Finish an authentication flow.
@@ -347,7 +368,13 @@ open class FxAccountManager {
                 case .initialize: do {
                         if let acct = tryRestoreAccount() {
                             account = acct
-                            return .accountRestored
+                            if !acct.isInMigrationState() {
+                                return .accountRestored
+                            } else {
+                                // We may have attempted a migration previously, which failed
+                                // in a way that allows us to retry it.
+                                return .inFlightMigration
+                            }
                         } else {
                             return .accountNotFound
                         }
@@ -376,7 +403,45 @@ open class FxAccountManager {
                 case .accountNotFound: do {
                         account = createAccount()
                     }
+                case let .authenticateViaMigration(sessionToken, kSync, kXCS): do {
+                        let acct = requireAccount()
+                        FxALog.info("Registering persistence callback")
+                        acct.registerPersistCallback(statePersistenceCallback)
+
+                        if acct.migrateFromSessionToken(
+                            sessionToken: sessionToken,
+                            kSync: kSync,
+                            kXCS: kXCS,
+                            copySessionToken: false
+                        ) {
+                            return .authenticatedViaMigration
+                        }
+                        if acct.isInMigrationState() {
+                            return .retryMigrationLater
+                        }
+                    }
                 default: break // Do nothing
+                }
+            }
+        case .canAutoretryMigration: do {
+                switch via {
+                case .retryMigration, .inFlightMigration: do {
+                        let acct = requireAccount()
+                        FxALog.info("Registering persistence callback")
+                        acct.registerPersistCallback(statePersistenceCallback)
+
+                        // Case 1: Success!
+                        if acct.retryMigrateFromSessionToken() {
+                            return .authenticatedViaMigration
+                        }
+                        // Case 2: Transient error, we can still retry later.
+                        if acct.isInMigrationState() {
+                            return .retryMigrationLater
+                        }
+                        // Case 3: Non-recoverable error, at this point there's nothing we can do.
+                        return .migrationFailure
+                    }
+                default: break // Do Nothing
                 }
             }
         case .authenticatedNoProfile: do {
@@ -415,6 +480,19 @@ open class FxAccountManager {
                         requireConstellation().ensureCapabilities(capabilities: deviceConfig.capabilities)
 
                         postAuthenticated(authType: .existingAccount)
+
+                        return Event.fetchProfile(ignoreCache: false)
+                    }
+                case .authenticatedViaMigration: do {
+                        // Note that we are not registering an account persistence callback here like
+                        // we do in other `.authenticatedNoProfile` cases, because it would have been
+                        // already registered while handling any of the precursor events, such as
+                        // `.authenticateViaMigration`, `.retryMigration` or `.inFlightMigration`
+                        FxALog.info("Ensuring device capabilities...")
+                        // At the minimum, we need to ensure the device capabilities.
+                        requireConstellation().ensureCapabilities(capabilities: deviceConfig.capabilities)
+
+                        postAuthenticated(authType: .migrated)
 
                         return Event.fetchProfile(ignoreCache: false)
                     }
@@ -625,6 +703,7 @@ public enum FxaAuthType {
     case signup
     case pairing
     case recovered
+    case migrated
     case other(reason: String)
 
     internal static func fromActionQueryParam(_ action: String) -> FxaAuthType {

--- a/components/fxa-client/ios/FxAClient/FxAccountMigration.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountMigration.swift
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+public enum MigrationResult {
+    // Sign-in failed due to an intermittent problem (such as a network failure). A retry attempt will
+    // be performed automatically during account manager initialization.
+    // The app should try to do the same regularly (e.g. before syncing).
+    case willRetry
+    // Sign-in succeeded with no issues.
+    // Applications may treat this account as "authenticated" after seeing this result.
+    case success
+    // Sign-in failed due to non-recoverable issues.
+    case failure
+}

--- a/components/fxa-client/ios/FxAClient/FxAccountState.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountState.swift
@@ -13,6 +13,7 @@ internal enum AccountState {
     case authenticationProblem
     case authenticatedNoProfile
     case authenticatedWithProfile
+    case canAutoretryMigration
 }
 
 /**
@@ -23,18 +24,29 @@ internal enum Event {
     case initialize
     case accountNotFound
     case accountRestored
+    case authenticateViaMigration(
+        sessionToken: String,
+        kSync: String,
+        kXCS: String
+    )
     case changedPassword(newSessionToken: String)
     case authenticated(authData: FxaAuthData)
+    case authenticatedViaMigration
     case authenticationError /* (error: AuthException) */
     case recoveredFromAuthenticationProblem
     case fetchProfile(ignoreCache: Bool)
     case fetchedProfile
     case failedToFetchProfile
     case logout
+    case inFlightMigration
+    case retryMigrationLater
+    case retryMigration
+    case migrationFailure
 }
 
 extension FxAccountManager {
     // State transition matrix. Returns nil if there's no transition.
+    // swiftlint:disable function_body_length
     static func nextState(state: AccountState, event: Event) -> AccountState? {
         switch state {
         case .start:
@@ -42,11 +54,24 @@ extension FxAccountManager {
             case .initialize: return .start
             case .accountNotFound: return .notAuthenticated
             case .accountRestored: return .authenticatedNoProfile
+            case .inFlightMigration: return .canAutoretryMigration
             default: return nil
             }
         case .notAuthenticated:
             switch event {
             case .authenticated: return .authenticatedNoProfile
+            case .authenticateViaMigration: return .notAuthenticated
+            case .authenticatedViaMigration: return .authenticatedNoProfile
+            case .retryMigrationLater: return .canAutoretryMigration
+            default: return nil
+            }
+        case .canAutoretryMigration:
+            switch event {
+            case .retryMigration: return .canAutoretryMigration
+            case .authenticatedViaMigration: return .authenticatedNoProfile
+            case .retryMigrationLater: return .canAutoretryMigration
+            case .logout: return .notAuthenticated
+            case .migrationFailure: return .notAuthenticated
             default: return nil
             }
         case .authenticatedNoProfile:
@@ -77,4 +102,6 @@ extension FxAccountManager {
             }
         }
     }
+
+    // swiftlint:enable function_body_length
 }

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -656,6 +656,57 @@ interface FirefoxAccount {
   //
   [Throws=FxaError]
   string gather_telemetry();
+  
+
+  // Sign in by using legacy session-token state.
+  //
+  // **💾 This method alters the persisted account state.**
+  //
+  // When migrating to use the FxA client component, create a [`FirefoxAccount`] instance
+  // and then pass any legacy sign-in state to this method. It will attempt to use the
+  // session token to bootstrap a full internal state of OAuth tokens, and will store the
+  // provided credentials internally in case it needs to retry after e.g. a network failure.
+  //
+  // # Arguments
+  //
+  //    - `session_token` - the session token from legacy sign-in state
+  //    - `k_sync` - the Firefox Sync encryption key from legacy sign-in state
+  //    - `k_xcs` - the Firefox Sync "X-Client-State: value from legacy sign-in state
+  //    - `copy_session_token` - if true, copy the given session token rather than using it directly
+  //
+  // # Notes
+  //
+  //    - If successful, this method will return an [`FxAMigrationResult`] with some statistics
+  //      about the migration process.
+  //    - If unsuccessful this method will throw an error, but you may be able to retry the
+  //      migration again at a later time.
+  //    - Use [is_in_migration_state](FirefoxAccount::is_in_migration_state) to check whether the
+  //      persisted account state includes a a pending migration that can be retried.
+  //
+  [Throws=FxaError]
+  FxAMigrationResult migrate_from_session_token([ByRef] string session_token, [ByRef] string k_sync, [ByRef] string k_xcs,  boolean copy_session_token );
+  
+
+  // Retry a previously failed migration from legacy session-token state.
+  //
+  // **💾 This method alters the persisted account state.**
+  //
+  // If an earlier call to [`migrate_from_session_token`](FirefoxAccount::migrate_from_session_token)
+  // failed, it may have stored the provided state for retrying at a later time. Call this method
+  // in order to execute such a retry.
+  //
+  [Throws=FxaError]
+  FxAMigrationResult retry_migrate_from_session_token();
+  
+
+  // Check for a previously failed migration from legacy session-token state.
+  //
+  // If an earlier call to [`migrate_from_session_token`](FirefoxAccount::migrate_from_session_token)
+  // failed, it may have stored the provided state for retrying at a later time. Call this method
+  // in check whether such state exists, then retry at an appropriate time.
+  //
+  MigrationState is_in_migration_state();
+  
 };
 
 dictionary FxaConfig {
@@ -891,6 +942,22 @@ dictionary Profile {
   boolean is_default_avatar;
 };
 
+// Statistics about the completion of a migration from legacy sign-in data.
+//
+// Applications migrating from legacy sign-in data would typically want to
+// report telemetry about whether and how that succeeded, and can use the
+// results reported in this struct to help do so.
+//
+dictionary FxAMigrationResult {
+
+  // The time taken to migrate, in milliseconds.
+  //
+  // Note that this is a signed integer, for compatibility with languages
+  // that do not have unsigned integers.
+  i64 total_duration;
+};
+
+
 // A "capability" offered by a device.
 //
 // In the FxA ecosystem, connected devices may advertize their ability to respond
@@ -976,4 +1043,24 @@ interface IncomingDeviceCommand {
 
   // Indicates that a tab has been sent to this device.
   TabReceived(Device? sender, SendTabPayload payload );
+};
+
+
+// The current state migration from legacy sign-in data.
+//
+// This enum distinguishes the different states of a potential in-flight
+// migration from legacy sign-in data. A value other than [`None`](MigrationState::None)
+// indicates that there was a previously-failed migration that should be
+// retried.
+//
+enum MigrationState {
+
+  // No in-flight migration.
+  "None",
+
+  // An in-flight migration that will copy the sessionToken.
+  "CopySessionToken",
+
+  // An in-flight migration that will re-use the sessionToken.
+  "ReuseSessionToken",
 };

--- a/components/fxa-client/src/internal/migrator.rs
+++ b/components/fxa-client/src/internal/migrator.rs
@@ -1,0 +1,369 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::{scopes, FirefoxAccount};
+use crate::{Error, FxAMigrationResult, MigrationState, Result, ScopedKey};
+use serde_derive::*;
+use std::time::Instant;
+
+// Migration-related data that we may need to serialize in the persisted account state.
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct MigrationData {
+    k_xcs: String,
+    k_sync: String,
+    copy_session_token: bool,
+    session_token: String,
+}
+
+impl FirefoxAccount {
+    /// Migrate from a logged-in with a sessionToken Firefox Account.
+    ///
+    /// * `session_token` - Hex-formatted session token.
+    /// * `k_xcs` - Hex-formatted kXCS.
+    /// * `k_sync` - Hex-formatted kSync.
+    /// * `copy_session_token` - If true then the provided 'session_token' will be duplicated
+    ///     and the resulting session will use a new session token. If false, the provided
+    ///     token will be reused.
+    ///
+    /// This method remembers the provided token details and may persist them in the
+    /// account state if it encounters a temporary failure such as a network error.
+    /// Calling code is expected to store the updated state even if an error is thrown.
+    ///
+    /// **💾 This method alters the persisted account state.**
+    pub fn migrate_from_session_token(
+        &mut self,
+        session_token: &str,
+        k_sync: &str,
+        k_xcs: &str,
+        copy_session_token: bool,
+    ) -> Result<FxAMigrationResult> {
+        // if there is already a session token on account, we error out.
+        if self.state.session_token.is_some() {
+            return Err(Error::IllegalState("Session Token is already set."));
+        }
+
+        self.state.in_flight_migration = Some(MigrationData {
+            k_sync: k_sync.to_string(),
+            k_xcs: k_xcs.to_string(),
+            copy_session_token,
+            session_token: session_token.to_string(),
+        });
+
+        self.try_migration()
+    }
+
+    /// Check if the client is in a pending migration state
+    pub fn is_in_migration_state(&self) -> MigrationState {
+        match self.state.in_flight_migration {
+            None => MigrationState::None,
+            Some(MigrationData {
+                copy_session_token: true,
+                ..
+            }) => MigrationState::CopySessionToken,
+            Some(MigrationData {
+                copy_session_token: false,
+                ..
+            }) => MigrationState::ReuseSessionToken,
+        }
+    }
+
+    pub fn try_migration(&mut self) -> Result<FxAMigrationResult> {
+        let import_start = Instant::now();
+
+        match self.network_migration() {
+            Ok(_) => {}
+            Err(err) => {
+                match err {
+                    Error::RemoteError {
+                        code: 500..=599, ..
+                    }
+                    | Error::RemoteError { code: 429, .. }
+                    | Error::RequestError(_) => {
+                        // network errors that will allow hopefully migrate later
+                        log::warn!("Network error: {:?}", err);
+                        return Err(err);
+                    }
+                    _ => {
+                        // probably will not recover
+
+                        self.state.in_flight_migration = None;
+
+                        return Err(err);
+                    }
+                };
+            }
+        }
+
+        self.state.in_flight_migration = None;
+
+        let metrics = FxAMigrationResult {
+            // The foreign-language bindings are limited to an i64.
+            total_duration: i64::try_from(import_start.elapsed().as_secs()).unwrap_or(i64::MAX),
+        };
+
+        Ok(metrics)
+    }
+
+    fn network_migration(&mut self) -> Result<()> {
+        let migration_data = match self.state.in_flight_migration {
+            Some(ref data) => data.clone(),
+            None => {
+                return Err(Error::NoMigrationData);
+            }
+        };
+
+        // If we need to copy the sessionToken, do that first so we can use it
+        // for subsequent requests. TODO: we should store the duplicated token
+        // in the account state in case we fail in later steps, but need to remember
+        // the original value of `copy_session_token` if we do so.
+        let migration_session_token = if migration_data.copy_session_token {
+            let duplicate_session = self
+                .client
+                .duplicate_session_token(&self.state.config, &migration_data.session_token)?;
+
+            duplicate_session.session_token
+        } else {
+            migration_data.session_token.to_string()
+        };
+
+        // Synthesize a scoped key from our kSync.
+        // Do this before creating OAuth tokens because it doesn't have any side-effects,
+        // so it's low-consequence if we fail in later steps.
+        let k_sync = hex::decode(&migration_data.k_sync)?;
+        let k_sync = base64::encode_config(k_sync, base64::URL_SAFE_NO_PAD);
+        let k_xcs = hex::decode(&migration_data.k_xcs)?;
+        let k_xcs = base64::encode_config(k_xcs, base64::URL_SAFE_NO_PAD);
+        let scoped_key_data = self.client.get_scoped_key_data(
+            &self.state.config,
+            &migration_session_token,
+            &self.state.config.client_id,
+            scopes::OLD_SYNC,
+        )?;
+        let oldsync_key_data = scoped_key_data
+            .get(scopes::OLD_SYNC)
+            .ok_or(Error::IllegalState(
+                "The session token doesn't have access to kSync!",
+            ))?;
+        let kid = format!("{}-{}", oldsync_key_data.key_rotation_timestamp, k_xcs);
+        let k_sync_scoped_key = ScopedKey {
+            kty: "oct".to_string(),
+            scope: scopes::OLD_SYNC.to_string(),
+            k: k_sync,
+            kid,
+        };
+
+        // Trade our session token for a refresh token.
+        let oauth_response = self.client.create_refresh_token_using_session_token(
+            &self.state.config,
+            &migration_session_token,
+            &[scopes::PROFILE, scopes::OLD_SYNC],
+        )?;
+
+        // Store the new tokens in the account state.
+        // We do this all at one at the end to avoid leaving partial state.
+        self.state.session_token = Some(migration_session_token);
+        self.handle_oauth_response(oauth_response, None)?;
+        self.state
+            .scoped_keys
+            .insert(scopes::OLD_SYNC.to_string(), k_sync_scoped_key);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::internal::{http_client::*, Config};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn setup() -> FirefoxAccount {
+        // I'd love to be able to configure a single mocked client here,
+        // but can't work out how to do that within the typesystem.
+        let config = Config::stable_dev("12345678", "https://foo.bar");
+        FirefoxAccount::with_config(config)
+    }
+
+    #[test]
+    fn test_migration_can_retry_after_network_errors() {
+        let mut fxa = setup();
+
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
+
+        // Initial attempt fails with a server-side failure, which we can retry.
+        let mut client = FxAClientMock::new();
+        client
+            .expect_duplicate_session_token(mockiato::Argument::any, |arg| {
+                arg.partial_eq("session")
+            })
+            .returns_once(Err(Error::RemoteError {
+                code: 500,
+                errno: 999,
+                error: "server error".to_string(),
+                message: "there was a server error".to_string(),
+                info: "fyi, there was a server error".to_string(),
+            }));
+        fxa.set_client(Arc::new(client));
+
+        let err = fxa
+            .migrate_from_session_token("session", "aabbcc", "ddeeff", true)
+            .unwrap_err();
+        assert!(matches!(err, Error::RemoteError { code: 500, .. }));
+        assert!(matches!(
+            fxa.is_in_migration_state(),
+            MigrationState::CopySessionToken
+        ));
+
+        // Retrying can succeed.
+        // It makes a lot of network requests, so we have a lot to mock!
+        let mut client = FxAClientMock::new();
+        client
+            .expect_duplicate_session_token(mockiato::Argument::any, |arg| {
+                arg.partial_eq("session")
+            })
+            .returns_once(Ok(DuplicateTokenResponse {
+                uid: "userid".to_string(),
+                session_token: "dup_session".to_string(),
+                verified: true,
+                auth_at: 12345,
+            }));
+        let mut key_data = HashMap::new();
+        key_data.insert(
+            scopes::OLD_SYNC.to_string(),
+            ScopedKeyDataResponse {
+                identifier: scopes::OLD_SYNC.to_string(),
+                key_rotation_secret: "00000000000000000000000000000000".to_string(),
+                key_rotation_timestamp: 12345,
+            },
+        );
+        client
+            .expect_get_scoped_key_data(
+                mockiato::Argument::any,
+                |arg| arg.partial_eq("dup_session"),
+                |arg| arg.partial_eq("12345678"),
+                |arg| arg.partial_eq(scopes::OLD_SYNC),
+            )
+            .returns_once(Ok(key_data));
+        client
+            .expect_create_refresh_token_using_session_token(
+                mockiato::Argument::any,
+                |arg| arg.partial_eq("dup_session"),
+                |arg| arg.unordered_vec_eq([scopes::PROFILE, scopes::OLD_SYNC].to_vec()),
+            )
+            .returns_once(Ok(OAuthTokenResponse {
+                keys_jwe: None,
+                refresh_token: Some("refresh".to_string()),
+                session_token: None,
+                expires_in: 12345,
+                scope: "profile oldsync".to_string(),
+                access_token: "access".to_string(),
+            }));
+        client
+            .expect_destroy_access_token(mockiato::Argument::any, |arg| arg.partial_eq("access"))
+            .returns_once(Ok(()));
+        fxa.set_client(Arc::new(client));
+
+        fxa.try_migration().unwrap();
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
+    }
+
+    #[test]
+    fn test_migration_cannot_retry_after_other_errors() {
+        let mut fxa = setup();
+
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
+
+        let mut client = FxAClientMock::new();
+        client
+            .expect_duplicate_session_token(mockiato::Argument::any, |arg| {
+                arg.partial_eq("session")
+            })
+            .returns_once(Err(Error::RemoteError {
+                code: 400,
+                errno: 102,
+                error: "invalid token".to_string(),
+                message: "the token was invalid".to_string(),
+                info: "fyi, the provided token was invalid".to_string(),
+            }));
+        fxa.set_client(Arc::new(client));
+
+        let err = fxa
+            .migrate_from_session_token("session", "aabbcc", "ddeeff", true)
+            .unwrap_err();
+        assert!(matches!(err, Error::RemoteError { code: 400, .. }));
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
+    }
+
+    #[test]
+    fn try_migration_fails_if_nothing_in_flight() {
+        let mut fxa = setup();
+
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
+
+        let err = fxa.try_migration().unwrap_err();
+        assert!(matches!(err, Error::NoMigrationData));
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
+    }
+
+    #[test]
+    fn test_migration_state_remembers_whether_to_copy_session_token() {
+        let mut fxa = setup();
+
+        assert!(matches!(fxa.is_in_migration_state(), MigrationState::None));
+
+        let mut client = FxAClientMock::new();
+        client
+            .expect_get_scoped_key_data(
+                mockiato::Argument::any,
+                |arg| arg.partial_eq("session"),
+                |arg| arg.partial_eq("12345678"),
+                |arg| arg.partial_eq(scopes::OLD_SYNC),
+            )
+            .returns_once(Err(Error::RemoteError {
+                code: 500,
+                errno: 999,
+                error: "server error".to_string(),
+                message: "there was a server error".to_string(),
+                info: "fyi, there was a server error".to_string(),
+            }));
+        fxa.set_client(Arc::new(client));
+
+        let err = fxa
+            .migrate_from_session_token("session", "aabbcc", "ddeeff", false)
+            .unwrap_err();
+        assert!(matches!(err, Error::RemoteError { code: 500, .. }));
+        assert!(matches!(
+            fxa.is_in_migration_state(),
+            MigrationState::ReuseSessionToken
+        ));
+
+        // Retrying should fail again in the same way (as opposed to, say, trying
+        // to duplicate the sessionToken rather than reusing it).
+        let mut client = FxAClientMock::new();
+        client
+            .expect_get_scoped_key_data(
+                mockiato::Argument::any,
+                |arg| arg.partial_eq("session"),
+                |arg| arg.partial_eq("12345678"),
+                |arg| arg.partial_eq(scopes::OLD_SYNC),
+            )
+            .returns_once(Err(Error::RemoteError {
+                code: 500,
+                errno: 999,
+                error: "server error".to_string(),
+                message: "there was a server error".to_string(),
+                info: "fyi, there was a server error".to_string(),
+            }));
+        fxa.set_client(Arc::new(client));
+
+        let err = fxa.try_migration().unwrap_err();
+        assert!(matches!(err, Error::RemoteError { code: 500, .. }));
+        assert!(matches!(
+            fxa.is_in_migration_state(),
+            MigrationState::ReuseSessionToken
+        ));
+    }
+}

--- a/components/fxa-client/src/internal/mod.rs
+++ b/components/fxa-client/src/internal/mod.rs
@@ -25,6 +25,7 @@ mod commands;
 pub mod config;
 pub mod device;
 mod http_client;
+mod migrator;
 mod oauth;
 mod profile;
 mod push;
@@ -84,6 +85,7 @@ impl FirefoxAccount {
             current_device_id: None,
             last_seen_profile: None,
             access_token_cache: HashMap::new(),
+            in_flight_migration: None,
         })
     }
 

--- a/components/fxa-client/src/internal/state_persistence.rs
+++ b/components/fxa-client/src/internal/state_persistence.rs
@@ -35,6 +35,7 @@ use std::collections::{HashMap, HashSet};
 use super::{
     config::Config,
     device::Capability as DeviceCapability,
+    migrator::MigrationData,
     oauth::{AccessTokenInfo, RefreshToken},
     profile::Profile,
     CachedResponse, Result,
@@ -105,6 +106,7 @@ pub(crate) struct StateV2 {
     pub(crate) access_token_cache: HashMap<String, AccessTokenInfo>,
     pub(crate) session_token: Option<String>, // Hex-formatted string.
     pub(crate) last_seen_profile: Option<CachedResponse<Profile>>,
+    pub(crate) in_flight_migration: Option<MigrationData>,
 }
 
 impl StateV2 {
@@ -127,6 +129,7 @@ impl StateV2 {
             access_token_cache: HashMap::new(),
             device_capabilities: HashSet::new(),
             session_token: None,
+            in_flight_migration: None,
         }
     }
 }

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -41,6 +41,7 @@ mod auth;
 mod device;
 mod error;
 mod internal;
+mod migration;
 mod profile;
 mod push;
 mod storage;
@@ -50,6 +51,7 @@ mod token;
 pub use auth::{AuthorizationInfo, MetricsParams};
 pub use device::{AttachedClient, Device, DeviceCapability};
 pub use error::{Error, FxaError};
+pub use migration::{FxAMigrationResult, MigrationState};
 use parking_lot::Mutex;
 pub use profile::Profile;
 pub use push::{

--- a/components/fxa-client/src/migration.rs
+++ b/components/fxa-client/src/migration.rs
@@ -1,0 +1,109 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! # Migration Support Methods
+//!
+//! Some applications may have existing signed-in account state from a bespoke implementation
+//! of the Firefox Accounts signin protocol, but want to move to using this component in order
+//! to reduce maintenance costs.
+//!
+//! The sign-in state for a legacy FxA integration would typically consist of a session token
+//! and a pair of cryptographic keys used for accessing Firefox Sync. The methods in this section
+//! can be used to help migrate from such legacy state into state that's suitable for use with
+//! this component.
+
+use crate::{ApiResult, Error, FirefoxAccount};
+use error_support::handle_error;
+
+impl FirefoxAccount {
+    /// Sign in by using legacy session-token state.
+    ///
+    /// **💾 This method alters the persisted account state.**
+    ///
+    /// When migrating to use the FxA client component, create a [`FirefoxAccount`] instance
+    /// and then pass any legacy sign-in state to this method. It will attempt to use the
+    /// session token to bootstrap a full internal state of OAuth tokens, and will store the
+    /// provided credentials internally in case it needs to retry after e.g. a network failure.
+    ///
+    /// # Arguments
+    ///
+    ///    - `session_token` - the session token from legacy sign-in state
+    ///    - `k_sync` - the Firefox Sync encryption key from legacy sign-in state
+    ///    - `k_xcs` - the Firefox Sync "X-Client-State: value from legacy sign-in state
+    ///    - `copy_session_token` - if true, copy the given session token rather than using it directly
+    ///
+    /// # Notes
+    ///
+    ///    - If successful, this method will return an [`FxAMigrationResult`] with some statistics
+    ///      about the migration process.
+    ///    - If unsuccessful this method will throw an error, but you may be able to retry the
+    ///      migration again at a later time.
+    ///    - Use [is_in_migration_state](FirefoxAccount::is_in_migration_state) to check whether the
+    ///      persisted account state includes a pending migration that can be retried.
+    #[handle_error(Error)]
+    pub fn migrate_from_session_token(
+        &self,
+        session_token: &str,
+        k_sync: &str,
+        k_xcs: &str,
+        copy_session_token: bool,
+    ) -> ApiResult<FxAMigrationResult> {
+        self.internal.lock().migrate_from_session_token(
+            session_token,
+            k_sync,
+            k_xcs,
+            copy_session_token,
+        )
+    }
+
+    /// Retry a previously failed migration from legacy session-token state.
+    ///
+    /// **💾 This method alters the persisted account state.**
+    ///
+    /// If an earlier call to [`migrate_from_session_token`](FirefoxAccount::migrate_from_session_token)
+    /// failed, it may have stored the provided state for retrying at a later time. Call this method
+    /// in order to execute such a retry.
+    #[handle_error(Error)]
+    pub fn retry_migrate_from_session_token(&self) -> ApiResult<FxAMigrationResult> {
+        self.internal.lock().try_migration()
+    }
+
+    /// Check for a previously failed migration from legacy session-token state.
+    ///
+    /// If an earlier call to [`migrate_from_session_token`](FirefoxAccount::migrate_from_session_token)
+    /// failed, it may have stored the provided state for retrying at a later time. Call this method
+    /// in check whether such state exists, then retry at an appropriate time.
+    pub fn is_in_migration_state(&self) -> MigrationState {
+        self.internal.lock().is_in_migration_state()
+    }
+}
+
+/// The current state migration from legacy sign-in data.
+///
+/// This enum distinguishes the different states of a potential in-flight
+/// migration from legacy sign-in data. A value other than [`None`](MigrationState::None)
+/// indicates that there was a previously-failed migration that should be
+/// retried.
+pub enum MigrationState {
+    /// No in-flight migration.
+    None,
+    /// An in-flight migration that will copy the sessionToken.
+    CopySessionToken,
+    /// An in-flight migration that will re-use the sessionToken.
+    ReuseSessionToken,
+}
+
+/// Statistics about the completion of a migration from legacy sign-in data.
+///
+/// Applications migrating from legacy sign-in data would typically want to
+/// report telemetry about whether and how that succeeded, and can use the
+/// results reported in this struct to help do so.
+#[derive(Debug)]
+pub struct FxAMigrationResult {
+    /// The time taken to migrate, in milliseconds.
+    ///
+    /// Note that this is a signed integer, for compatibility with languages
+    /// that do not have unsigned integers.
+    pub total_duration: i64,
+}

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		1BE9B61027C9CD770029D11A /* logins.udl in Sources */ = {isa = PBXBuildFile; fileRef = 1B58D8A627AE12850075168B /* logins.udl */; };
 		1BE9B61127C9CD770029D11A /* fxa_client.udl in Sources */ = {isa = PBXBuildFile; fileRef = 1BB9C31F27B4924D001E5BBF /* fxa_client.udl */; };
 		1BF50F0C27B1E17B00A9C8A5 /* KeychainWrapper+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAC56727AE085F00DAFEF2 /* KeychainWrapper+.swift */; };
+		1BF50F0D27B1E17B00A9C8A5 /* FxAccountMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAC56E27AE085F00DAFEF2 /* FxAccountMigration.swift */; };
 		1BF50F0E27B1E17B00A9C8A5 /* FxAccountLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAC56C27AE085F00DAFEF2 /* FxAccountLogging.swift */; };
 		1BF50F0F27B1E17B00A9C8A5 /* FxAccountOAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAC56827AE085F00DAFEF2 /* FxAccountOAuth.swift */; };
 		1BF50F1027B1E17B00A9C8A5 /* FxAccountStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBAC56927AE085F00DAFEF2 /* FxAccountStorage.swift */; };
@@ -167,6 +168,7 @@
 		1BBAC56B27AE085F00DAFEF2 /* FxAccountManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FxAccountManager.swift; path = "../../../components/fxa-client/ios/FxAClient/FxAccountManager.swift"; sourceTree = SOURCE_ROOT; };
 		1BBAC56C27AE085F00DAFEF2 /* FxAccountLogging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FxAccountLogging.swift; path = "../../../components/fxa-client/ios/FxAClient/FxAccountLogging.swift"; sourceTree = SOURCE_ROOT; };
 		1BBAC56D27AE085F00DAFEF2 /* FxAccountConfig.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FxAccountConfig.swift; path = "../../../components/fxa-client/ios/FxAClient/FxAccountConfig.swift"; sourceTree = SOURCE_ROOT; };
+		1BBAC56E27AE085F00DAFEF2 /* FxAccountMigration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FxAccountMigration.swift; path = "../../../components/fxa-client/ios/FxAClient/FxAccountMigration.swift"; sourceTree = SOURCE_ROOT; };
 		1BBAC58627AE09C600DAFEF2 /* LoginsStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LoginsStorage.swift; path = ../../../components/logins/ios/Logins/LoginsStorage.swift; sourceTree = SOURCE_ROOT; };
 		1BBAC5A527AE0F2E00DAFEF2 /* Bookmark.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Bookmark.swift; path = ../../../components/places/ios/Places/Bookmark.swift; sourceTree = SOURCE_ROOT; };
 		1BBAC5A627AE0F2E00DAFEF2 /* HistoryMetadata.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HistoryMetadata.swift; path = ../../../components/places/ios/Places/HistoryMetadata.swift; sourceTree = SOURCE_ROOT; };
@@ -410,6 +412,7 @@
 				1BBAC56B27AE085F00DAFEF2 /* FxAccountManager.swift */,
 				1BBAC56C27AE085F00DAFEF2 /* FxAccountLogging.swift */,
 				1BBAC56D27AE085F00DAFEF2 /* FxAccountConfig.swift */,
+				1BBAC56E27AE085F00DAFEF2 /* FxAccountMigration.swift */,
 			);
 			name = FxAClient;
 			path = "../../../components/fxa-client/ios/FxAClient";
@@ -788,6 +791,7 @@
 				1BF50F1127B1E17B00A9C8A5 /* FxAccountDeviceConstellation.swift in Sources */,
 				1BF50F0F27B1E17B00A9C8A5 /* FxAccountOAuth.swift in Sources */,
 				1BF50F0C27B1E17B00A9C8A5 /* KeychainWrapper+.swift in Sources */,
+				1BF50F0D27B1E17B00A9C8A5 /* FxAccountMigration.swift in Sources */,
 				1B3BC94527B1D6A500229CF6 /* SyncUnlockInfo.swift in Sources */,
 				F8BEFFDA299C4F1100776186 /* RustSyncTelemetryPing.swift in Sources */,
 				1B3BC94B27B1D79B00229CF6 /* LoginsStorage.swift in Sources */,

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/FxAccountManagerTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/FxAccountManagerTests.swift
@@ -18,6 +18,13 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchedProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .logout))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .recoveredFromAuthenticationProblem))
+
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticateViaMigration(sessionToken: "foo", kSync: "bar", kXCS: "bobo")))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticatedViaMigration))
+        XCTAssertEqual(.canAutoretryMigration, FxAccountManager.nextState(state: state, event: .inFlightMigration))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .retryMigrationLater))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .retryMigration))
     }
 
     func testStateTransitionsNotAuthenticated() {
@@ -32,6 +39,12 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .logout))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .recoveredFromAuthenticationProblem))
+
+        XCTAssertEqual(.notAuthenticated, FxAccountManager.nextState(state: state, event: .authenticateViaMigration(sessionToken: "foo", kSync: "bar", kXCS: "bobo")))
+        XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .authenticatedViaMigration))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .inFlightMigration))
+        XCTAssertEqual(.canAutoretryMigration, FxAccountManager.nextState(state: state, event: .retryMigrationLater))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .retryMigration))
     }
 
     func testStateTransitionsAuthenticatedNoProfile() {
@@ -46,6 +59,12 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertEqual(.notAuthenticated, FxAccountManager.nextState(state: state, event: .logout))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .recoveredFromAuthenticationProblem))
+
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticateViaMigration(sessionToken: "foo", kSync: "bar", kXCS: "bobo")))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticatedViaMigration))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .inFlightMigration))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .retryMigrationLater))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .retryMigration))
     }
 
     func testStateTransitionsAuthenticatedWithProfile() {
@@ -60,6 +79,12 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertEqual(.notAuthenticated, FxAccountManager.nextState(state: state, event: .logout))
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .recoveredFromAuthenticationProblem))
+
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticateViaMigration(sessionToken: "foo", kSync: "bar", kXCS: "bobo")))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticatedViaMigration))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .inFlightMigration))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .retryMigrationLater))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .retryMigration))
     }
 
     func testStateTransitionsAuthenticationProblem() {
@@ -74,6 +99,32 @@ class FxAccountManagerTests: XCTestCase {
         XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
         XCTAssertEqual(.notAuthenticated, FxAccountManager.nextState(state: state, event: .logout))
         XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .recoveredFromAuthenticationProblem))
+
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticateViaMigration(sessionToken: "foo", kSync: "bar", kXCS: "bobo")))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticatedViaMigration))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .inFlightMigration))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .retryMigrationLater))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .retryMigration))
+    }
+
+    func testStateTransitionscanAutoretryMigration() {
+        let state: AccountState = .canAutoretryMigration
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .initialize))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .accountNotFound))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .accountRestored))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticated(authData: FxaAuthData(code: "foo", state: "bar", actionQueryParam: "bobo"))))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticationError))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchProfile(ignoreCache: false)))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .fetchedProfile))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .failedToFetchProfile))
+        XCTAssertEqual(.notAuthenticated, FxAccountManager.nextState(state: state, event: .logout))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .recoveredFromAuthenticationProblem))
+
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .authenticateViaMigration(sessionToken: "foo", kSync: "bar", kXCS: "bobo")))
+        XCTAssertEqual(.authenticatedNoProfile, FxAccountManager.nextState(state: state, event: .authenticatedViaMigration))
+        XCTAssertNil(FxAccountManager.nextState(state: state, event: .inFlightMigration))
+        XCTAssertEqual(.canAutoretryMigration, FxAccountManager.nextState(state: state, event: .retryMigrationLater))
+        XCTAssertEqual(.canAutoretryMigration, FxAccountManager.nextState(state: state, event: .retryMigration))
     }
 
     func testAccountNotFound() {

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/FxAccountMocks.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/FxAccountMocks.swift
@@ -33,6 +33,10 @@ class MockFxAccount: PersistedFirefoxAccount {
         fatalError("init(config:) has not been implemented")
     }
 
+    override func isInMigrationState() -> Bool {
+        return false
+    }
+
     override func initializeDevice(name _: String, deviceType _: DeviceType, supportedCapabilities _: [DeviceCapability]) throws {
         queue.sync { invocations.append(.initializeDevice) }
     }


### PR DESCRIPTION
…implementations"

This reverts commit e2598e30b34e017ecc20fdba553603916546d4ef.

This commit seems like the right thing to do, but it's causing build issues with firefox-ios
(https://app.bitrise.io/build/ca2da5d9-ffe2-4a3a-ad76-2e87c7d7cedf).  I think the safest thing to do is revert it for the 116 branch and fix the firefox-ios breakage in 117.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
