### PR TITLE
Stop running Taskcluster tasks on 'github-release' events

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -20,12 +20,9 @@ tasks:
                   else:
                       $if: 'tasks_for == "github-pull-request"'
                       then: '${event.pull_request.user.login}@users.noreply.github.com'
-                      else:
-                          $if: 'tasks_for == "github-release"'
-                          then: '${event.sender.login}@users.noreply.github.com'
 
           baseRepoUrl:
-              $if: 'tasks_for in ["github-push", "github-release"]'
+              $if: 'tasks_for == "github-push"'
               then: '${event.repository.html_url}'
               else:
                   $if: 'tasks_for == "github-pull-request"'
@@ -34,7 +31,7 @@ tasks:
                       $if: 'tasks_for in ["cron", "action"]'
                       then: '${repository.url}'
           repoUrl:
-              $if: 'tasks_for in ["github-push", "github-release"]'
+              $if: 'tasks_for == "github-push"'
               then: '${event.repository.html_url}'
               else:
                   $if: 'tasks_for == "github-pull-request"'
@@ -43,7 +40,7 @@ tasks:
                       $if: 'tasks_for in ["cron", "action"]'
                       then: '${repository.url}'
           project:
-              $if: 'tasks_for in ["github-push", "github-release"]'
+              $if: 'tasks_for == "github-push"'
               then: '${event.repository.name}'
               else:
                   $if: 'tasks_for == "github-pull-request"'
@@ -58,11 +55,8 @@ tasks:
                   $if: 'tasks_for == "github-push"'
                   then: ${event.ref}
                   else:
-                      $if: 'tasks_for == "github-release"'
-                      then: '${event.release.target_commitish}'
-                      else:
-                          $if: 'tasks_for in ["cron", "action"]'
-                          then: '${push.branch}'
+                      $if: 'tasks_for in ["cron", "action"]'
+                      then: '${push.branch}'
           head_sha:
               $if: 'tasks_for == "github-push"'
               then: '${event.after}'
@@ -70,15 +64,8 @@ tasks:
                   $if: 'tasks_for == "github-pull-request"'
                   then: '${event.pull_request.head.sha}'
                   else:
-                      $if: 'tasks_for == "github-release"'
-                      then: '${event.release.tag_name}'
-                      else:
-                          $if: 'tasks_for in ["cron", "action"]'
-                          then: '${push.revision}'
-          head_tag:
-              $if: 'tasks_for == "github-release"'
-              then: '${event.release.tag_name}'
-              else: ''
+                      $if: 'tasks_for in ["cron", "action"]'
+                      then: '${push.revision}'
           ownTaskId:
               $if: '"github" in tasks_for'
               then: {$eval: as_slugid("decision_task")}
@@ -89,20 +76,15 @@ tasks:
               $if: 'tasks_for == "github-pull-request"'
               then: ${event.action}
               else: 'UNDEFINED'
-          releaseAction:
-              $if: 'tasks_for == "github-release"'
-              then: ${event.action}
-              else: 'UNDEFINED'
       in:
           $if: >
             tasks_for in ["action", "cron"]
             || (tasks_for == "github-pull-request" && pullRequestAction in ["opened", "reopened", "synchronize"])
             || (tasks_for == "github-push" && (head_branch == "refs/heads/main" || head_branch[:19] == "refs/heads/release-"))
-            || (tasks_for == "github-release" && releaseAction == "published")
           then:
               $let:
                   level:
-                      $if: 'tasks_for in ["github-push", "github-release", "action", "cron"] && repoUrl == "https://github.com/mozilla/application-services"'
+                      $if: 'tasks_for in ["github-push", "action", "cron"] && repoUrl == "https://github.com/mozilla/application-services"'
                       then: '3'
                       else: '1'
                   short_head_branch:
@@ -127,7 +109,7 @@ tasks:
                           $merge:
                               - owner: "${ownerEmail}"
                                 source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
-                              - $if: 'tasks_for in ["github-push", "github-pull-request", "github-release"]'
+                              - $if: 'tasks_for in ["github-push", "github-pull-request"]'
                                 then:
                                     name: "Decision Task"
                                     description: 'The task that creates all of the other tasks in the task graph'
@@ -185,16 +167,12 @@ tasks:
                               then:
                                   - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
                               else:
-                                  $if: 'tasks_for == "github-release"'
+                                  $if: 'tasks_for == "action"'
                                   then:
-                                      - 'assume:repo:${repoUrl[8:]}:release:${releaseAction}'
+                                      # when all actions are hooks, we can calculate this directly rather than using a variable
+                                      - '${action.repo_scope}'
                                   else:
-                                      $if: 'tasks_for == "action"'
-                                      then:
-                                          # when all actions are hooks, we can calculate this directly rather than using a variable
-                                          - '${action.repo_scope}'
-                                      else:
-                                          - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
+                                      - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
                       requires: all-completed
                       priority: lowest
                       retries: 5
@@ -208,7 +186,6 @@ tasks:
                                     APPSERVICES_HEAD_REPOSITORY: '${repoUrl}'
                                     APPSERVICES_HEAD_REF: '${head_branch}'
                                     APPSERVICES_HEAD_REV: '${head_sha}'
