### PR TITLE
Fixes SYNC-3866: Remove the read-only transaction from `fetch_tree_with_depth`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Full Changelog](In progress)
 
+## Places
+
+### 🦊 What's Changed 🦊
+
+- `fetch_tree_with_depth` no longer starts a transaction when reading from the database. The transaction causes issues with concurrent calls, and isn't needed for consistency anymore ([#5790](https://github.com/mozilla/application-services/pull/5790)).
+
 # v118.0 (_2023-08-28_)
 
 ## General

--- a/components/places/src/storage/bookmarks/fetch.rs
+++ b/components/places/src/storage/bookmarks/fetch.rs
@@ -226,7 +226,6 @@ pub fn fetch_tree_with_depth(
     item_guid: &SyncGuid,
     target_depth: &FetchDepth,
 ) -> Result<Option<Item>> {
-    let _tx = db.begin_transaction()?;
     let (tree, parent_guid, position) = if let Some((tree, parent_guid, position)) =
         json_tree::fetch_tree(db, item_guid, target_depth)?
     {


### PR DESCRIPTION
Originally, we used multiple SELECTs to populate the tree, and the transaction was needed to avoid interleaved writes. These SELECTs were removed in #1289, so the transaction is no longer necessary, and can also cause issues when calling `fetch_tree_with_depth` concurrently.

Closes #5773.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
