### PR TITLE
Change manifest locations, repos and branches based on major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v123.0 (In progress)
 
+## Nimbus CLI [⛅️🔬🔭👾](./components/support/nimbus-cli)
+
+### 🦊 What's Changed 🦊
+
+- Changed the locations of firefox-ios and focus-ios feature manifest files ([#6012](https://github.com/mozilla/application-services/pull/6012)) and added version sensitivity.
+
 [Full Changelog](In progress)
 
 # v122.0 (_2023-12-18_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/components/support/nimbus-cli/Cargo.toml
+++ b/components/support/nimbus-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nimbus-cli"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Nimbus SDK Engineering"]
 license = "MPL-2.0"

--- a/components/support/nimbus-cli/src/main.rs
+++ b/components/support/nimbus-cli/src/main.rs
@@ -11,6 +11,7 @@ mod protocol;
 mod sources;
 mod updater;
 mod value_utils;
+mod version_utils;
 
 use anyhow::{bail, Result};
 use clap::Parser;

--- a/components/support/nimbus-cli/src/sources/manifest.rs
+++ b/components/support/nimbus-cli/src/sources/manifest.rs
@@ -58,10 +58,13 @@ impl ManifestSource {
                     manifest_file,
                 },
                 (_, Some(channel), Some(_)) => {
-                    let github_repo = params.github_repo()?.to_string();
+                    let github_repo = params.github_repo(&value.version)?.to_string();
                     let ref_ = params.ref_from_version(&value.version, &value.ref_)?;
-                    let manifest_file =
-                        format!("@{}/{}", github_repo, params.manifest_location()?,);
+                    let manifest_file = format!(
+                        "@{}/{}",
+                        github_repo,
+                        params.manifest_location(&value.version)?,
+                    );
                     Self::FromGithub {
                         channel,
                         manifest_file,

--- a/components/support/nimbus-cli/src/version_utils.rs
+++ b/components/support/nimbus-cli/src/version_utils.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use anyhow::Result;
+
+pub(crate) fn is_before(current_version: &Option<String>, upto_version: usize) -> bool {
+    if current_version.is_none() {
+        false
+    } else {
+        let current_version = current_version.as_deref().unwrap();
+        is_between(0, current_version, upto_version).unwrap_or(false)
+    }
+}
+
+fn is_between(min_version: usize, current_version: &str, max_version: usize) -> Result<bool> {
+    let (major, _) = current_version
+        .split_once('.')
+        .unwrap_or((current_version, ""));
+    let v = major.parse::<usize>()?;
+    Ok(min_version <= v && v < max_version)
+}
+
+/// The following are dumb string manipulations to pad out a version number.
+/// We might use a version library if we need much more functionality, but right now
+/// it's isolated in a single file where it can be replaced as/when necessary.
+
+/// pad_major_minor_patch will zero pad the minor and patch versions if they are not present.
+/// 112.1.3 --> 112.1.3
+/// 112.1   --> 112.1.0
+/// 112     --> 112.0.0
+pub(crate) fn pad_major_minor_patch(version: &str) -> String {
+    match version_split(version) {
+        (Some(_), Some(_), Some(_)) => version.to_owned(),
+        (Some(major), Some(minor), None) => format!("{major}.{minor}.0"),
+        (Some(major), None, None) => format!("{major}.0.0"),
+        _ => format!("{version}.0.0"),
+    }
+}
+
+/// pad_major_minor will zero pad the minor version if it is not present.
+/// If the patch version is present, then it is left intact.
+/// 112.1.3 --> 112.1.3
+/// 112.1   --> 112.1
+/// 112     --> 112.0
+pub(crate) fn pad_major_minor(version: &str) -> String {
+    match version_split(version) {
+        (Some(_), Some(_), Some(_)) => version.to_owned(),
+        (Some(major), Some(minor), None) => format!("{major}.{minor}"),
+        (Some(major), None, None) => format!("{major}.0"),
+        _ => format!("{version}.0"),
+    }
+}
+
+/// pad_major will keep the string as it is.
+/// If the minor and/or patch versions are present, then they are left intact.
+/// 112.1.3 --> 112.1.3
+/// 112.1   --> 112.1
+/// 112     --> 112
+pub(crate) fn pad_major(version: &str) -> String {
+    version.to_owned()
+}
+
+fn version_split(version: &str) -> (Option<&str>, Option<&str>, Option<&str>) {
+    let mut split = version.splitn(3, '.');
+    (split.next(), split.next(), split.next())
+}


### PR DESCRIPTION
Fixes [ EXP-4162](https://mozilla-hub.atlassian.net/browse/EXP-4162).

Following the moves of firefox-ios and focus-ios, this PR adds version awareness to the manifest locations, repositories, and branch format.

All of these things have varied independently of one another.

Testing of this PR has been done only by visual inspection, with scripts like this:

```sh
min_version=108
app=focus_ios
experiment=https://experimenter.services.mozilla.com/nimbus/viewpoint-android-dec-2023
for n in $(seq $min_version 122); do
    nimbus-cli --app focus_ios --channel release validate --version $n $experiment 
done
```

This is due to no single experiment is valid across all versions of an app. This will change once we can feed the calculated URL (or equivalent) to the FML command line. To limit the scope of the PR this is not done here.

A speedy landing will unblock QA who will be unexpectedly blocked from testing firefox and focus experiments on iOS today.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
