### PR TITLE
Fixes DISCO-2712: Add an `ON DELETE CASCADE` action to `prefix_keywords.suggestion_id`.

### DIFF
--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -6,7 +6,7 @@
 use rusqlite::{Connection, Transaction};
 use sql_support::open_database::{self, ConnectionInitializer};
 
-pub const VERSION: u32 = 8;
+pub const VERSION: u32 = 9;
 
 pub const SQL: &str = "
     CREATE TABLE meta(
@@ -26,8 +26,8 @@ pub const SQL: &str = "
         keyword_suffix TEXT NOT NULL DEFAULT '',
         confidence INTEGER NOT NULL DEFAULT 0,
         rank INTEGER NOT NULL,
-        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id),
-        PRIMARY KEY (keyword_prefix, keyword_suffix, suggestion_id) 
+        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+        PRIMARY KEY (keyword_prefix, keyword_suffix, suggestion_id)
     ) WITHOUT ROWID;
 
     CREATE UNIQUE INDEX keywords_suggestion_id_rank ON keywords(suggestion_id, rank);
@@ -48,8 +48,7 @@ pub const SQL: &str = "
         impression_url TEXT NOT NULL,
         click_url TEXT NOT NULL,
         icon_id TEXT NOT NULL,
-        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id)
-        ON DELETE CASCADE
+        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
     );
 
     CREATE TABLE pocket_custom_details(
@@ -70,8 +69,7 @@ pub const SQL: &str = "
         rating TEXT,
         number_of_ratings INTEGER NOT NULL,
         score REAL NOT NULL,
-        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id)
-        ON DELETE CASCADE
+        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
     );
 
     CREATE INDEX suggestions_record_id ON suggestions(record_id);
@@ -110,7 +108,7 @@ impl ConnectionInitializer for SuggestConnectionInitializer {
 
     fn upgrade_from(&self, _db: &Transaction<'_>, version: u32) -> open_database::Result<()> {
         match version {
-            1..=7 => {
+            1..=8 => {
                 // These schema versions were used during development, and never
                 // shipped in any applications. Treat these databases as
                 // corrupt, so that they'll be replaced.


### PR DESCRIPTION
This missing action caused "FOREIGN KEY constraint failed" errors when re-ingesting AMO and Pocket suggestions. AMP and Wikipedia suggestions are unaffected, because they store their keywords in the `keywords` table, and `keywords.suggestion_id` has the action.

After landing this, let's make sure to re-vendor (and maybe uplift, if we can?) in m-c, and also Fenix 122.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
