### PR TITLE
Rename Swift Collection methods to match Kotlin versions

### DIFF
--- a/components/nimbus/ios/Nimbus/Collections+.swift
+++ b/components/nimbus/ios/Nimbus/Collections+.swift
@@ -12,11 +12,12 @@ public extension Dictionary {
         return [K1: Value](uniqueKeysWithValues: transformed)
     }
 
+    @inline(__always)
     func mapValuesNotNull<V1>(_ transform: (Value) -> V1?) -> [Key: V1] {
         return compactMapValues(transform)
     }
 
-    func mapNotNull<K1, V1>(_ keyTransform: (Key) -> K1?, _ valueTransform: (Value) -> V1?) -> [K1: V1] {
+    func mapEntriesNotNull<K1, V1>(_ keyTransform: (Key) -> K1?, _ valueTransform: (Value) -> V1?) -> [K1: V1] {
         let transformed: [(K1, V1)] = compactMap { k, v in
             guard let k1 = keyTransform(k),
                   let v1 = valueTransform(v)
@@ -34,6 +35,13 @@ public extension Dictionary {
         }
 
         return merging(defaults, uniquingKeysWith: valueMerger)
+    }
+}
+
+public extension Array {
+    @inline(__always)
+    func mapNotNull<ElementOfResult>(_ transform: (Element) throws -> ElementOfResult?) rethrows -> [ElementOfResult] {
+        try compactMap(transform)
     }
 }
 


### PR DESCRIPTION
Relates to [ EXP-3490](https://mozilla-hub.atlassian.net/browse/EXP-3490).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This small _n_ PR renames and re-implements the Swift extension methods for Map and Array to match the Kotlin counterparts.

This is to make it easier to verify generated code is correct, and to cut context switching when moving between Kotlin and Swift.

| Class | Old name | New name |
| - | - | - |
| `Dictionary` | `mapNotNull` | `mapEntriesNotNull` |
| `Array` | `compactMap` | `mapNotNull` |

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
