### PR TITLE
Move FxA changes in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,6 @@
 ### ⚠️ Breaking Changes ⚠️
   - `wipe_local` and `prune_destructively` have been removed from history API. `delete_everything` or `run_maintenance_*` methods should be used instead.
 
-[Full Changelog](https://github.com/mozilla/application-services/compare/v120.0...v121.0)
-
-# v120.0 (_2023-10-23_)
-
 ## FxA-Client
 
 ### 🦊 What's Changed 🦊
@@ -58,6 +54,10 @@
 - Check for missing sync scoped keys and return an error if they're not present
 - Began implementing functionality to track the authorization state
 - Added methods to simulate auth errors
+
+[Full Changelog](https://github.com/mozilla/application-services/compare/v120.0...v121.0)
+
+# v120.0 (_2023-10-23_)
 
 ## Nimbus SDK ⛅️🔬🔭
 


### PR DESCRIPTION
These were inserted in the 120 release notes, but they actually landed in 121.  I think what happened was the PR was opened before we did the release, but merged afterwards.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
