### PR TITLE
remote_settings: Pin `url` version to 2.1.

### DIFF
--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -16,7 +16,7 @@ serde = "1"
 serde_json = "1"
 parking_lot = "0.12"
 viaduct = { path = "../viaduct" }
-url = "2.2"
+url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [build-dependencies]
 uniffi = { version = "0.24.1", features = ["build"] }


### PR DESCRIPTION
We can't vendor the new `suggest` component into Desktop just yet, because it depends on `remote_settings`, which depends on `url = "2.2"`, while Desktop pins `url = "2.1.0"` (bug 1734538 strikes again! 🐞).

As a workaround, let's pin `remote_settings` to the same `url` version as Desktop.

This isn't an externally visible change, but please let me know if you'd still like a `CHANGELOG` entry!

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
