### PR TITLE
Fix nimbus-fml breaking deterministic builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
   - This adds a non-user-facing method to the `FeatureManifestInterface`, `getCoenrollingFeatureIds`, in both Kotlin and Swift.
 - Exposes a method to get the coenrolling feature ids in the FML client ([#5714](https://github.com/mozilla/application-services/pull/5714)), as well as the NimbusBuilders for both Kotlin and Swift ([#5718](https://github.com/mozilla/application-services/pull/5718)).
 
+### 🦊 What's Changed 🦊
+
+- Make sure deterministic builds of downstream consumers are not broken ([#5736](https://github.com/mozilla/application-services/pull/5736)).
+
 ## Nimbus CLI [⛅️🔬🔭👾](./components/support/nimbus-cli)
 
 ### ✨ What's New ✨

--- a/components/support/nimbus-fml/src/backends/frontend_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/frontend_manifest.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use crate::frontend::{
     EnumBody, EnumVariantBody, FeatureBody, FieldBody, ManifestFrontEnd, ObjectBody, Types,
@@ -89,7 +89,7 @@ impl From<ObjectDef> for ObjectBody {
 
 impl From<EnumDef> for EnumBody {
     fn from(value: EnumDef) -> Self {
-        let mut variants = HashMap::new();
+        let mut variants = BTreeMap::new();
         for v in value.variants {
             variants.insert(v.name.clone(), v.into());
         }

--- a/components/support/nimbus-fml/src/frontend.rs
+++ b/components/support/nimbus-fml/src/frontend.rs
@@ -27,7 +27,7 @@ pub(crate) struct EnumVariantBody {
 #[serde(deny_unknown_fields)]
 pub(crate) struct EnumBody {
     pub(crate) description: String,
-    pub(crate) variants: HashMap<String, EnumVariantBody>,
+    pub(crate) variants: BTreeMap<String, EnumVariantBody>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -115,7 +115,7 @@ pub(crate) struct ImportBlock {
     pub(crate) path: String,
     pub(crate) channel: String,
     #[serde(default)]
-    pub(crate) features: HashMap<String, Vec<DefaultBlock>>,
+    pub(crate) features: BTreeMap<String, Vec<DefaultBlock>>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]


### PR DESCRIPTION
This commit makes sure that users of `nimbus-fml` can be deterministically built, by switching to `BTreeMap` instead of `HashMap` in certain types.

Checking its correctness is quite difficult, because it needs to be ran in an environment in which inputs are already all deterministic.
Maybe it could be possible to add a test on the generated output.

I wrote a patch for 115 (that is what we use for Tor Browser), but there were some major refactors after that version, so I tried to apply my patch to them.
If this binary is still compatible, I can try to inject a more recent `nimbus-fml` in a 115 build.

Fixes #5735.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
