### PR TITLE
Don't run PRAGMA optimize on close of read-only connection

### DIFF
--- a/components/places/src/db/db.rs
+++ b/components/places/src/db/db.rs
@@ -207,6 +207,10 @@ impl Drop for PlacesDb {
     fn drop(&mut self) {
         // In line with both the recommendations from SQLite and the behavior of places in
         // Database.cpp, we run `PRAGMA optimize` before closing the connection.
+        if let ConnectionType::ReadOnly = self.conn_type() {
+            // A reader connection can't execute an optimize
+            return;
+        }
         let res = self.db.execute_batch("PRAGMA optimize(0x02);");
         if let Err(e) = res {
             log::warn!("Failed to execute pragma optimize (DB locked?): {}", e);


### PR DESCRIPTION
While debugging the sqlite crash was getting lots of logs of the pragma optimize failing on the reader connection because it was trying to write to the database

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
