### PR TITLE
Fixes DISCO-2605: Replace template parameters in AMP suggestion URLs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@
 ### ✨ What's New ✨
 
 - The Suggest component now has Swift bindings for Firefox for iOS ([#5806](https://github.com/mozilla/application-services/pull/5806)).
+
+### 🦊 What's Changed 🦊
+
+- AMP suggestions now replace all template parameters in their `url` and `click_url` fields, and carry the original "raw" URLs in the `raw_url` and `raw_click_url` fields. Consumers can use the `raw_suggestion_url_matches()` function to determine if a `raw_url` or `raw_click_url` matches a URL string with replacements. This is a source-breaking change in Swift only, and doesn't affect Firefox for iOS, because iOS isn't consuming the Suggest component yet ([#5826](https://github.com/mozilla/application-services/pull/5826)).
+
 ## Logins
 
 ### ⚠️ Breaking Changes ⚠️

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4089,6 +4089,7 @@ name = "suggest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "env_logger 0.7.1",
  "expect-test",
  "hex",

--- a/components/suggest/Cargo.toml
+++ b/components/suggest/Cargo.toml
@@ -9,6 +9,7 @@ exclude = ["/android", "/ios"]
 
 [dependencies]
 anyhow = "1.0"
+chrono = "0.4"
 interrupt-support = { path = "../support/interrupt" }
 once_cell = "1.5"
 parking_lot = ">=0.11,<=0.12"

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -168,21 +168,13 @@ impl<'a> SuggestDao<'a> {
                                     advertiser: row.get("advertiser")?,
                                     iab_category: row.get("iab_category")?,
                                     title,
-                                    // If we have a cooked URL, use it; if not,
-                                    // fall back to the raw URL.
-                                    url: cooked_url.clone().unwrap_or_else(|| raw_url.clone()),
-                                    // Only include the raw URL if we have a
-                                    // cooked URL. Otherwise, `raw_url` would be
-                                    // the same as `url`, and there's no need to
-                                    // include it twice.
-                                    raw_url: cooked_url.map(|_| raw_url),
+                                    url: cooked_url,
+                                    raw_url,
                                     full_keyword: full_keyword(keyword, &keywords),
                                     icon: row.get("icon")?,
                                     impression_url: row.get("impression_url")?,
-                                    // We handle `{raw_}click_url` the same way
-                                    // as `{raw_}url`.
-                                    click_url: cooked_click_url.clone().unwrap_or_else(|| raw_click_url.clone()),
-                                    raw_click_url: cooked_click_url.map(|_| raw_click_url)
+                                    click_url: cooked_click_url,
+                                    raw_click_url,
                                 })
                             }
                         )

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -16,7 +16,7 @@ mod suggestion;
 pub use error::SuggestApiError;
 pub use provider::SuggestionProvider;
 pub use store::{SuggestIngestionConstraints, SuggestStore};
-pub use suggestion::Suggestion;
+pub use suggestion::{raw_suggestion_url_matches, Suggestion};
 
 pub(crate) type Result<T> = std::result::Result<T, error::Error>;
 pub type SuggestApiResult<T> = std::result::Result<T, error::SuggestApiError>;

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -573,7 +573,7 @@ mod tests {
                     Amp {
                         title: "Los Pollos Hermanos - Albuquerque",
                         url: "https://www.lph-nm.biz",
-                        raw_url: None,
+                        raw_url: "https://www.lph-nm.biz",
                         icon: None,
                         full_keyword: "los",
                         block_id: 0,
@@ -581,7 +581,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
-                        raw_click_url: None,
+                        raw_click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -657,7 +657,7 @@ mod tests {
                     Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
-                        raw_url: None,
+                        raw_url: "https://www.lasagna.restaurant",
                         icon: Some(
                             [
                                 105,
@@ -680,7 +680,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
-                        raw_click_url: None,
+                        raw_click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -690,7 +690,7 @@ mod tests {
                     Amp {
                         title: "Penne for Your Thoughts",
                         url: "https://penne.biz",
-                        raw_url: None,
+                        raw_url: "https://penne.biz",
                         icon: Some(
                             [
                                 105,
@@ -713,7 +713,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
-                        raw_click_url: None,
+                        raw_click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -768,7 +768,7 @@ mod tests {
                     Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
-                        raw_url: None,
+                        raw_url: "https://www.lasagna.restaurant",
                         icon: None,
                         full_keyword: "lasagna",
                         block_id: 0,
@@ -776,7 +776,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
-                        raw_click_url: None,
+                        raw_click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -842,7 +842,7 @@ mod tests {
                     Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
-                        raw_url: None,
+                        raw_url: "https://www.lasagna.restaurant",
                         icon: None,
                         full_keyword: "lasagna",
                         block_id: 0,
@@ -850,7 +850,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
-                        raw_click_url: None,
+                        raw_click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -907,7 +907,7 @@ mod tests {
                     Amp {
                         title: "Los Pollos Hermanos - Now Serving at 14 Locations!",
                         url: "https://www.lph-nm.biz",
-                        raw_url: None,
+                        raw_url: "https://www.lph-nm.biz",
                         icon: None,
                         full_keyword: "los pollos",
                         block_id: 0,
@@ -915,7 +915,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
-                        raw_click_url: None,
+                        raw_click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -925,7 +925,7 @@ mod tests {
                     Amp {
                         title: "Penne for Your Thoughts",
                         url: "https://penne.biz",
-                        raw_url: None,
+                        raw_url: "https://penne.biz",
                         icon: None,
                         full_keyword: "penne",
                         block_id: 0,
@@ -933,7 +933,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
-                        raw_click_url: None,
+                        raw_click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -1062,7 +1062,7 @@ mod tests {
                     Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
-                        raw_url: None,
+                        raw_url: "https://www.lasagna.restaurant",
                         icon: Some(
                             [
                                 110,
@@ -1089,7 +1089,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
-                        raw_click_url: None,
+                        raw_click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -1099,7 +1099,7 @@ mod tests {
                     Amp {
                         title: "Los Pollos Hermanos - Albuquerque",
                         url: "https://www.lph-nm.biz",
-                        raw_url: None,
+                        raw_url: "https://www.lph-nm.biz",
                         icon: Some(
                             [
                                 110,
@@ -1125,7 +1125,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
-                        raw_click_url: None,
+                        raw_click_url: "https://example.com/click_url",
                     },
                 ]
             "#]]
@@ -1436,7 +1436,7 @@ mod tests {
                         Amp {
                             title: "Lasagna Come Out Tomorrow",
                             url: "https://www.lasagna.restaurant",
-                            raw_url: None,
+                            raw_url: "https://www.lasagna.restaurant",
                             icon: Some(
                                 [
                                     105,
@@ -1459,7 +1459,7 @@ mod tests {
                             iab_category: "8 - Food & Drink",
                             impression_url: "https://example.com/impression_url",
                             click_url: "https://example.com/click_url",
-                            raw_click_url: None,
+                            raw_click_url: "https://example.com/click_url",
                         },
                     ]
                 "#]],
@@ -1476,7 +1476,7 @@ mod tests {
                         Amp {
                             title: "Lasagna Come Out Tomorrow",
                             url: "https://www.lasagna.restaurant",
-                            raw_url: None,
+                            raw_url: "https://www.lasagna.restaurant",
                             icon: Some(
                                 [
                                     105,
@@ -1499,7 +1499,7 @@ mod tests {
                             iab_category: "8 - Food & Drink",
                             impression_url: "https://example.com/impression_url",
                             click_url: "https://example.com/click_url",
-                            raw_click_url: None,
+                            raw_click_url: "https://example.com/click_url",
                         },
                     ]
                 "#]],

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -573,6 +573,7 @@ mod tests {
                     Amp {
                         title: "Los Pollos Hermanos - Albuquerque",
                         url: "https://www.lph-nm.biz",
+                        raw_url: None,
                         icon: None,
                         full_keyword: "los",
                         block_id: 0,
@@ -580,6 +581,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
+                        raw_click_url: None,
                     },
                 ]
             "#]]
@@ -655,6 +657,7 @@ mod tests {
                     Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
+                        raw_url: None,
                         icon: Some(
                             [
                                 105,
@@ -677,6 +680,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
+                        raw_click_url: None,
                     },
                 ]
             "#]]
@@ -686,6 +690,7 @@ mod tests {
                     Amp {
                         title: "Penne for Your Thoughts",
                         url: "https://penne.biz",
+                        raw_url: None,
                         icon: Some(
                             [
                                 105,
@@ -708,6 +713,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
+                        raw_click_url: None,
                     },
                 ]
             "#]]
@@ -762,6 +768,7 @@ mod tests {
                     Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
+                        raw_url: None,
                         icon: None,
                         full_keyword: "lasagna",
                         block_id: 0,
@@ -769,6 +776,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
+                        raw_click_url: None,
                     },
                 ]
             "#]]
@@ -834,6 +842,7 @@ mod tests {
                     Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
+                        raw_url: None,
                         icon: None,
                         full_keyword: "lasagna",
                         block_id: 0,
@@ -841,6 +850,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
+                        raw_click_url: None,
                     },
                 ]
             "#]]
@@ -897,6 +907,7 @@ mod tests {
                     Amp {
                         title: "Los Pollos Hermanos - Now Serving at 14 Locations!",
                         url: "https://www.lph-nm.biz",
+                        raw_url: None,
                         icon: None,
                         full_keyword: "los pollos",
                         block_id: 0,
@@ -904,6 +915,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
+                        raw_click_url: None,
                     },
                 ]
             "#]]
@@ -913,6 +925,7 @@ mod tests {
                     Amp {
                         title: "Penne for Your Thoughts",
                         url: "https://penne.biz",
+                        raw_url: None,
                         icon: None,
                         full_keyword: "penne",
                         block_id: 0,
@@ -920,6 +933,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
+                        raw_click_url: None,
                     },
                 ]
             "#]]
@@ -1048,6 +1062,7 @@ mod tests {
                     Amp {
                         title: "Lasagna Come Out Tomorrow",
                         url: "https://www.lasagna.restaurant",
+                        raw_url: None,
                         icon: Some(
                             [
                                 110,
@@ -1074,6 +1089,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
+                        raw_click_url: None,
                     },
                 ]
             "#]]
@@ -1083,6 +1099,7 @@ mod tests {
                     Amp {
                         title: "Los Pollos Hermanos - Albuquerque",
                         url: "https://www.lph-nm.biz",
+                        raw_url: None,
                         icon: Some(
                             [
                                 110,
@@ -1108,6 +1125,7 @@ mod tests {
                         iab_category: "8 - Food & Drink",
                         impression_url: "https://example.com/impression_url",
                         click_url: "https://example.com/click_url",
+                        raw_click_url: None,
                     },
                 ]
             "#]]
@@ -1418,6 +1436,7 @@ mod tests {
                         Amp {
                             title: "Lasagna Come Out Tomorrow",
                             url: "https://www.lasagna.restaurant",
+                            raw_url: None,
                             icon: Some(
                                 [
                                     105,
@@ -1440,6 +1459,7 @@ mod tests {
                             iab_category: "8 - Food & Drink",
                             impression_url: "https://example.com/impression_url",
                             click_url: "https://example.com/click_url",
+                            raw_click_url: None,
                         },
                     ]
                 "#]],
@@ -1456,6 +1476,7 @@ mod tests {
                         Amp {
                             title: "Lasagna Come Out Tomorrow",
                             url: "https://www.lasagna.restaurant",
+                            raw_url: None,
                             icon: Some(
                                 [
                                     105,
@@ -1478,6 +1499,7 @@ mod tests {
                             iab_category: "8 - Food & Drink",
                             impression_url: "https://example.com/impression_url",
                             click_url: "https://example.com/click_url",
+                            raw_click_url: None,
                         },
                     ]
                 "#]],

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -8,13 +8,14 @@ typedef extern RemoteSettingsConfig;
 
 namespace suggest {
 
+boolean raw_suggestion_url_matches([ByRef] string raw_url, [ByRef] string url);
+
 };
 
 [Error]
 interface SuggestApiError {
     Other(string reason);
 };
-
 
 enum SuggestionProvider {
     "Amp",
@@ -26,13 +27,15 @@ interface Suggestion {
     Amp(
         string title,
         string url,
+        string? raw_url,
         sequence<u8>? icon,
         string full_keyword,
         i64 block_id,
         string advertiser,
         string iab_category,
         string impression_url,
-        string click_url
+        string click_url,
+        string? raw_click_url
     );
     Wikipedia(
         string title,

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -27,7 +27,7 @@ interface Suggestion {
     Amp(
         string title,
         string url,
-        string? raw_url,
+        string raw_url,
         sequence<u8>? icon,
         string full_keyword,
         i64 block_id,
@@ -35,7 +35,7 @@ interface Suggestion {
         string iab_category,
         string impression_url,
         string click_url,
-        string? raw_click_url
+        string raw_click_url
     );
     Wikipedia(
         string title,

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -68,7 +68,12 @@ pub fn raw_suggestion_url_matches(raw_url: &str, cooked_url: &str) -> bool {
     ) else {
         return false;
     };
-    raw_url_prefix == cooked_url_prefix && raw_url_suffix == cooked_url_suffix
+    if raw_url_prefix != cooked_url_prefix || raw_url_suffix != cooked_url_suffix {
+        return false;
+    }
+    let maybe_timestamp =
+        &cooked_url[raw_url_prefix.len()..raw_url_prefix.len() + TIMESTAMP_LENGTH];
+    maybe_timestamp.bytes().all(|b| b.is_ascii_digit())
 }
 
 #[cfg(test)]
@@ -146,6 +151,16 @@ mod tests {
         assert!(!raw_suggestion_url_matches(
             raw_url_with_trailing_segment,          // `a&b`.
             "https://example.com?a=5555555555&c=c"  // `a&c`.
+        ));
+
+        // Not a timestamp.
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_one_timestamp,
+            "https://example.com?a=bcdefghijk"
+        ));
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_trailing_segment,
+            "https://example.com?a=bcdefghijk&b=c"
         ));
     }
 

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -3,12 +3,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+use std::fmt::Write;
+
+use chrono::{Datelike, Local, Timelike};
+
+/// The template parameter for a timestamp in a "raw" sponsored suggestion URL.
+const TIMESTAMP_TEMPLATE: &str = "%YYYYMMDDHH%";
+
+/// The length, in bytes, of a timestamp in a "cooked" sponsored suggestion URL.
+///
+/// Cooked timestamps don't include the leading or trailing `%`, so this is
+/// 2 bytes shorter than [`TIMESTAMP_TEMPLATE`].
+const TIMESTAMP_LENGTH: usize = 10;
+
 /// A suggestion from the database to show in the address bar.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Suggestion {
     Amp {
         title: String,
         url: String,
+        raw_url: Option<String>,
         icon: Option<Vec<u8>>,
         full_keyword: String,
         block_id: i64,
@@ -16,6 +30,7 @@ pub enum Suggestion {
         iab_category: String,
         impression_url: String,
         click_url: String,
+        raw_click_url: Option<String>,
     },
     Wikipedia {
         title: String,
@@ -29,5 +44,190 @@ impl Suggestion {
     /// Returns `true` if the suggestion is sponsored.
     pub(crate) fn is_sponsored(&self) -> bool {
         matches!(self, Self::Amp { .. })
+    }
+}
+
+/// Replaces all template parameters in a "raw" sponsored suggestion URL,
+/// producing a "cooked" URL with real values. Returns `None` if the raw
+/// URL doesn't contain any template parameters.
+pub(crate) fn cook_raw_suggestion_url(raw_url: &str) -> Option<String> {
+    let now = Local::now();
+    let mut cooked_url = String::new();
+    let mut last_index = 0;
+    for (index, _) in raw_url.match_indices(TIMESTAMP_TEMPLATE) {
+        cooked_url.push_str(&raw_url[last_index..index]);
+        write!(
+            &mut cooked_url,
+            "{:04}{:02}{:02}{:02}",
+            now.year(),
+            now.month(),
+            now.day(),
+            now.hour()
+        )
+        .expect("Failed to replace timestamp template parameter");
+        last_index = index + TIMESTAMP_TEMPLATE.len();
+    }
+    if cooked_url.is_empty() {
+        return None;
+    }
+    cooked_url.push_str(&raw_url[last_index..]);
+    Some(cooked_url)
+}
+
+/// Determines whether a "raw" sponsored suggestion URL is equivalent to a
+/// "cooked" URL. The two URLs are equivalent if they are identical except for
+/// their replaced template parameters, which can be different.
+pub fn raw_suggestion_url_matches(raw_url: &str, cooked_url: &str) -> bool {
+    let mut last_raw_url_index = 0;
+
+    // The running difference between indices in the raw URL and the
+    // corresponding indices in the cooked URL.
+    let mut cooked_url_diff = 0;
+
+    // Ensure that the segments between the timestamps are the same.
+    for (raw_url_index, _) in raw_url.match_indices(TIMESTAMP_TEMPLATE) {
+        let raw_url_segment = &raw_url[last_raw_url_index..raw_url_index];
+        let Some(cooked_url_segment) =
+            cooked_url.get(last_raw_url_index - cooked_url_diff..raw_url_index - cooked_url_diff)
+        else {
+            // The corresponding indices in the cooked URL are out-of-bounds,
+            // so the URLs can't match.
+            return false;
+        };
+        if raw_url_segment != cooked_url_segment {
+            // The corresponding segments between the last timestamp and this
+            // timestamp are different, so the URLs can't match.
+            return false;
+        }
+        last_raw_url_index = raw_url_index + TIMESTAMP_TEMPLATE.len();
+        cooked_url_diff += TIMESTAMP_TEMPLATE.len() - TIMESTAMP_LENGTH;
+    }
+
+    // Ensure that the last corresponding segments, after the last timestamp,
+    // are the same.
+    let last_raw_url_segment = &raw_url[last_raw_url_index..];
+    match cooked_url.get(last_raw_url_index - cooked_url_diff..) {
+        Some(last_cooked_url_segment) => last_raw_url_segment == last_cooked_url_segment,
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cook_url_with_template_parameters() {
+        let raw_url_with_one_timestamp = "https://example.com?a=%YYYYMMDDHH%";
+        let cooked_url_with_one_timestamp = cook_raw_suggestion_url(raw_url_with_one_timestamp)
+            .expect("Should cook URL with 1 timestamp template parameter");
+        assert_eq!(
+            cooked_url_with_one_timestamp.len(),
+            raw_url_with_one_timestamp.len() - 2
+        );
+        assert_ne!(raw_url_with_one_timestamp, cooked_url_with_one_timestamp);
+
+        let raw_url_with_trailing_segment = "https://example.com?a=%YYYYMMDDHH%&b=c";
+        let cooked_url_with_trailing_segment =
+            cook_raw_suggestion_url(raw_url_with_trailing_segment)
+                .expect("Should cook URL with 1 parameter and trailing segment");
+        assert_eq!(
+            cooked_url_with_trailing_segment.len(),
+            raw_url_with_trailing_segment.len() - 2
+        );
+        assert_ne!(
+            raw_url_with_trailing_segment,
+            cooked_url_with_trailing_segment
+        );
+
+        let raw_url_with_two_timestamps = "https://example.com?a=%YYYYMMDDHH%&b=%YYYYMMDDHH%";
+        let cooked_url_with_two_timestamps = cook_raw_suggestion_url(raw_url_with_two_timestamps)
+            .expect("Should cook URL with 2 timestamp template parameters");
+        assert_eq!(
+            cooked_url_with_two_timestamps.len(),
+            raw_url_with_two_timestamps.len() - 4
+        );
+        assert_ne!(raw_url_with_two_timestamps, cooked_url_with_two_timestamps);
+    }
+
+    #[test]
+    fn cook_url_without_template_parameters() {
+        assert!(cook_raw_suggestion_url("http://example.com/123").is_none());
+    }
+
+    #[test]
+    fn url_with_template_parameters_matches() {
+        let raw_url_with_one_timestamp = "https://example.com?a=%YYYYMMDDHH%";
+        let raw_url_with_trailing_segment = "https://example.com?a=%YYYYMMDDHH%&b=c";
+        let raw_url_with_two_timestamps = "https://example.com?a=%YYYYMMDDHH%&b=%YYYYMMDDHH%";
+
+        // Equivalent, except for their replaced template parameters.
+        assert!(raw_suggestion_url_matches(
+            raw_url_with_one_timestamp,
+            "https://example.com?a=0000000000"
+        ));
+        assert!(raw_suggestion_url_matches(
+            raw_url_with_trailing_segment,
+            "https://example.com?a=1111111111&b=c"
+        ));
+        assert!(raw_suggestion_url_matches(
+            raw_url_with_two_timestamps,
+            "https://example.com?a=2222222222&b=3333333333"
+        ));
+
+        // Different lengths.
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_one_timestamp,
+            "https://example.com?a=1234567890&c=d"
+        ));
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_one_timestamp,
+            "https://example.com?a=123456789"
+        ));
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_trailing_segment,
+            "https://example.com?a=0987654321"
+        ));
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_trailing_segment,
+            "https://example.com?a=0987654321&b=c&d=e"
+        ));
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_two_timestamps,
+            "https://example.com?a=456123789"
+        ));
+
+        // Different query parameter names.
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_one_timestamp,         // `a`.
+            "https://example.com?b=4444444444"  // `b`.
+        ));
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_trailing_segment,          // `a&b`.
+            "https://example.com?a=5555555555&c=c"  // `a&c`.
+        ));
+        assert!(!raw_suggestion_url_matches(
+            raw_url_with_two_timestamps,                     // `a&b`.
+            "https://example.com?a=6666666666&c=7777777777"  // `a&c`.
+        ));
+    }
+
+    #[test]
+    fn url_without_template_parameters_matches() {
+        let raw_url = "http://example.com/123";
+
+        assert!(raw_suggestion_url_matches(
+            raw_url,
+            "http://example.com/123"
+        ));
+        assert!(!raw_suggestion_url_matches(raw_url, "http://example.com"));
+        assert!(!raw_suggestion_url_matches(
+            raw_url,
+            "http://example.com/456"
+        ));
+        assert!(!raw_suggestion_url_matches(
+            raw_url,
+            "http://example.com/123456"
+        ));
     }
 }


### PR DESCRIPTION
Some AMP suggestion URLs contain template parameters, like `%YYYYMMDDHH%`, which we must "cook" with real values before returning the suggestion. This means that an AMP suggestion's URL can vary depending on when it's shown.

When deduping suggestions, though, we want to treat all variations of these URLs as equivalent, and ignore the replaced parameters. Otherwise, the address bar might show an AMP suggestion twice, as on Desktop in bug 1735894: once from history, with one set of parameters; and once from Suggest, with a different set of parameters.

To address both of these needs, this commit adds:

* A `SuggestionUrl` type that holds both the "cooked" URL string, and the locations of replaced template parameters within that string.
* A `suggestion_url_matches` function that compares a `SuggestionUrl` with a URL string, to determine if they're identical except for their replaced parameters.

/cc @0c0w3

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
