### PR TITLE
Updating the breaking changes docs

### DIFF
--- a/docs/howtos/breaking-changes.md
+++ b/docs/howtos/breaking-changes.md
@@ -15,8 +15,14 @@ You can test this code locally using the autopublish flow ([Android](./locally-p
 ## Merging
 
 Do not merge any PRs until all are approved.  Once they are all approved then:
-  - Merge the `application-services` PR into `main` and manually trigger a nightly build.
-  - On the next day, the application-services nightly bump PRs fail for the `firefox-android` and
-    `firefox-ios` repositories since there are breaking changes.  This is expected and normal.
-  - Merge your branches on `firefox-android` and `firefox-ios` into the branch with the nightly
-    bump.  This should resolve the issues and the nightly can be merged as normal.
+  - Merge the `application-services` PR into `main`
+  - Manually trigger a new nightly build using the taskcluster hook:
+    https://firefox-ci-tc.services.mozilla.com/hooks/project-releng/cron-task-mozilla-application-services%2Fnightly
+  - Once the nightly task completes, trigger a new rust-components-swift build using the github action:
+    https://github.com/mozilla/rust-components-swift/actions/workflows/update-as-nightly.yml
+  - Update the `firefox-android` and `firefox-ios` PRs to use the newly built nightly:
+    * [example of firefox-android changes](https://github.com/mozilla-mobile/firefox-android/pull/4056/files)
+    * [example of firefox-ios changes](https://github.com/mozilla-mobile/firefox-ios/pull/16783/files)
+  - Ideally, get the PRs merged before the firefox-android/firefox-ios nightly bump the next day.
+    If you don't get these merged, then the nightly bump PR will fail.  Add a link to your PR in
+    the nightly bump PR so the mobile teams know how to fix this.


### PR DESCRIPTION
These ones have instructions on how to avoid issues the next day when the nightly bump PR is created.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
