### PR TITLE
Move error detection away from error construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,6 +2583,7 @@ dependencies = [
  "email_address",
  "glob",
  "heck 0.3.3",
+ "itertools",
  "jsonschema",
  "lazy_static",
  "reqwest",

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -33,6 +33,7 @@ console = "0.15.5"
 lazy_static = "1.4"
 email_address = { version = "0.2.4", features = ["serde"] }
 sha2 = "^0.10"
+itertools = "0"
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"], optional = true }

--- a/components/support/nimbus-fml/src/client/mod.rs
+++ b/components/support/nimbus-fml/src/client/mod.rs
@@ -290,7 +290,11 @@ mod unit_tests {
             })
         );
         assert_eq!(result.errors.len(), 1);
-        assert_eq!(result.errors[0].to_string(), "Validation Error at features/feature_i.prop_i_1: Mismatch between type String and default 1".to_string());
+        assert_eq!(
+            result.errors[0].to_string(),
+            "Validation Error at features/feature_i.prop_i_1: Invalid value 1 for type String"
+                .to_string()
+        );
 
         Ok(())
     }

--- a/components/support/nimbus-fml/src/editing/error_converter.rs
+++ b/components/support/nimbus-fml/src/editing/error_converter.rs
@@ -1,0 +1,120 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#[cfg(feature = "client-lib")]
+use super::FmlEditorError;
+use super::{values_finder::ValuesFinder, ErrorKind, FeatureValidationError};
+use crate::{
+    error::FMLError,
+    intermediate_representation::{EnumDef, FeatureDef, ObjectDef},
+};
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[allow(dead_code)]
+pub(crate) struct ErrorConverter<'a> {
+    pub(crate) enum_defs: &'a BTreeMap<String, EnumDef>,
+    pub(crate) object_defs: &'a BTreeMap<String, ObjectDef>,
+}
+
+impl<'a> ErrorConverter<'a> {
+    pub(crate) fn new(
+        enum_defs: &'a BTreeMap<String, EnumDef>,
+        object_defs: &'a BTreeMap<String, ObjectDef>,
+    ) -> Self {
+        Self {
+            enum_defs,
+            object_defs,
+        }
+    }
+
+    pub(crate) fn convert_feature_error(
+        &self,
+        feature_def: &FeatureDef,
+        feature_value: &Value,
+        error: FeatureValidationError,
+    ) -> FMLError {
+        let values = ValuesFinder::new(self.enum_defs, feature_def, feature_value);
+        let long_message = self.long_message(&values, &error);
+        FMLError::ValidationError(error.path.path, long_message)
+    }
+
+    #[allow(dead_code)]
+    #[cfg(feature = "client-lib")]
+    pub(crate) fn convert_into_editor_errors(
+        &self,
+        feature_def: &FeatureDef,
+        feature_value: &Value,
+        src: &str,
+        errors: &Vec<FeatureValidationError>,
+    ) -> Vec<FmlEditorError> {
+        let mut editor_errors: Vec<_> = Default::default();
+        let values = ValuesFinder::new(self.enum_defs, feature_def, feature_value);
+        for e in errors {
+            let message = self.long_message(&values, e);
+            let highlight = e.path.last_token().map(str::to_string);
+            let (line, col) = e.path.line_col(src);
+            let error = FmlEditorError {
+                message,
+                line: line as u32,
+                col: col as u32,
+                highlight,
+            };
+            editor_errors.push(error);
+        }
+        editor_errors
+    }
+
+    pub(crate) fn convert_object_error(&self, error: FeatureValidationError) -> FMLError {
+        FMLError::ValidationError(error.path.path.to_owned(), self.message(&error))
+    }
+}
+
+impl ErrorConverter<'_> {
+    fn long_message(&self, values: &ValuesFinder, error: &FeatureValidationError) -> String {
+        let message = self.message(error);
+        let mut suggestions = self.suggested_replacements(error, values);
+        let dym = did_you_mean(&mut suggestions);
+        format!("{message}{dym}")
+    }
+
+    fn message(&self, error: &FeatureValidationError) -> String {
+        let token = error.path.last_token().unwrap_or("unknown");
+        error.kind.message(token)
+    }
+
+    fn suggested_replacements(
+        &self,
+        error: &FeatureValidationError,
+        values: &ValuesFinder,
+    ) -> BTreeSet<String> {
+        match &error.kind {
+            ErrorKind::InvalidKey { key_type: t, .. }
+            | ErrorKind::InvalidValue { value_type: t, .. }
+            | ErrorKind::TypeMismatch { value_type: t } => values.all(t),
+            ErrorKind::InvalidPropKey { valid, .. } => valid.to_owned(),
+            ErrorKind::InvalidNestedValue { .. } => Default::default(),
+        }
+    }
+}
+
+fn did_you_mean(words: &mut BTreeSet<String>) -> String {
+    let mut words = words.iter();
+    match words.len() {
+        0 => String::from(""),
+        1 => format!("; did you mean \"{}\"?", words.next().unwrap()),
+        2 => format!(
+            "; did you mean \"{}\" or \"{}\"?",
+            words.next().unwrap(),
+            words.next().unwrap(),
+        ),
+        _ => {
+            let last = words.next_back().unwrap();
+            format!(
+                "; did you mean one of \"{}\" or \"{last}\"?",
+                itertools::join(words, "\", \"")
+            )
+        }
+    }
+}

