### PR TITLE
Bump `cc` to 1.0.83.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -528,9 +528,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cexpr"

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -460,7 +460,7 @@ The following text applies to code linked from these dependencies:
 [block-buffer](https://github.com/RustCrypto/utils),
 [camino](https://github.com/camino-rs/camino),
 [cargo-platform](https://github.com/rust-lang/cargo),
-[cc](https://github.com/alexcrichton/cc-rs),
+[cc](https://github.com/rust-lang/cc-rs),
 [cexpr](https://github.com/jethrogb/rust-cexpr),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -440,7 +440,7 @@ The following text applies to code linked from these dependencies:
 [block-buffer](https://github.com/RustCrypto/utils),
 [camino](https://github.com/camino-rs/camino),
 [cargo-platform](https://github.com/rust-lang/cargo),
-[cc](https://github.com/alexcrichton/cc-rs),
+[cc](https://github.com/rust-lang/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -118,7 +118,7 @@ the details of which are reproduced below.
   </license>
   <license>
     <name>Apache License 2.0: cc</name>
-    <url>https://github.com/alexcrichton/cc-rs/blob/main/LICENSE-APACHE</url>
+    <url>https://github.com/rust-lang/cc-rs/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
     <name>Apache License 2.0: cfg-if</name>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -453,7 +453,7 @@ The following text applies to code linked from these dependencies:
 [block-buffer](https://github.com/RustCrypto/utils),
 [camino](https://github.com/camino-rs/camino),
 [cargo-platform](https://github.com/rust-lang/cargo),
-[cc](https://github.com/alexcrichton/cc-rs),
+[cc](https://github.com/rust-lang/cc-rs),
 [cexpr](https://github.com/jethrogb/rust-cexpr),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),

--- a/megazords/ios-rust/focus/DEPENDENCIES.md
+++ b/megazords/ios-rust/focus/DEPENDENCIES.md
@@ -440,7 +440,7 @@ The following text applies to code linked from these dependencies:
 [block-buffer](https://github.com/RustCrypto/utils),
 [camino](https://github.com/camino-rs/camino),
 [cargo-platform](https://github.com/rust-lang/cargo),
-[cc](https://github.com/alexcrichton/cc-rs),
+[cc](https://github.com/rust-lang/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),


### PR DESCRIPTION
This version contains rust-lang/cc-rs#759, which fixes our M1 iOS Simulator megazord builds.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
