### PR TITLE
Removed FxA MetricsParams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v122.0 (In progress)
 
+## Places
+
+### ⚠️ Breaking Changes ⚠️
+  - Removed the `metrics_params` arguments from `begin_oauth_flow` and `begin_pairing_flow`.
+    This is technically a breaking change, but no consumers were using these optional params so it shouldn't cause any issues downstream.
+
 [Full Changelog](In progress)
 
 # v121.0 (_2023-11-20_)

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
@@ -100,16 +100,14 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
      *
      * @param scopes List of OAuth scopes for which the client wants access
      * @param entrypoint to be used for metrics
-     * @param metricsParams optional parameters used for metrics
      * @return String that resolves to the flow URL when complete
      */
     fun beginOAuthFlow(
         scopes: Array<String>,
         entrypoint: String,
-        metricsParams: MetricsParams = MetricsParams(mapOf()),
     ): String {
         return withMetrics {
-            this.inner.beginOauthFlow(scopes.toList(), entrypoint, metricsParams)
+            this.inner.beginOauthFlow(scopes.toList(), entrypoint)
         }
     }
 
@@ -121,17 +119,15 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
      * @param pairingUrl the url to initilaize the paring flow with
      * @param scopes List of OAuth scopes for which the client wants access
      * @param entrypoint to be used for metrics
