### PR TITLE
Nimbus: add enrollment_status metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 [Full Changelog](In progress)
 
+## Nimbus SDK ⛅️🔬🔭
+
+### ✨ What's New ✨
+
+- Added the `enrollment_status` metric and defined a host metric callback handler interface ([#5857](https://github.com/mozilla/application-services/pull/5857)).
+
 ## Rust log forwarder
 
 ### 🦊 What's Changed 🦊

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -33,6 +33,8 @@ import org.mozilla.experiments.nimbus.internal.AvailableRandomizationUnits
 import org.mozilla.experiments.nimbus.internal.EnrolledExperiment
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEvent
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEventType
+import org.mozilla.experiments.nimbus.internal.EnrollmentStatusExtraDef
+import org.mozilla.experiments.nimbus.internal.MetricsHandler
 import org.mozilla.experiments.nimbus.internal.NimbusClient
 import org.mozilla.experiments.nimbus.internal.NimbusClientInterface
 import org.mozilla.experiments.nimbus.internal.NimbusException
@@ -77,6 +79,23 @@ open class Nimbus(
 
     private val logger = delegate.logger
 
+    private val metricsHandler = object : MetricsHandler {
+        override fun recordEnrollmentStatuses(enrollmentStatusExtras: List<EnrollmentStatusExtraDef>) {
+            for (extra in enrollmentStatusExtras) {
+                NimbusEvents.enrollmentStatus.record(
+                    NimbusEvents.EnrollmentStatusExtra(
+                        branch = extra.branch,
+                        slug = extra.slug,
+                        status = extra.status,
+                        reason = extra.reason,
+                        errorString = extra.errorString,
+                        conflictSlug = extra.conflictSlug,
+                    ),
+                )
+            }
+        }
+    }
+
     private val nimbusClient: NimbusClientInterface
 
     override var globalUserParticipation: Boolean
@@ -118,6 +137,7 @@ open class Nimbus(
             // The "dummy" field here is required for obscure reasons when generating code on desktop,
             // so we just automatically set it to a dummy value.
             AvailableRandomizationUnits(clientId = null, userId = null, nimbusId = null, dummy = 0),
+            metricsHandler,
         )
     }
 

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -12,11 +12,20 @@ fn main() -> Result<()> {
     use clap::{App, Arg, SubCommand};
     use env_logger::Env;
     use nimbus::{
+        metrics::{EnrollmentStatusExtraDef, MetricsHandler},
         AppContext, AvailableRandomizationUnits, EnrollmentStatus, NimbusClient,
         NimbusTargetingHelper, RemoteSettingsConfig,
     };
     use std::collections::HashMap;
     use std::io::prelude::*;
+
+    pub struct NoopMetricsHandler;
+
+    impl MetricsHandler for NoopMetricsHandler {
+        fn record_enrollment_statuses(&self, _: Vec<EnrollmentStatusExtraDef>) {
+            // do nothing
+        }
+    }
 
     // We set the logging level to be `warn` here, meaning that only
     // logs of `warn` or higher will be actually be shown, any other
@@ -208,6 +217,7 @@ fn main() -> Result<()> {
         db_path,
         Some(config),
         aru,
+        Box::new(NoopMetricsHandler),
     )?;
     log::info!("Nimbus ID is {}", nimbus_client.nimbus_id()?);
 

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Foundation
+import Glean
 import UIKit
 
 private let logTag = "Nimbus.swift"
@@ -15,6 +16,22 @@ public let defaultErrorReporter: NimbusErrorReporter = { err in
         logger.error("Nimbus error: \(description)")
     default:
         logger.error("Nimbus error: \(err)")
+    }
+}
+
+class GleanMetricsHandler: MetricsHandler {
+    func recordEnrollmentStatuses(enrollmentStatusExtras: [EnrollmentStatusExtraDef]) {
+        for extra in enrollmentStatusExtras {
+            GleanMetrics.NimbusEvents.enrollmentStatus
+                .record(GleanMetrics.NimbusEvents.EnrollmentStatusExtra(
+                    branch: extra.branch,
+                    conflictSlug: extra.conflictSlug,
+                    errorString: extra.errorString,
+                    reason: extra.reason,
+                    slug: extra.slug,
+                    status: extra.status
+                ))
+        }
     }
 }
 
@@ -63,7 +80,8 @@ public extension Nimbus {
                 userId: nil,
                 nimbusId: nil,
                 dummy: 0
-            )
+            ),
+            metricsHandler: GleanMetricsHandler()
         )
 
         return Nimbus(nimbusClient: nimbusClient, resourceBundles: resourceBundles, errorReporter: errorReporter)

