### PR TITLE
Refactor FeatureManifest internal representation to use faster BTreeMaps instead of Vec

### DIFF
--- a/components/support/nimbus-fml/fixtures/ir/app_menu.json
+++ b/components/support/nimbus-fml/fixtures/ir/app_menu.json
@@ -68,8 +68,8 @@
       ]
     }
   },
-  "features": [
-    {
+  "features": {
+    "app-menu": {
       "name": "app-menu",
       "doc": "Represents the app-menu feature",
       "props": [
@@ -237,5 +237,5 @@
       "allow_coenrollment": false,
       "default": null
     }
-  ]
+  }
 }

--- a/components/support/nimbus-fml/fixtures/ir/app_menu.json
+++ b/components/support/nimbus-fml/fixtures/ir/app_menu.json
@@ -48,8 +48,8 @@
       ]
     }
   },
-  "objects": [
-    {
+  "objects": {
+    "MenuItem": {
       "name": "MenuItem",
       "doc": "An object defining a menu item",
       "props": [
@@ -67,7 +67,7 @@
         }
       ]
     }
-  ],
+  },
   "features": [
     {
       "name": "app-menu",

--- a/components/support/nimbus-fml/fixtures/ir/app_menu.json
+++ b/components/support/nimbus-fml/fixtures/ir/app_menu.json
@@ -10,8 +10,8 @@
       "module": "App"
     }
   },
-  "enums": [
-    {
+  "enums": {
+    "MenuItemId": {
       "name": "MenuItemId",
       "doc": "The menu items id",
       "variants": [
@@ -33,7 +33,7 @@
         }
       ]
     },
-    {
+    "PlayerProfile": {
       "name": "PlayerProfile",
       "doc": "The sections of the homescreen",
       "variants": [
@@ -47,7 +47,7 @@
         }
       ]
     }
-  ],
+  },
   "objects": [
     {
       "name": "MenuItem",

--- a/components/support/nimbus-fml/fixtures/ir/full_homescreen.json
+++ b/components/support/nimbus-fml/fixtures/ir/full_homescreen.json
@@ -34,7 +34,7 @@
       ]
     }
   },
-  "objects": [],
+  "objects": {},
   "features": [
     {
       "name": "homescreen",

--- a/components/support/nimbus-fml/fixtures/ir/full_homescreen.json
+++ b/components/support/nimbus-fml/fixtures/ir/full_homescreen.json
@@ -35,8 +35,8 @@
     }
   },
   "objects": {},
-  "features": [
-    {
+  "features": {
+    "homescreen": {
       "name": "homescreen",
       "doc": "Represents the homescreen feature",
       "props": [
@@ -77,5 +77,5 @@
       "default": null,
       "allow_coenrollment": false
     }
-  ]
+  }
 }

--- a/components/support/nimbus-fml/fixtures/ir/full_homescreen.json
+++ b/components/support/nimbus-fml/fixtures/ir/full_homescreen.json
@@ -6,8 +6,8 @@
       "package": "com.example.app"
     }
   },
-  "enums": [
-    {
+  "enums": {
+    "HomeScreenSection": {
       "name": "HomeScreenSection",
       "doc": "The sections of the homescreen",
       "variants": [
@@ -33,7 +33,7 @@
         }
       ]
     }
-  ],
+  },
   "objects": [],
   "features": [
     {

--- a/components/support/nimbus-fml/fixtures/ir/simple_homescreen.json
+++ b/components/support/nimbus-fml/fixtures/ir/simple_homescreen.json
@@ -1,6 +1,6 @@
 {
-  "enums": [
-    {
+  "enums": {
+    "HomeScreenSection": {
       "name": "HomeScreenSection",
       "doc": "The sections of the homescreen",
       "variants": [
@@ -26,7 +26,7 @@
         }
       ]
     }
-  ],
+  },
   "objects": [],
   "features": [
     {

--- a/components/support/nimbus-fml/fixtures/ir/simple_homescreen.json
+++ b/components/support/nimbus-fml/fixtures/ir/simple_homescreen.json
@@ -28,8 +28,8 @@
     }
   },
   "objects": {},
-  "features": [
-    {
+  "features": {
+    "homescreen": {
       "name": "homescreen",
       "doc": "Represents the homescreen feature",
       "props": [
@@ -55,5 +55,5 @@
       ],
       "default": null
     }
-  ]
+  }
 }

--- a/components/support/nimbus-fml/fixtures/ir/simple_homescreen.json
+++ b/components/support/nimbus-fml/fixtures/ir/simple_homescreen.json
@@ -27,7 +27,7 @@
       ]
     }
   },
