### PR TITLE
Fixes FeatureHolderAny initializer not public

### DIFF
--- a/components/nimbus/ios/Nimbus/FeatureHolder.swift
+++ b/components/nimbus/ios/Nimbus/FeatureHolder.swift
@@ -156,7 +156,7 @@ extension FeatureHolder: FeatureHolderInterface {
 public class FeatureHolderAny {
     let inner: FeatureHolderInterface
     let innerValue: FMLFeatureInterface
-    init<T>(wrapping holder: FeatureHolder<T>) {
+    public init<T>(wrapping holder: FeatureHolder<T>) {
         inner = holder
         innerValue = holder.value()
     }


### PR DESCRIPTION
Fixes breaking change in https://github.com/mozilla-mobile/firefox-ios/pull/17523

Was simple enough so I pushed it up 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
