### PR TITLE
Bug 1866370: Recovers logins when modified remotely if deleted locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Changed the locations of firefox-ios and focus-ios feature manifest files ([#6012](https://github.com/mozilla/application-services/pull/6012)) and added version sensitivity.
 
+### Logins
+- Logins now correctly handle the following sync conflict resolution:
+   - When the client locally deleted a login, and before it synced another client modified the same login, the client will recover the login
+
 [Full Changelog](In progress)
 
 # v122.0 (_2023-12-18_)

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -1223,11 +1223,11 @@ mod tests {
             .query_row(
                 "SELECT * FROM loginsL WHERE guid = :guid",
                 named_params! { ":guid": login.guid_str() },
-                |row| Ok(LocalLogin::from_row(row).unwrap()),
+                |row| Ok(LocalLogin::test_raw_from_row(row).unwrap()),
             )
             .unwrap();
-        assert_eq!(local_login.login.fields.http_realm, None);
-        assert_eq!(local_login.login.fields.form_action_origin, None);
+        assert_eq!(local_login.fields.http_realm, None);
+        assert_eq!(local_login.fields.form_action_origin, None);
 
         assert!(!db.exists(login.guid_str()).unwrap());
     }

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -742,6 +742,16 @@ pub mod test_utils {
         }
     }
 
+    pub fn insert_encrypted_login(
+        db: &LoginDb,
+        local: &EncryptedLogin,
+        mirror: &EncryptedLogin,
+        server_modified: &ServerTimestamp,
+    ) {
+        db.insert_new_login(local).unwrap();
+        add_mirror(db, mirror, server_modified, true).unwrap();
+    }
+
     pub fn add_mirror(
         db: &LoginDb,
         login: &EncryptedLogin,

--- a/components/logins/src/sync/merge.rs
+++ b/components/logins/src/sync/merge.rs
@@ -52,6 +52,11 @@ impl LocalLogin {
             local_modified: util::system_time_millis_from_row(row, "local_modified")?,
         })
     }
+
+    pub fn is_tombstone(&self) -> bool {
+        // For all sync purposes, if the secure fields are not present, this is a tombstone
+        self.login.sec_fields.is_empty()
+    }
 }
 
 macro_rules! impl_login {

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -409,8 +409,6 @@ fn main() -> Result<()> {
     log::debug!("db: {:?}", db_path);
     // Lets not log the encryption key, it's just not a good habit to be in.
 
-    // TODO: allow users to use stage/etc.
-    let cli_fxa = get_cli_fxa(get_default_fxa_config(), cred_file)?;
     let (store, encdec, encryption_key) = open_database(db_path)?;
     let store = Arc::new(store);
 
@@ -481,6 +479,8 @@ fn main() -> Result<()> {
                 let sync_key = URL_SAFE_NO_PAD.encode(
                     token_info.key.unwrap().key_bytes()?,
                 );
+                // TODO: allow users to use stage/etc.
+                let cli_fxa = get_cli_fxa(get_default_fxa_config(), cred_file)?;
                 match do_sync(
                     Arc::clone(&store),
                     cli_fxa.client_init.key_id.clone(),


### PR DESCRIPTION
This PR probably requires a bit of careful review, especially the semantics of how login syncs with regard to local tombstones

I believe this PR would fix both https://bugzilla.mozilla.org/show_bug.cgi?id=1866370 and https://bugzilla.mozilla.org/show_bug.cgi?id=1870876 and help bring up our sync success rate up from 95% to closer to the other engines ~99%

The issue was **very** subtle, and is triggered in the following case:
1. Locally, we deleted a login, modifying it locally to be a tombstone
2. Another client modified they login before we synced it
3. When it's time for our next sync, we detect a conflict and initiate a three-way merge
   - In the three-way merge, we start by calculating the delta between our local record (the tombstone!) and the mirror record
   - To even start calculating the delta, we attempt to decrypt the secure data... However, that data has already been wiped in the delete in step 1 so we fail the three-way merge, and subsequently the sync.

## Important Note
 I made an assumption here that in this case, the incoming record should win and the login gets re-established. Another possible approaches:
- Make sure server deletes the login
- Based on which change is "younger" we can either delete, or keep the login

Neither approach is perfect and I'd be happy to do it the other way around

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