-  "objects": [],
+  "objects": {},
   "features": [
     {
       "name": "homescreen",

--- a/components/support/nimbus-fml/fixtures/ir/simple_nimbus_validation.json
+++ b/components/support/nimbus-fml/fixtures/ir/simple_nimbus_validation.json
@@ -10,8 +10,8 @@
       "module": "Megazord"
     }
   },
-  "enums": [
-    {
+  "enums": {
+    "Position": {
       "name": "Position",
       "doc": "Where to put the menu bar?",
       "variants": [
@@ -25,7 +25,7 @@
         }
       ]
     }
-  ],
+  },
   "objects": [],
   "features": [
     {

--- a/components/support/nimbus-fml/fixtures/ir/simple_nimbus_validation.json
+++ b/components/support/nimbus-fml/fixtures/ir/simple_nimbus_validation.json
@@ -27,8 +27,8 @@
     }
   },
   "objects": {},
-  "features": [
-    {
+  "features": {
+    "nimbus-validation": {
       "name": "nimbus-validation",
       "doc": "A simple validation feature",
       "props": [
@@ -116,5 +116,5 @@
       "default": null,
       "allow_coenrollment": false
     }
-  ]
+  }
 }

--- a/components/support/nimbus-fml/fixtures/ir/simple_nimbus_validation.json
+++ b/components/support/nimbus-fml/fixtures/ir/simple_nimbus_validation.json
@@ -26,7 +26,7 @@
       ]
     }
   },
-  "objects": [],
+  "objects": {},
   "features": [
     {
       "name": "nimbus-validation",

--- a/components/support/nimbus-fml/fixtures/ir/with_objects.json
+++ b/components/support/nimbus-fml/fixtures/ir/with_objects.json
@@ -10,7 +10,7 @@
       "module": "Megazord"
     }
   },
-  "enums": [],
+  "enums": {},
   "objects": [
     {
       "name": "ExampleObject",

--- a/components/support/nimbus-fml/fixtures/ir/with_objects.json
+++ b/components/support/nimbus-fml/fixtures/ir/with_objects.json
@@ -11,8 +11,8 @@
     }
   },
   "enums": {},
-  "objects": [
-    {
+  "objects": {
+    "ExampleObject": {
       "name": "ExampleObject",
       "doc": "An example object",
       "props": [
@@ -40,7 +40,7 @@
         }
       ]
     },
-    {
+    "Nested": {
       "name": "Nested",
       "doc": "An object for nesting in others",
       "props": [
@@ -52,7 +52,7 @@
         }
       ]
     }
-  ],
+  },
   "features": [
     {
       "name": "with-objects-feature",

--- a/components/support/nimbus-fml/fixtures/ir/with_objects.json
+++ b/components/support/nimbus-fml/fixtures/ir/with_objects.json
@@ -53,8 +53,8 @@
       ]
     }
   },
-  "features": [
-    {
+  "features": {
+    "with-objects-feature": {
       "name": "with-objects-feature",
       "doc": "A feature with objects feature",
       "props": [
@@ -108,5 +108,5 @@
       },
       "allow_coenrollment": false
     }
-  ]
+  }
 }

