### PR TITLE
Remove names from BundleText and BundleImage

### DIFF
--- a/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
+++ b/components/support/nimbus-fml/src/backends/experimenter_manifest.rs
@@ -129,10 +129,9 @@ impl From<TypeRef> for ExperimentManifestPropType {
             | TypeRef::List(_) => Self::Json,
             TypeRef::Boolean => Self::Boolean,
             TypeRef::Int => Self::Int,
-            TypeRef::String
-            | TypeRef::BundleImage(_)
-            | TypeRef::BundleText(_)
-            | TypeRef::Enum(_) => Self::String,
+            TypeRef::String | TypeRef::BundleImage | TypeRef::BundleText | TypeRef::Enum(_) => {
+                Self::String
+            }
             TypeRef::Option(inner) => Self::from(inner),
         }
     }

--- a/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/kotlin/gen_structs/mod.rs
@@ -149,8 +149,8 @@ impl ConcreteCodeOracle {
             TypeIdentifier::String => Box::new(primitives::StringCodeType),
             TypeIdentifier::Int => Box::new(primitives::IntCodeType),
 
-            TypeIdentifier::BundleText(_) => Box::new(bundled::TextCodeType),
-            TypeIdentifier::BundleImage(_) => Box::new(bundled::ImageCodeType),
+            TypeIdentifier::BundleText => Box::new(bundled::TextCodeType),
+            TypeIdentifier::BundleImage => Box::new(bundled::ImageCodeType),
 
             TypeIdentifier::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
             TypeIdentifier::Object(id) => Box::new(object::ObjectCodeType::new(id)),

--- a/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
+++ b/components/support/nimbus-fml/src/backends/swift/gen_structs/mod.rs
@@ -121,8 +121,8 @@ impl ConcreteCodeOracle {
             TypeIdentifier::String => Box::new(primitives::StringCodeType),
             TypeIdentifier::Int => Box::new(primitives::IntCodeType),
 
-            TypeIdentifier::BundleText(_) => Box::new(bundled::TextCodeType),
-            TypeIdentifier::BundleImage(_) => Box::new(bundled::ImageCodeType),
+            TypeIdentifier::BundleText => Box::new(bundled::TextCodeType),
+            TypeIdentifier::BundleImage => Box::new(bundled::ImageCodeType),
 
             TypeIdentifier::Enum(id) => Box::new(enum_::EnumCodeType::new(id)),
             TypeIdentifier::Object(id) => Box::new(object::ObjectCodeType::new(id)),

--- a/components/support/nimbus-fml/src/defaults/validator.rs
+++ b/components/support/nimbus-fml/src/defaults/validator.rs
@@ -62,8 +62,8 @@ impl<'a> DefaultsValidator<'a> {
     ) -> Result<()> {
         match (type_ref, default) {
             (TypeRef::Boolean, Value::Bool(_))
-            | (TypeRef::BundleImage(_), Value::String(_))
-            | (TypeRef::BundleText(_), Value::String(_))
+            | (TypeRef::BundleImage, Value::String(_))
+            | (TypeRef::BundleText, Value::String(_))
             | (TypeRef::String, Value::String(_))
             | (TypeRef::Int, Value::Number(_))
             | (TypeRef::Option(_), Value::Null) => Ok(()),
@@ -367,11 +367,7 @@ mod test_types {
 
     #[test]
     fn test_validate_prop_defaults_bundle_image() -> Result<()> {
-        let mut prop = PropDef::new(
-            "key",
-            TypeRef::BundleImage("Icon".into()),
-            json!("IconBlue"),
-        );
+        let mut prop = PropDef::new("key", TypeRef::BundleImage, json!("IconBlue"));
         let enums1 = Default::default();
         let objs = Default::default();
         let fm = DefaultsValidator::new(&enums1, &objs);
@@ -386,11 +382,7 @@ mod test_types {
 
     #[test]
     fn test_validate_prop_defaults_bundle_text() -> Result<()> {
-        let mut prop = PropDef::new(
-            "key",
-            TypeRef::BundleText("Text".into()),
-            json!("BundledText"),
-        );
+        let mut prop = PropDef::new("key", TypeRef::BundleText, json!("BundledText"));
         let enums1 = Default::default();
         let objs = Default::default();
         let fm = DefaultsValidator::new(&enums1, &objs);

--- a/components/support/nimbus-fml/src/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/intermediate_representation.rs
@@ -72,10 +72,10 @@ pub enum TypeRef {
     Boolean,
 
     // Strings can be coerced into a few types.
-    // The types here will require the app's bundle or context to look up the final value.
-    // They will likely have
-    BundleText(StringId),
-    BundleImage(StringId),
+    // The types here will require the app's bundle or context to look
+    // up the final value.
+    BundleText,
+    BundleImage,
 
     Enum(String),
     // JSON objects can represent a data class.
@@ -97,8 +97,8 @@ impl Display for TypeRef {
             Self::String => f.write_str("String"),
             Self::Int => f.write_str("Int"),
             Self::Boolean => f.write_str("Boolean"),
-            Self::BundleImage(_) => f.write_str("Image"),
-            Self::BundleText(_) => f.write_str("Text"),
+            Self::BundleImage => f.write_str("Image"),
+            Self::BundleText => f.write_str("Text"),
             Self::Enum(v) => f.write_str(v),
             Self::Object(v) => f.write_str(v),
             Self::Option(v) => f.write_fmt(format_args!("Option<{v}>")),
@@ -112,7 +112,7 @@ impl Display for TypeRef {
 impl TypeRef {
     pub(crate) fn supports_prefs(&self) -> bool {
         match self {
-            Self::Boolean | Self::String | Self::Int | Self::BundleText(_) => true,
+            Self::Boolean | Self::String | Self::Int | Self::BundleText => true,
             // There may be a chance that we can get Self::Option to work, but not at this time.
             // This may be done by adding a branch to this match and adding a `preference_getter` to
             // the `OptionalCodeType`.
@@ -205,8 +205,6 @@ impl TypeFinder for TypeRef {
         }
     }
 }
-
-pub(crate) type StringId = String;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct FeatureManifest {

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -43,12 +43,8 @@ pub(crate) fn get_typeref_from_string(
         "String" => TypeRef::String,
         "Int" => TypeRef::Int,
         "Boolean" => TypeRef::Boolean,
-        "BundleText" | "Text" => {
-            TypeRef::BundleText(type_name.unwrap_or_else(|| "unnamed".to_string()))
-        }
-        "BundleImage" | "Drawable" | "Image" => {
-            TypeRef::BundleImage(type_name.unwrap_or_else(|| "unnamed".to_string()))
-        }
+        "BundleText" | "Text" => TypeRef::BundleText,
+        "BundleImage" | "Drawable" | "Image" => TypeRef::BundleImage,
         "Enum" => TypeRef::Enum(type_name.unwrap()),
         "Object" => TypeRef::Object(type_name.unwrap()),
         "List" => TypeRef::List(Box::new(get_typeref_from_string(
@@ -751,10 +747,6 @@ mod unit_tests {
     fn test_convert_to_typeref_bundletext() -> Result<()> {
         // Testing converting to TypeRef::BundleText
         let types = Default::default();
-        assert_eq!(
-            get_typeref_from_string("BundleText<test_name>".to_string(), &types).unwrap(),
-            TypeRef::BundleText("test_name".to_string())
-        );
         get_typeref_from_string("bundletext(something)".to_string(), &types).unwrap_err();
         get_typeref_from_string("BundleText()".to_string(), &types).unwrap_err();
 
@@ -774,7 +766,7 @@ mod unit_tests {
         let types = Default::default();
         assert_eq!(
             get_typeref_from_string("BundleImage<test_name>".to_string(), &types).unwrap(),
-            TypeRef::BundleImage("test_name".to_string())
+            TypeRef::BundleImage
         );
         get_typeref_from_string("bundleimage(something)".to_string(), &types).unwrap_err();
         get_typeref_from_string("BundleImage()".to_string(), &types).unwrap_err();


### PR DESCRIPTION
Relates to [ EXP-3675](https://mozilla-hub.atlassian.net/browse/EXP-3675).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_1_) change.

This PR removes the name parameters from the enum variants

```rs
BundleText(StringId),
BundleImage(StringId),
```

to 

```rs
BundleText,
BundleImage,
```

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
