### PR TITLE
Record the refresh token length in the get devices breadcrumb

### DIFF
--- a/components/fxa-client/src/internal/http_client.rs
+++ b/components/fxa-client/src/internal/http_client.rs
@@ -368,7 +368,10 @@ impl FxAClient for Client {
     fn get_devices(&self, config: &Config, refresh_token: &str) -> Result<Vec<GetDeviceResponse>> {
         let url = config.auth_url_path("v1/account/devices")?;
         let timestamp = util::past_timestamp(DEVICES_FILTER_DAYS).to_string();
-        breadcrumb!("get_devices timestamp: {timestamp}");
+        breadcrumb!(
+            "get_devices timestamp: {timestamp}, refresh_token.len(): {}",
+            refresh_token.len()
+        );
         let request = Request::get(url)
             .header(header_names::AUTHORIZATION, bearer_token(refresh_token))?
             .query(&[("filterIdleDevicesTimestamp", &timestamp)]);


### PR DESCRIPTION
My current theory is that this happens when we send FxA an invalid refresh token.  Maybe this extra data in the breadcrumb will help identify that. See the bug for details.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
