### PR TITLE
Adding FxA state machine

### DIFF
--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -187,6 +187,12 @@ pub enum Error {
 
     #[error("Invalid Push Event")]
     InvalidPushEvent,
+
+    #[error("Invalid state transition: {0}")]
+    InvalidStateTransition(String),
+
+    #[error("Internal error in the state machine: {0}")]
+    StateMachineLogicError(String),
 }
 
 // Define how our internal errors are handled and converted to external errors
@@ -212,6 +218,12 @@ impl GetErrorHandling for Error {
             }
             Error::BackoffError(_) => {
                 ErrorHandling::convert(FxaError::Other).report_error("fxa-client-backoff")
+            }
+            Error::InvalidStateTransition(_) => {
+                ErrorHandling::convert(FxaError::Other).report_error("fxa-state-machine-error")
+            }
+            Error::StateMachineLogicError(_) => {
+                ErrorHandling::convert(FxaError::Other).report_error("fxa-state-machine-error")
             }
             Error::OriginMismatch(_) => ErrorHandling::convert(FxaError::OriginMismatch),
             _ => ErrorHandling::convert(FxaError::Other).report_error("fxa-client-other-error"),

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -679,6 +679,24 @@ interface FirefoxAccount {
   void simulate_permanent_auth_token_issue();
 };
 
