### PR TITLE
Fix a typo in the branch naming when cutting a release

### DIFF
--- a/docs/howtos/releases.md
+++ b/docs/howtos/releases.md
@@ -26,7 +26,7 @@ Release builds are generated from the `release-vXXX` branches and triggered in S
 
 On Merge Day we take a snapshot of the current `main`, and prepare a release. See [Firefox Release Calendar](https://whattrainisitnow.com/calendar/).
 
-1. Create a branch name with the format `releases-v[release_version]` off of the `main` branch (for example, `release-v118`) through the GitHub UI.
+1. Create a branch name with the format `release-v[release_version]` off of the `main` branch (for example, `release-v118`) through the GitHub UI.
 `[release_version]` should follow the Firefox release number. See [Firefox Release Calendar](https://whattrainisitnow.com/calendar/).
 
 2. Create a PR against the release branch that updates `version.txt` and updates the `CHANGELOG.md` as follows:


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
