### PR TITLE
Allow inactive bool field in tabs records and payloads [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - Logins now correctly handle the following sync conflict resolution:
    - When the client locally deleted a login, and before it synced another client modified the same login, the client will recover the login
 
+### Tabs
+- RemoteTabRecord now has an `inactive` boolean with a default value of false ([#6026](https://github.com/mozilla/application-services/pull/6026/)).
+  Mobile platforms can populate this to indicate if the tab is "inactive" allowing other devices to treat them specially (eg, group them together, hide them by default, etc.)
+
 [Full Changelog](In progress)
 
 # v122.0 (_2023-12-18_)

--- a/components/tabs/android/src/test/java/mozilla/appservices/remotetabs/RemoteTabsTest.kt
+++ b/components/tabs/android/src/test/java/mozilla/appservices/remotetabs/RemoteTabsTest.kt
@@ -44,6 +44,7 @@ class RemoteTabsTest {
                         urlHistory = listOf(),
                         icon = null,
                         lastUsed = 12,
+                        inactive = true,
                     ),
                 ),
             )

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -30,12 +30,13 @@ const FAR_FUTURE: i64 = 4_102_405_200_000; // 2100/01/01
 const MAX_PAYLOAD_SIZE: usize = 512 * 1024; // Twice as big as desktop, still smaller than server max (2MB)
 const MAX_TITLE_CHAR_LENGTH: usize = 512; // We put an upper limit on title sizes for tabs to reduce memory
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RemoteTab {
     pub title: String,
     pub url_history: Vec<String>,
     pub icon: Option<String>,
     pub last_used: i64, // In ms.
+    pub inactive: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -495,13 +496,10 @@ mod tests {
         assert_eq!(storage.prepare_local_tabs_for_upload(), None);
         storage.update_local_state(vec![
             RemoteTab {
-                title: "".to_owned(),
                 url_history: vec!["about:blank".to_owned(), "https://foo.bar".to_owned()],
-                icon: None,
-                last_used: 0,
+                ..Default::default()
             },
             RemoteTab {
-                title: "".to_owned(),
                 url_history: vec![
                     "https://foo.bar".to_owned(),
                     "about:blank".to_owned(),
@@ -512,11 +510,9 @@ mod tests {
                     "about:blank".to_owned(),
                     "about:blank".to_owned(),
                 ],
-                icon: None,
-                last_used: 0,
+                ..Default::default()
             },
             RemoteTab {
-                title: "".to_owned(),
                 url_history: vec![
                     "https://foo.bar".to_owned(),
                     "about:blank".to_owned(),
@@ -526,27 +522,20 @@ mod tests {
                     "https://foo5.bar".to_owned(),
                     "https://foo6.bar".to_owned(),
                 ],
-                icon: None,
-                last_used: 0,
+                ..Default::default()
             },
             RemoteTab {
-                title: "".to_owned(),
-                url_history: vec![],
-                icon: None,
-                last_used: 0,
+                ..Default::default()
             },
         ]);
         assert_eq!(
             storage.prepare_local_tabs_for_upload(),
             Some(vec![
                 RemoteTab {
-                    title: "".to_owned(),
                     url_history: vec!["https://foo.bar".to_owned()],
-                    icon: None,
-                    last_used: 0,
+                    ..Default::default()
                 },
                 RemoteTab {
-                    title: "".to_owned(),
                     url_history: vec![
                         "https://foo.bar".to_owned(),
                         "https://foo2.bar".to_owned(),
@@ -554,8 +543,7 @@ mod tests {
                         "https://foo4.bar".to_owned(),
                         "https://foo5.bar".to_owned()
                     ],
-                    icon: None,
-                    last_used: 0,
+                    ..Default::default()
                 },
             ])
         );
@@ -567,8 +555,7 @@ mod tests {
         storage.update_local_state(vec![RemoteTab {
             title: "a".repeat(MAX_TITLE_CHAR_LENGTH + 10), // Fill a string more than max
             url_history: vec!["https://foo.bar".to_owned()],
-            icon: None,
-            last_used: 0,
+            ..Default::default()
         }]);
         let ellipsis_char = '\u{2026}';
         let mut truncated_title = "a".repeat(MAX_TITLE_CHAR_LENGTH - ellipsis_char.len_utf8());
@@ -580,8 +567,7 @@ mod tests {
                 RemoteTab {
                     title: truncated_title, // title was trimmed to only max char length
                     url_history: vec!["https://foo.bar".to_owned()],
-                    icon: None,
-                    last_used: 0,
+                    ..Default::default()
                 },
             ])
         );
@@ -594,14 +580,12 @@ mod tests {
             RemoteTab {
                 title: "😍".repeat(MAX_TITLE_CHAR_LENGTH + 10), // Fill a string more than max
                 url_history: vec!["https://foo.bar".to_owned()],
-                icon: None,
-                last_used: 0,
+                ..Default::default()
             },
             RemoteTab {
                 title: "を".repeat(MAX_TITLE_CHAR_LENGTH + 5), // Fill a string more than max
                 url_history: vec!["https://foo_jp.bar".to_owned()],
-                icon: None,
-                last_used: 0,
+                ..Default::default()
             },
         ]);
         let ellipsis_char = '\u{2026}';
@@ -618,14 +602,12 @@ mod tests {
                 RemoteTab {
                     title: truncated_title, // title was trimmed to only max char length
                     url_history: vec!["https://foo.bar".to_owned()],
-                    icon: None,
-                    last_used: 0,
+                    ..Default::default()
                 },
                 RemoteTab {
                     title: truncated_jp_title, // title was trimmed to only max char length
                     url_history: vec!["https://foo_jp.bar".to_owned()],
-                    icon: None,
-                    last_used: 0,
+                    ..Default::default()
                 },
             ]
         );
@@ -643,8 +625,7 @@ mod tests {
                 title: "aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa aaaa" //50 characters
                     .to_owned(),
                 url_history: vec![format!("https://foo{}.bar", n)],
-                icon: None,
-                last_used: 0,
+                ..Default::default()
             });
         }
         let tabs_mem_size = compute_serialized_size(&too_many_tabs);
@@ -681,6 +662,7 @@ mod tests {
                         url_history: vec!["https://mozilla.org/".to_string()],
                         icon: Some("https://mozilla.org/icon".to_string()),
                         last_used: 1643764207000,
+                        ..Default::default()
                     }],
                 },
                 last_modified: 1643764207000,
