### PR TITLE
Expose nimbus_id to the targeting context

### DIFF
--- a/components/nimbus/src/stateful/evaluator.rs
+++ b/components/nimbus/src/stateful/evaluator.rs
@@ -21,6 +21,7 @@ pub struct TargetingAttributes {
     pub enrollments_map: HashMap<String, String>,
     #[serde(with = "chrono::serde::ts_seconds")]
     pub current_date: DateTime<Utc>,
+    pub nimbus_id: Option<String>,
 }
 
 #[cfg(feature = "stateful")]


### PR DESCRIPTION
This is required for the rolling enrollments (EXP-4102).

Fixes EXP-4132

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
