### PR TITLE
Reset telemetry identifiers to default

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -412,12 +412,9 @@ open class Nimbus(
     }
 
     override fun resetTelemetryIdentifiers() {
-        // The "dummy" field here is required for obscure reasons when generating code on desktop,
-        // so we just automatically set it to a dummy value.
-        val aru = AvailableRandomizationUnits(clientId = null, userId = null, nimbusId = null, dummy = 0)
         dbScope.launch {
             withCatchAll("resetTelemetryIdentifiers") {
-                nimbusClient.resetTelemetryIdentifiers(aru).also { enrollmentChangeEvents ->
+                nimbusClient.resetTelemetryIdentifiers().also { enrollmentChangeEvents ->
                     recordExperimentTelemetryEvents(enrollmentChangeEvents)
                 }
             }

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -264,8 +264,8 @@ extension Nimbus {
         postEnrollmentCalculation(changes)
     }
 
-    func resetTelemetryIdentifiersOnThisThread(_ identifiers: AvailableRandomizationUnits) throws {
-        let changes = try nimbusClient.resetTelemetryIdentifiers(newRandomizationUnits: identifiers)
+    func resetTelemetryIdentifiersOnThisThread() throws {
+        let changes = try nimbusClient.resetTelemetryIdentifiers()
         postEnrollmentCalculation(changes)
     }
 }
@@ -314,10 +314,7 @@ extension Nimbus: NimbusUserConfiguration {
 
     public func resetTelemetryIdentifiers() {
         _ = catchAll(dbQueue) { _ in
-            // The "dummy" field here is required for obscure reasons when generating code on desktop,
-            // so we just automatically set it to a dummy value.
-            let aru = AvailableRandomizationUnits(clientId: nil, userId: nil, nimbusId: nil, dummy: 0)
-            try self.resetTelemetryIdentifiersOnThisThread(aru)
+            try self.resetTelemetryIdentifiersOnThisThread()
         }
     }
 }

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -244,7 +244,7 @@ interface NimbusClient {
     //      misleading incomplete data.
     //
     [Throws=NimbusError]
-    sequence<EnrollmentChangeEvent> reset_telemetry_identifiers(AvailableRandomizationUnits new_randomization_units);
+    sequence<EnrollmentChangeEvent> reset_telemetry_identifiers();
 
     // This provides low level access to the targeting machinery for other uses by the application (e.g. messages)
     // Additional parameters can be added via the optional JSON object. This allows for many JEXL expressions

--- a/components/nimbus/src/stateful/nimbus_client.rs
+++ b/components/nimbus/src/stateful/nimbus_client.rs
@@ -537,10 +537,7 @@ impl NimbusClient {
     /// across the telemetry reset, since we could use Nimbus metrics to link their pings from
     /// before and after the reset.
     ///
-    pub fn reset_telemetry_identifiers(
-        &self,
-        new_randomization_units: AvailableRandomizationUnits,
-    ) -> Result<Vec<EnrollmentChangeEvent>> {
+    pub fn reset_telemetry_identifiers(&self) -> Result<Vec<EnrollmentChangeEvent>> {
         let mut events = vec![];
         let db = self.db()?;
         let mut writer = db.write()?;
@@ -562,7 +559,7 @@ impl NimbusClient {
         }
 
         // (No need to commit `writer` if the above check was false, since we didn't change anything)
-        state.available_randomization_units = new_randomization_units;
+        state.available_randomization_units = Default::default();
 
         Ok(events)
     }

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -85,7 +85,7 @@ fn test_telemetry_reset() -> Result<()> {
     let orig_nimbus_id = client.nimbus_id()?;
     assert_eq!(get_client_id(), Some(mock_client_id));
 
-    let events = client.reset_telemetry_identifiers(AvailableRandomizationUnits::default())?;
+    let events = client.reset_telemetry_identifiers()?;
 
     // We should have reset our nimbus_id.
     assert_ne!(orig_nimbus_id, client.nimbus_id()?);


### PR DESCRIPTION
Both callers of `NimbusClient.reset_telemetry_identifiers` always passed in a default set of `AvailableRandomizationUnits`. Additionally, if the method was ever called with non-default randomization units, the database state and internal state would become out of sync as soon as `NimbusClient.read_or_create_nimbus_id` is called. This did not matter in production, because we only ever evaluate recipes once at startup, but if that behaviour ever changes it would end up causing bugs.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
