### PR TITLE
Always use default AvailableRandomizationUnits

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -30,7 +30,6 @@ import org.mozilla.experiments.nimbus.GleanMetrics.NimbusEvents
 import org.mozilla.experiments.nimbus.GleanMetrics.NimbusHealth
 import org.mozilla.experiments.nimbus.internal.AppContext
 import org.mozilla.experiments.nimbus.internal.AvailableExperiment
-import org.mozilla.experiments.nimbus.internal.AvailableRandomizationUnits
 import org.mozilla.experiments.nimbus.internal.EnrolledExperiment
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEvent
 import org.mozilla.experiments.nimbus.internal.EnrollmentChangeEventType
@@ -169,9 +168,6 @@ open class Nimbus(
             coenrollingFeatureIds,
             dataDir.path,
             remoteSettingsConfig,
-            // The "dummy" field here is required for obscure reasons when generating code on desktop,
-            // so we just automatically set it to a dummy value.
-            AvailableRandomizationUnits(clientId = null, userId = null, nimbusId = null, dummy = 0),
             metricsHandler,
         )
     }

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -223,15 +223,12 @@ fn main() -> Result<()> {
         collection_name: collection_name.to_string(),
     };
 
-    let aru = AvailableRandomizationUnits::with_client_id(&client_id);
-
     // Here we initialize our main `NimbusClient` struct
     let nimbus_client = NimbusClient::new(
         context.clone(),
         Default::default(),
         db_path,
         Some(config),
-        aru,
         Box::new(NoopMetricsHandler),
     )?;
     log::info!("Nimbus ID is {}", nimbus_client.nimbus_id()?);

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -102,14 +102,6 @@ public extension Nimbus {
             coenrollingFeatureIds: coenrollingFeatureIds,
             dbpath: dbPath,
             remoteSettingsConfig: remoteSettings,
-            // The "dummy" field here is required for obscure reasons when generating code on desktop,
-            // so we just automatically set it to a dummy value.
-            availableRandomizationUnits: AvailableRandomizationUnits(
-                clientId: nil,
-                userId: nil,
-                nimbusId: nil,
-                dummy: 0
-            ),
             metricsHandler: GleanMetricsHandler()
         )
 

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -44,16 +44,6 @@ dictionary ExperimentBranch {
     i32 ratio;
 };
 
-dictionary AvailableRandomizationUnits {
-    string? client_id;
-    string? user_id;
-    string? nimbus_id;
-    // work around uniffi-rs #331 by including a non-optional value. We'll
-    // try and hide this in the bindings used by clients and eventually remove
-    // it entirely.
-    i8 dummy;
-};
-
 dictionary EnrollmentChangeEvent {
     string experiment_slug;
     string branch_slug;
@@ -120,7 +110,6 @@ interface NimbusClient {
         sequence<string> coenrolling_feature_ids,
         string dbpath,
         RemoteSettingsConfig? remote_settings_config,
-        AvailableRandomizationUnits available_randomization_units,
         MetricsHandler metrics_handler
     );
 

--- a/components/nimbus/src/stateful/nimbus_client.rs
+++ b/components/nimbus/src/stateful/nimbus_client.rs
@@ -83,13 +83,12 @@ impl NimbusClient {
         coenrolling_feature_ids: Vec<String>,
         db_path: P,
         config: Option<RemoteSettingsConfig>,
-        available_randomization_units: AvailableRandomizationUnits,
         metrics_handler: Box<dyn MetricsHandler>,
     ) -> Result<Self> {
         let settings_client = Mutex::new(create_client(config)?);
 
         let mutable_state = Mutex::new(InternalMutableState {
-            available_randomization_units,
+            available_randomization_units: Default::default(),
             targeting_attributes: app_context.clone().into(),
         });
 

--- a/components/nimbus/src/tests/helpers.rs
+++ b/components/nimbus/src/tests/helpers.rs
@@ -540,7 +540,7 @@ pub fn get_targeted_experiment(slug: &str, targeting: &str) -> serde_json::Value
             "start": 0,
             "total": 10000,
             "namespace": "secure-gold",
-            "randomizationUnit": "client_id"
+            "randomizationUnit": "nimbus_id"
         },
         "targeting": targeting,
         "userFacingName": "test experiment",

--- a/components/nimbus/src/tests/stateful/client/test_null_client.rs
+++ b/components/nimbus/src/tests/stateful/client/test_null_client.rs
@@ -18,13 +18,11 @@ fn test_null_client() -> Result<()> {
 
     let tmp_dir = tempfile::tempdir()?;
 
-    let aru = Default::default();
     let client = NimbusClient::new(
         Default::default(),
         Default::default(),
         tmp_dir.path(),
         None,
-        aru,
         Box::new(metrics),
     )?;
     client.fetch_experiments()?;

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -18,8 +18,8 @@ use crate::{
         get_single_feature_rollout, get_targeted_experiment, to_local_experiments_string,
         TestMetrics,
     },
-    AppContext, AvailableRandomizationUnits, Experiment, NimbusClient, TargetingAttributes,
-    DB_KEY_APP_VERSION, DB_KEY_UPDATE_DATE,
+    AppContext, Experiment, NimbusClient, TargetingAttributes, DB_KEY_APP_VERSION,
+    DB_KEY_UPDATE_DATE,
 };
 use chrono::{DateTime, Duration, Utc};
 use serde_json::json;
@@ -31,7 +31,6 @@ use uuid::Uuid;
 #[test]
 fn test_telemetry_reset() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
     let mock_exp_slug = "exp-1".to_string();
     let mock_exp_branch = "branch-1".to_string();
 
@@ -41,22 +40,8 @@ fn test_telemetry_reset() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id.clone()),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
-
-    let get_client_id = || {
-        client
-            .mutable_state
-            .lock()
-            .unwrap()
-            .available_randomization_units
-            .client_id
-            .clone()
-    };
 
     // Mock being enrolled in a single experiment.
     let db = client.db()?;
