### PR TITLE
update record_enrollment_status_telemetry to only send metrics for available experiments (backport #5916)

### DIFF
--- a/components/nimbus/src/stateful/nimbus_client.rs
+++ b/components/nimbus/src/stateful/nimbus_client.rs
@@ -156,7 +156,7 @@ impl NimbusClient {
             .collect();
         self.database_cache
             .commit_and_update(db, writer, &coenrolling_ids)?;
-        self.record_enrollment_status_telemetry()?;
+        self.record_enrollment_status_telemetry(state)?;
         Ok(())
     }
 
@@ -691,12 +691,24 @@ impl NimbusClient {
         Ok(())
     }
 
-    fn record_enrollment_status_telemetry(&self) -> Result<()> {
+    fn record_enrollment_status_telemetry(
+        &self,
+        state: &mut MutexGuard<InternalMutableState>,
+    ) -> Result<()> {
+        let targeting_helper = NimbusTargetingHelper::new(
+            state.targeting_attributes.clone(),
+            self.event_store.clone(),
+        );
         let experiments = self
             .database_cache
             .get_experiments()?
             .iter()
-            .map(|exp| exp.slug.clone())
+            .filter_map(
+                |exp| match is_experiment_available(&targeting_helper, exp, true) {
+                    true => Some(exp.slug.clone()),
+                    false => None,
+                },
+            )
             .collect::<HashSet<String>>();
         self.metrics_handler.record_enrollment_statuses(
             self.database_cache


### PR DESCRIPTION
This is a backport of pull request https://github.com/mozilla/application-services/pull/5916 for the v120 release.