### PR TITLE
Rewrite serde_json::Value as serde_json::json

### DIFF
--- a/components/support/nimbus-fml/src/client/mod.rs
+++ b/components/support/nimbus-fml/src/client/mod.rs
@@ -211,7 +211,7 @@ mod unit_tests {
         fixtures::intermediate_representation::get_feature_manifest,
         intermediate_representation::{FeatureDef, ModuleId, PropDef, TypeRef},
     };
-    use serde_json::{json, Map, Number, Value};
+    use serde_json::{json, Value};
     use std::collections::HashMap;
 
     fn create_manifest() -> FeatureManifest {
@@ -273,7 +273,10 @@ mod unit_tests {
 
         assert!(client.is_feature_valid(
             "feature".to_string(),
-            Map::from_iter([("prop_1".to_string(), Value::String("new value".into()))])
+            json!({ "prop_1": "new value" })
+                .as_object()
+                .unwrap()
+                .clone()
         )?);
 
         Ok(())
@@ -286,11 +289,14 @@ mod unit_tests {
         let result = client.merge(HashMap::from_iter([
             (
                 "feature".to_string(),
-                Map::from_iter([("prop_1".to_string(), Value::String("new value".to_string()))]),
+                json!({ "prop_1": "new value" })
+                    .as_object()
+                    .unwrap()
+                    .clone(),
             ),
             (
                 "feature_i".to_string(),
-                Map::from_iter([("prop_i_1".to_string(), Value::Number(Number::from(1)))]),
+                json!({"prop_i_1": 1}).as_object().unwrap().clone(),
             ),
         ]))?;
 

--- a/components/support/nimbus-fml/src/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/intermediate_representation.rs
@@ -1413,11 +1413,11 @@ mod imports_tests {
         let json = fm.default_json();
         assert_eq!(
             json.get("feature_i").unwrap().get("prop_i_1").unwrap(),
-            &Value::String("prop_i_1_value".into())
+            &json!("prop_i_1_value")
         );
         assert_eq!(
             json.get("feature").unwrap().get("prop_1").unwrap(),
-            &Value::String("prop_1_value".into())
+            &json!("prop_1_value")
         );
 
         Ok(())
@@ -1426,7 +1426,7 @@ mod imports_tests {
 
 #[cfg(test)]
 mod feature_config_tests {
-    use serde_json::{json, Number};
+    use serde_json::json;
 
     use super::*;
     use crate::fixtures::intermediate_representation::get_feature_manifest;
@@ -1448,14 +1448,8 @@ mod feature_config_tests {
             HashMap::new(),
         );
 
-        let result = fm.validate_feature_config(
-            "feature",
-            Value::Object(Map::from_iter([(
-                "prop_1".to_string(),
-                Value::String("new value".into()),
-            )])),
-        )?;
-        assert_eq!(result.props[0].default, Value::String("new value".into()));
+        let result = fm.validate_feature_config("feature", json!({ "prop_1": "new value" }))?;
+        assert_eq!(result.props[0].default, json!("new value"));
 
         Ok(())
     }
@@ -1477,13 +1471,7 @@ mod feature_config_tests {
             HashMap::new(),
         );
 
-        let result = fm.validate_feature_config(
-            "feature-1",
-            Value::Object(Map::from_iter([(
-                "prop_1".to_string(),
-                Value::String("new value".into()),
-            )])),
-        );
+        let result = fm.validate_feature_config("feature-1", json!({ "prop_1": "new value" }));
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
@@ -1539,10 +1527,9 @@ mod feature_config_tests {
 
         let result = fm.validate_feature_config(
             "feature",
-            Value::Object(Map::from_iter([(
-                "prop_1".to_string(),
-                Value::Number(Number::from(1)),
-            )])),
+            json!({
+                "prop_1": 1,
+            }),
         );
         assert!(result.is_err());
         assert_eq!(result.err().unwrap().to_string(), "Validation Error at features/feature.prop_1: Mismatch between type String and default 1".to_string());


### PR DESCRIPTION
Relates to [ EXP-3938](https://mozilla-hub.atlassian.net/browse/EXP-3938).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_1_) change.

This is a fairly mechanical PR which rewrites some tests to use the `json!` macro instead of the variants of `Value` directly.

For example:

- `Value::String("a-string".to_string())` --> `json!("a-string")`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
