### PR TITLE
Expose rust-log-forwarder component for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 [Full Changelog](In progress)
 
-v119.0 (_2023-09-25_)
+## Rust log forwarder
+
+### 🦊 What's Changed 🦊
+- Exposed rust-log-forwarder for iOS ([#5840](https://github.com/mozilla/application-services/pull/5840)).
+
+# v119.0 (_2023-09-25_)
 
 ## Nimbus SDK ⛅️🔬🔭
 

--- a/megazords/ios-rust/MozillaRustComponents.h
+++ b/megazords/ios-rust/MozillaRustComponents.h
@@ -21,3 +21,4 @@
 #import "remote_settingsFFI.h"
 #import "as_ohttp_clientFFI.h"
 #import "suggestFFI.h"
+#import "rustlogforwarderFFI.h"

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		F814DE8029DF762800FD26F5 /* SyncManagerTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F814DE7F29DF762800FD26F5 /* SyncManagerTelemetryTests.swift */; };
 		F81C7B9829DE305C00FAF8F9 /* SyncManagerTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81C7B9729DE305C00FAF8F9 /* SyncManagerTelemetry.swift */; };
 		F81C7B9A29DE309C00FAF8F9 /* SyncManagerComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81C7B9929DE309C00FAF8F9 /* SyncManagerComponent.swift */; };
+		F8368DB02AC1189000182381 /* rust_log_forwarder.udl in Sources */ = {isa = PBXBuildFile; fileRef = F8368DAF2AC1181900182381 /* rust_log_forwarder.udl */; };
 		F85ED649299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F85ED648299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift */; };
 		F8BEFFDA299C4F1100776186 /* RustSyncTelemetryPing.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BEFFD9299C4F1100776186 /* RustSyncTelemetryPing.swift */; };
 		F8C88393298B4BF80006E9E9 /* syncmanager.udl in Sources */ = {isa = PBXBuildFile; fileRef = F8AAC1CC298B41FC000BCDEC /* syncmanager.udl */; };