@@ -83,15 +68,11 @@ fn test_telemetry_reset() -> Result<()> {
 
     // Check expected state before resetting telemetry.
     let orig_nimbus_id = client.nimbus_id()?;
-    assert_eq!(get_client_id(), Some(mock_client_id));
 
     let events = client.reset_telemetry_identifiers()?;
 
     // We should have reset our nimbus_id.
     assert_ne!(orig_nimbus_id, client.nimbus_id()?);
-
-    // We should have updated the randomization units.
-    assert_eq!(get_client_id(), None);
 
     // We should have been disqualified from the enrolled experiment.
     assert_eq!(client.get_experiment_branch(mock_exp_slug)?, None);
@@ -105,7 +86,6 @@ fn test_telemetry_reset() -> Result<()> {
 #[test]
 fn test_installation_date() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
     let tmp_dir = tempfile::tempdir()?;
     // Step 1: We first test that the SDK will default to using the
     // value in the app context if it exists
@@ -121,10 +101,6 @@ fn test_installation_date() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id.clone()),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics.clone()),
     )?;
 
@@ -159,10 +135,6 @@ fn test_installation_date() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id.clone()),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics.clone()),
     )?;
     delete_test_creation_date(tmp_dir.path()).ok();
@@ -184,10 +156,6 @@ fn test_installation_date() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id.clone()),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics.clone()),
     )?;
     client.initialize()?;
@@ -217,10 +185,6 @@ fn test_installation_date() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
     client.initialize()?;
@@ -251,7 +215,6 @@ fn test_days_since_calculation_happens_at_startup() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        Default::default(),
         Box::new(metrics.clone()),
     )?;
 
@@ -278,7 +241,6 @@ fn test_days_since_calculation_happens_at_startup() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        Default::default(),
         Box::new(metrics),
     )?;
     client.apply_pending_experiments()?;
@@ -292,17 +254,12 @@ fn test_days_since_calculation_happens_at_startup() -> Result<()> {
 #[test]
 fn test_days_since_update_changes_with_context() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
     let tmp_dir = tempfile::tempdir()?;
     let client = NimbusClient::new(
         AppContext::default(),
         Default::default(),
         tmp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id.clone()),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics.clone()),
     )?;
     client.initialize()?;
@@ -322,10 +279,6 @@ fn test_days_since_update_changes_with_context() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id.clone()),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics.clone()),
     )?;
     client.initialize()?;
