### PR TITLE
all: Exclude Android and iOS bindings from Cargo packages.

### DIFF
--- a/components/as-ohttp-client/Cargo.toml
+++ b/components/as-ohttp-client/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Ted Campbell <tcampbell@mozilla.com>"]
 description = "An Oblivious HTTP client for iOS applications"
 license = "MPL-2.0"
+exclude = ["/ios"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2021"
 version = "0.1.0"
 authors = ["application-services@mozilla.com"]
 license = "MPL-2.0"
+exclude = ["/android"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -7,6 +7,7 @@ description = "A rapid experiment library"
 readme = "README.md"
 license = "MPL-2.0"
 keywords = ["experiment", "nimbus"]
+exclude = ["/android", "/ios"]
 
 [lib]
 name = "nimbus"

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 authors = ["The Android Mobile Team <firefox-android-team@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A Remote Settings client intended for application layer platforms."
 license = "MPL-2.0" 
+exclude = ["/android"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
I noticed that `./mach vendor rust` was [vendoring the Remote Settings Kotlin test](https://phabricator.services.mozilla.com/D187323), and fixed up the other components' Cargo manifests while I was there.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