+interface FxaStateMachine {
+  // Create an FxaStateMachine
+  //
+  // Note: When restoring a connected account, only `device_config.capabilities` will be used.  We
+  // will use the device type and device name info that's stored on the server.
+  constructor(FirefoxAccount account, string oauth_entrypoint, DeviceConfig device_config);
+
+  // Get the current auth state
+  FxaState state();
+
+  // Process a auth event (login, logout, etc).
+  //
+  // On success, returns the new state.
+  // On error, the state will remain the same.
+  [Throws=FxaError]
+  FxaState process_event(FxaEvent event);
+};
+
 dictionary FxaConfig {
     // FxaServer to connect with
     FxaServer server;
@@ -924,6 +942,26 @@ dictionary Profile {
 
   // Whether the `avatar` URL represents the default avatar image.
   boolean is_default_avatar;
+};
+
+[Enum]
+interface FxaState {
+  Uninitialized();
+  Disconnected();
+  Authenticating(string oauth_url);
+  Connected();
+  AuthIssues();
+};
+
+[Enum]
+interface FxaEvent {
+  Initialize();
+  BeginOAuthFlow(sequence<string> scopes);
+  BeginPairingFlow(string pairing_url, sequence<string> scopes);
+  CompleteOAuthFlow(string code, string state);
+  CancelOAuthFlow();
+  CheckAuthorizationStatus();
+  Disconnect();
 };
 
 enum FxaRustAuthState {

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -43,6 +43,7 @@ mod error;
 mod internal;
 mod profile;
 mod push;
+mod state_machine;
 mod storage;
 mod telemetry;
 mod token;
@@ -60,6 +61,7 @@ pub use profile::Profile;
 pub use push::{
     AccountEvent, DevicePushSubscription, IncomingDeviceCommand, SendTabPayload, TabHistoryEntry,
 };
+pub use state_machine::{FxaEvent, FxaState, FxaStateMachine};
 pub use token::{AccessTokenInfo, AuthorizationParameters, ScopedKey};
 
 /// Result returned by internal functions

--- a/components/fxa-client/src/state_machine/logic.rs
+++ b/components/fxa-client/src/state_machine/logic.rs
@@ -1,0 +1,327 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::types::{Event, FxaState, State};
+use crate::{Error, FxaRustAuthState, Result};
+use error_support::report_error;
+
+/// Advance the internal state machine
+///
+/// * For public states, if a valid event is sent then we transition to one of the internal states.
+/// * The internal states correspond to [crate::internal::FirefoxAccount] call.
+/// * Internal states are be transitioned out of with a event that corresponds to a successful
+///   result, or `Event::CallError` if there was an error making the call.
+///
+/// prev_public_state is the state that the state machine was in before `process_event` was called.
+pub fn next_state(state: State, event: Event, prev_public_state: &FxaState) -> Result<State> {
+    Ok(match (state, event) {
+        // Initialization transitions
+        (State::Uninitialized, Event::Initialize) => State::GetAuthState,
+        (State::GetAuthState, Event::GetAuthStateSuccess { auth_state }) => match auth_state {
+            FxaRustAuthState::Disconnected => State::Disconnected,
+            FxaRustAuthState::AuthIssues => State::AuthIssues,
+            FxaRustAuthState::Connected => State::EnsureDeviceCapabilities,
+        },
+        (State::EnsureDeviceCapabilities, Event::EnsureDeviceCapabilitiesSuccess) => {
+            State::Connected
+        }
+        (State::EnsureDeviceCapabilities, Event::CallError) => State::Disconnected,
+
+        // Begin oauth flow transitions
+        (State::Disconnected, Event::BeginOAuthFlow { scopes }) => State::BeginOAuthFlow { scopes },
+        (State::BeginOAuthFlow { .. }, Event::BeginOAuthFlowSuccess { oauth_url }) => {
+            State::Authenticating { oauth_url }
+        }
+        (State::BeginOAuthFlow { .. }, Event::CallError) => prev_public_state.clone().into(),
+
+        // Begin pairing flow transitions
+        (
+            State::Disconnected,
+            Event::BeginPairingFlow {
+                pairing_url,
+                scopes,
+            },
+        ) => State::BeginPairingFlow {
+            pairing_url,
+            scopes,
+        },
+        (State::BeginPairingFlow { .. }, Event::BeginPairingFlowSuccess { oauth_url }) => {
+            State::Authenticating { oauth_url }
+        }
+        (State::BeginPairingFlow { .. }, Event::CallError) => State::Disconnected,
+
+        // Complete oauth flow transitions
+        (State::Authenticating { .. }, Event::CompleteOAuthFlow { code, state }) => {
+            State::CompleteOAuthFlow { code, state }
+        }
+        (State::Authenticating { .. }, Event::CancelOAuthFlow) => State::Disconnected,
+        (State::CompleteOAuthFlow { .. }, Event::CompleteOAuthFlowSuccess) => {
+            State::InitializeDevice
+        }
+        (State::InitializeDevice, Event::EnsureDeviceCapabilitiesSuccess) => State::Connected,
+        (State::CompleteOAuthFlow { .. }, Event::CallError) => prev_public_state.clone().into(),
+        (State::InitializeDevice, Event::CallError) => prev_public_state.clone().into(),
+
+        // Disconnect transitions
+        (State::Connected, Event::Disconnect) => State::Disconnect,
+        (State::Disconnect, Event::DisconnectSuccess) => State::Disconnected,
+        (State::Disconnect, Event::CallError) => {
+            // disconnect() is currently infallible, but let's handle errors anyway in case we
+            // refactor it in the future.
+            report_error!("fxa-state-machine-error", "saw CallError after Disconnect");
+            State::Disconnected
+        }
+
+        // Check authorization status transitions
+        (State::Connected, Event::CheckAuthorizationStatus) => State::CheckAuthorizationStatus,
+        (State::CheckAuthorizationStatus, Event::CheckAuthorizationStatusSuccess { active }) => {
+            if active {
+                State::Connected
+            } else {
+                State::Disconnected
+            }
+        }
+        (State::CheckAuthorizationStatus, Event::CallError) => State::Disconnected,
+
+        // Reauthorization from AuthIssues
+        (State::AuthIssues, Event::BeginOAuthFlow { scopes }) => State::BeginOAuthFlow { scopes },
+
+        // All other transitions are errors
+        (state, event) => {
+            return Err(Error::InvalidStateTransition(format!(
+                "({state} -> {event})"
+            )))
+        }
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Clone)]
+    struct StateMachineTester {
+        state: State,
+        initial_public_state: FxaState,
+    }
+
+    impl StateMachineTester {
+        fn new(initial_public_state: FxaState) -> Self {
+            Self {
+                state: initial_public_state.clone().into(),
+                initial_public_state,
+            }
+        }
+
+        // Calculate the next state, but don't move to it.  Useful for testing error branches.
+        fn peek_next_state(&self, event: Event) -> State {
+            next_state(self.state.clone(), event, &self.initial_public_state).unwrap()
+        }
+
+        fn advance_to_next_state(&mut self, event: Event) -> State {
+            let new_state = self.peek_next_state(event);
+            self.state = new_state.clone();
+            new_state
+        }
+
+        fn is_event_invalid(&self, event: Event) -> bool {
+            next_state(self.state.clone(), event, &self.initial_public_state).is_err()
+        }
+    }
+
+    #[test]
+    fn test_initialize() {
+        let mut tester = StateMachineTester::new(FxaState::Uninitialized);
+        assert_eq!(
+            tester.advance_to_next_state(Event::Initialize),
+            State::GetAuthState
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::GetAuthStateSuccess {
+                auth_state: FxaRustAuthState::Disconnected
+            }),
+            State::Disconnected
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::GetAuthStateSuccess {
+                auth_state: FxaRustAuthState::AuthIssues
+            }),
+            State::AuthIssues
+        );
+
+        assert_eq!(
+            tester.advance_to_next_state(Event::GetAuthStateSuccess {
+                auth_state: FxaRustAuthState::Connected
+            }),
+            State::EnsureDeviceCapabilities
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::CallError),
+            State::Disconnected
+        );
+        assert_eq!(
+            tester.advance_to_next_state(Event::EnsureDeviceCapabilitiesSuccess),
+            State::Connected
+        );
+    }
+
+    #[test]
+    fn test_oauth_flow() {
+        let mut tester = StateMachineTester::new(FxaState::Disconnected);
+        assert_eq!(
+            tester.advance_to_next_state(Event::BeginOAuthFlow {
+                scopes: vec!["profile".to_owned()],
+            }),
+            State::BeginOAuthFlow {
+                scopes: vec!["profile".to_owned()],
+            }
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::CallError),
+            State::Disconnected
+        );
+        assert_eq!(
+            tester.advance_to_next_state(Event::BeginOAuthFlowSuccess {
+                oauth_url: "http://example.com/oauth-start".to_owned()
+            }),
+            State::Authenticating {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_pairing_flow() {
+        let mut tester = StateMachineTester::new(FxaState::Disconnected);
+        assert_eq!(
+            tester.advance_to_next_state(Event::BeginPairingFlow {
+                pairing_url: "https://example.com/pairing-url".to_owned(),
+                scopes: vec!["profile".to_owned()],
+            },),
+            State::BeginPairingFlow {
+                pairing_url: "https://example.com/pairing-url".to_owned(),
+                scopes: vec!["profile".to_owned()],
+            }
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::CallError),
+            State::Disconnected,
+        );
+        assert_eq!(
+            tester.advance_to_next_state(Event::BeginPairingFlowSuccess {
+                oauth_url: "http://example.com/oauth-start".to_owned()
+            },),
+            State::Authenticating {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_complete_oauth_flow() {
+        let mut tester = StateMachineTester::new(FxaState::Authenticating {
+            oauth_url: "http://example.com/oauth-start".to_owned(),
+        });
+        assert_eq!(
+            tester.peek_next_state(Event::CancelOAuthFlow),
+            State::Disconnected,
+        );
+        assert_eq!(
+            tester.advance_to_next_state(Event::CompleteOAuthFlow {
+                code: "test-code".to_owned(),
+                state: "test-state".to_owned(),
+            }),
+            State::CompleteOAuthFlow {
+                code: "test-code".to_owned(),
+                state: "test-state".to_owned(),
+            },
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::CallError),
+            State::Authenticating {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            },
+        );
+        assert_eq!(
+            tester.advance_to_next_state(Event::CompleteOAuthFlowSuccess),
+            State::InitializeDevice,
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::CallError),
+            State::Authenticating {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            },
+        );
+        assert_eq!(
+            tester.advance_to_next_state(Event::EnsureDeviceCapabilitiesSuccess),
+            State::Connected,
+        );
+    }
+
+    #[test]
+    fn test_disconnect() {
+        let mut tester = StateMachineTester::new(FxaState::Connected);
+        assert_eq!(
+            tester.advance_to_next_state(Event::Disconnect),
+            State::Disconnect
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::DisconnectSuccess),
+            State::Disconnected
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::CallError),
+            State::Disconnected
+        );
+    }
+
+    #[test]
+    fn test_check_authorization() {
+        let mut tester = StateMachineTester::new(FxaState::Connected);
+        assert_eq!(
+            tester.advance_to_next_state(Event::CheckAuthorizationStatus),
+            State::CheckAuthorizationStatus
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::CheckAuthorizationStatusSuccess { active: true }),
+            State::Connected
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::CheckAuthorizationStatusSuccess { active: false }),
+            State::Disconnected
+        );
+        assert_eq!(
+            tester.peek_next_state(Event::CallError),
+            State::Disconnected
+        );
+    }
+
+    #[test]
+    fn test_reauthenticate() {
+        let mut tester = StateMachineTester::new(FxaState::AuthIssues);
+        // Pairing flow is intended for connecting new devices only and isn't valid for
+        // reauthentication after auth issues.
+        assert!(tester.is_event_invalid(Event::BeginPairingFlow {
+            pairing_url: "https://example.com/pairing-url".to_owned(),
+            scopes: vec!["profile".to_owned()],
+        }));
+        assert_eq!(
+            tester.advance_to_next_state(Event::BeginOAuthFlow {
+                scopes: vec!["profile".to_owned()],
+            }),
+            State::BeginOAuthFlow {
+                scopes: vec!["profile".to_owned()],
+            }
+        );
+        assert_eq!(tester.peek_next_state(Event::CallError), State::AuthIssues);
+        assert_eq!(
+            tester.advance_to_next_state(Event::BeginOAuthFlowSuccess {
+                oauth_url: "http://example.com/oauth-start".to_owned()
+            }),
+            State::Authenticating {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            }
+        );
+    }
+}