@@ -695,6 +677,7 @@ mod tests {
                         url_history: vec!["https://mozilla.org/".to_string()],
                         icon: Some("https://mozilla.org/icon".to_string()),
                         last_used: 1643764207000,
+                        ..Default::default()
                     }],
                 },
                 last_modified: 1443764207000, // old

--- a/components/tabs/src/sync/bridge.rs
+++ b/components/tabs/src/sync/bridge.rs
@@ -149,14 +149,14 @@ mod tests {
             RemoteTab {
                 title: "my first tab".to_string(),
                 url_history: vec!["http://1.com".to_string()],
-                icon: None,
                 last_used: 2,
+                ..Default::default()
             },
             RemoteTab {
                 title: "my second tab".to_string(),
                 url_history: vec!["http://2.com".to_string()],
-                icon: None,
                 last_used: 1,
+                ..Default::default()
             },
         ];
         store.set_local_tabs(my_tabs.clone());

--- a/components/tabs/src/sync/engine.rs
+++ b/components/tabs/src/sync/engine.rs
@@ -92,6 +92,7 @@ impl RemoteTab {
             url_history: tab.url_history.clone(),
             icon: tab.icon.clone(),
             last_used: tab.last_used.checked_mul(1000).unwrap_or_default(),
+            inactive: tab.inactive,
         }
     }
     pub(super) fn to_record_tab(&self) -> TabsRecordTab {
@@ -100,6 +101,7 @@ impl RemoteTab {
             url_history: self.url_history.clone(),
             icon: self.icon.clone(),
             last_used: self.last_used.checked_div(1000).unwrap_or_default(),
+            inactive: self.inactive,
         }
     }
 }

