### PR TITLE
Fxa state machine

### DIFF
--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -197,7 +197,7 @@ impl FirefoxAccount {
 }
 
 /// Device configuration
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DeviceConfig {
     pub name: String,
     pub device_type: sync15::DeviceType,

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -187,6 +187,12 @@ pub enum Error {
 
     #[error("Invalid Push Event")]
     InvalidPushEvent,
+
+    #[error("Invalid state transition: {0}")]
+    InvalidStateTransition(String),
+
+    #[error("Internal error in the state machine: {0}")]
+    StateMachineLogicError(String),
 }
 
 // Define how our internal errors are handled and converted to external errors
@@ -212,6 +218,9 @@ impl GetErrorHandling for Error {
             }
             Error::BackoffError(_) => {
                 ErrorHandling::convert(FxaError::Other).report_error("fxa-client-backoff")
+            }
+            Error::InvalidStateTransition(_) | Error::StateMachineLogicError(_) => {
+                ErrorHandling::convert(FxaError::Other).report_error("fxa-state-machine-error")
             }
             Error::OriginMismatch(_) => ErrorHandling::convert(FxaError::OriginMismatch),
             _ => ErrorHandling::convert(FxaError::Other).report_error("fxa-client-other-error"),

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -1050,3 +1050,45 @@ interface IncomingDeviceCommand {
   // Indicates that a tab has been sent to this device.
   TabReceived(Device? sender, SendTabPayload payload );
 };
+
+// Machinery for dry-run testing of FxaAuthStateMachine
+//
+// Remove this once we've migrated the firefox-android and firefox-ios code to using FxaAuthStateMachine
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1867793
+
+interface FxaStateMachineChecker {
+  constructor();
+
+  void handle_public_event(FxaEvent event);
+  void handle_internal_event(FxaStateCheckerEvent event);
+  void check_public_state(FxaState state);
+  void check_internal_state(FxaStateCheckerState state);
+};
+
+[Enum]
+interface FxaStateCheckerEvent {
+  GetAuthStateSuccess(FxaRustAuthState auth_state);
+  BeginOAuthFlowSuccess(string oauth_url);
+  BeginPairingFlowSuccess(string oauth_url);
+  CompleteOAuthFlowSuccess();
+  InitializeDeviceSuccess();
+  EnsureDeviceCapabilitiesSuccess();
+  CheckAuthorizationStatusSuccess(boolean active);
+  DisconnectSuccess();
+  CallError();
+  EnsureCapabilitiesAuthError();
+};
+
+[Enum]
+interface FxaStateCheckerState {
+  GetAuthState();
+  BeginOAuthFlow(sequence<string> scopes, string entrypoint);
+  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint);
+  CompleteOAuthFlow(string code, string state);
+  InitializeDevice();
+  EnsureDeviceCapabilities();
+  CheckAuthorizationStatus();
+  Disconnect();
+  Complete(FxaState new_state);
+  Cancel();
+};

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -259,7 +259,19 @@ interface FirefoxAccount {
   void on_auth_issues();
 
   // Get the high-level authentication state of the client
+  //
+  // Deprecated: Use get_state() instead
   FxaRustAuthState get_auth_state();
+
+  // Get the current state
+  FxaState get_state();
+
+  // Process an event (login, logout, etc).
+  //
+  // On success, update the current state and return it.
+  // On error, the current state will remain the same.
+  [Throws=FxaError]
+  FxaState process_event(FxaEvent event);
 
   // Get profile information for the signed-in user, if any.
   //
@@ -924,6 +936,26 @@ dictionary Profile {
 
   // Whether the `avatar` URL represents the default avatar image.
   boolean is_default_avatar;
+};
+
+[Enum]
+interface FxaState {
+  Uninitialized();
+  Disconnected();
+  Authenticating(string oauth_url);
+  Connected();
+  AuthIssues();
+};
+
+[Enum]
+interface FxaEvent {
+  Initialize(DeviceConfig device_config);
+  BeginOAuthFlow(sequence<string> scopes, string entrypoint);
+  BeginPairingFlow(string pairing_url, sequence<string> scopes, string entrypoint);
+  CompleteOAuthFlow(string code, string state);
+  CancelOAuthFlow();
+  CheckAuthorizationStatus();
+  Disconnect();
 };
 
 enum FxaRustAuthState {

--- a/components/fxa-client/src/internal/mod.rs
+++ b/components/fxa-client/src/internal/mod.rs
@@ -11,7 +11,7 @@ use self::{
     state_persistence::PersistedState,
     telemetry::FxaTelemetry,
 };
-use crate::{Error, FxaConfig, FxaRustAuthState, Result};
+use crate::{DeviceConfig, Error, FxaConfig, FxaRustAuthState, FxaState, Result};
 use serde_derive::*;
 use std::{
     collections::{HashMap, HashSet},
@@ -54,6 +54,11 @@ pub struct FirefoxAccount {
     devices_cache: Option<CachedResponse<Vec<http_client::GetDeviceResponse>>>,
     auth_circuit_breaker: AuthCircuitBreaker,
     telemetry: FxaTelemetry,
+    // TODO: Cleanup our usage of the word "state" and change this field name to `state`
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1868610
+    pub(crate) auth_state: FxaState,
+    // Set via `FxaEvent::Initialize`
+    pub(crate) device_config: Option<DeviceConfig>,
 }
 
 impl FirefoxAccount {
@@ -65,6 +70,8 @@ impl FirefoxAccount {
             devices_cache: None,
             auth_circuit_breaker: Default::default(),
             telemetry: FxaTelemetry::new(),
+            auth_state: FxaState::Uninitialized,
+            device_config: None,
         }
     }
 

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -63,6 +63,12 @@ pub use push::{
 };
 pub use token::{AccessTokenInfo, AuthorizationParameters, ScopedKey};
 
+// Used for auth state checking.  Remove this once firefox-android and firefox-ios are migrated to
+// using FxaAuthStateMachine
+pub use state_machine::checker::{
+    FxaStateCheckerEvent, FxaStateCheckerState, FxaStateMachineChecker,
+};
+
 /// Result returned by internal functions
 pub type Result<T> = std::result::Result<T, Error>;
 /// Result returned by public-facing API functions

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -43,6 +43,7 @@ mod error;
 mod internal;
 mod profile;
 mod push;
+mod state_machine;
 mod storage;
 mod telemetry;
 mod token;
@@ -52,7 +53,7 @@ use std::fmt;
 pub use sync15::DeviceType;
 use url::Url;
 
-pub use auth::{AuthorizationInfo, FxaRustAuthState};
+pub use auth::{AuthorizationInfo, FxaEvent, FxaRustAuthState, FxaState};
 pub use device::{AttachedClient, Device, DeviceCapability, DeviceConfig, LocalDevice};
 pub use error::{Error, FxaError};
 use parking_lot::Mutex;

--- a/components/fxa-client/src/state_machine/README.md
+++ b/components/fxa-client/src/state_machine/README.md
@@ -1,0 +1,85 @@
+# The Public FxA State Machine
+
+The public FxA state machine tracks a user's authentication state as they perform operations on their account.
+The state machine, its states, and its events are visible to the consumer applications.
+Applications generally track the state and update the UI based on it, for example providing a login button for the `Disconnected` state and link to the FxA account management page for the `Connected` state.
+
+The public state machine events correspond to user actions, for example clicking the login button or completing the OAuth flow.
+The public state machine is non-deterministic -- from a given state and event, there are multiple possibilities for the next state.
+Usually there are two possible transitions: one for a successful operation and one for a failed one.
+For example, when completing an oauth flow, if the operation is successful the state machine transitions to the `Connected` state, while if it fails it stays in the `Authenticating` state.
+
+Here is an overview containing some of the states and transitions:
+
+```mermaid
+graph LR;
+    Disconnected --> |"BeginOAuthFlow(Success)"| Authenticating
+    Disconnected --> |"BeginOAuthFlow(Failure)"| Disconnected
+    Disconnected --> |"BeginPairingFlow(Success)"| Authenticating
+    Disconnected --> |"BeginPairingFlow(Failure)"| Disconnected
+    Authenticating --> |"CompleteOAuthFlow(Success)"| Connected
+    Authenticating --> |"CompleteOAuthFlow(Failure)"| Authenticating
+    Authenticating --> |"CancelOAuthFlow"| Disconnected
+    Connected --> |"Disconnect"| Disconnected
+
+    classDef default fill:#0af, color:black, stroke:black
+```
+
+# The Internal State Machines
+
+For each public state, we also define an internal state machine that represents the process of transitioning out of that state.
+Internal state machine states correspond to `FirefoxAccount` method calls and events correspond to call results.
+Unlike the public state machine, the internal state machines are deterministic meaning that each `(state, event)` pair always results in the same next state.
+
+There are two terminal states for the internal state machines:
+  - `Complete(new_state)`: Complete the process and transition the public state machine to a new state
+  - `Cancel`: Cancel the process and don't change the current public state.
+
+Here are some example internal state machines:
+
+## Disconnected
+
+```mermaid
+graph TD;
+    Authenticating["Complete(Authenticating)"]:::terminal
+    BeginOAuthFlow --> |BeginOAuthFlowSuccess| Authenticating
+    BeginPairingFlow --> |BeginPairingFlowSuccess| Authenticating
+    BeginOAuthFlow --> |Error| Cancel:::terminal
+    BeginPairingFlow --> |Error| Cancel:::terminal
+
+    classDef default fill:#0af, color:black, stroke:black
+    classDef terminal fill:#FC766A, stroke: black;
+```
+
+## Authenticating
+
+```mermaid
+graph TD;
+    Connected["Complete(Connected)"]:::terminal
+    CompleteOAuthFlow --> |CompleteOAuthFlowSuccess| InitializeDevice
+    CompleteOAuthFlow --> |Error| Cancel:::terminal
+    InitializeDevice --> |InitializeDeviceSuccess| Connected
+    InitializeDevice --> |Error| Cancel:::terminal
+
+    classDef default fill:#0af, color:black, stroke:black
+    classDef terminal fill:#FC766A, stroke: black;
+```
+
+## Uninitialized
+
+This is the initial state for the public state machine (not shown in the diagram above).
+
+```mermaid
+graph TD;
+    Disconnected["Complete(Disconnected)"]:::terminal
+    Connected["Complete(Connected)"]:::terminal
+    AuthIssues["Complete(AuthIssues)"]:::terminal
+    GetAuthState --> |"GetAuthStateSuccess(Disconnected)"| Disconnected:::terminal
+    GetAuthState --> |"GetAuthStateSuccess(AuthIssues)"| AuthIssues:::terminal
+    GetAuthState --> |"GetAuthStateSuccess(Connected)"| EnsureCapabilities
+    EnsureCapabilities --> |EnsureCapabilitiesSuccess| Connected:::terminal
+    EnsureCapabilities --> |Error| AuthIssues:::terminal
+
+    classDef default fill:#0af, color:black, stroke:black
+    classDef terminal fill:#FC766A, stroke: black;
+```

--- a/components/fxa-client/src/state_machine/checker.rs
+++ b/components/fxa-client/src/state_machine/checker.rs
@@ -1,0 +1,253 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This module contains code to dry-run test the state machine in against the existing Android/iOS implementations.
+//! The idea is to create a `FxaStateChecker` instance, manually drive the state transitions and
+//! check its state against the FirefoxAccount calls the existing implementation makes.
+//!
+//! Initially this will be tested by devs / QA.  Then we will ship it to real users and monitor which errors come back in Sentry.
+
+use crate::{FxaEvent, FxaState};
+use error_support::{breadcrumb, report_error};
+use parking_lot::Mutex;
+
+pub use super::internal_machines::Event as FxaStateCheckerEvent;
+use super::internal_machines::State as InternalState;
+use super::internal_machines::*;
+
+/// State passed to the state checker, this is exactly the same as `internal_machines::State`
+/// except the `Complete` variant uses a named field for UniFFI compatibility.
+pub enum FxaStateCheckerState {
+    GetAuthState,
+    BeginOAuthFlow {
+        scopes: Vec<String>,
+        entrypoint: String,
+    },
+    BeginPairingFlow {
+        pairing_url: String,
+        scopes: Vec<String>,
+        entrypoint: String,
+    },
+    CompleteOAuthFlow {
+        code: String,
+        state: String,
+    },
+    InitializeDevice,
+    EnsureDeviceCapabilities,
+    CheckAuthorizationStatus,
+    Disconnect,
+    Complete {
+        new_state: FxaState,
+    },
+    Cancel,
+}
+
+pub struct FxaStateMachineChecker {
+    inner: Mutex<FxaStateMachineCheckerInner>,
+}
+
+struct FxaStateMachineCheckerInner {
+    public_state: FxaState,
+    internal_state: InternalState,
+    state_machine: Box<dyn InternalStateMachine + Send>,
+    // Did we report an error?  If so, then we should give up checking things since the error is
+    // likely to cascade
+    reported_error: bool,
+}
+
+impl Default for FxaStateMachineChecker {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(FxaStateMachineCheckerInner {
+                public_state: FxaState::Uninitialized,
+                internal_state: InternalState::Cancel,
+                state_machine: Box::new(UninitializedStateMachine),
+                reported_error: false,
+            }),
+        }
+    }
+}
+
+impl FxaStateMachineChecker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Advance the internal state based on a public event
+    pub fn handle_public_event(&self, event: FxaEvent) {
+        let mut inner = self.inner.lock();
+        if inner.reported_error {
+            return;
+        }
+        match &inner.internal_state {
+            InternalState::Complete(_) | InternalState::Cancel => (),
+            internal_state => {
+                report_error!(
+                    "fxa-state-machine-checker",
+                    "handle_public_event called with non-terminal internal state: {internal_state} ({event})",
+                 );
+                inner.reported_error = true;
+                return;
+            }
+        }
+
+        inner.state_machine = make_state_machine(&inner.public_state);
+        match inner.state_machine.initial_state(event.clone()) {
+            Ok(state) => {
+                breadcrumb!("fxa-state-machine-checker: {event} -> {state}");
+                inner.internal_state = state;
+            }
+            Err(e) => {
+                report_error!(
+                    "fxa-state-machine-checker",
+                    "Error in handle_public_event: {e}"
+                );
+                inner.reported_error = true;
+            }
+        }
+    }
+
+    /// Advance the internal state based on an internal event
+    pub fn handle_internal_event(&self, event: FxaStateCheckerEvent) {
+        let mut inner = self.inner.lock();
+        if inner.reported_error {
+            return;
+        }
+        match inner
+            .state_machine
+            .next_state(inner.internal_state.clone(), event.clone())
+        {
+            Ok(state) => {
+                breadcrumb!("fxa-state-machine-checker: {event} -> {state}");
+                if let InternalState::Complete(new_state) = &state {
+                    inner.public_state = new_state.clone();
+                }
+                inner.internal_state = state;
+            }
+            Err(e) => {
+                report_error!(
+                    "fxa-state-machine-checker",
+                    "Error in handle_internal_event: {e}"
+                );
+                inner.reported_error = true;
+            }
+        }
+    }
+
+    /// Check the internal state
+    ///
+    /// Call this when `processQueue`/`processEvent` has advanced the existing state machine to a public state.
+    pub fn check_public_state(&self, state: FxaState) {
+        let mut inner = self.inner.lock();
+        if inner.reported_error {
+            return;
+        }
+        match &inner.internal_state {
+            InternalState::Complete(_) | InternalState::Cancel => (),
+            internal_state => {
+                report_error!(
+                    "fxa-state-machine-checker",
+                    "check_public_state called with non-terminal internal state: {internal_state} ({state})",
+                 );
+                inner.reported_error = true;
+                return;
+            }
+        }
+        if inner.public_state != state {
+            report_error!(
+                "fxa-state-machine-checker",
+                "State mismatch: {} vs {state}",
+                inner.internal_state
+            );
+            inner.reported_error = true;
+        }
+    }
+
+    /// Check the internal state
+    ///
+    /// Call this when a FirefoxAccount call is about to be made
+    pub fn check_internal_state(&self, state: FxaStateCheckerState) {
+        let mut inner = self.inner.lock();
+        if inner.reported_error {
+            return;
+        }
+        let state: InternalState = state.into();
+        if inner.internal_state != state {
+            report_error!(
+                "fxa-state-machine-checker",
+                "State mismatch: {} vs {state}",
+                inner.internal_state
+            );
+            inner.reported_error = true;
+        }
+    }
+}
+
+fn make_state_machine(public_state: &FxaState) -> Box<dyn InternalStateMachine + Send> {
+    match public_state {
+        FxaState::Uninitialized => Box::new(UninitializedStateMachine),
+        FxaState::Disconnected => Box::new(DisconnectedStateMachine),
+        FxaState::Authenticating { .. } => Box::new(AuthenticatingStateMachine),
+        FxaState::Connected => Box::new(ConnectedStateMachine),
+        FxaState::AuthIssues => Box::new(AuthIssuesStateMachine),
+    }
+}
+
+impl From<InternalState> for FxaStateCheckerState {
+    fn from(state: InternalState) -> Self {
+        match state {
+            InternalState::GetAuthState => Self::GetAuthState,
+            InternalState::BeginOAuthFlow { scopes, entrypoint } => {
+                Self::BeginOAuthFlow { scopes, entrypoint }
+            }
+            InternalState::BeginPairingFlow {
+                pairing_url,
+                scopes,
+                entrypoint,
+            } => Self::BeginPairingFlow {
+                pairing_url,
+                scopes,
+                entrypoint,
+            },
+            InternalState::CompleteOAuthFlow { code, state } => {
+                Self::CompleteOAuthFlow { code, state }
+            }
+            InternalState::InitializeDevice => Self::InitializeDevice,
+            InternalState::EnsureDeviceCapabilities => Self::EnsureDeviceCapabilities,
+            InternalState::CheckAuthorizationStatus => Self::CheckAuthorizationStatus,
+            InternalState::Disconnect => Self::Disconnect,
+            InternalState::Complete(new_state) => Self::Complete { new_state },
+            InternalState::Cancel => Self::Cancel,
+        }
+    }
+}
+
+impl From<FxaStateCheckerState> for InternalState {
+    fn from(state: FxaStateCheckerState) -> Self {
+        match state {
+            FxaStateCheckerState::GetAuthState => Self::GetAuthState,
+            FxaStateCheckerState::BeginOAuthFlow { scopes, entrypoint } => {
+                Self::BeginOAuthFlow { scopes, entrypoint }
+            }
+            FxaStateCheckerState::BeginPairingFlow {
+                pairing_url,
+                scopes,
+                entrypoint,
+            } => Self::BeginPairingFlow {
+                pairing_url,
+                scopes,
+                entrypoint,
+            },
+            FxaStateCheckerState::CompleteOAuthFlow { code, state } => {
+                Self::CompleteOAuthFlow { code, state }
+            }
+            FxaStateCheckerState::InitializeDevice => Self::InitializeDevice,
+            FxaStateCheckerState::EnsureDeviceCapabilities => Self::EnsureDeviceCapabilities,
+            FxaStateCheckerState::CheckAuthorizationStatus => Self::CheckAuthorizationStatus,
+            FxaStateCheckerState::Disconnect => Self::Disconnect,
+            FxaStateCheckerState::Complete { new_state } => Self::Complete(new_state),
+            FxaStateCheckerState::Cancel => Self::Cancel,
+        }
+    }
+}

