### PR TITLE
taskcluster: Fixes for running the Taskcluster scripts locally with pyenv `python3` shims

### DIFF
--- a/automation/tests.py
+++ b/automation/tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """
 Run application-services tests
 

--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from collections import namedtuple
 import argparse
@@ -135,7 +135,7 @@ def generate_glean_metrics(args):
     env = {
         'SOURCE_ROOT': str(args.glean_work_dir),
         'PROJECT': "MozillaAppServices",
-        'GLEAN_PYTHON': '/usr/bin/python3',
+        'GLEAN_PYTHON': '/usr/bin/env python3',
         'LC_ALL': 'C.UTF-8',
         'LANG': 'C.UTF-8',
     }

--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -138,6 +138,7 @@ def generate_glean_metrics(args):
         'GLEAN_PYTHON': '/usr/bin/env python3',
         'LC_ALL': 'C.UTF-8',
         'LANG': 'C.UTF-8',
+        'PATH': os.environ['PATH'],
     }
     glean_script = ROOT_DIR / "components/external/glean/glean-core/ios/sdk_generator.sh"
     out_dir = args.out_dir / 'all' / 'Generated' / 'Metrics'

--- a/taskcluster/scripts/deps-complete.py
+++ b/taskcluster/scripts/deps-complete.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import json
 import os

--- a/taskcluster/scripts/nimbus-build.py
+++ b/taskcluster/scripts/nimbus-build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import subprocess

--- a/taskcluster/scripts/setup-branch-build-firefox-android.py
+++ b/taskcluster/scripts/setup-branch-build-firefox-android.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/taskcluster/scripts/setup-branch-build-firefox-ios.py
+++ b/taskcluster/scripts/setup-branch-build-firefox-ios.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os


### PR DESCRIPTION
I use pyenv to manage Python versions locally, so the `python3` executable in my `PATH` is a shim that's different from the system `python3`. The first commit ensures that running the Taskcluster scripts locally uses the `python3` shims in my `PATH`. On a machine that only has the system `python3`, this ought to work the same way as now! 😊

The second commit is to work around a `KeyError` when installing MarkupSafe on my machine. MarkupSafe is one of the Glean build script's Python dependencies, and my `python3` executable is a pyenv shim, which might help explain why this doesn't fail with the system `python3`. There's a bit more context in [this internal Slack thread](https://mozilla.slack.com/archives/C0559DDDPQF/p1694121631262619).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
