### PR TITLE
Fixes EXP-3655: Expose getter for coenrolling feature ids in FML client and udl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `allow-coenrollment` property for features in the Feature Manifest Language. This relaxes the feature exclusion rules for features marked with `allow-coenrollment: true`. ([#5688](https://github.com/mozilla/application-services/pull/5688)).
   - This adds a non-user-facing method to the `FeatureManifestInterface`, `getCoenrollingFeatureIds`, in both Kotlin and Swift.
+- Exposes a method, `get_coenrolling_feature_ids`, in the FML client ([#5714](https://github.com/mozilla/application-services/pull/5714)).
 
 [Full Changelog](In progress)
 

--- a/components/support/nimbus-fml/src/client.rs
+++ b/components/support/nimbus-fml/src/client.rs
@@ -96,6 +96,11 @@ impl FmlClient {
     pub fn get_default_json(&self) -> Result<String> {
         Ok(serde_json::to_string(&self.default_json)?)
     }
+
+    /// Returns a list of feature ids that support coenrollment.
+    pub fn get_coenrolling_feature_ids(&self) -> Result<Vec<String>> {
+        Ok(&self.manifest.get_coenrolling_feature_ids())
+    }
 }
 
 type JsonObject = serde_json::Map<String, serde_json::Value>;
@@ -170,6 +175,7 @@ mod unit_tests {
                     default: Value::String("prop_1_value".into()),
                     doc: "".into(),
                 }],
+                allow_coenrollment: true,
                 ..Default::default()
             }],
             HashMap::from([(ModuleId::Local("test".into()), fm_i)]),
@@ -235,6 +241,16 @@ mod unit_tests {
         );
         assert_eq!(result.errors.len(), 1);
         assert_eq!(result.errors[0].to_string(), "Validation Error at features/feature_i.prop_i_1: Mismatch between type String and default 1".to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_coenrolling_feature_ids() -> Result<()> {
+        let client: FmlClient = create_manifest().into();
+        let result = client.get_coenrolling_feature_ids();
+
+        assert_eq!(result, vec!["feature"]);
 
         Ok(())
     }

--- a/components/support/nimbus-fml/src/client.rs
+++ b/components/support/nimbus-fml/src/client.rs
@@ -250,7 +250,7 @@ mod unit_tests {
         let client: FmlClient = create_manifest().into();
         let result = client.get_coenrolling_feature_ids();
 
-        assert_eq!(Value::Object(result), vec!["feature"]);
+        assert_eq!(result.unwrap(), vec!["feature"]);
 
         Ok(())
     }

--- a/components/support/nimbus-fml/src/client.rs
+++ b/components/support/nimbus-fml/src/client.rs
@@ -99,7 +99,7 @@ impl FmlClient {
 
     /// Returns a list of feature ids that support coenrollment.
     pub fn get_coenrolling_feature_ids(&self) -> Result<Vec<String>> {
-        Ok(&self.manifest.get_coenrolling_feature_ids())
+        Ok(self.manifest.get_coenrolling_feature_ids())
     }
 }
 
@@ -250,7 +250,7 @@ mod unit_tests {
         let client: FmlClient = create_manifest().into();
         let result = client.get_coenrolling_feature_ids();
 
-        assert_eq!(result, vec!["feature"]);
+        assert_eq!(Value::Object(result), vec!["feature"]);
 
         Ok(())
     }

--- a/components/support/nimbus-fml/src/fml.udl
+++ b/components/support/nimbus-fml/src/fml.udl
@@ -37,4 +37,8 @@ interface FmlClient {
     // Returns the default feature JSON for the loaded FML's selected channel.
     [Throws=FMLError]
     string get_default_json();
+
+    // Returns a list of feature ids that support coenrollment.
+    [Throws=FMLError]
+    sequence<string> get_coenrolling_feature_ids();
 };

--- a/megazords/cirrus/tests/python-tests/resources/includes-and-imports/import1-include1.fml.yml
+++ b/megazords/cirrus/tests/python-tests/resources/includes-and-imports/import1-include1.fml.yml
@@ -10,3 +10,4 @@ features:
         description: If the feature is enabled
         type: Boolean
         default: false
+    allow-coenrollment: true

--- a/megazords/cirrus/tests/python-tests/resources/test-include-import.fml.yml
+++ b/megazords/cirrus/tests/python-tests/resources/test-include-import.fml.yml
@@ -24,6 +24,7 @@ features:
         description: Another variable
         type: Option<String>
         default: null
+    allow-coenrollment: true
     defaults:
       - channel: nightly
         value: {

--- a/megazords/cirrus/tests/python-tests/test_fml.py
+++ b/megazords/cirrus/tests/python-tests/test_fml.py
@@ -105,3 +105,10 @@ def test_merge_included_and_imported_features(fml_client):
         "imported-module-1-included-feature-1"
     ]
     assert imported_module_1_included_feature_1["enabled"] is True
+
+
+def test_get_coenrolling_feature_ids(fml_client):
+    client = fml_client("test-include-import.fml.yml", "developer")
+    result = client.get_coenrolling_feature_ids()
+
+    assert result == ["example-feature","imported-module-1-included-feature-1"]


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/EXP-3655

* Expose `get_coenrolling_feature_ids()` in `nimbus-fml/src/client.rs` + tests
* Expose `get_coenrolling_feature_ids()` in `nimbus-fml/src/fml.udl`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
