### PR TITLE
nimbus-fml: Use the GitHub API to get download URLs when an API key is present

### DIFF
--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -25,7 +25,7 @@ textwrap = "0.14.2"
 heck = "0.3.3"
 unicode-segmentation = "1.8.0"
 url = { version = "2", features = ["serde"] }
-reqwest = { version = "0.11", features = ["blocking", "native-tls-vendored"] }
+reqwest = { version = "0.11", features = ["blocking", "json", "native-tls-vendored"] }
 glob = "0.3.0"
 uniffi = { workspace = true, optional = true }
 cfg-if = "1.0.0"

--- a/components/support/nimbus-fml/src/error.rs
+++ b/components/support/nimbus-fml/src/error.rs
@@ -50,6 +50,9 @@ pub enum FMLError {
 
     #[error("Feature `{0}` not found on manifest")]
     InvalidFeatureError(String),
+
+    #[error("Invalid API token GITHUB_BEARER_TOKEN")]
+    InvalidApiToken,
 }
 
 #[cfg(feature = "client-lib")]

--- a/components/support/nimbus-fml/src/fml.udl
+++ b/components/support/nimbus-fml/src/fml.udl
@@ -12,6 +12,7 @@ enum FMLError {
     "IOError", "JSONError", "YAMLError", "UrlError", "EmailError", "FetchError", "InvalidPath",
     "TemplateProblem", "Fatal", "InternalError", "ValidationError", "TypeParsingError",
     "InvalidChannelError", "FMLModuleError", "CliError", "ClientError", "InvalidFeatureError",
+    "InvalidApiToken",
 };
 
 dictionary MergedJsonWithErrors {

--- a/components/support/nimbus-fml/src/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/intermediate_representation.rs
@@ -174,6 +174,7 @@ impl TryFrom<&FilePath> for ModuleId {
                 ModuleId::Local(p.display().to_string())
             }
             FilePath::Remote(u) => ModuleId::Remote(u.to_string()),
+            FilePath::GitHub(p) => ModuleId::Remote(p.default_download_url_as_str()),
         })
     }
 }

--- a/components/support/nimbus-fml/src/util/loaders.rs
+++ b/components/support/nimbus-fml/src/util/loaders.rs
@@ -169,22 +169,22 @@ pub struct FileLoader {
 impl TryFrom<&LoaderConfig> for FileLoader {
     type Error = FMLError;
 
-    fn try_from(value: &LoaderConfig) -> Result<Self, Self::Error> {
-        let cache_dir = value.cache_dir.clone();
-        let cwd = value.cwd.clone();
+    fn try_from(loader_config: &LoaderConfig) -> Result<Self, Self::Error> {
+        let cache_dir = loader_config.cache_dir.clone();
+        let cwd = loader_config.cwd.clone();
 
-        let mut files = Self::new(cwd, cache_dir, Default::default())?;
+        let mut file_loader = Self::new(cwd, cache_dir, Default::default())?;
 
-        for (k, v) in &value.refs {
-            files.add_repo(k, v)?;
+        for (repo_id, git_ref) in &loader_config.refs {
+            file_loader.add_repo(repo_id, git_ref)?;
         }
 
-        for f in &value.repo_files {
-            let path = files.file_path(f)?;
-            files.add_repo_file(&path)?;
+        for f in &loader_config.repo_files {
+            let path = file_loader.file_path(f)?;
+            file_loader.add_repo_file(&path)?;
         }
 
-        Ok(files)
+        Ok(file_loader)
     }
 }
 

--- a/components/support/nimbus-fml/src/util/loaders.rs
+++ b/components/support/nimbus-fml/src/util/loaders.rs
@@ -105,14 +105,10 @@ impl FilePath {
 
 impl Display for FilePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Local(p) => p.display().to_string(),
-                Self::Remote(u) => u.to_string(),
-            }
-        )
+        match self {
+            Self::Local(p) => p.display().fmt(f),
+            Self::Remote(u) => u.fmt(f),
+        }
     }
 }
 

--- a/components/support/nimbus-fml/src/util/loaders.rs
+++ b/components/support/nimbus-fml/src/util/loaders.rs
@@ -262,7 +262,7 @@ impl FileLoader {
 
         // Standardize the form of repo id. We accept `@user/repo` or `user/repo`, but store it as
         // `user/repo`.
-        let repo_id = repo_id.replacen('@', "", 1);
+        let repo_id = repo_id.strip_prefix('@').unwrap_or(repo_id);
 
         // The `loc`, whatever the current working directory, is going to end up as a part of a path.
         // A trailing slash ensures it gets treated like a directoy, rather than a file.
@@ -288,7 +288,7 @@ impl FileLoader {
         };
 
         // Finally, add the absolute path that we use every time the user refers to @user/repo.
-        self.config.insert(repo_id, v);
+        self.config.insert(repo_id.into(), v);
         Ok(())
     }
 

--- a/components/support/nimbus-fml/src/util/loaders.rs
+++ b/components/support/nimbus-fml/src/util/loaders.rs
@@ -276,7 +276,7 @@ impl FileLoader {
 
         // We construct the FilePath. We want to be able to tell the difference between a what `FilePath`s
         // can already reason about (relative file paths, absolute file paths and URLs) and what git knows about (refs, tags, versions).
-        let v = if loc.starts_with('.')
+        let file_path = if loc.starts_with('.')
             || loc.starts_with('/')
             || loc.contains(":\\")
             || loc.contains("://")
@@ -289,7 +289,7 @@ impl FileLoader {
         };
 
         // Finally, add the absolute path that we use every time the user refers to @user/repo.
-        self.repo_refs.insert(repo_id.into(), v);
+        self.repo_refs.insert(repo_id.into(), file_path);
         Ok(())
     }
 


### PR DESCRIPTION
I also snuck in a few minor clean-ups and renames to make the module a bit simpler to understand.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
