### PR TITLE
Tidy intermediate_representation tests Part I

### DIFF
--- a/components/support/nimbus-fml/src/client/mod.rs
+++ b/components/support/nimbus-fml/src/client/mod.rs
@@ -207,8 +207,9 @@ uniffi::include_scaffolding!("fml");
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-    use crate::intermediate_representation::{
-        unit_tests::get_feature_manifest, FeatureDef, ModuleId, PropDef, TypeRef,
+    use crate::{
+        fixtures::intermediate_representation::get_feature_manifest,
+        intermediate_representation::{FeatureDef, ModuleId, PropDef, TypeRef},
     };
     use serde_json::{json, Map, Number, Value};
     use std::collections::HashMap;


### PR DESCRIPTION
Relates to [ EXP-3938](https://mozilla-hub.atlassian.net/browse/EXP-3938).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_1_) change.

This moves some tests around, as a precursor to some more refactoring. No actual code is being changed here.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
