### PR TITLE
Update Rust version to 1.75, MSR to 1.70

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ commands:
   setup-rust-min-version:
     steps:
       # https://searchfox.org/mozilla-central/source/python/mozboot/mozboot/util.py#26
-      - run: rustup override set 1.65.0
+      - run: rustup override set 1.70.0
 
   full-checkout:
     steps:

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -4,9 +4,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-pub use super::http_client::{
-    DeviceLocation as Location, GetDeviceResponse as Device, PushSubscription,
-};
+pub use super::http_client::{GetDeviceResponse as Device, PushSubscription};
 use super::{
     commands::{self, IncomingDeviceCommand},
     http_client::{

--- a/components/nimbus/src/stateful/behavior.rs
+++ b/components/nimbus/src/stateful/behavior.rs
@@ -356,7 +356,7 @@ impl EventQueryType {
                 self
             )));
         }
-        let event = serde_json::from_value::<String>(args.get(0).unwrap().clone())?;
+        let event = serde_json::from_value::<String>(args.first().unwrap().clone())?;
         let interval = serde_json::from_value::<String>(args.get(1).unwrap().clone())?;
         let interval = Interval::from_str(&interval)?;
         let num_buckets = match args.get(2).unwrap().as_f64() {
@@ -392,7 +392,7 @@ impl EventQueryType {
                 self
             )));
         }
-        let event = serde_json::from_value::<String>(args.get(0).unwrap().clone())?;
+        let event = serde_json::from_value::<String>(args.first().unwrap().clone())?;
         let interval = serde_json::from_value::<String>(args.get(1).unwrap().clone())?;
         let interval = Interval::from_str(&interval)?;
         let zero = &Value::from(0);

