### PR TITLE
adjust enrollment status telemetry to only send for active experiments

### DIFF
--- a/components/nimbus/src/stateful/dbcache.rs
+++ b/components/nimbus/src/stateful/dbcache.rs
@@ -24,6 +24,7 @@ use std::sync::RwLock;
 // This struct is the cached data. This is never mutated, but instead
 // recreated every time the cache is updated.
 struct CachedData {
+    pub experiments: Vec<Experiment>,
     pub enrollments: Vec<ExperimentEnrollment>,
     pub experiments_by_slug: HashMap<String, EnrolledExperiment>,
     pub features_by_feature_id: HashMap<String, EnrolledFeatureConfig>,
@@ -81,6 +82,7 @@ impl DatabaseCache {
         // This is where rollouts (promoted experiments on a given feature) will be merged in to the feature variables.
 
         let data = CachedData {
+            experiments,
             enrollments,
             experiments_by_slug,
             features_by_feature_id,
@@ -152,6 +154,10 @@ impl DatabaseCache {
                 .map(|e| e.to_owned())
                 .collect::<Vec<EnrolledExperiment>>()
         })
+    }
+
+    pub fn get_experiments(&self) -> Result<Vec<Experiment>> {
+        self.get_data(|data| data.experiments.to_vec())
     }
 
     pub fn get_enrollments(&self) -> Result<Vec<ExperimentEnrollment>> {

--- a/components/nimbus/src/stateful/nimbus_client.rs
+++ b/components/nimbus/src/stateful/nimbus_client.rs
@@ -692,11 +692,20 @@ impl NimbusClient {
     }
 
     fn record_enrollment_status_telemetry(&self) -> Result<()> {
+        let experiments = self
+            .database_cache
+            .get_experiments()?
+            .iter()
+            .map(|exp| exp.slug.clone())
+            .collect::<HashSet<String>>();
         self.metrics_handler.record_enrollment_statuses(
             self.database_cache
                 .get_enrollments()?
                 .into_iter()
-                .map(|e| e.into())
+                .filter_map(|e| match experiments.contains(&e.slug) {
+                    true => Some(e.into()),
+                    false => None,
+                })
                 .collect(),
         );
         Ok(())

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -1402,28 +1402,24 @@ fn test_enrollment_status_metrics_recorded() -> Result<()> {
 
     let metric_records: Vec<EnrollmentStatusExtraDef> =
         serde_json::from_value(metrics.assert_get_vec_value("enrollment_status"))?;
-    assert_eq!(metric_records.len(), 7);
+    assert_eq!(metric_records.len(), 6);
 
-    assert_eq!(metric_records[3].slug(), slug_1);
-    assert_eq!(metric_records[3].status(), "WasEnrolled");
-    assert_eq!(metric_records[3].branch(), "treatment");
+    assert_eq!(metric_records[3].slug(), slug_2);
+    assert_eq!(metric_records[3].status(), "Disqualified");
+    assert_eq!(metric_records[3].reason(), "NotTargeted");
+    assert_eq!(metric_records[3].branch(), "control");
 
-    assert_eq!(metric_records[4].slug(), slug_2);
-    assert_eq!(metric_records[4].status(), "Disqualified");
-    assert_eq!(metric_records[4].reason(), "NotTargeted");
-    assert_eq!(metric_records[4].branch(), "control");
-
-    assert_eq!(metric_records[5].slug(), slug_4);
-    assert_eq!(metric_records[5].status(), "Error");
+    assert_eq!(metric_records[4].slug(), slug_4);
+    assert_eq!(metric_records[4].status(), "Error");
     assert_eq!(
-        metric_records[5].error_string(),
+        metric_records[4].error_string(),
         "EvaluationError: Identifier 'blah' is undefined"
     );
 
-    assert_eq!(metric_records[6].slug(), slug_3);
-    assert_eq!(metric_records[6].status(), "Disqualified");
-    assert_eq!(metric_records[6].reason(), "NotSelected");
-    assert_eq!(metric_records[6].branch(), "control");
+    assert_eq!(metric_records[5].slug(), slug_3);
+    assert_eq!(metric_records[5].status(), "Disqualified");
+    assert_eq!(metric_records[5].reason(), "NotSelected");
+    assert_eq!(metric_records[5].branch(), "control");
 
     Ok(())
 }


### PR DESCRIPTION
https://sql.telemetry.mozilla.org/queries/95445/source#235860

^ `enrollment_status` is sending 15mil/day in Nightly Fenix. It's including all experiment enrollments that exist in the database on-device, which could go back a year.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
