### PR TITLE
FxA State machine checker message improvements

### DIFF
--- a/components/fxa-client/src/state_machine/checker.rs
+++ b/components/fxa-client/src/state_machine/checker.rs
@@ -95,6 +95,7 @@ impl FxaStateMachineChecker {
         inner.state_machine = make_state_machine(&inner.public_state);
         match inner.state_machine.initial_state(event.clone()) {
             Ok(state) => {
+                breadcrumb!("fxa-state-machine-checker: public transition start");
                 breadcrumb!("fxa-state-machine-checker: {event} -> {state}");
                 inner.internal_state = state;
             }
@@ -122,6 +123,7 @@ impl FxaStateMachineChecker {
                 breadcrumb!("fxa-state-machine-checker: {event} -> {state}");
                 if let InternalState::Complete(new_state) = &state {
                     inner.public_state = new_state.clone();
+                    breadcrumb!("fxa-state-machine-checker: public transition end");
                 }
                 inner.internal_state = state;
             }
@@ -157,7 +159,7 @@ impl FxaStateMachineChecker {
         if inner.public_state != state {
             report_error!(
                 "fxa-state-machine-checker",
-                "State mismatch: {} vs {state}",
+                "State mismatch: expected: {state}, actual: {}",
                 inner.internal_state
             );
             inner.reported_error = true;


### PR DESCRIPTION
When looking through the logs, I found myself wanting a couple things:
  - When a public state transition starts/ends
  - Better messaging when an unexpected state is observed

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
