### PR TITLE
Remove redundant is_feature_valid

### DIFF
--- a/components/support/nimbus-fml/src/client/inspector.rs
+++ b/components/support/nimbus-fml/src/client/inspector.rs
@@ -50,12 +50,6 @@ impl FmlFeatureInspector {
         }
     }
 
-    pub fn is_feature_valid(&self, value: JsonObject) -> Result<bool> {
-        self.manifest
-            .validate_feature_config(&self.feature_id, serde_json::Value::Object(value))
-            .map(|_| true)
-    }
-
     pub fn get_first_error(&self, string: String) -> Option<FmlEditorError> {
         match self.get_syntax_error(&string) {
             Ok(json) => self.get_semantic_error(&string, json).err(),

--- a/components/support/nimbus-fml/src/client/mod.rs
+++ b/components/support/nimbus-fml/src/client/mod.rs
@@ -110,13 +110,6 @@ impl FmlClient {
         }
     }
 
-    /// Validates a supplied feature configuration. Returns true or an FMLError.
-    pub fn is_feature_valid(&self, feature_id: String, value: JsonObject) -> Result<bool> {
-        self.manifest
-            .validate_feature_config(&feature_id, serde_json::Value::Object(value))
-            .map(|_| true)
-    }
-
     /// Validates a supplied list of feature configurations. The valid configurations will be merged into the manifest's
     /// default feature JSON, and invalid configurations will be returned as a list of their respective errors.
     pub fn merge(
@@ -263,21 +256,6 @@ mod unit_tests {
                 }
             })
         );
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_validate_feature_config() -> Result<()> {
-        let client: FmlClient = create_manifest().into();
-
-        assert!(client.is_feature_valid(
-            "feature".to_string(),
-            json!({ "prop_1": "new value" })
-                .as_object()
-                .unwrap()
-                .clone()
-        )?);
 
         Ok(())
     }

--- a/components/support/nimbus-fml/src/fml.udl
+++ b/components/support/nimbus-fml/src/fml.udl
@@ -41,10 +41,6 @@ interface FmlClient {
     [Name=new_with_config, Throws=FMLError]
     constructor(string manifest, string channel, FmlLoaderConfig config);
 
-    // Validates a supplied feature configuration. Returns true or an FMLError.
-    [Throws=FMLError]
-    boolean is_feature_valid(string feature_id, JsonObject value);
-
     // Validates a supplied list of feature configurations. The valid configurations will be merged into the manifest's
     // default feature JSON, and invalid configurations will be returned as a list of their respective errors.
     [Throws=FMLError]

--- a/megazords/cirrus/tests/python-tests/test_fml.py
+++ b/megazords/cirrus/tests/python-tests/test_fml.py
@@ -37,20 +37,6 @@ def test_default_json(fml_client):
     assert defaults["example-feature"].get("something") is None
 
 
-def test_is_feature_valid(fml_client):
-    client = fml_client("test.fml.yml", "developer")
-    config = {"enabled": True}
-    assert client.is_feature_valid("example-feature", config) is True
-
-
-def test_is_feature_valid_is_invalid(fml_client):
-    client = fml_client("test.fml.yml", "developer")
-    config = {"enabled": True}
-
-    with pytest.raises(FmlError):
-        client.is_feature_valid("example-featurea", config)
-
-
 def test_merge(fml_client):
     client = fml_client("test.fml.yml", "developer")
     configs = {"example-feature": {"enabled": True}}


### PR DESCRIPTION
Relates to [ EXP-4110](https://mozilla-hub.atlassian.net/browse/EXP-4110).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_1_) change.

This PR removes the `is_feature_valid` method call from the FML FFI. There are no callers in Application Services or Experimenter. (the mobile SDKs don't ship with this feature enabled).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