--- a/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
@@ -41,14 +41,8 @@ pub(crate) struct ExperimenterFeatureProperty {
 impl TryFrom<FeatureManifest> for ExperimenterManifest {
     type Error = crate::error::FMLError;
     fn try_from(fm: FeatureManifest) -> Result<Self> {
-        fm.all_imports
-            .values()
-            .chain(vec![&fm])
-            .flat_map(|fm| {
-                fm.feature_defs
-                    .iter()
-                    .map(|f| Ok((f.name(), fm.create_experimenter_feature(f)?)))
-            })
+        fm.iter_all_feature_defs()
+            .map(|(fm, f)| Ok((f.name(), fm.create_experimenter_feature(f)?)))
             .collect()
     }
 }

--- a/components/support/nimbus-fml/src/backends/frontend_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/frontend_manifest.rs
@@ -13,9 +13,9 @@ use crate::intermediate_representation::{
 
 impl From<FeatureManifest> for ManifestFrontEnd {
     fn from(value: FeatureManifest) -> Self {
-        let features = merge(&value, |fm| fm.feature_defs(), |f| &f.name);
-        let objects = merge(&value, |fm| fm.object_defs(), |o| &o.name);
-        let enums = merge(&value, |fm| fm.enum_defs(), |e| &e.name);
+        let features = merge(&value, |fm| fm.iter_feature_defs().collect(), |f| &f.name);
+        let objects = merge(&value, |fm| fm.iter_object_defs().collect(), |o| &o.name);
+        let enums = merge(&value, |fm| fm.iter_enum_defs().collect(), |e| &e.name);
 
         let about = value.about.description_only();
 

--- a/components/support/nimbus-fml/src/defaults_merger.rs
+++ b/components/support/nimbus-fml/src/defaults_merger.rs
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde_json::json;
 
@@ -13,7 +13,7 @@ use crate::{
 };
 
 pub struct DefaultsMerger<'object> {
-    objects: HashMap<String, &'object ObjectDef>,
+    objects: &'object BTreeMap<String, ObjectDef>,
 
     supported_channels: Vec<String>,
     channel: String,
@@ -21,7 +21,7 @@ pub struct DefaultsMerger<'object> {
 
 impl<'object> DefaultsMerger<'object> {
     pub fn new(
-        objects: HashMap<String, &'object ObjectDef>,
+        objects: &'object BTreeMap<String, ObjectDef>,
         supported_channels: Vec<String>,
         channel: String,
     ) -> Self {
@@ -959,8 +959,9 @@ mod unit_tests {
     #[test]
     fn test_merge_feature_default_unsupported_channel() -> Result<()> {
         let mut feature_def: FeatureDef = Default::default();
+        let objects = Default::default();
         let merger = DefaultsMerger::new(
-            Default::default(),
+            &objects,
             vec!["release".into(), "beta".into()],
             "nightly".into(),
         );
@@ -1009,8 +1010,9 @@ mod unit_tests {
                 }
             },
         ]))?;
+        let objects = Default::default();
         let merger = DefaultsMerger::new(
-            Default::default(),
+            &objects,
             vec!["release".into(), "beta".into(), "nightly".into()],
             "nightly".into(),
         );
@@ -1051,8 +1053,9 @@ mod unit_tests {
                 "button-color": "light-green"
             }
         }]))?;
+        let objects = Default::default();
         let merger = DefaultsMerger::new(
-            Default::default(),
+            &objects,
             vec!["release".into(), "beta".into(), "nightly".into()],
             "nightly".into(),
         );
@@ -1124,8 +1127,9 @@ mod unit_tests {
                 }
             },
         ]))?;
+        let objects = Default::default();
         let merger = DefaultsMerger::new(
-            Default::default(),
+            &objects,
             vec!["release".into(), "beta".into(), "nightly".into()],
             "release".into(),
         );
