### PR TITLE
Move finding the manifest and feature into inspector

### DIFF
--- a/components/support/nimbus-fml/src/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/intermediate_representation.rs
@@ -448,7 +448,7 @@ impl FeatureManifest {
             .ok_or_else(|| InvalidFeatureError(feature_name.to_string()))?;
 
         let merger = DefaultsMerger::new(&manifest.obj_defs, Default::default(), None);
-        let merged_value = merger.merge_feature_config(feature_def, &feature_value)?;
+        let merged_value = merger.merge_feature_config(feature_def, &feature_value);
 
         let validator = DefaultsValidator::new(&manifest.enum_defs, &manifest.obj_defs);
         let errors = validator.get_errors(feature_def, &merged_value, &feature_value);
@@ -463,34 +463,15 @@ impl FeatureManifest {
     #[cfg(feature = "client-lib")]
     pub(crate) fn merge_and_errors(
         &self,
-        feature_name: &str,
+        feature_def: &FeatureDef,
         feature_value: &Value,
-    ) -> Result<(Value, Vec<crate::editing::FeatureValidationError>)> {
-        let (manifest, feature_def) = self
-            .find_feature(feature_name)
-            .ok_or_else(|| InvalidFeatureError(feature_name.to_string()))?;
-        let merger = DefaultsMerger::new(&manifest.obj_defs, Default::default(), None);
-        let merged_value = merger.merge_feature_config(feature_def, feature_value)?;
+    ) -> (Value, Vec<crate::editing::FeatureValidationError>) {
+        let merger = DefaultsMerger::new(&self.obj_defs, Default::default(), None);
+        let merged_value = merger.merge_feature_config(feature_def, feature_value);
 
-        let validator = DefaultsValidator::new(&manifest.enum_defs, &manifest.obj_defs);
+        let validator = DefaultsValidator::new(&self.enum_defs, &self.obj_defs);
         let errors = validator.get_errors(feature_def, &merged_value, feature_value);
-        Ok((merged_value, errors))
-    }
-
-    pub fn get_schema_hash(&self, feature_name: &str) -> Result<String> {
-        let (manifest, feature_def) = self
-            .find_feature(feature_name)
-            .ok_or_else(|| InvalidFeatureError(feature_name.to_string()))?;
-
-        Ok(manifest.feature_schema_hash(feature_def))
-    }
-
-    pub fn get_defaults_hash(&self, feature_name: &str) -> Result<String> {
-        let (manifest, feature_def) = self
-            .find_feature(feature_name)
-            .ok_or_else(|| InvalidFeatureError(feature_name.to_string()))?;
-
-        Ok(manifest.feature_defaults_hash(feature_def))
+        (merged_value, errors)
     }
 }
 


### PR DESCRIPTION
Relates to [ EXP-3204](https://mozilla-hub.atlassian.net/browse/EXP-3204).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This PR: 

1. moves several calls to `find_feature` (which returns a feature and a manifest) from the FeatureManifest class into the FeatureInspector struct.
2. There is a second change which is only tangentially related, which is removing the `Result<_>` from the `DefaultsMerger`. This was done to get rid of an `unreachable!()` in `get_semantic_errors` which was uncovered when simplifying the method after the first move. 


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
