### PR TITLE
Updates docs on how to prepare a component for rust-component-swift

### DIFF
--- a/docs/howtos/adding-a-new-component.md
+++ b/docs/howtos/adding-a-new-component.md
@@ -200,8 +200,12 @@ Use the Xcode Test Navigator to run your tests and check whether
 they're passing.
 
 ## Distribute your component with `rust-components-swift`
+The Swift source code and generated UniFFI bindings are distributed to consumers (eg: Firefox iOS) through [`rust-components-swift`](https://github.com/mozilla/rust-components-swift).
 
-To distribute your component with `rust-components-swift`, you need to add logic for dynamically generating any swift code to the [`generate.sh` script in the `rust-components-swift` repo](https://github.com/mozilla/rust-components-swift/blob/main/generate.sh). You can use that script to:
-    - Generate `uniffi` bindings
-    - Generate `Glean` metrics
-    - Copy over any handwritten code
+A nightly taskcluster job prepares the `rust-component-swift` packages from the source code in the application-services repository. To distribute your component with `rust-component-swift`, add the following to the taskcluster script in `taskcluster/scripts/build-and-test-swift.py`:
+- Add the path to the `<your_crate_name>.udl` file to `BINDINGS_UDL_PATHS`
+  - Optionally also to `FOCUS_UDL_PATHS` if your component is also targeting Firefox Focus
+- Add the path to the directory containing any hand-written swift code to `SOURCE_TO_COPY`
+  - Optionally also to `FOCUS_SOURCE_TO_COPY` if your component is also targeting Firefox Focus
+
+Your component should now automatically get included in the next `rust-component-swift` nightly release.


### PR DESCRIPTION
over in #5749 I realized that our docs don't mention that we should add a new component to the taskcluster script.


cc @linabutler we'll also need to do this for suggest so it gets included in iOS

This PR updates the docs to include 
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
