### PR TITLE
Use new ErrorPath in FeatureValidationError

### DIFF
--- a/components/support/nimbus-fml/src/client/inspector.rs
+++ b/components/support/nimbus-fml/src/client/inspector.rs
@@ -113,7 +113,7 @@ impl FmlFeatureInspector {
         let mut editor_errors: Vec<_> = Vec::with_capacity(errors.len());
         for e in errors {
             let message = e.message;
-            let literals = e.literals;
+            let literals = e.path.literals;
             let highlight = literals.last().cloned();
             let (line, col) = find_err(src, literals.into_iter());
             let error = FmlEditorError {

--- a/components/support/nimbus-fml/src/defaults/validator.rs
+++ b/components/support/nimbus-fml/src/defaults/validator.rs
@@ -250,8 +250,7 @@ impl<'a> DefaultsValidator<'a> {
                 }
                 let path = path.final_error_quoted(s);
                 errors.push(FeatureValidationError {
-                    path: path.path,
-                    literals: path.literals,
+                    path,
                     message: format!("\"{s}\" is not a valid {enum_name}{}", did_you_mean(valid)),
                 });
             }
@@ -286,8 +285,7 @@ impl<'a> DefaultsValidator<'a> {
                     if !valid.contains(map_key) {
                         let path = path.map_key(map_key);
                         errors.push(FeatureValidationError {
-                            path: path.path,
-                            literals: path.literals,
+                            path,
                             message: format!("Invalid key \"{map_key}\"{}", did_you_mean(valid.clone())),
                         });
                     }
@@ -318,8 +316,7 @@ impl<'a> DefaultsValidator<'a> {
             _ => {
                 let path = path.final_error(&default.to_string());
                 errors.push(FeatureValidationError {
-                    path: path.path,
-                    literals: path.literals,
+                    path,
                     message: format!("Mismatch between type {type_ref} and default {default}"),
                 });
             }
@@ -350,8 +347,7 @@ impl<'a> DefaultsValidator<'a> {
             if !valid.contains(map_key) {
                 let path = path.final_error_quoted(map_key);
                 errors.push(FeatureValidationError {
-                    path: path.path,
-                    literals: path.literals,
+                    path,
                     message: format!(
                         "Invalid property \"{map_key}\"{}",
                         did_you_mean(valid.clone())
@@ -479,8 +475,7 @@ impl<'a> DefaultsValidator<'a> {
                         if !suberrors.is_empty() {
                             let path = path.open_brace();
                             errors.push(FeatureValidationError {
-                                literals: path.literals,
-                                path: path.path,
+                                path,
                                 message: format!(
                                     "A valid value for {prop_nm} of type {} is missing",
                                     &prop.typ
@@ -511,8 +506,7 @@ fn check_string_aliased_property(
                 collect_string_alias_values(alias_type, &prop.typ, def_value, &mut valid);
                 let path = path.final_error_quoted(value);
                 errors.push(FeatureValidationError {
-                    literals: path.literals,
-                    path: path.path,
+                    path,
                     message: format!(
                         "Invalid value \"{value}\" for type {alias_nm}{}",
                         did_you_mean(valid)

--- a/components/support/nimbus-fml/src/editing/mod.rs
+++ b/components/support/nimbus-fml/src/editing/mod.rs
@@ -16,18 +16,13 @@ use crate::{
 };
 
 pub(crate) struct FeatureValidationError {
-    pub(crate) literals: Vec<String>,
-    pub(crate) path: String,
+    pub(crate) path: ErrorPath,
     pub(crate) message: String,
 }
 
 impl From<FeatureValidationError> for FMLError {
     fn from(value: FeatureValidationError) -> Self {
-        Self::FeatureValidationError {
-            message: value.message,
-            literals: value.literals,
-            path: value.path,
-        }
+        Self::ValidationError(value.path.path, value.message)
     }
 }
 

--- a/components/support/nimbus-fml/src/error.rs
+++ b/components/support/nimbus-fml/src/error.rs
@@ -34,12 +34,6 @@ pub enum FMLError {
     InternalError(&'static str),
     #[error("Validation Error at {0}: {1}")]
     ValidationError(String, String),
-    #[error("Validation Error at {path}: {message}")]
-    FeatureValidationError {
-        literals: Vec<String>,
-        path: String,
-        message: String,
-    },
     #[error("Type Parsing Error: {0}")]
     TypeParsingError(String),
     #[error("Invalid Channel error: The channel `{0}` is specified, but only {1:?} are supported for the file")]

--- a/components/support/nimbus-fml/src/fml.udl
+++ b/components/support/nimbus-fml/src/fml.udl
@@ -12,7 +12,6 @@ enum FMLError {
     "IOError", "JSONError", "YAMLError", "UrlError", "EmailError", "FetchError", "InvalidPath",
     "TemplateProblem", "Fatal", "InternalError", "ValidationError", "TypeParsingError",
     "InvalidChannelError", "FMLModuleError", "CliError", "ClientError", "InvalidFeatureError",
-    "FeatureValidationError",
 };
 
 dictionary MergedJsonWithErrors {


### PR DESCRIPTION
Relates to [ EXP-4110](https://mozilla-hub.atlassian.net/browse/EXP-4110).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_1_) change.

This PR moves `path: String` and `literals: Vec<String>` out of `FeatureValidationError` and replaces it with the new `ErrorPath` struct directly.

The use of `ErrorPath`– in `inspector.rs` is elaborated upon in later PRs.

Note: this PR relies on #5998, so only one commit need be reviewed.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
