### PR TITLE
Support null as incoming sync15 "command" arguments.

### DIFF
--- a/components/sync15/src/clients_engine/record.rs
+++ b/components/sync15/src/clients_engine/record.rs
@@ -79,7 +79,7 @@ pub struct CommandRecord {
     /// Extra, command-specific arguments. Note that we must send an empty
     /// array if the command expects no arguments.
     #[serde(default)]
-    pub args: Vec<String>,
+    pub args: Vec<Option<String>>,
 
     /// Some commands, like repair, send a "flow ID" that other cliennts can
     /// record in their telemetry. We don't currently send commands with
@@ -89,13 +89,44 @@ pub struct CommandRecord {
 }
 
 impl CommandRecord {
+    // In an ideal future we'd treat non-string args as "soft errors" rather than a hard
+    // serde failure, but there's no evidence we actually see these. There *is* evidence of
+    // seeing nulls instead of strings though (presumably due to old sendTab commands), so we
+    // do handle that.
+    fn get_single_string_arg(&self) -> Option<String> {
+        let cmd_name = &self.name;
+        if self.args.len() == 1 {
+            match &self.args[0] {
+                Some(name) => Some(name.into()),
+                None => {
+                    log::error!("Incoming '{cmd_name}' command has null argument");
+                    None
+                }
+            }
+        } else {
+            log::error!(
+                "Incoming '{cmd_name}' command has wrong number of arguments ({})",
+                self.args.len()
+            );
+            None
+        }
+    }
+
     /// Converts a serialized command into one that we can apply. Returns `None`
     /// if we don't support the command.
     pub fn as_command(&self) -> Option<Command> {
         match self.name.as_str() {
-            "wipeEngine" => self.args.get(0).map(|e| Command::Wipe(e.into())),
-            "resetEngine" => self.args.get(0).map(|e| Command::Reset(e.into())),
-            "resetAll" => Some(Command::ResetAll),
+            "wipeEngine" => self.get_single_string_arg().map(Command::Wipe),
+            "resetEngine" => self.get_single_string_arg().map(Command::Reset),
+            "resetAll" => {
+                if self.args.is_empty() {
+                    Some(Command::ResetAll)
+                } else {
+                    log::error!("Invalid arguments for 'resetAll' command");
+                    None
+                }
+            }
+            // Note callers are expected to log on an unknown command.
             _ => None,
         }
     }
@@ -106,12 +137,12 @@ impl From<Command> for CommandRecord {
         match command {
             Command::Wipe(engine) => CommandRecord {
                 name: "wipeEngine".into(),
-                args: vec![engine],
+                args: vec![Some(engine)],
                 flow_id: None,
             },
             Command::Reset(engine) => CommandRecord {
                 name: "resetEngine".into(),
-                args: vec![engine],
+                args: vec![Some(engine)],
                 flow_id: None,
             },
             Command::ResetAll => CommandRecord {
@@ -120,5 +151,54 @@ impl From<Command> for CommandRecord {
                 flow_id: None,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_valid_commands() {
+        let ser = serde_json::json!({"command": "wipeEngine", "args": ["foo"]});
+        let record: CommandRecord = serde_json::from_value(ser).unwrap();
+        assert_eq!(record.as_command(), Some(Command::Wipe("foo".to_string())));
+
+        let ser = serde_json::json!({"command": "resetEngine", "args": ["foo"]});
+        let record: CommandRecord = serde_json::from_value(ser).unwrap();
+        assert_eq!(record.as_command(), Some(Command::Reset("foo".to_string())));
+
+        let ser = serde_json::json!({"command": "resetAll"});
+        let record: CommandRecord = serde_json::from_value(ser).unwrap();
+        assert_eq!(record.as_command(), Some(Command::ResetAll));
+    }
+
+    #[test]
+    fn test_unknown_command() {
+        let ser = serde_json::json!({"command": "unknown", "args": ["foo", "bar"]});
+        let record: CommandRecord = serde_json::from_value(ser).unwrap();
+        assert_eq!(record.as_command(), None);
+    }
+
+    #[test]
+    fn test_bad_args() {
+        let ser = serde_json::json!({"command": "wipeEngine", "args": ["foo", "bar"]});
+        let record: CommandRecord = serde_json::from_value(ser).unwrap();
+        assert_eq!(record.as_command(), None);
+
+        let ser = serde_json::json!({"command": "wipeEngine"});
+        let record: CommandRecord = serde_json::from_value(ser).unwrap();
+        assert_eq!(record.as_command(), None);
+
+        let ser = serde_json::json!({"command": "resetAll", "args": ["foo"]});
+        let record: CommandRecord = serde_json::from_value(ser).unwrap();
+        assert_eq!(record.as_command(), None);
+    }
+
+    #[test]
+    fn test_null_args() {
+        let ser = serde_json::json!({"command": "unknown", "args": ["foo", null]});
+        let record: CommandRecord = serde_json::from_value(ser).unwrap();
+        assert_eq!(record.as_command(), None);
     }
 }

--- a/components/sync15/src/clients_engine/ser.rs
+++ b/components/sync15/src/clients_engine/ser.rs
@@ -85,12 +85,12 @@ mod tests {
         let mut commands = vec![
             CommandRecord {
                 name: "wipeEngine".into(),
-                args: vec!["bookmarks".into()],
+                args: vec![Some("bookmarks".into())],
                 flow_id: Some("flow".into()),
             },
             CommandRecord {
                 name: "resetEngine".into(),
-                args: vec!["history".into()],
+                args: vec![Some("history".into())],
                 flow_id: Some("flow".into()),
             },
             CommandRecord {


### PR DESCRIPTION
There's evidence of us seeing commands with null as an argument instead of a string. This is almost certainly very old Firefoxes trying to send us an openTab command. This patch handles null in all arguments. All all supported commands will treat such as arg as invalid and log an error, which is an improvement over throwing a serde error and treating the entire record as invalid.

Fixes #5861

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
