### PR TITLE
Add string-alias `invalid_key` errors plus tests

### DIFF
--- a/components/support/nimbus-fml/fixtures/fe/string-aliases.fml.yaml
+++ b/components/support/nimbus-fml/fixtures/fe/string-aliases.fml.yaml
@@ -93,6 +93,25 @@ features:
         value:
           available-players: ["Aka", "Ekeka", "Hene", "Iolana", "Keoni", "Lino", "Mele", "Nona", "Oliwa", "Pama", "Upana", "Wene"]
 
+  my-coverall-team:
+    description: Properties to mop up the other cases found with string-alias.
+    variables:
+      players:
+        description: The list of players
+        type: List<PlayerName>
+        string-alias: PlayerName
+        default: []
+
+      top-player:
+        description: The player with the highest score this year
+        type: Option<PlayerName>
+        default: null
+
+      availability:
+        description: Player availability
+        type: Map<PlayerName, Boolean>
+        default: {}
+
 objects:
   Team:
     description: A group of players


### PR DESCRIPTION
Relates to [ EXP-4154](https://mozilla-hub.atlassian.net/browse/EXP-4154).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This breaks out from #6006 but is related: it reports different errors with string-aliases depending on where they are found, most notably: if a `Map<StringAlias, T>` has an invalid key, then it's reported as an `invalid_key`; everything else is reported as an `invalid_value`.

Most of the PR is tests, test fixtures and additional documentation. The functional bits are to do with `is_string_alias_value_valid` – the call sites now do the reporting of the errors themselves, and the function body is simpler.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