@@ -1183,8 +1187,9 @@ mod unit_tests {
                 }
             },
         ]))?;
+        let objects = Default::default();
         let merger = DefaultsMerger::new(
-            Default::default(),
+            &objects,
             vec!["release".into(), "beta".into(), "nightly".into()],
             "nightly".into(),
         );
@@ -1220,8 +1225,8 @@ mod unit_tests {
                 }
             }
         ]))?;
-        let merger =
-            DefaultsMerger::new(Default::default(), vec!["nightly".into()], "nightly".into());
+        let objects = Default::default();
+        let merger = DefaultsMerger::new(&objects, vec!["nightly".into()], "nightly".into());
         let result = merger.merge_feature_defaults(&mut feature_def, &default_blocks);
 
         assert!(result.is_err());

--- a/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
@@ -26,26 +26,29 @@ pub(crate) fn get_simple_homescreen_feature() -> FeatureManifest {
             },
         )]),
         obj_defs: Default::default(),
-        feature_defs: vec![FeatureDef::new(
-            "homescreen",
-            "Represents the homescreen feature",
-            vec![PropDef {
-                name: "sections-enabled".into(),
-                doc: "A map of booleans".into(),
-                typ: TypeRef::EnumMap(
-                    Box::new(TypeRef::Enum("HomeScreenSection".into())),
-                    Box::new(TypeRef::Boolean),
-                ),
-                default: json!({
-                    "top-sites": true,
-                    "jump-back-in": false,
-                    "recently-saved": false,
-                    "recent-explorations": false,
-                    "pocket": false,
-                }),
-            }],
-            false,
-        )],
+        feature_defs: BTreeMap::from([(
+            "homescreen".to_string(),
+            FeatureDef::new(
+                "homescreen",
+                "Represents the homescreen feature",
+                vec![PropDef {
+                    name: "sections-enabled".into(),
+                    doc: "A map of booleans".into(),
+                    typ: TypeRef::EnumMap(
+                        Box::new(TypeRef::Enum("HomeScreenSection".into())),
+                        Box::new(TypeRef::Boolean),
+                    ),
+                    default: json!({
+                        "top-sites": true,
+                        "jump-back-in": false,
+                        "recently-saved": false,
+                        "recent-explorations": false,
+                        "pocket": false,
+                    }),
+                }],
+                false,
+            ),
+        )]),
         ..Default::default()
     }
 }

--- a/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
@@ -2,6 +2,8 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::collections::BTreeMap;
+
 use crate::intermediate_representation::{
     EnumDef, FeatureDef, FeatureManifest, PropDef, TypeRef, VariantDef,
 };