--- a/components/support/nimbus-fml/src/editing/error_kind.rs
+++ b/components/support/nimbus-fml/src/editing/error_kind.rs
@@ -1,0 +1,88 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::BTreeSet;
+
+use serde_json::{Map, Value};
+
+use crate::intermediate_representation::{PropDef, TypeRef};
+
+pub(crate) enum ErrorKind {
+    InvalidKey {
+        key_type: TypeRef,
+        _in_use: BTreeSet<String>,
+    },
+    InvalidPropKey {
+        valid: BTreeSet<String>,
+        _in_use: BTreeSet<String>,
+    },
+    InvalidValue {
+        value_type: TypeRef,
+    },
+    InvalidNestedValue {
+        prop_name: String,
+        prop_type: TypeRef,
+    },
+    TypeMismatch {
+        value_type: TypeRef,
+    },
+}
+
+impl ErrorKind {
+    pub(crate) fn invalid_key(type_ref: &TypeRef, map: &Map<String, Value>) -> Self {
+        let keys = map.keys().cloned().collect();
+        Self::InvalidKey {
+            key_type: type_ref.clone(),
+            _in_use: keys,
+        }
+    }
+
+    pub(crate) fn invalid_value(type_ref: &TypeRef) -> Self {
+        Self::InvalidValue {
+            value_type: type_ref.clone(),
+        }
+    }
+
+    pub(crate) fn invalid_nested_value(prop_name: &str, type_ref: &TypeRef) -> Self {
+        Self::InvalidNestedValue {
+            prop_name: prop_name.to_owned(),
+            prop_type: type_ref.clone(),
+        }
+    }
+
+    pub(crate) fn invalid_prop(props: &[PropDef], map: &Map<String, Value>) -> Self {
+        let keys = map.keys().cloned().collect();
+        let props = props.iter().map(|p| p.name.clone()).collect();
+        Self::InvalidPropKey {
+            valid: props,
+            _in_use: keys,
+        }
+    }
+
+    pub(crate) fn type_mismatch(type_ref: &TypeRef) -> Self {
+        Self::TypeMismatch {
+            value_type: type_ref.clone(),
+        }
+    }
+}
+
+impl ErrorKind {
+    pub(crate) fn message(&self, token: &str) -> String {
+        match self {
+            Self::InvalidKey { key_type: t, .. } => match t {
+                TypeRef::String => format!("Invalid key {token}"),
+                _ => format!("Invalid key {token} for type {t}"),
+            },
+            Self::InvalidPropKey { .. } => format!("Invalid property {token}"),
+            Self::InvalidValue { value_type: t } => format!("Invalid value {token} for type {t}"),
+            Self::InvalidNestedValue {
+                prop_name,
+                prop_type: t,
+            } => {
+                format!("A valid value for {prop_name} of type {t} is missing")
+            }
+            Self::TypeMismatch { value_type: t } => format!("Invalid value {token} for type {t}"),
+        }
+    }
+}