--- a/components/fxa-client/src/state_machine/display.rs
+++ b/components/fxa-client/src/state_machine/display.rs
@@ -1,0 +1,75 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Display impls for state machine types
+//!
+//! These are sent to Sentry, so they must not leak PII.
+//! In general this means they don't output values for inner fields.
+
+use super::{internal_machines, FxaEvent, FxaState};
+use std::fmt;
+
+impl fmt::Display for FxaState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            Self::Uninitialized => "Uninitialized",
+            Self::Disconnected => "Disconnected",
+            Self::Authenticating { .. } => "Authenticating",
+            Self::Connected => "Connected",
+            Self::AuthIssues => "AuthIssues",
+        };
+        write!(f, "{name}")
+    }
+}
+
+impl fmt::Display for FxaEvent {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            Self::Initialize { .. } => "Initialize",
+            Self::BeginOAuthFlow { .. } => "BeginOAuthFlow",
+            Self::BeginPairingFlow { .. } => "BeginPairingFlow",
+            Self::CompleteOAuthFlow { .. } => "CompleteOAuthFlow",
+            Self::CancelOAuthFlow => "CancelOAuthFlow",
+            Self::CheckAuthorizationStatus => "CheckAuthorizationStatus",
+            Self::Disconnect => "Disconnect",
+        };
+        write!(f, "{name}")
+    }
+}
+
+impl fmt::Display for internal_machines::State {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            Self::GetAuthState => "GetAuthState",
+            Self::BeginOAuthFlow { .. } => "BeginOAuthFlow",
+            Self::BeginPairingFlow { .. } => "BeginPairingFlow",
+            Self::CompleteOAuthFlow { .. } => "CompleteOAuthFlow",
+            Self::InitializeDevice => "InitializeDevice",
+            Self::EnsureDeviceCapabilities => "EnsureDeviceCapabilities",
+            Self::CheckAuthorizationStatus => "CheckAuthorizationStatus",
+            Self::Disconnect => "Disconnect",
+            Self::Complete(_) => "Complete",
+            Self::Cancel => "Cancel",
+        };
+        write!(f, "{name}")
+    }
+}
+
+impl fmt::Display for internal_machines::Event {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            Self::GetAuthStateSuccess { .. } => "GetAuthStateSuccess",
+            Self::BeginOAuthFlowSuccess { .. } => "BeginOAuthFlowSuccess",
+            Self::BeginPairingFlowSuccess { .. } => "BeginPairingFlowSuccess",
+            Self::CompleteOAuthFlowSuccess => "CompleteOAuthFlowSuccess",
+            Self::InitializeDeviceSuccess => "InitializeDeviceSuccess",
+            Self::EnsureDeviceCapabilitiesSuccess => "EnsureDeviceCapabilitiesSuccess",
+            Self::CheckAuthorizationStatusSuccess { .. } => "CheckAuthorizationStatusSuccess",
+            Self::DisconnectSuccess => "DisconnectSuccess",
+            Self::CallError => "CallError",
+            Self::EnsureCapabilitiesAuthError => "EnsureCapabilitiesAuthError",
+        };
+        write!(f, "{name}")
+    }
+}

