### PR TITLE
Add read method to load either json and yaml

### DIFF
--- a/components/support/nimbus-fml/src/command_line/workflows.rs
+++ b/components/support/nimbus-fml/src/command_line/workflows.rs
@@ -131,8 +131,7 @@ fn load_feature_manifest(
         let parser: Parser = Parser::new(files, path)?;
         parser.get_intermediate_representation(channel)?
     } else {
-        let string = files.read_to_string(&path)?;
-        serde_json::from_str::<FeatureManifest>(&string)?
+        files.read::<FeatureManifest>(&path)?
     };
     ir.validate_manifest()?;
     Ok(ir)

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -106,11 +106,9 @@ impl Parser {
     ) -> Result<ManifestFrontEnd> {
         let id: ModuleId = path.try_into()?;
         let files = &self.files;
-        let s = files
-            .read_to_string(path)
-            .map_err(|e| FMLError::FMLModuleError(id.clone(), e.to_string()))?;
 
-        let mut parent = serde_yaml::from_str::<ManifestFrontEnd>(&s)
+        let mut parent = files
+            .read::<ManifestFrontEnd>(path)
             .map_err(|e| FMLError::FMLModuleError(id.clone(), e.to_string()))?;
 
         // We canonicalize the paths to the import files really soon after the loading so when we merge


### PR DESCRIPTION
Relates to [ EXP-4204](https://mozilla-hub.atlassian.net/browse/EXP-4204).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This small PR adds a type safe deserializing `read` method to the `FileLoader`, that loads either JSON or YAML, ~~depending on the file extension~~.

Recall: the `FileLoader` loads files from disk, remotely or from a private Github repo.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