-                                    APPSERVICES_HEAD_TAG: '${head_tag}'
                                     APPSERVICES_PIP_REQUIREMENTS: taskcluster/requirements.txt
                                     APPSERVICES_REPOSITORY_TYPE: git
                                     REPOSITORIES: {$json: {appservices: "Application Services"}}
@@ -265,7 +242,6 @@ tasks:
                                     --head-repository="$APPSERVICES_HEAD_REPOSITORY"
                                     --head-ref="$APPSERVICES_HEAD_REF"
                                     --head-rev="$APPSERVICES_HEAD_REV"
-                                    --head-tag="$APPSERVICES_HEAD_TAG"
                                     --repository-type="$APPSERVICES_REPOSITORY_TYPE"
                                     --tasks-for='${tasks_for}'
                                     ${extraArgs}
@@ -292,15 +268,11 @@ tasks:
                                           then:
                                               symbol: D
                                           else:
-                                              $if: 'tasks_for == "github-release"'
+                                              $if: 'tasks_for == "action"'
                                               then:
-                                                  symbol: 'ship_app_services'
-                                              else:
-                                                  $if: 'tasks_for == "action"'
-                                                  then:
-                                                      groupName: 'action-callback'
-                                                      groupSymbol: AC
-                                                      symbol: "${action.symbol}"
+                                                  groupName: 'action-callback'
+                                                  groupSymbol: AC
+                                                  symbol: "${action.symbol}"
                               - $if: 'tasks_for == "action"'
                                 then:
                                     parent: '${action.taskGroupId}'

--- a/taskcluster/app_services_taskgraph/__init__.py
+++ b/taskcluster/app_services_taskgraph/__init__.py
@@ -47,23 +47,7 @@ def _import_modules(modules):
         import_module(f".{module}", package=__name__)
 
 def get_decision_parameters(graph_config, parameters):
-    if parameters["tasks_for"] == "github-release":
-        head_tag = parameters["head_tag"]
-        if not head_tag:
-            raise ValueError(
-                "Cannot run github-release if `head_tag` is not defined. Got {}".format(
-                    head_tag
-                )
-            )
-        version = get_version_from_version_txt()
-        # XXX: tags are in the format of `v<semver>`
-        if head_tag[1:] != version:
-            raise ValueError(
-                "Cannot run github-release if tag {} is different than in-tree "
-                "{version} from buildconfig.yml".format(head_tag[1:], version)
-            )
-        parameters["target_tasks_method"] = "full"
-    elif parameters["tasks_for"] == "github-pull-request":
+    if parameters["tasks_for"] == "github-pull-request":
         pr_title = os.environ.get("APPSERVICES_PULL_REQUEST_TITLE", "")
         preview_match = PREVIEW_RE.search(pr_title)
         if preview_match is not None:

--- a/taskcluster/app_services_taskgraph/transforms/module_build.py
+++ b/taskcluster/app_services_taskgraph/transforms/module_build.py
@@ -24,22 +24,6 @@ def rustup_setup(config, tasks):
         )
         yield task
 
-@transforms.add
-def release_upload_symbols(config, tasks):
-    for task in tasks:
-        if (config.params["tasks_for"] == "github-release" and
-            task["attributes"]["buildconfig"]["uploadSymbols"]):
-                task["run"].setdefault("post-gradlew", [])
-                task["run"]["post-gradlew"].append(
-                    [
-                        "source",
-                        "automation/upload_android_symbols.sh",
-                        task["attributes"]["buildconfig"]["path"]
-                    ]
-                )
-
-        yield task
-
 
 @transforms.add
 def build_task(config, tasks):

--- a/taskcluster/ci/android-build/kind.yml
+++ b/taskcluster/ci/android-build/kind.yml
@@ -20,7 +20,7 @@ tasks:
       run-on-pr-type: all
       resource-monitor: true
     needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
-    run-on-tasks-for: [github-pull-request, github-release, cron]
+    run-on-tasks-for: [github-pull-request, cron]
     description: Build and test (Android - linux-x86-64)
     scopes:
       - project:releng:services/tooltool/api/download/internal

--- a/taskcluster/ci/release-publish/kind.yml
+++ b/taskcluster/ci/release-publish/kind.yml
@@ -27,7 +27,7 @@ tasks:
       release-type: release-only
     label: "Build publish task"
     description: "Publish build artifacts"
-    run-on-tasks-for: [github-release, cron]
+    run-on-tasks-for: [cron]
     worker-type: b-linux
     worker:
       chain-of-trust: true

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -20,7 +20,7 @@ tasks:
       copy-attributes: true
     attributes:
       shipping_phase: promote
-    run-on-tasks-for: [github-release, cron]
+    run-on-tasks-for: [cron]
     description: 'Sign release module {}'
     worker-type: signing
     worker:

--- a/taskcluster/ci/swift/kind.yml
+++ b/taskcluster/ci/swift/kind.yml
@@ -25,7 +25,7 @@ tasks:
       release-routes:
         - index.project.{project}.v2.swift.{appservices_version}
     needs-sccache: false # TODO: Bug 1623426 deal with this once we're in prod
-    run-on-tasks-for: [github-push, github-pull-request, github-release, cron]
+    run-on-tasks-for: [github-push, github-pull-request, cron]
     description: Build and test (Swift)
     scopes:
       - project:releng:services/tooltool/api/download/internal


### PR DESCRIPTION
We now use release promotion and shipit to manage releases.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
