### PR TITLE
Add --patch option for all commands that takes an experiment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
   - This adds a non-user-facing method to the `FeatureManifestInterface`, `getCoenrollingFeatureIds`, in both Kotlin and Swift.
 - Exposes a method to get the coenrolling feature ids in the FML client ([#5714](https://github.com/mozilla/application-services/pull/5714)), as well as the NimbusBuilders for both Kotlin and Swift ([#5718](https://github.com/mozilla/application-services/pull/5718)).
 
+## Nimbus CLI [⛅️🔬🔭👾](./components/support/nimbus-cli)
+
+### 🦊 What's Changed 🦊
+
+- Added a `--patch` option to all commands that accept an experiment. ([#5721](https://github.com/mozilla/application-services/pull/5721))
+
 [Full Changelog](In progress)
 
 # v116.0 (_2023-07-03_)

--- a/components/support/nimbus-cli/README.md
+++ b/components/support/nimbus-cli/README.md
@@ -59,25 +59,37 @@ The experiment slug is a combination of the actual slug, and the server it came 
 
 These can be further combined: e.g. $slug, preview/$slug, stage/$slug, stage/preview/$slug
 
-Usage: nimbus-cli --app <APP> --channel <CHANNEL> enroll [OPTIONS] --branch <BRANCH> <SLUG> [ROLLOUTS]...
+Usage: nimbus-cli --app <APP> --channel <CHANNEL> enroll [OPTIONS] --branch <BRANCH> <EXPERIMENT_SLUG> [ROLLOUTS]... [-- <PASSTHROUGH_ARGS>...]
 
 Arguments:
-  <SLUG>
+  <EXPERIMENT_SLUG>
           The experiment slug, including the server and collection
 
   [ROLLOUTS]...
           Optional rollout slugs, including the server and collection
 
+  [PASSTHROUGH_ARGS]...
+          Optionally, add platform specific arguments to the adb or xcrun command.
+
+          By default, arguments are added to the end of the command, likely to be passed directly to the app.
+
+          Arguments before a special placeholder `{}` are passed to `adb am start` or `xcrun simctl launch` commands directly.
+
 Options:
       --file <EXPERIMENTS_FILE>
           An optional file from which to get the experiment.
-          
+
           By default, the file is fetched from the server.
 
       --use-rs
           Use remote settings to fetch the experiment recipe.
-          
+
           By default, the file is fetched from the v6 api of experimenter.
+
+      --patch <PATCH_FILE>
+          An optional patch file, used to patch feature configurations
+
+          This is of the format that comes from the `features --multi` or `defaults` commands.
 
   -b, --branch <BRANCH>
           The branch slug
@@ -96,7 +108,7 @@ Options:
 
       --preserve-nimbus-db
           Keeps existing enrollments and experiments before enrolling.
-          
+
           This is unlikely what you want to do.
 
       --no-validate
@@ -110,7 +122,7 @@ Options:
 
       --ref <APP_VERSION>
           The branch/tag/commit for the version of the manifest to get from Github
-          
+
           [default: main]
 
   -h, --help
@@ -152,7 +164,9 @@ Configure an application feature with one or more feature config files.
 
 One file per branch. The branch slugs will correspond to the file names.
 
-Usage: nimbus-cli --app <APP> --channel <CHANNEL> test-feature [OPTIONS] <FEATURE_ID> [FILES]...
+By default, the files are validated against the manifest; this can be overridden with `--no-validate`.
+
+Usage: nimbus-cli --app <APP> --channel <CHANNEL> test-feature [OPTIONS] <FEATURE_ID> [FILES]... [-- <PASSTHROUGH_ARGS>...]
 
 Arguments:
   <FEATURE_ID>
@@ -161,14 +175,38 @@ Arguments:
   [FILES]...
           One or more files containing a feature config for the feature
 
+  [PASSTHROUGH_ARGS]...
+          Optionally, add platform specific arguments to the adb or xcrun command.
+          
+          By default, arguments are added to the end of the command, likely to be passed directly to the app.
+          
+          Arguments before a special placeholder `{}` are passed to `adb am start` or `xcrun simctl launch` commands directly.
+
 Options:
+      --patch <PATCH_FILE>
+          An optional patch file, used to patch feature configurations
+          
+          This is of the format that comes from the `features --multi` or `defaults` commands.
+
+      --deeplink <DEEPLINK>
+          Optional deeplink. If present, launch with this link
+
       --reset-app
           Resets the app back to its initial state before launching
 
-      --deeplink <DEEPLINK>
-          Optional deeplink.
+      --no-validate
+          Don't validate the feature config files before enrolling
 
-          Instead of mimicking the app launcher, send open a URL to the device, which may or may not be handled by the app.
+      --manifest <MANIFEST_FILE>
+          An optional manifest file
+
+      --version <APP_VERSION>
+          An optional version of the app. If present, constructs the `ref` from an app specific template. Due to inconsistencies in branching names, this isn't always reliable
+
+      --ref <APP_VERSION>
+          The branch/tag/commit for the version of the manifest to get from Github
+          
+          [default: main]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/components/support/nimbus-cli/src/cli.rs
+++ b/components/support/nimbus-cli/src/cli.rs
@@ -224,6 +224,13 @@ pub(crate) enum CliCommand {
         /// One or more files containing a feature config for the feature.
         files: Vec<PathBuf>,
 
+        /// An optional patch file, used to patch feature configurations
+        ///
+        /// This is of the format that comes from the
+        /// `features --multi` or `defaults` commands.
+        #[arg(long, value_name = "PATCH_FILE")]
+        patch: Option<PathBuf>,
+
         #[command(flatten)]
         open: OpenArgs,
 
@@ -305,6 +312,13 @@ pub(crate) struct ExperimentArgs {
     /// By default, the file is fetched from the v6 api of experimenter.
     #[arg(long, default_value = "false")]
     pub(crate) use_rs: bool,
+
+    /// An optional patch file, used to patch feature configurations
+    ///
+    /// This is of the format that comes from the
+    /// `features --multi` or `defaults` commands.
+    #[arg(long, value_name = "PATCH_FILE")]
+    pub(crate) patch: Option<PathBuf>,
 }
 
 #[derive(Args, Clone, Debug, Default)]

--- a/components/support/nimbus-cli/src/cmd.rs
+++ b/components/support/nimbus-cli/src/cmd.rs
@@ -5,7 +5,8 @@
 use crate::{
     sources::ManifestSource,
     value_utils::{
-        prepare_experiment, prepare_rollout, try_find_branches, try_find_features, CliUtils,
+        prepare_experiment, prepare_rollout, try_find_branches_from_experiment,
+        try_find_features_from_branch, CliUtils,
     },
     AppCommand, AppOpenArgs, ExperimentListSource, ExperimentSource, LaunchableApp, NimbusApp,
 };
@@ -583,9 +584,9 @@ impl NimbusApp {
         };
 
         let mut is_valid = true;
-        for b in try_find_branches(&value)? {
+        for b in try_find_branches_from_experiment(&value)? {
             let branch = b.get_str("slug")?;
-            for f in try_find_features(&b)? {
+            for f in try_find_features_from_branch(&b)? {
                 let id = f.get_str("featureId")?;
                 let value = f
                     .get("value")

--- a/components/support/nimbus-cli/src/output/features.rs
+++ b/components/support/nimbus-cli/src/output/features.rs
@@ -75,14 +75,14 @@ impl ExperimentSource {
         let value = self.try_into()?;
 
         // Find the named branch.
-        let branches = value_utils::try_find_branches(&value)?;
+        let branches = value_utils::try_find_branches_from_experiment(&value)?;
         let b = branches
             .iter()
             .find(|b| b.get_str("slug").unwrap() == branch)
             .ok_or_else(|| anyhow::format_err!("Branch '{branch}' does not exist"))?;
 
         // Find the features for this branch: there may be more than one.
-        let feature_values = value_utils::try_find_features(b)?;
+        let feature_values = value_utils::try_find_features_from_branch(b)?;
 
         // Now extract the relevant features out of the branches.
         let mut result = serde_json::value::Map::new();


### PR DESCRIPTION
Fixes [EXP-3668](https://mozilla-hub.atlassian.net/browse/EXP-3668).

This PR adds a `--patch FILE` option to all commands that accept an experiment as input:

- `enroll`
- `features`
- `fetch`
- `info`
- `validate` 

The patch file is expected to be structured:

```json
{
   "feature1": {},
   "feature2": {}
}
```

This is the same format that `defaults` and `features --multi` use.

The patch file can be kept by the user and used over and over, or generated on the fly, e.g. with `jq`.

Examples may be: 

```sh
experiment="release-ios-re-engagement-notifications-ab-experiment-1141"
branch="control"
app="firefox_ios"
channel="developer"
```

1. generating a patch file with all trigger expressions set to "true"
```sh
nimbus-cli --app $app --channel $channel defaults |\
    jq '.messaging|{ messaging: { triggers: .triggers|map_values("true") } }' \
   > patch.json
```

2. generating a patch file from a messaging experiment removing `message-under-experiment`, adding `experiment: "{experiment}"` and changing the trigger to `["ALWAYS"]`:
```sh
nimbus-cli --app $app --channel $channel features $experiment --branch $branch --multi |\
	jq '.messaging|{ messaging: { "message-under-experiment": null, messages: .messages|map_values({ experiment: "{experiment}", trigger: ["ALWAYS"] })} }' \
	> patch.json
```

However you get the patch file:

```sh
nimbus-cli --app $app --channel $channel enroll $experiment --branch $branch --patch patch.json
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
