### PR TITLE
Collect editing errors instead of throwing the first one

### DIFF
--- a/components/support/nimbus-fml/src/defaults/merger.rs
+++ b/components/support/nimbus-fml/src/defaults/merger.rs
@@ -238,7 +238,7 @@ impl<'object> DefaultsMerger<'object> {
 
     /// A convenience method to get the defaults from the feature, and merger it
     /// with the passed value.
-    pub(crate) fn _merge_feature_config(
+    pub(crate) fn merge_feature_config(
         &self,
         feature_def: &FeatureDef,
         value: &Value,

--- a/components/support/nimbus-fml/src/editing/mod.rs
+++ b/components/support/nimbus-fml/src/editing/mod.rs
@@ -5,3 +5,59 @@
 mod error_path;
 
 pub(crate) use error_path::ErrorPath;
+
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+
+use crate::{
+    error::FMLError,
+    intermediate_representation::{EnumDef, FeatureDef, ObjectDef},
+};
+
+pub(crate) struct FeatureValidationError {
+    pub(crate) literals: Vec<String>,
+    pub(crate) path: String,
+    pub(crate) message: String,
+}
+
+impl From<FeatureValidationError> for FMLError {
+    fn from(value: FeatureValidationError) -> Self {
+        Self::FeatureValidationError {
+            message: value.message,
+            literals: value.literals,
+            path: value.path,
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) struct ErrorConverter<'a> {
+    enum_defs: &'a BTreeMap<String, EnumDef>,
+    object_defs: &'a BTreeMap<String, ObjectDef>,
+}
+
+impl<'a> ErrorConverter<'a> {
+    pub(crate) fn new(
+        enum_defs: &'a BTreeMap<String, EnumDef>,
+        object_defs: &'a BTreeMap<String, ObjectDef>,
+    ) -> Self {
+        Self {
+            enum_defs,
+            object_defs,
+        }
+    }
+
+    pub(crate) fn convert_feature_error(
+        &self,
+        _feature_def: &FeatureDef,
+        _value: &Value,
+        error: FeatureValidationError,
+    ) -> FMLError {
+        error.into()
+    }
+
+    pub(crate) fn convert_object_error(&self, error: FeatureValidationError) -> FMLError {
+        error.into()
+    }
+}


### PR DESCRIPTION
Relates to [ EXP-4110](https://mozilla-hub.atlassian.net/browse/EXP-4110).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR is quite large, and was quite difficult to split up; I am hesitant to give it a O(_k*n_) label– it may just be large.

- changes `FMLError::FeatureValidationError` to an intermediate struct `FeatureValidationError`
- collects all of them, instead of throwing at the first one.
- Introduces a new `get_errors` method which does all validation for manifest defaults _and_ experimental JSON (feature value)
- This unifies all error detection for feature values into one place. Previously, spurious properties were detected and thrown in the `DefaultsMerger`.
- The `validate_feature_def` method has been re-written in terms of this `get_errors`, and is now _only_ used for validating manifest defaults.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
