### PR TITLE
Add string-alias to FML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 
 ## Nimbus FML ⛅️🔬🔭🔧
 
+### ✨ What's New ✨
+
+- Added `string-alias` capability to feature variables ([#5928](https://github.com/mozilla/application-services/pull/5928)).
+  - This adds quite a lot of type safety around complex features that relied on Strings, e.g. messaging, onboarding.
+
 ### 🦊 What's Changed 🦊
 
 - FML errors are now sorted so that they are no longer non-deterministic ([#9741](https://github.com/mozilla/experimenter/issues/9741)).

--- a/components/support/nimbus-fml/fixtures/fe/string-aliases.fml.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/string-aliases.fml.yaml
@@ -1,0 +1,118 @@
+---
+about:
+  description: A coverall for string-alias.
+  swift:
+    class: AppConfig
+    module: application
+  kotlin:
+    package: org.mozilla.examples.nimbus
+    class: .stringalias.AppConfig
+channels:
+  - storms   # names from https://www.metoffice.gov.uk/about-us/press-office/news/weather-and-climate/2023/weather-responders-included-in-2023-24-storm-names
+  - cyclones # names from https://www.nhc.noaa.gov/aboutnames.shtml
+features:
+  my-simple-team:
+    description: |
+      This uses the players in player availability to make up a basic team.
+    variables:
+      player-availability:
+        description: Names of all players with their availability
+        type: Map<PlayerName, Boolean>
+        string-alias: PlayerName
+        default: {}
+      captain:
+        description: The captain of this week's team
+        type: Option<PlayerName>
+        default: null
+      the-team:
+        description: All players in this week's lineup
+        type: List<PlayerName>
+        default: []
+    defaults:
+      - channel: storms
+        value:
+          player-availability:
+            Agnes: true
+            Babet: true
+            Ciarán: true
+            Debi: true
+            Elin: true
+            Fergus: true
+            Gerrit: true
+            Henk: true
+            Isha: true
+            Jocelyn: true
+            Kathleen: true
+            Lilian: true
+          captain: Agnes
+
+  my-sports:
+    description: |
+      A contrived example to show PlayerNames used in objects
+    variables:
+      available-players:
+        description: Describes the list of valid players
+        type: List<PlayerName>
+        string-alias: PlayerName
+        default: []
+      my-favorite-teams:
+        description: My favourite teams in various sports
+        type: Map<SportName, Team>
+        string-alias: SportName
+        default: {}
+    defaults:
+      - channel: storms
+        value:
+          available-players: ["Agnes", "Babet", "Ciarán", "Debi", "Elin", "Fergus", "Gerrit", "Henk", "Isha", "Jocelyn", "Kathleen", "Lilian"]
+      - channel: cyclones
+        value:
+          available-players: ["Aka", "Ekeka", "Hene", "Iolana", "Keoni", "Lino", "Mele", "Nona", "Oliwa", "Pama", "Upana", "Wene"]
+
+  my-fixture:
+    description: Anoter contrived example, showing a deeply nested object within an object.
+    variables:
+      available-players:
+        description: Describes the list of valid players
+        type: List<PlayerName>
+        string-alias: PlayerName
+        default: []
+      the-sport:
+        description: The sport being played
+        type: SportName
+        string-alias: SportName
+        default: MY_DEFAULT
+      the-match:
+        description: The match
+        type: Match
+        default: {}
+    defaults:
+      - channel: storms
+        value:
+          available-players: ["Agnes", "Babet", "Ciarán", "Debi", "Elin", "Fergus", "Gerrit", "Henk", "Isha", "Jocelyn", "Kathleen", "Lilian"]
+      - channel: cyclones
+        value:
+          available-players: ["Aka", "Ekeka", "Hene", "Iolana", "Keoni", "Lino", "Mele", "Nona", "Oliwa", "Pama", "Upana", "Wene"]
+
+objects:
+  Team:
+    description: A group of players
+    fields:
+      players:
+        description: The list of players in this team
+        type: List<PlayerName>
+        default: []
+      sport:
+        description: The sport this team plays
+        type: SportName
+        default: MY_DEFAULT
+  Match:
+    description: A fixture between two teams
+    fields:
+      home:
+        description: The home team
+        type: Team
+        default: {}
+      away:
+        description: The away team
+        type: Team
+        default: {}

--- a/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
@@ -129,9 +129,11 @@ impl From<TypeRef> for ExperimentManifestPropType {
             | TypeRef::List(_) => Self::Json,
             TypeRef::Boolean => Self::Boolean,
             TypeRef::Int => Self::Int,
-            TypeRef::String | TypeRef::BundleImage | TypeRef::BundleText | TypeRef::Enum(_) => {
-                Self::String
-            }
+            TypeRef::String
+            | TypeRef::BundleImage
+            | TypeRef::BundleText
+            | TypeRef::StringAlias(_)
+            | TypeRef::Enum(_) => Self::String,
             TypeRef::Option(inner) => Self::from(inner),
         }
     }

--- a/components/support/nimbus-fml/src/backends/frontend_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/frontend_manifest.rs
@@ -9,7 +9,7 @@ use crate::frontend::{
     ObjectBody, Types,
 };
 use crate::intermediate_representation::{
-    EnumDef, FeatureDef, FeatureManifest, ObjectDef, PropDef, VariantDef,
+    EnumDef, FeatureDef, FeatureManifest, ObjectDef, PropDef, TypeRef, VariantDef,
 };
 
 impl From<FeatureManifest> for ManifestFrontEnd {
@@ -125,6 +125,7 @@ impl From<PropDef> for FeatureFieldBody {
     fn from(value: PropDef) -> Self {
         Self {
             pref_key: value.pref_key.clone(),
+            string_alias: value.string_alias.as_ref().map(TypeRef::to_string),
             field: value.into(),
         }
     }

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
@@ -146,7 +146,9 @@ impl ConcreteCodeOracle {
     fn create_code_type(&self, type_: TypeIdentifier) -> Box<dyn CodeType> {
         match type_ {
             TypeIdentifier::Boolean => Box::new(primitives::BooleanCodeType),
-            TypeIdentifier::String => Box::new(primitives::StringCodeType),
+            TypeIdentifier::String | TypeIdentifier::StringAlias(_) => {
+                Box::new(primitives::StringCodeType)
+            }
             TypeIdentifier::Int => Box::new(primitives::IntCodeType),
 
             TypeIdentifier::BundleText => Box::new(bundled::TextCodeType),

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
@@ -118,7 +118,9 @@ impl ConcreteCodeOracle {
     fn create_code_type(&self, type_: TypeIdentifier) -> Box<dyn CodeType> {
         match type_ {
             TypeIdentifier::Boolean => Box::new(primitives::BooleanCodeType),
-            TypeIdentifier::String => Box::new(primitives::StringCodeType),
+            TypeIdentifier::String | TypeIdentifier::StringAlias(_) => {
+                Box::new(primitives::StringCodeType)
+            }
             TypeIdentifier::Int => Box::new(primitives::IntCodeType),
 
             TypeIdentifier::BundleText => Box::new(bundled::TextCodeType),

--- a/components/support/nimbus-fml/src/defaults/validator.rs
+++ b/components/support/nimbus-fml/src/defaults/validator.rs
@@ -65,6 +65,7 @@ impl<'a> DefaultsValidator<'a> {
             | (TypeRef::BundleImage, Value::String(_))
             | (TypeRef::BundleText, Value::String(_))
             | (TypeRef::String, Value::String(_))
+            | (TypeRef::StringAlias(_), Value::String(_))
             | (TypeRef::Int, Value::Number(_))
             | (TypeRef::Option(_), Value::Null) => Ok(()),
             (TypeRef::Option(inner), v) => {
@@ -154,7 +155,7 @@ impl<'a> DefaultsValidator<'a> {
                 }
                 Ok(())
             }
-            (TypeRef::EnumMap(_, map_type), Value::Object(map))
+            (TypeRef::EnumMap(_, map_type), Value::Object(map)) // Map<string-alias, T>
             | (TypeRef::StringMap(map_type), Value::Object(map)) => {
                 for (key, value) in map {
                     let path = format!("{path}['{key}']");
@@ -463,7 +464,6 @@ mod test_types {
 
         fm.validate_prop_defaults(&prop)
             .expect_err("Should error out since default is not a valid enum variant");
-
         Ok(())
     }
 

--- a/components/support/nimbus-fml/src/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/intermediate_representation.rs
@@ -756,6 +756,9 @@ pub struct PropDef {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) pref_key: Option<String>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) string_alias: Option<TypeRef>,
 }
 
 impl PropDef {
@@ -827,6 +830,7 @@ pub mod unit_tests {
                 typ,
                 default,
                 pref_key: None,
+                string_alias: None,
             }
         }
 
@@ -837,6 +841,7 @@ pub mod unit_tests {
                 typ,
                 default,
                 pref_key: None,
+                string_alias: None,
             }
         }
     }


### PR DESCRIPTION
Relates to [EXP-3675](https://mozilla-hub.atlassian.net/browse/EXP-3675).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR introduces the concept of string-aliases, which are a specialized `typealias`, to the FML.

The intention is that a set of valid strings can be defined as a value, a list of values, the keys to a map or the values of a map wiithin a feature configuration.

The string aliases can then be used elsewhere in the feature config; the FML will then validate its usage.

For example, if the set of `actions` is given by a `Map<ActionName, String>`, the string-alias is the `ActionName`, and the URL is the value.

Elsewhere in the feature or object, the `action` can be specified as of type `ActionName`, i.e. a string which has to be in the `actions` map.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