@@ -9,17 +11,20 @@ use serde_json::json;
 
 pub(crate) fn get_simple_homescreen_feature() -> FeatureManifest {
     FeatureManifest {
-        enum_defs: vec![EnumDef {
-            name: "HomeScreenSection".into(),
-            doc: "The sections of the homescreen".into(),
-            variants: vec![
-                VariantDef::new("top-sites", "The original frecency sorted sites"),
-                VariantDef::new("jump-back-in", "Jump back in section"),
-                VariantDef::new("recently-saved", "Tabs that have been bookmarked recently"),
-                VariantDef::new("recent-explorations", "Tabs from another source"),
-                VariantDef::new("pocket", "Tabs from another source"),
-            ],
-        }],
+        enum_defs: BTreeMap::from([(
+            "HomeScreenSection".to_string(),
+            EnumDef {
+                name: "HomeScreenSection".into(),
+                doc: "The sections of the homescreen".into(),
+                variants: vec![
+                    VariantDef::new("top-sites", "The original frecency sorted sites"),
+                    VariantDef::new("jump-back-in", "Jump back in section"),
+                    VariantDef::new("recently-saved", "Tabs that have been bookmarked recently"),
+                    VariantDef::new("recent-explorations", "Tabs from another source"),
+                    VariantDef::new("pocket", "Tabs from another source"),
+                ],
+            },
+        )]),
         obj_defs: Default::default(),
         feature_defs: vec![FeatureDef::new(
             "homescreen",

--- a/components/support/nimbus-fml/src/frontend.rs
+++ b/components/support/nimbus-fml/src/frontend.rs
@@ -289,27 +289,28 @@ impl ManifestFrontEnd {
     /// Retrieves all the Enum type definitions represented in the manifest
     ///
     /// # Returns
-    /// Returns a [`std::vec::Vec<EnumDef>`]
-    fn get_enums(&self) -> Vec<EnumDef> {
+    /// Returns a [`std::collections::BTreeMap<String, EnumDef>`]
+    fn get_enums(&self) -> BTreeMap<String, EnumDef> {
         let types = self.legacy_types.as_ref().unwrap_or(&self.types);
-        types
-            .enums
-            .clone()
-            .into_iter()
-            .map(|t| EnumDef {
-                name: t.0,
-                doc: t.1.description,
-                variants: t
-                    .1
-                    .variants
-                    .iter()
-                    .map(|v| VariantDef {
-                        name: v.0.clone(),
-                        doc: v.1.description.clone(),
-                    })
-                    .collect(),
-            })
-            .collect()
+        let mut enums: BTreeMap<_, _> = Default::default();
+        for (name, body) in &types.enums {
+            let mut variants: Vec<_> = Default::default();
+            for (v_name, v_body) in &body.variants {
+                variants.push(VariantDef {
+                    name: v_name.clone(),
+                    doc: v_body.description.clone(),
+                });
+            }
+            enums.insert(
+                name.to_owned(),
+                EnumDef {
+                    name: name.clone(),
+                    doc: body.description.clone(),
+                    variants,
+                },
+            );
+        }
+        enums
     }
 
     pub(crate) fn get_intermediate_representation(

--- a/components/support/nimbus-fml/src/frontend.rs
+++ b/components/support/nimbus-fml/src/frontend.rs
@@ -326,16 +326,14 @@ impl ManifestFrontEnd {
             None => Default::default(),
         };
 
-        Ok(FeatureManifest {
-            id: id.clone(),
-            channel: channel.to_string(),
+        Ok(FeatureManifest::new(
+            id.clone(),
+            channel,
+            features,
+            enums,
+            objects,
             about,
-            enum_defs: enums,
-            obj_defs: objects,
-            feature_defs: features,
-
-            ..Default::default()
-        })
+        ))
     }
 }
 

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -477,9 +477,7 @@ fn merge_import_block(a: &ImportBlock, b: &ImportBlock) -> Result<ImportBlock> {
 /// Check if this parent can import this child.
 fn check_can_import_manifest(parent: &FeatureManifest, child: &FeatureManifest) -> Result<()> {
     check_can_import_list(parent, child, "enum", |fm: &FeatureManifest| {
-        fm.iter_enum_defs()
-            .map(|e| &e.name)
-            .collect::<HashSet<&String>>()
+        fm.enum_defs.keys().collect()
     })?;
     check_can_import_list(parent, child, "objects", |fm: &FeatureManifest| {
         fm.iter_object_defs()
@@ -545,7 +543,7 @@ mod unit_tests {
 
         // Validate parsed enums
         assert!(ir.enum_defs.len() == 1);
-        let enum_def = ir.enum_defs.first().unwrap();
+        let enum_def = &ir.enum_defs["PlayerProfile"];
         assert!(enum_def.name == *"PlayerProfile");
         assert!(enum_def.doc == *"This is an enum type");
         assert!(enum_def.variants.contains(&VariantDef {


### PR DESCRIPTION
As per https://github.com/mozilla/application-services/pull/5827#pullrequestreview-1634318804 splitting this out.

Since this is an internal refactor with no change in functionality, there is no CHANGELOG.md entry.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
