### PR TITLE
Rename `schema_version` to `v` for `UnparsableRecord`

### DIFF
--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -6,7 +6,7 @@
 use rusqlite::{Connection, Transaction};
 use sql_support::open_database::{self, ConnectionInitializer};
 
-pub const VERSION: u32 = 6;
+pub const VERSION: u32 = 7;
 
 pub const SQL: &str = "
     CREATE TABLE meta(
@@ -110,7 +110,7 @@ impl ConnectionInitializer for SuggestConnectionInitializer {
 
     fn upgrade_from(&self, _db: &Transaction<'_>, version: u32) -> open_database::Result<()> {
         match version {
-            1..=5 => {
+            1..=6 => {
                 // These schema versions were used during development, and never
                 // shipped in any applications. Treat these databases as
                 // corrupt, so that they'll be replaced.

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -91,6 +91,7 @@ impl ToSql for UnparsableRecords {
 
 #[derive(Deserialize, Serialize, Debug)]
 pub(crate) struct UnparsableRecord {
+    #[serde(rename = "v")]
     pub schema_version: u32,
 }
 
@@ -2124,10 +2125,10 @@ mod tests {
                     UnparsableRecords(
                         {
                             "clippy-2": UnparsableRecord {
-                                schema_version: 6,
+                                schema_version: 7,
                             },
                             "fancy-new-suggestions-1": UnparsableRecord {
-                                schema_version: 6,
+                                schema_version: 7,
                             },
                         },
                     ),
@@ -2192,10 +2193,10 @@ mod tests {
                     UnparsableRecords(
                         {
                             "clippy-2": UnparsableRecord {
-                                schema_version: 6,
+                                schema_version: 7,
                             },
                             "fancy-new-suggestions-1": UnparsableRecord {
-                                schema_version: 6,
+                                schema_version: 7,
                             },
                         },
                     ),
@@ -2298,10 +2299,10 @@ mod tests {
                     UnparsableRecords(
                         {
                             "clippy-2": UnparsableRecord {
-                                schema_version: 6,
+                                schema_version: 7,
                             },
                             "fancy-new-suggestions-1": UnparsableRecord {
-                                schema_version: 6,
+                                schema_version: 7,
                             },
                         },
                     ),
@@ -2311,6 +2312,13 @@ mod tests {
             Ok(())
         })?;
 
+        Ok(())
+    }
+
+    #[test]
+    fn unparsable_record_serialized_correctly() -> anyhow::Result<()> {
+        let unparseable_record = UnparsableRecord { schema_version: 1 };
+        assert_eq!(serde_json::to_value(unparseable_record)?, json!({ "v": 1 }),);
         Ok(())
     }
 }


### PR DESCRIPTION
The serialized `schema_version` uses up unnecessary space in the database. So, this change is to rename it to `v` to reduce the size of the serialized string that is stored in the database.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