--- a/components/fxa-client/src/state_machine/internal_machines/auth_issues.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/auth_issues.rs
@@ -1,0 +1,68 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::{invalid_transition, Event, InternalStateMachine, State};
+use crate::{Error, FxaEvent, FxaState, Result};
+
+pub struct AuthIssuesStateMachine;
+
+// Save some typing
+use Event::*;
+use State::*;
+
+impl InternalStateMachine for AuthIssuesStateMachine {
+    fn initial_state(&self, event: FxaEvent) -> Result<State> {
+        match event {
+            FxaEvent::BeginOAuthFlow { scopes, entrypoint } => Ok(BeginOAuthFlow {
+                scopes: scopes.clone(),
+                entrypoint: entrypoint.clone(),
+            }),
+            e => Err(Error::InvalidStateTransition(format!("AuthIssues -> {e}"))),
+        }
+    }
+
+    fn next_state(&self, state: State, event: Event) -> Result<State> {
+        Ok(match (state, event) {
+            (BeginOAuthFlow { .. }, BeginOAuthFlowSuccess { oauth_url }) => {
+                Complete(FxaState::Authenticating { oauth_url })
+            }
+            (BeginOAuthFlow { .. }, CallError) => Cancel,
+            (state, event) => return invalid_transition(state, event),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::StateMachineTester;
+    use super::*;
+
+    #[test]
+    fn test_reauthenticate() {
+        let tester = StateMachineTester::new(
+            AuthIssuesStateMachine,
+            FxaEvent::BeginOAuthFlow {
+                scopes: vec!["profile".to_owned()],
+                entrypoint: "test-entrypoint".to_owned(),
+            },
+        );
+
+        assert_eq!(
+            tester.state,
+            BeginOAuthFlow {
+                scopes: vec!["profile".to_owned()],
+                entrypoint: "test-entrypoint".to_owned()
+            }
+        );
+        assert_eq!(tester.peek_next_state(CallError), Cancel);
+        assert_eq!(
+            tester.peek_next_state(BeginOAuthFlowSuccess {
+                oauth_url: "http://example.com/oauth-start".to_owned()
+            }),
+            Complete(FxaState::Authenticating {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            })
+        );
+    }
+}

--- a/components/fxa-client/src/state_machine/internal_machines/authenticating.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/authenticating.rs
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::{invalid_transition, Event, InternalStateMachine, State};
+use crate::{Error, FxaEvent, FxaState, Result};
+
+pub struct AuthenticatingStateMachine;
+
+// Save some typing
+use Event::*;
+use State::*;
+
+impl InternalStateMachine for AuthenticatingStateMachine {
+    fn initial_state(&self, event: FxaEvent) -> Result<State> {
+        match event {
+            FxaEvent::CompleteOAuthFlow { code, state } => Ok(CompleteOAuthFlow {
+                code: code.clone(),
+                state: state.clone(),
+            }),
+            FxaEvent::CancelOAuthFlow => Ok(Complete(FxaState::Disconnected)),
+            e => Err(Error::InvalidStateTransition(format!(
+                "Authenticating -> {e}"
+            ))),
+        }
+    }
+
+    fn next_state(&self, state: State, event: Event) -> Result<State> {
+        Ok(match (state, event) {
+            (CompleteOAuthFlow { .. }, CompleteOAuthFlowSuccess) => InitializeDevice,
+            (CompleteOAuthFlow { .. }, CallError) => Cancel,
+            (InitializeDevice, InitializeDeviceSuccess) => Complete(FxaState::Connected),
+            (InitializeDevice, CallError) => Cancel,
+            (state, event) => return invalid_transition(state, event),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::StateMachineTester;
+    use super::*;
+
+    #[test]
+    fn test_complete_oauth_flow() {
+        let mut tester = StateMachineTester::new(
+            AuthenticatingStateMachine,
+            FxaEvent::CompleteOAuthFlow {
+                code: "test-code".to_owned(),
+                state: "test-state".to_owned(),
+            },
+        );
+        assert_eq!(
+            tester.state,
+            CompleteOAuthFlow {
+                code: "test-code".to_owned(),
+                state: "test-state".to_owned(),
+            }
+        );
+        assert_eq!(tester.peek_next_state(CallError), Cancel);
+
+        tester.next_state(CompleteOAuthFlowSuccess);
+        assert_eq!(tester.state, InitializeDevice);
+        assert_eq!(tester.peek_next_state(CallError), Cancel);
+        assert_eq!(
+            tester.peek_next_state(InitializeDeviceSuccess),
+            Complete(FxaState::Connected)
+        );
+    }
+
+    #[test]
+    fn test_cancel_oauth_flow() {
+        let tester = StateMachineTester::new(AuthenticatingStateMachine, FxaEvent::CancelOAuthFlow);
+        assert_eq!(tester.state, Complete(FxaState::Disconnected));
+    }
+}

--- a/components/fxa-client/src/state_machine/internal_machines/connected.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/connected.rs
@@ -1,0 +1,83 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::{invalid_transition, Event, InternalStateMachine, State};
+use crate::{Error, FxaEvent, FxaState, Result};
+use error_support::report_error;
+
+pub struct ConnectedStateMachine;
+
+// Save some typing
+use Event::*;
+use State::*;
+
+impl InternalStateMachine for ConnectedStateMachine {
+    fn initial_state(&self, event: FxaEvent) -> Result<State> {
+        match event {
+            FxaEvent::Disconnect => Ok(Disconnect),
+            FxaEvent::CheckAuthorizationStatus => Ok(CheckAuthorizationStatus),
+            e => Err(Error::InvalidStateTransition(format!("Connected -> {e}"))),
+        }
+    }
+
+    fn next_state(&self, state: State, event: Event) -> Result<State> {
+        Ok(match (state, event) {
+            (Disconnect, DisconnectSuccess) => Complete(FxaState::Disconnected),
+            (Disconnect, CallError) => {
+                // disconnect() is currently infallible, but let's handle errors anyway in case we
+                // refactor it in the future.
+                report_error!("fxa-state-machine-error", "saw CallError after Disconnect");
+                Complete(FxaState::Disconnected)
+            }
+            (CheckAuthorizationStatus, CheckAuthorizationStatusSuccess { active }) => {
+                if active {
+                    Complete(FxaState::Connected)
+                } else {
+                    Complete(FxaState::AuthIssues)
+                }
+            }
+            (CheckAuthorizationStatus, CallError) => Complete(FxaState::AuthIssues),
+            (state, event) => return invalid_transition(state, event),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::StateMachineTester;
+    use super::*;
+
+    #[test]
+    fn test_disconnect() {
+        let tester = StateMachineTester::new(ConnectedStateMachine, FxaEvent::Disconnect);
+        assert_eq!(tester.state, Disconnect);
+        assert_eq!(
+            tester.peek_next_state(CallError),
+            Complete(FxaState::Disconnected)
+        );
+        assert_eq!(
+            tester.peek_next_state(DisconnectSuccess),
+            Complete(FxaState::Disconnected)
+        );
+    }
+
+    #[test]
+    fn test_check_authorization() {
+        let tester =
+            StateMachineTester::new(ConnectedStateMachine, FxaEvent::CheckAuthorizationStatus);
+        assert_eq!(tester.state, CheckAuthorizationStatus);
+        assert_eq!(
+            tester.peek_next_state(CallError),
+            Complete(FxaState::AuthIssues)
+        );
+        assert_eq!(
+            tester.peek_next_state(CheckAuthorizationStatusSuccess { active: true }),
+            Complete(FxaState::Connected),
+        );
+        assert_eq!(
+            tester.peek_next_state(CheckAuthorizationStatusSuccess { active: false }),
+            Complete(FxaState::AuthIssues)
+        );
+    }
+}

--- a/components/fxa-client/src/state_machine/internal_machines/disconnected.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/disconnected.rs
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::{invalid_transition, Event, InternalStateMachine, State};
+use crate::{Error, FxaEvent, FxaState, Result};
+
+pub struct DisconnectedStateMachine;
+
+// Save some typing
+use Event::*;
+use State::*;
+
+impl InternalStateMachine for DisconnectedStateMachine {
+    fn initial_state(&self, event: FxaEvent) -> Result<State> {
+        match event {
+            FxaEvent::BeginOAuthFlow { scopes, entrypoint } => {
+                Ok(State::BeginOAuthFlow { scopes, entrypoint })
+            }
+            FxaEvent::BeginPairingFlow {
+                pairing_url,
+                scopes,
+                entrypoint,
+            } => Ok(State::BeginPairingFlow {
+                pairing_url,
+                scopes,
+                entrypoint,
+            }),
+            e => Err(Error::InvalidStateTransition(format!(
+                "Disconnected -> {e}"
+            ))),
+        }
+    }
+
+    fn next_state(&self, state: State, event: Event) -> Result<State> {
+        Ok(match (state, event) {
+            (BeginOAuthFlow { .. }, BeginOAuthFlowSuccess { oauth_url }) => {
+                Complete(FxaState::Authenticating { oauth_url })
+            }
+            (BeginPairingFlow { .. }, BeginPairingFlowSuccess { oauth_url }) => {
+                Complete(FxaState::Authenticating { oauth_url })
+            }
+            (BeginOAuthFlow { .. }, CallError) => Cancel,
+            (BeginPairingFlow { .. }, CallError) => Cancel,
+            (state, event) => return invalid_transition(state, event),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::StateMachineTester;
+    use super::*;
+
+    #[test]
+    fn test_oauth_flow() {
+        let tester = StateMachineTester::new(
+            DisconnectedStateMachine,
+            FxaEvent::BeginOAuthFlow {
+                scopes: vec!["profile".to_owned()],
+                entrypoint: "test-entrypoint".to_owned(),
+            },
+        );
+        assert_eq!(
+            tester.state,
+            BeginOAuthFlow {
+                scopes: vec!["profile".to_owned()],
+                entrypoint: "test-entrypoint".to_owned(),
+            }
+        );
+        assert_eq!(tester.peek_next_state(CallError), Cancel);
+        assert_eq!(
+            tester.peek_next_state(BeginOAuthFlowSuccess {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            }),
+            Complete(FxaState::Authenticating {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            })
+        );
+    }
+
+    #[test]
+    fn test_pairing_flow() {
+        let tester = StateMachineTester::new(
+            DisconnectedStateMachine,
+            FxaEvent::BeginPairingFlow {
+                pairing_url: "https://example.com/pairing-url".to_owned(),
+                scopes: vec!["profile".to_owned()],
+                entrypoint: "test-entrypoint".to_owned(),
+            },
+        );
+        assert_eq!(
+            tester.state,
+            BeginPairingFlow {
+                pairing_url: "https://example.com/pairing-url".to_owned(),
+                scopes: vec!["profile".to_owned()],
+                entrypoint: "test-entrypoint".to_owned(),
+            }
+        );
+        assert_eq!(tester.peek_next_state(CallError), Cancel);
+        assert_eq!(
+            tester.peek_next_state(BeginPairingFlowSuccess {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            }),
+            Complete(FxaState::Authenticating {
+                oauth_url: "http://example.com/oauth-start".to_owned(),
+            })
+        );
+    }
+}

--- a/components/fxa-client/src/state_machine/internal_machines/mod.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/mod.rs
@@ -1,0 +1,212 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Internal state machine code
+
+mod auth_issues;
+mod authenticating;
+mod connected;
+mod disconnected;
+mod uninitialized;
+
+use crate::{
+    internal::FirefoxAccount, DeviceConfig, Error, FxaError, FxaEvent, FxaRustAuthState, FxaState,
+    Result,
+};
+pub use auth_issues::AuthIssuesStateMachine;
+pub use authenticating::AuthenticatingStateMachine;
+pub use connected::ConnectedStateMachine;
+pub use disconnected::DisconnectedStateMachine;
+use error_support::convert_log_report_error;
+pub use uninitialized::UninitializedStateMachine;
+
+pub trait InternalStateMachine {
+    /// Initial state to start handling an public event
+    fn initial_state(&self, event: FxaEvent) -> Result<State>;
+
+    /// State transition from an internal event
+    fn next_state(&self, state: State, event: Event) -> Result<State>;
+}
+
+/// Internal state machine states
+///
+/// Most variants either represent a [FirefoxAccount] method call.
+/// `Complete` and `Cancel` are a terminal states which indicate the public state transition is complete.
+/// Each internal state machine uses the same `State` enum, but they only actually transition to a subset of the variants.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
+pub enum State {
+    GetAuthState,
+    BeginOAuthFlow {
+        scopes: Vec<String>,
+        entrypoint: String,
+    },
+    BeginPairingFlow {
+        pairing_url: String,
+        scopes: Vec<String>,
+        entrypoint: String,
+    },
+    CompleteOAuthFlow {
+        code: String,
+        state: String,
+    },
+    InitializeDevice,
+    EnsureDeviceCapabilities,
+    CheckAuthorizationStatus,
+    Disconnect,
+    /// Complete the current [FxaState] transition by transitioning to a new state
+    Complete(FxaState),
+    /// Complete the current [FxaState] transition by remaining at the current state
+    Cancel,
+}
+
+/// Internal state machine events
+///
+/// These represent the results of the method calls for each internal state.
+/// Each internal state machine uses the same `Event` enum, but they only actually respond to a subset of the variants.
+#[derive(Clone, Debug)]
+pub enum Event {
+    GetAuthStateSuccess {
+        auth_state: FxaRustAuthState,
+    },
+    BeginOAuthFlowSuccess {
+        oauth_url: String,
+    },
+    BeginPairingFlowSuccess {
+        oauth_url: String,
+    },
+    CompleteOAuthFlowSuccess,
+    InitializeDeviceSuccess,
+    EnsureDeviceCapabilitiesSuccess,
+    CheckAuthorizationStatusSuccess {
+        active: bool,
+    },
+    DisconnectSuccess,
+    CallError,
+    /// Auth error for the `ensure_capabilities` call that we do on startup.
+    /// This should likely go away when we do https://bugzilla.mozilla.org/show_bug.cgi?id=1868418
+    EnsureCapabilitiesAuthError,
+}
+
+impl State {
+    /// Perform the [FirefoxAccount] method call that corresponds to this state
+    pub fn make_call(
+        &self,
+        account: &mut FirefoxAccount,
+        device_config: &DeviceConfig,
+    ) -> Result<Event> {
+        let is_ensure_capabilities = matches!(self, State::EnsureDeviceCapabilities);
+        self.make_call_inner(account, device_config).or_else(|e| {
+            // All errors get converted to events, except StateMachineLogicError
+            if matches!(e, Error::StateMachineLogicError(_)) {
+                Err(e)
+            } else {
+                // This call is mostly to report the error, but converting `Error` to `FxaError`
+                // also simplifies the match for authentication errors since multiple `Error`
+                // variants map to `FxaError::Authentication`.
+                let fxa_error = convert_log_report_error(e);
+                if is_ensure_capabilities && matches!(fxa_error, FxaError::Authentication) {
+                    Ok(Event::EnsureCapabilitiesAuthError)
+                } else {
+                    Ok(Event::CallError)
+                }
+            }
+        })
+    }
+
+    fn make_call_inner(
+        &self,
+        account: &mut FirefoxAccount,
+        device_config: &DeviceConfig,
+    ) -> Result<Event> {
+        Ok(match self {
+            State::GetAuthState => Event::GetAuthStateSuccess {
+                auth_state: account.get_auth_state(),
+            },
+            State::EnsureDeviceCapabilities => {
+                account.ensure_capabilities(&device_config.capabilities)?;
+                Event::EnsureDeviceCapabilitiesSuccess
+            }
+            State::BeginOAuthFlow { scopes, entrypoint } => {
+                let scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
+                let oauth_url = account.begin_oauth_flow(&scopes, entrypoint)?;
+                Event::BeginOAuthFlowSuccess { oauth_url }
+            }
+            State::BeginPairingFlow {
+                pairing_url,
+                scopes,
+                entrypoint,
+            } => {
+                let scopes: Vec<&str> = scopes.iter().map(String::as_str).collect();
+                let oauth_url = account.begin_pairing_flow(pairing_url, &scopes, entrypoint)?;
+                Event::BeginPairingFlowSuccess { oauth_url }
+            }
+            State::CompleteOAuthFlow { code, state } => {
+                account.complete_oauth_flow(code, state)?;
+                Event::CompleteOAuthFlowSuccess
+            }
+            State::InitializeDevice => {
+                account.initialize_device(
+                    &device_config.name,
+                    device_config.device_type,
+                    &device_config.capabilities,
+                )?;
+                Event::InitializeDeviceSuccess
+            }
+            State::CheckAuthorizationStatus => {
+                let active = account.check_authorization_status()?.active;
+                Event::CheckAuthorizationStatusSuccess { active }
+            }
+            State::Disconnect => {
+                account.disconnect();
+                Event::DisconnectSuccess
+            }
+            state => {
+                return Err(Error::StateMachineLogicError(format!(
+                    "process_call: Don't know how to handle {state}"
+                )))
+            }
+        })
+    }
+}
+
+fn invalid_transition(state: State, event: Event) -> Result<State> {
+    Err(Error::InvalidStateTransition(format!("{state} -> {event}")))
+}
+
+#[cfg(test)]
+struct StateMachineTester<T> {
+    state_machine: T,
+    state: State,
+}
+
+#[cfg(test)]
+impl<T: InternalStateMachine> StateMachineTester<T> {
+    fn new(state_machine: T, event: FxaEvent) -> Self {
+        let initial_state = state_machine
+            .initial_state(event)
+            .expect("Error getting initial state");
+        Self {
+            state_machine,
+            state: initial_state,
+        }
+    }
+
+    /// Transition to a new state based on an event
+    fn next_state(&mut self, event: Event) {
+        self.state = self.peek_next_state(event);
+    }
+
+    /// peek_next_state what the next state would be without transitioning to it
+    fn peek_next_state(&self, event: Event) -> State {
+        self.state_machine
+            .next_state(self.state.clone(), event.clone())
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Error getting next state: {e} state: {:?} event: {event:?}",
+                    self.state
+                )
+            })
+    }
+}

--- a/components/fxa-client/src/state_machine/internal_machines/uninitialized.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/uninitialized.rs
@@ -1,0 +1,116 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::{invalid_transition, Event, InternalStateMachine, State};
+use crate::{Error, FxaEvent, FxaRustAuthState, FxaState, Result};
+
+pub struct UninitializedStateMachine;
+
+// Save some typing
+use Event::*;
+use State::*;
+
+impl InternalStateMachine for UninitializedStateMachine {
+    fn initial_state(&self, event: FxaEvent) -> Result<State> {
+        match event {
+            FxaEvent::Initialize { .. } => Ok(GetAuthState),
+            e => Err(Error::InvalidStateTransition(format!(
+                "Uninitialized -> {e}"
+            ))),
+        }
+    }
+
+    fn next_state(&self, state: State, event: Event) -> Result<State> {
+        Ok(match (state, event) {
+            (GetAuthState, GetAuthStateSuccess { auth_state }) => match auth_state {
+                FxaRustAuthState::Disconnected => Complete(FxaState::Disconnected),
+                FxaRustAuthState::AuthIssues => {
+                    // FIXME: We should move to `AuthIssues` here, but we don't in order to
+                    // match the current firefox-android behavior
+                    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1794212
+                    EnsureDeviceCapabilities
+                }
+                FxaRustAuthState::Connected => EnsureDeviceCapabilities,
+            },
+            (EnsureDeviceCapabilities, EnsureDeviceCapabilitiesSuccess) => {
+                Complete(FxaState::Connected)
+            }
+            (EnsureDeviceCapabilities, CallError) => Complete(FxaState::Disconnected),
+            (EnsureDeviceCapabilities, EnsureCapabilitiesAuthError) => CheckAuthorizationStatus,
+
+            // FIXME: we should re-run `ensure_capabilities` in this case, but we don't in order to
+            // match the current firefox-android behavior.
+            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1868418
+            (CheckAuthorizationStatus, CheckAuthorizationStatusSuccess { active: true }) => {
+                Complete(FxaState::Connected)
+            }
+            (CheckAuthorizationStatus, CheckAuthorizationStatusSuccess { active: false })
+            | (CheckAuthorizationStatus, CallError) => Complete(FxaState::AuthIssues),
+            (state, event) => return invalid_transition(state, event),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::super::StateMachineTester;
+    use super::*;
+    use crate::{DeviceConfig, DeviceType};
+
+    #[test]
+    fn test_state_machine() {
+        let mut tester = StateMachineTester::new(
+            UninitializedStateMachine,
+            FxaEvent::Initialize {
+                device_config: DeviceConfig {
+                    name: "test-device".to_owned(),
+                    device_type: DeviceType::Mobile,
+                    capabilities: vec![],
+                },
+            },
+        );
+        assert_eq!(tester.state, GetAuthState);
+        assert_eq!(
+            tester.peek_next_state(GetAuthStateSuccess {
+                auth_state: FxaRustAuthState::Disconnected
+            }),
+            Complete(FxaState::Disconnected)
+        );
+        assert_eq!(
+            tester.peek_next_state(GetAuthStateSuccess {
+                auth_state: FxaRustAuthState::AuthIssues
+            }),
+            // FIXME: https://bugzilla.mozilla.org/show_bug.cgi?id=1794212
+            EnsureDeviceCapabilities,
+        );
+
+        tester.next_state(GetAuthStateSuccess {
+            auth_state: FxaRustAuthState::Connected,
+        });
+        assert_eq!(tester.state, EnsureDeviceCapabilities);
+        assert_eq!(
+            tester.peek_next_state(CallError),
+            Complete(FxaState::Disconnected)
+        );
+        assert_eq!(
+            tester.peek_next_state(EnsureDeviceCapabilitiesSuccess),
+            Complete(FxaState::Connected)
+        );
+
+        tester.next_state(EnsureCapabilitiesAuthError);
+        assert_eq!(tester.state, CheckAuthorizationStatus);
+        assert_eq!(
+            tester.peek_next_state(CallError),
+            Complete(FxaState::AuthIssues)
+        );
+        assert_eq!(
+            tester.peek_next_state(CheckAuthorizationStatusSuccess { active: false }),
+            Complete(FxaState::AuthIssues)
+        );
+        assert_eq!(
+            tester.peek_next_state(CheckAuthorizationStatusSuccess { active: true }),
+            Complete(FxaState::Connected)
+        );
+    }
+}

--- a/components/fxa-client/src/state_machine/mod.rs
+++ b/components/fxa-client/src/state_machine/mod.rs
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! FxA state machine
+//!
+//! This presents a high-level API for logging in, logging out, dealing with authentication token issues, etc.
+
+use error_support::breadcrumb;
+
+use crate::{internal::FirefoxAccount, DeviceConfig, Error, FxaEvent, FxaState, Result};
+
+mod display;
+mod internal_machines;
+
+/// Number of state transitions to perform before giving up and assuming the internal state machine
+/// is stuck in an infinite loop
+const MAX_INTERNAL_TRANSITIONS: usize = 20;
+
+use internal_machines::InternalStateMachine;
+use internal_machines::State as InternalState;
+
+impl FirefoxAccount {
+    /// Get the current state
+    pub fn get_state(&self) -> FxaState {
+        self.auth_state.clone()
+    }
+
+    /// Process an event (login, logout, etc).
+    ///
+    /// On success, returns the new state.
+    /// On error, the state will remain the same.
+    pub fn process_event(&mut self, event: FxaEvent) -> Result<FxaState> {
+        match &self.auth_state {
+            FxaState::Uninitialized => self.process_event_with_internal_state_machine(
+                internal_machines::UninitializedStateMachine,
+                event,
+            ),
+            FxaState::Disconnected => self.process_event_with_internal_state_machine(
+                internal_machines::DisconnectedStateMachine,
+                event,
+            ),
+            FxaState::Authenticating { .. } => self.process_event_with_internal_state_machine(
+                internal_machines::AuthenticatingStateMachine,
+                event,
+            ),
+            FxaState::Connected => self.process_event_with_internal_state_machine(
+                internal_machines::ConnectedStateMachine,
+                event,
+            ),
+            FxaState::AuthIssues => self.process_event_with_internal_state_machine(
+                internal_machines::AuthIssuesStateMachine,
+                event,
+            ),
+        }
+    }
+
+    fn process_event_with_internal_state_machine<T: InternalStateMachine>(
+        &mut self,
+        state_machine: T,
+        event: FxaEvent,
+    ) -> Result<FxaState> {
+        let device_config = self.handle_state_machine_initialization(&event)?;
+
+        breadcrumb!("FxaStateMachine.process_event starting");
+        let mut internal_state = state_machine.initial_state(event)?;
+        let mut count = 0;
+        // Loop through internal state transitions until we reach a terminal state
+        //
+        // See `README.md` for details.
+        loop {
+            count += 1;
+            if count > MAX_INTERNAL_TRANSITIONS {
+                breadcrumb!("FxaStateMachine.process_event finished");
+                return Err(Error::StateMachineLogicError(
+                    "infinite loop detected".to_owned(),
+                ));
+            }
+            match internal_state {
+                InternalState::Complete(new_state) => {
+                    breadcrumb!("FxaStateMachine.process_event finished");
+                    self.auth_state = new_state.clone();
+                    return Ok(new_state);
+                }
+                InternalState::Cancel => {
+                    breadcrumb!("FxaStateMachine.process_event finished");
+                    return Ok(self.auth_state.clone());
+                }
+                state => {
+                    let event = state.make_call(self, &device_config)?;
+                    internal_state = state_machine.next_state(state, event)?;
+                }
+            }
+        }
+    }
+
+    /// Handles initialization before we process an event
+    ///
+    /// This checks that the first event we see is `FxaEvent::Initialize` and it returns the
+    /// `DeviceConfig` from that event.
+    fn handle_state_machine_initialization(&mut self, event: &FxaEvent) -> Result<DeviceConfig> {
+        match &event {
+            FxaEvent::Initialize { device_config } => match self.device_config {
+                Some(_) => Err(Error::InvalidStateTransition(
+                    "Initialize already sent".to_owned(),
+                )),
+                None => {
+                    self.device_config = Some(device_config.clone());
+                    Ok(device_config.clone())
+                }
+            },
+            _ => match &self.device_config {
+                Some(device_config) => Ok(device_config.clone()),
+                None => Err(Error::InvalidStateTransition(
+                    "Initialize not yet sent".to_owned(),
+                )),
+            },
+        }
+    }
+}

--- a/components/fxa-client/src/state_machine/mod.rs
+++ b/components/fxa-client/src/state_machine/mod.rs
@@ -10,6 +10,7 @@ use error_support::breadcrumb;
 
 use crate::{internal::FirefoxAccount, DeviceConfig, Error, FxaEvent, FxaState, Result};
 
+pub mod checker;
 mod display;
 mod internal_machines;
 


### PR DESCRIPTION
Adding an FxA state machine in the Rust code.  This one works similarly to the ones in `android-components` and our Swift wrapper.  The main differences are:

- Internal states directly correspond to `FirefoxAccount` method calls.  This makes everything much more testable.  We can write unit tests against the state machine logic without mocking out the `FirefoxAccount` object.  Even better, we can do a dry-run test against the existing implementations before we switch over.  I also think it makes the internal states more meaningful and understandable.
- Clearer separation of which states/events should be visible to the consumer application and which should be internal to the component.
- We always track the last public state that the component was in, so that we can go back to it if we fail in the middle of many internal state transitions.

TODO is the network retry / auth rechecking logic.  I think we can start testing this against the android-components code without that.

This is on top of #5960, let's merge that first.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
