### PR TITLE
Add feature inspector to FML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,21 @@
 
 ### ✨ What's New ✨
 
-- The `set_experiments` method has been updated to filter down the list of experiments to only those that match the configured `app_name` and `channel` ([#5813](https://github.com/mozilla/application-services/pull/5813)). 
+- The `set_experiments` method has been updated to filter down the list of experiments to only those that match the configured `app_name` and `channel` ([#5813](https://github.com/mozilla/application-services/pull/5813)).
 
+## Nimbus FML ⛅️🔬🔭🔧
+
+### ✨ What's New ✨
+
+- Added support to fetch different versions of a manifest to the `FmlClient` ([#5827](https://github.com/mozilla/application-services/pull/5827)).
+- Added a `FmlFeatureInspector` to the `FmlClient` ([#5827](https://github.com/mozilla/application-services/pull/5827)).
+  - This adds methods to parse a feature configuration and return errors.
+- Added a `FmlFeatureDescriptor` to the `FmlClient` ([#5815](https://github.com/mozilla/application-services/pull/5815)).
+  - This adds methods to get the feature_ids and descriptions from a loaded manifest.
+
+### ✨ What's New ✨
+
+- The `set_experiments` method has been updated to filter down the list of experiments to only those that match the configured `app_name` and `channel` ([#5813](https://github.com/mozilla/application-services/pull/5813)).
 ## Places
 
 ### 🦊 What's Changed 🦊

--- a/components/support/nimbus-fml/fixtures/fe/browser.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/browser.yaml
@@ -68,7 +68,7 @@ features:
         type: Option<IconType>
         default: letter
         description: "Describes the icon of spotlight"
-      eum-map:
+      enum-map:
         description: A enum map that was causing problem
         type: Map<IconType, Int>
         default:

--- a/components/support/nimbus-fml/src/client/config.rs
+++ b/components/support/nimbus-fml/src/client/config.rs
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+
+use crate::util::loaders::LoaderConfig;
+
+#[derive(Debug, Default)]
+pub struct FmlLoaderConfig {
+    pub cache: Option<String>,
+    pub refs: HashMap<String, String>,
+    pub ref_files: Vec<String>,
+}
+
+impl From<FmlLoaderConfig> for LoaderConfig {
+    fn from(value: FmlLoaderConfig) -> Self {
+        let cwd = std::env::current_dir().expect("Current Working Directory is not set");
+        let cache = value.cache.map(|v| cwd.join(v));
+        Self {
+            cwd,
+            refs: value.refs.into_iter().collect(),
+            repo_files: value.ref_files,
+            cache_dir: cache,
+        }
+    }
+}

--- a/components/support/nimbus-fml/src/client/descriptor.rs
+++ b/components/support/nimbus-fml/src/client/descriptor.rs
@@ -1,0 +1,91 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::BTreeSet;
+
+use crate::{intermediate_representation::FeatureDef, FmlClient};
+
+#[derive(Debug, PartialEq)]
+pub struct FmlFeatureDescriptor {
+    pub(crate) id: String,
+    pub(crate) description: String,
+    pub(crate) is_coenrolling: bool,
+}
+
+impl From<&FeatureDef> for FmlFeatureDescriptor {
+    fn from(f: &FeatureDef) -> Self {
+        Self {
+            id: f.name(),
+            description: f.doc(),
+            is_coenrolling: f.allow_coenrollment,
+        }
+    }
+}
+
+impl FmlClient {
+    pub fn get_feature_ids(&self) -> Vec<String> {
+        let mut res: BTreeSet<String> = Default::default();
+        for (_, f) in self.manifest.iter_all_feature_defs() {
+            res.insert(f.name());
+        }
+        res.into_iter().collect()
+    }
+
+    pub fn get_feature_descriptor(&self, id: String) -> Option<FmlFeatureDescriptor> {
+        let (_, f) = self.manifest.find_feature(&id)?;
+        Some(f.into())
+    }
+
+    pub fn get_feature_descriptors(&self) -> Vec<FmlFeatureDescriptor> {
+        let mut res: Vec<_> = Default::default();
+        for (_, f) in self.manifest.iter_all_feature_defs() {
+            res.push(f.into());
+        }
+        res
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+    use crate::{client::test_helper::client, error::Result};
+
+    #[test]
+    fn test_feature_ids() -> Result<()> {
+        let client = client("./bundled_resouces.yaml", "testing")?;
+        let result = client.get_feature_ids();
+
+        assert_eq!(result, vec!["my_images", "my_strings"]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_feature() -> Result<()> {
+        let client = client("./bundled_resouces.yaml", "testing")?;
+
+        let result = client.get_feature_descriptor("my_strings".to_string());
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap(),
+            FmlFeatureDescriptor {
+                id: "my_strings".to_string(),
+                description: "Testing all the ways bundled text can work".to_string(),
+                is_coenrolling: false
+            }
+        );
+
+        let result = client.get_feature_descriptor("my_images".to_string());
+        assert!(result.is_some());
+        assert_eq!(
+            result.unwrap(),
+            FmlFeatureDescriptor {
+                id: "my_images".to_string(),
+                description: "Testing all the ways bundled images can work".to_string(),
+                is_coenrolling: false
+            }
+        );
+
+        Ok(())
+    }
+}

--- a/components/support/nimbus-fml/src/client/inspector.rs
+++ b/components/support/nimbus-fml/src/client/inspector.rs
@@ -1,0 +1,492 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{
+    error::{ClientError, FMLError, Result},
+    intermediate_representation::FeatureManifest,
+    FmlClient, JsonObject,
+};
+use serde_json::Value;
+use std::sync::Arc;
+
+impl FmlClient {
+    pub fn get_feature_inspector(&self, id: String) -> Option<Arc<FmlFeatureInspector>> {
+        _ = self.manifest.find_feature(&id)?;
+        Some(Arc::new(FmlFeatureInspector::new(
+            self.manifest.clone(),
+            id,
+        )))
+    }
+}
+
+pub struct FmlFeatureInspector {
+    manifest: Arc<FeatureManifest>,
+    feature_id: String,
+}
+
+impl FmlFeatureInspector {
+    pub(crate) fn new(manifest: Arc<FeatureManifest>, feature_id: String) -> Self {
+        Self {
+            manifest,
+            feature_id,
+        }
+    }
+
+    pub fn get_default_json(&self) -> Result<JsonObject> {
+        match self
+            .manifest
+            .find_feature(&self.feature_id)
+            .map(|(_, f)| f.default_json())
+            // We know it's safe to unwrap here, because find_feature returns something, because we constructed
+            // a inspector with the feature id.
+            .unwrap()
+        {
+            Value::Object(map) => Ok(map),
+            _ => Err(FMLError::ClientError(ClientError::InvalidFeatureValue(
+                "A non-JSON object is returned as default. This is likely a Nimbus FML bug."
+                    .to_string(),
+            ))),
+        }
+    }
+
+    pub fn is_feature_valid(&self, value: JsonObject) -> Result<bool> {
+        self.manifest
+            .validate_feature_config(&self.feature_id, serde_json::Value::Object(value))
+            .map(|_| true)
+    }
+
+    pub fn get_first_error(&self, string: String) -> Option<FmlEditorError> {
+        match self.get_syntax_error(&string) {
+            Ok(json) => self.get_semantic_error(&string, json).err(),
+            Err(err) => Some(err),
+        }
+    }
+
+    pub fn get_errors(&self, string: String) -> Option<Vec<FmlEditorError>> {
+        self.get_first_error(string).map(|e| vec![e])
+    }
+}
+
+impl FmlFeatureInspector {
+    fn get_syntax_error(&self, string: &str) -> Result<Value, FmlEditorError> {
+        let json = serde_json::from_str::<Value>(string);
+        if let Err(e) = json {
+            let col = e.column();
+            return Err(FmlEditorError {
+                message: "Need valid JSON object".to_string(),
+                // serde_json errors are 1 indexed.
+                line: e.line() as u32 - 1,
+                col: if col == 0 { 0 } else { col - 1 } as u32,
+                hightlight: None,
+            });
+        }
+        let json = json.ok().unwrap();
+        if json.is_object() {
+            Ok(json)
+        } else {
+            Err(FmlEditorError {
+                message: "Need valid JSON object".to_string(),
+                line: 0,
+                col: 0,
+                hightlight: Some(string.to_string()),
+            })
+        }
+    }
+
+    fn get_semantic_error(&self, src: &str, value: Value) -> Result<(), FmlEditorError> {
+        self.manifest
+            .validate_feature_config(&self.feature_id, value)
+            .map_err(|e| match e {
+                FMLError::FeatureValidationError {
+                    literals, message, ..
+                } => {
+                    let hightlight = literals.last().cloned();
+                    let (line, col) = find_err(src, literals.into_iter());
+                    FmlEditorError {
+                        message,
+                        line: line as u32,
+                        col: col as u32,
+                        hightlight,
+                    }
+                }
+                _ => {
+                    unreachable!("Error {e:?} should be caught as FeatureValidationError");
+                }
+            })
+            .map(|_| ())
+    }
+}
+
+fn find_err(src: &str, path: impl Iterator<Item = String>) -> (usize, usize) {
+    let mut lines = src.lines();
+
+    let mut line_no = 0;
+    let mut col_no = 0;
+
+    let mut first_match = false;
+    let mut cur = lines.next().unwrap_or_default();
+
+    for p in path {
+        loop {
+            // If we haven't had our first match of the line, then start there at the beginning.
+            // Otherwise, start one char on from where we were last time.
+            let start = if !first_match { 0 } else { col_no + 1 };
+
+            // if let Some(i) = cur[start..].find(&p).map(|i| i + start) {
+            if let Some(i) = find_index(cur, &p, start) {
+                col_no = i;
+                first_match = true;
+                break;
+            } else if let Some(next) = lines.next() {
+                // we try the next line!
+                cur = next;
+                line_no += 1;
+                first_match = false;
+                col_no = 0;
+            } else {
+                // we've run out of lines, so we should return
+                return (0, 0);
+            }
+        }
+    }
+
+    (line_no, col_no)
+}
+
+fn find_index(cur: &str, pattern: &str, start: usize) -> Option<usize> {
+    cur.match_indices(pattern)
+        .find(|(i, _)| i >= &start)
+        .map(|(i, _)| i)
+}
+
+#[derive(Debug, PartialEq)]
+pub struct FmlEditorError {
+    pub message: String,
+    pub line: u32,
+    pub col: u32,
+    pub hightlight: Option<String>,
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use crate::client::test_helper::client;
+
+    use super::*;
+
+    #[test]
+    fn test_construction() -> Result<()> {
+        let client = client("./nimbus_features.yaml", "release")?;
+        assert_eq!(
+            client.get_feature_ids(),
+            vec!["dialog-appearance".to_string()]
+        );
+        let f = client.get_feature_inspector("dialog-appearance".to_string());
+        assert!(f.is_some());
+
+        let f = client.get_feature_inspector("not-there".to_string());
+        assert!(f.is_none());
+
+        Ok(())
+    }
+
+    fn error(message: &str, line: u32, col: u32, token: Option<&str>) -> FmlEditorError {
+        FmlEditorError {
+            message: message.to_string(),
+            line,
+            col,
+            hightlight: token.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn test_get_first_error_invalid_json() -> Result<()> {
+        let client = client("./nimbus_features.yaml", "release")?;
+        let f = client
+            .get_feature_inspector("dialog-appearance".to_string())
+            .unwrap();
+
+        fn test_syntax_error(f: &FmlFeatureInspector, input: &str, col: u32, highlight: bool) {
+            if let Some(e) = f.get_first_error(input.to_string()) {
+                let highlight = if highlight { Some(input) } else { None };
+                assert_eq!(e, error("Need valid JSON object", 0, col, highlight))
+            } else {
+                unreachable!("No error for \"{input}\"");
+            }
+        }
+
+        test_syntax_error(&f, "", 0, false);
+        test_syntax_error(&f, "x", 0, false);
+        test_syntax_error(&f, "{ \"\" }, ", 5, false);
+        test_syntax_error(&f, "{ \"foo\":", 7, false);
+
+        test_syntax_error(&f, "[]", 0, true);
+        test_syntax_error(&f, "1", 0, true);
+        test_syntax_error(&f, "true", 0, true);
+        test_syntax_error(&f, "\"string\"", 0, true);
+
+        assert!(f.get_first_error("{}".to_string()).is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_first_error_type_invalid() -> Result<()> {
+        let client = client("./nimbus_features.yaml", "release")?;
+        let f = client
+            .get_feature_inspector("dialog-appearance".to_string())
+            .unwrap();
+
+        let s = r#"{}"#;
+        assert!(f.get_first_error(s.to_string()).is_none());
+        let s = r#"{
+            "positive": {}
+        }"#;
+        assert!(f.get_first_error(s.to_string()).is_none());
+
+        let s = r#"{
+            "positive": 1
+        }"#;
+        if let Some(_err) = f.get_first_error(s.to_string()) {
+        } else {
+            unreachable!("No error for \"{s}\"");
+        }
+
+        let s = r#"{
+            "positive1": {}
+        }"#;
+        if let Some(_err) = f.get_first_error(s.to_string()) {
+        } else {
+            unreachable!("No error for \"{s}\"");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_err() -> Result<()> {
+        fn do_test(s: &str, path: &[&str], expected: (usize, usize)) {
+            let p = path.last().unwrap();
+            let path = path.iter().map(|p| p.to_string());
+            assert_eq!(
+                find_err(s, path),
+                expected,
+                "Can't find \"{p}\" at {expected:?} in {s}"
+            );
+        }
+
+        fn do_multi(s: &[&str], path: &[&str], expected: (usize, usize)) {
+            let s = s.join("\n");
+            do_test(&s, path, expected);
+        }
+
+        do_test("ab cd", &["ab", "cd"], (0, 3));
+
+        do_test("ab ab", &["ab"], (0, 0));
+        do_test("ab ab", &["ab", "ab"], (0, 3));
+
+        do_multi(
+            &["ab xx cd", "xx ef xx gh", "ij xx"],
+            &["ab", "cd", "gh", "xx"],
+            (2, 3),
+        );
+
+        do_multi(
+            &[
+                "{",                       // 0
+                "  boolean: true,",        // 1
+                "  object: {",             // 2
+                "    integer: \"string\"", // 3
+                "  }",                     // 4
+                "}",                       // 5
+            ],
+            &["object", "integer", "\"string\""],
+            (3, 13),
+        );
+
+        // pathological case
+        do_multi(
+            &[
+                "{",                       // 0
+                "  boolean: true,",        // 1
+                "  object: {",             // 2
+                "    integer: 1,",         // 3
+                "    astring: \"string\"", // 4
+                "  },",                    // 5
+                "  integer: \"string\"",   // 6
+                "}",                       // 7
+            ],
+            &["integer", "\"string\""],
+            (4, 13),
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_index_from() -> Result<()> {
+        assert_eq!(find_index("012345601", "01", 0), Some(0));
+        assert_eq!(find_index("012345601", "01", 1), Some(7));
+        assert_eq!(find_index("012345602", "01", 1), None);
+
+        // TODO unicode indexing does not work.
+        // assert_eq!(find_index("åéîø token", "token", 0), Some(5));
+        Ok(())
+    }
+
+    #[test]
+    fn test_semantic_errors() -> Result<()> {
+        let client = client("./browser.yaml", "release")?;
+        let inspector = client
+            .get_feature_inspector("nimbus-validation".to_string())
+            .unwrap();
+
+        let do_test = |lines: &[&str], token: &str, expected: (u32, u32)| {
+            let input = lines.join("\n");
+            let err = inspector
+                .get_first_error(input.clone())
+                .unwrap_or_else(|| unreachable!("No error for \"{input}\""));
+
+            assert_eq!(
+                err.hightlight,
+                Some(token.to_string()),
+                "Token {token} not detected in error in {input}"
+            );
+
+            let observed = (err.line, err.col);
+            assert_eq!(
+                expected, observed,
+                "Error at {token} in the wrong place in {input}"
+            );
+        };
+
+        // invalid property name.
+        do_test(
+            &[
+                // 012345678901234567890
+                r#"{"#,              // 0
+                r#"  "invalid": 1"#, // 1
+                r#"}"#,              // 2
+            ],
+            "\"invalid\"",
+            (1, 2),
+        );
+
+        // simple type mismatch
+        do_test(
+            &[
+                // 012345678901234567890
+                r#"{"#,                // 0
+                r#"  "icon-type": 1"#, // 1
+                r#"}"#,                // 2
+            ],
+            "1",
+            (1, 15),
+        );
+
+        // enum mismatch
+        do_test(
+            &[
+                // 012345678901234567890
+                r#"{"#,                        // 0
+                r#"  "icon-type": "invalid""#, // 1
+                r#"}"#,                        // 2
+            ],
+            "\"invalid\"",
+            (1, 15),
+        );
+
+        // invalid field within object
+        do_test(
+            &[
+                // 012345678901234567890
+                r#"{"#,                   // 0
+                r#"  "nested": {"#,       // 1
+                r#"    "invalid": true"#, // 2
+                r#"  }"#,                 // 3
+                r#"}"#,                   // 4
+            ],
+            "\"invalid\"",
+            (2, 4),
+        );
+
+        // nested in an object type mismatch
+        do_test(
+            &[
+                // 012345678901234567890
+                r#"{"#,                    // 0
+                r#"  "nested": {"#,        // 1
+                r#"    "is-useful": 256"#, // 2
+                r#"  }"#,                  // 3
+                r#"}"#,                    // 4
+            ],
+            "256",
+            (2, 17),
+        );
+
+        // nested in a map type mismatch
+        do_test(
+            &[
+                // 012345678901234567890
+                r#"{"#,                      // 0
+                r#"  "string-int-map": {"#,  // 1
+                r#"    "valid": "invalid""#, // 2
+                r#"  }"#,                    // 3
+                r#"}"#,                      // 4
+            ],
+            "\"invalid\"",
+            (2, 13),
+        );
+
+        // invalid key in enum map
+        do_test(
+            &[
+                // 012345678901234567890
+                r#"{"#,                 // 0
+                r#"  "enum-map": {"#,   // 1
+                r#"    "invalid": 42"#, // 2
+                r#"  }"#,               // 3
+                r#"}"#,                 // 4
+            ],
+            "\"invalid\"",
+            (2, 4),
+        );
+
+        // type mismatch in list
+        do_test(
+            &[
+                // 012345678901234567890
+                r#"{"#,                         // 0
+                r#"  "nested-list": ["#,        // 1
+                r#"     {"#,                    // 2
+                r#"        "is-useful": true"#, // 3
+                r#"     },"#,                   // 4
+                r#"     false"#,                // 5
+                r#"  ]"#,                       // 6
+                r#"}"#,                         // 7
+            ],
+            "false",
+            (5, 5),
+        );
+
+        // Difficult!
+        do_test(
+            &[
+                // 012345678901234567890
+                r#"{"#,                          // 0
+                r#"  "string-int-map": {"#,      // 1
+                r#"    "nested": 1,"#,           // 2
+                r#"    "is-useful": 2,"#,        // 3
+                r#"    "invalid": 3"#,           // 4 error is not here!
+                r#"  },"#,                       // 5
+                r#"  "nested": {"#,              // 6
+                r#"    "is-useful": "invalid""#, // 7 error is here!
+                r#"  }"#,                        // 8
+                r#"}"#,                          // 9
+            ],
+            "\"invalid\"",
+            (7, 17),
+        );
+
+        Ok(())
+    }
+}

--- a/components/support/nimbus-fml/src/client/test_helper.rs
+++ b/components/support/nimbus-fml/src/client/test_helper.rs
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::{error::Result, intermediate_representation::FeatureManifest, FmlClient};
+
+pub(crate) fn client(path: &str, channel: &str) -> Result<FmlClient> {
+    let root = env!("CARGO_MANIFEST_DIR");
+    let fixtures = format!("{root}/fixtures/fe");
+    FmlClient::new_with_ref(
+        format!("@my/fixtures/{path}"),
+        channel.to_string(),
+        Some(fixtures),
+    )
+}
+
+impl From<FeatureManifest> for FmlClient {
+    fn from(manifest: FeatureManifest) -> Self {
+        Self::new_from_manifest(manifest)
+    }
+}

--- a/components/support/nimbus-fml/src/fml.udl
+++ b/components/support/nimbus-fml/src/fml.udl
@@ -1,5 +1,8 @@
 namespace fml {};
 
+[Custom]
+typedef string JsonObject;
+
 [Error]
 enum FMLError {
     "IOError", "JSONError", "YAMLError", "UrlError", "FetchError", "InvalidPath",
@@ -13,8 +16,11 @@ dictionary MergedJsonWithErrors {
     sequence<FMLError> errors;
 };
 
-[Custom]
-typedef string JsonObject;
+dictionary FmlLoaderConfig {
+    string? cache;
+    record<DOMString, string> refs;
+    sequence<string> ref_files;
+};
 
 interface FmlClient {
     // Constructs a new FmlClient object.
@@ -24,6 +30,12 @@ interface FmlClient {
     // - `channel`: The channel that should be loaded for the manifest.
     [Throws=FMLError]
     constructor(string manifest, string channel);
+
+    [Name=new_with_ref, Throws=FMLError]
+    constructor(string manifest, string channel, string? ref_);
+
+    [Name=new_with_config, Throws=FMLError]
+    constructor(string manifest, string channel, FmlLoaderConfig config);
 
     // Validates a supplied feature configuration. Returns true or an FMLError.
     [Throws=FMLError]

--- a/components/support/nimbus-fml/src/fml.udl
+++ b/components/support/nimbus-fml/src/fml.udl
@@ -5,7 +5,7 @@ enum FMLError {
     "IOError", "JSONError", "YAMLError", "UrlError", "FetchError", "InvalidPath",
     "TemplateProblem", "Fatal", "InternalError", "ValidationError", "TypeParsingError",
     "InvalidChannelError", "FMLModuleError", "CliError", "ClientError", "InvalidFeatureError",
-    "InvalidPropertyError"
+    "FeatureValidationError",
 };
 
 dictionary MergedJsonWithErrors {
@@ -52,10 +52,32 @@ interface FmlClient {
     // Returns a description of the given feature.
     // If no feature exists, returns None.
     sequence<FmlFeatureDescriptor> get_feature_descriptors();
+
+    FmlFeatureInspector? get_feature_inspector(string id);
 };
 
 dictionary FmlFeatureDescriptor {
     string id;
     string description;
     boolean is_coenrolling;
+};
+
+interface FmlFeatureInspector {
+    // Parses the string and returns a list of errors.
+    // Current implementation will only return one error.
+    sequence<FmlEditorError>? get_errors(string src);
+
+    // Returns the default JSON for the feature for this channel.
+    [Throws=FMLError]
+    JsonObject get_default_json();
+};
+
+dictionary FmlEditorError {
+    string message;
+    // zero indexed line number for the error.
+    u32 line;
+    // zero indexed column number for the error.
+    u32 col;
+    // the text to hightlight.
+    string? hightlight;
 };


### PR DESCRIPTION
Fixes [EXP-3793](https://mozilla-hub.atlassian.net/browse/EXP-3793).

This PR turned out larger than I was expecting:

- ~~changed the IR of `FeatureManifest` from `Vec<_>` to `BTreeMap<String, _>`. This is long overdue, but I've been resisting doing it until now.~~
- added ref support to the `FMLClient`.
- refactor `client.rs` into `client/mod.rs` and associated files.
- serde_json and serde_yaml don't support line/column numbers. Worse, while serde_json can be configured to preserve insertion order, it's not clear we're not clobbering the order some place in the code. So we need to provide hints on where the error messages are based upon the paths through the JSON.
- added a `find_index` method to get the (line, col) number for where the errors occur.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