--- a/components/tabs/src/sync/record.rs
+++ b/components/tabs/src/sync/record.rs
@@ -4,6 +4,11 @@
 
 use serde_derive::{Deserialize, Serialize};
 
+// copy/pasta...
+fn skip_if_default<T: PartialEq + Default>(v: &T) -> bool {
+    *v == T::default()
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct TabsRecordTab {
@@ -11,6 +16,8 @@ pub struct TabsRecordTab {
     pub url_history: Vec<String>,
     pub icon: Option<String>,
     pub last_used: i64, // Seconds since epoch!
+    #[serde(default, skip_serializing_if = "skip_if_default")]
+    pub inactive: bool,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -51,6 +58,7 @@ pub mod test {
         assert_eq!(tab.title, "the title");
         assert_eq!(tab.icon, Some("https://mozilla.org/icon".to_string()));
         assert_eq!(tab.last_used, 1643764207);
+        assert!(!tab.inactive);
     }
 
     #[test]
@@ -63,6 +71,7 @@ pub mod test {
                 url_history: vec!["https://mozilla.org/".into()],
                 icon: Some("https://mozilla.org/icon".into()),
                 last_used: 1643764207,
+                inactive: true,
             }],
         };
         let round_tripped =

--- a/components/tabs/src/tabs.udl
+++ b/components/tabs/src/tabs.udl
@@ -37,6 +37,7 @@ dictionary RemoteTabRecord {
     string? icon;
     // Number of ms since the unix epoch (as reported by the client's clock)
     i64 last_used;
+    boolean inactive = false;
 };
 
 dictionary ClientRemoteTabs {

--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -129,8 +129,7 @@ fn main() -> Result<()> {
                 let tabs = vec![RemoteTabRecord {
                     title: "Mozilla".to_string(),
                     url_history: vec!["https://www.mozilla.org".to_string()],
-                    icon: None,
-                    last_used: 0,
+                    ..Default::default()
                 }];
                 dbg!(&tabs);
                 store.storage.lock().unwrap().update_local_state(tabs);
@@ -240,6 +239,7 @@ fn read_local_state() -> Vec<RemoteTabRecord> {
             url_history,
             icon,
             last_used,
+            inactive: false,
         });
     }
     local_state

--- a/testing/sync-test/src/tabs.rs
+++ b/testing/sync-test/src/tabs.rs
@@ -47,10 +47,10 @@ fn test_tabs(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Update tabs on c0");
 
     let t0 = RemoteTab {
-        icon: None,
         last_used: 1_572_265_044_661,
         title: "Welcome to Bobo".to_owned(),
         url_history: vec!["https://bobo.moz".to_owned()],
+        ..Default::default()
     };
     c0.tabs_store.set_local_tabs(vec![t0.clone()]);
 
@@ -69,16 +69,16 @@ fn test_tabs(c0: &mut TestClient, c1: &mut TestClient) {
     );
 
     let t1 = RemoteTab {
-        icon: None,
         last_used: 1_572_267_197_207,
         title: "Foo".to_owned(),
         url_history: vec!["https://foo.org".to_owned()],
+        ..Default::default()
     };
     let t2 = RemoteTab {
-        icon: None,
         last_used: 1_572_267_191_104,
         title: "Bar".to_owned(),
         url_history: vec!["https://bar.org".to_owned()],
+        ..Default::default()
     };
 
     c1.tabs_store.set_local_tabs(vec![t1.clone(), t2.clone()]);


### PR DESCRIPTION
This adds an `inactive` field to a `RemoteTabRecord` with the default value being `false`. The intent is for the mobile platforms to start populating this, then all platforms can choose how to handle such tabs (eg, they may not show them by default and instead add a button which shows them).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
