### PR TITLE
Fixing the nimbus-fml release artifact download URL

### DIFF
--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -201,7 +201,7 @@ class NimbusPlugin implements Plugin<Project> {
 
             def successfulHost = tryDownload(archive.getParentFile(), archive.getName(),
                 // Try archive.mozilla.org release first
-                "https://archive.mozilla.org/pub/app-services/$asVersion",
+                "https://archive.mozilla.org/pub/app-services/releases/$asVersion",
                 // Try a github release next (TODO: remove this once we verify that publishing to
                 // archive.mozilla.org is working).
                 "https://github.com/mozilla/application-services/releases/download/v$asVersion",


### PR DESCRIPTION
It was missing the `releases` component, which forced us to fallback to the github URL for the 116.0 release.  Hopefully this makes things work the next time around.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
