### PR TITLE
rust_log_forwarder: renamed `Logger` to `AppServicesLogger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 - Added an OHTTP client library for iOS based on `ohttp` Rust crate ([#5749](https://github.com/mozilla/application-services/pull/5749)). This allows iOS products to use the same OHTTP libraries as Gecko-based products.
 
+
+## Rust log forwarder
+### 🦊 What's Changed 🦊
+
+- Renamed `Logger` to `AppServicesLogger` to avoid a name conflict on Swift.
+
 # v117.0 (_2023-07-31_)
 
 ## General

--- a/components/support/rust-log-forwarder/src/foreign_logger.rs
+++ b/components/support/rust-log-forwarder/src/foreign_logger.rs
@@ -17,7 +17,7 @@ pub struct Record {
     pub message: String,
 }
 
-pub trait Logger: Sync + Send {
+pub trait AppServicesLogger: Sync + Send {
     fn log(&self, record: Record);
 }
 

--- a/components/support/rust-log-forwarder/src/lib.rs
+++ b/components/support/rust-log-forwarder/src/lib.rs
@@ -6,14 +6,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 mod foreign_logger;
 mod rust_logger;
 
-pub use foreign_logger::{Level, Logger, Record};
+pub use foreign_logger::{AppServicesLogger, Level, Record};
 
 static HAVE_SET_MAX_LEVEL: AtomicBool = AtomicBool::new(false);
 
 /// Set the logger to forward to.
 ///
 /// Pass in None to disable logging.
-pub fn set_logger(logger: Option<Box<dyn Logger>>) {
+pub fn set_logger(logger: Option<Box<dyn AppServicesLogger>>) {
     // Set a default max level, if none has already been set
     if !HAVE_SET_MAX_LEVEL.load(Ordering::Relaxed) {
         set_max_level(Level::Debug);
@@ -55,7 +55,7 @@ mod test {
         }
     }
 
-    impl Logger for TestLogger {
+    impl AppServicesLogger for TestLogger {
         fn log(&self, record: Record) {
             self.records.lock().unwrap().push(record)
         }

--- a/components/support/rust-log-forwarder/src/rust_log_forwarder.udl
+++ b/components/support/rust-log-forwarder/src/rust_log_forwarder.udl
@@ -6,7 +6,7 @@ namespace rust_log_forwarder {
     // Set the logger to forward to.
     //
     // Pass in null to disable logging.
-    void set_logger(Logger? logger);
+    void set_logger(AppServicesLogger? logger);
     // Set the maximum log level filter.  Records below this level will not be sent to the logger.
     void set_max_level(Level level);
 };
@@ -26,6 +26,6 @@ dictionary Record {
     string message;
 };
 
-callback interface Logger {
+callback interface AppServicesLogger {
     void log(Record record);
 };

--- a/components/support/rust-log-forwarder/src/rust_logger.rs
+++ b/components/support/rust-log-forwarder/src/rust_logger.rs
@@ -7,7 +7,7 @@
 //! This is responsible for taking logs from the rust log crate and forwarding them to a
 //! foreign_logger::Logger instance.
 
-use crate::foreign_logger::Logger as ForeignLogger;
+use crate::foreign_logger::AppServicesLogger as ForeignLogger;
 use parking_lot::RwLock;
 use std::sync::{
     atomic::{AtomicBool, Ordering},


### PR DESCRIPTION
Tarik reports that `Logger` causes a swift name collision, so we should avoid it.

This is technically a breaking change, but it won't cause many problems.  The work to integrate this on Swift hasn't started yet and the [Android PR](https://github.com/mozilla-mobile/firefox-android/pull/728) hasn't been merged yet.  We'll just need to update that PR once this gets merged into a nightly.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