@@ -208,6 +209,7 @@
 		AB65933B2A0C524E00DBF059 /* remote_settings.udl */ = {isa = PBXFileReference; lastKnownFileType = text; name = remote_settings.udl; path = ../src/remote_settings.udl; sourceTree = "<group>"; };
 		AB65933E2A0C52A000DBF059 /* remote_settingsFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = remote_settingsFFI.h; sourceTree = "<group>"; };
 		AB9C392C2A0D9E2D00AF5ADE /* remote_settings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = remote_settings.swift; sourceTree = "<group>"; };
+		D8C96FB4B97E950644E8ADA0 /* suggestFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = suggestFFI.h; sourceTree = "<group>"; };
 		F40A9DCB29765DCB0033D10E /* sync15.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = sync15.udl; path = ../../../components/sync15/src/sync15.udl; sourceTree = SOURCE_ROOT; };
 		F4FCED2E2976605400BA127E /* sync15FFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = sync15FFI.h; path = ../../../components/sync15/ios/Generated/sync15FFI.h; sourceTree = SOURCE_ROOT; };
 		F4FCED2F2976605400BA127E /* sync15.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = sync15.swift; path = ../../../components/sync15/ios/Generated/sync15.swift; sourceTree = SOURCE_ROOT; };
@@ -219,13 +221,15 @@
 		F814DE7F29DF762800FD26F5 /* SyncManagerTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncManagerTelemetryTests.swift; sourceTree = "<group>"; };
 		F81C7B9729DE305C00FAF8F9 /* SyncManagerTelemetry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SyncManagerTelemetry.swift; path = ../../../components/sync_manager/ios/SyncManager/SyncManagerTelemetry.swift; sourceTree = SOURCE_ROOT; };
 		F81C7B9929DE309C00FAF8F9 /* SyncManagerComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SyncManagerComponent.swift; path = ../../../components/sync_manager/ios/SyncManager/SyncManagerComponent.swift; sourceTree = SOURCE_ROOT; };
+		F8368DAF2AC1181900182381 /* rust_log_forwarder.udl */ = {isa = PBXFileReference; lastKnownFileType = text; name = rust_log_forwarder.udl; path = "../../../../components/support/rust-log-forwarder/src/rust_log_forwarder.udl"; sourceTree = "<group>"; };
+		F8368DB22AC1197C00182381 /* rust_log_forwarder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = rust_log_forwarder.swift; path = "../../../../components/support/rust-log-forwarder/ios/Generated/rust_log_forwarder.swift"; sourceTree = "<group>"; };
+		F8368DB32AC1197C00182381 /* rustlogforwarderFFI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = rustlogforwarderFFI.h; path = "../../../../components/support/rust-log-forwarder/ios/Generated/rustlogforwarderFFI.h"; sourceTree = "<group>"; };
 		F85ED648299C1F49005EEF36 /* RustSyncTelemetryPingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RustSyncTelemetryPingTests.swift; sourceTree = "<group>"; };
 		F8AAC1CC298B41FC000BCDEC /* syncmanager.udl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = syncmanager.udl; path = ../../../components/sync_manager/src/syncmanager.udl; sourceTree = SOURCE_ROOT; };
 		F8BEFFD9299C4F1100776186 /* RustSyncTelemetryPing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RustSyncTelemetryPing.swift; path = ../../../components/sync15/ios/Sync15/RustSyncTelemetryPing.swift; sourceTree = SOURCE_ROOT; };
 		F8C88394298B4EC00006E9E9 /* syncmanagerFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = syncmanagerFFI.h; path = ../../../components/sync_manager/ios/Generated/syncmanagerFFI.h; sourceTree = SOURCE_ROOT; };
 		F8C88395298B4EC00006E9E9 /* syncmanager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = syncmanager.swift; path = ../../../components/sync_manager/ios/Generated/syncmanager.swift; sourceTree = SOURCE_ROOT; };
 		FA3C4E62BAEBB59E7D1EC881 /* suggest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = suggest.swift; sourceTree = "<group>"; };
-		D8C96FB4B97E950644E8ADA0 /* suggestFFI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = suggestFFI.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -349,6 +353,7 @@
 		1BBAC4FA27AE049500DAFEF2 /* MozillaTestServices */ = {
 			isa = PBXGroup;
 			children = (
+				F8368DAE2AC1178000182381 /* RustLogForwarder */,
 				F54D38032A564653005087FB /* ASOhttpClient */,
 				AB65933A2A0C51F300DBF059 /* RemoteSettings */,
 				F8AAC1CB298B40B8000BCDEC /* SyncManager */,
@@ -580,6 +585,15 @@
 			name = Generated;
 			sourceTree = "<group>";
 		};
+		9D2D69255AD5D783D9458AFE /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				FA3C4E62BAEBB59E7D1EC881 /* suggest.swift */,
+				D8C96FB4B97E950644E8ADA0 /* suggestFFI.h */,
+			);
+			path = Generated;
+			sourceTree = "<group>";
+		};
 		AB65933A2A0C51F300DBF059 /* RemoteSettings */ = {
 			isa = PBXGroup;
 			children = (
@@ -629,6 +643,24 @@
 			path = Generated;
 			sourceTree = "<group>";
 		};
+		F8368DAE2AC1178000182381 /* RustLogForwarder */ = {
+			isa = PBXGroup;
+			children = (
+				F8368DB12AC118E800182381 /* Generated */,
+				F8368DAF2AC1181900182381 /* rust_log_forwarder.udl */,
+			);
+			name = RustLogForwarder;
+			sourceTree = "<group>";
+		};
+		F8368DB12AC118E800182381 /* Generated */ = {
+			isa = PBXGroup;
+			children = (
+				F8368DB22AC1197C00182381 /* rust_log_forwarder.swift */,
+				F8368DB32AC1197C00182381 /* rustlogforwarderFFI.h */,
+			);
+			name = Generated;
+			sourceTree = "<group>";
+		};
 		F8AAC1CB298B40B8000BCDEC /* SyncManager */ = {
 			isa = PBXGroup;
 			children = (
@@ -660,15 +692,6 @@
 			name = Suggest;
 			path = ../../../components/suggest/ios;
 			sourceTree = SOURCE_ROOT;
-		};
-		9D2D69255AD5D783D9458AFE /* Generated */ = {
-			isa = PBXGroup;
-			children = (
-				FA3C4E62BAEBB59E7D1EC881 /* suggest.swift */,
-				D8C96FB4B97E950644E8ADA0 /* suggestFFI.h */,
-			);
-			path = Generated;
-			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
@@ -804,6 +827,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F8368DB02AC1189000182381 /* rust_log_forwarder.udl in Sources */,
 				BCFF93E82AA7E1ED005B5B71 /* suggest.udl in Sources */,
 				F54D38112A5E09F4005087FB /* as_ohttp_client.udl in Sources */,
 				AB9C392E2A0DA61900AF5ADE /* remote_settings.udl in Sources */,

--- a/megazords/ios-rust/build-xcframework.sh
+++ b/megazords/ios-rust/build-xcframework.sh
@@ -147,6 +147,7 @@ cp "$REPO_ROOT/components/viaduct/ios/RustViaductFFI.h" "$COMMON/Headers"
 $CARGO uniffi-bindgen generate "$REPO_ROOT/components/remote_settings/src/remote_settings.udl" -l swift -o "$COMMON/Headers"
 $CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l swift -o "$COMMON/Headers"
 $CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/error/src/errorsupport.udl" -l swift -o "$COMMON/Headers"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/rust-log-forwarder/src/rust_log_forwarder.udl" -l swift -o "$COMMON/Headers"
 
 
 

--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -23,6 +23,7 @@ BINDINGS_UDL_PATHS = [
     "components/sync15/src/sync15.udl",
     "components/sync_manager/src/syncmanager.udl",
     "components/tabs/src/tabs.udl",
+    "components/support/rust-log-forwarder/src/rust_log_forwarder.udl",
 ]
 
 # List of udl_paths to generate bindings for
@@ -30,6 +31,7 @@ FOCUS_UDL_PATHS = [
     "components/nimbus/src/nimbus.udl",
     "components/remote_settings/src/remote_settings.udl",
     "components/support/error/src/errorsupport.udl",
+    "components/support/rust-log-forwarder/src/rust_log_forwarder.udl",
 ]
 
 # List of globs to copy the sources from


### PR DESCRIPTION
Exposing `rust-log-forwarder` to iOS for Sentry breadcrumb work.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
