### PR TITLE
Removes wipe from logins engine implementation [firefox-android: main]

### DIFF
--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -34,11 +34,6 @@ class DatabaseLoginsStorage(dbPath: String) : AutoCloseable {
     }
 
     @Throws(LoginsApiException::class)
-    fun wipe() {
-        this.store.wipe()
-    }
-
-    @Throws(LoginsApiException::class)
     fun wipeLocal() {
         this.store.wipeLocal()
     }

--- a/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
+++ b/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
@@ -183,21 +183,6 @@ class DatabaseLoginsStorageTest {
     }
 
     @Test
-    fun testListWipe() {
-        val test = getTestStore()
-        val logins = test.list()
-        assertEquals(2, logins.size)
-
-        test.wipe()
-        assertEquals(0, test.list().size)
-
-        assertNull(test.get(logins[0].record.id))
-        assertNull(test.get(logins[1].record.id))
-
-        finishAndClose(test)
-    }
-
-    @Test
     fun testWipeLocal() {
         val test = getTestStore()
         val logins = test.list()

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -124,9 +124,6 @@ interface LoginStore {
     boolean delete([ByRef] string id);
 
     [Throws=LoginsApiError]
-    void wipe();
-
-    [Throws=LoginsApiError]
     void wipe_local();
 
     [Throws=LoginsApiError, Self=ByArc]

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -103,19 +103,6 @@ impl LoginStore {
     }
 
     #[handle_error(Error)]
-    pub fn wipe(&self) -> ApiResult<()> {
-        // This should not be exposed - it wipes the server too and there's
-        // no good reason to expose that to consumers. wipe_local makes some
-        // sense though.
-        // TODO: this is exposed to android-components consumers - we should
-        // check if anyone actually calls it.
-        let db = self.db.lock();
-        let scope = db.begin_interrupt_scope()?;
-        db.wipe(&scope)?;
-        Ok(())
-    }
-
-    #[handle_error(Error)]
     pub fn wipe_local(&self) -> ApiResult<()> {
         self.db.lock().wipe_local()?;
         Ok(())

--- a/components/logins/src/sync/engine.rs
+++ b/components/logins/src/sync/engine.rs
@@ -495,12 +495,6 @@ impl SyncEngine for LoginsSyncEngine {
         self.do_reset(assoc)?;
         Ok(())
     }
-
-    fn wipe(&self) -> anyhow::Result<()> {
-        let db = self.store.db.lock();
-        db.wipe(&self.scope)?;
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/components/sync15/src/engine/sync_engine.rs
+++ b/components/sync15/src/engine/sync_engine.rs
@@ -223,7 +223,15 @@ pub trait SyncEngine {
     /// `assoc` defines how this store is to be associated with sync.
     fn reset(&self, assoc: &EngineSyncAssociation) -> Result<()>;
 
-    fn wipe(&self) -> Result<()>;
+    /// Wipes the engine's data
+    /// This is typically triggered by a client command, which at the time of writing, only
+    /// supported wiping bookmarks.
+    ///
+    /// This panics if triggered on a sync engine that does not explicitly implement wipe, because
+    /// that implies a confustion that shouldn't occur.
+    fn wipe(&self) -> Result<()> {
+        unimplemented!("The engine does not implement wipe, no wipe should be requested")
+    }
 }
 
 #[cfg(test)]

--- a/components/sync_manager/src/lib.rs
+++ b/components/sync_manager/src/lib.rs
@@ -21,29 +21,19 @@ lazy_static::lazy_static! {
     static ref MANAGER: Mutex<SyncManager> = Mutex::new(SyncManager::new());
 }
 
-pub fn disconnect() {
-    let manager = MANAGER.lock();
-    manager.disconnect();
-}
-
-pub fn wipe(engine: &str) -> Result<()> {
+pub(crate) fn wipe(engine: &str) -> Result<()> {
     let manager = MANAGER.lock();
     manager.wipe(engine)
 }
 
-pub fn reset(engine: &str) -> Result<()> {
+pub(crate) fn reset(engine: &str) -> Result<()> {
     let manager = MANAGER.lock();
     manager.reset(engine)
 }
 
-pub fn reset_all() -> Result<()> {
+pub(crate) fn reset_all() -> Result<()> {
     let manager = MANAGER.lock();
     manager.reset_all()
-}
-
-pub fn sync(params: SyncParams) -> Result<SyncResult> {
-    let manager = MANAGER.lock();
-    manager.sync(params)
 }
 
 uniffi::include_scaffolding!("syncmanager");

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -475,12 +475,6 @@ fn main() -> Result<()> {
                     log::warn!("Failed to reset! {}", e);
                 }
             }
-            'W' | 'w' => {
-                log::info!("Wiping all data from client!");
-                if let Err(e) = store.wipe() {
-                    log::warn!("Failed to wipe! {}", e);
-                }
-            }
             'S' | 's' => {
                 log::info!("Syncing!");
                 let (_, token_info) = get_account_and_token(get_default_fxa_config(), cred_file)?;


### PR DESCRIPTION
Wipe was never used by consumers and was not triggered by the sync manager (because the client command to wipe only supports bookmarks)

I'll hold off on landing this till https://bugzilla.mozilla.org/show_bug.cgi?id=1870923 is closed, to prevent us from creating a breaking change

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
