### PR TITLE
Refactor nimbus_id out of params and into AvailableRandomizationUnits

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -117,7 +117,7 @@ open class Nimbus(
             remoteSettingsConfig,
             // The "dummy" field here is required for obscure reasons when generating code on desktop,
             // so we just automatically set it to a dummy value.
-            AvailableRandomizationUnits(clientId = null, userId = null, dummy = 0),
+            AvailableRandomizationUnits(clientId = null, userId = null, nimbusId = null dummy = 0),
         )
     }
 
@@ -359,7 +359,7 @@ open class Nimbus(
     override fun resetTelemetryIdentifiers() {
         // The "dummy" field here is required for obscure reasons when generating code on desktop,
         // so we just automatically set it to a dummy value.
-        val aru = AvailableRandomizationUnits(clientId = null, userId = null, dummy = 0)
+        val aru = AvailableRandomizationUnits(clientId = null, userId = null, nimbusId = null, dummy = 0)
         dbScope.launch {
             withCatchAll("resetTelemetryIdentifiers") {
                 nimbusClient.resetTelemetryIdentifiers(aru).also { enrollmentChangeEvents ->

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -117,7 +117,7 @@ open class Nimbus(
             remoteSettingsConfig,
             // The "dummy" field here is required for obscure reasons when generating code on desktop,
             // so we just automatically set it to a dummy value.
-            AvailableRandomizationUnits(clientId = null, userId = null, nimbusId = null dummy = 0),
+            AvailableRandomizationUnits(clientId = null, userId = null, nimbusId = null, dummy = 0),
         )
     }
 

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -299,10 +299,10 @@ fn main() -> Result<()> {
             }
 
             let mut num_tries = 0;
-            let mut aru = AvailableRandomizationUnits::with_client_id(&client_id);
+            let aru = AvailableRandomizationUnits::with_client_id(&client_id);
             'outer: loop {
                 let uuid = uuid::Uuid::new_v4();
-                aru.nimbus_id = Some(uuid.to_string());
+                let aru = aru.apply_nimbus_id(&uuid);
                 let mut num_of_experiments_enrolled = 0;
                 let event_store = nimbus_client.event_store();
                 let th = NimbusTargetingHelper::new(&context, event_store.clone());

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -299,14 +299,15 @@ fn main() -> Result<()> {
             }
 
             let mut num_tries = 0;
-            let aru = AvailableRandomizationUnits::with_client_id(&client_id);
+            let mut aru = AvailableRandomizationUnits::with_client_id(&client_id);
             'outer: loop {
                 let uuid = uuid::Uuid::new_v4();
+                aru.nimbus_id = Some(uuid.to_string());
                 let mut num_of_experiments_enrolled = 0;
                 let event_store = nimbus_client.event_store();
                 let th = NimbusTargetingHelper::new(&context, event_store.clone());
                 for exp in &all_experiments {
-                    let enr = nimbus::evaluate_enrollment(&uuid, &aru, exp, &th)?;
+                    let enr = nimbus::evaluate_enrollment(&aru, exp, &th)?;
                     if enr.status.is_enrolled() {
                         num_of_experiments_enrolled += 1;
                         if num_of_experiments_enrolled >= num {
@@ -360,9 +361,10 @@ fn main() -> Result<()> {
                 // by the experiment just generate a new uuid for all possible
                 // options.
                 let uuid = uuid::Uuid::new_v4();
-                let aru = AvailableRandomizationUnits::with_client_id(&client_id);
+                let aru =
+                    AvailableRandomizationUnits::with_client_id(&client_id).apply_nimbus_id(&uuid);
                 let th = NimbusTargetingHelper::new(&context, event_store.clone());
-                let enrollment = nimbus::evaluate_enrollment(&uuid, &aru, &exp, &th)?;
+                let enrollment = nimbus::evaluate_enrollment(&aru, &exp, &th)?;
                 let key = match enrollment.status.clone() {
                     EnrollmentStatus::Enrolled { .. } => "Enrolled",
                     EnrollmentStatus::NotEnrolled { .. } => "NotEnrolled",

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -354,7 +354,7 @@ extension Nimbus: NimbusUserConfiguration {
         _ = catchAll(dbQueue) { _ in
             // The "dummy" field here is required for obscure reasons when generating code on desktop,
             // so we just automatically set it to a dummy value.
-            let aru = AvailableRandomizationUnits(clientId: nil, userId: nil, dummy: 0)
+            let aru = AvailableRandomizationUnits(clientId: nil, userId: nil, nimbusId: nil, dummy: 0)
             try self.resetTelemetryIdentifiersOnThisThread(aru)
         }
     }

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -58,7 +58,12 @@ public extension Nimbus {
             remoteSettingsConfig: remoteSettings,
             // The "dummy" field here is required for obscure reasons when generating code on desktop,
             // so we just automatically set it to a dummy value.
-            availableRandomizationUnits: AvailableRandomizationUnits(clientId: nil, userId: nil, nimbusId: nil, dummy: 0)
+            availableRandomizationUnits: AvailableRandomizationUnits(
+                clientId: nil,
+                userId: nil,
+                nimbusId: nil,
+                dummy: 0
+            )
         )
 
         return Nimbus(nimbusClient: nimbusClient, resourceBundles: resourceBundles, errorReporter: errorReporter)

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -58,7 +58,7 @@ public extension Nimbus {
             remoteSettingsConfig: remoteSettings,
             // The "dummy" field here is required for obscure reasons when generating code on desktop,
             // so we just automatically set it to a dummy value.
-            availableRandomizationUnits: AvailableRandomizationUnits(clientId: nil, userId: nil, dummy: 0)
+            availableRandomizationUnits: AvailableRandomizationUnits(clientId: nil, userId: nil, nimbusId: nil, dummy: 0)
         )
 
         return Nimbus(nimbusClient: nimbusClient, resourceBundles: resourceBundles, errorReporter: errorReporter)

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -91,7 +91,6 @@ impl ExperimentEnrollment {
     /// we are seeing for the first time.
     fn from_new_experiment(
         is_user_participating: bool,
-        nimbus_id: &Uuid,
         available_randomization_units: &AvailableRandomizationUnits,
         experiment: &Experiment,
         targeting_helper: &NimbusTargetingHelper,
@@ -112,12 +111,8 @@ impl ExperimentEnrollment {
                 },
             }
         } else {
-            let enrollment = evaluate_enrollment(
-                nimbus_id,
-                available_randomization_units,
-                experiment,
-                targeting_helper,
-            )?;
+            let enrollment =
+                evaluate_enrollment(available_randomization_units, experiment, targeting_helper)?;
             log::debug!(
                 "Experiment '{}' is new - enrollment status is {:?}",
                 &enrollment.slug,
@@ -164,7 +159,6 @@ impl ExperimentEnrollment {
     fn on_experiment_updated(
         &self,
         is_user_participating: bool,
-        nimbus_id: &Uuid,
         available_randomization_units: &AvailableRandomizationUnits,
         updated_experiment: &Experiment,
         targeting_helper: &NimbusTargetingHelper,
@@ -176,7 +170,6 @@ impl ExperimentEnrollment {
                     self.clone()
                 } else {
                     let updated_enrollment = evaluate_enrollment(
-                        nimbus_id,
                         available_randomization_units,
                         updated_experiment,
                         targeting_helper,
@@ -220,7 +213,6 @@ impl ExperimentEnrollment {
                     self.clone()
                 } else {
                     let evaluated_enrollment = evaluate_enrollment(
-                        nimbus_id,
                         available_randomization_units,
                         updated_experiment,
                         targeting_helper,
@@ -284,7 +276,6 @@ impl ExperimentEnrollment {
                     )
                 {
                     let evaluated_enrollment = evaluate_enrollment(
-                        nimbus_id,
                         available_randomization_units,
                         updated_experiment,
                         targeting_helper,
@@ -610,7 +601,6 @@ pub fn get_enrollments<'r>(
 }
 
 pub(crate) struct EnrollmentsEvolver<'a> {
-    nimbus_id: &'a Uuid,
     available_randomization_units: &'a AvailableRandomizationUnits,
     targeting_helper: &'a NimbusTargetingHelper,
     coenrolling_feature_ids: &'a HashSet<&'a str>,
@@ -618,13 +608,11 @@ pub(crate) struct EnrollmentsEvolver<'a> {
 
 impl<'a> EnrollmentsEvolver<'a> {
     pub(crate) fn new(
-        nimbus_id: &'a Uuid,
         available_randomization_units: &'a AvailableRandomizationUnits,
         targeting_helper: &'a NimbusTargetingHelper,
         coenrolling_feature_ids: &'a HashSet<&str>,
     ) -> Self {
         Self {
-            nimbus_id,
             available_randomization_units,
             targeting_helper,
             coenrolling_feature_ids,
@@ -975,7 +963,6 @@ impl<'a> EnrollmentsEvolver<'a> {
             // New experiment.
             (None, Some(experiment), None) => Some(ExperimentEnrollment::from_new_experiment(
                 is_user_participating,
-                self.nimbus_id,
                 self.available_randomization_units,
                 experiment,
                 &th,
@@ -989,7 +976,6 @@ impl<'a> EnrollmentsEvolver<'a> {
             (Some(_), Some(experiment), Some(enrollment)) => {
                 Some(enrollment.on_experiment_updated(
                     is_user_participating,
-                    self.nimbus_id,
                     self.available_randomization_units,
                     experiment,
                     &th,

--- a/components/nimbus/src/evaluator.rs
+++ b/components/nimbus/src/evaluator.rs
@@ -14,7 +14,6 @@ use crate::{matcher::AppContext, sampling};
 use crate::{Branch, Experiment, NimbusTargetingHelper};
 use serde_derive::*;
 use serde_json::Value;
-use uuid::Uuid;
 
 #[cfg(feature = "stateful")]
 use std::collections::HashSet;
@@ -120,7 +119,6 @@ fn split_locale(locale: String) -> (Option<String>, Option<String>) {
 /// Determine the enrolment status for an experiment.
 ///
 /// # Arguments:
-/// - `nimbus_id` The auto-generated nimbus_id
 /// - `available_randomization_units` The app provded available randomization units
 /// - `targeting_attributes` The attributes to use when evaluating targeting
 /// - `exp` The `Experiment` to evaluate.
@@ -136,7 +134,6 @@ fn split_locale(locale: String) -> (Option<String>, Option<String>) {
 /// - If the bucket sampling failed (i.e we could not find if the user should or should not be enrolled in the experiment based on the bucketing)
 /// - If an error occurs while determining the branch the user should be enrolled in any of the experiments
 pub fn evaluate_enrollment(
-    nimbus_id: &Uuid,
     available_randomization_units: &AvailableRandomizationUnits,
     exp: &Experiment,
     th: &NimbusTargetingHelper,
@@ -164,9 +161,7 @@ pub fn evaluate_enrollment(
         slug: exp.slug.clone(),
         status: {
             let bucket_config = exp.bucket_config.clone();
-            match available_randomization_units
-                .get_value(&nimbus_id.to_string(), &bucket_config.randomization_unit)
-            {
+            match available_randomization_units.get_value(&bucket_config.randomization_unit) {
                 Some(id) => {
                     if sampling::bucket_sample(
                         vec![id.to_owned(), bucket_config.namespace],

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -54,6 +54,7 @@ dictionary ExperimentBranch {
 dictionary AvailableRandomizationUnits {
     string? client_id;
     string? user_id;
+    string? nimbus_id;
     // work around uniffi-rs #331 by including a non-optional value. We'll
     // try and hide this in the bindings used by clients and eventually remove
     // it entirely.

--- a/components/nimbus/src/nimbus_client.rs
+++ b/components/nimbus/src/nimbus_client.rs
@@ -123,6 +123,8 @@ impl NimbusClient {
         writer: &mut Writer,
         state: &mut MutexGuard<InternalMutableState>,
     ) -> Result<()> {
+        let id = self.read_or_create_nimbus_id(db, writer)?;
+        state.available_randomization_units.nimbus_id = Some(id.to_string());
         self.update_ta_install_dates(db, writer, state)?;
         self.event_store.lock().unwrap().read_from_db(db)?;
         Ok(())
@@ -345,7 +347,6 @@ impl NimbusClient {
         state: &mut InternalMutableState,
         experiments: &[Experiment],
     ) -> Result<Vec<EnrollmentChangeEvent>> {
-        let nimbus_id = self.read_or_create_nimbus_id(db, writer)?;
         let targeting_helper =
             NimbusTargetingHelper::new(&state.targeting_attributes, self.event_store.clone());
         let coenrolling_feature_ids = self
@@ -354,7 +355,6 @@ impl NimbusClient {
             .map(|s| s.as_str())
             .collect();
         let evolver = EnrollmentsEvolver::new(
-            &nimbus_id,
             &state.available_randomization_units,
             &targeting_helper,
             &coenrolling_feature_ids,

--- a/components/nimbus/src/schema.rs
+++ b/components/nimbus/src/schema.rs
@@ -6,6 +6,7 @@ use crate::{defaults::Defaults, enrollment::ExperimentMetadata, NimbusError, Res
 use serde_derive::*;
 use serde_json::{Map, Value};
 use std::collections::HashSet;
+use uuid::Uuid;
 
 const DEFAULT_TOTAL_BUCKETS: u32 = 10000;
 
@@ -259,6 +260,7 @@ impl Default for RandomizationUnit {
 pub struct AvailableRandomizationUnits {
     pub client_id: Option<String>,
     pub user_id: Option<String>,
+    pub nimbus_id: Option<String>,
     #[allow(dead_code)]
     pub(crate) dummy: i8, // See comments in nimbus.udl for why this hacky item exists.
 }
@@ -270,6 +272,7 @@ impl AvailableRandomizationUnits {
         Self {
             client_id: Some(client_id.to_string()),
             user_id: None,
+            nimbus_id: None,
             dummy: 0,
         }
     }
@@ -280,17 +283,32 @@ impl AvailableRandomizationUnits {
         Self {
             client_id: None,
             user_id: Some(user_id.to_string()),
+            nimbus_id: None,
             dummy: 0,
         }
     }
 
-    pub fn get_value<'a>(
-        &'a self,
-        nimbus_id: &'a str,
-        wanted: &'a RandomizationUnit,
-    ) -> Option<&'a str> {
+    pub fn with_nimbus_id(nimbus_id: &Uuid) -> Self {
+        Self {
+            client_id: None,
+            user_id: None,
+            nimbus_id: Some(nimbus_id.to_string()),
+            dummy: 0,
+        }
+    }
+
+    pub fn apply_nimbus_id(&self, nimbus_id: &Uuid) -> Self {
+        Self {
+            client_id: self.client_id.clone(),
+            user_id: self.user_id.clone(),
+            nimbus_id: Some(nimbus_id.to_string()),
+            dummy: 0,
+        }
+    }
+
+    pub fn get_value<'a>(&'a self, wanted: &'a RandomizationUnit) -> Option<&'a str> {
         match wanted {
-            RandomizationUnit::NimbusId => Some(nimbus_id),
+            RandomizationUnit::NimbusId => self.nimbus_id.as_deref(),
             RandomizationUnit::ClientId => self.client_id.as_deref(),
             RandomizationUnit::UserId => self.user_id.as_deref(),
         }

--- a/components/nimbus/src/stateless/cirrus_client.rs
+++ b/components/nimbus/src/stateless/cirrus_client.rs
@@ -16,7 +16,6 @@ use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Mutex;
-use uuid::Uuid;
 
 /// EnrollmentResponse is a DTO for the response from handling enrollment for a given client.
 ///
@@ -131,12 +130,8 @@ impl CirrusClient {
         is_user_participating: bool,
         prev_enrollments: &[ExperimentEnrollment],
     ) -> Result<EnrollmentResponse> {
-        // nimbus_id is set randomly here because all applications using the CirrusClient will not
-        // be using nimbus_id as the bucket randomization unit. This will be refactored out as a
-        // part of https://mozilla-hub.atlassian.net/browse/EXP-3401
-        let nimbus_id = Uuid::new_v4();
         let available_randomization_units =
-            AvailableRandomizationUnits::with_user_id(user_id.as_str()).apply_nimbus_id(&nimbus_id);
+            AvailableRandomizationUnits::with_user_id(user_id.as_str());
         let ta = TargetingAttributes::new(self.app_context.clone(), request_context);
         let th = NimbusTargetingHelper::new(ta);
         let coenrolling_ids = self

--- a/components/nimbus/src/stateless/cirrus_client.rs
+++ b/components/nimbus/src/stateless/cirrus_client.rs
@@ -136,7 +136,7 @@ impl CirrusClient {
         // part of https://mozilla-hub.atlassian.net/browse/EXP-3401
         let nimbus_id = Uuid::new_v4();
         let available_randomization_units =
-            AvailableRandomizationUnits::with_user_id(user_id.as_str());
+            AvailableRandomizationUnits::with_user_id(user_id.as_str()).apply_nimbus_id(&nimbus_id);
         let ta = TargetingAttributes::new(self.app_context.clone(), request_context);
         let th = NimbusTargetingHelper::new(ta);
         let coenrolling_ids = self
@@ -144,12 +144,8 @@ impl CirrusClient {
             .iter()
             .map(|s| s.as_str())
             .collect();
-        let enrollments_evolver = EnrollmentsEvolver::new(
-            &nimbus_id,
-            &available_randomization_units,
-            &th,
-            &coenrolling_ids,
-        );
+        let enrollments_evolver =
+            EnrollmentsEvolver::new(&available_randomization_units, &th, &coenrolling_ids);
         let state = self.state.lock().unwrap();
 
         let (enrollments, events) = enrollments_evolver

--- a/components/nimbus/src/tests/test_evaluator.rs
+++ b/components/nimbus/src/tests/test_evaluator.rs
@@ -474,8 +474,12 @@ fn test_qualified_enrollment() {
 
     let id = uuid::Uuid::new_v4();
 
-    let enrollment =
-        evaluate_enrollment(&id, &Default::default(), &experiment, &ctx.clone().into()).unwrap();
+    let enrollment = evaluate_enrollment(
+        &AvailableRandomizationUnits::with_nimbus_id(&id),
+        &experiment,
+        &ctx.clone().into(),
+    )
+    .unwrap();
     println!("Uh oh!  {:#?}", enrollment.status);
     assert!(matches!(
         enrollment.status,
@@ -490,8 +494,12 @@ fn test_qualified_enrollment() {
     ctx.channel = "Nightly".to_string();
 
     // Now we will be enrolled in the experiment because we have the right channel, but with different capitalization
-    let enrollment =
-        evaluate_enrollment(&id, &Default::default(), &experiment, &ctx.into()).unwrap();
+    let enrollment = evaluate_enrollment(
+        &AvailableRandomizationUnits::with_nimbus_id(&id),
+        &experiment,
+        &ctx.into(),
+    )
+    .unwrap();
     assert!(matches!(
         enrollment.status,
         EnrollmentStatus::Enrolled {
@@ -549,8 +557,7 @@ fn test_wrong_randomization_units() {
     // experiment is requesting the `ClientId` and the `Default::default()` here will just have the
     // NimbusId.
     let enrollment = evaluate_enrollment(
-        &uuid::Uuid::new_v4(),
-        &Default::default(),
+        &AvailableRandomizationUnits::with_nimbus_id(&uuid::Uuid::new_v4()),
         &experiment,
         &ctx.clone().into(),
     )
@@ -562,8 +569,7 @@ fn test_wrong_randomization_units() {
     let available_randomization_units = AvailableRandomizationUnits::with_client_id("bobo");
     let id = uuid::Uuid::parse_str("542213c0-9aef-47eb-bc6b-3b8529736ba2").unwrap();
     let enrollment = evaluate_enrollment(
-        &id,
-        &available_randomization_units,
+        &available_randomization_units.apply_nimbus_id(&id),
         &experiment,
         &ctx.into(),
     )
@@ -624,8 +630,12 @@ fn test_not_targeted_for_enrollment() {
     };
 
     // We won't be enrolled in the experiment because we don't have the right app_name
-    let enrollment =
-        evaluate_enrollment(&id, &Default::default(), &experiment, &ctx.clone().into()).unwrap();
+    let enrollment = evaluate_enrollment(
+        &AvailableRandomizationUnits::with_nimbus_id(&id),
+        &experiment,
+        &ctx.clone().into(),
+    )
+    .unwrap();
     assert!(matches!(
         enrollment.status,
         EnrollmentStatus::NotEnrolled {
@@ -639,8 +649,12 @@ fn test_not_targeted_for_enrollment() {
 
     // Now we won't be enrolled in the experiment because we don't have the right channel, but with the same
     // `NotTargeted` reason
-    let enrollment =
-        evaluate_enrollment(&id, &Default::default(), &experiment, &ctx.into()).unwrap();
+    let enrollment = evaluate_enrollment(
+        &AvailableRandomizationUnits::with_nimbus_id(&id),
+        &experiment,
+        &ctx.into(),
+    )
+    .unwrap();
     assert!(matches!(
         enrollment.status,
         EnrollmentStatus::NotEnrolled {
@@ -685,7 +699,7 @@ fn test_enrollment_bucketing() {
         ..Default::default()
     };
 
-    let available_randomization_units = Default::default();
+    let available_randomization_units: AvailableRandomizationUnits = Default::default();
     // 299eed1e-be6d-457d-9e53-da7b1a03f10d uuid fits in start: 0, count: 2000, total: 10000 with the example namespace, to the treatment-variation-b branch
     // Tested against the desktop implementation
     let id = uuid::Uuid::parse_str("299eed1e-be6d-457d-9e53-da7b1a03f10d").unwrap();
@@ -697,8 +711,7 @@ fn test_enrollment_bucketing() {
     };
 
     let enrollment = evaluate_enrollment(
-        &id,
-        &available_randomization_units,
+        &available_randomization_units.apply_nimbus_id(&id),
         &experiment,
         &ctx.into(),
     )


### PR DESCRIPTION
This PR refactors the `nimbus_id` parameter that is passed throughout enrollment/evaluation functions into the `AvailableRandomizationUnits` type. Its value is set during the `begin_initialize` method and used throughout the lifetime of the client instance.

Two new methods have been added to `AvailableRandomizationUnits`:
- `with_nimbus_id` — similar to our existing constructors, `with_client_id` and `with_user_id`.
- `apply_nimbus_id`— a departure from our existing methods, this uses an existing aru to create a new aru instance with the `nimbus_id` applied to it.

https://mozilla-hub.atlassian.net/browse/EXP-3401

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
