### PR TITLE
Make ErrorPath handle multi-token errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,6 +3833,7 @@ version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
+ "indexmap",
  "itoa 1.0.9",
  "ryu",
  "serde",

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -16,7 +16,7 @@ name = "nimbus_fml"
 [dependencies]
 clap = {version = "2.33.0", features = ["yaml"]}
 anyhow = "1.0.44"
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.8.21"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0.29"

--- a/components/support/nimbus-fml/src/client/inspector.rs
+++ b/components/support/nimbus-fml/src/client/inspector.rs
@@ -568,7 +568,6 @@ mod correction_candidates {
     // The solution is to make error_path keep track of the start token and end token, and calculate
     // an `error_range(src: &src) -> (from: CursorPosition, to: CursorPosition)`.
     // Until that happens, we'll ignore this test.
-    #[ignore]
     #[test]
     fn test_correction_candidates_replacing_structural_plus_whitespace() -> Result<()> {
         let fm = client("./browser.yaml", "release")?;

--- a/components/support/nimbus-fml/src/defaults/validator.rs
+++ b/components/support/nimbus-fml/src/defaults/validator.rs
@@ -316,7 +316,7 @@ impl<'a> DefaultsValidator<'a> {
                 self.validate_props_types(&path.object_value(obj_name), &obj_def.props, map, errors);
             }
             _ => {
-                let path = path.final_error(&default.to_string());
+                let path = path.final_error_value(default);
                 errors.push(FeatureValidationError {
                     path,
                     kind: ErrorKind::type_mismatch(type_ref),

--- a/components/support/nimbus-fml/src/editing/cursor_position.rs
+++ b/components/support/nimbus-fml/src/editing/cursor_position.rs
@@ -22,6 +22,12 @@ impl CursorPosition {
     }
 }
 
+impl From<(usize, usize)> for CursorPosition {
+    fn from((line, col): (usize, usize)) -> Self {
+        Self::new(line, col)
+    }
+}
+
 /// CursorSpan is used to for reporting errors and defining corrections.
 /// This is passed across the FFI and used by the editor.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -67,6 +73,17 @@ impl Add<&str> for CursorPosition {
         };
 
         Self::Output { from: self, to }
+    }
+}
+
+impl Add<CursorSpan> for CursorPosition {
+    type Output = CursorSpan;
+
+    fn add(self, rhs: CursorSpan) -> Self::Output {
+        Self::Output {
+            from: self,
+            to: rhs.to,
+        }
     }
 }
 

--- a/components/support/nimbus-fml/src/editing/error_converter.rs
+++ b/components/support/nimbus-fml/src/editing/error_converter.rs
@@ -58,7 +58,8 @@ impl<'a> ErrorConverter<'a> {
             // After experimenter is using the corrections, we can switch to
             // let message = self.message(error);
 
-            let highlight = error.path.last_token().map(String::from);
+            let highlight = error.path.first_error_token().map(String::from);
+            // TODO: derive the highlighted token from the error span.
             let error_span = error.path.error_span(src);
 
             let corrections = self.correction_candidates(&values, src, error);
@@ -94,8 +95,8 @@ impl ErrorConverter<'_> {
     }
 
     fn message(&self, error: &FeatureValidationError) -> String {
-        let token = error.path.last_token().unwrap_or("unknown");
-        error.kind.message(token)
+        let token = error.path.error_token_abbr();
+        error.kind.message(&token)
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
Fixes [EXP-4178](https://mozilla-hub.atlassian.net/browse/EXP-4178).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

`ErrorPath` is a stuct responsible for recording where an error was detected: the main method was the `error_span` method which returned the `from` and `to` positions of the error.

Before this PR, `ErrorPath` was only able to reliably generate spans for errors that were detected in a single token. For most of the time, this was ok. 

However, type mismatches could spread across multple tokens (e.g. `[ 1 ]` is three tokens), and the error was recorded as being at a single token `[1]`. If the source code had spaces, as above, then the error would be reported at `0, 0`.

This PR fixes that: the `error_span` method has been beefed up, and now identifies multi-token errors. It also changes the error messages given by returning an abbreviation of arrays and objects, instead of calling the `to_string()` on it and using that.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
