### PR TITLE
Support rolling enrollments in stateful clients

### DIFF
--- a/components/nimbus/src/stateful/evaluator.rs
+++ b/components/nimbus/src/stateful/evaluator.rs
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 use crate::{evaluator::split_locale, stateful::matcher::AppContext};
+use chrono::{DateTime, Utc};
 use serde_derive::*;
 use std::collections::{HashMap, HashSet};
 
@@ -18,6 +19,8 @@ pub struct TargetingAttributes {
     pub active_experiments: HashSet<String>,
     pub enrollments: HashSet<String>,
     pub enrollments_map: HashMap<String, String>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub current_date: DateTime<Utc>,
 }
 
 #[cfg(feature = "stateful")]

--- a/components/nimbus/src/tests/stateful/test_evaluator.rs
+++ b/components/nimbus/src/tests/stateful/test_evaluator.rs
@@ -401,3 +401,49 @@ fn test_targeting_is_already_enrolled() {
         })
     );
 }
+
+#[test]
+fn test_bucket_sample() {
+    let cases = [
+        (
+            "1.1",
+            "1000",
+            "1000",
+            Some(EnrollmentStatus::Error {
+                reason: "EvaluationError: Custom error: start is not an integer".into(),
+            }),
+        ),
+        (
+            "0",
+            "1.1",
+            "1000",
+            Some(EnrollmentStatus::Error {
+                reason: "EvaluationError: Custom error: count is not an integer".into(),
+            }),
+        ),
+        (
+            "0",
+            "0",
+            "1000.1",
+            Some(EnrollmentStatus::Error {
+                reason: "EvaluationError: Custom error: total is not an integer".into(),
+            }),
+        ),
+    ];
+
+    for (start, count, total, expected) in cases {
+        let expr = format!("0|bucketSample({start}, {count}, {total})");
+        println!("{}", expr);
+        let targeting_attributes: TargetingAttributes = AppContext {
+            app_name: "nimbus_test".into(),
+            app_id: "nimbus-test".into(),
+            channel: "test".into(),
+            ..Default::default()
+        }
+        .into();
+
+        let result = targeting(&expr, &targeting_attributes.clone().into());
+
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION
To support rolling enrollments on mobile like we do on Desktop, we add a `current_date` member to the `TargetingAttributes` and expose `bucket_sample` as a JEXL transform.

Fixes [EXP-4102](https://mozilla-hub.atlassian.net/browse/EXP-4102)

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
