### PR TITLE
[ci full] Switch to macOS 13.3 SDK

### DIFF
--- a/taskcluster/scripts/nimbus-build-osx.sh
+++ b/taskcluster/scripts/nimbus-build-osx.sh
@@ -5,7 +5,7 @@ set -ex
 # This runs in front of `build-nimbus-fml.py`  The only reason it exists is that it's easier to
 # setup the enviroment in a script.
 
-SDK=macosx11.0
+SDK=macosx13.3
 xcodebuild -showsdks
 SDKROOT=$(xcrun -sdk $SDK --show-sdk-path)
 MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk $SDK --show-sdk-platform-version)


### PR DESCRIPTION
Switches to using the macOS 13.3 SDK in builds, as with the new xcode version, the former version is no longer available.
Context can be found in [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1841884).