### PR TITLE
[ci full] Update NSS to 3.97

### DIFF
--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -2,10 +2,10 @@
 
 set -euvx
 
-NSS="nss-3.93"
-NSS_ARCHIVE="nss-3.93-with-nspr-4.35.tar.gz"
-NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_93_RTM/src/${NSS_ARCHIVE}"
-NSS_SHA256="4a5b5df21f8accc65b80d38b6acf8b017a5d03b5f81f0d23295a11575f300183"
+NSS="nss-3.97"
+NSS_ARCHIVE="nss-3.97-with-nspr-4.35.tar.gz"
+NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_97_RTM/src/${NSS_ARCHIVE}"
+NSS_SHA256="a7a920d295998563b33d9e06c1a36b799201493d81b64537fab42f2a733411ce"
 
 # End of configuration.
 

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -62,8 +62,8 @@ if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
     # run-task has already downloaded + extracted the dependency
     NSS_DIST_DIR="${MOZ_FETCHES_DIR}/dist"
   else
-    curl -sfSL --retry 5 --retry-delay 10 -O "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/app-services.cache.level-3.content.v1.nss-artifact.latest/artifacts/public/dist.tar.bz2"
-    SHA256="15e8cab63a4e0484564231a24d23d8be349217ba6add53b56609c339bb306829"
+    curl -sfSL --retry 5 --retry-delay 10 -O "https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/yFaMDJo8TgSJeZ51Npqxbg/runs/0/artifacts/public/dist.tar.bz2"
+    SHA256="1f4ba2d130a59f3c95e316d39667fc8a0e9d5db052469091ed17bef18a563066"
     echo "${SHA256}  dist.tar.bz2" | shasum -a 256 -c - || exit 2
     tar xvjf dist.tar.bz2 && rm -rf dist.tar.bz2
     NSS_DIST_DIR=$(abspath "dist")

--- a/libs/macos-cc-tools.manifest
+++ b/libs/macos-cc-tools.manifest
@@ -1,13 +1,5 @@
 [
   {
-    "size": 31991917,
-    "visibility": "internal",
-    "digest": "c5c0be09972b56b5980dc9d06b61ff49cf58c4572913437256a79b202e19e936af3c0ab0924df72b9f648d518c257597f84800a84bb80e68af4eabdaf1df5f24",
-    "algorithm": "sha512",
-    "unpack": true,
-    "filename": "MacOSX10.12.sdk.tar.xz"
-  },
-  {
     "size": 68798037,
     "visibility": "internal",
     "digest": "5bdc3270d0b660889b66194aa8cbcdbdb9163188bf976f31cc87837e6b0b5590db8d76cc17e9ea863b50f6735779cfd4338a4121997888b13139f4af1fdbb504",

--- a/libs/macos-cc-tools.manifest
+++ b/libs/macos-cc-tools.manifest
@@ -6,5 +6,13 @@
     "algorithm": "sha512",
     "unpack": true,
     "filename": "MacOSX10.12.sdk.tar.xz"
+  },
+  {
+    "size": 68798037,
+    "visibility": "internal",
+    "digest": "5bdc3270d0b660889b66194aa8cbcdbdb9163188bf976f31cc87837e6b0b5590db8d76cc17e9ea863b50f6735779cfd4338a4121997888b13139f4af1fdbb504",
+    "algorithm": "sha512",
+    "unpack": true,
+    "filename": "MacOSX11.0.sdk.tar.zst"
   }
 ]

--- a/taskcluster/kinds/fetch/kind.yml
+++ b/taskcluster/kinds/fetch/kind.yml
@@ -37,6 +37,6 @@ tasks:
         description: fetches the built NSS artifacts from NSS CI
         fetch:
             type: static-url
-            url: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/bez00P-rQwutueyGXoy5Wg/runs/0/artifacts/public/dist.tar.bz2
-            sha256: 9913a33376ef849903ebd5f032106ef420416aef599030d57641786a2c6a02e5
-            size: 22735146
+            url: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/yFaMDJo8TgSJeZ51Npqxbg/runs/0/artifacts/public/dist.tar.bz2
+            sha256: 1f4ba2d130a59f3c95e316d39667fc8a0e9d5db052469091ed17bef18a563066
+            size: 23671514

