### PR TITLE
Add a Places API to recursively count the number of descendants in a … [firefox-android: mhammond/count-bookmarks-in-trees] 

### DIFF
--- a/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/Bookmarks.kt
@@ -119,6 +119,19 @@ interface ReadableBookmarksConnection : InterruptibleConnection {
      * has its `interrupt()` method called on another thread.
      */
     fun getRecentBookmarks(limit: Int): List<BookmarkItem>
+
+    /**
+     * Counts the number of bookmark items in the bookmark trees under the specified GUIDs.
+
+     * @param guids The guids of folders to query.
+     * @return Count of all bookmark items (ie, not folders or separators) in all specified folders recursively.
+     * Empty folders, non-existing GUIDs and non-existing items will return zero.
+     * The result is implementation dependant if the trees overlap.
+     *
+     * @throws OperationInterrupted if this database implements [InterruptibleConnection] and
+     * has its `interrupt()` method called on another thread.
+     */
+    fun countBookmarksInTrees(guids: List<Guid>): UInt
 }
 
 /**

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -262,6 +262,12 @@ open class PlacesReaderConnection internal constructor(conn: UniffiPlacesConnect
         }
     }
 
+    override fun countBookmarksInTrees(guids: List<Guid>): UInt {
+        return readQueryCounters.measure {
+            this.conn.bookmarksCountBookmarksInTrees(guids)
+        }
+    }
+
     private val readQueryCounters: PlacesManagerCounterMetrics by lazy {
         PlacesManagerCounterMetrics(
             PlacesManagerMetrics.readQueryCount,

--- a/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
+++ b/components/places/android/src/test/java/mozilla/appservices/places/PlacesConnectionTest.kt
@@ -385,6 +385,40 @@ class PlacesConnectionTest {
     }
 
     @Test
+    fun testCountBookmarks() {
+        assertEquals(db.countBookmarksInTrees(listOf(BookmarkRoot.Unfiled.id)), 0U)
+
+        db.createBookmarkItem(
+            parentGUID = BookmarkRoot.Unfiled.id,
+            url = "https://www.example.com/",
+            title = "example",
+        )
+        assertEquals(db.countBookmarksInTrees(listOf(BookmarkRoot.Unfiled.id)), 1U)
+
+        val folderGUID = db.createFolder(
+            parentGUID = BookmarkRoot.Unfiled.id,
+            title = "example folder",
+        )
+        // Folders don't get counted.
+        assertEquals(db.countBookmarksInTrees(listOf(BookmarkRoot.Unfiled.id)), 1U)
+
+        // new item in the child folder does.
+        db.createBookmarkItem(
+            parentGUID = folderGUID,
+            url = "https://www.example.com/",
+            title = "example",
+        )
+        assertEquals(db.countBookmarksInTrees(listOf(BookmarkRoot.Unfiled.id)), 2U)
+
+        // A separator is not counted.
+        db.createSeparator(
+            parentGUID = BookmarkRoot.Unfiled.id,
+            position = 0u,
+        )
+        assertEquals(db.countBookmarksInTrees(listOf(BookmarkRoot.Unfiled.id)), 2U)
+    }
+
+    @Test
     fun testHistoryMetricsGathering() {
         assertNull(PlacesManagerMetrics.writeQueryCount.testGetValue())
         assertNull(PlacesManagerMetrics.writeQueryErrorCount["url_parse_failed"].testGetValue())

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -574,6 +574,11 @@ impl PlacesConnection {
     }
 
     #[handle_error(crate::Error)]
+    pub fn bookmarks_count_bookmarks_in_trees(&self, guids: &[Guid]) -> ApiResult<u32> {
+        self.with_conn(|conn| bookmarks::count_bookmarks_in_trees(conn, guids))
+    }
+
+    #[handle_error(crate::Error)]
     pub fn places_history_import_from_ios(
         &self,
         db_path: String,

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -204,6 +204,13 @@ interface PlacesConnection {
     [Throws=PlacesApiError]
     Guid bookmarks_insert(InsertableBookmarkItem bookmark);
 
+    // Counts the number of bookmarks in the bookmark tree under the specified GUID. Does not count
+    // the passed item, so an empty folder will return zero, as will a non-existing GUID or the
+    // guid of a non-folder item.
+    // Counts only bookmark items - ie, sub-folders and separators are not counted.
+    [Throws=PlacesApiError]
+    u32 bookmarks_count_bookmarks_in_trees([ByRef] sequence<Guid> folder_guids);
+
     [Throws=PlacesApiError]
     HistoryMigrationResult places_history_import_from_ios(string db_path, i64 last_sync_timestamp);
 };


### PR DESCRIPTION
…set of folders

Fixes #5789 - that issue implies the API should just count in a single folder, but the link android-components code ends up wanting to do multiple folders, so having this API take a list of folders makes life easier for them - ie, a-c does something like:

```
bookmarksStorage.countBookmarksInTrees(listOf(BookmarkRoot.Menu.id, BookmarkRoot.Toolbar.id, BookmarkRoot.Unfiled.id)
```

(I'm shaving many many yaks trying to get a-c to build with this, which are unrelated to the patch, so thought I'd get this up while I fight that)

@linabutler, wdyt?