--- a/components/support/nimbus-fml/src/editing/error_path.rs
+++ b/components/support/nimbus-fml/src/editing/error_path.rs
@@ -119,7 +119,9 @@ impl ErrorPath {
     pub(crate) fn line_col(&self, src: &str) -> (usize, usize) {
         line_col(src, self.literals.iter().map(|s| s.as_str()))
     }
+}
 
+impl ErrorPath {
     pub(crate) fn last_token(&self) -> Option<&str> {
         self.literals.last().map(|x| x.as_str())
     }
@@ -143,6 +145,7 @@ fn append_quoted(original: &[String], new: &str) -> Vec<String> {
     append1(original, &format!("\"{new}\""))
 }
 
+#[allow(dead_code)]
 fn line_col<'a>(src: &'a str, path: impl Iterator<Item = &'a str>) -> (usize, usize) {
     let mut lines = src.lines();
 
@@ -182,6 +185,7 @@ fn line_col<'a>(src: &'a str, path: impl Iterator<Item = &'a str>) -> (usize, us
 /// Find the index in `line` of the next instance of `pattern`, after `start`
 ///
 /// A current weakness with this method is that it is not unicode aware.
+#[allow(dead_code)]
 fn find_index(line: &str, pattern: &str, start: usize) -> Option<usize> {
     line.match_indices(pattern)
         .find(|(i, _)| i >= &start)

--- a/components/support/nimbus-fml/src/editing/mod.rs
+++ b/components/support/nimbus-fml/src/editing/mod.rs
@@ -2,21 +2,20 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+mod error_converter;
+mod error_kind;
 mod error_path;
+mod values_finder;
 
+pub(crate) use error_converter::ErrorConverter;
+pub(crate) use error_kind::ErrorKind;
 pub(crate) use error_path::ErrorPath;
 
-use std::collections::BTreeMap;
-
-use serde_json::Value;
-
-use crate::{
-    error::FMLError,
-    intermediate_representation::{EnumDef, FeatureDef, ObjectDef},
-};
+use crate::error::FMLError;
 
 pub(crate) struct FeatureValidationError {
     pub(crate) path: ErrorPath,
+    pub(crate) kind: ErrorKind,
     pub(crate) message: String,
 }
 
@@ -26,33 +25,10 @@ impl From<FeatureValidationError> for FMLError {
     }
 }
 
-#[allow(dead_code)]
-pub(crate) struct ErrorConverter<'a> {
-    enum_defs: &'a BTreeMap<String, EnumDef>,
-    object_defs: &'a BTreeMap<String, ObjectDef>,
-}
-
-impl<'a> ErrorConverter<'a> {
-    pub(crate) fn new(
-        enum_defs: &'a BTreeMap<String, EnumDef>,
-        object_defs: &'a BTreeMap<String, ObjectDef>,
-    ) -> Self {
-        Self {
-            enum_defs,
-            object_defs,
-        }
-    }
-
-    pub(crate) fn convert_feature_error(
-        &self,
-        _feature_def: &FeatureDef,
-        _value: &Value,
-        error: FeatureValidationError,
-    ) -> FMLError {
-        error.into()
-    }
-
-    pub(crate) fn convert_object_error(&self, error: FeatureValidationError) -> FMLError {
-        error.into()
-    }
+#[derive(Debug, PartialEq)]
+pub struct FmlEditorError {
+    pub message: String,
+    pub line: u32,
+    pub col: u32,
+    pub highlight: Option<String>,
 }

--- a/components/support/nimbus-fml/src/editing/mod.rs
+++ b/components/support/nimbus-fml/src/editing/mod.rs
@@ -11,18 +11,9 @@ pub(crate) use error_converter::ErrorConverter;
 pub(crate) use error_kind::ErrorKind;
 pub(crate) use error_path::ErrorPath;
 
-use crate::error::FMLError;
-
 pub(crate) struct FeatureValidationError {
     pub(crate) path: ErrorPath,
     pub(crate) kind: ErrorKind,
-    pub(crate) message: String,
-}
-
-impl From<FeatureValidationError> for FMLError {
-    fn from(value: FeatureValidationError) -> Self {
-        Self::ValidationError(value.path.path, value.message)
-    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/components/support/nimbus-fml/src/editing/values_finder.rs
+++ b/components/support/nimbus-fml/src/editing/values_finder.rs
@@ -1,0 +1,161 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use serde_json::Value;
+
+use crate::intermediate_representation::{EnumDef, FeatureDef, PropDef, TypeRef};
+
+pub(crate) struct ValuesFinder<'a> {
+    enum_defs: &'a BTreeMap<String, EnumDef>,
+    string_aliases: HashMap<&'a str, &'a PropDef>,
+    feature_value: &'a Value,
+}
+
+impl<'a> ValuesFinder<'a> {
+    pub(crate) fn new(
+        enum_defs: &'a BTreeMap<String, EnumDef>,
+        feature_def: &'a FeatureDef,
+        feature_value: &'a Value,
+    ) -> Self {
+        Self {
+            enum_defs,
+            string_aliases: feature_def.get_string_aliases(),
+            feature_value,
+        }
+    }
+
+    pub(crate) fn all(&self, type_ref: &TypeRef) -> BTreeSet<String> {
+        match type_ref {
+            TypeRef::StringAlias(_) => self.get_string_alias_values(type_ref),
+            TypeRef::Enum(type_name) => self.get_enum_values(type_name),
+            _ => Default::default(),
+        }
+    }
+}
+
+impl<'a> ValuesFinder<'a> {
+    fn get_enum_values(&self, type_name: &str) -> BTreeSet<String> {
+        if let Some(def) = self.enum_defs.get(type_name) {
+            def.variants.iter().map(|v| v.name()).collect()
+        } else {
+            Default::default()
+        }
+    }
+
+    fn get_string_alias_values(&self, alias_type: &TypeRef) -> BTreeSet<String> {
+        let type_name = alias_type.name().unwrap();
+        let prop = self.string_aliases[type_name];
+
+        let def_type = &prop.typ;
+        let def_value = self.feature_value.get(&prop.name).unwrap();
+
+        let mut set = BTreeSet::new();
+        collect_string_alias_values(alias_type, def_type, def_value, &mut set);
+        set
+    }
+}
+
+/// Takes
+/// - a string-alias type, StringAlias("TeammateName") / TeamMateName
+/// - a type definition of a wider collection of teammates: e.g. Map<TeamMateName, TeamMate>
+/// - an a value for the collection of teammates: e.g. {"Alice": {}, "Bonnie": {}, "Charlie": {}, "Dawn"}
+///
+/// and fills a hash set with the full set of TeamMateNames, in this case: ["Alice", "Bonnie", "Charlie", "Dawn"]
+fn collect_string_alias_values(
+    alias_type: &TypeRef,
+    def_type: &TypeRef,
+    def_value: &Value,
+    set: &mut BTreeSet<String>,
+) {
+    match (def_type, def_value) {
+        (TypeRef::StringAlias(_), Value::String(s)) if alias_type == def_type => {
+            set.insert(s.clone());
+        }
+        (TypeRef::Option(dt), dv) if dv != &Value::Null => {
+            collect_string_alias_values(alias_type, dt, dv, set);
+        }
+        (TypeRef::EnumMap(kt, _), Value::Object(map)) if alias_type == &**kt => {
+            set.extend(map.keys().cloned());
+        }
+        (TypeRef::EnumMap(_, vt), Value::Object(map))
+        | (TypeRef::StringMap(vt), Value::Object(map)) => {
+            for item in map.values() {
+                collect_string_alias_values(alias_type, vt, item, set);
+            }
+        }
+        (TypeRef::List(vt), Value::Array(array)) => {
+            for item in array {
+                collect_string_alias_values(alias_type, vt, item, set);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod string_alias {
+
+    use super::*;
+    use serde_json::json;
+
+    fn test_set(alias_type: &TypeRef, def_type: &TypeRef, def_value: &Value, set: &[&str]) {
+        let mut observed = BTreeSet::new();
+        collect_string_alias_values(alias_type, def_type, def_value, &mut observed);
+
+        let expected: BTreeSet<_> = set.iter().map(|s| s.to_owned().to_owned()).collect();
+        assert_eq!(expected, observed);
+    }
+
+    // Does this string belong in the type definition?
+    #[test]
+    fn test_validate_value() {
+        let sa = TypeRef::StringAlias("Name".to_string());
+
+        // type definition is Name
+        let def = sa.clone();
+        let value = json!("yes");
+        test_set(&sa, &def, &value, &["yes"]);
+
+        // type definition is Name?
+        let def = TypeRef::Option(Box::new(sa.clone()));
+        let value = json!("yes");
+        test_set(&sa, &def, &value, &["yes"]);
+
+        let value = json!(null);
+        test_set(&sa, &def, &value, &[]);
+
+        // type definition is Map<Name, Boolean>
+        let def = TypeRef::EnumMap(Box::new(sa.clone()), Box::new(TypeRef::Boolean));
+        let value = json!({
+            "yes": true,
+            "YES": false,
+        });
+        test_set(&sa, &def, &value, &["yes", "YES"]);
+
+        // type definition is Map<String, Name>
+        let def = TypeRef::EnumMap(Box::new(TypeRef::String), Box::new(sa.clone()));
+        let value = json!({
+            "ok": "yes",
+            "OK": "YES",
+        });
+        test_set(&sa, &def, &value, &["yes", "YES"]);
+
+        // type definition is List<String>
+        let def = TypeRef::List(Box::new(sa.clone()));
+        let value = json!(["yes", "YES"]);
+        test_set(&sa, &def, &value, &["yes", "YES"]);
+
+        // type definition is List<Map<String, Name>>
+        let def = TypeRef::List(Box::new(TypeRef::StringMap(Box::new(sa.clone()))));
+        let value = json!([{"y": "yes"}, {"Y": "YES"}]);
+        test_set(&sa, &def, &value, &["yes", "YES"]);
+
+        // type definition is Map<String, List<Name>>
+        let def = TypeRef::StringMap(Box::new(TypeRef::List(Box::new(sa.clone()))));
+        let value = json!({"y": ["yes"], "Y": ["YES"]});
+        test_set(&sa, &def, &value, &["yes", "YES"]);
+    }
+}

--- a/components/support/nimbus-fml/src/error.rs
+++ b/components/support/nimbus-fml/src/error.rs
@@ -4,7 +4,6 @@
  * */
 
 use crate::intermediate_representation::ModuleId;
-use std::collections::HashSet;
 
 #[derive(Debug, thiserror::Error)]
 pub enum FMLError {
@@ -67,19 +66,3 @@ pub enum ClientError {
 }
 
 pub type Result<T, E = FMLError> = std::result::Result<T, E>;
-
-pub(crate) fn did_you_mean(words: HashSet<String>) -> String {
-    if words.is_empty() {
-        "".to_string()
-    } else if words.len() == 1 {
-        format!("; did you mean \"{}\"?", words.iter().next().unwrap())
-    } else {
-        let mut words = words.into_iter().collect::<Vec<_>>();
-        words.sort();
-        let last = words.remove(words.len() - 1);
-        format!(
-            "; did you mean one of \"{}\" or \"{last}\"?",
-            words.join("\", \"")
-        )
-    }
-}


### PR DESCRIPTION
Relates to [ EXP-4154](https://mozilla-hub.atlassian.net/browse/EXP-4154).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This relatively large PR does several things:

- Codifies the errors as they are detected into `ErrorKind`s.
- Moves the construction of the error message out to a new `ErrorConverter`.
- Introduces a new `ValuesFinder` which looks after the "did you mean" part of the error message, and will drive the correction/replacement actions.
- Moves the client `FMLEditorError` into the editing module.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
