### PR TITLE
Fixes DISCO-2566: Improve Remote Settings client ergonomics for the Suggest component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Added an OHTTP client library for iOS based on `ohttp` Rust crate ([#5749](https://github.com/mozilla/application-services/pull/5749)). This allows iOS products to use the same OHTTP libraries as Gecko-based products.
 - The Remote Settings client has a new `Client::get_records_with_options()` method ([#5764](https://github.com/mozilla/application-services/pull/5764)). This is for Rust consumers only; it's not exposed to Swift or Kotlin.
+- `RemoteSettingsRecord` objects have a new `deleted` property that indicates if the record is a tombstone ([#5764](https://github.com/mozilla/application-services/pull/5764)).
 
 
 ## Rust log forwarder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### ✨ What's New ✨
 
 - Added an OHTTP client library for iOS based on `ohttp` Rust crate ([#5749](https://github.com/mozilla/application-services/pull/5749)). This allows iOS products to use the same OHTTP libraries as Gecko-based products.
+- The Remote Settings client has a new `Client::get_records_with_options()` method ([#5764](https://github.com/mozilla/application-services/pull/5764)). This is for Rust consumers only; it's not exposed to Swift or Kotlin.
 
 
 ## Rust log forwarder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🦊 What's Changed 🦊
 
 - Changes to Suggestion schema to accomodate custom details for providers. ([#5745](https://github.com/mozilla/application-services/pull/5745)) 
+- The Remote Settings `Client::get_attachment()` method now returns a `Vec<u8>` instead of a Viaduct `Response` ([#5764](https://github.com/mozilla/application-services/pull/5764)). You can use the new `Client::get_attachment_raw()` method if you need the `Response`. This is a backward-incompatible change for Rust consumers only; Swift and Kotlin are unaffected.
 
 ### ✨ What's New ✨
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Changes to Suggestion schema to accomodate custom details for providers. ([#5745](https://github.com/mozilla/application-services/pull/5745)) 
 - The Remote Settings `Client::get_attachment()` method now returns a `Vec<u8>` instead of a Viaduct `Response` ([#5764](https://github.com/mozilla/application-services/pull/5764)). You can use the new `Client::get_attachment_raw()` method if you need the `Response`. This is a backward-incompatible change for Rust consumers only; Swift and Kotlin are unaffected.
+- The Remote Settings client now parses `ETag` response headers from Remote Settings correctly ([#5764](https://github.com/mozilla/application-services/pull/5764)).
 
 ### ✨ What's New ✨
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,6 +3667,7 @@ checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 name = "remote_settings"
 version = "0.1.0"
 dependencies = [
+ "expect-test",
  "mockito",
  "parking_lot",
  "serde",

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -22,5 +22,6 @@ url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 uniffi = { version = "0.24.1", features = ["build"] }
 
 [dev-dependencies]
+expect-test = "1.4"
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
 mockito = "0.31"

--- a/components/remote_settings/android/src/test/java/org/mozilla/appservices/remotesettings/RemoteSettingsTest.kt
+++ b/components/remote_settings/android/src/test/java/org/mozilla/appservices/remotesettings/RemoteSettingsTest.kt
@@ -31,7 +31,7 @@ class RemoteSettingsTest {
 
     private var fakeUrl = ""
     private var fakeStatus = 200
-    private var fakeHeaders: Headers = MutableHeaders("etag" to "1000")
+    private var fakeHeaders: Headers = MutableHeaders("etag" to "\"1000\"")
     private var fakeBodyStream = "".byteInputStream()
     private var fakeContentType = ""
     private var fakeBody = Response.Body(fakeBodyStream, fakeContentType)

--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -101,7 +101,12 @@ impl Client {
     /// Downloads an attachment from [attachment_location]. NOTE: there are no
     /// guarantees about a maximum size, so use care when fetching potentially
     /// large attachments.
-    pub fn get_attachment(&self, attachment_location: &str) -> Result<Response> {
+    pub fn get_attachment(&self, attachment_location: &str) -> Result<Vec<u8>> {
+        Ok(self.get_attachment_raw(attachment_location)?.body)
+    }
+
+    /// Fetches a raw network [Response] for an attachment.
+    pub fn get_attachment_raw(&self, attachment_location: &str) -> Result<Response> {
         // Important: We use a `let` binding here to ensure that the mutex is
         // unlocked immediately after cloning the URL. If we matched directly on
         // the `.lock()` expression, the mutex would stay locked until the end
@@ -539,8 +544,8 @@ mod test {
 
         server_info_m.expect(1).assert();
         attachment_m.expect(2).assert();
-        assert_eq!(first_resp.body, attachment_bytes);
-        assert_eq!(second_resp.body, attachment_bytes);
+        assert_eq!(first_resp, attachment_bytes);
+        assert_eq!(second_resp, attachment_bytes);
     }
 
     #[test]

--- a/components/remote_settings/src/error.rs
+++ b/components/remote_settings/src/error.rs
@@ -8,8 +8,6 @@ pub enum RemoteSettingsError {
     JSONError(#[from] serde_json::Error),
     #[error("Error writing downloaded attachment: {0}")]
     FileError(#[from] std::io::Error),
-    #[error("ParseIntError: {0}")]
-    ParseIntError(#[from] std::num::ParseIntError),
     /// An error has occured while sending a request.
     #[error("Error sending request: {0}")]
     RequestError(#[from] viaduct::Error),

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -45,7 +45,7 @@ impl RemoteSettings {
     ) -> Result<()> {
         let resp = self.client.get_attachment(&attachment_location)?;
         let mut file = File::create(path)?;
-        file.write_all(&resp.body)?;
+        file.write_all(&resp)?;
         Ok(())
     }
 }

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -66,7 +66,7 @@ mod test {
         .with_body(response_body())
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_header("etag", "1000")
+        .with_header("etag", "\"1000\"")
         .create();
 
         let config = RemoteSettingsConfig {
@@ -94,7 +94,7 @@ mod test {
         .with_body(response_body())
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_header("etag", "1000")
+        .with_header("etag", "\"1000\"")
         .create();
 
         let config = RemoteSettingsConfig {

--- a/components/remote_settings/src/remote_settings.udl
+++ b/components/remote_settings/src/remote_settings.udl
@@ -21,6 +21,7 @@ dictionary RemoteSettingsResponse {
 dictionary RemoteSettingsRecord {
     string id;
     u64 last_modified;
+    boolean deleted;
     Attachment? attachment;
     RsJsonObject fields;
 };

--- a/components/remote_settings/src/remote_settings.udl
+++ b/components/remote_settings/src/remote_settings.udl
@@ -38,7 +38,6 @@ dictionary Attachment {
 enum RemoteSettingsError {
     "JSONError",
     "FileError",
-    "ParseIntError",
     "RequestError",
     "UrlParsingError",
     "BackoffError",


### PR DESCRIPTION
This PR adds a few conveniences to the Remote Settings Rust client, and reworks the Suggest component to use them. These conveniences let Suggest use the `RemoteSettingsResponse` and `RemoteSettingsRecord` types directly, instead of defining its own duplicate "shadow types".

* The new `get_records_with_options` method returns a `RemoteSettingsResponse`, complementing the other `_raw` variants that return the Viaduct `Response`.
* `get_attachment` now returns a `Vec<u8>`, and the old logic moves to `get_attachment_raw`. This change makes it easier to mock the Remote Settings client in Suggest—check out the simplified `SuggestRemoteSettingsClient` trait.
* There's a new `RemoteSettingsRecord::deleted` property that surfaces whether a record is a tombstone. This makes it easier to tell tombstones apart, and handle them separately.
* The bulk of the Suggest changes are tests, to remove an extra layer of nesting for the fake Remote Settings records.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
