### PR TITLE
Fixes DISCO-2571: Fix re-ingesting icons in the Suggest Rust component

### DIFF
--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -352,7 +352,7 @@ impl<'a> SuggestDao<'a> {
     /// Sets the value for a metadata key.
     pub fn put_meta(&mut self, key: &str, value: impl ToSql) -> Result<()> {
         self.conn.execute_cached(
-            "REPLACE INTO meta(key, value) VALUES(:key, :value)",
+            "INSERT OR REPLACE INTO meta(key, value) VALUES(:key, :value)",
             named_params! { ":key": key, ":value": value },
         )?;
         Ok(())

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -292,10 +292,10 @@ impl<'a> SuggestDao<'a> {
         Ok(())
     }
 
-    /// Inserts an icon for a suggestion into the database.
-    pub fn insert_icon(&mut self, icon_id: &str, data: &[u8]) -> Result<()> {
+    /// Inserts or replaces an icon for a suggestion into the database.
+    pub fn put_icon(&mut self, icon_id: &str, data: &[u8]) -> Result<()> {
         self.conn.execute(
-            "INSERT INTO icons(
+            "INSERT OR REPLACE INTO icons(
                  id,
                  data
              )


### PR DESCRIPTION
We used `INSERT` instead of `REPLACE` to store icons, so trying to re-ingest an updated icon would fail with a unique constraint error.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