--- a/components/nimbus/src/targeting.rs
+++ b/components/nimbus/src/targeting.rs
@@ -121,7 +121,7 @@ pub fn jexl_eval<Context: serde::Serialize>(
 }
 
 fn version_compare(args: &[Value]) -> Result<Value> {
-    let curr_version = args.get(0).ok_or_else(|| {
+    let curr_version = args.first().ok_or_else(|| {
         NimbusError::VersionParsingError("current version doesn't exist in jexl transform".into())
     })?;
     let curr_version = curr_version.as_str().ok_or_else(|| {
@@ -174,7 +174,7 @@ fn bucket_sample(args: &[Value]) -> anyhow::Result<Value> {
     }
 
     let input = args
-        .get(0)
+        .first()
         .ok_or_else(|| anyhow!("input doesn't exist in jexl transform"))?;
     let start = get_arg_as_u32(args, 1, "start")?;
     let count = get_arg_as_u32(args, 2, "count")?;

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -1105,7 +1105,7 @@ fn test_previous_enrollments_in_targeting() -> Result<()> {
         .collect_all(&db.write()?)?;
     assert_eq!(enrollments.len(), 5);
     assert!(matches!(
-        enrollments.get(0).unwrap(),
+        enrollments.first().unwrap(),
         ExperimentEnrollment {
             slug: _slug_1,
             status: EnrollmentStatus::WasEnrolled { .. }

--- a/components/nimbus/src/tests/test_enrollment.rs
+++ b/components/nimbus/src/tests/test_enrollment.rs
@@ -831,7 +831,7 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(true, &[], &recipes, &[])?;
 
     assert_eq!(enrollments.len(), 1);
-    let enr = enrollments.get(0).unwrap();
+    let enr = enrollments.first().unwrap();
     assert_eq!(&enr.slug, slug);
     assert!(matches!(&enr.status, EnrollmentStatus::NotEnrolled { .. }));
 
@@ -847,7 +847,7 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
         enrollments.as_slice(),
     )?;
     assert_eq!(enrollments.len(), 1);
-    let enr = enrollments.get(0).unwrap();
+    let enr = enrollments.first().unwrap();
     assert_eq!(&enr.slug, slug);
     assert!(matches!(&enr.status, EnrollmentStatus::Enrolled { .. }));
 
@@ -863,7 +863,7 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
         enrollments.as_slice(),
     )?;
     assert_eq!(enrollments.len(), 1);
-    let enr = enrollments.get(0).unwrap();
+    let enr = enrollments.first().unwrap();
     assert_eq!(&enr.slug, slug);
     assert!(matches!(
         &enr.status,
@@ -892,7 +892,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
     let (enrollments, _) = evolver.evolve_enrollments::<Experiment>(true, &[], &recipes, &[])?;
 
     assert_eq!(enrollments.len(), 1);
-    let enr = enrollments.get(0).unwrap();
+    let enr = enrollments.first().unwrap();
     assert_eq!(&enr.slug, slug);
     assert!(matches!(&enr.status, EnrollmentStatus::NotEnrolled { .. }));
 
@@ -908,7 +908,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
         enrollments.as_slice(),
     )?;
     assert_eq!(enrollments.len(), 1);
-    let enr = enrollments.get(0).unwrap();
+    let enr = enrollments.first().unwrap();
     assert_eq!(&enr.slug, slug);
     assert!(matches!(&enr.status, EnrollmentStatus::Enrolled { .. }));
 
@@ -924,7 +924,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
         enrollments.as_slice(),
     )?;
     assert_eq!(enrollments.len(), 1);
-    let enr = enrollments.get(0).unwrap();
+    let enr = enrollments.first().unwrap();
     assert_eq!(&enr.slug, slug);
     assert!(matches!(
         &enr.status,
@@ -946,7 +946,7 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
         enrollments.as_slice(),
     )?;
     assert_eq!(enrollments.len(), 1);
-    let enr = enrollments.get(0).unwrap();
+    let enr = enrollments.first().unwrap();
     assert_eq!(&enr.slug, slug);
     assert!(matches!(&enr.status, EnrollmentStatus::Enrolled { .. }));
 
@@ -994,7 +994,7 @@ fn test_experiment_does_not_reenroll_from_disqualified_not_selected_or_not_targe
 
     assert_eq!(enrollments.len(), 2);
 
-    let enr = enrollments.get(0).unwrap();
+    let enr = enrollments.first().unwrap();
     assert_eq!(&enr.slug, slug_1);
     assert!(matches!(&enr.status, EnrollmentStatus::Disqualified { .. }));
 

--- a/components/support/error/tests/returns_not_result.stderr
+++ b/components/support/error/tests/returns_not_result.stderr
@@ -9,3 +9,7 @@ error[E0308]: mismatched types
    = note: expected struct `String`
                 found enum `Result<String, ExternalError>`
    = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using `Result::expect` to unwrap the `Result<String, ExternalError>` value, panicking if the value is a `Result::Err`
+   |
+39 |  #[handle_error(Error)].expect("REASON")
+   |                        +++++++++++++++++

--- a/components/support/error/tests/returns_result_but_incorrect_error.stderr
+++ b/components/support/error/tests/returns_result_but_incorrect_error.stderr
@@ -9,3 +9,7 @@ error[E0308]: mismatched types
    = note: expected enum `std::result::Result<String, ExternalError>`
               found enum `std::result::Result<_, OtherExternalError>`
    = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the `?` operator to extract the `std::result::Result<_, OtherExternalError>` value, propagating a `Result::Err` value to the caller
+   |
+50 |  #[handle_error(Error)]?
+   |                        +

--- a/components/support/nimbus-fml/src/client/mod.rs
+++ b/components/support/nimbus-fml/src/client/mod.rs
@@ -351,7 +351,7 @@ mod string_aliases {
         let expected = r#"Invalid value "Donkey" for type PlayerName; did you mean one of "Agnes", "Babet", "Ciarán", "Debi", "Elin", "Fergus", "Gerrit", "Henk", "Isha", "Jocelyn", "Kathleen" or "Lilian"?"#;
         assert!(errors.is_some());
         let errors = errors.unwrap();
-        let err = errors.get(0).unwrap();
+        let err = errors.first().unwrap();
         assert_eq!(Some("\"Donkey\""), err.highlight.as_deref());
         assert_eq!(expected, err.message.as_str());
 
@@ -367,7 +367,7 @@ mod string_aliases {
         );
         assert!(errors.is_some());
         let errors = errors.unwrap();
-        let err = errors.get(0).unwrap();
+        let err = errors.first().unwrap();
         assert_eq!(Some("\"Donkey\""), err.highlight.as_deref());
         assert_eq!(expected, err.message.as_str());
 
@@ -439,7 +439,7 @@ mod string_aliases {
         );
         assert!(errors.is_some());
         let errors = errors.unwrap();
-        let err = errors.get(0).unwrap();
+        let err = errors.first().unwrap();
         assert_eq!(Some("\"CONNECT-4\""), err.highlight.as_deref());
         assert_eq!(
             "Invalid value \"CONNECT-4\" for type SportName; did you mean \"CHESS\"?",
@@ -461,7 +461,7 @@ mod string_aliases {
         );
         assert!(errors.is_some());
         let errors = errors.unwrap();
-        let err = errors.get(0).unwrap();
+        let err = errors.first().unwrap();
         assert_eq!(Some("{"), err.highlight.as_deref());
         assert_eq!(
             "A valid value for sport of type SportName is missing",
@@ -483,7 +483,7 @@ mod string_aliases {
         );
         assert!(errors.is_some());
         let errors = errors.unwrap();
-        let err = errors.get(0).unwrap();
+        let err = errors.first().unwrap();
         assert_eq!(Some("\"Donkey\""), err.highlight.as_deref());
 
         // ------------------------------------------------------------------
@@ -503,7 +503,7 @@ mod string_aliases {
         );
         assert!(errors.is_some());
         let errors = errors.unwrap();
-        let err = errors.get(0).unwrap();
+        let err = errors.first().unwrap();
         assert_eq!(Some("\"Aka\""), err.highlight.as_deref());
 
         // ------------------------------------------------------------
@@ -594,7 +594,7 @@ mod string_aliases {
         );
         assert!(errors.is_some());
         let errors = errors.unwrap();
-        let err = errors.get(0).unwrap();
+        let err = errors.first().unwrap();
         assert_eq!(Some("\"Archery\""), err.highlight.as_deref());
 
         Ok(())

--- a/components/support/nimbus-fml/src/command_line/mod.rs
+++ b/components/support/nimbus-fml/src/command_line/mod.rs
@@ -244,7 +244,7 @@ mod cli_tests {
 
     fn package_dir() -> Result<PathBuf> {
         let string = env::var("CARGO_MANIFEST_DIR")?;
-        Ok(PathBuf::try_from(string)?)
+        Ok(PathBuf::from(string))
     }
 
     // All these tests just exercise the command line parsing.

--- a/components/support/nimbus-fml/src/command_line/workflows.rs
+++ b/components/support/nimbus-fml/src/command_line/workflows.rs
@@ -383,7 +383,6 @@ mod test {
         // and while we still have to support setting those options from the commmand line.
         // We will deprecate setting classnames, package names etc, then we can simplify.
         let from_file = ir.about;
-        let from_cli = from_cli;
         let kotlin_about = from_cli.kotlin_about.or(from_file.kotlin_about);
         let swift_about = from_cli.swift_about.or(from_file.swift_about);
         let about = AboutBlock {

--- a/components/support/nimbus-fml/src/schema/validator.rs
+++ b/components/support/nimbus-fml/src/schema/validator.rs
@@ -120,7 +120,7 @@ impl<'a> SchemaValidator<'a> {
             .collect();
 
         if !unaccounted.is_empty() {
-            let t = unaccounted.get(0).unwrap();
+            let t = unaccounted.first().unwrap();
             return Err(FMLError::ValidationError(
                 path.to_string(),
                 format!("A string-alias {t} is used by– but has not been defined in– the {feature} feature"),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,7 +7,7 @@
 #   supported and used in CI.
 
 [toolchain]
-channel = "1.72.0"
+channel = "1.75.0"
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",


### PR DESCRIPTION
m-c is now on [1.75 for workers](https://bugzilla.mozilla.org/show_bug.cgi?id=1857090), [1.70 for MSR](https://searchfox.org/mozilla-central/source/python/mozboot/mozboot/util.py#14). As per [our policy](https://github.com/mozilla/application-services/blob/main/docs/design/rust-versions.md), we should update.