-     * @param metricsParams optional parameters used for metrics
      * @return String that resoles to the flow URL when complete
      */
     fun beginPairingFlow(
         pairingUrl: String,
         scopes: Array<String>,
         entrypoint: String,
-        metricsParams: MetricsParams = MetricsParams(mapOf()),
     ): String {
         return withMetrics {
-            this.inner.beginPairingFlow(pairingUrl, scopes.toList(), entrypoint, metricsParams)
+            this.inner.beginPairingFlow(pairingUrl, scopes.toList(), entrypoint)
         }
     }
 

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -99,7 +99,6 @@ open class FxAccountManager {
     /// `finishAuthentication(...)` to complete the flow.
     public func beginAuthentication(
         entrypoint: String,
-        metrics: MetricsParams = MetricsParams(parameters: [:]),
         completionHandler: @escaping (Result<URL, Error>) -> Void
     ) {
         FxALog.info("beginAuthentication")
@@ -107,8 +106,7 @@ open class FxAccountManager {
             let result = self.updatingLatestAuthState { account in
                 try account.beginOAuthFlow(
                     scopes: self.applicationScopes,
-                    entrypoint: entrypoint,
-                    metrics: metrics
+                    entrypoint: entrypoint
                 )
             }
             DispatchQueue.main.async { completionHandler(result) }
@@ -127,7 +125,6 @@ open class FxAccountManager {
     public func beginPairingAuthentication(
         pairingUrl: String,
         entrypoint: String,
-        metrics: MetricsParams = MetricsParams(parameters: [:]),
         completionHandler: @escaping (Result<URL, Error>) -> Void
     ) {
         DispatchQueue.global().async {
@@ -135,8 +132,7 @@ open class FxAccountManager {
                 try account.beginPairingFlow(
                     pairingUrl: pairingUrl,
                     scopes: self.applicationScopes,
-                    entrypoint: entrypoint,
-                    metrics: metrics
+                    entrypoint: entrypoint
                 )
             }
             DispatchQueue.main.async { completionHandler(result) }

--- a/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
@@ -54,14 +54,12 @@ class PersistedFirefoxAccount {
 
     public func beginOAuthFlow(
         scopes: [String],
-        entrypoint: String,
-        metrics: MetricsParams = MetricsParams(parameters: [:])
+        entrypoint: String
     ) throws -> URL {
         return try notifyAuthErrors {
             try URL(string: self.inner.beginOauthFlow(
                 scopes: scopes,
-                entrypoint: entrypoint,
-                metrics: metrics
+                entrypoint: entrypoint
             ))!
         }
     }
@@ -73,14 +71,12 @@ class PersistedFirefoxAccount {
     public func beginPairingFlow(
         pairingUrl: String,
         scopes: [String],
-        entrypoint: String,
-        metrics: MetricsParams = MetricsParams(parameters: [:])
+        entrypoint: String
     ) throws -> URL {
         return try notifyAuthErrors {
             try URL(string: self.inner.beginPairingFlow(pairingUrl: pairingUrl,
                                                         scopes: scopes,
-                                                        entrypoint: entrypoint,
-                                                        metrics: metrics))!
+                                                        entrypoint: entrypoint))!
         }
     }
 

--- a/components/fxa-client/src/auth.rs
+++ b/components/fxa-client/src/auth.rs
@@ -25,7 +25,6 @@
 
 use crate::{ApiResult, Error, FirefoxAccount};
 use error_support::handle_error;
-use std::collections::HashMap;
 
 impl FirefoxAccount {
     /// Get the high-level authentication state of the client
@@ -61,12 +60,9 @@ impl FirefoxAccount {
         // Allow both &[String] and &[&str] since UniFFI can't represent `&[&str]` yet,
         scopes: &[T],
         entrypoint: &str,
-        metrics: Option<MetricsParams>,
     ) -> ApiResult<String> {
         let scopes = scopes.iter().map(T::as_ref).collect::<Vec<_>>();
-        self.internal
-            .lock()
-            .begin_oauth_flow(&scopes, entrypoint, metrics)
+        self.internal.lock().begin_oauth_flow(&scopes, entrypoint)
     }
 
     /// Get the URL at which to begin a device-pairing signin flow.
@@ -109,13 +105,12 @@ impl FirefoxAccount {
         pairing_url: &str,
         scopes: &[String],
         entrypoint: &str,
-        metrics: Option<MetricsParams>,
     ) -> ApiResult<String> {
         // UniFFI can't represent `&[&str]` yet, so convert it internally here.
         let scopes = scopes.iter().map(String::as_str).collect::<Vec<_>>();
         self.internal
             .lock()
-            .begin_pairing_flow(pairing_url, &scopes, entrypoint, metrics)
+            .begin_pairing_flow(pairing_url, &scopes, entrypoint)
     }
 
     /// Complete an OAuth flow.
@@ -191,11 +186,6 @@ impl FirefoxAccount {
 /// connected to the user's account.
 pub struct AuthorizationInfo {
     pub active: bool,
-}
-
-/// Additional metrics tracking parameters to include in an OAuth request.
-pub struct MetricsParams {
-    pub parameters: HashMap<String, String>,
 }
 
 /// High-level view of the authorization state

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -163,7 +163,7 @@ interface FirefoxAccount {
   //       - These will be included as query parameters in the resulting URL.
   //
   [Throws=FxaError]
-  string begin_oauth_flow([ByRef] sequence<string> scopes, [ByRef] string entrypoint,  MetricsParams? metrics );
+  string begin_oauth_flow([ByRef] sequence<string> scopes, [ByRef] string entrypoint);
   
 
   // Get the URL at which to begin a device-pairing signin flow.
@@ -202,7 +202,7 @@ interface FirefoxAccount {
   //       - These will be included as query parameters in the resulting URL.
   //
   [Throws=FxaError]
-  string begin_pairing_flow([ByRef] string pairing_url, [ByRef] sequence<string> scopes, [ByRef] string entrypoint,  MetricsParams? metrics );
+  string begin_pairing_flow([ByRef] string pairing_url, [ByRef] sequence<string> scopes, [ByRef] string entrypoint);
   
 
   // Complete an OAuth flow.
@@ -709,12 +709,6 @@ interface FxaServer {
 //
 dictionary AuthorizationInfo {
   boolean active;
-};
-
-// Additional metrics tracking parameters to include in an OAuth request.
-//
-dictionary MetricsParams {
-  record<DOMString, string> parameters;
 };
 
 // An OAuth access token, with its associated keys and metadata.

--- a/components/fxa-client/src/internal/oauth.rs
+++ b/components/fxa-client/src/internal/oauth.rs
@@ -11,7 +11,7 @@ use super::{
     scoped_keys::ScopedKeysFlow,
     util, FirefoxAccount,
 };
-use crate::{AuthorizationParameters, Error, FxaServer, MetricsParams, Result, ScopedKey};
+use crate::{AuthorizationParameters, Error, FxaServer, Result, ScopedKey};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use jwcrypto::{EncryptionAlgorithm, EncryptionParameters};
 use rate_limiter::RateLimiter;
@@ -125,13 +125,9 @@ impl FirefoxAccount {
         pairing_url: &str,
         scopes: &[&str],
         entrypoint: &str,
-        metrics: Option<MetricsParams>,
     ) -> Result<String> {
         let mut url = self.state.config().pair_supp_url()?;
         url.query_pairs_mut().append_pair("entrypoint", entrypoint);
-        if let Some(metrics) = metrics {
-            metrics.append_params_to_url(&mut url);
-        }
         let pairing_url = Url::parse(pairing_url)?;
         if url.host_str() != pairing_url.host_str() {
             let fxa_server = FxaServer::from(&url);
@@ -149,12 +145,7 @@ impl FirefoxAccount {
     /// * `scopes` - Space-separated list of requested scopes.
     /// * `entrypoint` - The entrypoint to be used for metrics
     /// * `metrics` - Optional metrics parameters
-    pub fn begin_oauth_flow(
-        &mut self,
-        scopes: &[&str],
-        entrypoint: &str,
-        metrics: Option<MetricsParams>,
-    ) -> Result<String> {
+    pub fn begin_oauth_flow(&mut self, scopes: &[&str], entrypoint: &str) -> Result<String> {
         let mut url = if self.state.last_seen_profile().is_some() {
             self.state.config().oauth_force_auth_url()?
         } else {
@@ -165,9 +156,6 @@ impl FirefoxAccount {
             .append_pair("action", "email")
             .append_pair("response_type", "code")
             .append_pair("entrypoint", entrypoint);
-        if let Some(metrics) = metrics {
-            metrics.append_params_to_url(&mut url);
-        }
 
         if let Some(cached_profile) = self.state.last_seen_profile() {
             url.query_pairs_mut()
@@ -520,17 +508,6 @@ impl TryFrom<Url> for AuthorizationParameters {
     }
 }
 
-impl MetricsParams {
-    fn append_params_to_url(&self, url: &mut Url) {
-        self.parameters
-            .iter()
-            .for_each(|(parameter_name, parameter_value)| {
-                url.query_pairs_mut()
-                    .append_pair(parameter_name, parameter_value);
-            });
-    }
-}
-
 #[derive(Clone, Serialize, Deserialize)]
 pub struct RefreshToken {
     pub token: String,
@@ -625,12 +602,9 @@ mod tests {
             "12345678",
             "https://foo.bar",
         );
-        let mut params = HashMap::new();
-        params.insert("flow_id".to_string(), "87654321".to_string());
-        let metrics_params = MetricsParams { parameters: params };
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_oauth_flow(&["profile"], "test_oauth_flow_url", Some(metrics_params))
+            .begin_oauth_flow(&["profile"], "test_oauth_flow_url")
             .unwrap();
         let flow_url = Url::parse(&url).unwrap();
 
@@ -638,7 +612,7 @@ mod tests {
         assert_eq!(flow_url.path(), "/authorization");
 
         let mut pairs = flow_url.query_pairs();
-        assert_eq!(pairs.count(), 12);
+        assert_eq!(pairs.count(), 11);
         assert_eq!(
             pairs.next(),
             Some((Cow::Borrowed("action"), Cow::Borrowed("email")))
@@ -653,10 +627,6 @@ mod tests {
                 Cow::Borrowed("entrypoint"),
                 Cow::Borrowed("test_oauth_flow_url")
             ))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("flow_id"), Cow::Borrowed("87654321")))
         );
         assert_eq!(
             pairs.next(),
@@ -704,7 +674,7 @@ mod tests {
         let email = "test@example.com";
         fxa.add_cached_profile("123", email);
         let url = fxa
-            .begin_oauth_flow(&["profile"], "test_force_auth_url", None)
+            .begin_oauth_flow(&["profile"], "test_force_auth_url")
             .unwrap();
         let url = Url::parse(&url).unwrap();
         assert_eq!(url.path(), "/oauth/force_auth");
@@ -727,7 +697,7 @@ mod tests {
         );
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_oauth_flow(SCOPES, "test_webchannel_context_url", None)
+            .begin_oauth_flow(SCOPES, "test_webchannel_context_url")
             .unwrap();
         let url = Url::parse(&url).unwrap();
         let query_params: HashMap<_, _> = url.query_pairs().into_owned().collect();
@@ -748,12 +718,7 @@ mod tests {
         );
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_pairing_flow(
-                PAIRING_URL,
-                SCOPES,
-                "test_webchannel_pairing_context_url",
-                None,
-            )
+            .begin_pairing_flow(PAIRING_URL, SCOPES, "test_webchannel_pairing_context_url")
             .unwrap();
         let url = Url::parse(&url).unwrap();
         let query_params: HashMap<_, _> = url.query_pairs().into_owned().collect();
@@ -773,18 +738,10 @@ mod tests {
             "12345678",
             "https://foo.bar",
         );
-        let mut params = HashMap::new();
-        params.insert("flow_id".to_string(), "87654321".to_string());
-        let metrics_params = MetricsParams { parameters: params };
 
         let mut fxa = FirefoxAccount::with_config(config);
         let url = fxa
-            .begin_pairing_flow(
-                PAIRING_URL,
-                SCOPES,
-                "test_pairing_flow_url",
-                Some(metrics_params),
-            )
+            .begin_pairing_flow(PAIRING_URL, SCOPES, "test_pairing_flow_url")
             .unwrap();
         let flow_url = Url::parse(&url).unwrap();
         let expected_parsed_url = Url::parse(EXPECTED_URL).unwrap();
@@ -794,17 +751,13 @@ mod tests {
         assert_eq!(flow_url.fragment(), expected_parsed_url.fragment());
 
         let mut pairs = flow_url.query_pairs();
-        assert_eq!(pairs.count(), 10);
+        assert_eq!(pairs.count(), 9);
         assert_eq!(
             pairs.next(),
             Some((
                 Cow::Borrowed("entrypoint"),
                 Cow::Borrowed("test_pairing_flow_url")
             ))
-        );
-        assert_eq!(
-            pairs.next(),
-            Some((Cow::Borrowed("flow_id"), Cow::Borrowed("87654321")))
         );
         assert_eq!(
             pairs.next(),
@@ -857,7 +810,6 @@ mod tests {
             PAIRING_URL,
             &["https://identity.mozilla.com/apps/oldsync"],
             "test_pairiong_flow_origin_mismatch",
-            None,
         );
 
         assert!(url.is_err());

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -52,7 +52,7 @@ use std::fmt;
 pub use sync15::DeviceType;
 use url::Url;
 
-pub use auth::{AuthorizationInfo, FxaRustAuthState, MetricsParams};
+pub use auth::{AuthorizationInfo, FxaRustAuthState};
 pub use device::{AttachedClient, Device, DeviceCapability, LocalDevice};
 pub use error::{Error, FxaError};
 use parking_lot::Mutex;

--- a/examples/cli-support/src/fxa_creds.rs
+++ b/examples/cli-support/src/fxa_creds.rs
@@ -46,7 +46,7 @@ fn load_or_create_fxa_creds(path: &str, cfg: FxaConfig) -> Result<FirefoxAccount
 
 fn create_fxa_creds(path: &str, cfg: FxaConfig) -> Result<FirefoxAccount> {
     let acct = FirefoxAccount::new(cfg);
-    let oauth_uri = acct.begin_oauth_flow(&[SYNC_SCOPE], "fxa_creds", None)?;
+    let oauth_uri = acct.begin_oauth_flow(&[SYNC_SCOPE], "fxa_creds")?;
 
     if webbrowser::open(oauth_uri.as_ref()).is_err() {
         log::warn!("Failed to open a web browser D:");

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/FxAccountMocks.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/FxAccountMocks.swift
@@ -71,8 +71,7 @@ class MockFxAccount: PersistedFirefoxAccount {
 
     override func beginOAuthFlow(
         scopes _: [String],
-        entrypoint _: String,
-        metrics _: MetricsParams = MetricsParams(parameters: [:])
+        entrypoint _: String
     ) throws -> URL {
         return URL(string: "https://foo.bar/oauth?state=bobo")!
     }


### PR DESCRIPTION
This allowed consumers to add extra query parameters to oauth flow URLs. However, it wasn't being used so let's kill it.

My evidence for this is searchfox: https://searchfox.org/mozilla-mobile/search?q=MetricsParams&path=&case=false&regexp=false.  I believe that would show up results in `firefox-android` or `firefox-ios` if the feature was being used.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
