### PR TITLE
Re-order members of RemoteSettingsConfig UDL dict [firefox-android: main] [firefox-ios: main]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Webext-Storage
 - Uniffied the webext-storage component in preparation for desktop integration ([#6057](https://github.com/mozilla/application-services/pull/6057)).
 
+### Remote Settings
+- The Remote Settings UniFFI bindings have been changed. The
+  `RemoteSettingsConfig` dictionary has had its field re-ordered to [fix code
+  generation for the Python
+  bindings](https://bugzilla.mozilla.org/show_bug.cgi?id=1874030). This also
+  affects the Swift bindings, since Swift enforces argument ordering.
+
 [Full Changelog](In progress)
 
 [Full Changelog](In progress)

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -93,8 +93,8 @@ public extension Nimbus {
         let context = Nimbus.buildExperimentContext(appSettings)
         let remoteSettings = server.map { server -> RemoteSettingsConfig in
             RemoteSettingsConfig(
-                serverUrl: server.url.absoluteString,
-                collectionName: server.collection
+                collectionName: server.collection,
+                serverUrl: server.url.absoluteString
             )
         }
         let nimbusClient = try NimbusClient(

--- a/components/remote_settings/src/remote_settings.udl
+++ b/components/remote_settings/src/remote_settings.udl
@@ -8,9 +8,9 @@ typedef string RsJsonObject;
 namespace remote_settings {};
 
 dictionary RemoteSettingsConfig {
-    string? server_url = null;
-    string? bucket_name = null;
     string collection_name;
+    string? bucket_name = null;
+    string? server_url = null;
 };
 
 dictionary RemoteSettingsResponse {
@@ -54,7 +54,7 @@ interface RemoteSettings {
     [Throws=RemoteSettingsError]
     RemoteSettingsResponse get_records();
 
-    // Fetch all records added to the server since the provided timestamp, 
+    // Fetch all records added to the server since the provided timestamp,
     // using the configuration this client was initialized with.
     [Throws=RemoteSettingsError]
     RemoteSettingsResponse get_records_since(u64 timestamp);


### PR DESCRIPTION
The order of dictionary members matters to uniffi when they are used to generate arguments for Python functions. In this case, the order was generating a method signature with defaulted kwargs before undefaulted args, which is a syntax error. Re-arranging these members will result in generating a valid Python method signature. The Swift bindings also need updating, because Swift enforces argument order for named arguments, but Kotlin does not.

Fixes bug 1874030

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