@@ -352,10 +305,6 @@ fn test_days_since_update_changes_with_context() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id.clone()),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics.clone()),
     )?;
     client.initialize()?;
@@ -388,10 +337,6 @@ fn test_days_since_update_changes_with_context() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
     client.initialize()?;
@@ -419,7 +364,6 @@ fn test_days_since_update_changes_with_context() -> Result<()> {
 #[test]
 fn test_days_since_install() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
     let app_context = AppContext {
@@ -433,10 +377,6 @@ fn test_days_since_install() -> Result<()> {
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
     let targeting_attributes = TargetingAttributes {
@@ -500,7 +440,6 @@ fn test_days_since_install() -> Result<()> {
 #[test]
 fn test_days_since_install_failed_targeting() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
     let app_context = AppContext {
@@ -514,10 +453,6 @@ fn test_days_since_install_failed_targeting() -> Result<()> {
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
     let targeting_attributes = TargetingAttributes {
@@ -580,7 +515,6 @@ fn test_days_since_install_failed_targeting() -> Result<()> {
 #[test]
 fn test_days_since_update() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
     let app_context = AppContext {
@@ -594,10 +528,6 @@ fn test_days_since_update() -> Result<()> {
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
     let targeting_attributes = TargetingAttributes {
@@ -661,7 +591,6 @@ fn test_days_since_update() -> Result<()> {
 #[test]
 fn test_days_since_update_failed_targeting() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
     let app_context = AppContext {
@@ -675,10 +604,6 @@ fn test_days_since_update_failed_targeting() -> Result<()> {
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
     let targeting_attributes = TargetingAttributes {
@@ -741,7 +666,6 @@ fn test_days_since_update_failed_targeting() -> Result<()> {
 #[test]
 fn event_store_exists_for_apply_pending_experiments() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
 
@@ -768,10 +692,6 @@ fn event_store_exists_for_apply_pending_experiments() -> Result<()> {
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
     let targeting_attributes = TargetingAttributes {
@@ -866,7 +786,6 @@ fn event_store_exists_for_apply_pending_experiments() -> Result<()> {
 #[test]
 fn event_store_on_targeting_attributes_is_updated_after_an_event_is_recorded() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
 
@@ -893,10 +812,6 @@ fn event_store_on_targeting_attributes_is_updated_after_an_event_is_recorded() -
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
     let targeting_attributes = TargetingAttributes {
@@ -982,7 +897,6 @@ fn delete_test_creation_date<P: AsRef<Path>>(path: P) -> Result<()> {
 #[test]
 fn test_ios_rollout() -> Result<()> {
     let metrics = TestMetrics::new();
-    let aru = Default::default();
     let ctx = AppContext {
         app_name: "firefox_ios".to_string(),
         channel: "release".to_string(),
@@ -996,7 +910,6 @@ fn test_ios_rollout() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        aru,
         Box::new(metrics),
     )?;
 
@@ -1031,7 +944,6 @@ fn test_fetch_enabled() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        Default::default(),
         Box::new(metrics.clone()),
     )?;
     client.set_fetch_enabled(false)?;
@@ -1044,7 +956,6 @@ fn test_fetch_enabled() -> Result<()> {
         Default::default(),
         tmp_dir.path(),
         None,
-        Default::default(),
         Box::new(metrics),
     )?;
     assert!(!client.is_fetch_enabled()?);
@@ -1054,7 +965,6 @@ fn test_fetch_enabled() -> Result<()> {
 #[test]
 fn test_active_enrollment_in_targeting() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
 
@@ -1069,10 +979,6 @@ fn test_active_enrollment_in_targeting() -> Result<()> {
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
     let targeting_attributes = TargetingAttributes {
@@ -1080,6 +986,7 @@ fn test_active_enrollment_in_targeting() -> Result<()> {
         ..Default::default()
     };
     client.with_targeting_attributes(targeting_attributes);
+    client.set_nimbus_id(&Uuid::from_str("00000000-0000-0000-0000-000000000004")?)?;
     client.initialize()?;
 
     // Apply an initial experiment
@@ -1115,7 +1022,6 @@ fn test_active_enrollment_in_targeting() -> Result<()> {
 #[test]
 fn test_previous_enrollments_in_targeting() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
 
@@ -1136,10 +1042,6 @@ fn test_previous_enrollments_in_targeting() -> Result<()> {
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
 
@@ -1265,7 +1167,6 @@ fn test_previous_enrollments_in_targeting() -> Result<()> {
 #[test]
 fn test_opt_out_multiple_experiments_same_feature_does_not_re_enroll() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
 
@@ -1283,10 +1184,6 @@ fn test_opt_out_multiple_experiments_same_feature_does_not_re_enroll() -> Result
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics),
     )?;
 
@@ -1397,7 +1294,6 @@ fn test_enrollment_status_metrics_recorded() -> Result<()> {
 #[test]
 fn test_enrollment_status_metrics_not_recorded_app_name_mismatch() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
 
     let temp_dir = tempfile::tempdir()?;
 
@@ -1413,10 +1309,6 @@ fn test_enrollment_status_metrics_not_recorded_app_name_mismatch() -> Result<()>
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics.clone()),
     )?;
     client.set_nimbus_id(&Uuid::from_str("53baafb3-b800-42ac-878c-c3451e250928")?)?;
@@ -1443,7 +1335,6 @@ fn test_enrollment_status_metrics_not_recorded_app_name_mismatch() -> Result<()>
 #[test]
 fn test_enrollment_status_metrics_not_recorded_channel_mismatch() -> Result<()> {
     let metrics = TestMetrics::new();
-    let mock_client_id = "client-1".to_string();
     let temp_dir = tempfile::tempdir()?;
 
     let app_context = AppContext {
@@ -1458,10 +1349,6 @@ fn test_enrollment_status_metrics_not_recorded_channel_mismatch() -> Result<()> 
         Default::default(),
         temp_dir.path(),
         None,
-        AvailableRandomizationUnits {
-            client_id: Some(mock_client_id),
-            ..AvailableRandomizationUnits::default()
-        },
         Box::new(metrics.clone()),
     )?;
     client.set_nimbus_id(&Uuid::from_str("53baafb3-b800-42ac-878c-c3451e250928")?)?;
@@ -1485,11 +1372,6 @@ fn test_enrollment_status_metrics_not_recorded_channel_mismatch() -> Result<()> 
 }
 
 fn with_metrics(metrics: &TestMetrics, coenrolling_feature: &str) -> Result<NimbusClient> {
-    let mock_client_id = "client-1".to_string();
-    let aru = AvailableRandomizationUnits {
-        client_id: Some(mock_client_id),
-        ..AvailableRandomizationUnits::default()
-    };
     let temp_dir = tempfile::tempdir()?;
 
     let app_context = AppContext {
@@ -1504,7 +1386,6 @@ fn with_metrics(metrics: &TestMetrics, coenrolling_feature: &str) -> Result<Nimb
         vec![coenrolling_feature.to_string()],
         temp_dir.path(),
         None,
-        aru,
         Box::new(metrics.clone()),
     )
 }

--- a/components/nimbus/tests/common/mod.rs
+++ b/components/nimbus/tests/common/mod.rs
@@ -62,7 +62,6 @@ fn new_test_client_internal(
         bucket_name: None,
         collection_name: "doesn't matter".to_string(),
     };
-    let aru = Default::default();
     let ctx = AppContext {
         app_name: "fenix".to_string(),
         app_id: "org.mozilla.fenix".to_string(),
@@ -75,7 +74,6 @@ fn new_test_client_internal(
         Default::default(),
         tmp_dir.path(),
         Some(config),
-        aru,
         Box::new(NoopMetricsHandler),
     )
 }

--- a/components/nimbus/tests/test_fs_client.rs
+++ b/components/nimbus/tests/test_fs_client.rs
@@ -32,13 +32,11 @@ fn test_simple() -> Result<()> {
     };
 
     let tmp_dir = tempfile::tempdir()?;
-    let aru = Default::default();
     let client = NimbusClient::new(
         Default::default(),
         Default::default(),
         tmp_dir.path(),
         Some(config),
-        aru,
         Box::new(NoopMetricsHandler),
     )?;
     client.fetch_experiments()?;


### PR DESCRIPTION
Both callers of the `NimbusClient` constructor always pass in a default `AvailableRandomizationUnits`. Instead of forcing our callers to care about this, we can always initialize it ourselves with a default value.

Blocked on #5988

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
