### PR TITLE
Remove old history delete methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
   - This was originally thought to be of use, but after running the system for sometime, we have found that this isn't needed.
   - In the spirit of reducing unique identifiers in telemetry and in the spirit of Lean Data, we have removed `enrollment_id` (and the code that generates it).
 
+## Places
+
+### ⚠️ Breaking Changes ⚠️
+  - `wipe_local` and `prune_destructively` have been removed from history API. `delete_everything` or `run_maintenance_*` methods should be used instead.
+
 # v120.0 (_2023-10-23_)
 
 ## FxA-Client

--- a/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
+++ b/components/places/android/src/main/java/mozilla/appservices/places/PlacesConnection.kt
@@ -341,10 +341,6 @@ class PlacesWriterConnection internal constructor(conn: UniffiPlacesConnection, 
         }
     }
 
-    override fun wipeLocal() {
-        this.conn.wipeLocalHistory()
-    }
-
     override fun runMaintenance(dbSizeLimit: UInt) {
         val pruneMetrics = PlacesManagerMetrics.runMaintenanceTime.measure {
             val pruneMetrics = PlacesManagerMetrics.runMaintenancePruneTime.measure {
@@ -365,10 +361,6 @@ class PlacesWriterConnection internal constructor(conn: UniffiPlacesConnection, 
             pruneMetrics
         }
         PlacesManagerMetrics.dbSizeAfterMaintenance.accumulateSamples(listOf(pruneMetrics.dbSizeAfter.toLong() / 1024))
-    }
-
-    override fun pruneDestructively() {
-        this.conn.pruneDestructively()
     }
 
     override fun deleteEverything() {
@@ -794,14 +786,6 @@ interface WritableHistoryConnection : ReadableHistoryConnection {
     fun noteObservation(data: VisitObservation)
 
     /**
-     * Deletes all history visits, without recording tombstones.
-     *
-     * That is, these deletions will not be synced. Any changes which were
-     * pending upload on the next sync are discarded and will be lost.
-     */
-    fun wipeLocal()
-
-    /**
      * Run periodic database maintenance. This might include, but is not limited
      * to:
      *
@@ -823,17 +807,6 @@ interface WritableHistoryConnection : ReadableHistoryConnection {
      * the amount. The default of 0 disables pruning.
      */
     fun runMaintenance(dbSizeLimit: UInt = 0U)
-
-    /**
-     * Aggressively prune history visits. These deletions are not intended
-     * to be synced, however due to the way history sync works, this can
-     * still cause data loss.
-     *
-     * As a result, this should only be called if a low disk space
-     * notification is received from the OS, and things like the network
-     * cache have already been cleared.
-     */
-    fun pruneDestructively()
 
     /**
      * Delete everything locally.

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -785,13 +785,6 @@ public class PlacesWriteConnection: PlacesReadConnection {
         }
     }
 
-    open func pruneDestructively() throws {
-        try queue.sync {
-            try self.checkApi()
-            try self.conn.pruneDestructively()
-        }
-    }
-
     open func acceptResult(searchString: String, url: String) throws {
         return try queue.sync {
             try self.checkApi()

--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -411,27 +411,11 @@ impl PlacesConnection {
             )
         })
     }
-
-    // XXX - We probably need to document/name this a little better as it's specifically for
-    // history and NOT bookmarks...
-    #[handle_error(crate::Error)]
-    pub fn wipe_local_history(&self) -> ApiResult<()> {
-        self.with_conn(history::wipe_local)
-    }
-
-    // Calls wipe_local_history but also updates the
-    // sync metadata to only sync after most recent visit to prevent
-    // further syncing of older data
+    // deletes all history and updates the sync metadata to only sync after
+    // most recent visit to prevent further syncing of older data
     #[handle_error(crate::Error)]
     pub fn delete_everything_history(&self) -> ApiResult<()> {
         history::delete_everything(&self.db.lock())
-    }
-
-    // XXX - This just calls wipe_local under the hood...
-    // should probably have this go away?
-    #[handle_error(crate::Error)]
-    pub fn prune_destructively(&self) -> ApiResult<()> {
-        self.with_conn(history::prune_destructively)
     }
 
     #[handle_error(crate::Error)]

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -117,20 +117,10 @@ interface PlacesConnection {
     [Throws=PlacesApiError]
     sequence<TopFrecentSiteInfo> get_top_frecent_site_infos(i32 num_items, FrecencyThresholdOption threshold_option);
 
-    // These three methods below are not actively being used by the consumers, we should investigate further
-    // and remove if so https://github.com/mozilla/application-services/issues/4719
-    [Throws=PlacesApiError]
-    void wipe_local_history();
-
     //From a-c: will not remove any history from remote devices, but it will prevent deleted
     // history from returning.
     [Throws=PlacesApiError]
     void delete_everything_history();
-
-    // Exactly the same as wipe_local_history
-    [Throws=PlacesApiError]
-    void prune_destructively();
-
 
     /// Run maintenance on the places DB (prune step)
     ///

--- a/components/places/src/storage/history_metadata.rs
+++ b/components/places/src/storage/history_metadata.rs
@@ -751,8 +751,8 @@ mod tests {
     };
     use crate::storage::fetch_page_info;
     use crate::storage::history::{
-        apply_observation, delete_visits_between, delete_visits_for, get_visit_count, url_to_guid,
-        wipe_local,
+        apply_observation, delete_everything, delete_visits_between, delete_visits_for,
+        get_visit_count, url_to_guid,
     };
     use crate::types::VisitType;
     use crate::VisitTransitionSet;
@@ -2006,7 +2006,7 @@ mod tests {
         assert_table_size!(&conn, "moz_origins", 2);
 
         // this somehow deletes 1 origin record, and our metadata
-        wipe_local(&conn).expect("places wipe succeeds");
+        delete_everything(&conn).expect("places wipe succeeds");
 
         assert_table_size!(&conn, "moz_places_metadata", 0);
         assert_table_size!(&conn, "moz_places_metadata_search_queries", 0);
@@ -2147,7 +2147,7 @@ mod tests {
         );
 
         // now, let's wipe places, and make sure none of the metadata stuff remains.
-        wipe_local(&conn).expect("places wipe succeeds");
+        delete_everything(&conn).expect("places wipe succeeds");
 
         assert_table_size!(&conn, "moz_places_metadata", 0);
         assert_table_size!(&conn, "moz_places_metadata_search_queries", 0);


### PR DESCRIPTION
fixes #4719 

`delete_everything` is still actively used on android and iOS for a useful way to wipe to the DB and should be kept in.

android PR landed removed the wrappers (wasn't actually being used): https://github.com/mozilla-mobile/firefox-android/commit/01bdb989d3f2fbd0b579346e099814067d877bf5

We should wait for the next nightly to merge this, but it can be reviewed!




### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
