### PR TITLE
One device capability

### DIFF
--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -15,9 +15,11 @@
 //! [Firefox Accounts Device Registration docs](
 //! https://github.com/mozilla/fxa/blob/main/packages/fxa-auth-server/docs/device_registration.md).
 
-use crate::{ApiResult, DevicePushSubscription, Error, FirefoxAccount};
 use error_support::handle_error;
+use serde::{Deserialize, Serialize};
 use sync15::DeviceType;
+
+use crate::{ApiResult, DevicePushSubscription, Error, FirefoxAccount};
 
 impl FirefoxAccount {
     /// Create a new device record for this application.
@@ -220,7 +222,7 @@ pub struct Device {
 /// use the variants of this enum to do so.
 ///
 /// In practice, the only currently-supported command is the ability to receive a tab.
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum DeviceCapability {
     SendTab,
 }

--- a/components/fxa-client/src/internal/state_manager.rs
+++ b/components/fxa-client/src/internal/state_manager.rs
@@ -6,13 +6,12 @@ use std::collections::{HashMap, HashSet};
 
 use crate::{
     internal::{
-        device,
         oauth::{AccessTokenInfo, RefreshToken},
         profile::Profile,
         state_persistence::state_to_json,
         CachedResponse, Config, OAuthFlow, PersistedState,
     },
-    Result, ScopedKey,
+    DeviceCapability, Result, ScopedKey,
 };
 
 /// Stores and manages the current state of the FxA client
@@ -51,14 +50,14 @@ impl StateManager {
     }
 
     /// Get the last known set of device capabilities that we sent to the server
-    pub fn last_sent_device_capabilities(&self) -> &HashSet<device::Capability> {
+    pub fn last_sent_device_capabilities(&self) -> &HashSet<DeviceCapability> {
         &self.persisted_state.device_capabilities
     }
 
     /// Update the last known set of device capabilities that we sent to the server
     pub fn update_last_sent_device_capabilities(
         &mut self,
-        capabilities_set: HashSet<device::Capability>,
+        capabilities_set: HashSet<DeviceCapability>,
     ) {
         self.persisted_state.device_capabilities = capabilities_set;
     }

--- a/components/fxa-client/src/internal/state_persistence.rs
+++ b/components/fxa-client/src/internal/state_persistence.rs
@@ -34,12 +34,11 @@ use std::collections::{HashMap, HashSet};
 
 use super::{
     config::Config,
-    device::Capability as DeviceCapability,
     oauth::{AccessTokenInfo, RefreshToken},
     profile::Profile,
     CachedResponse, Result,
 };
-use crate::ScopedKey;
+use crate::{DeviceCapability, ScopedKey};
 
 // These are the public API for working with the persisted state.
 


### PR DESCRIPTION
Merge the DeviceCapabilities enums
    
We had two identical enums with different names, let's just use one.

Please double check that the logic/test of the first commit to make sure I'm not messing up the serialization.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
