### PR TITLE
Prepare Nimbus SDK for messaging transition

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -460,8 +460,8 @@ open class Nimbus(
         nimbusClient.dumpStateToLog()
     }
 
-    override fun createMessageHelper(additionalContext: JSONObject?): GleanPlumbMessageHelper =
-        GleanPlumbMessageHelper(
+    override fun createMessageHelper(additionalContext: JSONObject?): NimbusMessagingHelper =
+        NimbusMessagingHelper(
             nimbusClient.createTargetingHelper(additionalContext),
             nimbusClient.createStringHelper(additionalContext),
         )

--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/NimbusInterface.kt
@@ -25,7 +25,7 @@ typealias EnrolledExperiment = EnrolledExperiment
 /**
  * This is the main experiments API, which is exposed through the global [Nimbus] object.
  */
-interface NimbusInterface : FeaturesInterface, GleanPlumbInterface, NimbusEventStore {
+interface NimbusInterface : FeaturesInterface, NimbusMessagingInterface, NimbusEventStore {
 
     /**
      * Get the list of currently enrolled experiments
@@ -190,7 +190,7 @@ interface NimbusInterface : FeaturesInterface, GleanPlumbInterface, NimbusEventS
         get() = false
         set(_) = Unit
 
-    val events: NimbusEventStore
+    override val events: NimbusEventStore
         get() = this
 
     /**

--- a/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/MessagingHelperTests.kt
+++ b/components/nimbus/android/src/test/java/org/mozilla/experiments/nimbus/MessagingHelperTests.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 import java.util.concurrent.Executors
 
 @RunWith(RobolectricTestRunner::class)
-class GleanPlumbTests {
+class MessagingHelperTests {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 

--- a/components/nimbus/ios/Nimbus/Nimbus.swift
+++ b/components/nimbus/ios/Nimbus/Nimbus.swift
@@ -76,10 +76,6 @@ extension Nimbus: NimbusQueues {
 }
 
 extension Nimbus: NimbusEventStore {
-    public var events: NimbusEventStore {
-        self
-    }
-
     public func recordEvent(_ eventId: String) {
         recordEvent(1, eventId)
     }
@@ -425,6 +421,10 @@ extension Nimbus: NimbusMessagingProtocol {
         let stringHelper = try nimbusClient.createStringHelper(additionalContext: string)
         return NimbusMessagingHelper(targetingHelper: targetingHelper, stringHelper: stringHelper)
     }
+
+    public var events: NimbusEventStore {
+        self
+    }
 }
 
 public class NimbusDisabled: NimbusApi {
@@ -522,4 +522,6 @@ extension NimbusDisabled: NimbusMessagingProtocol {
     public func createMessageHelper<T: Encodable>(additionalContext _: T) throws -> NimbusMessagingHelperProtocol {
         try createMessageHelper()
     }
+
+    public var events: NimbusEventStore { self }
 }

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -242,7 +242,7 @@ interface NimbusClient {
     NimbusTargetingHelper create_targeting_helper(optional JsonObject? additional_context = null);
 
     // This provides a unified String interpolation library which exposes the application context.
-    // It's first use is in GleanPlumb message helper, to add extra parameters to URLs.
+    // It's first use is in the messaging helper, to add extra parameters to URLs.
     [Throws=NimbusError]
     NimbusStringHelper create_string_helper(optional JsonObject? additional_context = null);
 

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusMessagingTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusMessagingTests.swift
@@ -17,7 +17,7 @@ class NimbusMessagingTests: XCTestCase {
     }
 
     func createNimbus() throws -> NimbusMessagingProtocol {
-        let appSettings = NimbusAppSettings(appName: "GleanPlumbTest", channel: "nightly")
+        let appSettings = NimbusAppSettings(appName: "NimbusMessagingTests", channel: "nightly")
         let nimbusEnabled = try Nimbus.create(nil, appSettings: appSettings, dbPath: createDatabasePath())
         XCTAssert(nimbusEnabled is Nimbus)
         if let nimbus = nimbusEnabled as? Nimbus {
@@ -30,8 +30,8 @@ class NimbusMessagingTests: XCTestCase {
         let nimbus = try createNimbus()
 
         let helper = try nimbus.createMessageHelper()
-        XCTAssertTrue(try helper.evalJexl(expression: "app_name == 'GleanPlumbTest'"))
-        XCTAssertFalse(try helper.evalJexl(expression: "app_name == 'tseTbmulPnaelG'"))
+        XCTAssertTrue(try helper.evalJexl(expression: "app_name == 'NimbusMessagingTests'"))
+        XCTAssertFalse(try helper.evalJexl(expression: "app_name == 'not-the-app-name'"))
 
         // The JEXL evaluator should error for unknown identifiers
         XCTAssertThrowsError(try helper.evalJexl(expression: "appName == 'snake_case_only'"))
@@ -62,7 +62,7 @@ class NimbusMessagingTests: XCTestCase {
 
         let helper = try nimbus.createMessageHelper(additionalContext: ["test_value_from_json": 42])
 
-        XCTAssertEqual(helper.stringFormat(template: "{app_name} version {test_value_from_json}", uuid: nil), "GleanPlumbTest version 42")
+        XCTAssertEqual(helper.stringFormat(template: "{app_name} version {test_value_from_json}", uuid: nil), "NimbusMessagingTests version 42")
     }
 
     func testStringHelperWithUUID() throws {


### PR DESCRIPTION
Fixes [EXP-4284](https://mozilla-hub.atlassian.net/browse/EXP-4284).

This PR fixes a number of very small issues:

- renames GleanPlumb to NimbusMessaging or NimbusHelper
- It implements a cache in the JEXL helper.
- it exposes event store to the apps via the NimbusMessaging protocol/interface.
- it adds a destroy() method to JEXL helper in Android.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
