### PR TITLE
Add experiment slug substitution to the feature config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # v117.0 (In progress)
 
+## Nimbus SDK ⛅️🔬🔭
+
+### ✨ What's New ✨
+
+- Add `recordExperimentExposure` to `FeatureHolder`, and substitute `{experiment}` for experiment slugs at enrollment in the feature configuration [#5715](https://github.com/mozilla/application-services/pull/5715).
+  - This is to enable exposure events to be assigned to the correct experiment in coenrolled features.
+  - Android and iOS are both supported.
+
 ## Nimbus FML ⛅️🔬🔭🔧
 
 ### ✨ What's New ✨

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeaturesInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeaturesInterface.kt
@@ -58,7 +58,7 @@ interface FeaturesInterface {
      * @param featureId string representing the id of the feature for which to record the exposure
      *     event.
      */
-    fun recordExposureEvent(featureId: String) = Unit
+    fun recordExposureEvent(featureId: String, experimentSlug: String? = null) = Unit
 
     /**
      * Records the `malformedFeature` event in telemetry.

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/HardcodedNimbusFeatures.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/HardcodedNimbusFeatures.kt
@@ -47,7 +47,7 @@ class HardcodedNimbusFeatures(
             JSONVariables(context, json)
         } ?: NullVariables.instance
 
-    override fun recordExposureEvent(featureId: String) {
+    override fun recordExposureEvent(featureId: String, experimentSlug: String?) {
         if (features[featureId] != null) {
             exposureCounts[featureId] = getExposureCount(featureId) + 1
         }

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
@@ -63,6 +63,19 @@ class FeatureHolder<T : FMLFeatureInterface>(
     }
 
     /**
+     * Send an exposure event for this feature, in the given experiment.
+     *
+     * If the experiment does not exist, or the client is not enrolled in that experiment, then no exposure event
+     * is recorded.
+     *
+     * If you are not sure of the experiment slug, then this is _not_ the API you need: you should use
+     * [recordExposure] instead.
+     */
+    fun recordExperimentExposure(slug: String) {
+        getSdk()?.recordExposureEvent(featureId, slug)
+    }
+
+    /**
      * A convenience method for calling [value()].[toJSONObject()].
      *
      * This is likely only useful for integrations that are going to serialize the configuration.

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/NimbusTests.kt
@@ -209,7 +209,7 @@ class NimbusTests {
     }
 
     @Test
-    fun `recordExposure records telemetry`() {
+    fun `recordExposure from feature records telemetry`() {
         // Load the experiment in nimbus so and optIn so that it will be active. This is necessary
         // because recordExposure checks for active experiments before recording.
         nimbus.setUpTestExperiments(packageName, appInfo)
@@ -221,7 +221,7 @@ class NimbusTests {
         )
 
         // Record a valid exposure event in Glean that matches the featureId from the test experiment
-        nimbus.recordExposureOnThisThread("about_welcome")
+        nimbus.recordExposureOnThisThread("about_welcome", null)
 
         // Use the Glean test API to check that the valid event is present
         assertNotNull("Event must have a value", NimbusEvents.exposure.testGetValue())
@@ -237,7 +237,56 @@ class NimbusTests {
 
         // Attempt to record an event for a non-existent or feature we are not enrolled in an
         // experiment in to ensure nothing is recorded.
-        nimbus.recordExposureOnThisThread("not-a-feature")
+        nimbus.recordExposureOnThisThread("not-a-feature", null)
+
+        // Verify the invalid event was ignored by checking again that the valid event is still the only
+        // event, and that it hasn't changed any of its extra properties.
+        assertNotNull("Event must have a value", NimbusEvents.exposure.testGetValue())
+        val exposureEventsTryTwo = NimbusEvents.exposure.testGetValue()!!
+        assertEquals("Event count must match", exposureEventsTryTwo.count(), 1)
+        val exposureEventExtrasTryTwo = exposureEventsTryTwo.first().extra!!
+        assertEquals(
+            "Experiment slug must match",
+            "test-experiment",
+            exposureEventExtrasTryTwo["experiment"],
+        )
+        assertEquals(
+            "Experiment branch must match",
+            "test-branch",
+            exposureEventExtrasTryTwo["branch"],
+        )
+    }
+
+    @Test
+    fun `recordExposure from experiment slug records telemetry`() {
+        // Load the experiment in nimbus so and optIn so that it will be active. This is necessary
+        // because recordExposure checks for active experiments before recording.
+        nimbus.setUpTestExperiments(packageName, appInfo)
+
+        // Assert that there are no events to start with
+        assertNull(
+            "There must not be any pre-existing events",
+            NimbusEvents.exposure.testGetValue(),
+        )
+
+        // Record a valid exposure event in Glean that matches the featureId from the test experiment
+        nimbus.recordExposureOnThisThread("about_welcome", "test-experiment")
+
+        // Use the Glean test API to check that the valid event is present
+        assertNotNull("Event must have a value", NimbusEvents.exposure.testGetValue())
+        val exposureEvents = NimbusEvents.exposure.testGetValue()!!
+        assertEquals("Event count must match", exposureEvents.count(), 1)
+        val exposureEventExtras = exposureEvents.first().extra!!
+        assertEquals(
+            "Experiment slug must match",
+            "test-experiment",
+            exposureEventExtras["experiment"],
+        )
+        assertEquals("Experiment branch must match", "test-branch", exposureEventExtras["branch"])
+
+        // Attempt to record an event for a non-existent or feature we are not enrolled in an
+        // experiment in to ensure nothing is recorded.
+        nimbus.recordExposureOnThisThread("about_welcome", "not-an-experiment")
 
         // Verify the invalid event was ignored by checking again that the valid event is still the only
         // event, and that it hasn't changed any of its extra properties.

--- a/components/nimbus/ios/Nimbus/FeatureHolder.swift
+++ b/components/nimbus/ios/Nimbus/FeatureHolder.swift
@@ -54,7 +54,20 @@ public class FeatureHolder<T> {
     /// Send an exposure event for this feature. This should be done when the user is shown the feature, and may change
     /// their behavior because of it.
     public func recordExposure() {
-        getSdk()?.recordExposureEvent(featureId: featureId)
+        getSdk()?.recordExposureEvent(featureId: featureId, experimentSlug: nil)
+    }
+
+    /// Send an exposure event for this feature, in the given experiment.
+    ///
+    /// If the experiment does not exist, or the client is not enrolled in that experiment, then no exposure event
+    /// is recorded.
+    ///
+    /// If you are not sure of the experiment slug, then this is _not_ the API you need: you should use
+    /// {recordExposure} instead.
+    ///
+    /// - Parameter slug the experiment identifier, likely derived from the {value}.
+    public func recordExperimentExposure(slug: String) {
+        getSdk()?.recordExposureEvent(featureId: featureId, experimentSlug: slug)
     }
 
     /// Send a malformed feature event for this feature.

--- a/components/nimbus/ios/Nimbus/FeatureInterface.swift
+++ b/components/nimbus/ios/Nimbus/FeatureInterface.swift
@@ -46,7 +46,7 @@ public protocol FeaturesInterface: AnyObject {
     /// - Parameter featureId string representing the id of the feature for which to record the exposure
     ///     event.
     ///
-    func recordExposureEvent(featureId: String)
+    func recordExposureEvent(featureId: String, experimentSlug: String?)
 
     /// Records an event signifying a malformed feature configuration, or part of one.
     ///

--- a/components/nimbus/ios/Nimbus/HardcodedNimbusFeatures.swift
+++ b/components/nimbus/ios/Nimbus/HardcodedNimbusFeatures.swift
@@ -82,7 +82,7 @@ extension HardcodedNimbusFeatures: FeaturesInterface {
         return NilVariables.instance
     }
 
-    public func recordExposureEvent(featureId: String) {
+    public func recordExposureEvent(featureId: String, experimentSlug _: String? = nil) {
         if features[featureId] != nil {
             exposureCounts[featureId] = getExposureCount(featureId: featureId) + 1
         }

--- a/components/nimbus/src/json.rs
+++ b/components/nimbus/src/json.rs
@@ -10,13 +10,7 @@ use std::collections::HashMap;
 /// This recursively descends into the object, looking at string values and keys.
 #[allow(dead_code)]
 pub(crate) fn replace_str(value: &mut Value, from: &str, to: &str) {
-    let replacer = |s: &str| -> Option<String> {
-        if s.contains(from) {
-            Some(s.replace(from, to))
-        } else {
-            None
-        }
-    };
+    let replacer = create_str_replacer(from, to);
     replace_str_with(value, &replacer);
 }
 
@@ -24,13 +18,7 @@ pub(crate) fn replace_str(value: &mut Value, from: &str, to: &str) {
 ///
 /// This recursively descends into the object, looking at string values and keys.
 pub(crate) fn replace_str_in_map(map: &mut Map<String, Value>, from: &str, to: &str) {
-    let replacer = |s: &str| -> Option<String> {
-        if s.contains(from) {
-            Some(s.replace(from, to))
-        } else {
-            None
-        }
-    };
+    let replacer = create_str_replacer(from, to);
     replace_str_in_map_with(map, &replacer);
 }
 
@@ -79,6 +67,16 @@ where
     for (k, new) in changes {
         let v = map.remove(&k).unwrap();
         _ = map.insert(new, v);
+    }
+}
+
+fn create_str_replacer<'a>(from: &'a str, to: &'a str) -> impl Fn(&str) -> Option<String> + 'a {
+    move |s: &str| -> Option<String> {
+        if s.contains(from) {
+            Some(s.replace(from, to))
+        } else {
+            None
+        }
     }
 }
 

--- a/components/nimbus/src/json.rs
+++ b/components/nimbus/src/json.rs
@@ -1,0 +1,149 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use serde_json::{Map, Value};
+use std::collections::HashMap;
+
+pub(crate) fn replace_str(value: &mut Value, pattern: &str, slug: &str) {
+    match value {
+        Value::String(s) => {
+            if s.contains(pattern) {
+                *s = s.replace(pattern, slug);
+            }
+        }
+
+        Value::Array(list) => {
+            for item in list.iter_mut() {
+                replace_str(item, pattern, slug)
+            }
+        }
+
+        Value::Object(map) => {
+            replace_str_in_map(map, pattern, slug);
+        }
+
+        _ => (),
+    };
+}
+
+pub(crate) fn replace_str_in_map(map: &mut Map<String, Value>, pattern: &str, slug: &str) {
+    // Replace values in place.
+    for v in map.values_mut() {
+        replace_str(v, pattern, slug);
+    }
+
+    // Replacing keys in place is a little trickier.
+    let mut changes = HashMap::new();
+    for k in map.keys() {
+        if k.contains(pattern) {
+            let new = k.replace(pattern, slug);
+            changes.insert(k.to_owned(), new);
+        }
+    }
+
+    for (k, new) in changes {
+        let v = map.remove(&k).unwrap();
+        _ = map.insert(new, v);
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_replace_str() {
+        let mut value = json!("{test}");
+        replace_str(&mut value, "{test}", "success");
+        assert_eq!(value, json!("success"));
+
+        let mut value = json!("{test}-postfix");
+        replace_str(&mut value, "{test}", "success");
+        assert_eq!(value, json!("success-postfix"));
+
+        let mut value = json!("prefix-{test}");
+        replace_str(&mut value, "{test}", "success");
+        assert_eq!(value, json!("prefix-success"));
+
+        let mut value = json!("prefix-{test}-postfix");
+        replace_str(&mut value, "{test}", "success");
+        assert_eq!(value, json!("prefix-success-postfix"));
+
+        let mut value = json!("prefix-{test}-multi-{test}-postfix");
+        replace_str(&mut value, "{test}", "success");
+        assert_eq!(value, json!("prefix-success-multi-success-postfix"));
+    }
+
+    #[test]
+    fn test_replace_str_in_array() {
+        let mut value = json!(["alice", "bob", "{placeholder}", "daphne"]);
+        replace_str(&mut value, "{placeholder}", "charlie");
+        assert_eq!(value, json!(["alice", "bob", "charlie", "daphne"]));
+    }
+
+    #[test]
+    fn test_replace_str_in_map() {
+        let mut value = json!({
+            "key": "{test}",
+            "not": true,
+            "or": 2,
+        });
+        replace_str(&mut value, "{test}", "success");
+        assert_eq!(
+            value,
+            json!({
+                "key": "success",
+                "not": true,
+                "or": 2,
+            })
+        );
+    }
+
+    #[test]
+    fn test_replace_str_in_map_keys() {
+        let mut value = json!({
+            "{test}-en-US": "{test}",
+            "not": true,
+            "or": 2,
+        });
+        replace_str(&mut value, "{test}", "success");
+        assert_eq!(
+            value,
+            json!({
+                "success-en-US": "success",
+                "not": true,
+                "or": 2,
+            })
+        );
+    }
+
+    #[test]
+    fn test_replace_str_mixed() {
+        let mut value = json!({
+            "messages": {
+                "{test}-en-US": {
+                    "test": "{test}"
+                },
+                "{test}{test}": {
+                    "test": "{test}{test}"
+                }
+            }
+        });
+        replace_str(&mut value, "{test}", "success");
+        assert_eq!(
+            value,
+            json!({
+                "messages": {
+                    "success-en-US": {
+                        "test": "success"
+                    },
+                    "successsuccess": {
+                        "test": "successsuccess"
+                    }
+                }
+            })
+        );
+    }
+}

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -5,6 +5,7 @@
 mod defaults;
 mod enrollment;
 mod evaluator;
+mod json;
 mod matcher;
 mod sampling;
 mod strings;
@@ -45,6 +46,8 @@ cfg_if::cfg_if! {
 
 // Exposed for Example only
 pub use evaluator::TargetingAttributes;
+
+pub(crate) const SLUG_REPLACEMENT_PATTERN: &str = "{experiment}";
 
 #[cfg(test)]
 mod tests;

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -108,11 +108,7 @@ interface NimbusClient {
     [Throws=NimbusError]
     void initialize();
 
-    // Returns the branch allocated for a given feature_id or experiment_slug.
-    // Search first by feature_id, then by experiment_slug, returning the
-    // the first hit. If the user is enrolled neither in an experiment with id
-    // as the feature_id nor with id as the experiment_slug for the feature,
-    // null is returned.
+    // Returns the branch allocated for a given slug or id.
     [Throws=NimbusError]
     string? get_experiment_branch(string id);
 
@@ -127,7 +123,7 @@ interface NimbusClient {
     [Throws=NimbusError]
     sequence<EnrolledExperiment> get_active_experiments();
 
-    // Returns details of a feature's enrollemnt.
+    // Returns details of a feature's enrollment.
     [Throws=NimbusError]
     EnrolledFeature? get_enrollment_by_feature(string feature_id);
 

--- a/components/support/nimbus-fml/fixtures/android/runtime/MockNimbus.kt
+++ b/components/support/nimbus-fml/fixtures/android/runtime/MockNimbus.kt
@@ -27,7 +27,7 @@ class MockNimbus(override val context: Context, val map: Map<String, JSONObject>
 
     private var exposureCounts = mutableMapOf<String, Int>()
 
-    override fun recordExposureEvent(featureId: String) {
+    override fun recordExposureEvent(featureId: String, experimentSlug: String?) {
         if (map[featureId] != null) {
             exposureCounts[featureId] = getExposureCount(featureId) + 1
         }


### PR DESCRIPTION
Fixes [EXP-3659](https://mozilla-hub.atlassian.net/browse/EXP-3659).

This implements [Option 3 in ADR0012](https://github.com/mozilla/experimenter/blob/jhugman/exp-3630-adr-for-exposure-events-of-coenrolling-features/docs/adrs/0012-exposure-events-and-coenrolling-features.md).

More concretely:

- the `replace_str` function recursively crawls through the FeatureConfig at enrollment, changing any string with `{experiment}` to the experiment slug.
- adds `recordExperimentExposure(slug: String)` to `FeatureHolder` in both Android and iOS.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
