### PR TITLE
Add Default to FmlEditorError

### DIFF
--- a/components/support/nimbus-fml/src/client/inspector.rs
+++ b/components/support/nimbus-fml/src/client/inspector.rs
@@ -89,7 +89,7 @@ impl FmlFeatureInspector {
                 // serde_json errors are 1 indexed.
                 line: e.line() as u32 - 1,
                 col: if col == 0 { 0 } else { col - 1 } as u32,
-                highlight: None,
+                ..Default::default()
             });
         }
         let json = json.ok().unwrap();
@@ -98,9 +98,8 @@ impl FmlFeatureInspector {
         } else {
             Err(FmlEditorError {
                 message: "Need valid JSON object".to_string(),
-                line: 0,
-                col: 0,
                 highlight: Some(string.to_string()),
+                ..Default::default()
             })
         }
     }
@@ -157,6 +156,7 @@ mod unit_tests {
             line,
             col,
             highlight: token.map(str::to_string),
+            ..Default::default()
         }
     }
 

--- a/components/support/nimbus-fml/src/editing/mod.rs
+++ b/components/support/nimbus-fml/src/editing/mod.rs
@@ -16,7 +16,7 @@ pub(crate) struct FeatureValidationError {
     pub(crate) kind: ErrorKind,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct FmlEditorError {
     pub message: String,
     pub line: u32,


### PR DESCRIPTION
Relates to [ EXP-4154](https://mozilla-hub.atlassian.net/browse/EXP-4154).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This very small PR tidies up some construction FMLEditorErrors.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
