### PR TITLE
Introducing CursorSpan and CursorPosition to represent insertions

### DIFF
--- a/components/support/nimbus-fml/src/editing/cursor_position.rs
+++ b/components/support/nimbus-fml/src/editing/cursor_position.rs
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::ops::Add;
+
+use unicode_segmentation::UnicodeSegmentation;
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CursorPosition {
+    pub line: u32,
+    pub col: u32,
+}
+
+#[allow(dead_code)]
+impl CursorPosition {
+    pub(crate) fn new(line: usize, col: usize) -> Self {
+        Self {
+            line: line as u32,
+            col: col as u32,
+        }
+    }
+}
+
+/// CursorSpan is used to for reporting errors and defining corrections.
+/// This is passed across the FFI and used by the editor.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CursorSpan {
+    pub from: CursorPosition,
+    pub to: CursorPosition,
+}
+
+/// CursorPosition + &str -> CursorSpan.
+/// This is a convenient way of making CursorSpans.
+impl Add<&str> for CursorPosition {
+    type Output = CursorSpan;
+
+    fn add(self, rhs: &str) -> Self::Output {
+        let mut line_count = 0;
+        let mut last_line = None;
+
+        for line in rhs.lines() {
+            line_count += 1;
+            last_line = Some(line);
+        }
+
+        if rhs.ends_with('\n') {
+            line_count += 1;
+            last_line = None;
+        }
+
+        let last_line_length = match last_line {
+            Some(line) => UnicodeSegmentation::graphemes(line, true).count(),
+            None => 0,
+        } as u32;
+
+        let to = match line_count {
+            0 => self.clone(),
+            1 => CursorPosition {
+                line: self.line,
+                col: self.col + last_line_length,
+            },
+            _ => CursorPosition {
+                line: self.line + line_count - 1,
+                col: last_line_length,
+            },
+        };
+
+        Self::Output { from: self, to }
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn test_add_str() {
+        // start at (10, 10) so we can check that things are zeroing properly.
+        let from = CursorPosition::new(10, 10);
+
+        assert_eq!(CursorPosition::new(10, 10), (from.clone() + "").to);
+        assert_eq!(CursorPosition::new(10, 11), (from.clone() + "0").to);
+        assert_eq!(CursorPosition::new(10, 12), (from.clone() + "01").to);
+
+        assert_eq!(CursorPosition::new(11, 1), (from.clone() + "\n0").to);
+        assert_eq!(CursorPosition::new(12, 1), (from.clone() + "\n\n0").to);
+
+        assert_eq!(CursorPosition::new(11, 0), (from.clone() + "\n").to);
+        assert_eq!(CursorPosition::new(12, 0), (from.clone() + "\n\n").to);
+    }
+}

--- a/components/support/nimbus-fml/src/editing/error_converter.rs
+++ b/components/support/nimbus-fml/src/editing/error_converter.rs
@@ -54,12 +54,14 @@ impl<'a> ErrorConverter<'a> {
         for e in errors {
             let message = self.long_message(&values, e);
             let highlight = e.path.last_token().map(str::to_string);
-            let (line, col) = e.path.line_col(src);
+            let position = e.path.line_col(src);
             let error = FmlEditorError {
                 message,
-                line: line as u32,
-                col: col as u32,
                 highlight,
+
+                // deprecated, can be removed once it's removed in experimenter.
+                line: position.line,
+                col: position.col,
             };
             editor_errors.push(error);
         }

--- a/components/support/nimbus-fml/src/editing/error_path.rs
+++ b/components/support/nimbus-fml/src/editing/error_path.rs
@@ -116,8 +116,9 @@ impl ErrorPath {
 #[allow(dead_code)]
 #[cfg(feature = "client-lib")]
 impl ErrorPath {
-    pub(crate) fn line_col(&self, src: &str) -> (usize, usize) {
-        line_col(src, self.literals.iter().map(|s| s.as_str()))
+    pub(crate) fn line_col(&self, src: &str) -> crate::editing::CursorPosition {
+        let (line, col) = line_col(src, self.literals.iter().map(|s| s.as_str()));
+        crate::editing::CursorPosition::new(line, col)
     }
 }
 

--- a/components/support/nimbus-fml/src/editing/mod.rs
+++ b/components/support/nimbus-fml/src/editing/mod.rs
@@ -2,11 +2,14 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+mod cursor_position;
 mod error_converter;
 mod error_kind;
 mod error_path;
 mod values_finder;
 
+#[cfg(feature = "client-lib")]
+pub(crate) use cursor_position::CursorPosition;
 pub(crate) use error_converter::ErrorConverter;
 pub(crate) use error_kind::ErrorKind;
 pub(crate) use error_path::ErrorPath;


### PR DESCRIPTION
Relates to [ EXP-4154](https://mozilla-hub.atlassian.net/browse/EXP-4154).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR introduces two structs: `CursorPosition` and `CursorSpan`.

- `CursorPosition` replaces the simpler tuple `(line: u32, co: u32)`.
- `CursorSpan` represents a span between two cursor positions.

`CursorSpan` is not used in _this_ PR, but it makes sense to introduce it here.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
