### PR TITLE
Tidy get_typeref_from_string to remove clone

### DIFF
--- a/components/support/nimbus-fml/src/frontend.rs
+++ b/components/support/nimbus-fml/src/frontend.rs
@@ -279,7 +279,7 @@ impl ManifestFrontEnd {
         PropDef {
             name: nm.into(),
             doc: body.description.clone(),
-            typ: match get_typeref_from_string(body.variable_type.to_owned(), Some(types.clone())) {
+            typ: match get_typeref_from_string(body.variable_type.to_owned(), &types) {
                 Ok(type_ref) => type_ref,
                 Err(e) => {
                     // Try matching against the user defined types


### PR DESCRIPTION
Relates to [EXP-3675](https://mozilla-hub.atlassian.net/browse/EXP-3675).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_1_) change.

This PR is a tidy of the `get_typeref_from_string` method:
- it changes the argument from an `Option<HashMap<String, TypeRef>>` to a borrow of the hashmap. This makes it much more efficient.
- it wraps the whole of the match statement in to a single `Ok()`, rather than wrapping each of the branches of the `match` in its own `Ok()`. This is more idiomatic.

The PR is small, and simple, yet only tangentially related to the larger string-alias task where it was done. It's split off to be reviewed and landed more quickly.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
