### PR TITLE
Fix toolchain-desktop-macos CI jobs [ci full]

### DIFF
--- a/docs/howtos/upgrading-nss-guide.md
+++ b/docs/howtos/upgrading-nss-guide.md
@@ -32,9 +32,10 @@ We use a Linux TC worker for cross-compiling NSS for iOS, Android and Linux desk
     > usually a description with something like _`Added tag NSS_3_90_RTM`_
 2. Select the build for the following system(s) (first task with the title "B"):
     * For Intel MacOS: `mac opt-static`
-3. Update [taskcluster/ci/fetch/kind.yml](https://github.com/mozilla/application-services/blob/main/taskcluster/ci/fetch/kind.yml), specifically `nss-artifact` task to the appropiate `url` and `checksum` and `size`
+3. Update [taskcluster/ci/fetch/kind.yml](https://github.com/mozilla/application-services/blob/main/taskcluster/ci/fetch/kind.yml), specifically `nss-artifact` task to the appropriate `url` and `checksum` and `size`
     > Note: _To get the checksum, you can run `shasum -a 256 {path-to-artifact}` or you can make a PR and see the output of the failed log._
-4. Open a pull request with these changes and it should update the [Taskcluster artifact](https://firefox-ci-tc.services.mozilla.com/tasks/index/app-services.cache.level-1.content.v1.nss-artifact/latest)
+4. Update the SHA256 value for darwin cross-compile in [libs/build-nss-desktop.sh](https://github.com/mozilla/application-services/blob/main/libs/build-nss-desktop.sh) to the same checksum as above.
+5. Open a pull request with these changes and it should update the [Taskcluster artifact](https://firefox-ci-tc.services.mozilla.com/tasks/index/app-services.cache.level-1.content.v1.nss-artifact/latest)
 
 ---
 

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -59,7 +59,7 @@ fi
 if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   #From https://firefox-ci-tc.services.mozilla.com/tasks/index/app-services.cache.level-3.content.v1.nss-artifact/latest
   curl -sfSL --retry 5 --retry-delay 10 -O "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/app-services.cache.level-3.content.v1.nss-artifact.latest/artifacts/public/dist.tar.bz2"
-  SHA256="1f667d17cd1f9c869de413c3f9797378af5b49314738d2364ca178b651eacd29"
+  SHA256="9573e640797200891dadc6401cdd9cb06e3fd48518a146cf2f578e83127cb7f2"
   echo "${SHA256}  dist.tar.bz2" | shasum -a 256 -c - || exit 2
   tar xvjf dist.tar.bz2 && rm -rf dist.tar.bz2
   NSS_DIST_DIR=$(abspath "dist")


### PR DESCRIPTION
When NSS was updated in #5752, the SHA256 value in build-nss-desktop.sh was not updated. This fixes that hash value and updates the docs.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