--- a/components/nimbus/metrics.yaml
+++ b/components/nimbus/metrics.yaml
@@ -203,6 +203,39 @@ nimbus_events:
       - jhugman@mozilla.com
       - nimbus-team@mozilla.com
     expires: never
+  enrollment_status:
+    type: event
+    description: >
+      Recorded for each enrollment status each time the SDK completes application of pending experiments.
+    extra_keys:
+      slug:
+        type: string
+        description: The slug/unique identifier of the experiment
+      status:
+        type: string
+        description: The status of this enrollment
+      reason:
+        type: string
+        description: The reason the client is in the noted status
+      branch:
+        type: string
+        description: The branch slug/identifier that was randomly chosen (if the client is enrolled)
+      error_string:
+        type: string
+        description: If the enrollment resulted in an error, the associated error string
+      conflict_slug:
+        type: string
+        description: If the enrollment hit a feature conflict, the slug of the conflicting experiment/rollout
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/EXP-3827
+    data_reviews:
+      - ''
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - chumphreys@mozilla.com
+      - project-nimbus@mozilla.com
+    expires: never
 nimbus_health:
   cache_not_ready_for_feature:
     type: event

--- a/components/nimbus/src/enrollment.rs
+++ b/components/nimbus/src/enrollment.rs
@@ -12,6 +12,7 @@ use ::uuid::Uuid;
 use serde_derive::*;
 use std::{
     collections::{HashMap, HashSet},
+    fmt::{Display, Formatter, Result as FmtResult},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -26,6 +27,18 @@ pub enum EnrolledReason {
     Qualified,
     /// Explicit opt-in.
     OptIn,
+}
+
+impl Display for EnrolledReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(
+            match self {
+                EnrolledReason::Qualified => "Qualified",
+                EnrolledReason::OptIn => "OptIn",
+            },
+            f,
+        )
+    }
 }
 
 // These are types we use internally for managing non-enrollments.
@@ -46,6 +59,21 @@ pub enum NotEnrolledReason {
     FeatureConflict,
 }
 
+impl Display for NotEnrolledReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(
+            match self {
+                NotEnrolledReason::OptOut => "OptOut",
+                NotEnrolledReason::NotSelected => "NotSelected",
+                NotEnrolledReason::NotTargeted => "NotTargeted",
+                NotEnrolledReason::EnrollmentsPaused => "EnrollmentsPaused",
+                NotEnrolledReason::FeatureConflict => "FeatureConflict",
+            },
+            f,
+        )
+    }
+}
+
 // These are types we use internally for managing disqualifications.
 
 // ⚠️ Attention : Changes to this type should be accompanied by a new test  ⚠️
@@ -60,6 +88,20 @@ pub enum DisqualifiedReason {
     NotTargeted,
     /// The bucketing has changed for an experiment.
     NotSelected,
+}
+
+impl Display for DisqualifiedReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        Display::fmt(
+            match self {
+                DisqualifiedReason::Error => "Error",
+                DisqualifiedReason::OptOut => "OptOut",
+                DisqualifiedReason::NotSelected => "NotSelected",
+                DisqualifiedReason::NotTargeted => "NotTargeted",
+            },
+            f,
+        )
+    }
 }
 
 // Every experiment has an ExperimentEnrollment, even when we aren't enrolled.
