### PR TITLE
Uniffi webext-storage component

### DIFF
--- a/.buildconfig-android.yml
+++ b/.buildconfig-android.yml
@@ -98,6 +98,14 @@ projects:
     - name: syncmanager
       type: aar
     description: Sync manager implementation
+  # TODO: Uncomment this code when webext-storage component is integrated in android
+  # webextstorage:
+    # path: components/webext-storage/android
+    # artifactId: webextstorage
+    # publications:
+    # - name: webextstorage
+    #   type: aar
+    # description: Component for web extenstion storage logic
   tabs:
     path: components/tabs/android
     artifactId: tabs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # v124.0 (In progress)
 
+## 🦊 What's Changed 🦊
+
+### Webext-Storage
+- Uniffied the webext-storage component in preparation for desktop integration ([#6057](https://github.com/mozilla/application-services/pull/6057)).
+
+[Full Changelog](In progress)
+
 [Full Changelog](In progress)
 
 # v123.0 (_2024-01-22_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5091,6 +5091,7 @@ dependencies = [
  "sync15",
  "tempfile",
  "thiserror",
+ "uniffi",
  "url",
 ]
 

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -24,6 +24,7 @@ serde_derive = "1"
 sql-support = { path = "../support/sql" }
 sync15 = {path = "../../components/sync15", features=["sync-engine"]}
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"] }
+uniffi = { workspace = true }
 url = { version = "2.1", features = ["serde"] }
 
 [dev-dependencies]
@@ -37,3 +38,4 @@ sql-support = { path = "../support/sql" }
 
 [build-dependencies]
 nss_build_common = { path = "../support/rc_crypto/nss/nss_build_common" }
+uniffi = { workspace = true, features = ["build"] }

--- a/components/webext-storage/android/build.gradle
+++ b/components/webext-storage/android/build.gradle
@@ -1,0 +1,22 @@
+// TODO: Uncomment this code when webext-storage component is integrated in android
+
+// apply from: "$rootDir/build-scripts/component-common.gradle"
+// apply from: "$rootDir/publish.gradle"
+
+// dependencies {
+//     // Part of the public API.
+//     api project(':sync15')
+
+//     implementation "org.mozilla.telemetry:glean:$glean_version"
+//     implementation "androidx.core:core-ktx:$androidx_core_version"
+
+//     testImplementation "androidx.test:core-ktx:$androidx_test_version"
+//     testImplementation "androidx.test.ext:junit-ktx:$androidx_test_junit_version"
+//     testImplementation "androidx.work:work-testing:$androidx_work_testing_version"
+//     testImplementation "org.mozilla.telemetry:glean-native-forUnitTests:$glean_version"
+// }
+
+
+// ext.configureUniFFIBindgen("../src/webext-storage.udl")
+// ext.dependsOnTheMegazord()
+// ext.configurePublish()

--- a/components/webext-storage/android/src/main/AndroidManifest.xml
+++ b/components/webext-storage/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="org.mozilla.appservices.webextstorage" />

--- a/components/webext-storage/android/src/test/java/mozilla/appservices/webextstorage/WebExtStorageTest.kt
+++ b/components/webext-storage/android/src/test/java/mozilla/appservices/webextstorage/WebExtStorageTest.kt
@@ -1,0 +1,76 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+package mozilla.appservices.webextstorage
+
+import mozilla.appservices.Megazord
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE)
+class WebExtStorageTest {
+    @Rule
+    @JvmField
+    val dbFolder = TemporaryFolder()
+
+    fun createTestStore(): WebExtStorageStore {
+        Megazord.init()
+        val dbPath = dbFolder.newFile()
+        return WebExtStorageStore(path = dbPath.absolutePath)
+    }
+
+    @Test
+    fun testSet() {
+        val store = createTestStore()
+        val extId = "ab"
+        val jsonString = """{"a":"a"}"""
+
+        store.set(extId, jsonString)
+        val data = store.get(extId, "null")
+        Assert.assertEquals(jsonString, data)
+        store.close()
+    }
+
+    @Test
+    fun testRemove() {
+        val store = createTestStore()
+        val extId = "ab"
+        val jsonString = """{"a":"a","b":"b"}"""
+
+        store.set(extId, jsonString)
+        val change = store.remove("ab", """["b"]""").changes[0]
+
+        Assert.assertEquals(change.key, "b")
+        Assert.assertEquals(change.oldValue, """"b"""")
+        Assert.assertNull(change.newValue)
+        store.close()
+    }
+
+    @Test
+    fun testClear() {
+        val store = createTestStore()
+        val extId = "ab"
+        val jsonString = """{"a":"a","b":"b"}"""
+
+        store.set(extId, jsonString)
+        val result = store.clear(extId)
+
+        val firstChange = result.changes[0]
+        Assert.assertEquals(firstChange.key, "a")
+        Assert.assertEquals(firstChange.oldValue, """"a"""")
+        Assert.assertNull(firstChange.newValue)
+
+        val secondChange = result.changes[1]
+        Assert.assertEquals(secondChange.key, "b")
+        Assert.assertEquals(secondChange.oldValue, """"b"""")
+        Assert.assertNull(secondChange.newValue)
+
+        store.close()
+    }
+}

--- a/components/webext-storage/build.rs
+++ b/components/webext-storage/build.rs
@@ -10,4 +10,6 @@ fn main() {
 
     // If NSS_DIR isn't set, we don't really care, ignore the Err case.
     let _ = nss_build_common::link_nss();
+
+    uniffi::generate_scaffolding("./src/webext-storage.udl").unwrap();
 }

--- a/components/webext-storage/ffi/src/lib.rs
+++ b/components/webext-storage/ffi/src/lib.rs
@@ -5,7 +5,7 @@
 use std::os::raw::c_char;
 
 use ffi_support::{define_handle_map_deleter, ConcurrentHandleMap, ExternError, FfiStr};
-use webext_storage::{error, store::Store};
+use webext_storage::{error, store::WebExtStorageStore as Store};
 
 lazy_static::lazy_static! {
     static ref STORES: ConcurrentHandleMap<Store> = ConcurrentHandleMap::new();

--- a/components/webext-storage/src/db.rs
+++ b/components/webext-storage/src/db.rs
@@ -214,11 +214,11 @@ pub fn ensure_url_path(p: impl AsRef<Path>) -> Result<Url> {
         if u.scheme() == "file" {
             Ok(u)
         } else {
-            Err(ErrorKind::IllegalDatabasePath(p.as_ref().to_owned()).into())
+            Err(Error::IllegalDatabasePath(p.as_ref().to_owned()))
         }
     } else {
         let p = p.as_ref();
-        let u = Url::from_file_path(p).map_err(|_| ErrorKind::IllegalDatabasePath(p.to_owned()))?;
+        let u = Url::from_file_path(p).map_err(|_| Error::IllegalDatabasePath(p.to_owned()))?;
         Ok(u)
     }
 }
@@ -243,11 +243,11 @@ fn normalize_path(p: impl AsRef<Path>) -> Result<PathBuf> {
     // parent directory, etc.
     let file_name = path
         .file_name()
-        .ok_or_else(|| ErrorKind::IllegalDatabasePath(path.clone()))?;
+        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
 
     let parent = path
         .parent()
-        .ok_or_else(|| ErrorKind::IllegalDatabasePath(path.clone()))?;
+        .ok_or_else(|| Error::IllegalDatabasePath(path.clone()))?;
 
     let mut canonical = parent.canonicalize()?;
     canonical.push(file_name);

--- a/components/webext-storage/src/ffi.rs
+++ b/components/webext-storage/src/ffi.rs
@@ -9,7 +9,7 @@
 /// a trait in `ffi_support` for a type in `webext_storage`).
 use ffi_support::{ErrorCode, ExternError};
 
-use crate::error::{Error, ErrorKind, QuotaReason};
+use crate::error::{Error, QuotaReason};
 
 mod error_codes {
     /// An unexpected error occurred which likely cannot be meaningfully handled
@@ -34,13 +34,13 @@ mod error_codes {
 
 impl From<Error> for ExternError {
     fn from(err: Error) -> ExternError {
-        let code = ErrorCode::new(match err.kind() {
-            ErrorKind::JsonError(_) => error_codes::INVALID_JSON,
-            ErrorKind::QuotaError(QuotaReason::TotalBytes) => {
-                error_codes::QUOTA_TOTAL_BYTES_EXCEEDED
-            }
-            ErrorKind::QuotaError(QuotaReason::ItemBytes) => error_codes::QUOTA_ITEM_BYTES_EXCEEDED,
-            ErrorKind::QuotaError(QuotaReason::MaxItems) => error_codes::QUOTA_MAX_ITEMS_EXCEEDED,
+        let code = ErrorCode::new(match &err {
+            Error::JsonError(_) => error_codes::INVALID_JSON,
+            Error::QuotaError(reason) => match reason {
+                QuotaReason::ItemBytes => error_codes::QUOTA_ITEM_BYTES_EXCEEDED,
+                QuotaReason::MaxItems => error_codes::QUOTA_MAX_ITEMS_EXCEEDED,
+                QuotaReason::TotalBytes => error_codes::QUOTA_TOTAL_BYTES_EXCEEDED,
+            },
             _ => error_codes::UNEXPECTED,
         });
         ExternError::new_error(code, err.to_string())

--- a/components/webext-storage/src/lib.rs
+++ b/components/webext-storage/src/lib.rs
@@ -23,4 +23,22 @@ pub use api::SYNC_MAX_ITEMS;
 pub use api::SYNC_QUOTA_BYTES;
 pub use api::SYNC_QUOTA_BYTES_PER_ITEM;
 
+pub use crate::error::{QuotaReason, WebExtStorageApiError};
+pub use crate::store::WebExtStorageStore;
 pub use api::UsageInfo;
+pub use api::{StorageChanges, StorageValueChange};
+
+uniffi::include_scaffolding!("webext-storage");
+
+use serde_json::Value as JsonValue;
+impl UniffiCustomTypeConverter for JsonValue {
+    type Builtin = String;
+
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<JsonValue> {
+        Ok(serde_json::from_str(val.as_str()).unwrap())
+    }
+
+    fn from_custom(obj: Self) -> Self::Builtin {
+        obj.to_string()
+    }
+}

--- a/components/webext-storage/src/store.rs
+++ b/components/webext-storage/src/store.rs
@@ -28,11 +28,11 @@ use serde_json::Value as JsonValue;
 /// Note that our Db implementation is behind an Arc<> because we share that
 /// connection with our sync engines - ie, these engines also hold an Arc<>
 /// around the same object.
-pub struct Store {
+pub struct WebExtStorageStore {
     db: Arc<ThreadSafeStorageDb>,
 }
 
-impl Store {
+impl WebExtStorageStore {
     /// Creates a store backed by a database at `db_path`. The path can be a
     /// file path or `file:` URI.
     pub fn new(db_path: impl AsRef<Path>) -> Result<Self> {
@@ -153,7 +153,7 @@ impl Store {
                 // connections, and the next rusqlite version will not panic anyway.
                 // So this-is-fine.jpg
                 log::warn!("Attempting to close a store while other DB references exist.");
-                return Err(ErrorKind::OtherConnectionReferencesExist.into());
+                return Err(Error::OtherConnectionReferencesExist);
             }
         };
         // consume the mutex and get back the inner.
@@ -207,11 +207,11 @@ pub mod test {
     fn test_send() {
         fn ensure_send<T: Send>() {}
         // Compile will fail if not send.
-        ensure_send::<Store>();
+        ensure_send::<WebExtStorageStore>();
     }
 
-    pub fn new_mem_store() -> Store {
-        Store {
+    pub fn new_mem_store() -> WebExtStorageStore {
+        WebExtStorageStore {
             db: Arc::new(ThreadSafeStorageDb::new(crate::db::test::new_mem_db())),
         }
     }

--- a/components/webext-storage/src/sync/bridge.rs
+++ b/components/webext-storage/src/sync/bridge.rs
@@ -50,7 +50,7 @@ impl BridgedEngine {
     fn thread_safe_storage_db(&self) -> Result<Arc<ThreadSafeStorageDb>> {
         self.db
             .upgrade()
-            .ok_or_else(|| crate::error::ErrorKind::DatabaseConnectionClosed.into())
+            .ok_or_else(|| crate::error::Error::DatabaseConnectionClosed.into())
     }
 }
 
@@ -184,7 +184,7 @@ impl sync15::engine::BridgedEngine for BridgedEngine {
 
 impl From<anyhow::Error> for crate::error::Error {
     fn from(value: anyhow::Error) -> Self {
-        crate::error::ErrorKind::SyncError(value.to_string()).into()
+        crate::error::Error::SyncError(value.to_string())
     }
 }
 

--- a/components/webext-storage/src/webext-storage.udl
+++ b/components/webext-storage/src/webext-storage.udl
@@ -1,0 +1,50 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+[Custom]
+typedef string JsonValue;
+
+namespace webextstorage {
+
+};
+
+enum QuotaReason {
+    "TotalBytes",
+    "ItemBytes",
+    "MaxItems",
+};
+
+[Error]
+interface WebExtStorageApiError {
+    UnexpectedError(string reason);
+    JsonError(string reason);
+    QuotaError(QuotaReason reason);
+};
+
+dictionary StorageValueChange {
+    string key;
+    JsonValue? old_value;
+    JsonValue? new_value;
+};
+
+dictionary StorageChanges {
+    sequence<StorageValueChange> changes;
+};
+
+interface WebExtStorageStore {
+    [Throws=WebExtStorageApiError]
+    constructor(string path);
+
+    [Throws=WebExtStorageApiError]
+    StorageChanges set([ByRef] string ext_id, JsonValue val);
+
+    [Throws=WebExtStorageApiError]
+    JsonValue get([ByRef] string ext_id, JsonValue keys);
+
+    [Throws=WebExtStorageApiError]
+    StorageChanges remove([ByRef] string ext_id, JsonValue keys);
+
+    [Throws=WebExtStorageApiError]
+    StorageChanges clear([ByRef] string ext_id);
+};

--- a/components/webext-storage/uniffi.toml
+++ b/components/webext-storage/uniffi.toml
@@ -1,0 +1,3 @@
+[bindings.kotlin]
+package_name = "mozilla.appservices.webextstorage"
+cdylib_name = "megazord"

--- a/megazords/full/Cargo.toml
+++ b/megazords/full/Cargo.toml
@@ -13,6 +13,8 @@ fxa-client = { path = "../../components/fxa-client" }
 logins = { path = "../../components/logins" }
 tabs = { path = "../../components/tabs/" }
 sync_manager = { path = "../../components/sync_manager/" }
+# TODO: Uncomment this code when webext-storage component is integrated in android
+# webext-storage = { path = "../../components/webext-storage/" }
 places = { path = "../../components/places" }
 push = { path = "../../components/push" }
 rc_log_ffi = { path = "../../components/rc_log" }

--- a/megazords/full/src/lib.rs
+++ b/megazords/full/src/lib.rs
@@ -25,6 +25,8 @@ pub use suggest;
 pub use sync_manager;
 pub use tabs;
 pub use viaduct;
+// TODO: Uncomment this code when webext-storage component is integrated in android
+// pub use webext_storage;
 
 /// In order to support the use case of consumers who don't know about megazords
 /// and don't need our e.g. networking or logging, we consider initialization

--- a/tools/update-moz-central-vendoring.py
+++ b/tools/update-moz-central-vendoring.py
@@ -16,6 +16,7 @@ def main():
     app_services_rev = get_app_services_rev()
     update_cargo_toml(moz_central_root / "Cargo.toml", app_services_rev)
     subprocess.run(["./mach", "vendor", "rust"], cwd=moz_central_root)
+    subprocess.run(["./mach", "uniffi", "generate"], cwd=moz_central_root)
 
     print("The vendoring was successful")
     print(" - If you saw a warning saying `There are 2 different versions of crate X`, then "


### PR DESCRIPTION
Re-merge the webext-storage uniffication changes first introduced in #5995 and backed out due to m-c vendoring issues.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