--- a/taskcluster/scripts/toolchain/cross-compile-setup.sh
+++ b/taskcluster/scripts/toolchain/cross-compile-setup.sh
@@ -11,9 +11,9 @@ export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_TOOLCHA
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_AR=/builds/worker/cctools/bin/x86_64-apple-darwin-ar
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RANLIB=/builds/worker/cctools/bin/x86_64-apple-darwin-ranlib
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_LD_LIBRARY_PATH=/builds/worker/clang/lib
-export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C linker=/builds/worker/clang/bin/clang -C link-arg=-fuse-ld=/builds/worker/cctools/bin/x86_64-apple-darwin-ld -C link-arg=-B -C link-arg=/builds/worker/cctools/bin -C link-arg=-target -C link-arg=x86_64-apple-darwin -C link-arg=-isysroot -C link-arg=/tmp/MacOSX10.12.sdk -C link-arg=-Wl,-syslibroot,/tmp/MacOSX10.12.sdk -C link-arg=-Wl,-dead_strip"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C linker=/builds/worker/clang/bin/clang -C link-arg=-fuse-ld=/builds/worker/cctools/bin/x86_64-apple-darwin-ld -C link-arg=-B -C link-arg=/builds/worker/cctools/bin -C link-arg=-target -C link-arg=x86_64-apple-darwin -C link-arg=-isysroot -C link-arg=/tmp/MacOSX11.0.sdk -C link-arg=-Wl,-syslibroot,/tmp/MacOSX11.0.sdk -C link-arg=-Wl,-dead_strip"
 # For ring's use of `cc`.
-export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /builds/worker/cctools/bin -target x86_64-apple-darwin -isysroot /tmp/MacOSX10.12.sdk -Wl,-syslibroot,/tmp/MacOSX10.12.sdk -Wl,-dead_strip"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /builds/worker/cctools/bin -target x86_64-apple-darwin -isysroot /tmp/MacOSX11.0.sdk -Wl,-syslibroot,/tmp/MacOSX10.12.sdk -Wl,-dead_strip"
 
 # x86_64 Windows
 # The wrong linker gets used otherwise: https://github.com/rust-lang/rust/issues/33465.
@@ -44,5 +44,10 @@ tooltool.py \
   --url=http://taskcluster/tooltool.mozilla-releng.net/ \
   --manifest="/builds/worker/checkouts/vcs/libs/macos-cc-tools.manifest" \
   fetch
+# tooltool doesn't know how to unpack zstd-files,
+# so we do it manually.
+tar -I zstd -xf "MacOSX11.0.sdk.tar.zst"
 
 popd || exit
+
+set +eu

--- a/taskcluster/scripts/toolchain/cross-compile-setup.sh
+++ b/taskcluster/scripts/toolchain/cross-compile-setup.sh
@@ -13,7 +13,7 @@ export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RANLIB=
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_LD_LIBRARY_PATH=/builds/worker/clang/lib
 export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS="-C linker=/builds/worker/clang/bin/clang -C link-arg=-fuse-ld=/builds/worker/cctools/bin/x86_64-apple-darwin-ld -C link-arg=-B -C link-arg=/builds/worker/cctools/bin -C link-arg=-target -C link-arg=x86_64-apple-darwin -C link-arg=-isysroot -C link-arg=/tmp/MacOSX11.0.sdk -C link-arg=-Wl,-syslibroot,/tmp/MacOSX11.0.sdk -C link-arg=-Wl,-dead_strip"
 # For ring's use of `cc`.
-export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /builds/worker/cctools/bin -target x86_64-apple-darwin -isysroot /tmp/MacOSX11.0.sdk -Wl,-syslibroot,/tmp/MacOSX10.12.sdk -Wl,-dead_strip"
+export ORG_GRADLE_PROJECT_RUST_ANDROID_GRADLE_TARGET_X86_64_APPLE_DARWIN_CFLAGS_x86_64_apple_darwin="-B /builds/worker/cctools/bin -target x86_64-apple-darwin -isysroot /tmp/MacOSX11.0.sdk -Wl,-syslibroot,/tmp/MacOSX11.0.sdk -Wl,-dead_strip"
 
 # x86_64 Windows
 # The wrong linker gets used otherwise: https://github.com/rust-lang/rust/issues/33465.


### PR DESCRIPTION
(thanks @mhammond  for this thought) To successfully build NSS to 3.97, we had to bump the SDK to Mac OSX 11.0. This has the implication that the minimum version to build our android stuffs to require having Mac OSX SDK 11.0 or higher. 

While I don't think this will impact anyone whose updated their computer in the last couple of years, there is a slight chance that some older machines might run into trouble. I'll/we'll monitor this closely within the next couple of weeks.  



### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
