### PR TITLE
Filter out non-alphanumeric prefixes for completions

### DIFF
--- a/components/support/nimbus-fml/src/editing/error_converter.rs
+++ b/components/support/nimbus-fml/src/editing/error_converter.rs
@@ -148,7 +148,14 @@ impl ErrorConverter<'_> {
             ErrorKind::InvalidKey { key_type: t, .. }
             | ErrorKind::InvalidValue { value_type: t, .. }
             | ErrorKind::TypeMismatch { value_type: t } => values.all_specific_strings(t),
-            ErrorKind::InvalidPropKey { valid, .. } => valid.to_owned(),
+            // For property keys that we don't want to suggest to the user, but we _do_ want them involved in
+            // validation or code generation, we make them never/difficult to be overridden by an experiment,
+            // by filtering them here.
+            ErrorKind::InvalidPropKey { valid, .. } => valid
+                .iter()
+                .filter(|s| s.starts_with(char::is_alphanumeric))
+                .map(ToOwned::to_owned)
+                .collect(),
             ErrorKind::InvalidNestedValue { .. } => Default::default(),
         };
 


### PR DESCRIPTION
Relates to [EXP-4154](https://mozilla-hub.atlassian.net/browse/EXP-4154).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

Very occassionally, feature engineer wish to make a property less discoverable by the experiment owner.

The property:

- is involved in validation of the rest of the configuration (e.g. via a string-alias)
- uses defaults from the feature manifest to generate code
- can be overridden by an experiment, but only _in extremis_ as an escape hatch with the feature engineer's help.

The alternative considered was having a `hidden` property on `PropDef`, but this is a whole lot more work for such a small feature.

This small PR adds a filter of the corrections suggested after an error is detected with a property. These corrections will drive autocomplete too.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
