### PR TITLE
Fix for the swift-build artifacts dir

### DIFF
--- a/taskcluster/scripts/setup-mac-worker.sh
+++ b/taskcluster/scripts/setup-mac-worker.sh
@@ -10,3 +10,6 @@ export PATH="$HOME/bin:$HOME/Library/Python/3.7/bin:$PATH"
 # UPLOAD_DIR is not set for the generic worker, so we need to set it ourselves
 # FIXME: what's the right way to get this value?
 export UPLOAD_DIR="${PWD}/../public/build"
+
+# delete the artifacts directory if it's left over from previous runs
+rm -fr artifacts

--- a/taskcluster/scripts/setup-mac-worker.sh
+++ b/taskcluster/scripts/setup-mac-worker.sh
@@ -12,4 +12,4 @@ export PATH="$HOME/bin:$HOME/Library/Python/3.7/bin:$PATH"
 export UPLOAD_DIR="${PWD}/../public/build"
 
 # delete the artifacts directory if it's left over from previous runs
-rm -fr artifacts
+rm -fr ../../artifacts


### PR DESCRIPTION
This was merged to `release-v116` in https://github.com/mozilla/application-services/pull/5705.  This PR cherry-picks the commit back to `main`.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
