### PR TITLE
Fixup flaky kotlin/swift tests by using separate directories

### DIFF
--- a/components/support/nimbus-fml/src/command_line/workflows.rs
+++ b/components/support/nimbus-fml/src/command_line/workflows.rs
@@ -416,11 +416,11 @@ mod test {
             .ok_or_else(|| anyhow!("Manifest file path isn't a file"))?
             .to_str()
             .ok_or_else(|| anyhow!("Manifest file path isn't a file with a sensible name"))?;
-        fs::create_dir_all(generated_src_dir())?;
+        let stem = pbuf.file_stem().unwrap().to_str().unwrap();
+        fs::create_dir_all(join(generated_src_dir(), stem))?;
         let manifest_out = format!(
-            "{}_{}.{}",
-            join(generated_src_dir(), file),
-            channel,
+            "{}/{stem}/{file}_{channel}.{}",
+            generated_src_dir(),
             language.extension()
         );
         let loader = Default::default();


### PR DESCRIPTION
Relates to [ EXP-3490](https://mozilla-hub.atlassian.net/browse/EXP-3490).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This is a very small PR which separates the generated files into directories named after the test file. This prevents a race condition when different tests generate manifest files of the same name.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
