### PR TITLE
Refactor VisitTransition to be VisitType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
 ### ⚠️ Breaking Changes ⚠️
 
 * The `include_sponsored` and `include_non_sponsored` Boolean options in `SuggestionQuery` have been replaced with a `providers` list. Consumers must now explicitly pass the providers they want to query ([#5867](https://github.com/mozilla/application-services/pull/5867)).
+## Places
+
+### ⚠️ Breaking Changes ⚠️
+
+- VisitTransition has been renamed to VisitType to match Desktop and reduce the amount of conversions needed in consumer APIs.
+
 
 # v119.0 (_2023-09-25_)
 

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -25,6 +25,7 @@ import mozilla.appservices.places.uniffi.SearchResult
 import mozilla.appservices.places.uniffi.SqlInterruptHandle
 import mozilla.appservices.places.uniffi.TopFrecentSiteInfo
 import mozilla.appservices.places.uniffi.VisitObservation
+import mozilla.appservices.places.uniffi.VisitType
 import mozilla.appservices.places.uniffi.placesApiNew
 import mozilla.appservices.sync15.SyncTelemetryPing
 import mozilla.telemetry.glean.private.CounterMetricType
@@ -276,10 +277,25 @@ open class PlacesReaderConnection internal constructor(conn: UniffiPlacesConnect
     }
 }
 
+internal fun VisitType.toInt(): Int {
+    return when (this) {
+        VisitType.LINK -> 1
+        VisitType.TYPED -> 2
+        VisitType.BOOKMARK -> 3
+        VisitType.EMBED -> 4
+        VisitType.REDIRECT_PERMANENT -> 5
+        VisitType.REDIRECT_TEMPORARY -> 6
+        VisitType.DOWNLOAD -> 7
+        VisitType.FRAMED_LINK -> 8
+        VisitType.RELOAD -> 9
+        VisitType.UPDATE_PLACE -> 10
+    }
+}
+
 fun visitTransitionSet(l: List<VisitType>): Int {
     var res = 0
     for (ty in l) {
-        res = res or (1 shl ty.type)
+        res = res or (1 shl ty.toInt())
     }
     return res
 }
@@ -895,28 +911,6 @@ interface WritableHistoryConnection : ReadableHistoryConnection {
      * @param url The chosen URL string
      */
     fun acceptResult(searchString: String, url: String)
-}
-
-enum class VisitType(val type: Int) {
-    /** This isn't a visit, but a request to update meta data about a page */
-    UPDATE_PLACE(-1),
-
-    /** This transition type means the user followed a link. */
-    LINK(1),
-
-    /** This transition type means that the user typed the page's URL in the
-     *  URL bar or selected it from UI (URL bar autocomplete results, etc).
-     */
-    TYPED(2),
-
-    // TODO: rest of docs
-    BOOKMARK(3),
-    EMBED(4),
-    REDIRECT_PERMANENT(5),
-    REDIRECT_TEMPORARY(6),
-    DOWNLOAD(7),
-    FRAMED_LINK(8),
-    RELOAD(9),
 }
 
 /**

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -11,7 +11,7 @@ import mozilla.appservices.places.uniffi.DocumentType
 import mozilla.appservices.places.uniffi.FrecencyThresholdOption
 import mozilla.appservices.places.uniffi.PlacesApiException
 import mozilla.appservices.places.uniffi.VisitObservation
-import mozilla.appservices.places.uniffi.VisitTransition
+import mozilla.appservices.places.uniffi.VisitType
 import mozilla.appservices.syncmanager.SyncManager
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.After
@@ -79,7 +79,7 @@ class PlacesConnectionTest {
         )
 
         for (url in toAdd) {
-            db.noteObservation(VisitObservation(url = url, visitType = VisitTransition.LINK))
+            db.noteObservation(VisitObservation(url = url, visitType = VisitType.LINK))
         }
 
         val toSearch = listOf(
@@ -128,7 +128,7 @@ class PlacesConnectionTest {
     @Test
     fun testNoteObservationBadUrl() {
         try {
-            db.noteObservation(VisitObservation(url = "http://www.[].com", visitType = VisitTransition.LINK))
+            db.noteObservation(VisitObservation(url = "http://www.[].com", visitType = VisitType.LINK))
         } catch (e: PlacesApiException) {
             assert(e is PlacesApiException.UrlParseFailed)
         }
@@ -150,7 +150,7 @@ class PlacesConnectionTest {
         )
 
         for (url in toAdd) {
-            db.noteObservation(VisitObservation(url = url, visitType = VisitTransition.LINK))
+            db.noteObservation(VisitObservation(url = url, visitType = VisitType.LINK))
         }
         // Should use the origin search
         assertEquals("https://www.example.com/", db.matchUrl("example.com"))
@@ -189,14 +189,14 @@ class PlacesConnectionTest {
         db.noteObservation(
             VisitObservation(
                 url = "https://www.example.com/0",
-                visitType = VisitTransition.LINK,
+                visitType = VisitType.LINK,
             ),
         )
 
         db.noteObservation(
             VisitObservation(
                 url = "https://www.example.com/1",
-                visitType = VisitTransition.LINK,
+                visitType = VisitType.LINK,
             ),
         )
 
@@ -204,7 +204,7 @@ class PlacesConnectionTest {
         db.noteObservation(
             VisitObservation(
                 url = "https://www.example.com/1",
-                visitType = VisitTransition.LINK,
+                visitType = VisitType.LINK,
                 previewImageUrl = "https://www.example.com/1/previewImage.png",
             ),
         )
@@ -213,7 +213,7 @@ class PlacesConnectionTest {
         db.noteObservation(
             VisitObservation(
                 url = "https://www.example.com/2",
-                visitType = VisitTransition.LINK,
+                visitType = VisitType.LINK,
                 previewImageUrl = "https://www.example.com/2/previewImage.png",
             ),
         )
@@ -228,12 +228,12 @@ class PlacesConnectionTest {
 
     @Test
     fun testGetTopFrecentSiteInfos() {
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.DOWNLOAD))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.EMBED))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.REDIRECT_PERMANENT))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.REDIRECT_TEMPORARY))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.FRAMED_LINK))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.RELOAD))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.DOWNLOAD))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.EMBED))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.REDIRECT_PERMANENT))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.REDIRECT_TEMPORARY))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.FRAMED_LINK))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.RELOAD))
 
         val toAdd = listOf(
             "https://www.example.com/123",
@@ -247,7 +247,7 @@ class PlacesConnectionTest {
         )
 
         for (url in toAdd) {
-            db.noteObservation(VisitObservation(url = url, visitType = VisitTransition.LINK))
+            db.noteObservation(VisitObservation(url = url, visitType = VisitType.LINK))
         }
 
         var infos = db.getTopFrecentSiteInfos(numItems = 0, frecencyThreshold = FrecencyThresholdOption.NONE)
@@ -291,11 +291,11 @@ class PlacesConnectionTest {
     // as well as the handling of invalid urls.
     @Test
     fun testGetVisitInfos() {
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.LINK, at = 100000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2a", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 130000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2b", visitType = VisitTransition.LINK, at = 150000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/3", visitType = VisitTransition.LINK, at = 200000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/4", visitType = VisitTransition.LINK, at = 250000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.LINK, at = 100000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2a", visitType = VisitType.REDIRECT_TEMPORARY, at = 130000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2b", visitType = VisitType.LINK, at = 150000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/3", visitType = VisitType.LINK, at = 200000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/4", visitType = VisitType.LINK, at = 250000))
         var infos = db.getVisitInfos(125000, 225000, excludeTypes = listOf(VisitType.REDIRECT_TEMPORARY))
         assertEquals(2, infos.size)
         assertEquals("https://www.example.com/2b", infos[0].url)
@@ -309,15 +309,15 @@ class PlacesConnectionTest {
 
     @Test
     fun testGetVisitPage() {
-        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitTransition.LINK, at = 100000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2", visitType = VisitTransition.LINK, at = 110000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/3a", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 120000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/3b", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 130000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/4", visitType = VisitTransition.LINK, at = 140000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/5", visitType = VisitTransition.LINK, at = 150000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/6", visitType = VisitTransition.LINK, at = 160000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/7", visitType = VisitTransition.LINK, at = 170000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/8", visitType = VisitTransition.LINK, at = 180000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/1", visitType = VisitType.LINK, at = 100000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2", visitType = VisitType.LINK, at = 110000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/3a", visitType = VisitType.REDIRECT_TEMPORARY, at = 120000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/3b", visitType = VisitType.REDIRECT_TEMPORARY, at = 130000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/4", visitType = VisitType.LINK, at = 140000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/5", visitType = VisitType.LINK, at = 150000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/6", visitType = VisitType.LINK, at = 160000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/7", visitType = VisitType.LINK, at = 170000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/8", visitType = VisitType.LINK, at = 180000))
 
         assertEquals(9, db.getVisitCount())
         assertEquals(7, db.getVisitCount(excludeTypes = listOf(VisitType.REDIRECT_TEMPORARY)))
@@ -423,15 +423,15 @@ class PlacesConnectionTest {
         assertNull(PlacesManagerMetrics.writeQueryCount.testGetValue())
         assertNull(PlacesManagerMetrics.writeQueryErrorCount["url_parse_failed"].testGetValue())
 
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2a", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 130000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/2b", visitType = VisitTransition.LINK, at = 150000))
-        db.noteObservation(VisitObservation(url = "https://www.example.com/3", visitType = VisitTransition.LINK, at = 200000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2a", visitType = VisitType.REDIRECT_TEMPORARY, at = 130000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/2b", visitType = VisitType.LINK, at = 150000))
+        db.noteObservation(VisitObservation(url = "https://www.example.com/3", visitType = VisitType.LINK, at = 200000))
 
         assertEquals(3, PlacesManagerMetrics.writeQueryCount.testGetValue())
         assertNull(PlacesManagerMetrics.writeQueryErrorCount["__other__"].testGetValue())
 
         try {
-            db.noteObservation(VisitObservation(url = "4", visitType = VisitTransition.REDIRECT_TEMPORARY, at = 160000))
+            db.noteObservation(VisitObservation(url = "4", visitType = VisitType.REDIRECT_TEMPORARY, at = 160000))
             fail("Should have thrown")
         } catch (e: PlacesApiException.UrlParseFailed) {
             // nothing to do here
@@ -530,7 +530,7 @@ class PlacesConnectionTest {
                 url = "https://www.ifixit.com/News/35377/which-wireless-earbuds-are-the-least-evil",
                 title = "Are All Wireless Earbuds As Evil As AirPods?",
                 previewImageUrl = "https://valkyrie.cdn.ifixit.com/media/2020/02/03121341/bose_soundsport_13.jpg",
-                visitType = VisitTransition.LINK,
+                visitType = VisitType.LINK,
             ),
         )
 

--- a/components/places/src/api/history.rs
+++ b/components/places/src/api/history.rs
@@ -34,7 +34,7 @@ pub struct AddablePlaceInfo {
 #[derive(Debug)]
 pub struct AddableVisit {
     pub date: Timestamp,
-    pub transition: VisitTransition,
+    pub transition: VisitType,
     pub referrer: Option<Url>,
     pub is_local: bool,
 }
@@ -67,7 +67,7 @@ mod tests {
         let date = Timestamp::now();
         let visits = vec![AddableVisit {
             date,
-            transition: VisitTransition::Link,
+            transition: VisitType::Link,
             referrer: None,
             is_local: true,
         }];
@@ -143,17 +143,17 @@ pub enum RedirectSourceType {
 // nsIHistory::VisitURI - this is the main interface used by the browser
 // itself to record visits.
 // This differs from the desktop implementation in one major way - instead
-// of using various browser-specific heuristics to compute the VisitTransition
+// of using various browser-specific heuristics to compute the VisitType
 // we assume the caller has already done this and passed the correct transition
 // flags in.
 pub fn visit_uri(
     conn: &mut PlacesDb,
     url: &Url,
     last_url: Option<Url>,
-    // To be more honest, this would *not* take a VisitTransition,
+    // To be more honest, this would *not* take a VisitType,
     // but instead other "internal" nsIHistory flags, from which
-    // it would deduce the VisitTransition.
-    transition: VisitTransition,
+    // it would deduce the VisitType.
+    transition: VisitType,
     redirect_source: Option<RedirectSourceType>,
     is_error_page: bool,
 ) -> Result<()> {
@@ -164,7 +164,7 @@ pub fn visit_uri(
     // Do not save a reloaded uri if we have visited the same URI recently.
     // (Note that desktop implies `reload` based of the "is it the same as last
     // and is it recent" check below) - but here we are asking for the
-    // VisitTransition to be passed in, which explicity has a value for reload.
+    // VisitType to be passed in, which explicity has a value for reload.
     // Note clear if we should try and unify these.
     // (and note that if we can, we can drop the recently_visited cache)
     if let Some(ref last) = last_url {
@@ -185,7 +185,7 @@ pub fn visit_uri(
 
     // EMBED visits are session-persistent and should not go through the database.
     // They exist only to keep track of isVisited status during the session.
-    if transition == VisitTransition::Embed {
+    if transition == VisitType::Embed {
         log::warn!("Embed visit, but in-memory storage of these isn't done yet");
         return Ok(());
     }

--- a/components/places/src/api/matcher.rs
+++ b/components/places/src/api/matcher.rs
@@ -611,7 +611,7 @@ mod tests {
     use crate::api::places_api::test::new_mem_connection;
     use crate::observation::VisitObservation;
     use crate::storage::history::apply_observation;
-    use crate::types::VisitTransition;
+    use crate::types::VisitType;
     use types::Timestamp;
 
     #[test]
@@ -666,7 +666,7 @@ mod tests {
         let url = Url::parse("http://example.com/123").unwrap();
         let visit = VisitObservation::new(url.clone())
             .with_title("Example page 123".to_string())
-            .with_visit_type(VisitTransition::Typed)
+            .with_visit_type(VisitType::Typed)
             .with_at(Timestamp::now());
 
         apply_observation(&conn, visit).expect("Should apply visit");
@@ -757,7 +757,7 @@ mod tests {
         let url = Url::parse("http://exämple.com/123").unwrap();
         let visit = VisitObservation::new(url)
             .with_title("Example page 123".to_string())
-            .with_visit_type(VisitTransition::Typed)
+            .with_visit_type(VisitType::Typed)
             .with_at(Timestamp::now());
 
         apply_observation(&conn, visit).expect("Should apply visit");

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -23,7 +23,7 @@ use crate::types::VisitTransitionSet;
 use crate::ConnectionType;
 use crate::UniffiCustomTypeConverter;
 use crate::VisitObservation;
-use crate::VisitTransition;
+use crate::VisitType;
 use crate::{PlacesApi, PlacesDb};
 use error_support::handle_error;
 use interrupt_support::register_interrupt;
@@ -599,7 +599,7 @@ pub struct HistoryVisitInfo {
     pub url: Url,
     pub title: Option<String>,
     pub timestamp: PlacesTimestamp,
-    pub visit_type: VisitTransition,
+    pub visit_type: VisitType,
     pub is_hidden: bool,
     pub preview_image_url: Option<Url>,
     pub is_remote: bool,

--- a/components/places/src/frecency.rs
+++ b/components/places/src/frecency.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::error::*;
-use crate::types::VisitTransition;
+use crate::types::VisitType;
 use error_support::trace_error;
 use rusqlite::Connection;
 use types::Timestamp;
@@ -81,7 +81,7 @@ impl FrecencySettings {
     // Note: in Places, `redirect` defaults to false.
     pub fn get_transition_bonus(
         &self,
-        visit_type: Option<VisitTransition>,
+        visit_type: Option<VisitType>,
         visited: bool,
         redirect: bool,
     ) -> i32 {
@@ -89,17 +89,18 @@ impl FrecencySettings {
             return self.redirect_source_visit_bonus;
         }
         match (visit_type, visited) {
-            (Some(VisitTransition::Link), _) => self.link_visit_bonus,
-            (Some(VisitTransition::Embed), _) => self.embed_visit_bonus,
-            (Some(VisitTransition::FramedLink), _) => self.framed_link_visit_bonus,
-            (Some(VisitTransition::RedirectPermanent), _) => self.temporary_redirect_visit_bonus,
-            (Some(VisitTransition::RedirectTemporary), _) => self.permanent_redirect_visit_bonus,
-            (Some(VisitTransition::Download), _) => self.download_visit_bonus,
-            (Some(VisitTransition::Reload), _) => self.reload_visit_bonus,
-            (Some(VisitTransition::Typed), true) => self.typed_visit_bonus,
-            (Some(VisitTransition::Typed), false) => self.unvisited_typed_bonus,
-            (Some(VisitTransition::Bookmark), true) => self.bookmark_visit_bonus,
-            (Some(VisitTransition::Bookmark), false) => self.unvisited_bookmark_bonus,
+            (Some(VisitType::Link), _) => self.link_visit_bonus,
+            (Some(VisitType::Embed), _) => self.embed_visit_bonus,
+            (Some(VisitType::FramedLink), _) => self.framed_link_visit_bonus,
+            (Some(VisitType::RedirectPermanent), _) => self.temporary_redirect_visit_bonus,
+            (Some(VisitType::RedirectTemporary), _) => self.permanent_redirect_visit_bonus,
+            (Some(VisitType::Download), _) => self.download_visit_bonus,
+            (Some(VisitType::Reload), _) => self.reload_visit_bonus,
+            (Some(VisitType::Typed), true) => self.typed_visit_bonus,
+            (Some(VisitType::Typed), false) => self.unvisited_typed_bonus,
+            (Some(VisitType::Bookmark), true) => self.bookmark_visit_bonus,
+            (Some(VisitType::Bookmark), false) => self.unvisited_bookmark_bonus,
+            (Some(VisitType::UpdatePlace), _) => self.default_visit_bonus,
             // 0 == undefined (see bug 375777 in bugzilla for details)
             (None, _) => self.default_visit_bonus,
         }
@@ -192,8 +193,8 @@ impl<'db, 's> FrecencyComputation<'db, 's> {
              WHERE v.place_id = :page_id
              ORDER BY v.visit_date DESC
              LIMIT {max_visits}",
-            redirect_permanent = VisitTransition::RedirectPermanent as u8,
-            redirect_temporary = VisitTransition::RedirectTemporary as u8,
+            redirect_permanent = VisitType::RedirectPermanent as u8,
+            redirect_temporary = VisitType::RedirectTemporary as u8,
             // in practice this is constant, so caching the query is fine.
             // (rusqlite has a max cache size too should things change)
             max_visits = self.settings.num_visits,
@@ -212,8 +213,8 @@ impl<'db, 's> FrecencyComputation<'db, 's> {
                 let age_in_days =
                     (now.as_millis() as f64 - visit_date.as_millis() as f64) / 86_400_000.0;
                 Ok((
-                    VisitTransition::from_primitive(visit_type),
-                    VisitTransition::from_primitive(target_visit_type),
+                    VisitType::from_primitive(visit_type),
+                    VisitType::from_primitive(target_visit_type),
                     age_in_days.round() as i32,
                 ))
             },
@@ -231,9 +232,9 @@ impl<'db, 's> FrecencyComputation<'db, 's> {
             let use_redirect_bonus = if self.most_recent_redirect_bonus == RedirectBonus::Unknown
                 || num_sampled_visits > 0
             {
-                target_visit_type == Some(VisitTransition::RedirectPermanent)
-                    || (target_visit_type == Some(VisitTransition::RedirectTemporary)
-                        && visit_type != Some(VisitTransition::Typed))
+                target_visit_type == Some(VisitType::RedirectPermanent)
+                    || (target_visit_type == Some(VisitType::RedirectTemporary)
+                        && visit_type != Some(VisitType::Typed))
             } else {
                 self.most_recent_redirect_bonus == RedirectBonus::Redirect
             };
@@ -243,11 +244,9 @@ impl<'db, 's> FrecencyComputation<'db, 's> {
                     .get_transition_bonus(visit_type, true, use_redirect_bonus);
 
             if self.has_bookmark() {
-                bonus += self.settings.get_transition_bonus(
-                    Some(VisitTransition::Bookmark),
-                    true,
-                    false,
-                );
+                bonus += self
+                    .settings
+                    .get_transition_bonus(Some(VisitType::Bookmark), true, false);
             }
             if bonus != 0 {
                 let weight = self.settings.get_frecency_aged_weight(age_in_days) as f32;
@@ -277,13 +276,13 @@ impl<'db, 's> FrecencyComputation<'db, 's> {
     fn compute_unvisited_bookmark_frecency(&self) -> i32 {
         // Make it so something bookmarked and typed will have a higher frecency
         // than something just typed or just bookmarked.
-        let mut bonus =
-            self.settings
-                .get_transition_bonus(Some(VisitTransition::Bookmark), false, false);
+        let mut bonus = self
+            .settings
+            .get_transition_bonus(Some(VisitType::Bookmark), false, false);
         if self.typed != 0 {
             bonus += self
                 .settings
-                .get_transition_bonus(Some(VisitTransition::Typed), false, false);
+                .get_transition_bonus(Some(VisitType::Typed), false, false);
         }
 
         // Assume "now" as our age_in_days, so use the first bucket.

--- a/components/places/src/history_sync/payload_evolution_tests.rs
+++ b/components/places/src/history_sync/payload_evolution_tests.rs
@@ -10,7 +10,7 @@ use crate::{
     history_sync::{record::HistoryRecord, HistorySyncEngine},
     observation::VisitObservation,
     storage::history::apply_observation,
-    types::{UnknownFields, VisitTransition},
+    types::{UnknownFields, VisitType},
 };
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
@@ -431,7 +431,7 @@ fn assert_outgoing_unknown_fields_eq(
 fn visit(url: &'static str, timestamp: i64) -> VisitObservation {
     let timestamp = (timestamp / 1000) as u64;
     VisitObservation::new(url.parse().unwrap())
-        .with_visit_type(VisitTransition::Link)
+        .with_visit_type(VisitType::Link)
         .with_at(Some(timestamp.into()))
 }
 

--- a/components/places/src/observation.rs
+++ b/components/places/src/observation.rs
@@ -23,7 +23,7 @@ use url::Url;
 pub struct VisitObservation {
     pub url: Url,
     pub title: Option<String>,
-    pub visit_type: Option<VisitTransition>,
+    pub visit_type: Option<VisitType>,
     pub is_error: Option<bool>,
     pub is_redirect_source: Option<bool>,
     pub is_permanent_redirect_source: Option<bool>,
@@ -57,7 +57,7 @@ impl VisitObservation {
         self
     }
 
-    pub fn with_visit_type(mut self, t: impl Into<Option<VisitTransition>>) -> Self {
+    pub fn with_visit_type(mut self, t: impl Into<Option<VisitType>>) -> Self {
         self.visit_type = t.into();
         self
     }
@@ -101,7 +101,7 @@ impl VisitObservation {
     pub fn get_redirect_frecency_boost(&self) -> bool {
         self.is_redirect_source.is_some()
             && match self.visit_type {
-                Some(t) => t != VisitTransition::Typed,
+                Some(t) => t != VisitType::Typed,
                 _ => true,
             }
     }
@@ -111,8 +111,8 @@ impl VisitObservation {
         match self.visit_type {
             Some(visit_type) => {
                 self.is_redirect_source.is_some()
-                    || visit_type == VisitTransition::FramedLink
-                    || visit_type == VisitTransition::Embed
+                    || visit_type == VisitType::FramedLink
+                    || visit_type == VisitType::Embed
             }
             None => false,
         }

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -258,7 +258,8 @@ enum DocumentType {
     "Media",
 };
 
-enum VisitTransition {
+// Mimics https://searchfox.org/mozilla-central/rev/57f94ca1d57ab745242daafc8926690377579b83/toolkit/components/places/nsINavHistoryService.idl#922
+enum VisitType {
     // This transition type means the user followed a link.
     "Link",
     // This transition type means that the user typed the page's URL in the
@@ -271,6 +272,8 @@ enum VisitTransition {
     "Download",
     "FramedLink",
     "Reload",
+     // Internal visit type used for meta data updates. Doesn't represent an actual page visit
+    "UpdatePlace",
 };
 
 // This is used as an "input" to the api.
@@ -313,7 +316,7 @@ dictionary HistoryVisitInfo {
     Url url;
     string? title;
     PlacesTimestamp timestamp;
-    VisitTransition visit_type;
+    VisitType visit_type;
     boolean is_hidden;
     Url? preview_image_url;
     boolean is_remote;
@@ -332,7 +335,7 @@ dictionary HistoryVisitInfosWithBound {
 dictionary VisitObservation {
     Url url;
     string? title = null;
-    VisitTransition? visit_type;
+    VisitType? visit_type;
     boolean? is_error = null;
     boolean? is_redirect_source = null;
     boolean? is_permanent_redirect_source = null;

--- a/components/places/src/storage/history/actions.rs
+++ b/components/places/src/storage/history/actions.rs
@@ -165,7 +165,7 @@ mod tests {
     use crate::observation::VisitObservation;
     use crate::storage::bookmarks::*;
     use crate::storage::history::apply_observation;
-    use crate::types::VisitTransition;
+    use crate::types::VisitType;
     use crate::{frecency, ConnectionType, SyncStatus};
     use rusqlite::params;
     use rusqlite::types::{FromSql, ToSql};
@@ -242,7 +242,7 @@ mod tests {
                     apply_observation(
                         conn,
                         VisitObservation::new(url.clone())
-                            .with_visit_type(VisitTransition::Link)
+                            .with_visit_type(VisitType::Link)
                             .with_at(*date),
                     )
                     .unwrap()

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -754,7 +754,7 @@ mod tests {
         apply_observation, delete_visits_between, delete_visits_for, get_visit_count, url_to_guid,
         wipe_local,
     };
-    use crate::types::VisitTransition;
+    use crate::types::VisitType;
     use crate::VisitTransitionSet;
     use pretty_assertions::assert_eq;
     use std::{thread, time};
@@ -1266,7 +1266,7 @@ mod tests {
             VisitObservation::new(
                 Url::parse("https://www.reddit.com/r/climbing").expect("Should parse URL"),
             )
-            .with_visit_type(VisitTransition::Link)
+            .with_visit_type(VisitType::Link)
             .with_at(Timestamp::now()),
         )
         .expect("Should apply observation");
@@ -1410,7 +1410,7 @@ mod tests {
                 .with_title(Some(String::from("Budget vows to build &#x27;for the long term&#x27; as it promises child care cash, projects massive deficits | CBC News")))
                 .with_preview_image_url(Some(Url::parse("https://i.cbc.ca/1.5993583.1618861792!/cpImage/httpImage/image.jpg_gen/derivatives/16x9_620/fedbudget-20210419.jpg").unwrap()))
                 .with_is_remote(false)
-                .with_visit_type(VisitTransition::Link);
+                .with_visit_type(VisitType::Link);
         apply_observation(&conn, observation1).unwrap();
 
         note_observation!(
@@ -1783,7 +1783,7 @@ mod tests {
             title: Some("bookmarked page".to_string()),
         };
         insert_bookmark(&conn, InsertableItem::Bookmark { b: bm }).expect("bookmark should insert");
-        let obs = VisitObservation::new(url.clone()).with_visit_type(VisitTransition::Link);
+        let obs = VisitObservation::new(url.clone()).with_visit_type(VisitType::Link);
         apply_observation(&conn, obs).expect("Should apply visit");
         note_observation!(
             &conn,
@@ -1823,7 +1823,7 @@ mod tests {
         let conn = PlacesDb::open_in_memory(ConnectionType::ReadWrite).expect("memory db");
         // Item is not bookmarked, but has regular visit and a metadata observation.
         let url = Url::parse("https://www.mozilla.org/not-bookmarked").unwrap();
-        let obs = VisitObservation::new(url.clone()).with_visit_type(VisitTransition::Link);
+        let obs = VisitObservation::new(url.clone()).with_visit_type(VisitType::Link);
         apply_observation(&conn, obs).expect("Should apply visit");
         note_observation!(
             &conn,
@@ -1899,13 +1899,13 @@ mod tests {
             .with_at(start_timestamp)
             .with_title(Some(String::from("Test page 0")))
             .with_is_remote(false)
-            .with_visit_type(VisitTransition::Link);
+            .with_visit_type(VisitType::Link);
 
         let observation2 = VisitObservation::new(other_url)
             .with_at(end_timestamp)
             .with_title(Some(String::from("Test page 1")))
             .with_is_remote(false)
-            .with_visit_type(VisitTransition::Link);
+            .with_visit_type(VisitType::Link);
 
         apply_observation(&conn, observation1).expect("Should apply visit");
         apply_observation(&conn, observation2).expect("Should apply visit");
@@ -1943,13 +1943,13 @@ mod tests {
             .with_at(now)
             .with_title(Some(String::from("Test page 0")))
             .with_is_remote(false)
-            .with_visit_type(VisitTransition::Link);
+            .with_visit_type(VisitType::Link);
 
         let observation2 = VisitObservation::new(parent_url.clone())
             .with_at(now)
             .with_title(Some(String::from("Test page 1")))
             .with_is_remote(false)
-            .with_visit_type(VisitTransition::Link);
+            .with_visit_type(VisitType::Link);
 
         apply_observation(&conn, observation1).expect("Should apply visit");
         apply_observation(&conn, observation2).expect("Should apply visit");
@@ -2022,19 +2022,19 @@ mod tests {
             .with_at(now)
             .with_title(Some(String::from("Test page 1")))
             .with_is_remote(false)
-            .with_visit_type(VisitTransition::Link);
+            .with_visit_type(VisitType::Link);
         let observation2 =
             VisitObservation::new(Url::parse("https://www.mozilla.org/another/").unwrap())
                 .with_at(Timestamp(now.as_millis() + 10000))
                 .with_title(Some(String::from("Test page 3")))
                 .with_is_remote(false)
-                .with_visit_type(VisitTransition::Link);
+                .with_visit_type(VisitType::Link);
         let observation3 =
             VisitObservation::new(Url::parse("https://www.mozilla.org/first/").unwrap())
                 .with_at(Timestamp(now.as_millis() - 10000))
                 .with_title(Some(String::from("Test page 0")))
                 .with_is_remote(true)
-                .with_visit_type(VisitTransition::Link);
+                .with_visit_type(VisitType::Link);
         apply_observation(&conn, observation1).expect("Should apply visit");
         apply_observation(&conn, observation2).expect("Should apply visit");
         apply_observation(&conn, observation3).expect("Should apply visit");

--- a/components/places/src/storage/mod.rs
+++ b/components/places/src/storage/mod.rs
@@ -15,7 +15,7 @@ use crate::error::{Error, InvalidPlaceInfo, Result};
 use crate::ffi::HistoryVisitInfo;
 use crate::ffi::TopFrecentSiteInfo;
 use crate::frecency::{calculate_frecency, DEFAULT_FRECENCY_SETTINGS};
-use crate::types::{SyncStatus, UnknownFields, VisitTransition};
+use crate::types::{SyncStatus, UnknownFields, VisitType};
 use interrupt_support::SqlInterruptScope;
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 use rusqlite::Result as RusqliteResult;
@@ -196,11 +196,11 @@ fn new_page_info(db: &PlacesDb, url: &Url, new_guid: Option<SyncGuid>) -> Result
 
 impl HistoryVisitInfo {
     fn from_row(row: &rusqlite::Row<'_>) -> Result<Self> {
-        let visit_type = VisitTransition::from_primitive(row.get::<_, u8>("visit_type")?)
+        let visit_type = VisitType::from_primitive(row.get::<_, u8>("visit_type")?)
             // Do we have an existing error we use for this? For now they
-            // probably don't care too much about VisitTransition, so this
+            // probably don't care too much about VisitType, so this
             // is fine.
-            .unwrap_or(VisitTransition::Link);
+            .unwrap_or(VisitType::Link);
         let visit_date: Timestamp = row.get("visit_date")?;
         let url: String = row.get("url")?;
         let preview_image_url: Option<String> = row.get("preview_image_url")?;
@@ -515,7 +515,7 @@ mod tests {
             &conn,
             VisitObservation::new(url)
                 .with_at(Timestamp::from(727_747_200_001))
-                .with_visit_type(VisitTransition::Link)
+                .with_visit_type(VisitType::Link)
         )
         .unwrap()
         .is_some());

--- a/components/places/src/types/visit_transition_set.rs
+++ b/components/places/src/types/visit_transition_set.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use super::{InvalidVisitType, VisitTransition};
+use super::{InvalidVisitType, VisitType};
 use rusqlite::types::ToSqlOutput;
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
@@ -10,15 +10,15 @@ pub struct VisitTransitionSet {
     pub(crate) bits: u16,
 }
 
-const ALL_BITS_SET: u16 = (1u16 << (VisitTransition::Link as u8))
-    | (1u16 << (VisitTransition::Typed as u8))
-    | (1u16 << (VisitTransition::Bookmark as u8))
-    | (1u16 << (VisitTransition::Embed as u8))
-    | (1u16 << (VisitTransition::RedirectPermanent as u8))
-    | (1u16 << (VisitTransition::RedirectTemporary as u8))
-    | (1u16 << (VisitTransition::Download as u8))
-    | (1u16 << (VisitTransition::FramedLink as u8))
-    | (1u16 << (VisitTransition::Reload as u8));
+const ALL_BITS_SET: u16 = (1u16 << (VisitType::Link as u8))
+    | (1u16 << (VisitType::Typed as u8))
+    | (1u16 << (VisitType::Bookmark as u8))
+    | (1u16 << (VisitType::Embed as u8))
+    | (1u16 << (VisitType::RedirectPermanent as u8))
+    | (1u16 << (VisitType::RedirectTemporary as u8))
+    | (1u16 << (VisitType::Download as u8))
+    | (1u16 << (VisitType::FramedLink as u8))
+    | (1u16 << (VisitType::Reload as u8));
 
 impl VisitTransitionSet {
     pub const fn new() -> Self {
@@ -33,13 +33,13 @@ impl VisitTransitionSet {
         Self { bits: ALL_BITS_SET }
     }
 
-    pub const fn single(ty: VisitTransition) -> Self {
+    pub const fn single(ty: VisitType) -> Self {
         Self {
             bits: (1u16 << (ty as u8)),
         }
     }
 
-    pub fn for_specific(tys: &[VisitTransition]) -> Self {
+    pub fn for_specific(tys: &[VisitType]) -> Self {
         tys.iter().cloned().collect()
     }
 
@@ -51,15 +51,15 @@ impl VisitTransitionSet {
         v.try_into()
     }
 
-    pub fn contains(self, t: VisitTransition) -> bool {
+    pub fn contains(self, t: VisitType) -> bool {
         (self.bits & (1 << (t as u32))) != 0
     }
 
-    pub fn insert(&mut self, t: VisitTransition) {
+    pub fn insert(&mut self, t: VisitType) {
         self.bits |= 1 << (t as u8);
     }
 
-    pub fn remove(&mut self, t: VisitTransition) {
+    pub fn remove(&mut self, t: VisitType) {
         self.bits &= !(1 << (t as u8));
     }
 
@@ -90,7 +90,7 @@ impl TryFrom<u16> for VisitTransitionSet {
 }
 
 impl IntoIterator for VisitTransitionSet {
-    type Item = VisitTransition;
+    type Item = VisitType;
     type IntoIter = VisitTransitionSetIter;
     fn into_iter(self) -> VisitTransitionSetIter {
         VisitTransitionSetIter {
@@ -106,7 +106,7 @@ pub struct VisitTransitionSetIter {
 }
 
 impl Iterator for VisitTransitionSetIter {
-    type Item = VisitTransition;
+    type Item = VisitType;
     fn next(&mut self) -> Option<Self::Item> {
         if self.bits == 0 {
             return None;
@@ -116,7 +116,7 @@ impl Iterator for VisitTransitionSetIter {
             self.bits >>= 1;
         }
         // Should always be fine unless VisitTransitionSet has a bug.
-        let result: VisitTransition = self.pos.try_into().expect("Bug in VisitTransitionSet");
+        let result: VisitType = self.pos.try_into().expect("Bug in VisitTransitionSet");
         self.pos += 1;
         self.bits >>= 1;
         Some(result)
@@ -134,10 +134,10 @@ impl From<VisitTransitionSet> for u16 {
     }
 }
 
-impl Extend<VisitTransition> for VisitTransitionSet {
+impl Extend<VisitType> for VisitTransitionSet {
     fn extend<I>(&mut self, iter: I)
     where
-        I: IntoIterator<Item = VisitTransition>,
+        I: IntoIterator<Item = VisitType>,
     {
         for element in iter {
             self.insert(element);
@@ -145,10 +145,10 @@ impl Extend<VisitTransition> for VisitTransitionSet {
     }
 }
 
-impl std::iter::FromIterator<VisitTransition> for VisitTransitionSet {
+impl std::iter::FromIterator<VisitType> for VisitTransitionSet {
     fn from_iter<I>(iterator: I) -> Self
     where
-        I: IntoIterator<Item = VisitTransition>,
+        I: IntoIterator<Item = VisitType>,
     {
         let mut ret = Self::new();
         ret.extend(iterator);
@@ -166,16 +166,16 @@ impl rusqlite::ToSql for VisitTransitionSet {
 mod test {
     use super::*;
 
-    const ALL_TRANSITIONS: &[VisitTransition] = &[
-        VisitTransition::Link,
-        VisitTransition::Typed,
-        VisitTransition::Bookmark,
-        VisitTransition::Embed,
-        VisitTransition::RedirectPermanent,
-        VisitTransition::RedirectTemporary,
-        VisitTransition::Download,
-        VisitTransition::FramedLink,
-        VisitTransition::Reload,
+    const ALL_TRANSITIONS: &[VisitType] = &[
+        VisitType::Link,
+        VisitType::Typed,
+        VisitType::Bookmark,
+        VisitType::Embed,
+        VisitType::RedirectPermanent,
+        VisitType::RedirectTemporary,
+        VisitType::Download,
+        VisitType::FramedLink,
+        VisitType::Reload,
     ];
     #[test]
     fn test_vtset() {
@@ -191,9 +191,9 @@ mod test {
         assert_eq!(vts_all, vts);
 
         let to_remove = &[
-            VisitTransition::Typed,
-            VisitTransition::RedirectPermanent,
-            VisitTransition::RedirectTemporary,
+            VisitType::Typed,
+            VisitType::RedirectPermanent,
+            VisitType::RedirectTemporary,
         ];
         for &r in to_remove {
             assert!(vts.contains(r));
@@ -217,9 +217,9 @@ mod test {
         assert_eq!(&vts.into_iter().collect::<Vec<_>>()[..], ALL_TRANSITIONS);
 
         let to_remove = &[
-            VisitTransition::Typed,
-            VisitTransition::RedirectPermanent,
-            VisitTransition::RedirectTemporary,
+            VisitType::Typed,
+            VisitType::RedirectPermanent,
+            VisitType::RedirectTemporary,
         ];
 
         for &r in to_remove {
@@ -227,12 +227,12 @@ mod test {
         }
 
         let want = &[
-            VisitTransition::Link,
-            VisitTransition::Bookmark,
-            VisitTransition::Embed,
-            VisitTransition::Download,
-            VisitTransition::FramedLink,
-            VisitTransition::Reload,
+            VisitType::Link,
+            VisitType::Bookmark,
+            VisitType::Embed,
+            VisitType::Download,
+            VisitType::FramedLink,
+            VisitType::Reload,
         ];
         assert_eq!(&vts.into_iter().collect::<Vec<_>>()[..], want);
 
@@ -248,7 +248,7 @@ mod test {
 
         assert_eq!(
             VisitTransitionSet::try_from(2),
-            Ok(VisitTransitionSet::single(VisitTransition::Link)),
+            Ok(VisitTransitionSet::single(VisitType::Link)),
         );
 
         assert!(VisitTransitionSet::try_from(ALL_BITS_SET + 1).is_err(),);

--- a/examples/places-autocomplete/src/autocomplete.rs
+++ b/examples/places-autocomplete/src/autocomplete.rs
@@ -6,7 +6,7 @@
 
 use anyhow::Result;
 use clap::value_t;
-use places::{PlacesDb, VisitObservation, VisitTransition};
+use places::{PlacesDb, VisitObservation, VisitType};
 use sql_support::ConnExt;
 use std::io::prelude::*;
 use std::time::Instant;
@@ -69,9 +69,7 @@ impl LegacyPlace {
         let url = Url::parse(&self.url)?;
         for v in self.visits {
             let obs = VisitObservation::new(url.clone())
-                .with_visit_type(
-                    VisitTransition::from_primitive(v.visit_type).unwrap_or(VisitTransition::Link),
-                )
+                .with_visit_type(VisitType::from_primitive(v.visit_type).unwrap_or(VisitType::Link))
                 .with_at(types::Timestamp((v.date / 1000) as u64))
                 .with_title(self._title.clone())
                 .with_is_remote(rand::random::<f64>() < options.remote_probability);

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -191,7 +191,7 @@ fn create_fake_visits(db: &PlacesDb, num_sites: usize, num_visits: usize) -> Res
         for visit_num in 0..num_visits {
             let obs = places::VisitObservation::new(url.clone())
                 .with_at(Some(st.into()))
-                .with_visit_type(places::VisitTransition::Link);
+                .with_visit_type(places::VisitType::Link);
             st = st.checked_sub(Duration::new(1, 0)).unwrap();
             places::storage::history::apply_observation_direct(db, obs)?;
             if interrupt_support::ShutdownInterruptee.was_interrupted() {

--- a/testing/separated/places-bench/src/database.rs
+++ b/testing/separated/places-bench/src/database.rs
@@ -39,7 +39,7 @@ fn init_db(db: &mut PlacesDb) -> places::Result<()> {
             let obs = places::VisitObservation::new(url.clone())
                 .with_title(entry.title.clone())
                 .with_is_remote(i < 10)
-                .with_visit_type(places::VisitTransition::Link)
+                .with_visit_type(places::VisitType::Link)
                 .with_at(Timestamp(now.0 - day_ms * (1 + i)));
             places::storage::history::apply_observation_direct(db, obs)?;
         }

--- a/testing/separated/places-tests/src/ios_history.rs
+++ b/testing/separated/places-tests/src/ios_history.rs
@@ -5,7 +5,7 @@ use places::{
     api::places_api::{ConnectionType, PlacesApi},
     apply_observation,
     storage::history::{self, get_visit_infos},
-    Result, VisitObservation, VisitTransition, VisitTransitionSet,
+    Result, VisitObservation, VisitTransitionSet, VisitType,
 };
 use rusqlite::Connection;
 use std::path::Path;
@@ -327,19 +327,19 @@ fn test_update_missing_title() -> Result<()> {
     apply_observation(
         &mut conn,
         VisitObservation::new(Url::parse("https://example.com/").unwrap())
-            .with_visit_type(Some(VisitTransition::Link)),
+            .with_visit_type(Some(VisitType::Link)),
     )?;
     apply_observation(
         &mut conn,
         VisitObservation::new(Url::parse("https://mozilla.org/").unwrap())
             .with_title(Some("Mozilla!".to_string()))
-            .with_visit_type(Some(VisitTransition::Link)),
+            .with_visit_type(Some(VisitType::Link)),
     )?;
     apply_observation(
         &mut conn,
         VisitObservation::new(Url::parse("https://firefox.com/").unwrap())
             .with_title(Some("Firefox!".to_string()))
-            .with_visit_type(Some(VisitTransition::Link)),
+            .with_visit_type(Some(VisitType::Link)),
     )?;
     let visit_infos = get_visit_infos(
         &conn,


### PR DESCRIPTION
1. Renames the `VisitTransition` enum in a-s to be `VisitType` to be closer to desktop https://searchfox.org/mozilla-central/source/toolkit/components/places/nsINavHistoryService.idl#186
2. Removes the android-specific VisitType as they can now use the Uniffi-ed version

This will unfortunately be a breaking change. However will potentially allow us to remove a bunch of conversion codes on the firefox-android side of things https://github.com/mozilla-mobile/firefox-android/blob/dad4c7ff2791f6340972b7589b8130e597f98a55/android-components/components/browser/storage-sync/src/main/java/mozilla/components/browser/storage/sync/Types.kt#L51-L100

firefox-android PR: https://github.com/mozilla-mobile/firefox-android/pull/3831
firefox-ios PR: https://github.com/mozilla-mobile/firefox-ios/pull/16707

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