--- a/components/fxa-client/src/state_machine/mod.rs
+++ b/components/fxa-client/src/state_machine/mod.rs
@@ -1,0 +1,167 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! FxA state machine
+//!
+//! This presents a high-level API for logging in, logging out, dealing with authentication token issues, etc.
+
+use std::sync::Arc;
+
+use error_support::{breadcrumb, convert_log_report_error, handle_error};
+use parking_lot::Mutex;
+
+use crate::{internal, ApiResult, DeviceConfig, Error, FirefoxAccount, Result};
+mod logic;
+mod types;
+
+pub use types::{Event, FxaEvent, FxaState, State};
+
+use logic::next_state;
+
+/// FxA state machine
+///
+/// This provides a high-level interface for using a [FirefoxAccount] -- login, logout, checking
+/// auth status, etc.
+pub struct FxaStateMachine {
+    account: Arc<FirefoxAccount>,
+    state: Mutex<FxaState>,
+    oauth_entrypoint: String,
+    device_config: DeviceConfig,
+}
+
+impl FxaStateMachine {
+    /// Create an FxaStateMachine
+    ///
+    /// Note: When restoring a connected account, only `device_config.capabilities` will be used.
+    /// We will use the device type and device name info that's stored on the server.
+    pub fn new(
+        account: Arc<FirefoxAccount>,
+        oauth_entrypoint: String,
+        device_config: DeviceConfig,
+    ) -> Self {
+        Self {
+            account,
+            state: Mutex::new(FxaState::Uninitialized),
+            oauth_entrypoint,
+            device_config,
+        }
+    }
+
+    /// Get the current state
+    pub fn state(&self) -> FxaState {
+        self.state.lock().clone()
+    }
+
+    /// Process an event (login, logout, etc).
+    ///
+    /// On success, returns the new state.
+    /// On error, the state will remain the same.
+    #[handle_error(Error)]
+    pub fn process_event(&self, event: FxaEvent) -> ApiResult<FxaState> {
+        breadcrumb!("FxaStateMachine.process_event starting");
+        let mut account = self.account.internal.lock();
+        let mut current_state = self.state.lock();
+
+        // Advance the state machine to an internal state
+        let mut state = next_state(current_state.clone().into(), event.into(), &current_state)?;
+
+        // Keep advancing the state machine until we reach a public state
+        let mut count = 0;
+        loop {
+            match state.try_into_public_state() {
+                Ok(public_state) => {
+                    *current_state = public_state.clone();
+                    breadcrumb!("FxaStateMachine.process_event finished");
+                    return Ok(public_state);
+                }
+                Err(internal_state) => {
+                    let event = match self.process_internal_state(&mut account, &internal_state) {
+                        Ok(event) => event,
+                        Err(e) => match e {
+                            // We we passed a state to `process_internal_state` that it didn't
+                            // expect, give up on processing the event.
+                            Error::StateMachineLogicError(_) => return Err(e),
+                            // For other errors, log/report them.
+                            // Throw away the converted error -- the state machine just needs to
+                            // process `Event::CallError` to get to the next state.
+                            _ => {
+                                convert_log_report_error(e);
+                                Event::CallError
+                            }
+                        },
+                    };
+                    state = next_state(internal_state, event, &current_state)?;
+                }
+            };
+            // Check that we're not just spinning our wheels and performing endless transitions
+            count += 1;
+            if count > 100 {
+                breadcrumb!("FxaStateMachine.process_event finished");
+                return Err(Error::StateMachineLogicError(
+                    "infinite loop detected".to_owned(),
+                ));
+            }
+        }
+    }
+
+    /// Perform the [FirefoxAccount] call for an internal state
+    ///
+    /// Returns the Event that's the result of the call
+    pub fn process_internal_state(
+        &self,
+        account: &mut internal::FirefoxAccount,
+        state: &State,
+    ) -> Result<Event> {
+        Ok(match state {
+            State::GetAuthState => Event::GetAuthStateSuccess {
+                auth_state: account.get_auth_state(),
+            },
+            State::BeginOAuthFlow { scopes } => {
+                let scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
+                let oauth_url = account.begin_oauth_flow(&scopes, &self.oauth_entrypoint)?;
+                Event::BeginOAuthFlowSuccess { oauth_url }
+            }
+            State::BeginPairingFlow {
+                pairing_url,
+                scopes,
+            } => {
+                let scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
+                let oauth_url =
+                    account.begin_pairing_flow(pairing_url, &scopes, &self.oauth_entrypoint)?;
+                Event::BeginOAuthFlowSuccess { oauth_url }
+            }
+            State::CompleteOAuthFlow { code, state } => {
+                account.complete_oauth_flow(code, state)?;
+                Event::CompleteOAuthFlowSuccess
+            }
+            State::InitializeDevice => {
+                account.initialize_device(
+                    &self.device_config.name,
+                    self.device_config.device_type,
+                    &self.device_config.capabilities,
+                )?;
+                Event::InitializeDeviceSuccess
+            }
+            State::EnsureDeviceCapabilities => {
+                account.ensure_capabilities(&self.device_config.capabilities)?;
+                Event::EnsureDeviceCapabilitiesSuccess
+            }
+            State::CheckAuthorizationStatus => {
+                let status = account.check_authorization_status()?;
+                Event::CheckAuthorizationStatusSuccess {
+                    active: status.active,
+                }
+            }
+            State::Disconnect => {
+                account.disconnect();
+                Event::DisconnectSuccess
+            }
+            _ => {
+                return Err(Error::StateMachineLogicError(format!(
+                    "invalid state in process_internal_state: {state}"
+                )))
+            }
+        })
+    }
+}

