### PR TITLE
Update NSS fetch task to unexpired artifact

### DIFF
--- a/taskcluster/ci/fetch/kind.yml
+++ b/taskcluster/ci/fetch/kind.yml
@@ -37,6 +37,6 @@ tasks:
         description: fetches the built NSS artifacts from NSS CI
         fetch:
             type: static-url
-            url: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/tzaXIqmxRLm3rGDDG0VA9w/runs/0/artifacts/public/dist.tar.bz2
-            sha256: 2e3aee6adc0c0110bcc51aea4a96b7fb57a00124718e064f38c5a29a6110b007
-            size: 22734643
+            url: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/bez00P-rQwutueyGXoy5Wg/runs/0/artifacts/public/dist.tar.bz2
+            sha256: 9913a33376ef849903ebd5f032106ef420416aef599030d57641786a2c6a02e5
+            size: 22735146


### PR DESCRIPTION
The artifact had expired, so when rebuilding cached tasks the `fetch-nss-artifact` failed. I re-triggered the same task it was previously pointing at, so I think it should be ok to simply swap in like this?

The sha / size is a bit different though, so the builds are not reproducible I guess.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
