### PR TITLE
Prevents vendoring android/ios directories to desktop

### DIFF
--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 version = "0.1.0"
 authors = ["Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
-exclude = ["/android"]
+exclude = ["/android", "/ios"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 authors = ["The Android Mobile Team <firefox-android-team@mozilla.com>", "The Glean Team <glean-team@mozilla.com>"]
 description = "A Remote Settings client intended for application layer platforms."
 license = "MPL-2.0" 
-exclude = ["/android"]
+exclude = ["/android", "/ios"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/components/support/error/Cargo.toml
+++ b/components/support/error/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Thom Chiovoloni <tchiovoloni@mozilla.com>"]
 edition = "2021"
 license = "MPL-2.0"
 autotests = false
+exclude = ["/android"]
 
 [dependencies]
 log = "0.4"

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -4,6 +4,7 @@ edition = "2021"
 version = "0.1.0"
 authors = ["sync-team@mozilla.com"]
 license = "MPL-2.0"
+exclude = ["/android"]
 
 [features]
 default = []


### PR DESCRIPTION
I noticed we vendor the error-support android directory to desktop in https://searchfox.org/mozilla-central/source/third_party/rust/error-support/android, this prevents that from happening (and preemptively exclude it for other crates so they also don't end up there if we vendor them to desktop) 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
