### PR TITLE
Don't report sentry errors for metadata view times too long

### DIFF
--- a/components/places/src/error.rs
+++ b/components/places/src/error.rs
@@ -268,6 +268,12 @@ impl GetErrorHandling for Error {
                     .report_error("places-unexpected-sync-error"),
                 }
             }
+            Error::InvalidMetadataObservation(InvalidMetadataObservation::ViewTimeTooLong) => {
+                ErrorHandling::convert(PlacesApiError::UnexpectedPlacesException {
+                    reason: self.to_string(),
+                })
+                .log_warning()
+            }
             _ => ErrorHandling::convert(PlacesApiError::UnexpectedPlacesException {
                 reason: self.to_string(),
             })


### PR DESCRIPTION
We're getting around 50-75 reports of these a day in Sentry for Fenix nightly and I don't think they're useful.

- [search for the Sentry errors](https://mozilla.sentry.io/discover/results/?field=title&field=release&field=environment&field=user.display&field=timestamp&name=places-unexpected-error%3A+Invalid+metadata+observation%3A+Observed+view+time+is+invalid+%28too+long%29&project=6295546&query=Observed+view+time+is+invalid+%28too+long%29&sort=-timestamp&statsPeriod=7d&yAxis=count%28%29)
- [the android-components code that I believe causes this](https://github.com/mozilla-mobile/firefox-android/blob/205ece4bf9234d24135ee780f886367d64b11735/fenix/app/src/main/java/org/mozilla/fenix/historymetadata/HistoryMetadataService.kt#L92-L121)

Maybe there's a bug in that code that we could fix (for example not reporting an observation if the `tab.id` key is missing), but I'm not sure it's worth it.  I also could see plenty of reasons for valid code to cause this, for example if the user's clock is adjusted.  I'm currently thinking that the best policy is to just ignore and clean up our sentry reports.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
