### PR TITLE
Update Cargo.lock for a previous commit which missed a syn upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5560,5 +5560,5 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.26",
 ]


### PR DESCRIPTION
It looks like 6c90ecc6b59e823364bdffae40d61bf7c7aef116 missed a crate.