### PR TITLE
Fixes DISCO-2569: Prepare to support other types of suggestions in the Suggest Rust component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## General
 ### 🦊 What's Changed 🦊
 
-- Changes to Suggestion schema to accomodate custom details for providers. ([#5745](https://github.com/mozilla/application-services/pull/5745)) 
+- Backward-incompatible changes to the Suggest database schema to accommodate custom details for providers ([#5745](https://github.com/mozilla/application-services/pull/5745)) and future suggestion types ([#5766](https://github.com/mozilla/application-services/pull/5766)). This only affects prototyping, because we aren't consuming Suggest in any of our products yet.
 - The Remote Settings `Client::get_attachment()` method now returns a `Vec<u8>` instead of a Viaduct `Response` ([#5764](https://github.com/mozilla/application-services/pull/5764)). You can use the new `Client::get_attachment_raw()` method if you need the `Response`. This is a backward-incompatible change for Rust consumers only; Swift and Kotlin are unaffected.
 - The Remote Settings client now parses `ETag` response headers from Remote Settings correctly ([#5764](https://github.com/mozilla/application-services/pull/5764)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### 🦊 What's Changed 🦊
 
 - Backward-incompatible changes to the Suggest database schema to accommodate custom details for providers ([#5745](https://github.com/mozilla/application-services/pull/5745)) and future suggestion types ([#5766](https://github.com/mozilla/application-services/pull/5766)). This only affects prototyping, because we aren't consuming Suggest in any of our products yet.
+- The `Suggestion` type in the Suggest component has changed from a dictionary to an enum ([#5766](https://github.com/mozilla/application-services/pull/5766)). This only affects prototyping, because we aren't consuming Suggest in any of our products yet.
 - The Remote Settings `Client::get_attachment()` method now returns a `Vec<u8>` instead of a Viaduct `Response` ([#5764](https://github.com/mozilla/application-services/pull/5764)). You can use the new `Client::get_attachment_raw()` method if you need the `Response`. This is a backward-incompatible change for Rust consumers only; Swift and Kotlin are unaffected.
 - The Remote Settings client now parses `ETag` response headers from Remote Settings correctly ([#5764](https://github.com/mozilla/application-services/pull/5764)).
 

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -16,7 +16,8 @@ use sql_support::{open_database::open_database_with_flags, ConnExt};
 
 use crate::{
     keyword::full_keyword,
-    rs::{DownloadedAmpWikipediaSuggestion, SuggestRecordId, SuggestionProvider},
+    provider::SuggestionProvider,
+    rs::{DownloadedAmpWikipediaSuggestion, SuggestRecordId},
     schema::SuggestConnectionInitializer,
     Result, Suggestion,
 };

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -10,29 +10,15 @@ mod keyword;
 mod rs;
 mod schema;
 mod store;
+mod suggestion;
 
 pub use error::SuggestApiError;
 use rs::SuggestionProvider;
 pub use store::{SuggestIngestionConstraints, SuggestStore};
+pub use suggestion::Suggestion;
 
 pub(crate) type Result<T> = std::result::Result<T, error::Error>;
 pub type SuggestApiResult<T> = std::result::Result<T, error::SuggestApiError>;
-
-/// A suggestion from the database to show in the address bar.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Suggestion {
-    pub block_id: i64,
-    pub advertiser: String,
-    pub iab_category: String,
-    pub is_sponsored: bool,
-    pub full_keyword: String,
-    pub title: String,
-    pub url: String,
-    pub icon: Option<Vec<u8>>,
-    pub impression_url: Option<String>,
-    pub click_url: Option<String>,
-    pub provider: SuggestionProvider,
-}
 
 /// A query for suggestions to show in the address bar.
 #[derive(Debug, Default)]

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -7,13 +7,14 @@ use remote_settings::RemoteSettingsConfig;
 mod db;
 mod error;
 mod keyword;
+mod provider;
 mod rs;
 mod schema;
 mod store;
 mod suggestion;
 
 pub use error::SuggestApiError;
-use rs::SuggestionProvider;
+pub use provider::SuggestionProvider;
 pub use store::{SuggestIngestionConstraints, SuggestStore};
 pub use suggestion::Suggestion;
 

--- a/components/suggest/src/provider.rs
+++ b/components/suggest/src/provider.rs
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use rusqlite::{
+    types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef},
+    Result as RusqliteResult,
+};
+
+/// A provider is a source of search suggestions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[repr(u8)]
+pub enum SuggestionProvider {
+    Amp = 1,
+    Wikipedia = 2,
+}
+
+impl FromSql for SuggestionProvider {
+    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
+        let v = value.as_i64()?;
+        u8::try_from(v)
+            .ok()
+            .and_then(SuggestionProvider::from_u8)
+            .ok_or_else(|| FromSqlError::OutOfRange(v))
+    }
+}
+
+impl SuggestionProvider {
+    #[inline]
+    pub(crate) fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            1 => Some(SuggestionProvider::Amp),
+            2 => Some(SuggestionProvider::Wikipedia),
+            _ => None,
+        }
+    }
+}
+
+impl ToSql for SuggestionProvider {
+    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
+        Ok(ToSqlOutput::from(*self as u8))
+    }
+}

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -1,13 +1,9 @@
 use std::borrow::Cow;
 
 use remote_settings::{GetItemsOptions, RemoteSettingsResponse};
-use rusqlite::{
-    types::{FromSql, FromSqlError, FromSqlResult, ToSql, ToSqlOutput, ValueRef},
-    Result as RusqliteResult,
-};
 use serde::{Deserialize, Deserializer};
 
-use crate::Result;
+use crate::{provider::SuggestionProvider, Result};
 
 /// The Suggest Remote Settings collection name.
 pub(crate) const REMOTE_SETTINGS_COLLECTION: &str = "quicksuggest";
@@ -142,41 +138,6 @@ pub(crate) struct DownloadedWikipediaSuggestion {
     pub common_details: DownloadedSuggestionCommonDetails,
     #[serde(rename = "icon")]
     pub icon_id: String,
-}
-
-/// Provider Types
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
-#[repr(u8)]
-pub enum SuggestionProvider {
-    Amp = 1,
-    Wikipedia = 2,
-}
-
-impl FromSql for SuggestionProvider {
-    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        let v = value.as_i64()?;
-        u8::try_from(v)
-            .ok()
-            .and_then(SuggestionProvider::from_u8)
-            .ok_or_else(|| FromSqlError::OutOfRange(v))
-    }
-}
-
-impl SuggestionProvider {
-    #[inline]
-    pub fn from_u8(v: u8) -> Option<Self> {
-        match v {
-            1 => Some(SuggestionProvider::Amp),
-            2 => Some(SuggestionProvider::Wikipedia),
-            _ => None,
-        }
-    }
-}
-
-impl ToSql for SuggestionProvider {
-    fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
-        Ok(ToSqlOutput::from(*self as u8))
-    }
 }
 
 /// A suggestion to ingest from an AMP-Wikipedia attachment downloaded from

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -1,3 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//! Crate-internal types for interacting with Remote Settings (`rs`). Types in
+//! this module describe records and attachments in the Suggest Remote Settings
+//! collection.
+//!
+//! To add a new suggestion `T` to this component, you'll generally need to:
+//!
+//!  1. Add a variant named `T` to [`SuggestRecord`]. The variant must have a
+//!     `#[serde(rename)]` attribute that matches the suggestion record's
+//!     `type` field.
+//!  2. Define a `DownloadedTSuggestion` type with the new suggestion's fields,
+//!     matching their attachment's schema. Your new type must derive or
+//!     implement [`serde::Deserialize`].
+//!  3. Update the database schema in the [`schema`] module to store the new
+//!     suggestion.
+//!  4. Add an `insert_t_suggestions()` method to [`db::SuggestDao`] that
+//!     inserts `DownloadedTSuggestion`s into the database.
+//!  5. Update [`store::SuggestStoreInner::ingest()`] to download, deserialize,
+//!     and store the new suggestion.
+//!  6. Add a variant named `T` to [`suggestion::Suggestion`], with the fields
+//!     that you'd like to expose to the application. These can be the same
+//!     fields as `DownloadedTSuggestion`, or slightly different, depending on
+//!     what the application needs to show the suggestion.
+//!  7. Update any [`db::SuggestDao`] methods that query the database to include
+//!     the new suggestion in their results, and return `Suggestion::T` variants
+//!     as needed.
+
 use std::borrow::Cow;
 
 use remote_settings::{GetItemsOptions, RemoteSettingsResponse};

--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -6,7 +6,7 @@
 use rusqlite::{Connection, Transaction};
 use sql_support::open_database::{self, ConnectionInitializer};
 
-pub const VERSION: u32 = 2;
+pub const VERSION: u32 = 3;
 
 pub const SQL: &str = "
     CREATE TABLE meta(
@@ -28,8 +28,7 @@ pub const SQL: &str = "
         record_id TEXT NOT NULL,
         provider INTEGER NOT NULL,
         title TEXT NOT NULL,
-        url TEXT NOT NULL,
-        icon_id TEXT NOT NULL
+        url TEXT NOT NULL
     );
 
     CREATE TABLE amp_custom_details(
@@ -39,8 +38,14 @@ pub const SQL: &str = "
         iab_category TEXT NOT NULL,
         impression_url TEXT NOT NULL,
         click_url TEXT NOT NULL,
+        icon_id TEXT NOT NULL,
         FOREIGN KEY(suggestion_id) REFERENCES suggestions(id)
         ON DELETE CASCADE
+    );
+
+    CREATE TABLE wikipedia_custom_details(
+        suggestion_id INTEGER PRIMARY KEY REFERENCES suggestions(id) ON DELETE CASCADE,
+        icon_id TEXT NOT NULL
     );
 
     CREATE INDEX suggestions_record_id ON suggestions(record_id);

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -141,8 +141,8 @@ impl<S> SuggestStoreInner<S> {
         Ok(suggestions
             .into_iter()
             .filter(|suggestion| {
-                (suggestion.is_sponsored && query.include_sponsored)
-                    || (!suggestion.is_sponsored && query.include_non_sponsored)
+                (suggestion.is_sponsored() && query.include_sponsored)
+                    || (!suggestion.is_sponsored() && query.include_non_sponsored)
             })
             .collect())
     }
@@ -469,22 +469,16 @@ mod tests {
             assert_eq!(dao.get_meta::<u64>(LAST_INGEST_META_KEY)?, Some(15));
             expect![[r#"
                 [
-                    Suggestion {
-                        block_id: 0,
-                        advertiser: "Los Pollos Hermanos",
-                        iab_category: "8 - Food & Drink",
-                        is_sponsored: true,
-                        full_keyword: "los",
+                    Amp {
                         title: "Los Pollos Hermanos - Albuquerque",
                         url: "https://www.lph-nm.biz",
                         icon: None,
-                        impression_url: Some(
-                            "https://example.com/impression_url",
-                        ),
-                        click_url: Some(
-                            "https://example.com/click_url",
-                        ),
-                        provider: Amp,
+                        full_keyword: "los",
+                        block_id: 0,
+                        advertiser: "Los Pollos Hermanos",
+                        iab_category: "8 - Food & Drink",
+                        impression_url: "https://example.com/impression_url",
+                        click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -560,12 +554,7 @@ mod tests {
         store.dbs()?.reader.read(|dao| {
             expect![[r#"
                 [
-                    Suggestion {
-                        block_id: 0,
-                        advertiser: "Good Place Eats",
-                        iab_category: "8 - Food & Drink",
-                        is_sponsored: true,
-                        full_keyword: "lasagna",
+                    Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
                         icon: Some(
@@ -584,25 +573,19 @@ mod tests {
                                 110,
                             ],
                         ),
-                        impression_url: Some(
-                            "https://example.com/impression_url",
-                        ),
-                        click_url: Some(
-                            "https://example.com/click_url",
-                        ),
-                        provider: Amp,
+                        full_keyword: "lasagna",
+                        block_id: 0,
+                        advertiser: "Good Place Eats",
+                        iab_category: "8 - Food & Drink",
+                        impression_url: "https://example.com/impression_url",
+                        click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
             .assert_debug_eq(&dao.fetch_by_keyword("la")?);
             expect![[r#"
                 [
-                    Suggestion {
-                        block_id: 0,
-                        advertiser: "Good Place Eats",
-                        iab_category: "8 - Food & Drink",
-                        is_sponsored: true,
-                        full_keyword: "penne",
+                    Amp {
                         title: "Penne for Your Thoughts",
                         url: "https://penne.biz",
                         icon: Some(
@@ -621,13 +604,12 @@ mod tests {
                                 110,
                             ],
                         ),
-                        impression_url: Some(
-                            "https://example.com/impression_url",
-                        ),
-                        click_url: Some(
-                            "https://example.com/click_url",
-                        ),
-                        provider: Amp,
+                        full_keyword: "penne",
+                        block_id: 0,
+                        advertiser: "Good Place Eats",
+                        iab_category: "8 - Food & Drink",
+                        impression_url: "https://example.com/impression_url",
+                        click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -682,22 +664,16 @@ mod tests {
         store.dbs()?.reader.read(|dao| {
             expect![[r#"
                 [
-                    Suggestion {
-                        block_id: 0,
-                        advertiser: "Good Place Eats",
-                        iab_category: "8 - Food & Drink",
-                        is_sponsored: true,
-                        full_keyword: "lasagna",
+                    Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
                         icon: None,
-                        impression_url: Some(
-                            "https://example.com/impression_url",
-                        ),
-                        click_url: Some(
-                            "https://example.com/click_url",
-                        ),
-                        provider: Amp,
+                        full_keyword: "lasagna",
+                        block_id: 0,
+                        advertiser: "Good Place Eats",
+                        iab_category: "8 - Food & Drink",
+                        impression_url: "https://example.com/impression_url",
+                        click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -763,22 +739,16 @@ mod tests {
             assert_eq!(dao.get_meta(LAST_INGEST_META_KEY)?, Some(15u64));
             expect![[r#"
                 [
-                    Suggestion {
-                        block_id: 0,
-                        advertiser: "Good Place Eats",
-                        iab_category: "8 - Food & Drink",
-                        is_sponsored: true,
-                        full_keyword: "lasagna",
+                    Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
                         icon: None,
-                        impression_url: Some(
-                            "https://example.com/impression_url",
-                        ),
-                        click_url: Some(
-                            "https://example.com/click_url",
-                        ),
-                        provider: Amp,
+                        full_keyword: "lasagna",
+                        block_id: 0,
+                        advertiser: "Good Place Eats",
+                        iab_category: "8 - Food & Drink",
+                        impression_url: "https://example.com/impression_url",
+                        click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -832,44 +802,32 @@ mod tests {
             assert!(dao.fetch_by_keyword("la")?.is_empty());
             expect![[r#"
                 [
-                    Suggestion {
-                        block_id: 0,
-                        advertiser: "Los Pollos Hermanos",
-                        iab_category: "8 - Food & Drink",
-                        is_sponsored: true,
-                        full_keyword: "los pollos",
+                    Amp {
                         title: "Los Pollos Hermanos - Now Serving at 14 Locations!",
                         url: "https://www.lph-nm.biz",
                         icon: None,
-                        impression_url: Some(
-                            "https://example.com/impression_url",
-                        ),
-                        click_url: Some(
-                            "https://example.com/click_url",
-                        ),
-                        provider: Amp,
+                        full_keyword: "los pollos",
+                        block_id: 0,
+                        advertiser: "Los Pollos Hermanos",
+                        iab_category: "8 - Food & Drink",
+                        impression_url: "https://example.com/impression_url",
+                        click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
             .assert_debug_eq(&dao.fetch_by_keyword("los ")?);
             expect![[r#"
                 [
-                    Suggestion {
-                        block_id: 0,
-                        advertiser: "Good Place Eats",
-                        iab_category: "8 - Food & Drink",
-                        is_sponsored: true,
-                        full_keyword: "penne",
+                    Amp {
                         title: "Penne for Your Thoughts",
                         url: "https://penne.biz",
                         icon: None,
-                        impression_url: Some(
-                            "https://example.com/impression_url",
-                        ),
-                        click_url: Some(
-                            "https://example.com/click_url",
-                        ),
-                        provider: Amp,
+                        full_keyword: "penne",
+                        block_id: 0,
+                        advertiser: "Good Place Eats",
+                        iab_category: "8 - Food & Drink",
+                        impression_url: "https://example.com/impression_url",
+                        click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -998,12 +956,7 @@ mod tests {
             assert_eq!(dao.get_meta(LAST_INGEST_META_KEY)?, Some(35u64));
             expect![[r#"
                 [
-                    Suggestion {
-                        block_id: 0,
-                        advertiser: "Good Place Eats",
-                        iab_category: "8 - Food & Drink",
-                        is_sponsored: true,
-                        full_keyword: "lasagna",
+                    Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
                         icon: Some(
@@ -1026,25 +979,19 @@ mod tests {
                                 110,
                             ],
                         ),
-                        impression_url: Some(
-                            "https://example.com/impression_url",
-                        ),
-                        click_url: Some(
-                            "https://example.com/click_url",
-                        ),
-                        provider: Amp,
+                        full_keyword: "lasagna",
+                        block_id: 0,
+                        advertiser: "Good Place Eats",
+                        iab_category: "8 - Food & Drink",
+                        impression_url: "https://example.com/impression_url",
+                        click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
             .assert_debug_eq(&dao.fetch_by_keyword("la")?);
             expect![[r#"
                 [
-                    Suggestion {
-                        block_id: 0,
-                        advertiser: "Los Pollos Hermanos",
-                        iab_category: "8 - Food & Drink",
-                        is_sponsored: true,
-                        full_keyword: "los",
+                    Amp {
                         title: "Los Pollos Hermanos - Albuquerque",
                         url: "https://www.lph-nm.biz",
                         icon: Some(
@@ -1066,13 +1013,12 @@ mod tests {
                                 110,
                             ],
                         ),
-                        impression_url: Some(
-                            "https://example.com/impression_url",
-                        ),
-                        click_url: Some(
-                            "https://example.com/click_url",
-                        ),
-                        provider: Amp,
+                        full_keyword: "los",
+                        block_id: 0,
+                        advertiser: "Los Pollos Hermanos",
+                        iab_category: "8 - Food & Drink",
+                        impression_url: "https://example.com/impression_url",
+                        click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -1392,12 +1338,7 @@ mod tests {
                 },
                 expect![[r#"
                     [
-                        Suggestion {
-                            block_id: 0,
-                            advertiser: "Good Place Eats",
-                            iab_category: "8 - Food & Drink",
-                            is_sponsored: true,
-                            full_keyword: "lasagna",
+                        Amp {
                             title: "Lasagna Come Out Tomorrow",
                             url: "https://www.lasagna.restaurant",
                             icon: Some(
@@ -1416,13 +1357,12 @@ mod tests {
                                     110,
                                 ],
                             ),
-                            impression_url: Some(
-                                "https://example.com/impression_url",
-                            ),
-                            click_url: Some(
-                                "https://example.com/click_url",
-                            ),
-                            provider: Amp,
+                            full_keyword: "lasagna",
+                            block_id: 0,
+                            advertiser: "Good Place Eats",
+                            iab_category: "8 - Food & Drink",
+                            impression_url: "https://example.com/impression_url",
+                            click_url: "https://example.com/click_url",
                         },
                     ]
                 "#]],
@@ -1436,12 +1376,7 @@ mod tests {
                 },
                 expect![[r#"
                     [
-                        Suggestion {
-                            block_id: 0,
-                            advertiser: "Good Place Eats",
-                            iab_category: "8 - Food & Drink",
-                            is_sponsored: true,
-                            full_keyword: "lasagna",
+                        Amp {
                             title: "Lasagna Come Out Tomorrow",
                             url: "https://www.lasagna.restaurant",
                             icon: Some(
@@ -1460,13 +1395,12 @@ mod tests {
                                     110,
                                 ],
                             ),
-                            impression_url: Some(
-                                "https://example.com/impression_url",
-                            ),
-                            click_url: Some(
-                                "https://example.com/click_url",
-                            ),
-                            provider: Amp,
+                            full_keyword: "lasagna",
+                            block_id: 0,
+                            advertiser: "Good Place Eats",
+                            iab_category: "8 - Food & Drink",
+                            impression_url: "https://example.com/impression_url",
+                            click_url: "https://example.com/click_url",
                         },
                     ]
                 "#]],
@@ -1524,12 +1458,7 @@ mod tests {
                 },
                 expect![[r#"
                     [
-                        Suggestion {
-                            block_id: 0,
-                            advertiser: "Wikipedia",
-                            iab_category: "5 - Education",
-                            is_sponsored: false,
-                            full_keyword: "california",
+                        Wikipedia {
                             title: "California",
                             url: "https://wikipedia.org/California",
                             icon: Some(
@@ -1548,9 +1477,7 @@ mod tests {
                                     110,
                                 ],
                             ),
-                            impression_url: None,
-                            click_url: None,
-                            provider: Wikipedia,
+                            full_keyword: "california",
                         },
                     ]
                 "#]],

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -21,18 +21,25 @@ enum SuggestionProvider {
     "Wikipedia",
 };
 
-dictionary Suggestion {
-    i64 block_id;
-    string advertiser;
-    string iab_category;
-    boolean is_sponsored;
-    string full_keyword;
-    string title;
-    string url;
-    sequence<u8>? icon;
-    string? impression_url;
-    string? click_url;
-    SuggestionProvider provider;
+[Enum]
+interface Suggestion {
+    Amp(
+        string title,
+        string url,
+        sequence<u8>? icon,
+        string full_keyword,
+        i64 block_id,
+        string advertiser,
+        string iab_category,
+        string impression_url,
+        string click_url
+    );
+    Wikipedia(
+        string title,
+        string url,
+        sequence<u8>? icon,
+        string full_keyword
+    );
 };
 
 dictionary SuggestionQuery {

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+/// A suggestion from the database to show in the address bar.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Suggestion {
+    Amp {
+        title: String,
+        url: String,
+        icon: Option<Vec<u8>>,
+        full_keyword: String,
+        block_id: i64,
+        advertiser: String,
+        iab_category: String,
+        impression_url: String,
+        click_url: String,
+    },
+    Wikipedia {
+        title: String,
+        url: String,
+        icon: Option<Vec<u8>>,
+        full_keyword: String,
+    },
+}
+
+impl Suggestion {
+    /// Returns `true` if the suggestion is sponsored.
+    pub(crate) fn is_sponsored(&self) -> bool {
+        matches!(self, Self::Amp { .. })
+    }
+}


### PR DESCRIPTION
This commit:

* Renames some of our crate-internal types to clarify that they're specific to AMP-Wikipedia suggestions.
* Removes `icon_id` from the common `suggestions` table, because not all suggestions that we'll support in the future have icon data. For example, Pocket suggestions don't have icons at all, and AMO suggestions have URLs instead of binary data.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