@@ -439,7 +481,9 @@ impl ExperimentEnrollment {
                 },
                 EnrollmentChangeEventType::Disqualification,
             ),
-            EnrollmentStatus::NotEnrolled { .. } | EnrollmentStatus::Error { .. } => unreachable!(),
+            EnrollmentStatus::NotEnrolled { .. } | EnrollmentStatus::Error { .. } => {
+                unreachable!()
+            }
         }
     }
 
@@ -494,6 +538,19 @@ pub enum EnrollmentStatus {
         // serde compatible, which isn't trivial nor desirable.
         reason: String,
     },
+}
+
+impl EnrollmentStatus {
+    pub fn name(&self) -> String {
+        match self {
+            EnrollmentStatus::Enrolled { .. } => "Enrolled",
+            EnrollmentStatus::NotEnrolled { .. } => "NotEnrolled",
+            EnrollmentStatus::Disqualified { .. } => "Disqualified",
+            EnrollmentStatus::WasEnrolled { .. } => "WasEnrolled",
+            EnrollmentStatus::Error { .. } => "Error",
+        }
+        .into()
+    }
 }
 
 impl EnrollmentStatus {

--- a/components/nimbus/src/error.rs
+++ b/components/nimbus/src/error.rs
@@ -66,6 +66,9 @@ pub enum NimbusError {
     #[cfg(not(feature = "stateful"))]
     #[error("Error in Cirrus: {0}")]
     CirrusError(#[from] CirrusClientError),
+    #[cfg(feature = "stateful")]
+    #[error("UniFFI callback error: {0}")]
+    UniFFICallbackError(#[from] uniffi::UnexpectedUniFFICallbackError),
 }
 
 #[cfg(feature = "stateful")]

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+extern crate core;
+
 mod defaults;
 mod enrollment;
 mod evaluator;
@@ -23,6 +25,8 @@ pub use targeting::NimbusTargetingHelper;
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "stateful")] {
+        pub mod metrics;
+
         pub mod stateful;
 
         pub use stateful::nimbus_client::*;

--- a/components/nimbus/src/metrics.rs
+++ b/components/nimbus/src/metrics.rs
@@ -1,0 +1,76 @@
+use crate::{enrollment::ExperimentEnrollment, EnrollmentStatus};
+use serde_derive::{Deserialize, Serialize};
+
+pub trait MetricsHandler: Send + Sync {
+    fn record_enrollment_statuses(&self, enrollment_status_extras: Vec<EnrollmentStatusExtraDef>);
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct EnrollmentStatusExtraDef {
+    pub branch: Option<String>,
+    pub conflict_slug: Option<String>,
+    pub error_string: Option<String>,
+    pub reason: Option<String>,
+    pub slug: Option<String>,
+    pub status: Option<String>,
+}
+
+#[cfg(test)]
+impl EnrollmentStatusExtraDef {
+    pub fn branch(&self) -> &str {
+        self.branch.as_ref().unwrap()
+    }
+
+    pub fn conflict_slug(&self) -> &str {
+        self.conflict_slug.as_ref().unwrap()
+    }
+
+    pub fn error_string(&self) -> &str {
+        self.error_string.as_ref().unwrap()
+    }
+
+    pub fn reason(&self) -> &str {
+        self.reason.as_ref().unwrap()
+    }
+
+    pub fn slug(&self) -> &str {
+        self.slug.as_ref().unwrap()
+    }
+
+    pub fn status(&self) -> &str {
+        self.status.as_ref().unwrap()
+    }
+}
+
+impl From<ExperimentEnrollment> for EnrollmentStatusExtraDef {
+    fn from(enrollment: ExperimentEnrollment) -> Self {
+        let mut branch_value: Option<String> = None;
+        let mut reason_value: Option<String> = None;
+        let mut error_value: Option<String> = None;
+        match &enrollment.status {
+            EnrollmentStatus::Enrolled { reason, branch, .. } => {
+                branch_value = Some(branch.to_owned());
+                reason_value = Some(reason.to_string());
+            }
+            EnrollmentStatus::Disqualified { reason, branch, .. } => {
+                branch_value = Some(branch.to_owned());
+                reason_value = Some(reason.to_string());
+            }
+            EnrollmentStatus::NotEnrolled { reason } => {
+                reason_value = Some(reason.to_string());
+            }
+            EnrollmentStatus::WasEnrolled { branch, .. } => branch_value = Some(branch.to_owned()),
+            EnrollmentStatus::Error { reason } => {
+                error_value = Some(reason.to_owned());
+            }
+        }
+        EnrollmentStatusExtraDef {
+            branch: branch_value,
+            conflict_slug: None,
+            error_string: error_value,
+            reason: reason_value,
+            slug: Some(enrollment.slug),
+            status: Some(enrollment.status.name()),
+        }
+    }
+}

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -77,6 +77,19 @@ enum EnrollmentChangeEventType {
     "UnenrollFailed",
 };
 
+callback interface MetricsHandler {
+    void record_enrollment_statuses(sequence<EnrollmentStatusExtraDef> enrollment_status_extras);
+};
+
+dictionary EnrollmentStatusExtraDef {
+    string? branch;
+    string? conflict_slug;
+    string? error_string;
+    string? reason;
+    string? slug;
+    string? status;
+};
+
 [Error]
 enum NimbusError {
     "InvalidPersistedData", "RkvError", "IOError",
@@ -85,7 +98,7 @@ enum NimbusError {
     "UuidError", "InvalidExperimentFormat",
     "InvalidPath", "InternalError", "NoSuchExperiment", "NoSuchBranch",
     "DatabaseNotReady", "VersionParsingError", "BehaviorError", "TryFromIntError",
-    "ParseIntError", "TransformParameterError", "ClientError",
+    "ParseIntError", "TransformParameterError", "ClientError", "UniFFICallbackError",
 };
 
 interface NimbusClient {
@@ -95,7 +108,8 @@ interface NimbusClient {
         optional sequence<string> coenrolling_feature_ids = [],
         string dbpath,
         RemoteSettingsConfig? remote_settings_config,
-        AvailableRandomizationUnits available_randomization_units
+        AvailableRandomizationUnits available_randomization_units,
+        MetricsHandler metrics_handler
     );
 
     // Initializes the database and caches enough information so that the

--- a/components/nimbus/src/stateful/dbcache.rs
+++ b/components/nimbus/src/stateful/dbcache.rs
@@ -24,6 +24,7 @@ use std::sync::RwLock;
 // This struct is the cached data. This is never mutated, but instead
 // recreated every time the cache is updated.
 struct CachedData {
+    pub enrollments: Vec<ExperimentEnrollment>,
     pub experiments_by_slug: HashMap<String, EnrolledExperiment>,
     pub features_by_feature_id: HashMap<String, EnrolledFeatureConfig>,
 }
@@ -80,6 +81,7 @@ impl DatabaseCache {
         // This is where rollouts (promoted experiments on a given feature) will be merged in to the feature variables.
 
         let data = CachedData {
+            enrollments,
             experiments_by_slug,
             features_by_feature_id,
         };
@@ -150,5 +152,9 @@ impl DatabaseCache {
                 .map(|e| e.to_owned())
                 .collect::<Vec<EnrolledExperiment>>()
         })
+    }
+
+    pub fn get_enrollments(&self) -> Result<Vec<ExperimentEnrollment>> {
+        self.get_data(|data| data.enrollments.to_owned())
     }
 }

--- a/components/nimbus/src/tests/mod.rs
+++ b/components/nimbus/src/tests/mod.rs
@@ -14,6 +14,7 @@ mod test_versioning;
 
 #[cfg(feature = "stateful")]
 mod stateful {
+    mod helpers;
     mod test_behavior;
     mod test_enrollment;
     mod test_evaluator;

--- a/components/nimbus/src/tests/stateful/client/test_null_client.rs
+++ b/components/nimbus/src/tests/stateful/client/test_null_client.rs
@@ -6,12 +6,14 @@
 #![allow(unused_imports)]
 
 use crate::error::Result;
+use crate::tests::stateful::helpers::TestMetrics;
 
 #[cfg(feature = "rkv-safe-mode")]
 #[test]
 fn test_null_client() -> Result<()> {
     use crate::NimbusClient;
 
+    let metrics = TestMetrics::new();
     let _ = env_logger::try_init();
 
     let tmp_dir = tempfile::tempdir()?;
@@ -23,6 +25,7 @@ fn test_null_client() -> Result<()> {
         tmp_dir.path(),
         None,
         aru,
+        Box::new(metrics),
     )?;
     client.fetch_experiments()?;
     client.apply_pending_experiments()?;

--- a/components/nimbus/src/tests/stateful/helpers.rs
+++ b/components/nimbus/src/tests/stateful/helpers.rs
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+use crate::metrics::{EnrollmentStatusExtraDef, MetricsHandler};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// A Rust implementation of the MetricsHandler trait
+/// Used to test recording of Glean metrics across the FFI within Rust
+///
+/// *NOTE: Use this struct's `new` method when instantiating it to lock the Glean store*
+#[derive(Clone)]
+pub struct TestMetrics {
+    state: Arc<Mutex<HashMap<String, serde_json::Value>>>,
+}
+
+impl TestMetrics {
+    pub fn new() -> Self {
+        TestMetrics {
+            state: Default::default(),
+        }
+    }
+
+    pub fn assert_get_vec_value(&self, key: &str) -> serde_json::Value {
+        self.state.lock().unwrap().get(key).unwrap().clone()
+    }
+}
+
+impl MetricsHandler for TestMetrics {
+    fn record_enrollment_statuses(&self, enrollment_status_extras: Vec<EnrollmentStatusExtraDef>) {
+        let key = "enrollment_status";
+        let mut state = self.state.lock().unwrap();
+        let new = serde_json::to_value(enrollment_status_extras).unwrap();
+        match state.get(key) {
+            Some(v) => {
+                let new_value = v
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .chain(new.as_array().unwrap())
+                    .cloned()
+                    .collect::<Vec<serde_json::Value>>();
+                state.insert(key.into(), new_value.into());
+            }
+            None => {
+                state.insert(key.into(), new);
+            }
+        };
+    }
+}

--- a/components/nimbus/tests/test_fs_client.rs
+++ b/components/nimbus/tests/test_fs_client.rs
@@ -1,17 +1,19 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![cfg(feature = "rkv-safe-mode")]
 
 // Simple tests for our file-system client
 
-#[cfg(feature = "rkv-safe-mode")]
 use nimbus::error::Result;
+
+mod common;
 
 // This test crashes lmdb for reasons that make no sense, so only run it
 // in the "safe mode" backend.
-#[cfg(feature = "rkv-safe-mode")]
 #[test]
 fn test_simple() -> Result<()> {
+    use common::NoopMetricsHandler;
     use nimbus::{NimbusClient, RemoteSettingsConfig};
     use std::path::PathBuf;
     use url::Url;
@@ -37,6 +39,7 @@ fn test_simple() -> Result<()> {
         tmp_dir.path(),
         Some(config),
         aru,
+        Box::new(NoopMetricsHandler),
     )?;
     client.fetch_experiments()?;
     client.apply_pending_experiments()?;

--- a/components/nimbus/tests/test_get_experiment_branch_by_id.rs
+++ b/components/nimbus/tests/test_get_experiment_branch_by_id.rs
@@ -1,10 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![cfg(feature = "rkv-safe-mode")]
 
 // Testing get_experiment_branch semantics.
 
-#[cfg(feature = "rkv-safe-mode")]
 mod common;
 
 #[allow(unused_imports)]
@@ -12,7 +12,6 @@ mod common;
 #[macro_use]
 use nimbus::error::Result;
 
-#[cfg(feature = "rkv-safe-mode")]
 #[test]
 fn test_before_open() -> Result<()> {
     use nimbus::error::NimbusError;
@@ -29,7 +28,6 @@ fn test_before_open() -> Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "rkv-safe-mode")]
 #[test]
 fn test_enrolled() -> Result<()> {
     let _ = env_logger::try_init();

--- a/components/nimbus/tests/test_message_helpers.rs
+++ b/components/nimbus/tests/test_message_helpers.rs
@@ -1,10 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![cfg(feature = "rkv-safe-mode")]
 
 // Testing get_experiment_branch semantics.
 
-#[cfg(feature = "rkv-safe-mode")]
 mod common;
 
 #[allow(unused_imports)]
@@ -12,7 +12,6 @@ mod common;
 #[macro_use]
 use nimbus::error::Result;
 
-#[cfg(feature = "rkv-safe-mode")]
 #[cfg(test)]
 mod message_tests {
 

--- a/components/nimbus/tests/test_restart.rs
+++ b/components/nimbus/tests/test_restart.rs
@@ -1,11 +1,10 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![cfg(feature = "rkv-safe-mode")]
 
-#[cfg(feature = "rkv-safe-mode")]
 mod common;
 
-#[cfg(feature = "rkv-safe-mode")]
 #[cfg(test)]
 mod test {
 

--- a/components/nimbus/tests/test_updates.rs
+++ b/components/nimbus/tests/test_updates.rs
@@ -1,15 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+#![cfg(feature = "rkv-safe-mode")]
 
 // Testing the two phase updates.
 // This test crashes lmdb for reasons that make no sense, so only run it
 // in the "safe mode" backend.
 
-#[cfg(feature = "rkv-safe-mode")]
 mod common;
 
-#[cfg(feature = "rkv-safe-mode")]
 #[cfg(test)]
 mod test {
     use super::common::{

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
@@ -467,6 +467,26 @@ class NimbusTests: XCTestCase {
         XCTAssertTrue(try helper.evalJexl(expression: "is_test"))
         XCTAssertFalse(try helper.evalJexl(expression: "is_first_run"))
     }
+
+    func testNimbusRecordsEnrollmentStatusMetrics() throws {
+        let appSettings = NimbusAppSettings(appName: "test", channel: "nightly")
+        let nimbus = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath()) as! Nimbus
+
+        try nimbus.setExperimentsLocallyOnThisThread(minimalExperimentJSON())
+        try nimbus.applyPendingExperimentsOnThisThread()
+
+        XCTAssertNotNil(GleanMetrics.NimbusEvents.enrollmentStatus.testGetValue(), "EnrollmentStatus event must exist")
+        let enrollmentStatusEvents = GleanMetrics.NimbusEvents.enrollmentStatus.testGetValue()!
+        XCTAssertEqual(enrollmentStatusEvents.count, 1, "event count must match")
+
+        let enrolledExtra = enrollmentStatusEvents[0].extra!
+        XCTAssertNotEqual(nil, enrolledExtra["branch"], "branch must not be nil")
+        XCTAssertEqual("secure-gold", enrolledExtra["slug"], "slug must match")
+        XCTAssertEqual("Enrolled", enrolledExtra["status"], "status must match")
+        XCTAssertEqual("Qualified", enrolledExtra["reason"], "reason must match")
+        XCTAssertEqual(nil, enrolledExtra["error_string"], "errorString must match")
+        XCTAssertEqual(nil, enrolledExtra["conflict_slug"], "conflictSlug must match")
+    }
 }
 
 private extension Device {


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/EXP-3827

This PR does a number of things, collectively a part of the above ticket.

* Define and records the enrollment_status glean metric
* Add testing for enrollment_status metric
* Create callback handler for host metrics
* Update iOS/Kotlin SDKs to define/use/supply the callback handler

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
