### PR TITLE
Add `pref-key` to FML feature variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
   - This adds methods to get the feature_ids and descriptions from a loaded manifest.
 - Added a `channels` subcommmand to the command line ([#5844](https://github.com/mozilla/application-services/pull/5844)).
   - This prints the channels for the given manifest.
+- Added `pref-key` to feature variables schema definition ([#5862](https://github.com/mozilla/application-services/pull/5862)).
+  - This allows developers to override remote and default values of top-level variables with preferences.
+  - Requires setting `userDefaults` and `sharedPreferences` in the call to `NimbusBuilder`.
 
 ### 🦊 What's Changed 🦊
 

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeaturesInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/FeaturesInterface.kt
@@ -5,6 +5,7 @@
 package org.mozilla.experiments.nimbus
 
 import android.content.Context
+import android.content.SharedPreferences
 
 /**
  * Small interface to get the feature variables out of the Nimbus SDK.
@@ -14,6 +15,9 @@ import android.content.Context
 interface FeaturesInterface {
 
     val context: Context
+
+    val prefs: SharedPreferences?
+        get() = null
 
     /**
      * Get the variables needed to configure the feature given by `featureId`.

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -7,6 +7,7 @@
 package org.mozilla.experiments.nimbus
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -58,6 +59,7 @@ data class NimbusServerSettings(
 @Suppress("LargeClass", "LongParameterList")
 open class Nimbus(
     override val context: Context,
+    override val prefs: SharedPreferences? = null,
     appInfo: NimbusAppInfo,
     coenrollingFeatureIds: List<String>,
     server: NimbusServerSettings?,

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusBuilder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusBuilder.kt
@@ -5,6 +5,7 @@
 package org.mozilla.experiments.nimbus
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.net.Uri
 import androidx.annotation.RawRes
 import kotlinx.coroutines.runBlocking
@@ -82,6 +83,11 @@ abstract class AbstractNimbusBuilder<T : NimbusInterface>(val context: Context) 
      * The `object` generated from the `nimbus.fml.yaml` file and the nimbus-gradle-plugin.
      */
     var featureManifest: FeatureManifestInterface<*>? = null
+
+    /**
+     * The shared preferences used to configure the app.
+     */
+    var sharedPreferences: SharedPreferences? = null
 
     /**
      * Build a [Nimbus] singleton for the given [NimbusAppInfo]. Instances built with this method
@@ -210,6 +216,7 @@ class DefaultNimbusBuilder(context: Context) : AbstractNimbusBuilder<NimbusInter
         Nimbus(
             context,
             appInfo = appInfo,
+            prefs = sharedPreferences,
             coenrollingFeatureIds = getCoenrollingFeatureIds(),
             server = serverSettings,
             deviceInfo = createDeviceInfo(),

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
@@ -4,6 +4,7 @@
 
 package org.mozilla.experiments.nimbus.internal
 
+import android.content.SharedPreferences
 import org.json.JSONObject
 import org.mozilla.experiments.nimbus.FeaturesInterface
 import org.mozilla.experiments.nimbus.HardcodedNimbusFeatures
@@ -22,7 +23,7 @@ import java.util.concurrent.locks.ReentrantLock
 class FeatureHolder<T : FMLFeatureInterface>(
     private var getSdk: () -> FeaturesInterface?,
     private val featureId: String,
-    private var create: (Variables) -> T,
+    private var create: (Variables, SharedPreferences?) -> T,
 ) {
     private val lock = ReentrantLock()
 
@@ -48,7 +49,8 @@ class FeatureHolder<T : FMLFeatureInterface>(
                 val variables = getSdk()?.getVariables(featureId, false) ?: run {
                     NullVariables.instance
                 }
-                create(variables).also { value ->
+                val prefs = getSdk()?.prefs
+                create(variables, prefs).also { value ->
                     cachedValue = value
                 }
             }
@@ -108,7 +110,7 @@ class FeatureHolder<T : FMLFeatureInterface>(
      *
      * This is most likely useful during testing and other generated code.
      */
-    fun withInitializer(create: (Variables) -> T) {
+    fun withInitializer(create: (Variables, SharedPreferences?) -> T) {
         lock.runBlock {
             this.create = create
             this.cachedValue = null

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/internal/FeatureHolder.kt
@@ -61,7 +61,9 @@ class FeatureHolder<T : FMLFeatureInterface>(
      * their behavior because of it.
      */
     fun recordExposure() {
-        getSdk()?.recordExposureEvent(featureId)
+        if (!value().isModified()) {
+            getSdk()?.recordExposureEvent(featureId)
+        }
     }
 
     /**
@@ -74,7 +76,9 @@ class FeatureHolder<T : FMLFeatureInterface>(
      * [recordExposure] instead.
      */
     fun recordExperimentExposure(slug: String) {
-        getSdk()?.recordExposureEvent(featureId, slug)
+        if (!value().isModified()) {
+            getSdk()?.recordExposureEvent(featureId, slug)
+        }
     }
 
     /**
@@ -172,8 +176,14 @@ interface FMLObjectInterface {
  *
  * App developers should use the generated concrete classes, which
  * implement this interface.
- *
- * This interface is really only here to allow bridging between Kotlin
- * and other languages.
  */
-interface FMLFeatureInterface : FMLObjectInterface
+interface FMLFeatureInterface : FMLObjectInterface {
+    /**
+     * A test if the feature configuration has been modified somehow, invalidating any experiment
+     * that uses it.
+     *
+     * This may be `true` if a `pref-key` has been set in the feature manifest and the user has
+     * set that preference.
+     */
+    fun isModified(): Boolean = false
+}

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/util/TestNimbusBuilder.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/util/TestNimbusBuilder.kt
@@ -19,7 +19,16 @@ class TestNimbusBuilder(context: Context) : AbstractNimbusBuilder<NimbusInterfac
         appInfo: NimbusAppInfo,
         serverSettings: NimbusServerSettings?,
     ): NimbusInterface =
-        Nimbus(context, appInfo, listOf(), serverSettings, NimbusDeviceInfo("en-US"), null, NimbusDelegate.default())
+        Nimbus(
+            context = context,
+            prefs = sharedPreferences,
+            appInfo = appInfo,
+            coenrollingFeatureIds = listOf(),
+            server = serverSettings,
+            deviceInfo = NimbusDeviceInfo("en-US"),
+            observer = null,
+            delegate = NimbusDelegate.default(),
+        )
 
     override fun newNimbusDisabled(): NimbusInterface =
         uninitialized()

--- a/components/nimbus/ios/Nimbus/FeatureHolder.swift
+++ b/components/nimbus/ios/Nimbus/FeatureHolder.swift
@@ -19,11 +19,11 @@ public class FeatureHolder<T> {
     private var getSdk: GetSdk
     private let featureId: String
 
-    private var create: (Variables) -> T
+    private var create: (Variables, UserDefaults?) -> T
 
     public init(_ getSdk: @escaping () -> FeaturesInterface?,
                 featureId: String,
-                with create: @escaping (Variables) -> T)
+                with create: @escaping (Variables, UserDefaults?) -> T)
     {
         self.getSdk = getSdk
         self.featureId = featureId
@@ -43,10 +43,12 @@ public class FeatureHolder<T> {
             return v
         }
         var variables: Variables = NilVariables.instance
+        var defaults: UserDefaults?
         if let sdk = getSdk() {
             variables = sdk.getVariables(featureId: featureId, sendExposureEvent: false)
+            defaults = sdk.userDefaults
         }
-        let v = create(variables)
+        let v = create(variables, defaults)
         cachedValue = v
         return v
     }
@@ -121,7 +123,7 @@ public class FeatureHolder<T> {
     /// This changes the mapping between a `Variables` and the feature configuration object.
     ///
     /// This is most likely useful during testing and other generated code.
-    public func with(initializer: @escaping (Variables) -> T) {
+    public func with(initializer: @escaping (Variables, UserDefaults?) -> T) {
         lock.lock()
         defer { self.lock.unlock() }
         cachedValue = nil

--- a/components/nimbus/ios/Nimbus/FeatureInterface.swift
+++ b/components/nimbus/ios/Nimbus/FeatureInterface.swift
@@ -7,6 +7,8 @@ import Foundation
 ///
 /// This is intended to be standalone to allow for testing the Nimbus FML.
 public protocol FeaturesInterface: AnyObject {
+    var userDefaults: UserDefaults? { get }
+
     /// Get the variables needed to configure the feature given by `featureId`.
     ///
     /// - Parameters:
@@ -55,4 +57,12 @@ public protocol FeaturesInterface: AnyObject {
     /// - Parameter partId string representing the card id or message id of the part of the feature that
     ///     is malformed, providing more detail to experiment owners of where to look for the problem.
     func recordMalformedConfiguration(featureId: String, with partId: String)
+}
+
+public extension FeaturesInterface {
+    var userDefaults: UserDefaults? {
+        get {
+            nil
+        }
+    }
 }

--- a/components/nimbus/ios/Nimbus/FeatureInterface.swift
+++ b/components/nimbus/ios/Nimbus/FeatureInterface.swift
@@ -61,8 +61,6 @@ public protocol FeaturesInterface: AnyObject {
 
 public extension FeaturesInterface {
     var userDefaults: UserDefaults? {
-        get {
-            nil
-        }
+        nil
     }
 }

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -36,7 +36,7 @@ public class Nimbus: NimbusInterface {
         self.errorReporter = errorReporter
         self.nimbusClient = nimbusClient
         self.resourceBundles = resourceBundles
-        self._userDefaults = userDefaults
+        _userDefaults = userDefaults
         NilVariables.instance.set(bundles: resourceBundles)
     }
 }
@@ -107,9 +107,7 @@ extension Nimbus: NimbusEventStore {
 
 extension Nimbus: FeaturesInterface {
     public var userDefaults: UserDefaults? {
-        get {
-            _userDefaults
-        }
+        _userDefaults
     }
 
     public func recordExposureEvent(featureId: String, experimentSlug: String? = nil) {

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -6,6 +6,8 @@ import Foundation
 import Glean
 
 public class Nimbus: NimbusInterface {
+    private let _userDefaults: UserDefaults?
+
     private let nimbusClient: NimbusClientProtocol
 
     private let resourceBundles: [Bundle]
@@ -28,11 +30,13 @@ public class Nimbus: NimbusInterface {
 
     init(nimbusClient: NimbusClientProtocol,
          resourceBundles: [Bundle],
+         userDefaults: UserDefaults?,
          errorReporter: @escaping NimbusErrorReporter)
     {
         self.errorReporter = errorReporter
         self.nimbusClient = nimbusClient
         self.resourceBundles = resourceBundles
+        self._userDefaults = userDefaults
         NilVariables.instance.set(bundles: resourceBundles)
     }
 }
@@ -102,6 +106,12 @@ extension Nimbus: NimbusEventStore {
 }
 
 extension Nimbus: FeaturesInterface {
+    public var userDefaults: UserDefaults? {
+        get {
+            _userDefaults
+        }
+    }
+
     public func recordExposureEvent(featureId: String, experimentSlug: String? = nil) {
         if let experimentSlug = experimentSlug {
             recordExposureFromExperiment(featureId: featureId, experimentSlug: experimentSlug)

--- a/components/nimbus/ios/Nimbus/NimbusBuilder.swift
+++ b/components/nimbus/ios/Nimbus/NimbusBuilder.swift
@@ -151,7 +151,7 @@ public class NimbusBuilder {
         return self
     }
 
-    var userDefaults: UserDefaults = UserDefaults.standard
+    var userDefaults = UserDefaults.standard
 
     /**
      * The command line arguments for the app. This is useful for QA, and can be safely left in the app in production.

--- a/components/nimbus/ios/Nimbus/NimbusBuilder.swift
+++ b/components/nimbus/ios/Nimbus/NimbusBuilder.swift
@@ -132,7 +132,7 @@ public class NimbusBuilder {
     var resourceBundles: [Bundle] = [.main]
 
     /**
-     * The object generated from the `nimbus.fml.yaml` file and the nimbus-gradle-plugin.
+     * The object generated from the `nimbus.fml.yaml` file.
      */
     @discardableResult
     public func with(featureManifest: FeatureManifestInterface) -> NimbusBuilder {
@@ -141,6 +141,17 @@ public class NimbusBuilder {
     }
 
     var featureManifest: FeatureManifestInterface?
+
+    /**
+     * Main user defaults for the app.
+     */
+    @discardableResult
+    public func with(userDefaults: UserDefaults) -> NimbusBuilder {
+        self.userDefaults = userDefaults
+        return self
+    }
+
+    var userDefaults: UserDefaults = UserDefaults.standard
 
     /**
      * The command line arguments for the app. This is useful for QA, and can be safely left in the app in production.
@@ -240,6 +251,7 @@ public class NimbusBuilder {
                           coenrollingFeatureIds: getCoenrollingFeatureIds(),
                           dbPath: dbFilePath,
                           resourceBundles: resourceBundles,
+                          userDefaults: userDefaults,
                           errorReporter: errorReporter)
     }
 

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -38,6 +38,7 @@ public extension Nimbus {
         dbPath: String,
         resourceBundles: [Bundle] = [Bundle.main],
         enabled: Bool = true,
+        userDefaults: UserDefaults? = nil,
         errorReporter: @escaping NimbusErrorReporter = defaultErrorReporter
     ) throws -> NimbusInterface {
         guard enabled else {
@@ -66,7 +67,7 @@ public extension Nimbus {
             )
         )
 
-        return Nimbus(nimbusClient: nimbusClient, resourceBundles: resourceBundles, errorReporter: errorReporter)
+        return Nimbus(nimbusClient: nimbusClient, resourceBundles: resourceBundles, userDefaults: userDefaults, errorReporter: errorReporter)
     }
 
     static func buildExperimentContext(

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -67,7 +67,12 @@ public extension Nimbus {
             )
         )
 
-        return Nimbus(nimbusClient: nimbusClient, resourceBundles: resourceBundles, userDefaults: userDefaults, errorReporter: errorReporter)
+        return Nimbus(
+            nimbusClient: nimbusClient,
+            resourceBundles: resourceBundles,
+            userDefaults: userDefaults,
+            errorReporter: errorReporter
+        )
     }
 
     static func buildExperimentContext(

--- a/components/support/nimbus-fml/fixtures/android/runtime/Context.kt
+++ b/components/support/nimbus-fml/fixtures/android/runtime/Context.kt
@@ -36,10 +36,19 @@ object Resources {
     fun getResourceName(resId: Int) = "res:$resId"
 }
 
-@Suppress("UNUSED_PARAMETER", "PACKAGE_OR_CLASSIFIER_REDECLARATION", "FunctionOnlyReturningConstant")
+@Suppress("PACKAGE_OR_CLASSIFIER_REDECLARATION")
 class SharedPreferences {
-    fun contains(key: String): Boolean = false
-    fun getBoolean(key: String, def: Boolean): Boolean = def
-    fun getString(key: String, def: String): String = def
-    fun getInt(key: String, def: Int): Int = def
+    // Minimal interface used by generated code.
+    fun contains(key: String): Boolean = map.containsKey(key)
+    fun getBoolean(key: String, def: Boolean): Boolean = (map[key] as? Boolean) ?: def
+    fun getString(key: String, def: String): String = (map[key] as? String) ?: def
+    fun getInt(key: String, def: Int): Int = (map[key] as? Int) ?: def
+
+    // For testing
+    val map = mutableMapOf<String, Any>()
+    fun put(key: String, value: Boolean) = map.put(key, value)
+    fun put(key: String, value: String) = map.put(key, value)
+    fun put(key: String, value: Int) = map.put(key, value)
+    fun clear() = map.clear()
+    fun remove(key: String) = map.remove(key)
 }

--- a/components/support/nimbus-fml/fixtures/android/runtime/Context.kt
+++ b/components/support/nimbus-fml/fixtures/android/runtime/Context.kt
@@ -35,3 +35,11 @@ object Resources {
 
     fun getResourceName(resId: Int) = "res:$resId"
 }
+
+@Suppress("UNUSED_PARAMETER", "PACKAGE_OR_CLASSIFIER_REDECLARATION", "FunctionOnlyReturningConstant")
+class SharedPreferences {
+    fun contains(key: String): Boolean = false
+    fun getBoolean(key: String, def: Boolean): Boolean = def
+    fun getString(key: String, def: String): String = def
+    fun getInt(key: String, def: Int): Int = def
+}

--- a/components/support/nimbus-fml/fixtures/fe/misc-features.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/misc-features.yaml
@@ -1,0 +1,28 @@
+---
+about:
+  description: A manifest that should round trip
+  android:
+    class: FooNimbus
+    package: com.example.nimbus
+  ios:
+    class: FooNimbus
+    module: App
+channels:
+  - debug
+features:
+  onboarding:
+    description: A feature containing a field with pref-key
+    variables:
+      enabled:
+        description: If true, enable new style onboarding.
+        type: Boolean
+        pref-key: enrollment_enabled
+        default: false
+  messaging:
+    description: A feature allowing coenrollment
+    allow-coenrollment: true
+    variables:
+      enabled:
+        description: If true, enable this feature
+        type: Boolean
+        default: false

--- a/components/support/nimbus-fml/fixtures/fe/pref_overrides.fml.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/pref_overrides.fml.yaml
@@ -4,6 +4,9 @@ about:
   kotlin:
     class: .AppConfig
     package: com.example.nimbus
+  swift:
+    class: AppConfig
+    module: App
 channels:
   - debug
 features:
@@ -24,9 +27,9 @@ features:
         type: String
         description: A String
         pref-key: my-string-pref-key
-        default: manifest
+        default: from manifest
       my-text:
         type: Text
         description: A Text
         pref-key: my-text-pref-key
-        default: the manifest
+        default: from manifest

--- a/components/support/nimbus-fml/fixtures/fe/pref_overrides.fml.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/pref_overrides.fml.yaml
@@ -1,0 +1,32 @@
+---
+about:
+  description: A test for gating via preference
+  kotlin:
+    class: .AppConfig
+    package: com.example.nimbus
+channels:
+  - debug
+features:
+  my-feature:
+    description: A feature with preference overrides
+    variables:
+      my-boolean:
+        type: Boolean
+        description: A boolean
+        pref-key: my-boolean-pref-key
+        default: false
+      my-int:
+        type: Int
+        description: An Int
+        pref-key: my-int-pref-key
+        default: 0
+      my-string:
+        type: String
+        description: A String
+        pref-key: my-string-pref-key
+        default: manifest
+      my-text:
+        type: Text
+        description: A Text
+        pref-key: my-text-pref-key
+        default: the manifest

--- a/components/support/nimbus-fml/src/backends/frontend_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/frontend_manifest.rs
@@ -5,7 +5,8 @@
 use std::collections::BTreeMap;
 
 use crate::frontend::{
-    EnumBody, EnumVariantBody, FeatureBody, FieldBody, ManifestFrontEnd, ObjectBody, Types,
+    EnumBody, EnumVariantBody, FeatureBody, FeatureFieldBody, FieldBody, ManifestFrontEnd,
+    ObjectBody, Types,
 };
 use crate::intermediate_representation::{
     EnumDef, FeatureDef, FeatureManifest, ObjectDef, PropDef, VariantDef,
@@ -116,6 +117,15 @@ impl From<PropDef> for FieldBody {
             description: value.doc,
             variable_type: value.typ.to_string(),
             default: Some(value.default),
+        }
+    }
+}
+
+impl From<PropDef> for FeatureFieldBody {
+    fn from(value: PropDef) -> Self {
+        Self {
+            pref_key: value.pref_key.clone(),
+            field: value.into(),
         }
     }
 }

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/bundled.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/bundled.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 
 use super::common::{code_type, quoted};
 use crate::backends::{CodeOracle, CodeType, LiteralRenderer, TypeIdentifier, VariablesType};
-use crate::intermediate_representation::Literal;
+use crate::intermediate_representation::{Literal, TypeRef};
 use heck::SnakeCase;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -84,6 +84,16 @@ impl CodeType for TextCodeType {
             }
             _ => unreachable!("Expecting a string"),
         }
+    }
+
+    fn preference_getter(
+        &self,
+        oracle: &dyn CodeOracle,
+        prefs: &dyn Display,
+        pref_key: &dyn Display,
+    ) -> Option<String> {
+        let ct = oracle.find(&TypeRef::String);
+        ct.preference_getter(oracle, prefs, pref_key)
     }
 
     fn is_resource_id(&self, literal: &Literal) -> bool {

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/filters.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/filters.rs
@@ -41,6 +41,20 @@ pub fn property(
     Ok(ct.property_getter(oracle, &vars, &prop, &default))
 }
 
+pub fn preference_getter(
+    type_: impl Borrow<TypeIdentifier>,
+    prefs: impl fmt::Display,
+    pref_key: impl fmt::Display,
+) -> Result<String, askama::Error> {
+    let oracle = &ConcreteCodeOracle;
+    let ct = oracle.find(type_.borrow());
+    if let Some(getter) = ct.preference_getter(oracle, &prefs, &pref_key) {
+        Ok(getter)
+    } else {
+        unreachable!("The preference for type {} isn't available. This is a bug in Nimbus FML Kotlin generator", type_.borrow());
+    }
+}
+
 pub fn to_json(
     prop: impl fmt::Display,
     type_: impl Borrow<TypeIdentifier>,

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
@@ -118,6 +118,7 @@ impl<'a> FeatureManifestDeclaration<'a> {
                 "org.mozilla.experiments.nimbus.internal.FeatureManifestInterface".to_string(),
                 "org.mozilla.experiments.nimbus.FeaturesInterface".to_string(),
                 "org.json.JSONObject".to_string(),
+                "android.content.SharedPreferences".to_string(),
             ])
             .filter(|i| i != &my_package)
             .collect::<HashSet<String>>()

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/primitives.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/primitives.rs
@@ -66,6 +66,15 @@ impl CodeType for BooleanCodeType {
             _ => unreachable!("Expecting a boolean"),
         }
     }
+
+    fn preference_getter(
+        &self,
+        _oracle: &dyn CodeOracle,
+        prefs: &dyn Display,
+        pref_key: &dyn Display,
+    ) -> Option<String> {
+        Some(format!("{prefs}.getBoolean({}, false)", quoted(pref_key)))
+    }
 }
 
 pub(crate) struct IntCodeType;
@@ -121,6 +130,15 @@ impl CodeType for IntCodeType {
             }
             _ => unreachable!("Expecting a number"),
         }
+    }
+
+    fn preference_getter(
+        &self,
+        _oracle: &dyn CodeOracle,
+        prefs: &dyn Display,
+        pref_key: &dyn Display,
+    ) -> Option<String> {
+        Some(format!("{prefs}.getInt({}, 0)", quoted(pref_key)))
     }
 }
 
@@ -180,6 +198,15 @@ impl CodeType for StringCodeType {
             }
             _ => unreachable!("Expecting a string"),
         }
+    }
+
+    fn preference_getter(
+        &self,
+        _oracle: &dyn CodeOracle,
+        prefs: &dyn Display,
+        pref_key: &dyn Display,
+    ) -> Option<String> {
+        Some(format!("{prefs}.getString({}, \"\")", quoted(pref_key)))
     }
 }
 

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureManifestTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureManifestTemplate.kt
@@ -39,8 +39,8 @@ object {{ nimbus_object }} : FeatureManifestInterface<{{ nimbus_object }}.Featur
         {%- let class_name = raw_name|class_name %}
         {{ f.doc()|comment("        ") }}
         val {{raw_name|var_name}}: FeatureHolder<{{class_name}}> by lazy {
-            FeatureHolder({{ nimbus_object }}.getSdk, {{ raw_name|quoted }}) { variables ->
-                {{ class_name }}(variables)
+            FeatureHolder({{ nimbus_object }}.getSdk, {{ raw_name|quoted }}) { variables, prefs ->
+                {{ class_name }}(variables, prefs)
             }
         }
         {%- endfor %}

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureTemplate.kt
@@ -4,4 +4,17 @@
 {{ inner.doc()|comment("") }}
 public class {{ inner.name()|class_name }}  {% call kt::render_constructor() %} : FMLFeatureInterface {
     {% call kt::render_class_body(inner) %}
+
+    {%- if inner.has_prefs() %}
+    override fun isModified(): Boolean =
+        {% call kt::prefs() %}?.let { prefs ->
+            listOf(
+            {%- for p in inner.props() %}
+            {%- if p.has_prefs() %}
+                {{ p.pref_key().unwrap()|quoted }},
+            {%- endif %}
+            {%- endfor %}
+            ).any { prefs.contains(it) }
+        } ?: false
+    {%- endif %}
 }

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/ImportedModuleInitializationTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/ImportedModuleInitializationTemplate.kt
@@ -1,12 +1,14 @@
 {%- import "macros.kt" as kt %}
 {%- let variables = "variables" %}
+{%- let prefs = "prefs" %}
 {%- let context = "variables.context" %}
 {%- let class_name = self.inner.about().nimbus_object_name_kt() %}
         {{- class_name }}.features.apply {
             {%- for f in self.inner.features() %}
-            {{ f.name()|var_name }}.withInitializer { {{ variables }} ->
+            {{ f.name()|var_name }}.withInitializer { {{ variables }}: Variables, {{ prefs }}: SharedPreferences? ->
                 {{ f.name()|class_name }}(
-                    {{ variables }}, {%- for p in f.props() %}
+                    _variables = {{ variables }},
+                    _prefs = {{ prefs }}, {%- for p in f.props() %}
                     {{p.name()|var_name}} = {{ p.typ()|literal(self, p.default(), context) }}{% if !loop.last %},{% endif %}
                     {%- endfor %}
                 )

--- a/components/support/nimbus-fml/src/backends/mod.rs
+++ b/components/support/nimbus-fml/src/backends/mod.rs
@@ -145,6 +145,15 @@ pub trait CodeType {
         None
     }
 
+    fn preference_getter(
+        &self,
+        _oracle: &dyn CodeOracle,
+        _prefs: &dyn Display,
+        _pref_key: &dyn Display,
+    ) -> Option<String> {
+        None
+    }
+
     /// Call from the template
     fn as_json(&self, oracle: &dyn CodeOracle, prop: &dyn Display) -> String {
         self.as_json_transform(oracle, prop)

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
@@ -100,6 +100,7 @@ impl<'a> FeatureManifestDeclaration<'a> {
                     .flatten(),
             )
             .chain(as_module)
+            .chain(vec!["Foundation".to_string()])
             .filter(|i| i != my_module)
             .collect::<HashSet<String>>()
             .into_iter()

--- a/components/support/nimbus-fml/src/backends/swift/templates/FeatureManifestTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/FeatureManifestTemplate.swift
@@ -100,8 +100,8 @@ public class {{ features_object }} {
     {%- let class_name = raw_name|class_name %}
     {{ f.doc()|comment("        ") }}
     public lazy var {{raw_name|var_name}}: FeatureHolder<{{class_name}}> = {
-        FeatureHolder({{ nimbus_object }}.shared.getSdk, featureId: {{ raw_name|quoted }}) { (variables) in
-            {{ class_name }}(variables)
+        FeatureHolder({{ nimbus_object }}.shared.getSdk, featureId: {{ raw_name|quoted }}) { variables, prefs in
+            {{ class_name }}(variables, prefs)
         }
     }()
     {%- endfor %}

--- a/components/support/nimbus-fml/src/backends/swift/templates/FeatureTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/FeatureTemplate.swift
@@ -1,3 +1,28 @@
 {%- import "macros.swift" as swift %}
 {%- let inner = self.inner() %}
+{%- let class_name = inner.name()|class_name -%}
 {% call swift::render_class(inner) %}
+
+{%- if inner.has_prefs() %}
+
+extension {{ class_name }}: FMLFeatureInterface {
+    public func isModified() -> Bool {
+        guard let prefs = {% call swift::prefs() %} else {
+            return false
+        }
+        let keys = [
+            {%- for p in inner.props() %}
+            {%- if p.has_prefs() %}
+            {{ p.pref_key().unwrap()|quoted }},
+            {%- endif %}
+            {%- endfor %}
+        ]
+        if let _ = keys.first(where: { prefs.object(forKey: $0) != nil }) {
+            return true
+        }
+        return false
+    }
+}
+{%- else %}
+extension {{ class_name }}: FMLFeatureInterface {}
+{%- endif %}

--- a/components/support/nimbus-fml/src/backends/swift/templates/ImportedModuleInitializationTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/ImportedModuleInitializationTemplate.swift
@@ -1,11 +1,14 @@
-{% import "macros.swift" as swift %}
+{%- import "macros.swift" as swift %}
 {%- let variables = "variables" %}
+{%- let prefs = "prefs" %}
 {%- let context = "" %}
 {%- let class_name = self.inner.about().nimbus_object_name_swift() %}
         {%- for f in self.inner.features() %}
-        {{ class_name }}.shared.features.{{ f.name()|var_name }}.with(initializer: { {{ variables }} in
+        {{ class_name }}.shared.features.{{ f.name()|var_name }}.with(initializer: { {{ variables }}, {{ prefs }} in
             {{ f.name()|class_name }}(
-                {{ variables }}, {%- for p in f.props() %}
+                {{ variables }},
+                {{ prefs }},
+                {%- for p in f.props() %}
                 {{p.name()|var_name}}: {{ p.typ()|literal(self, p.default(), context) }}{% if !loop.last %},{% endif %}
                 {%- endfor %}
             )

--- a/components/support/nimbus-fml/src/backends/swift/templates/ObjectTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/ObjectTemplate.swift
@@ -1,7 +1,7 @@
 {%- import "macros.swift" as swift %}
 {%- let inner = self.inner() %}
 {% call swift::render_class(inner) -%}
-{% let class_name = inner.name()|class_name -%}
+{%- let class_name = inner.name()|class_name %}
 
 public extension {{class_name}} {
     func _mergeWith(_ defaults: {{class_name}}?) -> {{class_name}} {

--- a/components/support/nimbus-fml/src/backends/swift/templates/ObjectTemplate.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/ObjectTemplate.swift
@@ -8,7 +8,7 @@ public extension {{class_name}} {
         guard let defaults = defaults else {
             return self
         }
-        return {{class_name}}(variables: self._variables, defaults: defaults._defaults)
+        return {{class_name}}(variables: self._variables, prefs: self._prefs, defaults: defaults._defaults)
     }
 
     static func create(_ variables: Variables?) -> {{class_name}} {

--- a/components/support/nimbus-fml/src/backends/swift/templates/macros.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/macros.swift
@@ -8,7 +8,7 @@
     and rendering literals for Objects.
 -#}
 
-{% macro render_class(inner) %}
+{%- macro render_class(inner) %}
 {%- let raw_name = inner.name() %}
 {% let class_name = inner.name()|class_name -%}
 
@@ -16,9 +16,11 @@
 public class {{class_name}} {
     private let _variables: Variables
     private let _defaults: Defaults
-    private init(variables: Variables = NilVariables.instance, defaults: Defaults) {
+    private let _prefs: UserDefaults?
+    private init(variables: Variables = NilVariables.instance, prefs: UserDefaults? = nil, defaults: Defaults) {
         self._variables = variables
         self._defaults = defaults
+        self._prefs = prefs
     }
     {# The struct holds the default values that come from the manifest. They should completely
     specify all values needed for the  feature #}
@@ -32,12 +34,14 @@ public class {{class_name}} {
     {#- A constructor for application tests to use.  #}
 
     public convenience init(
-        _ _variables: Variables = NilVariables.instance, {% for p in inner.props() %}
+        _ _variables: Variables = NilVariables.instance,
+        _ _prefs: UserDefaults? = nil,
+        {%- for p in inner.props() %}
         {%- let t = p.typ() %}
         {{p.name()|var_name}}: {{ t|defaults_type_label }} = {{ t|literal(self, p.default(), "") }}{% if !loop.last %},{% endif %}
     {%- endfor %}
     ) {
-        self.init(variables: _variables, defaults: Defaults({% for p in inner.props() %}
+        self.init(variables: _variables, prefs: _prefs, defaults: Defaults({% for p in inner.props() %}
             {{p.name()|var_name}}: {{p.name()|var_name}}{% if !loop.last %},{% endif %}
         {%- endfor %}))
     }

--- a/components/support/nimbus-fml/src/backends/swift/templates/macros.swift
+++ b/components/support/nimbus-fml/src/backends/swift/templates/macros.swift
@@ -13,7 +13,7 @@
 {% let class_name = inner.name()|class_name -%}
 
 {{ inner.doc()|comment("") }}
-public class {{class_name}} {
+public class {{class_name}}: FMLObjectInterface {
     private let _variables: Variables
     private let _defaults: Defaults
     private let _prefs: UserDefaults?
@@ -71,7 +71,7 @@ public class {{class_name}} {
 
             `has_prefs()` checks if the type can be got from UserDefaults.
             #}
-        if let {{ prefs }} = self._prefs,
+        if let {{ prefs }} = {% call prefs() %},
             let {{ prop_swift }} = {{ prefs }}.object(forKey: {{ key|quoted }}) as? {{ type_swift }} {
             return {{ prop_swift }}
         }
@@ -81,4 +81,6 @@ public class {{class_name}} {
     {% endfor %}
 }
 
-{% endmacro %}}
+{%- endmacro %}}
+
+{% macro prefs() %}self._prefs{% endmacro %}

--- a/components/support/nimbus-fml/src/client/mod.rs
+++ b/components/support/nimbus-fml/src/client/mod.rs
@@ -185,12 +185,11 @@ mod unit_tests {
             vec![],
             vec![FeatureDef {
                 name: "feature_i".into(),
-                props: vec![PropDef {
-                    name: "prop_i_1".into(),
-                    typ: TypeRef::String,
-                    default: Value::String("prop_i_1_value".into()),
-                    doc: "".into(),
-                }],
+                props: vec![PropDef::new(
+                    "prop_i_1",
+                    TypeRef::String,
+                    Value::String("prop_i_1_value".into()),
+                )],
                 doc: "feature_i description".to_string(),
                 ..Default::default()
             }],
@@ -202,12 +201,11 @@ mod unit_tests {
             vec![],
             vec![FeatureDef {
                 name: "feature".into(),
-                props: vec![PropDef {
-                    name: "prop_1".into(),
-                    typ: TypeRef::String,
-                    default: Value::String("prop_1_value".into()),
-                    doc: "".into(),
-                }],
+                props: vec![PropDef::new(
+                    "prop_1",
+                    TypeRef::String,
+                    Value::String("prop_1_value".into()),
+                )],
                 doc: "feature description".to_string(),
                 allow_coenrollment: true,
             }],

--- a/components/support/nimbus-fml/src/command_line/workflows.rs
+++ b/components/support/nimbus-fml/src/command_line/workflows.rs
@@ -989,9 +989,18 @@ mod test {
     }
 
     #[test]
-    fn test_with_preference_overrides() -> Result<()> {
+    fn test_with_preference_overrides_kt() -> Result<()> {
         generate_multiple_and_assert(
             "test/pref_overrides.kts",
+            &[("fixtures/fe/pref_overrides.fml.yaml", "debug")],
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_preference_overrides_swift() -> Result<()> {
+        generate_multiple_and_assert(
+            "test/pref_overrides.swift",
             &[("fixtures/fe/pref_overrides.fml.yaml", "debug")],
         )?;
         Ok(())

--- a/components/support/nimbus-fml/src/command_line/workflows.rs
+++ b/components/support/nimbus-fml/src/command_line/workflows.rs
@@ -987,4 +987,13 @@ mod test {
         )?;
         Ok(())
     }
+
+    #[test]
+    fn test_with_preference_overrides() -> Result<()> {
+        generate_multiple_and_assert(
+            "test/pref_overrides.kts",
+            &[("fixtures/fe/pref_overrides.fml.yaml", "debug")],
+        )?;
+        Ok(())
+    }
 }

--- a/components/support/nimbus-fml/src/command_line/workflows.rs
+++ b/components/support/nimbus-fml/src/command_line/workflows.rs
@@ -959,6 +959,8 @@ mod test {
         test_single_merged_manifest_file("fixtures/fe/importing/diamond/00-app.yaml", "debug")?;
         test_single_merged_manifest_file("fixtures/fe/importing/diamond/01-lib.yaml", "debug")?;
         test_single_merged_manifest_file("fixtures/fe/importing/diamond/02-sublib.yaml", "debug")?;
+
+        test_single_merged_manifest_file("fixtures/fe/misc-features.yaml", "debug")?;
         Ok(())
     }
 

--- a/components/support/nimbus-fml/src/defaults_merger.rs
+++ b/components/support/nimbus-fml/src/defaults_merger.rs
@@ -1036,12 +1036,7 @@ mod unit_tests {
     #[test]
     fn test_merge_feature_default_overwrite_field_default_based_on_channel() -> Result<()> {
         let mut feature_def = FeatureDef {
-            props: vec![PropDef {
-                name: "button-color".into(),
-                default: json!("blue"),
-                doc: "".into(),
-                typ: TypeRef::String,
-            }],
+            props: vec![PropDef::new("button-color", TypeRef::String, json!("blue"))],
             ..Default::default()
         };
         let default_blocks = serde_json::from_value(json!([
@@ -1073,12 +1068,11 @@ mod unit_tests {
         merger.merge_feature_defaults(&mut feature_def, &default_blocks)?;
         assert_eq!(
             feature_def.props,
-            vec![PropDef {
-                name: "button-color".into(),
-                default: json!("dark-green"),
-                doc: "".into(),
-                typ: TypeRef::String,
-            }]
+            vec![PropDef::new(
+                "button-color",
+                TypeRef::String,
+                json!("dark-green"),
+            )]
         );
         Ok(())
     }
@@ -1087,12 +1081,7 @@ mod unit_tests {
     fn test_merge_feature_default_field_default_not_overwritten_if_no_feature_default_for_channel(
     ) -> Result<()> {
         let mut feature_def = FeatureDef {
-            props: vec![PropDef {
-                name: "button-color".into(),
-                default: json!("blue"),
-                doc: "".into(),
-                typ: TypeRef::String,
-            }],
+            props: vec![PropDef::new("button-color", TypeRef::String, json!("blue"))],
             ..Default::default()
         };
         let default_blocks = serde_json::from_value(json!([{
@@ -1116,12 +1105,7 @@ mod unit_tests {
         merger.merge_feature_defaults(&mut feature_def, &default_blocks)?;
         assert_eq!(
             feature_def.props,
-            vec![PropDef {
-                name: "button-color".into(),
-                default: json!("blue"),
-                doc: "".into(),
-                typ: TypeRef::String,
-            }]
+            vec![PropDef::new("button-color", TypeRef::String, json!("blue"),)]
         );
         Ok(())
     }
@@ -1129,9 +1113,10 @@ mod unit_tests {
     #[test]
     fn test_merge_feature_default_overwrite_nested_field_default() -> Result<()> {
         let mut feature_def = FeatureDef {
-            props: vec![PropDef {
-                name: "Dialog".into(),
-                default: json!({
+            props: vec![PropDef::new(
+                "Dialog",
+                TypeRef::String,
+                json!({
                     "button-color": "blue",
                     "title": "hello",
                     "inner": {
@@ -1139,9 +1124,7 @@ mod unit_tests {
                         "other-field": "other-value"
                     }
                 }),
-                doc: "".into(),
-                typ: TypeRef::String,
-            }],
+            )],
 
             ..Default::default()
         };
@@ -1190,9 +1173,10 @@ mod unit_tests {
         merger.merge_feature_defaults(&mut feature_def, &default_blocks)?;
         assert_eq!(
             feature_def.props,
-            vec![PropDef {
-                name: "Dialog".into(),
-                default: json!({
+            vec![PropDef::new(
+                "Dialog",
+                TypeRef::String,
+                json!({
                         "button-color": "green",
                         "title": "hello",
                         "inner": {
@@ -1201,9 +1185,7 @@ mod unit_tests {
                             "new-field": "new-value"
                         }
                 }),
-                doc: "".into(),
-                typ: TypeRef::String,
-            }]
+            )]
         );
         Ok(())
     }
@@ -1212,12 +1194,7 @@ mod unit_tests {
     fn test_merge_feature_default_overwrite_field_default_based_on_channel_using_only_no_channel_default(
     ) -> Result<()> {
         let mut feature_def = FeatureDef {
-            props: vec![PropDef {
-                name: "button-color".into(),
-                default: json!("blue"),
-                doc: "".into(),
-                typ: TypeRef::String,
-            }],
+            props: vec![PropDef::new("button-color", TypeRef::String, json!("blue"))],
             ..Default::default()
         };
         let default_blocks = serde_json::from_value(json!([
@@ -1250,12 +1227,11 @@ mod unit_tests {
         merger.merge_feature_defaults(&mut feature_def, &default_blocks)?;
         assert_eq!(
             feature_def.props,
-            vec![PropDef {
-                name: "button-color".into(),
-                default: json!("dark-green"),
-                doc: "".into(),
-                typ: TypeRef::String,
-            }]
+            vec![PropDef::new(
+                "button-color",
+                TypeRef::String,
+                json!("dark-green"),
+            )]
         );
         Ok(())
     }
@@ -1264,12 +1240,7 @@ mod unit_tests {
     fn test_merge_feature_default_throw_error_if_property_not_found_on_feature() -> Result<()> {
         let mut feature_def = FeatureDef {
             name: "feature".into(),
-            props: vec![PropDef {
-                name: "button-color".into(),
-                default: json!("blue"),
-                doc: "".into(),
-                typ: TypeRef::String,
-            }],
+            props: vec![PropDef::new("button-color", TypeRef::String, json!("blue"))],
             ..Default::default()
         };
         let default_blocks = serde_json::from_value(json!([

--- a/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
@@ -31,21 +31,20 @@ pub(crate) fn get_simple_homescreen_feature() -> FeatureManifest {
             FeatureDef::new(
                 "homescreen",
                 "Represents the homescreen feature",
-                vec![PropDef {
-                    name: "sections-enabled".into(),
-                    doc: "A map of booleans".into(),
-                    typ: TypeRef::EnumMap(
+                vec![PropDef::new(
+                    "sections-enabled",
+                    TypeRef::EnumMap(
                         Box::new(TypeRef::Enum("HomeScreenSection".into())),
                         Box::new(TypeRef::Boolean),
                     ),
-                    default: json!({
+                    json!({
                         "top-sites": true,
                         "jump-back-in": false,
                         "recently-saved": false,
                         "recent-explorations": false,
                         "pocket": false,
                     }),
-                }],
+                )],
                 false,
             ),
         )]),

--- a/components/support/nimbus-fml/src/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/intermediate_representation.rs
@@ -824,6 +824,10 @@ impl FeatureDef {
 
         Value::Object(props)
     }
+
+    pub fn has_prefs(&self) -> bool {
+        self.props.iter().any(|p| p.has_prefs())
+    }
 }
 impl TypeFinder for FeatureDef {
     fn find_types(&self, types: &mut HashSet<TypeRef>) {

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -558,18 +558,18 @@ mod unit_tests {
         let obj_def = &ir.obj_defs["Button"];
         assert!(obj_def.name == *"Button");
         assert!(obj_def.doc == *"This is a button object");
-        assert!(obj_def.props.contains(&PropDef {
-            name: "label".to_string(),
-            doc: "This is the label for the button".to_string(),
-            typ: TypeRef::String,
-            default: serde_json::Value::String("REQUIRED FIELD".to_string()),
-        }));
-        assert!(obj_def.props.contains(&PropDef {
-            name: "color".to_string(),
-            doc: "This is the color of the button".to_string(),
-            typ: TypeRef::Option(Box::new(TypeRef::String)),
-            default: serde_json::Value::Null,
-        }));
+        assert!(obj_def.props.contains(&PropDef::new_with_doc(
+            "label",
+            "This is the label for the button",
+            TypeRef::String,
+            serde_json::Value::String("REQUIRED FIELD".to_string()),
+        )));
+        assert!(obj_def.props.contains(&PropDef::new_with_doc(
+            "color",
+            "This is the color of the button",
+            TypeRef::Option(Box::new(TypeRef::String)),
+            serde_json::Value::Null,
+        )));
 
         // Validate parsed features
         assert!(ir.feature_defs.len() == 1);

--- a/components/support/nimbus-fml/test/full_homescreen.kts
+++ b/components/support/nimbus-fml/test/full_homescreen.kts
@@ -20,7 +20,7 @@ val api = MockNimbus("homescreen" to """{
         "pocket": true
     }
 }""")
-val holder = FeatureHolder(getSdk = { api }, featureId = "homescreen") { Homescreen(it) }
+val holder = FeatureHolder(getSdk = { api }, featureId = "homescreen") { v, _ -> Homescreen(v) }
 val feature1 = holder.value()
 assert(feature1.sectionsEnabled[HomeScreenSection.TOP_SITES] == true)
 assert(feature1.sectionsEnabled[HomeScreenSection.JUMP_BACK_IN] == false)

--- a/components/support/nimbus-fml/test/pref_overrides.kts
+++ b/components/support/nimbus-fml/test/pref_overrides.kts
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import android.content.Context as MockContext
+import android.content.SharedPreferences as MockSharedPreferences
+
+import com.example.nimbus.AppConfig
+
+import org.mozilla.experiments.nimbus.HardcodedNimbusFeatures
+import org.mozilla.experiments.nimbus.FeaturesInterface
+
+import org.json.JSONObject
+
+class PrefNimbusFeatures(
+    override val prefs: MockSharedPreferences,
+    val nimbus: HardcodedNimbusFeatures,
+): FeaturesInterface {
+    override val context: MockContext = nimbus.context
+    override fun getVariables(featureId: String, recordExposureEvent: Boolean) =
+        nimbus.getVariables(featureId, recordExposureEvent)
+}
+
+val context = MockContext()
+val prefs = MockSharedPreferences()
+val nimbusFromRust = HardcodedNimbusFeatures(context,
+    "my-feature" to JSONObject(mapOf(
+        "my-boolean" to false,
+        "my-int" to 100,
+        "my-string" to "from json",
+        "my-text" to "from json"
+    ))
+)
+val nimbus = PrefNimbusFeatures(prefs, nimbusFromRust)
+
+AppConfig.initialize { nimbus }
+
+val feature = AppConfig.features.myFeature.value()
+
+assert(feature.myBoolean == false)
+assert(feature.myInt == 100)
+assert(feature.myString == "from json")
+assert(feature.myText == "from json")
+
+prefs.put("my-boolean-pref-key", true)
+prefs.put("my-int-pref-key", 42)
+prefs.put("my-string-pref-key", "from pref")
+prefs.put("my-text-pref-key", "from pref")
+
+assert(feature.myBoolean == true)
+assert(feature.myInt == 42)
+assert(feature.myString == "from pref")
+assert(feature.myText == "from pref")

--- a/components/support/nimbus-fml/test/pref_overrides.kts
+++ b/components/support/nimbus-fml/test/pref_overrides.kts
@@ -31,6 +31,17 @@ val nimbusFromRust = HardcodedNimbusFeatures(context,
         "my-text" to "from json"
     ))
 )
+
+// Before initialization with hardcoded, just get values from the manifest.
+val feature0 = AppConfig.features.myFeature.value()
+
+assert(feature0.myBoolean == false)
+assert(feature0.myInt == 0)
+assert(feature0.myString == "from manifest")
+assert(feature0.myText == "from manifest")
+assert(!feature0.isModified())
+
+
 val nimbus = PrefNimbusFeatures(prefs, nimbusFromRust)
 
 AppConfig.initialize { nimbus }
@@ -41,6 +52,7 @@ assert(feature.myBoolean == false)
 assert(feature.myInt == 100)
 assert(feature.myString == "from json")
 assert(feature.myText == "from json")
+assert(!feature.isModified())
 
 prefs.put("my-boolean-pref-key", true)
 prefs.put("my-int-pref-key", 42)
@@ -51,3 +63,4 @@ assert(feature.myBoolean == true)
 assert(feature.myInt == 42)
 assert(feature.myString == "from pref")
 assert(feature.myText == "from pref")
+assert(feature.isModified())

--- a/components/support/nimbus-fml/test/pref_overrides.swift
+++ b/components/support/nimbus-fml/test/pref_overrides.swift
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+import FeatureManifest
+import Foundation
+
+class PrefNimbusFeatures {
+    private let _userDefaults: UserDefaults
+    private let nimbus: HardcodedNimbusFeatures
+
+    init(_ prefs: UserDefaults, _ nimbus: HardcodedNimbusFeatures) {
+        self._userDefaults = prefs
+        self.nimbus = nimbus
+    }
+}
+
+extension PrefNimbusFeatures: FeaturesInterface {
+    public var userDefaults: UserDefaults? {
+        get {
+            _userDefaults
+        }
+    }
+
+    public func getVariables(featureId: String, sendExposureEvent: Bool) -> Variables {
+        return nimbus.getVariables(featureId: featureId, sendExposureEvent: sendExposureEvent)
+    }
+
+    public func recordExposureEvent(featureId: String, experimentSlug: String?) {
+        nimbus.recordExposureEvent(featureId: featureId, experimentSlug: experimentSlug)
+    }
+
+    public func recordMalformedConfiguration(featureId: String, with partId: String) {
+        nimbus.recordMalformedConfiguration(featureId: featureId, with: partId)
+    }
+}
+
+// Test the defaults still work.
+let feature0 = AppConfig.shared.features.myFeature.value()
+
+assert(feature0.myBoolean == false)
+assert(feature0.myInt == 0)
+assert(feature0.myString == "from manifest")
+assert(feature0.myText == "from manifest")
+
+// Now test that JSON still has an effect.
+let prefs = UserDefaults()
+prefs.removeObject(forKey: "my-boolean-pref-key")
+prefs.removeObject(forKey: "my-int-pref-key")
+prefs.removeObject(forKey: "my-string-pref-key")
+prefs.removeObject(forKey: "my-text-pref-key")
+
+let nimbusFromRust = HardcodedNimbusFeatures(with:
+    ["my-feature": [
+        "my-boolean": false,
+        "my-int": 100,
+        "my-string": "from json",
+        "my-text": "from json"
+    ]]
+)
+let nimbus = PrefNimbusFeatures(prefs, nimbusFromRust)
+AppConfig.shared.initialize { nimbus }
+
+let feature = AppConfig.shared.features.myFeature.value()
+
+assert(feature.myBoolean == false)
+assert(feature.myInt == 100)
+assert(feature.myString == "from json")
+assert(feature.myText == "from json")
+
+// Now set with prefs.
+
+prefs.set(true, forKey: "my-boolean-pref-key")
+prefs.set(42, forKey: "my-int-pref-key")
+prefs.set("from pref", forKey: "my-string-pref-key")
+prefs.set("from pref", forKey: "my-text-pref-key")
+
+assert(feature.myBoolean == true)
+assert(feature.myInt == 42)
+assert(feature.myString == "from pref")
+assert(feature.myText == "from pref")

--- a/components/support/nimbus-fml/test/pref_overrides.swift
+++ b/components/support/nimbus-fml/test/pref_overrides.swift
@@ -41,6 +41,7 @@ assert(feature0.myBoolean == false)
 assert(feature0.myInt == 0)
 assert(feature0.myString == "from manifest")
 assert(feature0.myText == "from manifest")
+assert(!feature0.isModified())
 
 // Now test that JSON still has an effect.
 let prefs = UserDefaults()
@@ -66,6 +67,7 @@ assert(feature.myBoolean == false)
 assert(feature.myInt == 100)
 assert(feature.myString == "from json")
 assert(feature.myText == "from json")
+assert(!feature.isModified())
 
 // Now set with prefs.
 
@@ -78,3 +80,4 @@ assert(feature.myBoolean == true)
 assert(feature.myInt == 42)
 assert(feature.myString == "from pref")
 assert(feature.myText == "from pref")
+assert(feature.isModified())

--- a/components/support/nimbus-fml/test/threadsafe_feature_holder.kts
+++ b/components/support/nimbus-fml/test/threadsafe_feature_holder.kts
@@ -20,7 +20,7 @@ class Feature(val string: String): FMLFeatureInterface {
         JSONObject(mapOf("string" to string))
 }
 
-val holder = FeatureHolder<Feature>({ api }, featureId = "test-feature-holder") { Feature("NO CRASH") }
+val holder = FeatureHolder<Feature>({ api }, featureId = "test-feature-holder") { v, p -> Feature("NO CRASH") }
 
 repeat(10000) {
     scope.submit {

--- a/components/support/nimbus-fml/test/threadsafe_feature_holder.swift
+++ b/components/support/nimbus-fml/test/threadsafe_feature_holder.swift
@@ -12,7 +12,7 @@ let queue: OperationQueue = {
 }()
 
 let api: FeaturesInterface = HardcodedNimbusFeatures(with: ["test-feature-holder": "{}"])
-let holder = FeatureHolder<String>({ api }, featureId: "test-feature-holder") { _ in "NO CRASH" }
+let holder = FeatureHolder<String>({ api }, featureId: "test-feature-holder") { _, _ in "NO CRASH" }
 
 for _ in 1 ..< 10000 {
     queue.addOperation {

--- a/components/support/nimbus-fml/test/threadsafe_feature_holder.swift
+++ b/components/support/nimbus-fml/test/threadsafe_feature_holder.swift
@@ -5,6 +5,13 @@
 import FeatureManifest
 import Foundation
 
+class Feature: FMLFeatureInterface {
+    let string: String
+    init(_ string: String) {
+        self.string = string
+    }
+}
+
 let queue: OperationQueue = {
     let queue = OperationQueue()
     queue.maxConcurrentOperationCount = 5
@@ -12,7 +19,7 @@ let queue: OperationQueue = {
 }()
 
 let api: FeaturesInterface = HardcodedNimbusFeatures(with: ["test-feature-holder": "{}"])
-let holder = FeatureHolder<String>({ api }, featureId: "test-feature-holder") { _, _ in "NO CRASH" }
+let holder = FeatureHolder<Feature>({ api }, featureId: "test-feature-holder") { _, _ in Feature("NO CRASH") }
 
 for _ in 1 ..< 10000 {
     queue.addOperation {


### PR DESCRIPTION
Fixes [EXP-2822](https://mozilla-hub.atlassian.net/browse/EXP-2822).

This PR adds to the FML a pref key to feature variables. For example

```yaml
features:
  my-feature:
    variables:
      is-enabled:
        type: Boolean
        default: false
        pref-key: "my-feature.enabled"
```

The `NimbusBuilder` now accepts a `userDefaults` or `sharedPreferences` which stores the prefs.

The generated code for `myFeature.isEnabled` now checks the prefs for a key `my-feature.enabled`.

This allows app code to toggle on or off features, via a pref rather than just experiment.

There are several restrictions for this feature:

- only top level variables in a feature are supported— nesting gets tricky quickly, so we need to see if this is a feature that is actually used.
- only `Boolean`, `Int`, `String`, and `Text` types are supported.

To detect if a user's preference has been set, a new`isModified()` method is provided. This returns `true` if any prefs in the feature have been set.

When `isModified` is `true`, exposure events are suppressed. 

NB. It's not clear (without seeing usage) if this suppressing exposure events is enough before the prefs can be changed by a general population. Alternatives may be to unenroll from any experiments involving the feature. Until this is clear, we advise only exposing such user preferences in a secret settings context.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
