### PR TITLE
Fixup enum-map-key error-path bug

### DIFF
--- a/components/support/nimbus-fml/src/defaults/validator.rs
+++ b/components/support/nimbus-fml/src/defaults/validator.rs
@@ -292,7 +292,7 @@ impl<'a> DefaultsValidator<'a> {
                         });
                     }
 
-                    self.validate_types(&path.enum_map_key(map_key, &enum_def.name), map_type, map_value, errors);
+                    self.validate_types(&path.enum_map_key(&enum_def.name, map_key), map_type, map_value, errors);
                 }
             }
             (TypeRef::EnumMap(_, map_type), Value::Object(map)) // Map<string-alias, T>


### PR DESCRIPTION
Relates to [ EXP-4154](https://mozilla-hub.atlassian.net/browse/EXP-4154).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

_n_ = 1.

There is an accompanying test for this in a different PR in this same stack.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
