### PR TITLE
Fix rust log forwarder bindings for Focus iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🦊 What's Changed 🦊
 - Exposed rust-log-forwarder for iOS ([#5840](https://github.com/mozilla/application-services/pull/5840)).
+- Fixed rust-log-forwarder bindings for Focus iOS ([5858](https://github.com/mozilla/application-services/pull/5858)).
 
 # v119.0 (_2023-09-25_)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "nimbus-sdk",
  "rc_log_ffi",
  "remote_settings",
+ "rust-log-forwarder",
  "viaduct",
  "viaduct-reqwest",
 ]

--- a/megazords/ios-rust/focus/Cargo.toml
+++ b/megazords/ios-rust/focus/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 rc_log_ffi = { path = "../../../components/rc_log" }
+rust-log-forwarder = { path = "../../../components/support/rust-log-forwarder" }
 viaduct = { path = "../../../components/viaduct" }
 viaduct-reqwest = { path = "../../../components/support/viaduct-reqwest" }
 nimbus-sdk = { path = "../../../components/nimbus" }

--- a/megazords/ios-rust/focus/MozillaRustComponents.h
+++ b/megazords/ios-rust/focus/MozillaRustComponents.h
@@ -10,3 +10,4 @@
 #import "nimbusFFI.h"
 #import "errorFFI.h"
 #import "remote_settingsFFI.h"
+#import "rustlogforwarderFFI.h"

--- a/megazords/ios-rust/focus/src/lib.rs
+++ b/megazords/ios-rust/focus/src/lib.rs
@@ -9,4 +9,5 @@ pub use error_support;
 pub use nimbus;
 pub use rc_log_ffi;
 pub use remote_settings;
+pub use rust_log_forwarder;
 pub use viaduct_reqwest;


### PR DESCRIPTION
Fixing issue building the rust log forwarder component for Focus iOS introduced in #5840. This should resolve the error in [Focus iOS PR #3875](https://github.com/mozilla-mobile/focus-ios/pull/3875),

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
