### PR TITLE
Adding state machine checking logic

### DIFF
--- a/components/fxa-client/src/auth.rs
+++ b/components/fxa-client/src/auth.rs
@@ -196,7 +196,7 @@ pub struct AuthorizationInfo {
 ///
 /// In the long-term, we should track that data in Rust, remove the wrapper, and rename this to
 /// `FxaAuthState`.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum FxaRustAuthState {
     Disconnected,
     Connected,

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -1056,3 +1056,51 @@ interface IncomingDeviceCommand {
   // Indicates that a tab has been sent to this device.
   TabReceived(Device? sender, SendTabPayload payload );
 };
+
+// Machinery for dry-run testing of FxaAuthStateMachine
+//
+// Remove this once we've migrated the firefox-android and firefox-ios code to using FxaAuthStateMachine
+
+interface FxaStateMachineChecker {
+  constructor();
+
+  void advance(FxaInternalEvent event);
+  void check_state(FxaInternalState state);
+};
+
+[Enum]
+interface FxaInternalState {
+  Uninitialized();
+  Disconnected();
+  Authenticating(string oauth_url);
+  Connected();
+  AuthIssues();
+  GetAuthState();
+  BeginOAuthFlow(sequence<string> scopes);
+  BeginPairingFlow(string pairing_url, sequence<string> scopes);
+  CompleteOAuthFlow(string code, string state);
+  InitializeDevice();
+  EnsureDeviceCapabilities();
+  CheckAuthorizationStatus();
+  Disconnect();
+};
+
+[Enum]
+interface FxaInternalEvent {
+  Initialize();
+  BeginOAuthFlow(sequence<string> scopes);
+  BeginPairingFlow(string pairing_url, sequence<string> scopes);
+  CompleteOAuthFlow(string code, string state);
+  CancelOAuthFlow();
+  CheckAuthorizationStatus();
+  Disconnect();
+  GetAuthStateSuccess(FxaRustAuthState auth_state);
+  BeginOAuthFlowSuccess(string oauth_url);
+  BeginPairingFlowSuccess(string oauth_url);
+  CompleteOAuthFlowSuccess();
+  InitializeDeviceSuccess();
+  EnsureDeviceCapabilitiesSuccess();
+  CheckAuthorizationStatusSuccess(boolean active);
+  DisconnectSuccess();
+  CallError();
+};

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -64,6 +64,12 @@ pub use push::{
 pub use state_machine::{FxaEvent, FxaState, FxaStateMachine};
 pub use token::{AccessTokenInfo, AuthorizationParameters, ScopedKey};
 
+// Used for auth state checking.  Remove this once firefox-android and firefox-ios are migrated to
+// using FxaAuthStateMachine
+pub use state_machine::Event as FxaInternalEvent;
+pub use state_machine::FxaStateMachineChecker;
+pub use state_machine::State as FxaInternalState;
+
 /// Result returned by internal functions
 pub type Result<T> = std::result::Result<T, Error>;
 /// Result returned by public-facing API functions

--- a/components/fxa-client/src/state_machine/checker.rs
+++ b/components/fxa-client/src/state_machine/checker.rs
@@ -1,0 +1,90 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This module contains code to dry-run test the state machine in against the existing Android/iOS implementations.
+//! The idea is to create a `FxaStateChecker` instance, manually drive the state transitions and
+//! check its state against the FirefoxAccount calls the existing implementation makes.
+
+use super::logic::next_state;
+use super::types::{Event, State};
+use crate::FxaState;
+use error_support::{breadcrumb, report_error};
+use parking_lot::Mutex;
+
+pub struct FxaStateMachineChecker {
+    inner: Mutex<FxaStateMachineCheckerInner>,
+}
+
+struct FxaStateMachineCheckerInner {
+    // Public state that the state machine is in.
+    // This is the state that `FxaStateMachine` would have been in before `process_event` was called.
+    current_state: FxaState,
+    // Internal state that the state machine is in.
+    // This is what `process_event` would have had in its loop.
+    state: State,
+    // Did we report an error?  If so, then we should give up checking things since the error is
+    // likely to cascade
+    reported_error: bool,
+}
+
+impl Default for FxaStateMachineChecker {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(FxaStateMachineCheckerInner {
+                current_state: FxaState::Uninitialized,
+                state: State::Uninitialized,
+                reported_error: false,
+            }),
+        }
+    }
+}
+
+impl FxaStateMachineChecker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Advance the internal state
+    ///
+    /// Call this when:
+    /// - A top-level event is passed to `processQueue`/`processEvent`
+    /// - A FirefoxAccount call finishes (either successfully or if it throws)
+    pub fn advance(&self, event: Event) {
+        let mut inner = self.inner.lock();
+        if inner.reported_error {
+            return;
+        }
+        let cloned_event = event.clone();
+        match next_state(inner.state.clone(), event, &inner.current_state) {
+            Ok(state) => {
+                breadcrumb!("fxa-state-machine-checker: {cloned_event} -> {state}");
+                inner.state = state;
+            }
+            Err(e) => {
+                report_error!("fxa-state-machine-checker", "Error in advance: {e}");
+                inner.reported_error = true;
+            }
+        }
+    }
+
+    /// Check the internal state
+    ///
+    /// Call this when:
+    /// - A FirefoxAccount call is about to be made
+    /// - `processQueue`/`processEvent` have advanced the existing state machine to a public state.
+    pub fn check_state(&self, state: State) {
+        let mut inner = self.inner.lock();
+        if inner.reported_error {
+            return;
+        }
+        if inner.state != state {
+            report_error!(
+                "fxa-state-machine-checker",
+                "State mismatch: {} vs {state}",
+                inner.state
+            );
+            inner.reported_error = true;
+        }
+    }
+}

--- a/components/fxa-client/src/state_machine/mod.rs
+++ b/components/fxa-client/src/state_machine/mod.rs
@@ -12,9 +12,11 @@ use error_support::{breadcrumb, convert_log_report_error, handle_error};
 use parking_lot::Mutex;
 
 use crate::{internal, ApiResult, DeviceConfig, Error, FirefoxAccount, Result};
+mod checker;
 mod logic;
 mod types;
 
+pub use checker::FxaStateMachineChecker;
 pub use types::{Event, FxaEvent, FxaState, State};
 
 use logic::next_state;

--- a/components/fxa-client/src/state_machine/types.rs
+++ b/components/fxa-client/src/state_machine/types.rs
@@ -127,7 +127,7 @@ impl State {
 ///
 /// There are also variants for interval events that represent the result of a
 /// [crate::internal::FirefoxAccount] call.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Event {
     // Public events
     Initialize,


### PR DESCRIPTION
This is temporary functionality to help migrate the state machine logic
from firefox-android/firefox-ios to app-services.

See
https://docs.google.com/document/d/1Us3Y6mjkCEYIqb-BCfRS15IX6jcoWhRkpHMVI0rKukg/edit
for details on this plan.

---

**Stack**:
- #5965 ⬅
- #5964
- #5963


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*