### PR TITLE
Update Glean to v53.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jna_version = '5.13.0'
         android_gradle_plugin_version = '7.4.2'
         android_components_version = '115.0.1'
-        glean_version = '53.0.0'
+        glean_version = '53.1.0'
 
         // NOTE: AndroidX libraries should be synced with AC to avoid compatibility issues
         androidx_annotation_version = '1.6.0'

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -1090,7 +1090,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 53.0.0;
+				minimumVersion = 53.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "f3f026c327b9964ebfa57f504debd166c25cfe58",
-        "version" : "53.0.0"
+        "revision" : "b7d587b698aaaa028fabba8cd13d5cb5069030b8",
+        "version" : "53.1.0"
       }
     }
   ],


### PR DESCRIPTION
#5678 already updated the submodule to the v53.1.0 commit, so just need to update the Android and iOS references.