### PR TITLE
Adding Fxa functionality

### DIFF
--- a/components/fxa-client/src/account.rs
+++ b/components/fxa-client/src/account.rs
@@ -19,16 +19,12 @@ impl FirefoxAccount {
     /// Get the token server URL
     ///
     /// The token server URL can be used to get the URL and access token for the user's sync data.
-    ///
-    /// **💾 This method alters the persisted account state.**
     #[handle_error(Error)]
     pub fn get_token_server_endpoint_url(&self) -> ApiResult<String> {
         self.internal.lock().get_token_server_endpoint_url()
     }
 
     /// Get a URL which shows a "successfully connected!" message.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// Applications can use this method after a successful signin, to redirect the
     /// user to a success message displayed in web content rather than having to
@@ -39,8 +35,6 @@ impl FirefoxAccount {
     }
 
     /// Get a URL at which the user can manage their account and profile data.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// Applications should link the user out to this URL from an appropriate place
     /// in their signed-in settings UI.
@@ -56,8 +50,6 @@ impl FirefoxAccount {
     }
 
     /// Get a URL at which the user can manage the devices connected to their account.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// Applications should link the user out to this URL from an appropriate place
     /// in their signed-in settings UI. For example, "Manage your devices..." may be

--- a/components/fxa-client/src/auth.rs
+++ b/components/fxa-client/src/auth.rs
@@ -115,8 +115,6 @@ impl FirefoxAccount {
 
     /// Complete an OAuth flow.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// At the conclusion of an OAuth flow, the user will be redirect to the
     /// application's registered `redirect_uri`. It should extract the `code`
     /// and `state` parameters from the resulting URL and pass them to this
@@ -133,8 +131,6 @@ impl FirefoxAccount {
 
     /// Check authorization status for this application.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// Applications may call this method to check with the FxA server about the status
     /// of their authentication tokens. It returns an [`AuthorizationInfo`] struct
     /// with details about whether the tokens are still active.
@@ -144,8 +140,6 @@ impl FirefoxAccount {
     }
 
     /// Disconnect from the user's account.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// This method destroys any tokens held by the client, effectively disconnecting
     /// from the user's account. Applications should call this when the user opts to

--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -22,8 +22,6 @@ use sync15::DeviceType;
 impl FirefoxAccount {
     /// Create a new device record for this application.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// This method register a device record for the application, providing basic metadata for
     /// the device along with a list of supported [Device Capabilities](DeviceCapability) for
     /// participating in the "device commands" ecosystem.
@@ -74,8 +72,6 @@ impl FirefoxAccount {
 
     /// Get the list of devices registered on the user's account.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// This method returns a list of [`Device`] structs representing all the devices
     /// currently attached to the user's account (including the current device).
     /// The application might use this information to e.g. display a list of appropriate
@@ -125,8 +121,6 @@ impl FirefoxAccount {
 
     /// Update the display name used for this application instance.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// This method modifies the name of the current application's device record, as seen by
     /// other applications and in the user's account management pages.
     ///
@@ -145,8 +139,6 @@ impl FirefoxAccount {
 
     /// Clear any custom display name used for this application instance.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// This method clears the name of the current application's device record, causing other
     /// applications or the user's account management pages to have to fill in some sort of
     /// default name when displaying this device.
@@ -161,8 +153,6 @@ impl FirefoxAccount {
     }
 
     /// Ensure that the device record has a specific set of capabilities.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// This method checks that the currently-registered device record is advertising the
     /// given set of capabilities in the FxA "device commands" ecosystem. If not, then it

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -55,6 +55,9 @@ pub enum Error {
     #[error("Server asked the client to back off, please wait {0} seconds to try again")]
     BackoffError(u64),
 
+    #[error("Auth state error: {0}")]
+    AuthState(String),
+
     #[error("Unknown OAuth State")]
     UnknownOAuthState,
 
@@ -195,6 +198,9 @@ impl GetErrorHandling for Error {
             }
             Error::RequestError(_) => {
                 ErrorHandling::convert(crate::FxaError::Network).log_warning()
+            }
+            Error::AuthState(_) => {
+                ErrorHandling::convert(crate::FxaError::Other).report_error("fxa-auth-state")
             }
             _ => ErrorHandling::convert(crate::FxaError::Other).log_warning(),
         }

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -82,6 +82,9 @@ pub enum Error {
     #[error("Device target is unknown (Device ID: {0})")]
     UnknownTargetDevice(String),
 
+    #[error("Invalid device data: {0}")]
+    InvalidDeviceData(String),
+
     #[error("Unrecoverable server error {0}")]
     UnrecoverableServerError(&'static str),
 
@@ -203,7 +206,9 @@ impl GetErrorHandling for Error {
 /// This error is thrown by the application code that implements the callback interfaces
 #[derive(Debug, thiserror::Error)]
 pub enum CallbackError {
-    /// An unexpected error occurred, right now this is the only type of callback error we support
+    /// An unexpected error occurred.
+    ///
+    /// Right now this is the only type of callback error we support
     #[error("CallbackError: {reason}")]
     Other { reason: String },
 }

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -197,3 +197,19 @@ impl GetErrorHandling for Error {
         }
     }
 }
+
+/// Error type thrown by [FirefoxAccount] callback interfaces
+///
+/// This error is thrown by the application code that implements the callback interfaces
+#[derive(Debug, thiserror::Error)]
+pub enum CallbackError {
+    /// An unexpected error occurred, right now this is the only type of callback error we support
+    #[error("CallbackError: {reason}")]
+    Other { reason: String },
+}
+
+impl From<uniffi::UnexpectedUniFFICallbackError> for CallbackError {
+    fn from(e: uniffi::UnexpectedUniFFICallbackError) -> Self {
+        Self::Other { reason: e.reason }
+    }
+}

--- a/components/fxa-client/src/events.rs
+++ b/components/fxa-client/src/events.rs
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{AuthState, CallbackResult, DeviceList, FirefoxAccount, IncomingDeviceCommand};
+
+impl FirefoxAccount {
+    /// Register to receive FxaEvent notifications
+    ///
+    /// If there is EventListener already registered, it will be unregistered.  Pass in None to
+    /// remove the current listener
+    pub fn register_event_listener(&self, listener: Option<Box<dyn EventListener>>) {
+        self.internal.lock().register_event_listener(listener);
+    }
+}
+
+/// Implemented by a foreign callback interface to listen for FxA events.
+/// Use `FirefoxAccount::register_event_listener()` to receive these events.
+pub trait EventListener: Send + Sync {
+    fn on_event(&self, event: FxaEvent) -> CallbackResult<()>;
+}
+
+#[derive(Debug)]
+pub enum FxaEvent {
+    /// The account's profile was updated
+    ProfileUpdated,
+    /// Account auth state changed
+    AuthStateChanged { state: AuthState },
+    /// The account itself was destroyed
+    AccountDestroyed,
+    /// An command from another device was received
+    DeviceCommandIncoming { command: IncomingDeviceCommand },
+    /// The list of devices was changed
+    DeviceListChanged { device_list: DeviceList },
+}

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -13,9 +13,10 @@
 //   signed-in state of the application.
 //     * On first startup, a new [`FirefoxAccount`] can be created by calling
 //       [`FirefoxAccount::new`] and passing the application's `client_id`.
-//     * For subsequent startups the object can be persisted using the
-//       [`to_json`](FirefoxAccount::to_json) method and re-created by
-//       calling [`FirefoxAccount::from_json`].
+//     * For subsequent startups the object can be re-created by calling [`FirefoxAccount::from_json`].
+//
+// * Register a StorageHandler with the `register_storage_handler()` method.  The `save_state` method
+//   will be called whenever the persistent state changes.
 //
 // * When the user wants to sign in to your application, direct them through
 //   a web-based OAuth flow using [`begin_oauth_flow`](FirefoxAccount::begin_oauth_flow)
@@ -45,7 +46,6 @@ namespace fxa_client {
 // Precise details of the error are hidden from consumers, mostly due to limitations of
 // how we expose this API to other languages. The type of the error indicates how the
 // calling code should respond.
-//
 [Error]
 enum FxaError {
 
@@ -84,7 +84,14 @@ enum FxaError {
   "Other",
 };
 
-
+// Error type thrown by [FirefoxAccount] callback interfaces
+//
+// This error is thrown by the application code that implements the callback interfaces
+[Error]
+interface CallbackError {
+  // An unexpected error occurred, right now this is the only type of callback error we support
+  Other(string reason);
+};
 
 // Object representing the signed-in state of an application.
 //
@@ -97,15 +104,13 @@ interface FirefoxAccount {
 
   // Create a new [`FirefoxAccount`] instance, not connected to any account.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // This method constructs as new [`FirefoxAccount`] instance configured to connect
   // the application to a user's account.
   constructor(FxaConfig config);
 
   // Restore a [`FirefoxAccount`] instance from serialized state.
   //
-  // Given a JSON string previously obtained from [`FirefoxAccount::to_json`], this
+  // Given a JSON string previously passed to [StorageHandler.saved_state()], this
   // method will deserialize it and return a live [`FirefoxAccount`] instance.
   //
   // **⚠️ Warning:** since the serialized state contains access tokens, you should
@@ -115,14 +120,16 @@ interface FirefoxAccount {
   //
   [Throws=FxaError,Name=from_json]
   constructor([ByRef] string data);
-  
 
-  // Save current state to a JSON string.
+  // Register a StorageHandler callback
   //
-  // This method serializes the current account state into a JSON string, which
-  // the application can use to persist the user's signed-in state across restarts.
-  // The application should call this method and update its persisted state after
-  // any potentially-state-changing operation.
+  // Any previously registered storage handler will be replaced.  Pass in None to clear out any
+  // storage handler.
+  void register_storage_handler(StorageHandler? handler);
+
+  // Save current state to a JSON string
+  //
+  // **Deprecated**: Use the [FirefoxAccount::register_storage_handler()] method instead.
   //
   // **⚠️ Warning:** the serialized state may contain encryption keys and access
   // tokens that let anyone holding them access the user's data in Firefox Sync
@@ -201,8 +208,6 @@ interface FirefoxAccount {
 
   // Complete an OAuth flow.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // At the conclusion of an OAuth flow, the user will be redirect to the
   // application's registered `redirect_uri`. It should extract the `code`
   // and `state` parameters from the resulting URL and pass them to this
@@ -219,8 +224,6 @@ interface FirefoxAccount {
 
   // Check authorization status for this application.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // Applications may call this method to check with the FxA server about the status
   // of their authentication tokens. It returns an [`AuthorizationInfo`] struct
   // with details about whether the tokens are still active.
@@ -230,8 +233,6 @@ interface FirefoxAccount {
   
 
   // Disconnect from the user's account.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // This method destroys any tokens held by the client, effectively disconnecting
   // from the user's account. Applications should call this when the user opts to
@@ -246,8 +247,6 @@ interface FirefoxAccount {
   
 
   // Get profile information for the signed-in user, if any.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // This method fetches a [`Profile`] struct with information about the currently-signed-in
   // user, either by using locally-cached profile information or by fetching fresh data from
@@ -271,8 +270,6 @@ interface FirefoxAccount {
   
 
   // Create a new device record for this application.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // This method registed a device record for the application, providing basic metadata for
   // the device along with a list of supported [Device Capabilities](DeviceCapability) for
@@ -314,8 +311,6 @@ interface FirefoxAccount {
 
   // Get the list of devices registered on the user's account.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // This method returns a list of [`Device`] structs representing all the devices
   // currently attached to the user's account (including the current device).
   // The application might use this information to e.g. display a list of appropriate
@@ -355,8 +350,6 @@ interface FirefoxAccount {
 
   // Update the display name used for this application instance.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // This method modifies the name of the current application's device record, as seen by
   // other applications and in the user's account management pages.
   //
@@ -375,8 +368,6 @@ interface FirefoxAccount {
 
   // Clear any custom display name used for this application instance.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // This method clears the name of the current application's device record, causing other
   // applications or the user's account management pages to have to fill in some sort of
   // default name when displaying this device.
@@ -391,8 +382,6 @@ interface FirefoxAccount {
   
 
   // Ensure that the device record has a specific set of capabilities.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // This method checks that the currently-registred device record is advertising the
   // given set of capabilities in the FxA "device commands" ecosystem. If not, then it
@@ -418,8 +407,6 @@ interface FirefoxAccount {
 
   // Set or update a push subscription endpoint for this device.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // This method registers the given webpush subscription with the FxA server, requesting
   // that is send notifications in the event of any significant changes to the user's
   // account. When the application receives a push message at the registered subscription
@@ -441,8 +428,6 @@ interface FirefoxAccount {
 
   // Process and respond to a server-delivered account update message
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // Applications should call this method whenever they receive a push notification from the Firefox Accounts server.
   // Such messages typically indicate a noteworthy change of state on the user's account, such as an update to their profile information
   // or the disconnection of a client. The [`FirefoxAccount`] struct will update its internal state
@@ -457,8 +442,6 @@ interface FirefoxAccount {
 
 
   // Poll the server for any pending device commands.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // Applications that have registered one or more [`DeviceCapability`]s with the server can use
   // this method to check whether other devices on the account have sent them any commands.
@@ -477,8 +460,6 @@ interface FirefoxAccount {
   
 
   // Use device commands to send a single tab to another device.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // If a device on the account has registered the [`SendTab`](DeviceCapability::SendTab)
   // capability, this method can be used to send it a tab.
@@ -499,15 +480,11 @@ interface FirefoxAccount {
 
   // Get the URL at which to access the user's sync data.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   [Throws=FxaError]
   string get_token_server_endpoint_url();
   
 
   // Get a URL which shows a "successfully connceted!" message.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // Applications can use this method after a successful signin, to redirect the
   // user to a success message displayed in web content rather than having to
@@ -518,8 +495,6 @@ interface FirefoxAccount {
   
 
   // Get a URL at which the user can manage their account and profile data.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // Applications should link the user out to this URL from an appropriate place
   // in their signed-in settings UI.
@@ -536,8 +511,6 @@ interface FirefoxAccount {
 
   // Get a URL at which the user can manage the devices connected to their account.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // Applications should link the user out to this URL from an appropriate place
   // in their signed-in settings UI. For example, "Manage your devices..." may be
   // a useful link to place somewhere near the device list in the send-tab UI.
@@ -553,8 +526,6 @@ interface FirefoxAccount {
   
 
   // Get a short-lived OAuth access token for the user's account.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // Applications that need to access resources on behalf of the user must obtain an
   // `access_token` in order to do so. For example, an access token is required when
@@ -582,8 +553,6 @@ interface FirefoxAccount {
 
   // Get the session token for the user's account, if one is available.
   //
-  // **💾 This method alters the persisted account state.**
-  //
   // Applications that function as a web browser may need to hold on to a session token
   // on behalf of Firefox Accounts web content. This method exists so that they can retreive
   // it an pass it back to said web content when required.
@@ -601,8 +570,6 @@ interface FirefoxAccount {
   
 
   // Update the stored session token for the user's account.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // Applications that function as a web browser may need to hold on to a session token
   // on behalf of Firefox Accounts web content. This method exists so that said web content
@@ -634,8 +601,6 @@ interface FirefoxAccount {
   
 
   // Clear the access token cache in response to an auth failure.
-  //
-  // **💾 This method alters the persisted account state.**
   //
   // Applications that receive an authentication error when trying to use an access token,
   // should call this method before creating a new token and retrying the failed operation.
@@ -976,4 +941,17 @@ interface IncomingDeviceCommand {
 
   // Indicates that a tab has been sent to this device.
   TabReceived(Device? sender, SendTabPayload payload );
+};
+
+callback interface StorageHandler {
+    // This is called whenever the saved state changes.  The StorageHandler should ensure that the
+    // state is saved to disk.  The next time the FirefoxAccount is constructed, it should be
+    // through `from_json()` with this json data.
+    //
+    // **⚠️ Warning:** the serialized state may contain encryption keys and access
+    // tokens that let anyone holding them access the user's data in Firefox Sync
+    // and/or other FxA services. Applications should take care to store the resulting
+    // data in a secure fashion, as appropriate for their target platform.
+    [Throws=CallbackError]
+    void save_state(string json);
 };

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -18,6 +18,9 @@
 // * Register a StorageHandler with the `register_storage_handler()` method.  The `save_state` method
 //   will be called whenever the persistent state changes.
 //
+// * Register an EventListener with the `register_event_listener()` method.  The `on_event` method
+//   will be called when on account events.
+//
 // * When the user wants to sign in to your application, direct them through
 //   a web-based OAuth flow using [`begin_oauth_flow`](FirefoxAccount::begin_oauth_flow)
 //   or [`begin_pairing_flow`](FirefoxAccount::begin_pairing_flow); when they return
@@ -156,6 +159,12 @@ interface FirefoxAccount {
   //
   [Throws=FxaError]
   string to_json();
+
+  // Register to receive FxaEvent notifications
+  //
+  // If there is EventListener already registered, it will be unregistered.  Pass in None to
+  // remove the current listener
+  void register_event_listener(EventListener? listener);
 
   // Initialize an uninitialized account
   //
@@ -482,6 +491,8 @@ interface FirefoxAccount {
 
   // Process and respond to a server-delivered account update message
   //
+  // **Deprecated: use [FirefoxAccount::process_push_message] instead.
+  //
   // Applications should call this method whenever they receive a push notification from the Firefox Accounts server.
   // Such messages typically indicate a noteworthy change of state on the user's account, such as an update to their profile information
   // or the disconnection of a client. The [`FirefoxAccount`] struct will update its internal state
@@ -492,8 +503,13 @@ interface FirefoxAccount {
   // [`FirefoxAccount::poll_device_commands`]
   //
   [Throws=FxaError]
-  AccountEvent handle_push_message([ByRef] string payload );
+  AccountEvent handle_push_message([ByRef] string payload);
 
+  // Process a server-delivered account update message
+  //
+  // This will usually end up in a [crate::FxaEvent] being sent to the current [crate::EventListener]
+  [Throws=FxaError]
+  void process_push_message([ByRef] string payload);
 
   // Poll the server for any pending device commands.
   //
@@ -988,6 +1004,29 @@ interface AccountEvent {
   //
   // When receiving this event, the application should gracefully ignore it.
   Unknown();
+};
+
+/// Implemented by a foreign callback interface to listen for FxA events.
+/// Use `FirefoxAccount::register_event_listener()` to receive these events.
+callback interface EventListener {
+    [Throws=CallbackError]
+    void on_event(FxaEvent event);
+};
+
+// Event trigged by the FirefoxAccount client.  Use `FirefoxAccount::register_event_listener()` to
+// receive these events.
+[Enum]
+interface FxaEvent {
+    /// The account's profile was updated
+    ProfileUpdated();
+    /// Account auth state changed
+    AuthStateChanged(AuthState state);
+    /// The account itself was destroyed
+    AccountDestroyed();
+    /// An command from another device was received
+    DeviceCommandIncoming(IncomingDeviceCommand command);
+    /// The list of devices was changed
+    DeviceListChanged(DeviceList device_list);
 };
 
 // High-level view of the client authorization state

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -130,6 +130,15 @@ interface FirefoxAccount {
   [Throws=FxaError,Name=from_json]
   constructor([ByRef] string data);
 
+  // Create a new [FirefoxAccount] instance in the `AuthState::Uninitialized` state
+  //
+  // This allows consumers to create an account early in the startup process, but wait to
+  // initialize it later on.  This is useful for deferring disk IO until after early startup.
+  //
+  // Call [FirefoxAccount::initialize] before using the account
+  [Name=new_uninitialized]
+  constructor(FxaConfig config);
+
   // Register a StorageHandler callback
   //
   // Any previously registered storage handler will be replaced.  Pass in None to clear out any
@@ -147,7 +156,15 @@ interface FirefoxAccount {
   //
   [Throws=FxaError]
   string to_json();
-  
+
+  // Initialize an uninitialized account
+  //
+  // saved_state can contain a JSON string previously passed to [StorageHandler.saved_state()].
+  [Throws=FxaError]
+  void initialize(string? saved_state);
+
+  // Get the current auth state
+  AuthState get_auth_state();
 
   // Initiate a web-based OAuth sign-in flow.
   //
@@ -230,8 +247,12 @@ interface FirefoxAccount {
   [Throws=FxaError]
   void complete_oauth_flow([ByRef] string code, [ByRef] string state );
   
+  // Cancels all in-progress OAuth flows
+  void cancel_oauth_flow();
 
   // Check authorization status for this application.
+  //
+  // **Deprecated**: Use [FirefoxAccount::check_auth_state] instead.
   //
   // Applications may call this method to check with the FxA server about the status
   // of their authentication tokens. It returns an [`AuthorizationInfo`] struct
@@ -239,7 +260,6 @@ interface FirefoxAccount {
   //
   [Throws=FxaError]
   AuthorizationInfo check_authorization_status();
-  
 
   // Disconnect from the user's account.
   //
@@ -251,9 +271,16 @@ interface FirefoxAccount {
   // user's last-seen profile information, if any. This may be useful in helping
   // the user to reconnnect to their account. If reconnecting to the same account
   // is not desired then the application should discard the persisted account state.
-  //
+  [Throws=FxaError]
   void disconnect();
-  
+
+  // Check the authorization state of the FxA client
+  //
+  // This method checks if the current auth tokens are still valid.  If not, it changes the client
+  // to [AuthState::Disconnected].
+  //
+  // After the check, the updated [AuthState] is returned
+  AuthState check_auth_state();
 
   // Get profile information for the signed-in user, if any.
   //
@@ -633,6 +660,7 @@ interface FirefoxAccount {
   // should call this method before creating a new token and retrying the failed operation.
   // It ensures that the expired token is removed and a fresh one generated.
   //
+  [Throws=FxaError]
   void clear_access_token_cache();
   
 
@@ -962,6 +990,21 @@ interface AccountEvent {
   Unknown();
 };
 
+// High-level view of the client authorization state
+[Enum]
+interface AuthState {
+  // Client is waiting for the `initialize()` call
+  Uninitialized();
+  // Client is disconnected from FxA
+  Disconnected(
+      // Was the client disconnected because of auth issues?
+      boolean from_auth_issues,
+      // Is the client currently in the middle of an OAuth flow?
+      boolean connecting
+  );
+  // Client is connected to FxA
+  Connected();
+};
 
 // A command invoked by another device.
 //

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -37,9 +37,16 @@
 typedef extern DeviceType;
 
 namespace fxa_client {
+  // Parse a push message out-of-band
+  //
+  // This function parses a push message without constructing a FirefoxAccount instance.  This is
+  // useful for platforms like iOS, where push message handling needs to happen in a secondary
+  // process.  In particular, using parse_push_message avoids any possibility of saving the state to
+  // disk, which could result in data corruption if both the main and secondary process write the
+  // state at the same time.
+  [Throws=FxaError]
+  AccountEvent parse_push_message([ByRef]string account_state, [ByRef] string payload);
 };
-
-
 
 // Generic error type thrown by many [`FirefoxAccount`] operations.
 //
@@ -89,7 +96,9 @@ enum FxaError {
 // This error is thrown by the application code that implements the callback interfaces
 [Error]
 interface CallbackError {
-  // An unexpected error occurred, right now this is the only type of callback error we support
+  // An unexpected error occurred
+  //
+  // Right now this is the only type of callback error we support
   Other(string reason);
 };
 
@@ -307,9 +316,27 @@ interface FirefoxAccount {
   //
   [Throws=FxaError]
   string get_current_device_id();
-  
+
+  // Get the list of known devices registered on the user's account.
+  //
+  // The application might use this information to e.g. display a list of appropriate
+  // send-tab targets.
+  //
+  // # Notes
+  //
+  //    - Device metadata is only visible to applications that have been
+  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
+  [Throws=FxaError]
+  DeviceList get_device_list();
+
+  // Like `get_device_list()`, but always fetch a new device list rather than using cached data.
+  [Throws=FxaError]
+  DeviceList refresh_device_list();
 
   // Get the list of devices registered on the user's account.
+  //
+  // **Deprecated**: use [FirefoxAccount::get_device_list] or [FirefoxAccount::refresh_device_list]
+  // instead.
   //
   // This method returns a list of [`Device`] structs representing all the devices
   // currently attached to the user's account (including the current device).
@@ -740,6 +767,12 @@ dictionary AuthorizationParameters {
   string? code_challenge;
   string? code_challenge_method;
   string? keys_jwk;
+};
+
+// List of known devices registered to the user's account
+dictionary DeviceList {
+    Device local_device;
+    sequence<Device> remote_devices;
 };
 
 // A device connected to the user's account.

--- a/components/fxa-client/src/internal/commands/mod.rs
+++ b/components/fxa-client/src/internal/commands/mod.rs
@@ -5,14 +5,14 @@
 pub mod send_tab;
 pub use send_tab::SendTabPayload;
 
-use super::device::Device;
+use super::http_client::GetDeviceResponse;
 use crate::{Error, Result};
 
 // Currently public for use by example crates, but should be made private eventually.
 #[derive(Clone, Debug)]
 pub enum IncomingDeviceCommand {
     TabReceived {
-        sender: Option<Device>,
+        sender: Option<GetDeviceResponse>,
         payload: SendTabPayload,
     },
 }

--- a/components/fxa-client/src/internal/commands/send_tab.rs
+++ b/components/fxa-client/src/internal/commands/send_tab.rs
@@ -18,7 +18,7 @@ use serde_derive::*;
 use rc_crypto::ece::{self, EcKeyComponents};
 use sync15::{EncryptedPayload, KeyBundle};
 
-use super::super::{device::Device, scopes, telemetry};
+use super::super::{http_client::GetDeviceResponse, scopes, telemetry};
 use crate::{Error, Result, ScopedKey};
 
 pub const COMMAND_NAME: &str = "https://identity.mozilla.com/cmd/open-uri";
@@ -217,7 +217,7 @@ impl From<PrivateSendTabKeys> for PublicSendTabKeys {
 
 pub fn build_send_command(
     scoped_key: &ScopedKey,
-    target: &Device,
+    target: &GetDeviceResponse,
     send_tab_payload: &SendTabPayload,
 ) -> Result<serde_json::Value> {
     let command = target

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -94,8 +94,6 @@ impl FirefoxAccount {
 
     /// Initalizes our own device, most of the time this will be called right after logging-in
     /// for the first time.
-    ///
-    /// **💾 This method alters the persisted account state.**
     pub fn initialize_device(
         &mut self,
         name: &str,
@@ -116,8 +114,6 @@ impl FirefoxAccount {
     /// As the only capability is Send Tab now, its command is registered with the server.
     /// Don't forget to also call this if the Sync Keys change as they
     /// encrypt the Send Tab command data.
-    ///
-    /// **💾 This method alters the persisted account state.**
     pub fn ensure_capabilities(&mut self, capabilities: &[Capability]) -> Result<()> {
         // Don't re-register if we already have exactly those capabilities.
         // Because of the way that our state object defaults `device_capabilities` to empty,
@@ -176,8 +172,6 @@ impl FirefoxAccount {
     /// commands delivery (push) can sometimes be unreliable on mobile devices.
     /// Typically called even when a push notification is received, so that
     /// any prior messages for which a push didn't arrive are still handled.
-    ///
-    /// **💾 This method alters the persisted account state.**
     pub fn poll_device_commands(
         &mut self,
         reason: CommandFetchReason,

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -43,7 +43,9 @@ impl FirefoxAccount {
         }
 
         let refresh_token = self.get_refresh_token()?;
-        let response = self.client.get_devices(&self.state.config, refresh_token)?;
+        let response = self
+            .client
+            .get_devices(self.state.config(), refresh_token)?;
 
         self.devices_cache = Some(CachedResponse {
             response: response.clone(),
@@ -85,7 +87,8 @@ impl FirefoxAccount {
         // Remember what capabilities we've registered, so we don't register the same ones again.
         // We write this to internal state before we've actually written the new device record,
         // but roll it back if the server update fails.
-        self.state.device_capabilities = capabilities_set;
+        self.state
+            .update_last_sent_device_capabilities(capabilities_set);
         Ok(commands)
     }
 
@@ -121,11 +124,11 @@ impl FirefoxAccount {
         // we can't tell the difference between "have never registered capabilities" and
         // have "explicitly registered an empty set of capabilities", so it's simpler to
         // just always re-register in that case.
-        if !self.state.device_capabilities.is_empty()
-            && self.state.device_capabilities.len() == capabilities.len()
+        if !self.state.last_sent_device_capabilities().is_empty()
+            && self.state.last_sent_device_capabilities().len() == capabilities.len()
             && capabilities
                 .iter()
-                .all(|c| self.state.device_capabilities.contains(c))
+                .all(|c| self.state.last_sent_device_capabilities().contains(c))
         {
             return Ok(());
         }
@@ -138,8 +141,12 @@ impl FirefoxAccount {
 
     /// Re-register the device capabilities, this should only be used internally.
     pub(crate) fn reregister_current_capabilities(&mut self) -> Result<()> {
-        let current_capabilities: Vec<Capability> =
-            self.state.device_capabilities.clone().into_iter().collect();
+        let current_capabilities: Vec<Capability> = self
+            .state
+            .last_sent_device_capabilities()
+            .clone()
+            .into_iter()
+            .collect();
         let commands = self.register_capabilities(&current_capabilities)?;
         let update = DeviceUpdateRequestBuilder::new()
             .available_commands(&commands)
@@ -156,7 +163,7 @@ impl FirefoxAccount {
     ) -> Result<()> {
         let refresh_token = self.get_refresh_token()?;
         self.client.invoke_command(
-            &self.state.config,
+            self.state.config(),
             refresh_token,
             command,
             &target.id,
@@ -175,7 +182,7 @@ impl FirefoxAccount {
         &mut self,
         reason: CommandFetchReason,
     ) -> Result<Vec<IncomingDeviceCommand>> {
-        let last_command_index = self.state.last_handled_command.unwrap_or(0);
+        let last_command_index = self.state.last_handled_command_index().unwrap_or(0);
         // We increment last_command_index by 1 because the server response includes the current index.
         self.fetch_and_parse_commands(last_command_index + 1, None, reason)
     }
@@ -184,7 +191,7 @@ impl FirefoxAccount {
         let refresh_token = self.get_refresh_token()?;
         let pending_commands =
             self.client
-                .get_pending_commands(&self.state.config, refresh_token, index, Some(1))?;
+                .get_pending_commands(self.state.config(), refresh_token, index, Some(1))?;
         self.parse_commands_messages(pending_commands.messages, CommandFetchReason::Push(index))?
             .into_iter()
             .next()
@@ -200,13 +207,14 @@ impl FirefoxAccount {
         let refresh_token = self.get_refresh_token()?;
         let pending_commands =
             self.client
-                .get_pending_commands(&self.state.config, refresh_token, index, limit)?;
+                .get_pending_commands(self.state.config(), refresh_token, index, limit)?;
         if pending_commands.messages.is_empty() {
             return Ok(Vec::new());
         }
         log::info!("Handling {} messages", pending_commands.messages.len());
         let device_commands = self.parse_commands_messages(pending_commands.messages, reason)?;
-        self.state.last_handled_command = Some(pending_commands.index);
+        self.state
+            .set_last_handled_command_index(pending_commands.index);
         Ok(device_commands)
     }
 
@@ -282,7 +290,7 @@ impl FirefoxAccount {
     // endpoint yet.
     #[allow(dead_code)]
     pub(crate) fn register_command(&mut self, command: &str, value: &str) -> Result<()> {
-        self.state.device_capabilities.clear();
+        self.state.clear_last_sent_device_capabilities();
         let mut commands = HashMap::new();
         commands.insert(command.to_owned(), value.to_owned());
         let update = DeviceUpdateRequestBuilder::new()
@@ -295,7 +303,7 @@ impl FirefoxAccount {
     // because the server does not have a `PATCH commands` endpoint yet.
     #[allow(dead_code)]
     pub(crate) fn unregister_command(&mut self, _: &str) -> Result<()> {
-        self.state.device_capabilities.clear();
+        self.state.clear_last_sent_device_capabilities();
         let commands = HashMap::new();
         let update = DeviceUpdateRequestBuilder::new()
             .available_commands(&commands)
@@ -305,7 +313,7 @@ impl FirefoxAccount {
 
     #[allow(dead_code)]
     pub(crate) fn clear_commands(&mut self) -> Result<()> {
-        self.state.device_capabilities.clear();
+        self.state.clear_last_sent_device_capabilities();
         let update = DeviceUpdateRequestBuilder::new()
             .clear_available_commands()
             .build();
@@ -319,7 +327,7 @@ impl FirefoxAccount {
         push_subscription: &Option<PushSubscription>,
         commands: &HashMap<String, String>,
     ) -> Result<()> {
-        self.state.device_capabilities.clear();
+        self.state.clear_last_sent_device_capabilities();
         let mut builder = DeviceUpdateRequestBuilder::new()
             .display_name(display_name)
             .device_type(device_type)
@@ -334,16 +342,16 @@ impl FirefoxAccount {
         let refresh_token = self.get_refresh_token()?;
         let res = self
             .client
-            .update_device_record(&self.state.config, refresh_token, update);
+            .update_device_record(self.state.config(), refresh_token, update);
         match res {
             Ok(resp) => {
-                self.state.current_device_id = Option::from(resp.id);
+                self.state.set_current_device_id(resp.id);
                 Ok(())
             }
             Err(err) => {
                 // We failed to write an update to the server.
                 // Clear local state so that we'll be sure to retry later.
-                self.state.device_capabilities.clear();
+                self.state.clear_last_sent_device_capabilities();
                 Err(err)
             }
         }
@@ -351,7 +359,7 @@ impl FirefoxAccount {
 
     /// Retrieve the current device id from state
     pub fn get_current_device_id(&mut self) -> Result<String> {
-        match self.state.current_device_id {
+        match self.state.current_device_id() {
             Some(ref device_id) => Ok(device_id.to_string()),
             None => Err(Error::NoCurrentDeviceId),
         }
@@ -419,11 +427,11 @@ mod tests {
         // but can't work out how to do that within the typesystem.
         let config = Config::stable_dev("12345678", "https://foo.bar");
         let mut fxa = FirefoxAccount::with_config(config);
-        fxa.state.refresh_token = Some(RefreshToken {
+        fxa.state.force_refresh_token(RefreshToken {
             token: "refreshtok".to_string(),
             scopes: HashSet::default(),
         });
-        fxa.state.scoped_keys.insert("https://identity.mozilla.com/apps/oldsync".to_string(), ScopedKey {
+        fxa.state.insert_scoped_key("https://identity.mozilla.com/apps/oldsync", ScopedKey {
             kty: "oct".to_string(),
             scope: "https://identity.mozilla.com/apps/oldsync".to_string(),
             k: "kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg".to_string(),
@@ -675,7 +683,7 @@ mod tests {
         )
         .unwrap();
 
-        assert!(fxa.state.device_capabilities.is_empty());
+        assert!(fxa.state.last_sent_device_capabilities().is_empty());
 
         // Do another call with the same capabilities.
         // It should re-register, as server-side state may have changed.

--- a/components/fxa-client/src/internal/mod.rs
+++ b/components/fxa-client/src/internal/mod.rs
@@ -49,7 +49,7 @@ unsafe impl<'a> Sync for http_client::FxAClientMock<'a> {}
 // to be modified.
 pub struct FirefoxAccount {
     client: Arc<FxAClient>,
-    state: StateManager,
+    pub state: StateManager,
     attached_clients_cache: Option<CachedResponse<Vec<http_client::GetAttachedClientResponse>>>,
     devices_cache: Option<CachedResponse<Vec<http_client::GetDeviceResponse>>>,
     auth_circuit_breaker: AuthCircuitBreaker,
@@ -192,8 +192,6 @@ impl FirefoxAccount {
     /// leave the account object in a state where it can eventually reconnect to the same user.
     /// This is a "best effort" infallible method: e.g. if the network is unreachable,
     /// the device could still be in the FxA devices manager.
-    ///
-    /// **💾 This method alters the persisted account state.**
     pub fn disconnect(&mut self) {
         let current_device_result;
         {

--- a/components/fxa-client/src/internal/mod.rs
+++ b/components/fxa-client/src/internal/mod.rs
@@ -361,7 +361,7 @@ mod tests {
             })
             .times(1)
             .returns_once(Ok(vec![
-                Device {
+                GetDeviceResponse {
                     common: http_client::DeviceResponseCommon {
                         id: "1234a".to_owned(),
                         display_name: "My Device".to_owned(),
@@ -379,7 +379,7 @@ mod tests {
                     },
                     last_access_time: None,
                 },
-                Device {
+                GetDeviceResponse {
                     common: http_client::DeviceResponseCommon {
                         id: "a4321".to_owned(),
                         display_name: "My Other Device".to_owned(),
@@ -429,7 +429,7 @@ mod tests {
                 token.partial_eq("refreshtok")
             })
             .times(1)
-            .returns_once(Ok(vec![Device {
+            .returns_once(Ok(vec![GetDeviceResponse {
                 common: http_client::DeviceResponseCommon {
                     id: "a4321".to_owned(),
                     display_name: "My Other Device".to_owned(),

--- a/components/fxa-client/src/internal/oauth.rs
+++ b/components/fxa-client/src/internal/oauth.rs
@@ -302,8 +302,6 @@ impl FirefoxAccount {
     /// Complete an OAuth flow initiated in `begin_oauth_flow` or `begin_pairing_flow`.
     /// The `code` and `state` parameters can be obtained by parsing out the
     /// redirect URL after a successful login.
-    ///
-    /// **💾 This method alters the persisted account state.**
     pub fn complete_oauth_flow(&mut self, code: &str, state: &str) -> Result<()> {
         self.clear_access_token_cache();
         let oauth_flow = match self.state.pop_oauth_flow(state) {
@@ -417,8 +415,6 @@ impl FirefoxAccount {
     /// Because the old refresh token is not valid anymore, we can't do like `handle_oauth_response`
     /// and re-create the device, so it is the responsibility of the caller to do so after we're
     /// done.
-    ///
-    /// **💾 This method alters the persisted account state.**
     pub fn handle_session_token_change(&mut self, session_token: &str) -> Result<()> {
         let old_refresh_token = self.state.refresh_token().ok_or(Error::NoRefreshToken)?;
         let scopes: Vec<&str> = old_refresh_token.scopes.iter().map(AsRef::as_ref).collect();

--- a/components/fxa-client/src/internal/oauth.rs
+++ b/components/fxa-client/src/internal/oauth.rs
@@ -43,16 +43,16 @@ impl FirefoxAccount {
         if scope.contains(' ') {
             return Err(Error::MultipleScopesRequested);
         }
-        if let Some(oauth_info) = self.state.access_token_cache.get(scope) {
+        if let Some(oauth_info) = self.state.get_cached_access_token(scope) {
             if oauth_info.expires_at > util::now_secs() + OAUTH_MIN_TIME_LEFT {
                 return Ok(oauth_info.clone());
             }
         }
-        let resp = match self.state.refresh_token {
-            Some(ref refresh_token) => {
+        let resp = match self.state.refresh_token() {
+            Some(refresh_token) => {
                 if refresh_token.scopes.contains(scope) {
                     self.client.create_access_token_using_refresh_token(
-                        &self.state.config,
+                        self.state.config(),
                         &refresh_token.token,
                         ttl,
                         &[scope],
@@ -61,9 +61,9 @@ impl FirefoxAccount {
                     return Err(Error::NoCachedToken(scope.to_string()));
                 }
             }
-            None => match self.state.session_token {
-                Some(ref session_token) => self.client.create_access_token_using_session_token(
-                    &self.state.config,
+            None => match self.state.session_token() {
+                Some(session_token) => self.client.create_access_token_using_session_token(
+                    self.state.config(),
                     session_token,
                     &[scope],
                 )?,
@@ -77,30 +77,29 @@ impl FirefoxAccount {
         let token_info = AccessTokenInfo {
             scope: resp.scope,
             token: resp.access_token,
-            key: self.state.scoped_keys.get(scope).cloned(),
+            key: self.state.get_scoped_key(scope).cloned(),
             expires_at,
         };
         self.state
-            .access_token_cache
-            .insert(scope.to_string(), token_info.clone());
+            .add_cached_access_token(scope, token_info.clone());
         Ok(token_info)
     }
 
     /// Retrieve the current session token from state
     pub fn get_session_token(&self) -> Result<String> {
-        match self.state.session_token {
-            Some(ref session_token) => Ok(session_token.to_string()),
+        match self.state.session_token() {
+            Some(session_token) => Ok(session_token.to_string()),
             None => Err(Error::NoSessionToken),
         }
     }
 
     /// Check whether user is authorized using our refresh token.
     pub fn check_authorization_status(&mut self) -> Result<IntrospectInfo> {
-        let resp = match self.state.refresh_token {
-            Some(ref refresh_token) => {
+        let resp = match self.state.refresh_token() {
+            Some(refresh_token) => {
                 self.auth_circuit_breaker.check()?;
                 self.client
-                    .check_refresh_token_status(&self.state.config, &refresh_token.token)?
+                    .check_refresh_token_status(self.state.config(), &refresh_token.token)?
             }
             None => return Err(Error::NoRefreshToken),
         };
@@ -123,7 +122,7 @@ impl FirefoxAccount {
         entrypoint: &str,
         metrics: Option<MetricsParams>,
     ) -> Result<String> {
-        let mut url = self.state.config.pair_supp_url()?;
+        let mut url = self.state.config().pair_supp_url()?;
         url.query_pairs_mut().append_pair("entrypoint", entrypoint);
         if let Some(metrics) = metrics {
             metrics.append_params_to_url(&mut url);
@@ -147,10 +146,10 @@ impl FirefoxAccount {
         entrypoint: &str,
         metrics: Option<MetricsParams>,
     ) -> Result<String> {
-        let mut url = if self.state.last_seen_profile.is_some() {
-            self.state.config.oauth_force_auth_url()?
+        let mut url = if self.state.last_seen_profile().is_some() {
+            self.state.config().oauth_force_auth_url()?
         } else {
-            self.state.config.authorization_endpoint()?
+            self.state.config().authorization_endpoint()?
         };
 
         url.query_pairs_mut()
@@ -161,13 +160,13 @@ impl FirefoxAccount {
             metrics.append_params_to_url(&mut url);
         }
 
-        if let Some(ref cached_profile) = self.state.last_seen_profile {
+        if let Some(cached_profile) = self.state.last_seen_profile() {
             url.query_pairs_mut()
                 .append_pair("email", &cached_profile.response.email);
         }
 
-        let scopes: Vec<String> = match self.state.refresh_token {
-            Some(ref refresh_token) => {
+        let scopes: Vec<String> = match self.state.refresh_token() {
+            Some(refresh_token) => {
                 // Union of the already held scopes and the one requested.
                 let mut all_scopes: Vec<String> = vec![];
                 all_scopes.extend(scopes.iter().map(ToString::to_string));
@@ -201,7 +200,7 @@ impl FirefoxAccount {
         // Validate request to ensure that the client is actually allowed to request
         // the scopes they requested
         let allowed_scopes = self.client.get_scoped_key_data(
-            &self.state.config,
+            self.state.config(),
             &session_token,
             &auth_params.client_id,
             &auth_params.scope.join(" "),
@@ -226,8 +225,7 @@ impl FirefoxAccount {
                     scoped_keys.insert(
                         scope,
                         self.state
-                            .scoped_keys
-                            .get(scope)
+                            .get_scoped_key(scope)
                             .ok_or_else(|| Error::NoScopedKey(scope.clone()))?,
                     );
                     Ok(())
@@ -256,7 +254,7 @@ impl FirefoxAccount {
         };
 
         let resp = self.client.create_authorization_code_using_session_token(
-            &self.state.config,
+            self.state.config(),
             &session_token,
             auth_request_params,
         )?;
@@ -275,7 +273,7 @@ impl FirefoxAccount {
         let jwk_json = serde_json::to_string(&jwk)?;
         let keys_jwk = base64::encode_config(jwk_json, base64::URL_SAFE_NO_PAD);
         url.query_pairs_mut()
-            .append_pair("client_id", &self.state.config.client_id)
+            .append_pair("client_id", &self.state.config().client_id)
             .append_pair("scope", &scopes.join(" "))
             .append_pair("state", &state)
             .append_pair("code_challenge_method", "S256")
@@ -283,16 +281,16 @@ impl FirefoxAccount {
             .append_pair("access_type", "offline")
             .append_pair("keys_jwk", &keys_jwk);
 
-        if self.state.config.redirect_uri == OAUTH_WEBCHANNEL_REDIRECT {
+        if self.state.config().redirect_uri == OAUTH_WEBCHANNEL_REDIRECT {
             url.query_pairs_mut()
                 .append_pair("context", "oauth_webchannel_v1");
         } else {
             url.query_pairs_mut()
-                .append_pair("redirect_uri", &self.state.config.redirect_uri);
+                .append_pair("redirect_uri", &self.state.config().redirect_uri);
         }
 
-        self.flow_store.insert(
-            state, // Since state is supposed to be unique, we use it to key our flows.
+        self.state.begin_oauth_flow(
+            state,
             OAuthFlow {
                 scoped_keys_flow: Some(scoped_keys_flow),
                 code_verifier,
@@ -308,12 +306,12 @@ impl FirefoxAccount {
     /// **💾 This method alters the persisted account state.**
     pub fn complete_oauth_flow(&mut self, code: &str, state: &str) -> Result<()> {
         self.clear_access_token_cache();
-        let oauth_flow = match self.flow_store.remove(state) {
+        let oauth_flow = match self.state.pop_oauth_flow(state) {
             Some(oauth_flow) => oauth_flow,
             None => return Err(Error::UnknownOAuthState),
         };
         let resp = self.client.create_refresh_token_using_authorization_code(
-            &self.state.config,
+            self.state.config(),
             code,
             &oauth_flow.code_verifier,
         )?;
@@ -342,8 +340,8 @@ impl FirefoxAccount {
                         scoped_keys.keys().map(|s| s.as_ref()).collect::<Vec<&str>>().join(", ")
                     );
                 }
-                scoped_keys.
-                    into_iter()
+                scoped_keys
+                    .into_iter()
                     .map(|(scope, key)| Ok((scope, serde_json::from_value(key)?)))
                     .collect::<Result<Vec<_>>>()?
             }
@@ -363,11 +361,11 @@ impl FirefoxAccount {
         // Let's be good citizens and destroy this access token.
         if let Err(err) = self
             .client
-            .destroy_access_token(&self.state.config, &resp.access_token)
+            .destroy_access_token(self.state.config(), &resp.access_token)
         {
             log::warn!("Access token destruction failure: {:?}", err);
         }
-        let old_refresh_token = self.state.refresh_token.clone();
+        let old_refresh_token = self.state.refresh_token().cloned();
         let new_refresh_token = resp.refresh_token.ok_or(Error::UnrecoverableServerError(
             "No refresh token in response",
         ))?;
@@ -388,7 +386,7 @@ impl FirefoxAccount {
         if let Some(ref refresh_token) = old_refresh_token {
             if let Err(err) = self
                 .client
-                .destroy_refresh_token(&self.state.config, &refresh_token.token)
+                .destroy_refresh_token(self.state.config(), &refresh_token.token)
             {
                 log::warn!("Refresh token destruction failure: {:?}", err);
             }
@@ -403,22 +401,14 @@ impl FirefoxAccount {
                 log::warn!("Device information restoration failed: {:?}", err);
             }
         }
-        // When our keys change, we might need to re-register device capabilities with the server.
-        // Ensure that this happens on the next call to ensure_capabilities.
-        self.state.device_capabilities.clear();
-
-        for (scope, key) in scoped_keys {
-            self.state.scoped_keys.insert(scope, key);
-        }
-        // If the client requested a 'tokens/session' OAuth scope then as part of the code
-        // exchange this will get a session_token in the response.
-        if resp.session_token.is_some() {
-            self.state.session_token = resp.session_token;
-        }
-        self.state.refresh_token = Some(RefreshToken {
-            token: new_refresh_token,
-            scopes: resp.scope.split(' ').map(ToString::to_string).collect(),
-        });
+        self.state.complete_oauth_flow(
+            scoped_keys,
+            RefreshToken {
+                token: new_refresh_token,
+                scopes: resp.scope.split(' ').map(ToString::to_string).collect(),
+            },
+            resp.session_token,
+        );
         Ok(())
     }
 
@@ -430,36 +420,30 @@ impl FirefoxAccount {
     ///
     /// **💾 This method alters the persisted account state.**
     pub fn handle_session_token_change(&mut self, session_token: &str) -> Result<()> {
-        let old_refresh_token = self
-            .state
-            .refresh_token
-            .as_ref()
-            .ok_or(Error::NoRefreshToken)?;
+        let old_refresh_token = self.state.refresh_token().ok_or(Error::NoRefreshToken)?;
         let scopes: Vec<&str> = old_refresh_token.scopes.iter().map(AsRef::as_ref).collect();
         let resp = self.client.create_refresh_token_using_session_token(
-            &self.state.config,
+            self.state.config(),
             session_token,
             &scopes,
         )?;
         let new_refresh_token = resp.refresh_token.ok_or(Error::UnrecoverableServerError(
             "No refresh token in response",
         ))?;
-        self.state.refresh_token = Some(RefreshToken {
-            token: new_refresh_token,
-            scopes: resp.scope.split(' ').map(ToString::to_string).collect(),
-        });
-        self.state.session_token = Some(session_token.to_owned());
-        self.clear_access_token_cache();
+        self.state.update_tokens(
+            session_token.to_owned(),
+            RefreshToken {
+                token: new_refresh_token,
+                scopes: resp.scope.split(' ').map(ToString::to_string).collect(),
+            },
+        );
         self.clear_devices_and_attached_clients_cache();
-        // When our keys change, we might need to re-register device capabilities with the server.
-        // Ensure that this happens on the next call to ensure_capabilities.
-        self.state.device_capabilities.clear();
         Ok(())
     }
 
     /// **💾 This method may alter the persisted account state.**
     pub fn clear_access_token_cache(&mut self) {
-        self.state.access_token_cache.clear();
+        self.state.clear_access_token_cache();
     }
 }
 
@@ -603,13 +587,11 @@ mod tests {
 
     impl FirefoxAccount {
         pub fn add_cached_token(&mut self, scope: &str, token_info: AccessTokenInfo) {
-            self.state
-                .access_token_cache
-                .insert(scope.to_string(), token_info);
+            self.state.add_cached_access_token(scope, token_info);
         }
 
         pub fn set_session_token(&mut self, session_token: &str) {
-            self.state.session_token = Some(session_token.to_owned());
+            self.state.force_session_token(session_token.to_owned());
         }
     }
 
@@ -876,7 +858,7 @@ mod tests {
         let mut fxa = FirefoxAccount::with_config(config);
 
         let refresh_token_scopes = std::collections::HashSet::new();
-        fxa.state.refresh_token = Some(RefreshToken {
+        fxa.state.force_refresh_token(RefreshToken {
             token: "refresh_token".to_owned(),
             scopes: refresh_token_scopes,
         });
@@ -900,7 +882,7 @@ mod tests {
         let mut fxa = FirefoxAccount::with_config(config);
 
         let refresh_token_scopes = std::collections::HashSet::new();
-        fxa.state.refresh_token = Some(RefreshToken {
+        fxa.state.force_refresh_token(RefreshToken {
             token: "refresh_token".to_owned(),
             scopes: refresh_token_scopes,
         });

--- a/components/fxa-client/src/internal/oauth/attached_clients.rs
+++ b/components/fxa-client/src/internal/oauth/attached_clients.rs
@@ -20,7 +20,7 @@ impl FirefoxAccount {
         let session_token = self.get_session_token()?;
         let response = self
             .client
-            .get_attached_clients(&self.state.config, &session_token)?;
+            .get_attached_clients(self.state.config(), &session_token)?;
 
         self.attached_clients_cache = Some(CachedResponse {
             response: response.clone(),

--- a/components/fxa-client/src/internal/profile.rs
+++ b/components/fxa-client/src/internal/profile.rs
@@ -25,7 +25,7 @@ impl FirefoxAccount {
                     log::warn!(
                         "Access token rejected, clearing the tokens cache and trying again."
                     );
-                    self.clear_access_token_cache();
+                    self.clear_access_token_cache()?;
                     self.clear_devices_and_attached_clients_cache();
                     self.get_profile_helper(ignore_cache)
                 }
@@ -54,7 +54,7 @@ impl FirefoxAccount {
                         response: response_and_etag.response.clone(),
                         cached_at: util::now(),
                         etag,
-                    });
+                    })?;
                 }
                 Ok(response_and_etag.response)
             }
@@ -68,7 +68,7 @@ impl FirefoxAccount {
                             cached_at: util::now(),
                             etag: cached_profile.etag.clone(),
                         };
-                        self.state.set_last_seen_profile(new_cached_profile);
+                        self.state.set_last_seen_profile(new_cached_profile)?;
                         Ok(response)
                     }
                     None => Err(Error::UnrecoverableServerError(
@@ -92,17 +92,19 @@ mod tests {
 
     impl FirefoxAccount {
         pub fn add_cached_profile(&mut self, uid: &str, email: &str) {
-            self.state.set_last_seen_profile(CachedResponse {
-                response: Profile {
-                    uid: uid.into(),
-                    email: email.into(),
-                    display_name: None,
-                    avatar: "".into(),
-                    avatar_default: true,
-                },
-                cached_at: util::now(),
-                etag: "fake etag".into(),
-            });
+            self.state
+                .set_last_seen_profile(CachedResponse {
+                    response: Profile {
+                        uid: uid.into(),
+                        email: email.into(),
+                        display_name: None,
+                        avatar: "".into(),
+                        avatar_default: true,
+                    },
+                    cached_at: util::now(),
+                    etag: "fake etag".into(),
+                })
+                .unwrap();
         }
     }
 

--- a/components/fxa-client/src/internal/profile.rs
+++ b/components/fxa-client/src/internal/profile.rs
@@ -38,7 +38,7 @@ impl FirefoxAccount {
 
     fn get_profile_helper(&mut self, ignore_cache: bool) -> Result<Profile> {
         let mut etag = None;
-        if let Some(ref cached_profile) = self.state.last_seen_profile {
+        if let Some(cached_profile) = self.state.last_seen_profile() {
             if !ignore_cache && util::now() < cached_profile.cached_at + PROFILE_FRESHNESS_THRESHOLD
             {
                 return Ok(cached_profile.response.clone());
@@ -48,11 +48,11 @@ impl FirefoxAccount {
         let profile_access_token = self.get_access_token(scopes::PROFILE, None)?.token;
         match self
             .client
-            .get_profile(&self.state.config, &profile_access_token, etag)?
+            .get_profile(self.state.config(), &profile_access_token, etag)?
         {
             Some(response_and_etag) => {
                 if let Some(etag) = response_and_etag.etag {
-                    self.state.last_seen_profile = Some(CachedResponse {
+                    self.state.set_last_seen_profile(CachedResponse {
                         response: response_and_etag.response.clone(),
                         cached_at: util::now(),
                         etag,
@@ -61,15 +61,17 @@ impl FirefoxAccount {
                 Ok(response_and_etag.response)
             }
             None => {
-                match self.state.last_seen_profile.take() {
-                    Some(ref cached_profile) => {
+                match self.state.last_seen_profile() {
+                    Some(cached_profile) => {
+                        let response = cached_profile.response.clone();
                         // Update `cached_at` timestamp.
-                        self.state.last_seen_profile.replace(CachedResponse {
+                        let new_cached_profile = CachedResponse {
                             response: cached_profile.response.clone(),
                             cached_at: util::now(),
                             etag: cached_profile.etag.clone(),
-                        });
-                        Ok(cached_profile.response.clone())
+                        };
+                        self.state.set_last_seen_profile(new_cached_profile);
+                        Ok(response)
                     }
                     None => Err(Error::UnrecoverableServerError(
                         "Got a 304 without having sent an eTag.",
@@ -92,7 +94,7 @@ mod tests {
 
     impl FirefoxAccount {
         pub fn add_cached_profile(&mut self, uid: &str, email: &str) {
-            self.state.last_seen_profile = Some(CachedResponse {
+            self.state.set_last_seen_profile(CachedResponse {
                 response: Profile {
                     uid: uid.into(),
                     email: email.into(),
@@ -161,7 +163,7 @@ mod tests {
         );
         let mut refresh_token_scopes = std::collections::HashSet::new();
         refresh_token_scopes.insert("profile".to_owned());
-        fxa.state.refresh_token = Some(RefreshToken {
+        fxa.state.force_refresh_token(RefreshToken {
             token: "refreshtok".to_owned(),
             scopes: refresh_token_scopes,
         });

--- a/components/fxa-client/src/internal/profile.rs
+++ b/components/fxa-client/src/internal/profile.rs
@@ -17,8 +17,6 @@ impl FirefoxAccount {
     ///
     /// * `ignore_cache` - If set to true, bypass the in-memory cache
     /// and fetch the entire profile data from the server.
-    ///
-    /// **💾 This method alters the persisted account state.**
     pub fn get_profile(&mut self, ignore_cache: bool) -> Result<Profile> {
         match self.get_profile_helper(ignore_cache) {
             Ok(res) => Ok(res),

--- a/components/fxa-client/src/internal/push.rs
+++ b/components/fxa-client/src/internal/push.rs
@@ -31,7 +31,7 @@ impl FirefoxAccount {
                 })
             }
             PushPayload::ProfileUpdated => {
-                self.state.clear_last_seen_profile();
+                self.state.clear_last_seen_profile()?;
                 Ok(AccountEvent::ProfileUpdated)
             }
             PushPayload::DeviceConnected(DeviceConnectedPushPayload { device_name }) => {
@@ -45,8 +45,7 @@ impl FirefoxAccount {
                     Ok(id) => id == device_id,
                 };
                 if is_local_device {
-                    // Note: self.disconnect calls self.start_over which clears the state for the FirefoxAccount instance
-                    self.disconnect();
+                    self.disconnect(false)?;
                 }
                 Ok(AccountEvent::DeviceDisconnected {
                     device_id,

--- a/components/fxa-client/src/internal/push.rs
+++ b/components/fxa-client/src/internal/push.rs
@@ -14,8 +14,6 @@ impl FirefoxAccount {
     /// This API is useful for when the app would like to get the AccountEvent associated
     /// with the push message, but would **not** like to retrieve missed commands while doing so.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// **⚠️ This API does not increment the command index if a command was received**
     pub fn handle_push_message(&mut self, payload: &str) -> Result<AccountEvent> {
         let payload = serde_json::from_str(payload).or_else(|err| {

--- a/components/fxa-client/src/internal/scoped_keys.rs
+++ b/components/fxa-client/src/internal/scoped_keys.rs
@@ -11,8 +11,7 @@ use crate::{Error, Result, ScopedKey};
 impl FirefoxAccount {
     pub(crate) fn get_scoped_key(&self, scope: &str) -> Result<&ScopedKey> {
         self.state
-            .scoped_keys
-            .get(scope)
+            .get_scoped_key(scope)
             .ok_or_else(|| Error::NoScopedKey(scope.to_string()))
     }
 }

--- a/components/fxa-client/src/internal/send_tab.rs
+++ b/components/fxa-client/src/internal/send_tab.rs
@@ -17,8 +17,6 @@ use crate::{Error, Result};
 
 impl FirefoxAccount {
     /// Generate the Send Tab command to be registered with the server.
-    ///
-    /// **💾 This method alters the persisted account state.**
     pub(crate) fn generate_send_tab_command_data(&mut self) -> Result<String> {
         let own_keys = self.load_or_generate_keys()?;
         let public_keys: PublicSendTabKeys = own_keys.into();

--- a/components/fxa-client/src/internal/send_tab.rs
+++ b/components/fxa-client/src/internal/send_tab.rs
@@ -37,7 +37,7 @@ impl FirefoxAccount {
             }
         }
         let keys = PrivateSendTabKeys::from_random()?;
-        self.state.set_send_tab_key(keys.serialize()?);
+        self.state.set_send_tab_key(keys.serialize()?)?;
         Ok(keys)
     }
 
@@ -111,7 +111,7 @@ impl FirefoxAccount {
                     }
                 };
                 // Reset the Send Tab keys.
-                self.state.clear_send_tab_key();
+                self.state.clear_send_tab_key()?;
                 self.reregister_current_capabilities()?;
                 Err(e)
             }

--- a/components/fxa-client/src/internal/state_manager.rs
+++ b/components/fxa-client/src/internal/state_manager.rs
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    internal::{
+        commands, device,
+        oauth::{AccessTokenInfo, RefreshToken},
+        profile::Profile,
+        state_persistence::state_to_json,
+        CachedResponse, Config, OAuthFlow, PersistedState,
+    },
+    Result, ScopedKey,
+};
+
+/// Stores and manages the current state of the FxA client
+///
+/// All fields are private, which means that all state mutations must go through this module.  This
+/// makes it easier to reason about state changes.
+pub struct StateManager {
+    /// State that's persisted to disk
+    persisted_state: PersistedState,
+    /// In-progress OAuth flows
+    flow_store: HashMap<String, OAuthFlow>,
+}
+
+impl StateManager {
+    pub(crate) fn new(persisted_state: PersistedState) -> Self {
+        Self {
+            persisted_state,
+            flow_store: HashMap::new(),
+        }
+    }
+
+    pub fn serialize_persisted_state(&self) -> Result<String> {
+        state_to_json(&self.persisted_state)
+    }
+
+    pub fn config(&self) -> &Config {
+        &self.persisted_state.config
+    }
+
+    pub fn refresh_token(&self) -> Option<&RefreshToken> {
+        self.persisted_state.refresh_token.as_ref()
+    }
+
+    pub fn session_token(&self) -> Option<&str> {
+        self.persisted_state.session_token.as_deref()
+    }
+
+    /// Get the last known set of device capabilities that we sent to the server
+    pub fn last_sent_device_capabilities(&self) -> &HashSet<device::Capability> {
+        &self.persisted_state.device_capabilities
+    }
+
+    /// Update the last known set of device capabilities that we sent to the server
+    pub fn update_last_sent_device_capabilities(
+        &mut self,
+        capabilities_set: HashSet<device::Capability>,
+    ) {
+        self.persisted_state.device_capabilities = capabilities_set;
+    }
+
+    /// Clear out the last known set of device_capabilities.  This means that the next call to
+    /// `ensure_capabilities()` will re-send our capabilities to the server
+    ///
+    /// This is typically called when something may invalidate the server's knowledge of our
+    /// capabilities, for example replacing our device info.
+    pub fn clear_last_sent_device_capabilities(&mut self) {
+        self.persisted_state.device_capabilities = HashSet::new();
+    }
+
+    pub fn send_tab_key(&self) -> Option<&str> {
+        self.persisted_state
+            .commands_data
+            .get(commands::send_tab::COMMAND_NAME)
+            .map(String::as_str)
+    }
+
+    pub fn set_send_tab_key(&mut self, key: String) {
+        self.persisted_state
+            .commands_data
+            .insert(commands::send_tab::COMMAND_NAME.into(), key);
+    }
+
+    pub fn clear_send_tab_key(&mut self) {
+        self.persisted_state
+            .commands_data
+            .remove(commands::send_tab::COMMAND_NAME);
+    }
+
+    pub fn last_handled_command_index(&self) -> Option<u64> {
+        self.persisted_state.last_handled_command
+    }
+
+    pub fn set_last_handled_command_index(&mut self, idx: u64) {
+        self.persisted_state.last_handled_command = Some(idx)
+    }
+
+    pub fn current_device_id(&self) -> Option<&str> {
+        self.persisted_state.current_device_id.as_deref()
+    }
+
+    pub fn set_current_device_id(&mut self, device_id: String) {
+        self.persisted_state.current_device_id = Some(device_id);
+    }
+
+    pub fn get_scoped_key(&self, scope: &str) -> Option<&ScopedKey> {
+        self.persisted_state.scoped_keys.get(scope)
+    }
+
+    pub(crate) fn last_seen_profile(&self) -> Option<&CachedResponse<Profile>> {
+        self.persisted_state.last_seen_profile.as_ref()
+    }
+
+    pub(crate) fn set_last_seen_profile(&mut self, profile: CachedResponse<Profile>) {
+        self.persisted_state.last_seen_profile = Some(profile)
+    }
+
+    pub fn clear_last_seen_profile(&mut self) {
+        self.persisted_state.last_seen_profile = None
+    }
+
+    pub fn get_cached_access_token(&mut self, scope: &str) -> Option<&AccessTokenInfo> {
+        self.persisted_state.access_token_cache.get(scope)
+    }
+
+    pub fn add_cached_access_token(&mut self, scope: impl Into<String>, token: AccessTokenInfo) {
+        self.persisted_state
+            .access_token_cache
+            .insert(scope.into(), token);
+    }
+
+    pub fn clear_access_token_cache(&mut self) {
+        self.persisted_state.access_token_cache.clear()
+    }
+
+    /// Begin an OAuth flow.  This saves the OAuthFlow for later.  `state` must be unique to this
+    /// oauth flow process.
+    pub fn begin_oauth_flow(&mut self, state: impl Into<String>, flow: OAuthFlow) {
+        self.flow_store.insert(state.into(), flow);
+    }
+
+    /// Get an OAuthFlow from a previous `begin_oauth_flow()` call
+    ///
+    /// This operation removes the OAuthFlow from the our internal map.  It can only be called once
+    /// per `state` value.
+    pub fn pop_oauth_flow(&mut self, state: &str) -> Option<OAuthFlow> {
+        self.flow_store.remove(state)
+    }
+
+    /// Complete an OAuth flow.
+    pub fn complete_oauth_flow(
+        &mut self,
+        scoped_keys: Vec<(String, ScopedKey)>,
+        refresh_token: RefreshToken,
+        session_token: Option<String>,
+    ) {
+        // When our keys change, we might need to re-register device capabilities with the server.
+        // Ensure that this happens on the next call to ensure_capabilities.
+        self.persisted_state.device_capabilities.clear();
+
+        for (scope, key) in scoped_keys {
+            self.persisted_state.scoped_keys.insert(scope, key);
+        }
+        self.persisted_state.refresh_token = Some(refresh_token);
+        self.persisted_state.session_token = session_token;
+        self.flow_store.clear();
+    }
+
+    /// Called when the account is disconnected.  This clears most of the auth state, but keeps
+    /// some information in order to eventually reconnect to the same user account later.
+    pub fn disconnect(&mut self) {
+        self.persisted_state = self.persisted_state.start_over();
+        self.flow_store.clear();
+    }
+
+    /// Handle the auth tokens changing
+    ///
+    /// This method updates the token data and clears out data that may be invalidated with the
+    /// token changes.
+    pub fn update_tokens(&mut self, session_token: String, refresh_token: RefreshToken) {
+        self.persisted_state.session_token = Some(session_token);
+        self.persisted_state.refresh_token = Some(refresh_token);
+        self.persisted_state.access_token_cache.clear();
+        self.persisted_state.device_capabilities.clear();
+    }
+}
+
+#[cfg(test)]
+impl StateManager {
+    pub fn is_access_token_cache_empty(&self) -> bool {
+        self.persisted_state.access_token_cache.is_empty()
+    }
+
+    pub fn force_refresh_token(&mut self, token: RefreshToken) {
+        self.persisted_state.refresh_token = Some(token)
+    }
+
+    pub fn force_session_token(&mut self, token: String) {
+        self.persisted_state.session_token = Some(token)
+    }
+
+    pub fn force_current_device_id(&mut self, device_id: impl Into<String>) {
+        self.persisted_state.current_device_id = Some(device_id.into())
+    }
+
+    pub fn insert_scoped_key(&mut self, scope: impl Into<String>, key: ScopedKey) {
+        self.persisted_state.scoped_keys.insert(scope.into(), key);
+    }
+}

--- a/components/fxa-client/src/internal/state_manager.rs
+++ b/components/fxa-client/src/internal/state_manager.rs
@@ -9,10 +9,10 @@ use crate::{
         commands, device,
         oauth::{AccessTokenInfo, RefreshToken},
         profile::Profile,
-        state_persistence::state_to_json,
+        state_persistence::{state_from_json, state_to_json},
         CachedResponse, Config, OAuthFlow, PersistedState,
     },
-    Result, ScopedKey, StorageHandler,
+    AuthState, Error, Result, ScopedKey, StorageHandler,
 };
 
 /// Stores and manages the current state of the FxA client
@@ -24,17 +24,47 @@ pub struct StateManager {
     persisted_state: PersistedState,
     /// In-progress OAuth flows
     flow_store: HashMap<String, OAuthFlow>,
+    /// Current authorization state
+    auth_state: AuthState,
     /// Application-supplied storage handlers
     storage_handler: Option<Box<dyn StorageHandler>>,
 }
 
 impl StateManager {
-    pub(crate) fn new(persisted_state: PersistedState) -> Self {
+    /// Construct a new state manager
+    ///
+    /// The `uninitialized` flag signals that the application is not yet ready to perform disk IO
+    /// and `persisted_state` is a placeholder that may be replaced when `initialize()` is called.
+    pub(crate) fn new(persisted_state: PersistedState, uninitialized: bool) -> Self {
         Self {
+            auth_state: Self::initial_auth_state(&persisted_state, uninitialized),
             persisted_state,
             flow_store: HashMap::new(),
             storage_handler: None,
         }
+    }
+
+    fn initial_auth_state(persisted_state: &PersistedState, uninitialized: bool) -> AuthState {
+        if uninitialized {
+            AuthState::Uninitialized
+        } else if persisted_state.session_token.is_some() || persisted_state.refresh_token.is_some()
+        {
+            AuthState::Connected
+        } else {
+            AuthState::Disconnected {
+                from_auth_issues: persisted_state.disconnected_from_auth_issues,
+                connecting: false,
+            }
+        }
+    }
+
+    /// Get the current auth state
+    pub fn get_auth_state(&self) -> AuthState {
+        self.auth_state.clone()
+    }
+
+    pub fn is_connected(&self) -> bool {
+        matches!(self.auth_state, AuthState::Connected)
     }
 
     pub fn register_storage_handler(&mut self, handler: Option<Box<dyn StorageHandler>>) {
@@ -57,6 +87,39 @@ impl StateManager {
         self.persisted_state.session_token.as_deref()
     }
 
+    pub fn check_initialized(&self, operation: &str) -> Result<()> {
+        match self.auth_state {
+            AuthState::Uninitialized => Err(Error::AuthState(format!(
+                "{operation}: client not initialized"
+            ))),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn check_disconnected(&self, operation: &str) -> Result<()> {
+        match self.auth_state {
+            AuthState::Uninitialized => Err(Error::AuthState(format!(
+                "{operation}: client not initialized"
+            ))),
+            AuthState::Connected => Err(Error::AuthState(format!(
+                "{operation}: client already connected"
+            ))),
+            _ => Ok(()),
+        }
+    }
+
+    pub fn check_connected(&self, operation: &str) -> Result<()> {
+        match self.auth_state {
+            AuthState::Uninitialized => Err(Error::AuthState(format!(
+                "{operation}: client not initialized"
+            ))),
+            AuthState::Disconnected { .. } => Err(Error::AuthState(format!(
+                "{operation}: client disconnected"
+            ))),
+            _ => Ok(()),
+        }
+    }
+
     /// Get the last known set of device capabilities that we sent to the server
     pub fn last_sent_device_capabilities(&self) -> &HashSet<device::Capability> {
         &self.persisted_state.device_capabilities
@@ -66,9 +129,11 @@ impl StateManager {
     pub fn update_last_sent_device_capabilities(
         &mut self,
         capabilities_set: HashSet<device::Capability>,
-    ) {
+    ) -> Result<()> {
+        self.check_initialized("update_last_sent_device_capabilities")?;
         self.persisted_state.device_capabilities = capabilities_set;
         self.save_state();
+        Ok(())
     }
 
     /// Clear out the last known set of device_capabilities.  This means that the next call to
@@ -76,9 +141,11 @@ impl StateManager {
     ///
     /// This is typically called when something may invalidate the server's knowledge of our
     /// capabilities, for example replacing our device info.
-    pub fn clear_last_sent_device_capabilities(&mut self) {
+    pub fn clear_last_sent_device_capabilities(&mut self) -> Result<()> {
+        self.check_initialized("clear_last_sent_device_capabilities")?;
         self.persisted_state.device_capabilities = HashSet::new();
         self.save_state();
+        Ok(())
     }
 
     pub fn send_tab_key(&self) -> Option<&str> {
@@ -88,36 +155,44 @@ impl StateManager {
             .map(String::as_str)
     }
 
-    pub fn set_send_tab_key(&mut self, key: String) {
+    pub fn set_send_tab_key(&mut self, key: String) -> Result<()> {
+        self.check_initialized("set_send_tab_key")?;
         self.persisted_state
             .commands_data
             .insert(commands::send_tab::COMMAND_NAME.into(), key);
         self.save_state();
+        Ok(())
     }
 
-    pub fn clear_send_tab_key(&mut self) {
+    pub fn clear_send_tab_key(&mut self) -> Result<()> {
+        self.check_initialized("clear_send_tab_key")?;
         self.persisted_state
             .commands_data
             .remove(commands::send_tab::COMMAND_NAME);
         self.save_state();
+        Ok(())
     }
 
     pub fn last_handled_command_index(&self) -> Option<u64> {
         self.persisted_state.last_handled_command
     }
 
-    pub fn set_last_handled_command_index(&mut self, idx: u64) {
+    pub fn set_last_handled_command_index(&mut self, idx: u64) -> Result<()> {
+        self.check_initialized("set_last_handled_command_index")?;
         self.persisted_state.last_handled_command = Some(idx);
         self.save_state();
+        Ok(())
     }
 
     pub fn current_device_id(&self) -> Option<&str> {
         self.persisted_state.current_device_id.as_deref()
     }
 
-    pub fn set_current_device_id(&mut self, device_id: String) {
+    pub fn set_current_device_id(&mut self, device_id: String) -> Result<()> {
+        self.check_initialized("set_current_device_id")?;
         self.persisted_state.current_device_id = Some(device_id);
         self.save_state();
+        Ok(())
     }
 
     pub fn get_scoped_key(&self, scope: &str) -> Option<&ScopedKey> {
@@ -128,45 +203,91 @@ impl StateManager {
         self.persisted_state.last_seen_profile.as_ref()
     }
 
-    pub(crate) fn set_last_seen_profile(&mut self, profile: CachedResponse<Profile>) {
+    pub(crate) fn set_last_seen_profile(&mut self, profile: CachedResponse<Profile>) -> Result<()> {
+        self.check_initialized("set_last_seen_profile")?;
         self.persisted_state.last_seen_profile = Some(profile);
         self.save_state();
+        Ok(())
     }
 
-    pub fn clear_last_seen_profile(&mut self) {
+    pub fn clear_last_seen_profile(&mut self) -> Result<()> {
+        self.check_initialized("clear_last_seen_profile")?;
         self.persisted_state.last_seen_profile = None;
         self.save_state();
+        Ok(())
     }
 
-    pub fn get_cached_access_token(&mut self, scope: &str) -> Option<&AccessTokenInfo> {
-        self.persisted_state.access_token_cache.get(scope)
+    pub fn get_cached_access_token(&mut self, scope: &str) -> Result<Option<&AccessTokenInfo>> {
+        self.check_initialized("get_cached_access_token")?;
+        Ok(self.persisted_state.access_token_cache.get(scope))
     }
 
-    pub fn add_cached_access_token(&mut self, scope: impl Into<String>, token: AccessTokenInfo) {
+    pub fn add_cached_access_token(
+        &mut self,
+        scope: impl Into<String>,
+        token: AccessTokenInfo,
+    ) -> Result<()> {
+        self.check_initialized("add_cached_access_token")?;
         self.persisted_state
             .access_token_cache
             .insert(scope.into(), token);
         self.save_state();
+        Ok(())
     }
 
-    pub fn clear_access_token_cache(&mut self) {
+    pub fn clear_access_token_cache(&mut self) -> Result<()> {
+        self.check_initialized("clear_access_token_cache")?;
         self.persisted_state.access_token_cache.clear();
         self.save_state();
+        Ok(())
     }
 
     /// Begin an OAuth flow.  This saves the OAuthFlow for later.  `state` must be unique to this
     /// oauth flow process.
-    pub fn begin_oauth_flow(&mut self, state: impl Into<String>, flow: OAuthFlow) {
+    pub fn initialize(&mut self, saved_state: Option<String>) -> Result<()> {
+        if let Some(json) = saved_state {
+            let state = state_from_json(&json)?;
+            self.persisted_state = state;
+        };
+        self.auth_state = Self::initial_auth_state(&self.persisted_state, false);
+        Ok(())
+    }
+
+    /// Begin an OAuth flow.  This saves the OAuthFlow for later.  `state` must be unique to this
+    /// oauth flow process.
+    pub fn begin_oauth_flow(&mut self, state: impl Into<String>, flow: OAuthFlow) -> Result<()> {
+        match self.auth_state {
+            AuthState::Disconnected {
+                from_auth_issues, ..
+            } => {
+                self.auth_state = AuthState::Disconnected {
+                    from_auth_issues,
+                    connecting: true,
+                }
+            }
+            AuthState::Uninitialized => {
+                return Err(Error::AuthState(
+                    "begin_oauth_flow: client not initialized".into(),
+                ))
+            }
+            AuthState::Connected => {
+                return Err(Error::AuthState(
+                    "begin_oauth_flow: client already connected".into(),
+                ))
+            }
+        }
         self.flow_store.insert(state.into(), flow);
         // Note: no need to save the state, since `flow_store` isn't persisted to disk
+        Ok(())
     }
 
     /// Get an OAuthFlow from a previous `begin_oauth_flow()` call
     ///
     /// This operation removes the OAuthFlow from the our internal map.  It can only be called once
     /// per `state` value.
-    pub fn pop_oauth_flow(&mut self, state: &str) -> Option<OAuthFlow> {
-        self.flow_store.remove(state)
+    pub fn pop_oauth_flow(&mut self, state: &str) -> Result<Option<OAuthFlow>> {
+        self.check_disconnected("pop_oauth_flow")?;
+        Ok(self.flow_store.remove(state))
         // Note: no need to save the state, since `flow_store` isn't persisted to disk
     }
 
@@ -176,7 +297,8 @@ impl StateManager {
         scoped_keys: Vec<(String, ScopedKey)>,
         refresh_token: RefreshToken,
         session_token: Option<String>,
-    ) {
+    ) -> Result<()> {
+        self.check_disconnected("complete_oauth_flow")?;
         // When our keys change, we might need to re-register device capabilities with the server.
         // Ensure that this happens on the next call to ensure_capabilities.
         self.persisted_state.device_capabilities.clear();
@@ -186,28 +308,58 @@ impl StateManager {
         }
         self.persisted_state.refresh_token = Some(refresh_token);
         self.persisted_state.session_token = session_token;
+        self.persisted_state.disconnected_from_auth_issues = false;
+        self.auth_state = AuthState::Connected;
         self.flow_store.clear();
         self.save_state();
+        Ok(())
+    }
+
+    /// Cancels any in-progress oauth flow
+    pub fn cancel_oauth_flow(&mut self) {
+        if let AuthState::Disconnected {
+            from_auth_issues,
+            connecting: true,
+        } = self.auth_state
+        {
+            self.auth_state = AuthState::Disconnected {
+                from_auth_issues,
+                connecting: false,
+            }
+        }
     }
 
     /// Called when the account is disconnected.  This clears most of the auth state, but keeps
     /// some information in order to eventually reconnect to the same user account later.
-    pub fn disconnect(&mut self) {
+    pub fn disconnect(&mut self, from_auth_issues: bool) -> Result<()> {
+        self.check_connected("disconnect")?;
         self.persisted_state = self.persisted_state.start_over();
+        self.persisted_state.disconnected_from_auth_issues = from_auth_issues;
         self.flow_store.clear();
+        self.auth_state = AuthState::Disconnected {
+            from_auth_issues,
+            connecting: false,
+        };
         self.save_state();
+        Ok(())
     }
 
     /// Handle the auth tokens changing
     ///
     /// This method updates the token data and clears out data that may be invalidated with the
     /// token changes.
-    pub fn update_tokens(&mut self, session_token: String, refresh_token: RefreshToken) {
+    pub fn update_tokens(
+        &mut self,
+        session_token: String,
+        refresh_token: RefreshToken,
+    ) -> Result<()> {
+        self.check_connected("update_tokens")?;
         self.persisted_state.session_token = Some(session_token);
         self.persisted_state.refresh_token = Some(refresh_token);
         self.persisted_state.access_token_cache.clear();
         self.persisted_state.device_capabilities.clear();
         self.save_state();
+        Ok(())
     }
 
     /// Save the state via our [StorageHandler], if one is registered
@@ -241,19 +393,34 @@ impl StateManager {
         self.persisted_state.access_token_cache.is_empty()
     }
 
+    pub fn force_connected(&mut self) {
+        self.auth_state = AuthState::Connected;
+    }
+
+    pub fn force_disconnected(&mut self) {
+        self.auth_state = AuthState::Disconnected {
+            from_auth_issues: false,
+            connecting: false,
+        };
+    }
+
     pub fn force_refresh_token(&mut self, token: RefreshToken) {
+        self.force_connected();
         self.persisted_state.refresh_token = Some(token)
     }
 
     pub fn force_session_token(&mut self, token: String) {
+        self.force_connected();
         self.persisted_state.session_token = Some(token)
     }
 
     pub fn force_current_device_id(&mut self, device_id: impl Into<String>) {
+        self.force_connected();
         self.persisted_state.current_device_id = Some(device_id.into())
     }
 
     pub fn insert_scoped_key(&mut self, scope: impl Into<String>, key: ScopedKey) {
+        self.force_connected();
         self.persisted_state.scoped_keys.insert(scope.into(), key);
     }
 }

--- a/components/fxa-client/src/internal/state_persistence.rs
+++ b/components/fxa-client/src/internal/state_persistence.rs
@@ -105,6 +105,8 @@ pub(crate) struct StateV2 {
     pub(crate) access_token_cache: HashMap<String, AccessTokenInfo>,
     pub(crate) session_token: Option<String>, // Hex-formatted string.
     pub(crate) last_seen_profile: Option<CachedResponse<Profile>>,
+    #[serde(default)]
+    pub(crate) disconnected_from_auth_issues: bool,
 }
 
 impl StateV2 {
@@ -127,6 +129,7 @@ impl StateV2 {
             access_token_cache: HashMap::new(),
             device_capabilities: HashSet::new(),
             session_token: None,
+            disconnected_from_auth_issues: false,
         }
     }
 }

--- a/components/fxa-client/src/internal/telemetry.rs
+++ b/components/fxa-client/src/internal/telemetry.rs
@@ -18,7 +18,7 @@ impl FirefoxAccount {
     /// forgivingly (eg, be tolerant of things not existing) to try and avoid
     /// too many changes as telemetry comes and goes.
     pub fn gather_telemetry(&mut self) -> Result<String> {
-        let telem = self.telemetry.replace(FxaTelemetry::new());
+        let telem = std::mem::replace(&mut self.telemetry, FxaTelemetry::new());
         Ok(serde_json::to_string(&telem)?)
     }
 }

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -22,6 +22,8 @@
 //! * Register a StorageHandler with the `register_storage_handler()` method.  The `save_state` method
 //!   will be called whenever the persistent state changes.
 //!
+//! * Register an EventListener with the `register_event_listener()` method.  The `on_event` method
+//!   will be called when on account events.
 //!
 //! * When the user wants to sign in to your application, direct them through
 //!   a web-based OAuth flow using [`begin_oauth_flow`](FirefoxAccount::begin_oauth_flow)
@@ -42,6 +44,7 @@ mod account;
 mod auth;
 mod device;
 mod error;
+mod events;
 mod internal;
 mod profile;
 mod push;
@@ -55,6 +58,7 @@ pub use sync15::DeviceType;
 pub use auth::{AuthState, AuthorizationInfo, MetricsParams};
 pub use device::{AttachedClient, Device, DeviceCapability, DeviceList};
 pub use error::{CallbackError, Error, FxaError};
+pub use events::{EventListener, FxaEvent};
 use parking_lot::Mutex;
 pub use profile::Profile;
 pub use push::{

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -17,9 +17,11 @@
 //!   signed-in state of the application.
 //!     * On first startup, a new [`FirefoxAccount`] can be created by calling
 //!       [`FirefoxAccount::new`] and passing the application's `client_id`.
-//!     * For subsequent startups the object can be persisted using the
-//!       [`to_json`](FirefoxAccount::to_json) method and re-created by
-//!       calling [`FirefoxAccount::from_json`].
+//!     * For subsequent startups the object can be re-created by calling [`FirefoxAccount::from_json`].
+//!
+//! * Register a StorageHandler with the `register_storage_handler()` method.  The `save_state` method
+//!   will be called whenever the persistent state changes.
+//!
 //!
 //! * When the user wants to sign in to your application, direct them through
 //!   a web-based OAuth flow using [`begin_oauth_flow`](FirefoxAccount::begin_oauth_flow)
@@ -51,18 +53,21 @@ pub use sync15::DeviceType;
 
 pub use auth::{AuthorizationInfo, MetricsParams};
 pub use device::{AttachedClient, Device, DeviceCapability};
-pub use error::{Error, FxaError};
+pub use error::{CallbackError, Error, FxaError};
 use parking_lot::Mutex;
 pub use profile::Profile;
 pub use push::{
     AccountEvent, DevicePushSubscription, IncomingDeviceCommand, SendTabPayload, TabHistoryEntry,
 };
+pub use storage::StorageHandler;
 pub use token::{AccessTokenInfo, AuthorizationParameters, ScopedKey};
 
 /// Result returned by internal functions
 pub type Result<T> = std::result::Result<T, Error>;
 /// Result returned by public-facing API functions
 pub type ApiResult<T> = std::result::Result<T, FxaError>;
+/// Result returned by callback interfaces
+pub type CallbackResult<T> = std::result::Result<T, CallbackError>;
 
 /// Object representing the signed-in state of an application.
 ///
@@ -79,8 +84,6 @@ pub struct FirefoxAccount {
 
 impl FirefoxAccount {
     /// Create a new [`FirefoxAccount`] instance, not connected to any account.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// This method constructs as new [`FirefoxAccount`] instance configured to connect
     /// the application to a user's account.

--- a/components/fxa-client/src/profile.rs
+++ b/components/fxa-client/src/profile.rs
@@ -12,8 +12,6 @@ use error_support::handle_error;
 impl FirefoxAccount {
     /// Get profile information for the signed-in user, if any.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// This method fetches a [`Profile`] struct with information about the currently-signed-in
     /// user, either by using locally-cached profile information or by fetching fresh data from
     /// the server.

--- a/components/fxa-client/src/push.rs
+++ b/components/fxa-client/src/push.rs
@@ -31,6 +31,8 @@ impl FirefoxAccount {
 
     /// Process and respond to a server-delivered account update message
     ///
+    /// **Deprecated: use [FirefoxAccount::process_push_message] instead.
+    ///
     /// Applications should call this method whenever they receive a push notification from the Firefox Accounts server.
     /// Such messages typically indicate a noteworthy change of state on the user's account, such as an update to their profile information
     /// or the disconnection of a client. The [`FirefoxAccount`] struct will update its internal state
@@ -42,6 +44,14 @@ impl FirefoxAccount {
     #[handle_error(Error)]
     pub fn handle_push_message(&self, payload: &str) -> ApiResult<AccountEvent> {
         self.internal.lock().handle_push_message(payload)
+    }
+
+    /// Process a server-delivered account update message
+    ///
+    /// This will usually end up in a [crate::FxaEvent] being sent to the current [crate::EventListener]
+    #[handle_error(Error)]
+    pub fn process_push_message(&self, payload: &str) -> ApiResult<()> {
+        self.internal.lock().process_push_message(payload)
     }
 
     /// Poll the server for any pending device commands.

--- a/components/fxa-client/src/push.rs
+++ b/components/fxa-client/src/push.rs
@@ -8,8 +8,6 @@ use error_support::handle_error;
 impl FirefoxAccount {
     /// Set or update a push subscription endpoint for this device.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// This method registers the given webpush subscription with the FxA server, requesting
     /// that is send notifications in the event of any significant changes to the user's
     /// account. When the application receives a push message at the registered subscription
@@ -33,8 +31,6 @@ impl FirefoxAccount {
 
     /// Process and respond to a server-delivered account update message
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// Applications should call this method whenever they receive a push notification from the Firefox Accounts server.
     /// Such messages typically indicate a noteworthy change of state on the user's account, such as an update to their profile information
     /// or the disconnection of a client. The [`FirefoxAccount`] struct will update its internal state
@@ -49,8 +45,6 @@ impl FirefoxAccount {
     }
 
     /// Poll the server for any pending device commands.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// Applications that have registered one or more [`DeviceCapability`]s with the server can use
     /// this method to check whether other devices on the account have sent them any commands.
@@ -74,8 +68,6 @@ impl FirefoxAccount {
     }
 
     /// Use device commands to send a single tab to another device.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// If a device on the account has registered the [`SendTab`](DeviceCapability::SendTab)
     /// capability, this method can be used to send it a tab.

--- a/components/fxa-client/src/push.rs
+++ b/components/fxa-client/src/push.rs
@@ -98,7 +98,7 @@ impl FirefoxAccount {
 ///
 /// Managing a web-push subscription is outside of the scope of this component.
 ///
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct DevicePushSubscription {
     pub endpoint: String,
     pub public_key: String,

--- a/components/fxa-client/src/token.rs
+++ b/components/fxa-client/src/token.rs
@@ -113,7 +113,8 @@ impl FirefoxAccount {
     /// Applications that receive an authentication error when trying to use an access token,
     /// should call this method before creating a new token and retrying the failed operation.
     /// It ensures that the expired token is removed and a fresh one generated.
-    pub fn clear_access_token_cache(&self) {
+    #[handle_error(Error)]
+    pub fn clear_access_token_cache(&self) -> ApiResult<()> {
         self.internal.lock().clear_access_token_cache()
     }
 }

--- a/components/fxa-client/src/token.rs
+++ b/components/fxa-client/src/token.rs
@@ -23,8 +23,6 @@ use std::convert::{TryFrom, TryInto};
 impl FirefoxAccount {
     /// Get a short-lived OAuth access token for the user's account.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// Applications that need to access resources on behalf of the user must obtain an
     /// `access_token` in order to do so. For example, an access token is required when
     /// fetching the user's profile data, or when accessing their data stored in Firefox Sync.
@@ -56,8 +54,6 @@ impl FirefoxAccount {
 
     /// Get the session token for the user's account, if one is available.
     ///
-    /// **💾 This method alters the persisted account state.**
-    ///
     /// Applications that function as a web browser may need to hold on to a session token
     /// on behalf of Firefox Accounts web content. This method exists so that they can retreive
     /// it an pass it back to said web content when required.
@@ -75,8 +71,6 @@ impl FirefoxAccount {
     }
 
     /// Update the stored session token for the user's account.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// Applications that function as a web browser may need to hold on to a session token
     /// on behalf of Firefox Accounts web content. This method exists so that said web content
@@ -115,8 +109,6 @@ impl FirefoxAccount {
     }
 
     /// Clear the access token cache in response to an auth failure.
-    ///
-    /// **💾 This method alters the persisted account state.**
     ///
     /// Applications that receive an authentication error when trying to use an access token,
     /// should call this method before creating a new token and retrying the failed operation.

--- a/examples/fxa-client/src/main.rs
+++ b/examples/fxa-client/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<()> {
         Command::Devices(args) => devices::run(&account, args),
         Command::SendTab(args) => send_tab::run(&account, args),
         Command::Disconnect => {
-            account.disconnect();
+            account.disconnect()?;
             Ok(())
         }
     }?;


### PR DESCRIPTION
This is my attempt to add more functionality to the FxA client with the hope that this shared code can replace a lot of the current Swift/Kotlin wrapper code.  This is based on top of https://github.com/mozilla/application-services/pull/5713.

This is basically non-breaking, although we now throw exceptions in more cases than before.  This mostly happens when you try to call a method that's not valid for the current auth state (`disconnect()` when the client isn't connected, `begin_oauth_flow()` when the client is uninitialized, etc).  I think we might be able merge this now without changing the consumer code.

The next step would be to update the Swift/Kotlin wrapper code to use this functionality and delete the wrapper classes there.

The best way to understand this is probably commit-by-commit.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
