### PR TITLE
FxA: Update the error simulation code

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
@@ -537,6 +537,21 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
         }
     }
 
+    /**
+     * Used by the application to test auth token issues
+     */
+    fun simulateNetworkError() = this.inner.simulateNetworkError()
+
+    /**
+     * Used by the application to test auth token issues
+     */
+    fun simulateTemporaryAuthTokenIssue() = this.inner.simulateTemporaryAuthTokenIssue()
+
+    /**
+     * Used by the application to test auth token issues
+     */
+    fun simulatePermanentAuthTokenIssue() = this.inner.simulatePermanentAuthTokenIssue()
+
     @Synchronized
     override fun close() {
         this.inner.destroy()

--- a/components/fxa-client/src/auth.rs
+++ b/components/fxa-client/src/auth.rs
@@ -285,4 +285,9 @@ pub enum FxaEvent {
     /// Send this when the user is asking to be logged out.  The state machine will transition to
     /// [FxaState::Disconnected].
     Disconnect,
+    /// Force a call to [FirefoxAccount::get_profile]
+    ///
+    /// This is used for testing the auth/network retry code, since it hits the network and
+    /// requires and auth token.
+    CallGetProfile,
 }

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -685,6 +685,9 @@ interface FirefoxAccount {
   string gather_telemetry();
 
   // Used by the application to test auth token issues
+  void simulate_network_error();
+
+  // Used by the application to test auth token issues
   void simulate_temporary_auth_token_issue();
 
   // Used by the application to test auth token issues
@@ -956,6 +959,7 @@ interface FxaEvent {
   CancelOAuthFlow();
   CheckAuthorizationStatus();
   Disconnect();
+  CallGetProfile();
 };
 
 enum FxaRustAuthState {
@@ -1075,6 +1079,7 @@ interface FxaStateCheckerEvent {
   EnsureDeviceCapabilitiesSuccess();
   CheckAuthorizationStatusSuccess(boolean active);
   DisconnectSuccess();
+  GetProfileSuccess();
   CallError();
   EnsureCapabilitiesAuthError();
 };
@@ -1089,6 +1094,7 @@ interface FxaStateCheckerState {
   EnsureDeviceCapabilities();
   CheckAuthorizationStatus();
   Disconnect();
+  GetProfile();
   Complete(FxaState new_state);
   Cancel();
 };

--- a/components/fxa-client/src/internal/http_client.rs
+++ b/components/fxa-client/src/internal/http_client.rs
@@ -21,6 +21,7 @@ use serde_derive::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
     collections::HashMap,
+    sync::atomic::{AtomicBool, Ordering},
     time::{Duration, Instant},
 };
 use sync15::DeviceType;
@@ -144,6 +145,7 @@ pub(crate) trait FxAClient {
     ) -> Result<HashMap<String, ScopedKeyDataResponse>>;
     fn get_fxa_client_configuration(&self, config: &Config) -> Result<ClientConfigurationResponse>;
     fn get_openid_configuration(&self, config: &Config) -> Result<OpenIdConfigurationResponse>;
+    fn simulate_network_error(&self) {}
 }
 
 enum HttpClientState {
@@ -156,6 +158,7 @@ enum HttpClientState {
 
 pub struct Client {
     state: Mutex<HashMap<String, HttpClientState>>,
+    simulate_network_error: AtomicBool,
 }
 impl FxAClient for Client {
     fn get_fxa_client_configuration(&self, config: &Config) -> Result<ClientConfigurationResponse> {
@@ -432,6 +435,10 @@ impl FxAClient for Client {
             .build()?;
         self.make_request(request)?.json().map_err(|e| e.into())
     }
+
+    fn simulate_network_error(&self) {
+        self.simulate_network_error.store(true, Ordering::Relaxed);
+    }
 }
 
 macro_rules! fetch {
@@ -456,6 +463,7 @@ impl Client {
     pub fn new() -> Self {
         Self {
             state: Mutex::new(HashMap::new()),
+            simulate_network_error: AtomicBool::new(false),
         }
     }
 
@@ -503,6 +511,12 @@ impl Client {
     }
 
     fn make_request(&self, request: Request) -> Result<Response> {
+        if self.simulate_network_error.swap(false, Ordering::Relaxed) {
+            return Err(Error::RequestError(viaduct::Error::NetworkError(
+                "Simulated error".to_owned(),
+            )));
+        }
+
         let url = request.url.path().to_string();
         if let HttpClientState::Backoff {
             backoff_end_duration,

--- a/components/fxa-client/src/internal/mod.rs
+++ b/components/fxa-client/src/internal/mod.rs
@@ -249,6 +249,10 @@ impl FirefoxAccount {
         self.telemetry = FxaTelemetry::new();
     }
 
+    pub fn simulate_network_error(&mut self) {
+        self.client.simulate_network_error();
+    }
+
     pub fn simulate_temporary_auth_token_issue(&mut self) {
         self.state.simulate_temporary_auth_token_issue()
     }

--- a/components/fxa-client/src/internal/state_manager.rs
+++ b/components/fxa-client/src/internal/state_manager.rs
@@ -237,6 +237,7 @@ impl StateManager {
         self.persisted_state.server_local_device_info = None;
     }
 
+    /// Used by the application to test auth token issues
     pub fn simulate_temporary_auth_token_issue(&mut self) {
         for (_, access_token) in self.persisted_state.access_token_cache.iter_mut() {
             access_token.token = "invalid-data".to_owned()

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -99,6 +99,11 @@ impl FirefoxAccount {
             internal: Mutex::new(internal::FirefoxAccount::new(config)),
         }
     }
+
+    /// Used by the application to test auth token issues
+    pub fn simulate_network_error(&self) {
+        self.internal.lock().simulate_network_error()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/components/fxa-client/src/state_machine/checker.rs
+++ b/components/fxa-client/src/state_machine/checker.rs
@@ -36,6 +36,7 @@ pub enum FxaStateCheckerState {
     InitializeDevice,
     EnsureDeviceCapabilities,
     CheckAuthorizationStatus,
+    GetProfile,
     Disconnect,
     Complete {
         new_state: FxaState,
@@ -219,6 +220,7 @@ impl From<InternalState> for FxaStateCheckerState {
             InternalState::EnsureDeviceCapabilities => Self::EnsureDeviceCapabilities,
             InternalState::CheckAuthorizationStatus => Self::CheckAuthorizationStatus,
             InternalState::Disconnect => Self::Disconnect,
+            InternalState::GetProfile => Self::GetProfile,
             InternalState::Complete(new_state) => Self::Complete { new_state },
             InternalState::Cancel => Self::Cancel,
         }
@@ -248,6 +250,7 @@ impl From<FxaStateCheckerState> for InternalState {
             FxaStateCheckerState::EnsureDeviceCapabilities => Self::EnsureDeviceCapabilities,
             FxaStateCheckerState::CheckAuthorizationStatus => Self::CheckAuthorizationStatus,
             FxaStateCheckerState::Disconnect => Self::Disconnect,
+            FxaStateCheckerState::GetProfile => Self::GetProfile,
             FxaStateCheckerState::Complete { new_state } => Self::Complete(new_state),
             FxaStateCheckerState::Cancel => Self::Cancel,
         }

--- a/components/fxa-client/src/state_machine/display.rs
+++ b/components/fxa-client/src/state_machine/display.rs
@@ -33,6 +33,7 @@ impl fmt::Display for FxaEvent {
             Self::CancelOAuthFlow => "CancelOAuthFlow",
             Self::CheckAuthorizationStatus => "CheckAuthorizationStatus",
             Self::Disconnect => "Disconnect",
+            Self::CallGetProfile => "CallGetProfile",
         };
         write!(f, "{name}")
     }
@@ -49,6 +50,7 @@ impl fmt::Display for internal_machines::State {
             Self::EnsureDeviceCapabilities => "EnsureDeviceCapabilities",
             Self::CheckAuthorizationStatus => "CheckAuthorizationStatus",
             Self::Disconnect => "Disconnect",
+            Self::GetProfile => "GetProfile",
             Self::Complete(_) => "Complete",
             Self::Cancel => "Cancel",
         };
@@ -67,6 +69,7 @@ impl fmt::Display for internal_machines::Event {
             Self::EnsureDeviceCapabilitiesSuccess => "EnsureDeviceCapabilitiesSuccess",
             Self::CheckAuthorizationStatusSuccess { .. } => "CheckAuthorizationStatusSuccess",
             Self::DisconnectSuccess => "DisconnectSuccess",
+            Self::GetProfileSuccess => "GetProfileSuccess",
             Self::CallError => "CallError",
             Self::EnsureCapabilitiesAuthError => "EnsureCapabilitiesAuthError",
         };

--- a/components/fxa-client/src/state_machine/internal_machines/connected.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/connected.rs
@@ -17,6 +17,7 @@ impl InternalStateMachine for ConnectedStateMachine {
         match event {
             FxaEvent::Disconnect => Ok(Disconnect),
             FxaEvent::CheckAuthorizationStatus => Ok(CheckAuthorizationStatus),
+            FxaEvent::CallGetProfile => Ok(GetProfile),
             e => Err(Error::InvalidStateTransition(format!("Connected -> {e}"))),
         }
     }
@@ -37,6 +38,8 @@ impl InternalStateMachine for ConnectedStateMachine {
                     Complete(FxaState::AuthIssues)
                 }
             }
+            (GetProfile, GetProfileSuccess) => Complete(FxaState::Connected),
+            (GetProfile, CallError) => Complete(FxaState::AuthIssues),
             (CheckAuthorizationStatus, CallError) => Complete(FxaState::AuthIssues),
             (state, event) => return invalid_transition(state, event),
         })

--- a/components/fxa-client/src/state_machine/internal_machines/mod.rs
+++ b/components/fxa-client/src/state_machine/internal_machines/mod.rs
@@ -55,6 +55,7 @@ pub enum State {
     EnsureDeviceCapabilities,
     CheckAuthorizationStatus,
     Disconnect,
+    GetProfile,
     /// Complete the current [FxaState] transition by transitioning to a new state
     Complete(FxaState),
     /// Complete the current [FxaState] transition by remaining at the current state
@@ -83,6 +84,7 @@ pub enum Event {
         active: bool,
     },
     DisconnectSuccess,
+    GetProfileSuccess,
     CallError,
     /// Auth error for the `ensure_capabilities` call that we do on startup.
     /// This should likely go away when we do https://bugzilla.mozilla.org/show_bug.cgi?id=1868418
@@ -161,6 +163,10 @@ impl State {
             State::Disconnect => {
                 account.disconnect();
                 Event::DisconnectSuccess
+            }
+            State::GetProfile => {
+                account.get_profile(true)?;
+                Event::GetProfileSuccess
             }
             state => {
                 return Err(Error::StateMachineLogicError(format!(


### PR DESCRIPTION
- Added the `simulate_network_error` method.
- Hooked up the methods to the Android wrapper
- Added the `CallGetProfile` event, which forces a call to `get_profile`.  This was the best method I found to check the error handling, since `get_profile` requires both a network request and an access token.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
