### PR TITLE
Calculate days_since_install closer to evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 ### Nimbus CLI [⛅️🔬🔭👾](./components/support/nimbus-cli)
 - Changed the locations of firefox-ios and focus-ios feature manifest files ([#6012](https://github.com/mozilla/application-services/pull/6012)) and added version sensitivity.
 
+### Nimbus SDK ⛅️🔬🔭
+- Moved the `days_since_install` calculation to closer to where it's needed ([#6042](https://github.com/mozilla/application-services/pull/6042)).
+  - This means that the Nimbus SDK can run for longer and the JEXL evaluator still is accurate.
+
 ### Logins
 - Logins now correctly handle the following sync conflict resolution:
    - When the client locally deleted a login, and before it synced another client modified the same login, the client will recover the login

--- a/components/nimbus/src/stateful/evaluator.rs
+++ b/components/nimbus/src/stateful/evaluator.rs
@@ -41,3 +41,16 @@ impl From<AppContext> for TargetingAttributes {
         }
     }
 }
+
+impl TargetingAttributes {
+    pub(crate) fn update_time_to_now(
+        &mut self,
+        now: DateTime<Utc>,
+        install_date: &Option<DateTime<Utc>>,
+        update_date: &Option<DateTime<Utc>>,
+    ) {
+        self.days_since_install = install_date.map(|then| (now - then).num_days() as i32);
+        self.days_since_update = update_date.map(|then| (now - then).num_days() as i32);
+        self.current_date = now;
+    }
+}

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -410,14 +410,7 @@ fn test_days_since_install() -> Result<()> {
         None,
         Box::new(metrics),
     )?;
-    let targeting_attributes = TargetingAttributes {
-        app_context,
-        days_since_install: Some(10),
-        days_since_update: None,
-        is_already_enrolled: false,
-        ..Default::default()
-    };
-    client.with_targeting_attributes(targeting_attributes);
+    client.set_install_time(Utc::now() - Duration::days(10));
     client.initialize()?;
     let experiment_json = serde_json::to_string(&json!({
         "data": [{
@@ -486,14 +479,7 @@ fn test_days_since_install_failed_targeting() -> Result<()> {
         None,
         Box::new(metrics),
     )?;
-    let targeting_attributes = TargetingAttributes {
-        app_context,
-        days_since_install: Some(10),
-        days_since_update: None,
-        is_already_enrolled: false,
-        ..Default::default()
-    };
-    client.with_targeting_attributes(targeting_attributes);
+    client.set_install_time(Utc::now() - Duration::days(10));
     client.initialize()?;
     let experiment_json = serde_json::to_string(&json!({
         "data": [{
@@ -561,14 +547,7 @@ fn test_days_since_update() -> Result<()> {
         None,
         Box::new(metrics),
     )?;
-    let targeting_attributes = TargetingAttributes {
-        app_context,
-        days_since_install: None,
-        days_since_update: Some(10),
-        is_already_enrolled: false,
-        ..Default::default()
-    };
-    client.with_targeting_attributes(targeting_attributes);
+    client.set_update_time(Utc::now() - Duration::days(10));
     client.initialize()?;
     let experiment_json = serde_json::to_string(&json!({
         "data": [{
@@ -637,14 +616,7 @@ fn test_days_since_update_failed_targeting() -> Result<()> {
         None,
         Box::new(metrics),
     )?;
-    let targeting_attributes = TargetingAttributes {
-        app_context,
-        days_since_install: None,
-        days_since_update: Some(10),
-        is_already_enrolled: false,
-        ..Default::default()
-    };
-    client.with_targeting_attributes(targeting_attributes);
+    client.set_update_time(Utc::now() - Duration::days(10));
     client.initialize()?;
     let experiment_json = serde_json::to_string(&json!({
         "data": [{

--- a/components/nimbus/tests/test_message_helpers.rs
+++ b/components/nimbus/tests/test_message_helpers.rs
@@ -15,7 +15,7 @@ use nimbus::error::Result;
 #[cfg(test)]
 mod message_tests {
 
-    use nimbus::{AppContext, TargetingAttributes};
+    use chrono::{Duration, Utc};
     use serde_json::json;
 
     use super::*;
@@ -115,22 +115,8 @@ mod message_tests {
 
         assert!(helper.eval_jexl("days_since_update == 0".to_string())?);
 
-        let app_context = AppContext {
-            app_name: "fenix".to_string(),
-            app_id: "org.mozilla.fenix".to_string(),
-            channel: "nightly".to_string(),
-            ..Default::default()
-        };
-
-        let targeting_attributes = TargetingAttributes {
-            app_context,
-            days_since_install: Some(10),
-            days_since_update: Some(5),
-            is_already_enrolled: false,
-            ..Default::default()
-        };
-
-        nimbus.with_targeting_attributes(targeting_attributes);
+        nimbus.set_install_time(Utc::now() - Duration::days(10));
+        nimbus.set_update_time(Utc::now() - Duration::days(5));
 
         let helper = nimbus.create_targeting_helper(None)?;
         assert!(helper.eval_jexl("days_since_install == 10".to_string())?);


### PR DESCRIPTION
Fixes [EXP-4181](https://mozilla-hub.atlassian.net/browse/EXP-4181).

This PR moves the derivation from the `install_time` and `update_time` away from the calculation of the `days_since_install` and `days_since_update`.

Calculating the `days_since_*` is now done immediately before the JEXL evaluator is created.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
