### PR TITLE
Fixes DISCO-2576: Replace Suggest databases with incompatible schema versions.

### DIFF
--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -83,6 +83,14 @@ impl ConnectionInitializer for SuggestConnectionInitializer {
     }
 
     fn upgrade_from(&self, _db: &Transaction<'_>, version: u32) -> open_database::Result<()> {
-        Err(open_database::Error::IncompatibleVersion(version))
+        match version {
+            1..=2 => {
+                // These schema versions were used during development, and never
+                // shipped in any applications. Treat these databases as
+                // corrupt, so that they'll be replaced.
+                Err(open_database::Error::Corrupt)
+            }
+            _ => Err(open_database::Error::IncompatibleVersion(version)),
+        }
     }
 }


### PR DESCRIPTION
We have some prototype Suggest integrations for Desktop and Android that will fail to open databases with older schema versions. We haven't been writing migration logic for these versions, since we haven't shipped the component to any users yet, and the Suggest dataset being "read-only" means we aren't super worried about user data loss.

We can work around this by deleting the database ourselves, but, since we already have machinery for replacing corrupt databases, let's extend it so that migrations can force replacement.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
