### PR TITLE
Check only unmerged feature value for better error messages

### DIFF
--- a/components/support/nimbus-fml/fixtures/fe/enums.fml.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/enums.fml.yaml
@@ -1,0 +1,46 @@
+---
+about:
+  description: A coverall for string-alias.
+  swift:
+    class: AppConfig
+    module: application
+  kotlin:
+    package: org.mozilla.examples.nimbus
+    class: .enums.AppConfig
+channels:
+  - release
+features:
+  my-coverall-feature:
+    description: |
+      Properties useful for testing enums
+    variables:
+      scalar:
+        type: ViewPosition
+        description: A single position
+        default: top
+      optional:
+        type: Option<ViewPosition>
+        description: Zero or one positions
+        default: null
+      list:
+        type: List<ViewPosition>
+        description: Zero or more positions
+        default: []
+      map:
+        type: Map<ViewPosition, Boolean>
+        description: Each position should be represented
+        default:
+          top: true
+          middle: true
+          bottom: true
+
+enums:
+  ViewPosition:
+    description: The positions a button can be in.
+    variants:
+      top:
+        description: The top of a view
+      middle:
+        description: The vertical middle of a view
+      bottom:
+        description: The bottom of a view

--- a/components/support/nimbus-fml/src/editing/error_kind.rs
+++ b/components/support/nimbus-fml/src/editing/error_kind.rs
@@ -11,11 +11,11 @@ use crate::intermediate_representation::{PropDef, TypeRef};
 pub(crate) enum ErrorKind {
     InvalidKey {
         key_type: TypeRef,
-        _in_use: BTreeSet<String>,
+        in_use: BTreeSet<String>,
     },
     InvalidPropKey {
         valid: BTreeSet<String>,
-        _in_use: BTreeSet<String>,
+        in_use: BTreeSet<String>,
     },
     InvalidValue {
         value_type: TypeRef,
@@ -34,7 +34,7 @@ impl ErrorKind {
         let keys = map.keys().cloned().collect();
         Self::InvalidKey {
             key_type: type_ref.clone(),
-            _in_use: keys,
+            in_use: keys,
         }
     }
 
@@ -56,7 +56,7 @@ impl ErrorKind {
         let props = props.iter().map(|p| p.name.clone()).collect();
         Self::InvalidPropKey {
             valid: props,
-            _in_use: keys,
+            in_use: keys,
         }
     }
 

--- a/components/support/nimbus-fml/src/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/intermediate_representation.rs
@@ -447,14 +447,14 @@ impl FeatureManifest {
             .ok_or_else(|| InvalidFeatureError(feature_name.to_string()))?;
 
         let merger = DefaultsMerger::new(&manifest.obj_defs, Default::default(), None);
-        let value = merger.merge_feature_config(feature_def, &feature_value)?;
+        let merged_value = merger.merge_feature_config(feature_def, &feature_value)?;
 
         let validator = DefaultsValidator::new(&manifest.enum_defs, &manifest.obj_defs);
-        let errors = validator.get_errors(feature_def, &value);
-        validator.guard_errors(feature_def, &value, errors)?;
+        let errors = validator.get_errors(feature_def, &merged_value, &feature_value);
+        validator.guard_errors(feature_def, &merged_value, errors)?;
 
         let mut feature_def = feature_def.clone();
-        merger.overwrite_defaults(&mut feature_def, &value);
+        merger.overwrite_defaults(&mut feature_def, &merged_value);
         Ok(feature_def)
     }
 
@@ -469,11 +469,11 @@ impl FeatureManifest {
             .find_feature(feature_name)
             .ok_or_else(|| InvalidFeatureError(feature_name.to_string()))?;
         let merger = DefaultsMerger::new(&manifest.obj_defs, Default::default(), None);
-        let value = merger.merge_feature_config(feature_def, feature_value)?;
+        let merged_value = merger.merge_feature_config(feature_def, feature_value)?;
 
         let validator = DefaultsValidator::new(&manifest.enum_defs, &manifest.obj_defs);
-        let errors = validator.get_errors(feature_def, &value);
-        Ok((value, errors))
+        let errors = validator.get_errors(feature_def, &merged_value, feature_value);
+        Ok((merged_value, errors))
     }
 
     pub fn get_schema_hash(&self, feature_name: &str) -> Result<String> {


### PR DESCRIPTION
Relates to [ EXP-4154](https://mozilla-hub.atlassian.net/browse/EXP-4154).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR is to allow token suggestions (currently the did_you_mean message) to be filtered, and the ones that are already in use are not shown as suggested replacements.

For example:

```json
{
  "valid-int": 1,
  "valid-bool": true,
  "invalid-string": "yes"
}
```

Before this PR, this error would have listed `valid-int` and `valid-bool` as a replacement for `invalid-string`.

After this change, it does not, because they are in use already.

This PR also works with `Map<Enum, T>` maps.

In order to get here, we perform an optimization that validates only the unmerged feature value; this should mean a more repsonsive editor/less resource intensive for both experimenter and cirrus use cases. This was opened up following #5981.

There is still work to do to ensure validating string alias values cause both `invalid-key` errors as well as `invalid-value` ones, but that is for another PR.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
