### PR TITLE
Rationalize PropDef, EnumDef and EnumDef test constructors

### DIFF
--- a/components/support/nimbus-fml/src/client/mod.rs
+++ b/components/support/nimbus-fml/src/client/mod.rs
@@ -222,8 +222,8 @@ mod unit_tests {
                 name: "feature_i".into(),
                 props: vec![PropDef::new(
                     "prop_i_1",
-                    TypeRef::String,
-                    Value::String("prop_i_1_value".into()),
+                    &TypeRef::String,
+                    &json!("prop_i_1_value"),
                 )],
                 metadata: Default::default(),
                 ..Default::default()
@@ -238,8 +238,8 @@ mod unit_tests {
                 name: "feature".into(),
                 props: vec![PropDef::new(
                     "prop_1",
-                    TypeRef::String,
-                    Value::String("prop_1_value".into()),
+                    &TypeRef::String,
+                    &json!("prop_1_value"),
                 )],
                 metadata: Default::default(),
                 allow_coenrollment: true,

--- a/components/support/nimbus-fml/src/defaults/merger.rs
+++ b/components/support/nimbus-fml/src/defaults/merger.rs
@@ -1036,7 +1036,11 @@ mod unit_tests {
     #[test]
     fn test_merge_feature_default_overwrite_field_default_based_on_channel() -> Result<()> {
         let mut feature_def = FeatureDef {
-            props: vec![PropDef::new("button-color", TypeRef::String, json!("blue"))],
+            props: vec![PropDef::new(
+                "button-color",
+                &TypeRef::String,
+                &json!("blue"),
+            )],
             ..Default::default()
         };
         let default_blocks = serde_json::from_value(json!([
@@ -1070,8 +1074,8 @@ mod unit_tests {
             feature_def.props,
             vec![PropDef::new(
                 "button-color",
-                TypeRef::String,
-                json!("dark-green"),
+                &TypeRef::String,
+                &json!("dark-green"),
             )]
         );
         Ok(())
@@ -1081,7 +1085,11 @@ mod unit_tests {
     fn test_merge_feature_default_field_default_not_overwritten_if_no_feature_default_for_channel(
     ) -> Result<()> {
         let mut feature_def = FeatureDef {
-            props: vec![PropDef::new("button-color", TypeRef::String, json!("blue"))],
+            props: vec![PropDef::new(
+                "button-color",
+                &TypeRef::String,
+                &json!("blue"),
+            )],
             ..Default::default()
         };
         let default_blocks = serde_json::from_value(json!([{
@@ -1105,7 +1113,11 @@ mod unit_tests {
         merger.merge_feature_defaults(&mut feature_def, &default_blocks)?;
         assert_eq!(
             feature_def.props,
-            vec![PropDef::new("button-color", TypeRef::String, json!("blue"),)]
+            vec![PropDef::new(
+                "button-color",
+                &TypeRef::String,
+                &json!("blue"),
+            )]
         );
         Ok(())
     }
@@ -1115,8 +1127,8 @@ mod unit_tests {
         let mut feature_def = FeatureDef {
             props: vec![PropDef::new(
                 "Dialog",
-                TypeRef::String,
-                json!({
+                &TypeRef::String,
+                &json!({
                     "button-color": "blue",
                     "title": "hello",
                     "inner": {
@@ -1175,8 +1187,8 @@ mod unit_tests {
             feature_def.props,
             vec![PropDef::new(
                 "Dialog",
-                TypeRef::String,
-                json!({
+                &TypeRef::String,
+                &json!({
                         "button-color": "green",
                         "title": "hello",
                         "inner": {
@@ -1184,7 +1196,7 @@ mod unit_tests {
                             "other-field": "other-value",
                             "new-field": "new-value"
                         }
-                }),
+                })
             )]
         );
         Ok(())
@@ -1194,7 +1206,11 @@ mod unit_tests {
     fn test_merge_feature_default_overwrite_field_default_based_on_channel_using_only_no_channel_default(
     ) -> Result<()> {
         let mut feature_def = FeatureDef {
-            props: vec![PropDef::new("button-color", TypeRef::String, json!("blue"))],
+            props: vec![PropDef::new(
+                "button-color",
+                &TypeRef::String,
+                &json!("blue"),
+            )],
             ..Default::default()
         };
         let default_blocks = serde_json::from_value(json!([
@@ -1229,8 +1245,8 @@ mod unit_tests {
             feature_def.props,
             vec![PropDef::new(
                 "button-color",
-                TypeRef::String,
-                json!("dark-green"),
+                &TypeRef::String,
+                &json!("dark-green"),
             )]
         );
         Ok(())
@@ -1240,7 +1256,11 @@ mod unit_tests {
     fn test_merge_feature_default_throw_error_if_property_not_found_on_feature() -> Result<()> {
         let mut feature_def = FeatureDef {
             name: "feature".into(),
-            props: vec![PropDef::new("button-color", TypeRef::String, json!("blue"))],
+            props: vec![PropDef::new(
+                "button-color",
+                &TypeRef::String,
+                &json!("blue"),
+            )],
             ..Default::default()
         };
         let default_blocks = serde_json::from_value(json!([

--- a/components/support/nimbus-fml/src/defaults/validator.rs
+++ b/components/support/nimbus-fml/src/defaults/validator.rs
@@ -517,7 +517,7 @@ mod test_types {
 
     use serde_json::json;
 
-    use crate::intermediate_representation::{PropDef, VariantDef};
+    use crate::intermediate_representation::PropDef;
 
     use super::*;
 
@@ -529,75 +529,60 @@ mod test_types {
     }
 
     fn enums() -> BTreeMap<String, EnumDef> {
-        let enum_ = EnumDef {
-            name: "ButtonColor".into(),
-            variants: vec![
-                VariantDef {
-                    name: "blue".into(),
-                    ..Default::default()
-                },
-                VariantDef {
-                    name: "green".into(),
-                    ..Default::default()
-                },
-            ],
-            ..Default::default()
-        };
+        let enum_ = EnumDef::new("ButtonColor", &["blue", "green"]);
 
-        BTreeMap::from([(enum_.name(), enum_)])
+        EnumDef::into_map(&[enum_])
     }
 
     fn objects() -> BTreeMap<String, ObjectDef> {
-        let obj1 = ObjectDef {
-            name: "SampleObj".into(),
-            props: vec![
-                PropDef::new("int", TypeRef::Int, json!(1)),
-                PropDef::new("string", TypeRef::String, json!("a string")),
-                PropDef::new("enum", TypeRef::Enum("ButtonColor".into()), json!("blue")),
+        let obj1 = ObjectDef::new(
+            "SampleObj",
+            &[
+                PropDef::new("int", &TypeRef::Int, &json!(1)),
+                PropDef::new("string", &TypeRef::String, &json!("a string")),
+                PropDef::new("enum", &TypeRef::Enum("ButtonColor".into()), &json!("blue")),
                 PropDef::new(
                     "list",
-                    TypeRef::List(Box::new(TypeRef::Boolean)),
-                    json!([true, false]),
+                    &TypeRef::List(Box::new(TypeRef::Boolean)),
+                    &json!([true, false]),
                 ),
                 PropDef::new(
                     "optional",
-                    TypeRef::Option(Box::new(TypeRef::Int)),
-                    json!(null),
+                    &TypeRef::Option(Box::new(TypeRef::Int)),
+                    &json!(null),
                 ),
                 PropDef::new(
                     "nestedObj",
-                    TypeRef::Object("NestedObject".into()),
-                    json!({
+                    &TypeRef::Object("NestedObject".into()),
+                    &json!({
                         "enumMap": {
                             "blue": 1,
                         },
                     }),
                 ),
             ],
-            ..Default::default()
-        };
+        );
 
-        let obj2 = ObjectDef {
-            name: "NestedObject".into(),
-            props: vec![PropDef::new(
+        let obj2 = ObjectDef::new(
+            "NestedObject",
+            &[PropDef::new(
                 "enumMap",
-                TypeRef::EnumMap(
+                &TypeRef::EnumMap(
                     Box::new(TypeRef::Enum("ButtonColor".into())),
                     Box::new(TypeRef::Int),
                 ),
-                json!({
+                &json!({
                     "blue": 4,
                     "green": 2,
                 }),
             )],
-            ..Default::default()
-        };
-        BTreeMap::from([(obj1.name(), obj1), (obj2.name(), obj2)])
+        );
+        ObjectDef::into_map(&[obj1, obj2])
     }
 
     #[test]
     fn test_validate_prop_defaults_string() -> Result<()> {
-        let mut prop = PropDef::new("key", TypeRef::String, json!("default!"));
+        let mut prop = PropDef::new("key", &TypeRef::String, &json!("default!"));
         let enums1 = Default::default();
         let objs = Default::default();
         let fm = DefaultsValidator::new(&enums1, &objs);
@@ -611,7 +596,7 @@ mod test_types {
 
     #[test]
     fn test_validate_prop_defaults_int() -> Result<()> {
-        let mut prop = PropDef::new("key", TypeRef::Int, json!(100));
+        let mut prop = PropDef::new("key", &TypeRef::Int, &json!(100));
         let enums1 = Default::default();
         let objs = Default::default();
         let fm = DefaultsValidator::new(&enums1, &objs);
@@ -625,7 +610,7 @@ mod test_types {
 
     #[test]
     fn test_validate_prop_defaults_bool() -> Result<()> {
-        let mut prop = PropDef::new("key", TypeRef::Boolean, json!(true));
+        let mut prop = PropDef::new("key", &TypeRef::Boolean, &json!(true));
         let enums1 = Default::default();
         let objs = Default::default();
         let fm = DefaultsValidator::new(&enums1, &objs);
@@ -639,7 +624,7 @@ mod test_types {
 
     #[test]
     fn test_validate_prop_defaults_bundle_image() -> Result<()> {
-        let mut prop = PropDef::new("key", TypeRef::BundleImage, json!("IconBlue"));
+        let mut prop = PropDef::new("key", &TypeRef::BundleImage, &json!("IconBlue"));
         let enums1 = Default::default();
         let objs = Default::default();
         let fm = DefaultsValidator::new(&enums1, &objs);
@@ -654,7 +639,7 @@ mod test_types {
 
     #[test]
     fn test_validate_prop_defaults_bundle_text() -> Result<()> {
-        let mut prop = PropDef::new("key", TypeRef::BundleText, json!("BundledText"));
+        let mut prop = PropDef::new("key", &TypeRef::BundleText, &json!("BundledText"));
         let enums1 = Default::default();
         let objs = Default::default();
         let fm = DefaultsValidator::new(&enums1, &objs);
@@ -671,8 +656,8 @@ mod test_types {
     fn test_validate_prop_defaults_option_null() -> Result<()> {
         let mut prop = PropDef::new(
             "key",
-            TypeRef::Option(Box::new(TypeRef::Boolean)),
-            json!(null),
+            &TypeRef::Option(Box::new(TypeRef::Boolean)),
+            &json!(null),
         );
         let enums1 = Default::default();
         let objs = Default::default();
@@ -690,8 +675,8 @@ mod test_types {
     fn test_validate_prop_defaults_nested_options() -> Result<()> {
         let prop = PropDef::new(
             "key",
-            TypeRef::Option(Box::new(TypeRef::Option(Box::new(TypeRef::Boolean)))),
-            json!(true),
+            &TypeRef::Option(Box::new(TypeRef::Option(Box::new(TypeRef::Boolean)))),
+            &json!(true),
         );
         let enums1 = Default::default();
         let objs = Default::default();
@@ -705,8 +690,8 @@ mod test_types {
     fn test_validate_prop_defaults_option_non_null() -> Result<()> {
         let mut prop = PropDef::new(
             "key",
-            TypeRef::Option(Box::new(TypeRef::Boolean)),
-            json!(true),
+            &TypeRef::Option(Box::new(TypeRef::Boolean)),
+            &json!(true),
         );
         let enums1 = Default::default();
         let objs = Default::default();
@@ -722,7 +707,7 @@ mod test_types {
 
     #[test]
     fn test_validate_prop_defaults_enum() -> Result<()> {
-        let mut prop = PropDef::new("key", TypeRef::Enum("ButtonColor".into()), json!("blue"));
+        let mut prop = PropDef::new("key", &TypeRef::Enum("ButtonColor".into()), &json!("blue"));
 
         let enums1 = enums();
         let objs = Default::default();
@@ -742,11 +727,11 @@ mod test_types {
     fn test_validate_prop_defaults_enum_map() -> Result<()> {
         let mut prop = PropDef::new(
             "key",
-            TypeRef::EnumMap(
+            &TypeRef::EnumMap(
                 Box::new(TypeRef::Enum("ButtonColor".into())),
                 Box::new(TypeRef::Int),
             ),
-            json!({
+            &json!({
                 "blue": 1,
                 "green": 22,
             }),
@@ -774,8 +759,8 @@ mod test_types {
     fn test_validate_prop_defaults_string_map() -> Result<()> {
         let mut prop = PropDef::new(
             "key",
-            TypeRef::StringMap(Box::new(TypeRef::Int)),
-            json!({
+            &TypeRef::StringMap(Box::new(TypeRef::Int)),
+            &json!({
                 "blue": 1,
                 "green": 22,
             }),
@@ -803,8 +788,8 @@ mod test_types {
     fn test_validate_prop_defaults_list() -> Result<()> {
         let mut prop = PropDef::new(
             "key",
-            TypeRef::List(Box::new(TypeRef::Int)),
-            json!([1, 3, 100]),
+            &TypeRef::List(Box::new(TypeRef::Int)),
+            &json!([1, 3, 100]),
         );
         let enums1 = Default::default();
         let objs = Default::default();
@@ -821,8 +806,8 @@ mod test_types {
     fn test_validate_prop_defaults_object() -> Result<()> {
         let mut prop = PropDef::new(
             "key",
-            TypeRef::Object("SampleObj".into()),
-            json!({
+            &TypeRef::Object("SampleObj".into()),
+            &json!({
                 "int": 1,
                 "string": "bobo",
                 "enum": "green",
@@ -912,11 +897,11 @@ mod test_types {
     fn test_validate_prop_defaults_enum_map_optional() -> Result<()> {
         let prop = PropDef::new(
             "key",
-            TypeRef::EnumMap(
+            &TypeRef::EnumMap(
                 Box::new(TypeRef::Enum("ButtonColor".into())),
                 Box::new(TypeRef::Option(Box::new(TypeRef::Int))),
             ),
-            json!({
+            &json!({
                 "blue": 1,
             }),
         );
@@ -1015,43 +1000,9 @@ mod string_alias {
         Ok(())
     }
 
-    impl PropDef {
-        pub(crate) fn simple(nm: &str, typ: &TypeRef, value: &Value) -> Self {
-            Self {
-                name: nm.to_string(),
-                typ: typ.clone(),
-                default: value.clone(),
-                doc: nm.to_string(),
-                pref_key: None,
-                string_alias: None,
-            }
-        }
-
-        pub(crate) fn with_string_alias(
-            nm: &str,
-            typ: &TypeRef,
-            value: &Value,
-            sa: &TypeRef,
-        ) -> Self {
-            PropDef {
-                name: nm.to_string(),
-                typ: typ.clone(),
-                default: value.clone(),
-                doc: nm.to_string(),
-                pref_key: None,
-                string_alias: Some(sa.clone()),
-            }
-        }
-    }
-
     fn objects(nm: &str, props: &[PropDef]) -> BTreeMap<String, ObjectDef> {
-        let obj1 = ObjectDef {
-            name: nm.to_string(),
-            props: props.into(),
-            ..Default::default()
-        };
-
-        BTreeMap::from([(nm.to_string(), obj1)])
+        let obj1 = ObjectDef::new(nm, props);
+        ObjectDef::into_map(&[obj1])
     }
 
     fn feature(props: &[PropDef]) -> FeatureDef {
@@ -1098,7 +1049,7 @@ mod string_alias {
         let t = mate.clone();
         let f = {
             let v = json!("Eve");
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
 
         validator.validate_feature_def(&f)?;
@@ -1106,7 +1057,7 @@ mod string_alias {
         let t = mate.clone();
         let f = {
             let v = json!("Nope");
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
         assert!(validator.validate_feature_def(&f).is_err());
 
@@ -1115,19 +1066,19 @@ mod string_alias {
         let t = TypeRef::Option(Box::new(mate.clone()));
         let f = {
             let v = json!(null);
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
         validator.validate_feature_def(&f)?;
 
         let f = {
             let v = json!("Charlie");
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
         validator.validate_feature_def(&f)?;
 
         let f = {
             let v = json!("Nope");
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
         assert!(validator.validate_feature_def(&f).is_err());
 
@@ -1137,19 +1088,19 @@ mod string_alias {
 
         let f = {
             let v = json!([]);
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
         validator.validate_feature_def(&f)?;
 
         let f = {
             let v = json!(["Alice", "Charlie"]);
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
         validator.validate_feature_def(&f)?;
 
         let f = {
             let v = json!(["Alice", "Nope"]);
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
         assert!(validator.validate_feature_def(&f).is_err());
 
@@ -1158,13 +1109,13 @@ mod string_alias {
         let t = TypeRef::EnumMap(Box::new(mate.clone()), Box::new(TypeRef::Boolean));
         let f = {
             let v = json!({"Bonnie": false, "Deborah": true});
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
         validator.validate_feature_def(&f)?;
 
         let f = {
             let v = json!({"Bonnie": false, "Nope": true});
-            feature(&[the_team.clone(), PropDef::simple(nm, &t, &v)])
+            feature(&[the_team.clone(), PropDef::new(nm, &t, &v)])
         };
         assert!(validator.validate_feature_def(&f).is_err());
 
@@ -1219,8 +1170,8 @@ mod string_alias {
         let objects = objects(
             "Player",
             &[
-                PropDef::simple("name", mate, &json!("Untested")),
-                PropDef::simple("position", &position, &json!("Untested")),
+                PropDef::new("name", mate, &json!("Untested")),
+                PropDef::new("position", &position, &json!("Untested")),
             ],
         );
         let enums = Default::default();
@@ -1234,7 +1185,7 @@ mod string_alias {
             feature(&[
                 the_team.clone(),
                 positions.clone(),
-                PropDef::simple(nm, &t, &v),
+                PropDef::new(nm, &t, &v),
             ])
         };
         validator.validate_feature_def(&f)?;
@@ -1244,7 +1195,7 @@ mod string_alias {
             feature(&[
                 the_team.clone(),
                 positions.clone(),
-                PropDef::simple(nm, &t, &v),
+                PropDef::new(nm, &t, &v),
             ])
         };
         assert!(validator.validate_feature_def(&f).is_err());

--- a/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
@@ -33,11 +33,11 @@ pub(crate) fn get_simple_homescreen_feature() -> FeatureManifest {
                 "Represents the homescreen feature",
                 vec![PropDef::new(
                     "sections-enabled",
-                    TypeRef::EnumMap(
+                    &TypeRef::EnumMap(
                         Box::new(TypeRef::Enum("HomeScreenSection".into())),
                         Box::new(TypeRef::Boolean),
                     ),
-                    json!({
+                    &json!({
                         "top-sites": true,
                         "jump-back-in": false,
                         "recently-saved": false,

--- a/components/support/nimbus-fml/src/fixtures/mod.rs
+++ b/components/support/nimbus-fml/src/fixtures/mod.rs
@@ -2,4 +2,80 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::intermediate_representation::{EnumDef, ObjectDef, PropDef, TypeRef, VariantDef};
+
 pub(crate) mod intermediate_representation;
+
+impl EnumDef {
+    pub(crate) fn new(nm: &str, variants: &[&str]) -> Self {
+        let variants = variants
+            .iter()
+            .map(|s| VariantDef {
+                name: s.to_string(),
+                doc: format!("Documentation for {s}"),
+            })
+            .collect();
+        Self {
+            name: nm.to_string(),
+            doc: format!("{nm} documentation"),
+            variants,
+        }
+    }
+
+    pub(crate) fn into_map(value: &[Self]) -> BTreeMap<String, Self> {
+        value.iter().map(|def| (def.name(), def.clone())).collect()
+    }
+}
+
+impl ObjectDef {
+    pub(crate) fn new(nm: &str, props: &[PropDef]) -> Self {
+        Self {
+            name: nm.to_string(),
+            doc: nm.to_string(),
+            props: props.into(),
+        }
+    }
+
+    pub(crate) fn into_map(value: &[Self]) -> BTreeMap<String, Self> {
+        value.iter().map(|def| (def.name(), def.clone())).collect()
+    }
+}
+
+impl PropDef {
+    pub(crate) fn new(nm: &str, typ: &TypeRef, value: &Value) -> Self {
+        Self {
+            name: nm.to_string(),
+            typ: typ.clone(),
+            default: value.clone(),
+            doc: format!("{nm} property of type {typ}"),
+            pref_key: None,
+            string_alias: None,
+        }
+    }
+
+    pub(crate) fn with_string_alias(nm: &str, typ: &TypeRef, value: &Value, sa: &TypeRef) -> Self {
+        PropDef {
+            name: nm.to_string(),
+            typ: typ.clone(),
+            default: value.clone(),
+            doc: nm.to_string(),
+            pref_key: None,
+            string_alias: Some(sa.clone()),
+        }
+    }
+
+    pub(crate) fn with_doc(nm: &str, doc: &str, typ: &TypeRef, default: &Value) -> Self {
+        PropDef {
+            name: nm.to_string(),
+            doc: doc.to_string(),
+            typ: typ.clone(),
+            default: default.clone(),
+            pref_key: None,
+            string_alias: None,
+        }
+    }
+}

--- a/components/support/nimbus-fml/src/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/intermediate_representation.rs
@@ -900,40 +900,6 @@ pub mod unit_tests {
     use crate::error::Result;
     use crate::fixtures::intermediate_representation::get_simple_homescreen_feature;
 
-    impl ObjectDef {
-        pub(crate) fn new(name: &str, props: &[PropDef]) -> Self {
-            Self {
-                name: name.into(),
-                doc: format!("Documentation for {name}"),
-                props: props.into(),
-            }
-        }
-    }
-
-    impl PropDef {
-        pub(crate) fn new(nm: &str, typ: TypeRef, default: Value) -> Self {
-            PropDef {
-                name: nm.into(),
-                doc: format!("{nm} property of type {typ}"),
-                typ,
-                default,
-                pref_key: None,
-                string_alias: None,
-            }
-        }
-
-        pub(crate) fn new_with_doc(nm: &str, doc: &str, typ: TypeRef, default: Value) -> Self {
-            PropDef {
-                name: nm.into(),
-                doc: doc.into(),
-                typ,
-                default,
-                pref_key: None,
-                string_alias: None,
-            }
-        }
-    }
-
     #[test]
     fn can_ir_represent_smoke_test() -> Result<()> {
         let reference_manifest = get_simple_homescreen_feature();
@@ -977,7 +943,11 @@ pub mod unit_tests {
         fm.add_feature(FeatureDef::new(
             "some_def",
             "my lovely qtest doc",
-            vec![PropDef::new("some prop", TypeRef::String, json!("default"))],
+            vec![PropDef::new(
+                "some prop",
+                &TypeRef::String,
+                &json!("default"),
+            )],
             true,
         ));
         fm.validate_manifest()?;
@@ -1004,11 +974,11 @@ mod manifest_structure {
             "Represents the homescreen feature",
             vec![PropDef::new(
                 "sections-enabled",
-                TypeRef::EnumMap(
+                &TypeRef::EnumMap(
                     Box::new(TypeRef::Enum("SectionId".into())),
                     Box::new(TypeRef::String),
                 ),
-                json!({
+                &json!({
                     "top-sites": true,
                     "jump-back-in": false,
                     "recently-saved": false,
@@ -1030,11 +1000,11 @@ mod manifest_structure {
             vec![
                 PropDef::new(
                     "duplicate-prop",
-                    TypeRef::EnumMap(
+                    &TypeRef::EnumMap(
                         Box::new(TypeRef::Enum("SectionId".into())),
                         Box::new(TypeRef::String),
                     ),
-                    json!({
+                    &json!({
                         "top-sites": true,
                         "jump-back-in": false,
                         "recently-saved": false,
@@ -1042,11 +1012,11 @@ mod manifest_structure {
                 ),
                 PropDef::new(
                     "duplicate-prop",
-                    TypeRef::EnumMap(
+                    &TypeRef::EnumMap(
                         Box::new(TypeRef::Enum("SectionId".into())),
                         Box::new(TypeRef::String),
                     ),
-                    json!({
+                    &json!({
                         "top-sites": true,
                         "jump-back-in": false,
                         "recently-saved": false,
@@ -1068,8 +1038,8 @@ mod manifest_structure {
             "test doc",
             vec![PropDef::new(
                 "prop name",
-                TypeRef::Enum("EnumDoesntExist".into()),
-                json!(null),
+                &TypeRef::Enum("EnumDoesntExist".into()),
+                &json!(null),
             )],
             false,
         ));
@@ -1087,8 +1057,8 @@ mod manifest_structure {
             "test doc",
             vec![PropDef::new(
                 "prop name",
-                TypeRef::Object("ObjDoesntExist".into()),
-                json!(null),
+                &TypeRef::Object("ObjDoesntExist".into()),
+                &json!(null),
             )],
             false,
         ));
@@ -1106,8 +1076,8 @@ mod manifest_structure {
             "test doc",
             vec![PropDef::new(
                 "prop name",
-                TypeRef::EnumMap(Box::new(TypeRef::String), Box::new(TypeRef::String)),
-                json!(null),
+                &TypeRef::EnumMap(Box::new(TypeRef::String), Box::new(TypeRef::String)),
+                &json!(null),
             )],
             false,
         ));
@@ -1124,8 +1094,8 @@ mod manifest_structure {
             "test doc",
             vec![PropDef::new(
                 "prop name",
-                TypeRef::List(Box::new(TypeRef::Enum("EnumDoesntExist".into()))),
-                json!(null),
+                &TypeRef::List(Box::new(TypeRef::Enum("EnumDoesntExist".into()))),
+                &json!(null),
             )],
             false,
         ));
@@ -1142,11 +1112,11 @@ mod manifest_structure {
             "test doc",
             vec![PropDef::new(
                 "prop name",
-                TypeRef::EnumMap(
+                &TypeRef::EnumMap(
                     Box::new(TypeRef::Enum("EnumDoesntExist".into())),
                     Box::new(TypeRef::String),
                 ),
-                json!(null),
+                &json!(null),
             )],
             false,
         ));
@@ -1164,11 +1134,11 @@ mod manifest_structure {
             "test doc",
             vec![PropDef::new(
                 "prop name",
-                TypeRef::EnumMap(
+                &TypeRef::EnumMap(
                     Box::new(TypeRef::Enum("SectionId".into())),
                     Box::new(TypeRef::Object("ObjDoesntExist".into())),
                 ),
-                json!(null),
+                &json!(null),
             )],
             false,
         ));
@@ -1185,8 +1155,8 @@ mod manifest_structure {
             "test doc",
             vec![PropDef::new(
                 "prop name",
-                TypeRef::StringMap(Box::new(TypeRef::Enum("EnumDoesntExist".into()))),
-                json!(null),
+                &TypeRef::StringMap(Box::new(TypeRef::Enum("EnumDoesntExist".into()))),
+                &json!(null),
             )],
             false,
         ));
@@ -1203,8 +1173,8 @@ mod manifest_structure {
             "test doc",
             vec![PropDef::new(
                 "prop name",
-                TypeRef::Option(Box::new(TypeRef::Option(Box::new(TypeRef::String)))),
-                json!(null),
+                &TypeRef::Option(Box::new(TypeRef::Option(Box::new(TypeRef::String)))),
+                &json!(null),
             )],
             false,
         ));
@@ -1229,30 +1199,28 @@ mod imports_tests {
     fn test_iter_object_defs_deep_iterates_on_all_imports() -> Result<()> {
         let prop_i = PropDef::new(
             "key_i",
-            TypeRef::Object("SampleObjImported".into()),
-            json!({
+            &TypeRef::Object("SampleObjImported".into()),
+            &json!({
                 "string": "bobo",
             }),
         );
-        let obj_defs_i = vec![ObjectDef {
-            name: "SampleObjImported".into(),
-            props: vec![PropDef::new("string", TypeRef::String, json!("a string"))],
-            ..Default::default()
-        }];
+        let obj_defs_i = vec![ObjectDef::new(
+            "SampleObjImported",
+            &[PropDef::new("string", &TypeRef::String, &json!("a string"))],
+        )];
         let fm_i = get_one_prop_feature_manifest(obj_defs_i, vec![], &prop_i);
 
         let prop = PropDef::new(
             "key",
-            TypeRef::Object("SampleObj".into()),
-            json!({
+            &TypeRef::Object("SampleObj".into()),
+            &json!({
                 "string": "bobo",
             }),
         );
-        let obj_defs = vec![ObjectDef {
-            name: "SampleObj".into(),
-            props: vec![PropDef::new("string", TypeRef::String, json!("a string"))],
-            ..Default::default()
-        }];
+        let obj_defs = vec![ObjectDef::new(
+            "SampleObj",
+            &[PropDef::new("string", &TypeRef::String, &json!("a string"))],
+        )];
         let fm = get_one_prop_feature_manifest_with_imports(
             obj_defs,
             vec![],
@@ -1270,10 +1238,10 @@ mod imports_tests {
 
     #[test]
     fn test_iter_feature_defs_deep_iterates_on_all_imports() -> Result<()> {
-        let prop_i = PropDef::new("key_i", TypeRef::String, json!("string"));
+        let prop_i = PropDef::new("key_i", &TypeRef::String, &json!("string"));
         let fm_i = get_one_prop_feature_manifest(vec![], vec![], &prop_i);
 
-        let prop = PropDef::new("key", TypeRef::String, json!("string"));
+        let prop = PropDef::new("key", &TypeRef::String, &json!("string"));
         let fm = get_one_prop_feature_manifest_with_imports(
             vec![],
             vec![],
@@ -1419,8 +1387,8 @@ mod imports_tests {
                 name: "feature_i".into(),
                 props: vec![PropDef::new(
                     "prop_i_1",
-                    TypeRef::String,
-                    Value::String("prop_i_1_value".into()),
+                    &TypeRef::String,
+                    &json!("prop_i_1_value"),
                 )],
                 ..Default::default()
             }],
@@ -1434,8 +1402,8 @@ mod imports_tests {
                 name: "feature".into(),
                 props: vec![PropDef::new(
                     "prop_1",
-                    TypeRef::String,
-                    Value::String("prop_1_value".into()),
+                    &TypeRef::String,
+                    &json!("prop_1_value"),
                 )],
                 ..Default::default()
             }],
@@ -1472,8 +1440,8 @@ mod feature_config_tests {
                 name: "feature".into(),
                 props: vec![PropDef::new(
                     "prop_1",
-                    TypeRef::String,
-                    Value::String("prop_1_value".into()),
+                    &TypeRef::String,
+                    &json!("prop_1_value"),
                 )],
                 ..Default::default()
             }],
@@ -1501,8 +1469,8 @@ mod feature_config_tests {
                 name: "feature".into(),
                 props: vec![PropDef::new(
                     "prop_1",
-                    TypeRef::String,
-                    Value::String("prop_1_value".into()),
+                    &TypeRef::String,
+                    &json!("prop_1_value"),
                 )],
                 ..Default::default()
             }],
@@ -1534,21 +1502,15 @@ mod feature_config_tests {
                 name: "feature".into(),
                 props: vec![PropDef::new(
                     "prop_1",
-                    TypeRef::Option(Box::new(TypeRef::String)),
-                    Value::Null,
+                    &TypeRef::Option(Box::new(TypeRef::String)),
+                    &Value::Null,
                 )],
                 ..Default::default()
             }],
             HashMap::new(),
         );
 
-        let result = fm.validate_feature_config(
-            "feature",
-            Value::Object(Map::from_iter([(
-                "prop".to_string(),
-                Value::String("new value".into()),
-            )])),
-        );
+        let result = fm.validate_feature_config("feature", json!({"prop": "new value"}));
         assert!(result.is_err());
         assert_eq!(
             result.err().unwrap().to_string(),
@@ -1567,8 +1529,8 @@ mod feature_config_tests {
                 name: "feature".into(),
                 props: vec![PropDef::new(
                     "prop_1",
-                    TypeRef::String,
-                    json!("prop_1_value"),
+                    &TypeRef::String,
+                    &json!("prop_1_value"),
                 )],
                 ..Default::default()
             }],
@@ -1590,11 +1552,10 @@ mod feature_config_tests {
 
     #[test]
     fn test_validate_feature_config_errors_on_invalid_object_prop() -> Result<()> {
-        let obj_defs = vec![ObjectDef {
-            name: "SampleObj".into(),
-            props: vec![PropDef::new("string", TypeRef::String, json!("a string"))],
-            ..Default::default()
-        }];
+        let obj_defs = vec![ObjectDef::new(
+            "SampleObj",
+            &[PropDef::new("string", &TypeRef::String, &json!("a string"))],
+        )];
         let fm = get_feature_manifest(
             obj_defs,
             vec![],
@@ -1602,8 +1563,8 @@ mod feature_config_tests {
                 name: "feature".into(),
                 props: vec![PropDef::new(
                     "prop_1",
-                    TypeRef::Object("SampleObj".into()),
-                    json!({
+                    &TypeRef::Object("SampleObj".into()),
+                    &json!({
                         "string": "a value"
                     }),
                 )],
@@ -1676,7 +1637,7 @@ mod string_aliases {
         let newest_member = {
             let t = &name;
             let v = json!("Alice"); // it doesn't matter for this test what the value is.
-            PropDef::simple("newest-member", t, &v)
+            PropDef::new("newest-member", t, &v)
         };
 
         // -> Verify that a property in a feature can validate against the a string-alias
@@ -1698,7 +1659,7 @@ mod string_aliases {
             let t = TypeRef::Object("Team".to_string());
             let v = json!({ "newest-member": "Alice" });
 
-            PropDef::simple("team", &t, &v)
+            PropDef::new("team", &t, &v)
         };
 
         // { all-names: ["Alice"], team: { newest-member: "Alice" } }
@@ -1717,7 +1678,7 @@ mod string_aliases {
             let t = TypeRef::Object("Match".to_string());
             let v = json!({ "team": { "newest-member": "Alice" }});
 
-            PropDef::simple("match", &t, &v)
+            PropDef::new("match", &t, &v)
         };
 
         // { all-names: ["Alice"], match: { team: { newest-member: "Alice" }} }

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -538,17 +538,17 @@ mod unit_tests {
         let obj_def = &ir.obj_defs["Button"];
         assert!(obj_def.name == *"Button");
         assert!(obj_def.doc == *"This is a button object");
-        assert!(obj_def.props.contains(&PropDef::new_with_doc(
+        assert!(obj_def.props.contains(&PropDef::with_doc(
             "label",
             "This is the label for the button",
-            TypeRef::String,
-            serde_json::Value::String("REQUIRED FIELD".to_string()),
+            &TypeRef::String,
+            &serde_json::json!("REQUIRED FIELD")
         )));
-        assert!(obj_def.props.contains(&PropDef::new_with_doc(
+        assert!(obj_def.props.contains(&PropDef::with_doc(
             "color",
             "This is the color of the button",
-            TypeRef::Option(Box::new(TypeRef::String)),
-            serde_json::Value::Null,
+            &TypeRef::Option(Box::new(TypeRef::String)),
+            &serde_json::Value::Null
         )));
 
         // Validate parsed features


### PR DESCRIPTION
Relates to [ EXP-3938](https://mozilla-hub.atlassian.net/browse/EXP-3938).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

These changes are to tests, and are all fairly mechanical, so this should be O(1). However, there are a few changes:

- moved multiple bare construction of structs into a `PropDef::new()`, in one place (was called `PropDef::simple`).
- moved multiple bare construction of structs into a `ObjectDef::new()`, in one place
- moved multiple bare construction of structs into a `EnumDef::new()`, in one place.
- changed the arguments to be borrows instead of owned types.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
