### PR TITLE
Avoid `brew update-reset` each time we check Swift formatting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,8 +212,6 @@ jobs:
     executor: macos
     steps:
       - full-checkout
-      # swiftlint moved? See https://github.com/Homebrew/discussions/discussions/691
-      - run: brew update-reset
       - run: brew install swiftlint swiftformat
       - run: ./automation/tests.py swiftlint
       - run: ./automation/tests.py swiftformat


### PR DESCRIPTION
This was a hack for a one-time problem which has almost certainly gone away now. If we did want to do this, it should probably be formalized and not a hack just for swift-lint, so let's just kill it if CI passes.

Fixes #4025