### PR TITLE
Fxa state refactor

### DIFF
--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -82,8 +82,8 @@ pub enum Error {
     #[error("Device target is unknown (Device ID: {0})")]
     UnknownTargetDevice(String),
 
-    #[error("Unrecoverable server error {0}")]
-    UnrecoverableServerError(&'static str),
+    #[error("Api client error {0}")]
+    ApiClientError(&'static str),
 
     #[error("Illegal state: {0}")]
     IllegalState(&'static str),

--- a/components/fxa-client/src/internal/http_client.rs
+++ b/components/fxa-client/src/internal/http_client.rs
@@ -740,11 +740,6 @@ impl<'a> DeviceUpdateRequestBuilder<'a> {
         self
     }
 
-    pub fn clear_available_commands(mut self) -> Self {
-        self.available_commands = Some(None);
-        self
-    }
-
     pub fn display_name(mut self, display_name: &'a str) -> Self {
         self.display_name = Some(Some(display_name));
         self

--- a/components/fxa-client/src/internal/oauth/attached_clients.rs
+++ b/components/fxa-client/src/internal/oauth/attached_clients.rs
@@ -20,7 +20,7 @@ impl FirefoxAccount {
         let session_token = self.get_session_token()?;
         let response = self
             .client
-            .get_attached_clients(&self.state.config, &session_token)?;
+            .get_attached_clients(self.state.config(), &session_token)?;
 
         self.attached_clients_cache = Some(CachedResponse {
             response: response.clone(),

--- a/components/fxa-client/src/internal/scoped_keys.rs
+++ b/components/fxa-client/src/internal/scoped_keys.rs
@@ -11,8 +11,7 @@ use crate::{Error, Result, ScopedKey};
 impl FirefoxAccount {
     pub(crate) fn get_scoped_key(&self, scope: &str) -> Result<&ScopedKey> {
         self.state
-            .scoped_keys
-            .get(scope)
+            .get_scoped_key(scope)
             .ok_or_else(|| Error::NoScopedKey(scope.to_string()))
     }
 }

--- a/components/fxa-client/src/internal/send_tab.rs
+++ b/components/fxa-client/src/internal/send_tab.rs
@@ -27,7 +27,7 @@ impl FirefoxAccount {
     }
 
     fn load_or_generate_keys(&mut self) -> Result<PrivateSendTabKeys> {
-        if let Some(s) = self.state.commands_data.get(send_tab::COMMAND_NAME) {
+        if let Some(s) = self.send_tab_key() {
             match PrivateSendTabKeys::deserialize(s) {
                 Ok(keys) => return Ok(keys),
                 Err(_) => {
@@ -39,9 +39,7 @@ impl FirefoxAccount {
             }
         }
         let keys = PrivateSendTabKeys::from_random()?;
-        self.state
-            .commands_data
-            .insert(send_tab::COMMAND_NAME.to_owned(), keys.serialize()?);
+        self.set_send_tab_key(keys.serialize()?);
         Ok(keys)
     }
 
@@ -66,7 +64,7 @@ impl FirefoxAccount {
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
         let command_payload = send_tab::build_send_command(oldsync_key, target, &payload)?;
         self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)?;
-        self.telemetry.borrow_mut().record_tab_sent(sent_telemetry);
+        self.telemetry.record_tab_sent(sent_telemetry);
         Ok(())
     }
 
@@ -76,15 +74,14 @@ impl FirefoxAccount {
         payload: serde_json::Value,
         reason: telemetry::ReceivedReason,
     ) -> Result<IncomingDeviceCommand> {
-        let send_tab_key: PrivateSendTabKeys =
-            match self.state.commands_data.get(send_tab::COMMAND_NAME) {
-                Some(s) => PrivateSendTabKeys::deserialize(s)?,
-                None => {
-                    return Err(Error::IllegalState(
-                        "Cannot find send-tab keys. Has initialize_device been called before?",
-                    ));
-                }
-            };
+        let send_tab_key: PrivateSendTabKeys = match self.send_tab_key() {
+            Some(s) => PrivateSendTabKeys::deserialize(s)?,
+            None => {
+                return Err(Error::IllegalState(
+                    "Cannot find send-tab keys. Has initialize_device been called before?",
+                ));
+            }
+        };
         let encrypted_payload: EncryptedSendTabPayload = serde_json::from_value(payload)?;
         match encrypted_payload.decrypt(&send_tab_key) {
             Ok(payload) => {
@@ -94,9 +91,7 @@ impl FirefoxAccount {
                     stream_id: payload.stream_id.clone(),
                     reason,
                 };
-                self.telemetry
-                    .borrow_mut()
-                    .record_tab_received(recd_telemetry);
+                self.telemetry.record_tab_received(recd_telemetry);
                 // The telemetry IDs escape to the consumer, but that's OK...
                 Ok(IncomingDeviceCommand::TabReceived { sender, payload })
             }
@@ -118,11 +113,23 @@ impl FirefoxAccount {
                     }
                 };
                 // Reset the Send Tab keys.
-                self.state.commands_data.remove(send_tab::COMMAND_NAME);
+                self.clear_send_tab_key();
                 self.reregister_current_capabilities()?;
                 Err(e)
             }
         }
+    }
+
+    fn send_tab_key(&self) -> Option<&str> {
+        self.state.get_commands_data(send_tab::COMMAND_NAME)
+    }
+
+    fn set_send_tab_key(&mut self, key: String) {
+        self.state.set_commands_data(send_tab::COMMAND_NAME, key)
+    }
+
+    fn clear_send_tab_key(&mut self) {
+        self.state.clear_commands_data(send_tab::COMMAND_NAME);
     }
 
     fn diagnose_remote_keys(&mut self, local_send_tab_key: PrivateSendTabKeys) -> Result<()> {

--- a/components/fxa-client/src/internal/state_manager.rs
+++ b/components/fxa-client/src/internal/state_manager.rs
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    internal::{
+        device,
+        oauth::{AccessTokenInfo, RefreshToken},
+        profile::Profile,
+        state_persistence::state_to_json,
+        CachedResponse, Config, OAuthFlow, PersistedState,
+    },
+    Result, ScopedKey,
+};
+
+/// Stores and manages the current state of the FxA client
+///
+/// All fields are private, which means that all state mutations must go through this module.  This
+/// makes it easier to reason about state changes.
+pub struct StateManager {
+    /// State that's persisted to disk
+    persisted_state: PersistedState,
+    /// In-progress OAuth flows
+    flow_store: HashMap<String, OAuthFlow>,
+}
+
+impl StateManager {
+    pub(crate) fn new(persisted_state: PersistedState) -> Self {
+        Self {
+            persisted_state,
+            flow_store: HashMap::new(),
+        }
+    }
+
+    pub fn serialize_persisted_state(&self) -> Result<String> {
+        state_to_json(&self.persisted_state)
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.persisted_state.config
+    }
+
+    pub fn refresh_token(&self) -> Option<&RefreshToken> {
+        self.persisted_state.refresh_token.as_ref()
+    }
+
+    pub fn session_token(&self) -> Option<&str> {
+        self.persisted_state.session_token.as_deref()
+    }
+
+    /// Get the last known set of device capabilities that we sent to the server
+    pub fn last_sent_device_capabilities(&self) -> &HashSet<device::Capability> {
+        &self.persisted_state.device_capabilities
+    }
+
+    /// Update the last known set of device capabilities that we sent to the server
+    pub fn update_last_sent_device_capabilities(
+        &mut self,
+        capabilities_set: HashSet<device::Capability>,
+    ) {
+        self.persisted_state.device_capabilities = capabilities_set;
+    }
+
+    /// Clear out the last known set of device_capabilities.  This means that the next call to
+    /// `ensure_capabilities()` will re-send our capabilities to the server
+    ///
+    /// This is typically called when something may invalidate the server's knowledge of our
+    /// capabilities, for example replacing our device info.
+    pub fn clear_last_sent_device_capabilities(&mut self) {
+        self.persisted_state.device_capabilities = HashSet::new();
+    }
+
+    pub fn get_commands_data(&self, key: &str) -> Option<&str> {
+        self.persisted_state
+            .commands_data
+            .get(key)
+            .map(String::as_str)
+    }
+
+    pub fn set_commands_data(&mut self, key: &str, data: String) {
+        self.persisted_state
+            .commands_data
+            .insert(key.to_string(), data);
+    }
+
+    pub fn clear_commands_data(&mut self, key: &str) {
+        self.persisted_state.commands_data.remove(key);
+    }
+
+    pub fn last_handled_command_index(&self) -> Option<u64> {
+        self.persisted_state.last_handled_command
+    }
+
+    pub fn set_last_handled_command_index(&mut self, idx: u64) {
+        self.persisted_state.last_handled_command = Some(idx)
+    }
+
+    pub fn current_device_id(&self) -> Option<&str> {
+        self.persisted_state.current_device_id.as_deref()
+    }
+
+    pub fn set_current_device_id(&mut self, device_id: String) {
+        self.persisted_state.current_device_id = Some(device_id);
+    }
+
+    pub fn get_scoped_key(&self, scope: &str) -> Option<&ScopedKey> {
+        self.persisted_state.scoped_keys.get(scope)
+    }
+
+    pub(crate) fn last_seen_profile(&self) -> Option<&CachedResponse<Profile>> {
+        self.persisted_state.last_seen_profile.as_ref()
+    }
+
+    pub(crate) fn set_last_seen_profile(&mut self, profile: CachedResponse<Profile>) {
+        self.persisted_state.last_seen_profile = Some(profile)
+    }
+
+    pub fn clear_last_seen_profile(&mut self) {
+        self.persisted_state.last_seen_profile = None
+    }
+
+    pub fn get_cached_access_token(&mut self, scope: &str) -> Option<&AccessTokenInfo> {
+        self.persisted_state.access_token_cache.get(scope)
+    }
+
+    pub fn add_cached_access_token(&mut self, scope: impl Into<String>, token: AccessTokenInfo) {
+        self.persisted_state
+            .access_token_cache
+            .insert(scope.into(), token);
+    }
+
+    pub fn clear_access_token_cache(&mut self) {
+        self.persisted_state.access_token_cache.clear()
+    }
+
+    /// Begin an OAuth flow.  This saves the OAuthFlow for later.  `state` must be unique to this
+    /// oauth flow process.
+    pub fn begin_oauth_flow(&mut self, state: impl Into<String>, flow: OAuthFlow) {
+        self.flow_store.insert(state.into(), flow);
+    }
+
+    /// Get an OAuthFlow from a previous `begin_oauth_flow()` call
+    ///
+    /// This operation removes the OAuthFlow from the our internal map.  It can only be called once
+    /// per `state` value.
+    pub fn pop_oauth_flow(&mut self, state: &str) -> Option<OAuthFlow> {
+        self.flow_store.remove(state)
+    }
+
+    /// Complete an OAuth flow.
+    pub fn complete_oauth_flow(
+        &mut self,
+        scoped_keys: Vec<(String, ScopedKey)>,
+        refresh_token: RefreshToken,
+        session_token: Option<String>,
+    ) {
+        // When our keys change, we might need to re-register device capabilities with the server.
+        // Ensure that this happens on the next call to ensure_capabilities.
+        self.persisted_state.device_capabilities.clear();
+
+        for (scope, key) in scoped_keys {
+            self.persisted_state.scoped_keys.insert(scope, key);
+        }
+        self.persisted_state.refresh_token = Some(refresh_token);
+        self.persisted_state.session_token = session_token;
+        self.flow_store.clear();
+    }
+
+    /// Called when the account is disconnected.  This clears most of the auth state, but keeps
+    /// some information in order to eventually reconnect to the same user account later.
+    pub fn disconnect(&mut self) {
+        self.persisted_state = self.persisted_state.start_over();
+        self.flow_store.clear();
+    }
+
+    /// Handle the auth tokens changing
+    ///
+    /// This method updates the token data and clears out data that may be invalidated with the
+    /// token changes.
+    pub fn update_tokens(&mut self, session_token: String, refresh_token: RefreshToken) {
+        self.persisted_state.session_token = Some(session_token);
+        self.persisted_state.refresh_token = Some(refresh_token);
+        self.persisted_state.access_token_cache.clear();
+        self.persisted_state.device_capabilities.clear();
+    }
+}
+
+#[cfg(test)]
+impl StateManager {
+    pub fn is_access_token_cache_empty(&self) -> bool {
+        self.persisted_state.access_token_cache.is_empty()
+    }
+
+    pub fn force_refresh_token(&mut self, token: RefreshToken) {
+        self.persisted_state.refresh_token = Some(token)
+    }
+
+    pub fn force_session_token(&mut self, token: String) {
+        self.persisted_state.session_token = Some(token)
+    }
+
+    pub fn force_current_device_id(&mut self, device_id: impl Into<String>) {
+        self.persisted_state.current_device_id = Some(device_id.into())
+    }
+
+    pub fn insert_scoped_key(&mut self, scope: impl Into<String>, key: ScopedKey) {
+        self.persisted_state.scoped_keys.insert(scope.into(), key);
+    }
+}

--- a/components/fxa-client/src/internal/telemetry.rs
+++ b/components/fxa-client/src/internal/telemetry.rs
@@ -18,7 +18,7 @@ impl FirefoxAccount {
     /// forgivingly (eg, be tolerant of things not existing) to try and avoid
     /// too many changes as telemetry comes and goes.
     pub fn gather_telemetry(&mut self) -> Result<String> {
-        let telem = self.telemetry.replace(FxaTelemetry::new());
+        let telem = std::mem::replace(&mut self.telemetry, FxaTelemetry::new());
         Ok(serde_json::to_string(&telem)?)
     }
 }


### PR DESCRIPTION
The main goal here is to make the state mutations easier to track.  I found it hard to understand what was going on when any method anywhere could mutate the state.

Related to that I also tried to make the state mutations more "atomic".  When we complete an oauth flow, we now wait until we're sure that everything is going to succeed before mutating the state.  Currently, we can save new the scoped keys from a response, but then fail because the refresh token isn't present.  I can't think of any way that would cause issues, but it makes my head hurt.

Along the way, I tried to name things a bit better.  Totally open to bikeshedding here.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
