### PR TITLE
Define the FxA `DeviceConfig` struct [firefox-ios: main]

### DIFF
--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -395,7 +395,7 @@ open class FxAccountManager {
                         FxALog.info("Initializing device")
                         requireConstellation().initDevice(
                             name: deviceConfig.name,
-                            type: deviceConfig.type,
+                            type: deviceConfig.deviceType,
                             capabilities: deviceConfig.capabilities
                         )
 
@@ -421,7 +421,7 @@ open class FxAccountManager {
                         FxALog.info("Initializing device")
                         requireConstellation().initDevice(
                             name: deviceConfig.name,
-                            type: deviceConfig.type,
+                            type: deviceConfig.deviceType,
                             capabilities: deviceConfig.capabilities
                         )
 
@@ -436,7 +436,7 @@ open class FxAccountManager {
                             FxALog.info("Initializing device")
                             requireConstellation().initDevice(
                                 name: deviceConfig.name,
-                                type: deviceConfig.type,
+                                type: deviceConfig.deviceType,
                                 capabilities: deviceConfig.capabilities
                             )
 
@@ -572,7 +572,7 @@ open class FxAccountManager {
                     self.deviceConfig = DeviceConfig(
                         name: localDevice.displayName,
                         // The other properties are likely to not get modified.
-                        type: self.deviceConfig.type,
+                        type: self.deviceConfig.deviceType,
                         capabilities: self.deviceConfig.capabilities
                     )
                 }
@@ -647,14 +647,8 @@ public struct FxaAuthData {
     }
 }
 
-public struct DeviceConfig {
-    let name: String
-    let type: DeviceType
-    let capabilities: [DeviceCapability]
-
-    public init(name: String, type: DeviceType, capabilities: [DeviceCapability]) {
-        self.name = name
-        self.type = type
-        self.capabilities = capabilities
+extension DeviceConfig {
+    init(name: String, type: DeviceType, capabilities: [DeviceCapability]) {
+        self.init(name: name, deviceType: type, capabilities: capabilities)
     }
 }

--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -196,6 +196,14 @@ impl FirefoxAccount {
     }
 }
 
+/// Device configuration
+#[derive(Debug)]
+pub struct DeviceConfig {
+    pub name: String,
+    pub device_type: sync15::DeviceType,
+    pub capabilities: Vec<DeviceCapability>,
+}
+
 /// Local device that's connecting to FxA
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocalDevice {

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -809,6 +809,13 @@ dictionary Device {
   i64? last_access_time;
 };
 
+// Device configuration
+dictionary DeviceConfig {
+  string name;
+  DeviceType device_type;
+  sequence<DeviceCapability> capabilities;
+};
+
 // Local device that's connecting to FxA
 //
 // This is returned by the device update methods and represents the server's view of the local

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -53,7 +53,7 @@ pub use sync15::DeviceType;
 use url::Url;
 
 pub use auth::{AuthorizationInfo, FxaRustAuthState};
-pub use device::{AttachedClient, Device, DeviceCapability, LocalDevice};
+pub use device::{AttachedClient, Device, DeviceCapability, DeviceConfig, LocalDevice};
 pub use error::{Error, FxaError};
 use parking_lot::Mutex;
 pub use profile::Profile;


### PR DESCRIPTION
This was defined in Swift, but I want to use it in the Rust code as well.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
