### PR TITLE
Removes incorrect comment declaring viaduct not safe for binary bodies

### DIFF
--- a/components/viaduct/src/lib.rs
+++ b/components/viaduct/src/lib.rs
@@ -236,8 +236,7 @@ pub struct Response {
     pub status: u16,
     /// The headers returned with this response.
     pub headers: Headers,
-    /// The body of the response. Note that responses with binary bodies are
-    /// currently unsupported.
+    /// The body of the response.
     pub body: Vec<u8>,
 }
 


### PR DESCRIPTION
Closes #5744

The comment is an old remnant of a time where the body was represented with a string type and not a `Vec<u8>`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