--- a/components/fxa-client/src/state_machine/types.rs
+++ b/components/fxa-client/src/state_machine/types.rs
@@ -1,0 +1,284 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::fmt;
+
+use crate::FxaRustAuthState;
+
+/// Fxa state
+///
+/// These are the states of [crate::FxaStateMachine] that consumers observe.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FxaState {
+    /// The state machine needs to be initialized via [Event::Initialize].
+    Uninitialized,
+    /// User has not connected to FxA or has logged out
+    Disconnected,
+    /// User is currently performing an OAuth flow
+    Authenticating { oauth_url: String },
+    /// User is currently connected to FxA
+    Connected,
+    /// User was connected to FxA, but we observed issues with the auth tokens.
+    /// The user needs to reauthenticate before the account can be used.
+    AuthIssues,
+}
+
+/// Fxa event
+///
+/// These are the events that consumers send to [crate::FxaStateMachine::process_event]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FxaEvent {
+    /// Initialize the state machine.  This must be the first event sent.
+    Initialize,
+    /// Begin an oauth flow
+    ///
+    /// If successful, the state machine will transition the [FxaState::Authenticating].  The next
+    /// step is to navigate the user to the `oauth_url` and let them sign and authorize the client.
+    BeginOAuthFlow { scopes: Vec<String> },
+    /// Begin an oauth flow using a URL from a pairing code
+    ///
+    /// If successful, the state machine will transition the [FxaState::Authenticating].  The next
+    /// step is to navigate the user to the `oauth_url` and let them sign and authorize the client.
+    BeginPairingFlow {
+        pairing_url: String,
+        scopes: Vec<String>,
+    },
+    /// Complete an OAuth flow.
+    ///
+    /// Send this event after the user has navigated through the OAuth flow and has reached the
+    /// redirect URI.  Extract `code` and `state` from the query parameters.  If successful the
+    /// state machine will transition to [FxaState::Connected].
+    CompleteOAuthFlow { code: String, state: String },
+    /// Cancel an OAuth flow.
+    ///
+    /// Use this to cancel an in-progress OAuth, returning to [FxaState::Disconnected] so the
+    /// process can begin again.
+    CancelOAuthFlow,
+    /// Check the authorization status for a connected account.
+    ///
+    /// Send this when issues are detected with the auth tokens for a connected account.  It will
+    /// double check for authentication issues with the account.  If it detects them, the state
+    /// machine will transition to [FxaState::AuthIssues].  From there you can start an OAuth flow
+    /// again to re-connect the user.
+    CheckAuthorizationStatus,
+    /// Disconnect the user
+    ///
+    /// Send this when the user is asking to be logged out.  The state machine will transition to
+    /// [FxaState::Disconnected].
+    Disconnect,
+}
+
+/// Internal [crate::FxaStateMachine] states
+///
+/// For each [FxaState] variant, there is a corresponding variant here.  These are called the
+/// public states since they are visible to consumer applications.
+///
+/// There are also variants for internal states.  This states indicate that the state machine is
+/// making a [crate::internal::FirefoxAccount] call. Internal states are temporary.
+/// [crate::FxaStateMachine] will transition to a new state once the call is complete and
+/// before `process_event` completes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum State {
+    // Public states
+    Uninitialized,
+    Disconnected,
+    Authenticating {
+        oauth_url: String,
+    },
+    Connected,
+    AuthIssues,
+    // Internal states
+    //
+    // Note: right now things are extremely simple because each `process_event()` transition makes
+    // a distinct set of FirefoxAccount calls, but this might not be true in the future. For
+    // example, if we defined a `finalize_device` method that merged the work of
+    // `initialize_device` and `ensure_capabilities`, then we would want to call that when handling
+    // both the `Initialize` and `CompleteOAuthFlow` events.  In that case, we might want to define
+    // both a `FinalizeDeviceForInitialize` and `FinalizeDeviceForLogin` state.
+    GetAuthState,
+    BeginOAuthFlow {
+        scopes: Vec<String>,
+    },
+    BeginPairingFlow {
+        pairing_url: String,
+        scopes: Vec<String>,
+    },
+    CompleteOAuthFlow {
+        code: String,
+        state: String,
+    },
+    InitializeDevice,
+    EnsureDeviceCapabilities,
+    CheckAuthorizationStatus,
+    Disconnect,
+}
+
+impl State {
+    pub fn try_into_public_state(self) -> Result<FxaState, State> {
+        self.try_into()
+    }
+}
+
+/// Internal [crate::FxaStateMachine] events
+///
+/// For each [FxaEvent] variant, there is a corresponding variant here.  These are called the
+/// public events, since they are visible to consumer applications.
+///
+/// There are also variants for interval events that represent the result of a
+/// [crate::internal::FirefoxAccount] call.
+#[derive(Debug)]
+pub enum Event {
+    // Public events
+    Initialize,
+    BeginOAuthFlow {
+        scopes: Vec<String>,
+    },
+    BeginPairingFlow {
+        pairing_url: String,
+        scopes: Vec<String>,
+    },
+    CompleteOAuthFlow {
+        code: String,
+        state: String,
+    },
+    CancelOAuthFlow,
+    CheckAuthorizationStatus,
+    Disconnect,
+    // Internal events
+    GetAuthStateSuccess {
+        auth_state: FxaRustAuthState,
+    },
+    BeginOAuthFlowSuccess {
+        oauth_url: String,
+    },
+    BeginPairingFlowSuccess {
+        oauth_url: String,
+    },
+    CompleteOAuthFlowSuccess,
+    InitializeDeviceSuccess,
+    EnsureDeviceCapabilitiesSuccess,
+    CheckAuthorizationStatusSuccess {
+        active: bool,
+    },
+    DisconnectSuccess,
+    CallError,
+}
+
+impl From<FxaState> for State {
+    fn from(state: FxaState) -> State {
+        match state {
+            FxaState::Uninitialized => State::Uninitialized,
+            FxaState::Disconnected => State::Disconnected,
+            FxaState::Authenticating { oauth_url } => State::Authenticating { oauth_url },
+            FxaState::Connected => State::Connected,
+            FxaState::AuthIssues => State::AuthIssues,
+        }
+    }
+}
+
+impl From<FxaEvent> for Event {
+    fn from(event: FxaEvent) -> Event {
+        match event {
+            FxaEvent::Initialize => Event::Initialize,
+            FxaEvent::BeginOAuthFlow { scopes } => Event::BeginOAuthFlow { scopes },
+            FxaEvent::BeginPairingFlow {
+                pairing_url,
+                scopes,
+            } => Event::BeginPairingFlow {
+                pairing_url,
+                scopes,
+            },
+            FxaEvent::CompleteOAuthFlow { code, state } => Event::CompleteOAuthFlow { code, state },
+            FxaEvent::CancelOAuthFlow => Event::CancelOAuthFlow,
+            FxaEvent::CheckAuthorizationStatus => Event::CheckAuthorizationStatus,
+            FxaEvent::Disconnect => Event::Disconnect,
+        }
+    }
+}
+
+// Try to convert a [State] to a [FxaState]
+//
+// On error, return the original state back
+impl TryFrom<State> for FxaState {
+    type Error = State;
+
+    fn try_from(state: State) -> Result<FxaState, State> {
+        match state {
+            State::Disconnected => Ok(FxaState::Disconnected),
+            State::Authenticating { oauth_url } => Ok(FxaState::Authenticating { oauth_url }),
+            State::Connected => Ok(FxaState::Connected),
+            State::AuthIssues => Ok(FxaState::AuthIssues),
+            _ => Err(state),
+        }
+    }
+}
+
+// Try to convert a [Event] to a [FxaEvent]
+//
+// On error, return the original event back
+impl TryFrom<Event> for FxaEvent {
+    type Error = Event;
+
+    fn try_from(event: Event) -> Result<FxaEvent, Event> {
+        match event {
+            Event::BeginOAuthFlow { scopes } => Ok(FxaEvent::BeginOAuthFlow { scopes }),
+            _ => Err(event),
+        }
+    }
+}
+
+// Display impl for State
+//
+// This only returns the variant name to avoid leaking any PII
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            Self::Uninitialized { .. } => "State::Uninitialized",
+            Self::Disconnected { .. } => "State::Disconnected",
+            Self::Authenticating { .. } => "State::Authenticating",
+            Self::Connected { .. } => "State::Connected",
+            Self::AuthIssues { .. } => "State::AuthIssues",
+            Self::GetAuthState { .. } => "State::GetAuthState",
+            Self::BeginOAuthFlow { .. } => "State::BeginOAuthFlow",
+            Self::BeginPairingFlow { .. } => "State::BeginPairingFlow",
+            Self::CompleteOAuthFlow { .. } => "State::CompleteOAuthFlow",
+            Self::InitializeDevice { .. } => "State::InitializeDevice",
+            Self::EnsureDeviceCapabilities { .. } => "State::EnsureDeviceCapabilities",
+            Self::CheckAuthorizationStatus { .. } => "State::CheckAuthorizationStatus",
+            Self::Disconnect { .. } => "State::Disconnect",
+        };
+        write!(f, "{name}")
+    }
+}
+
+// Display impl for Event
+//
+// This only returns the variant name to avoid leaking any PII
+impl fmt::Display for Event {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            Self::Initialize { .. } => "Event::Initialize",
+            Self::BeginOAuthFlow { .. } => "Event::BeginOAuthFlow",
+            Self::BeginPairingFlow { .. } => "Event::BeginPairingFlow",
+            Self::CompleteOAuthFlow { .. } => "Event::CompleteOAuthFlow",
+            Self::CancelOAuthFlow { .. } => "Event::CancelOAuthFlow",
+            Self::CheckAuthorizationStatus { .. } => "Event::CheckAuthorizationStatus",
+            Self::Disconnect { .. } => "Event::Disconnect",
+            Self::GetAuthStateSuccess { .. } => "Event::GetAuthStateSuccess",
+            Self::BeginOAuthFlowSuccess { .. } => "Event::BeginOAuthFlowSuccess",
+            Self::BeginPairingFlowSuccess { .. } => "Event::BeginPairingFlowSuccess",
+            Self::CompleteOAuthFlowSuccess { .. } => "Event::CompleteOAuthFlowSuccess",
+            Self::InitializeDeviceSuccess { .. } => "Event::InitializeDeviceSuccess",
+            Self::EnsureDeviceCapabilitiesSuccess { .. } => {
+                "Event::EnsureDeviceCapabilitiesSuccess"
+            }
+            Self::CheckAuthorizationStatusSuccess { .. } => {
+                "Event::CheckAuthorizationStatusSuccess"
+            }
+            Self::DisconnectSuccess { .. } => "Event::DisconnectSuccess",
+            Self::CallError { .. } => "Event::CallError",
+        };
+        write!(f, "{name}")
+    }
+}


### PR DESCRIPTION
This implements some of the functionality from the `FxaAccountManager`
classes that exist in `andorid-components` and in our Swift wrapper
layer.

The goal is move the functionality into Rust so that it's easier to
maintain and also so that other appliations can use it without depending
on `android-components`.

I created a new module directory for this code rather than putting it in
`internal`. This felt better to me since the state machine exists in a
layer above `FirefoxAccount`.