### PR TITLE
Update a number of crate package versions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,8 +25,21 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom",
  "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom",
+ "once_cell",
  "serde",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -176,7 +189,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -216,7 +229,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -241,7 +254,7 @@ name = "autofill"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger 0.7.1",
+ "env_logger",
  "error-support",
  "interrupt-support",
  "jwcrypto",
@@ -334,12 +347,6 @@ checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -420,9 +427,12 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block"
@@ -531,6 +541,12 @@ checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -666,7 +682,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -680,7 +696,7 @@ name = "cli-support"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger 0.7.1",
+ "env_logger",
  "fxa-client",
  "log",
  "sync15",
@@ -724,6 +740,16 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1026,6 +1052,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "dogear"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268360cf7696c0c2c83061edb6af090cfea85cbde7d1b8425d6e4ffe9f1c0ec9"
+checksum = "3f430ca247b6a905681a3cce3eb4f1a72062f3e8dc178e7660c1acd06c64ecce"
 dependencies = [
  "log",
  "smallbitvec",
@@ -1108,11 +1143,11 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
 name = "ece"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5463ffecc0677adcd786c4481f73b215714d4757edf2eb37a573c03d00459"
+checksum = "c2ea1d2f2cc974957a4e2575d8e5bb494549bab66338d6320c2789abcfff5746"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.21.2",
  "byteorder",
  "hex",
  "once_cell",
@@ -1165,26 +1200,14 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
- "atty",
- "humantime 1.3.0",
+ "humantime",
+ "is-terminal",
  "log",
  "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime 2.1.0",
- "log",
  "termcolor",
 ]
 
@@ -1244,7 +1267,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1410,9 +1433,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.7.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
@@ -1439,12 +1462,10 @@ dependencies = [
 
 [[package]]
 name = "find-places-db"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1594bf39a5c2a21fb4ea7fd6f6cfeeeba9ece09012d9c6081349c5de1c441076"
+version = "0.1.0"
 dependencies = [
  "anyhow",
- "dirs",
+ "dirs 4.0.0",
  "log",
 ]
 
@@ -1496,19 +1517,18 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
 [[package]]
 name = "fraction"
-version = "0.9.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3510011eee8825018be07f08d9643421de007eaf62a3bde58d89b058abfa7"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
 dependencies = [
  "lazy_static",
  "num",
@@ -1679,8 +1699,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1744,7 +1766,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1764,12 +1786,12 @@ dependencies = [
 
 [[package]]
 name = "hawk"
-version = "3.2.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7539c8d8699bae53238aacd3f93cfb0bcaef77b85dc963902b9367c5d7a84c48"
+checksum = "f42afdd0e58859aa7b944db9125bdddb5437233161726c20578fbb73c776f440"
 dependencies = [
  "anyhow",
- "base64 0.12.3",
+ "base64 0.13.0",
  "log",
  "once_cell",
  "thiserror",
@@ -1863,15 +1885,6 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
-
-[[package]]
-name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -1945,11 +1958,10 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -2023,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "iso8601"
-version = "0.4.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b94fbeb759754d87e1daea745bc8efd3037cd16980331fe1d1524c9a79ce96"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
 ]
@@ -2075,6 +2087,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "039022cdf4d7b1cf548d31f60ae783138e5fd42013f6271049d7df7afadef96c"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "js-sys"
 version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2085,19 +2117,22 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.13.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e398ffb23c1c311c417ef5e72e8699c3822dbf835468f009c6ce91b6c206b"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
- "ahash",
+ "ahash 0.8.7",
+ "anyhow",
  "base64 0.21.2",
  "bytecount",
  "fancy-regex",
  "fraction",
+ "getrandom",
  "iso8601",
- "itoa 0.4.8",
- "lazy_static",
+ "itoa 1.0.9",
+ "memchr",
  "num-cmp",
+ "once_cell",
  "parking_lot",
  "percent-encoding",
  "regex",
@@ -2220,29 +2255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
 
 [[package]]
-name = "lmdb-rkv"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447a296f7aca299cfbb50f4e4f3d49451549af655fb7215d7f8c0c3d64bad42b"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "libc",
- "lmdb-rkv-sys",
-]
-
-[[package]]
-name = "lmdb-rkv-sys"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b9ce6b3be08acefa3003c57b7565377432a89ec24476bbe72e11d101f852fe"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "local-ip-address"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,19 +2278,16 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "logins"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger 0.7.1",
+ "env_logger",
  "error-support",
  "interrupt-support",
  "jwcrypto",
@@ -2330,12 +2339,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "matchit"
@@ -2553,6 +2556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "neli"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2653,7 +2662,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "clap 2.34.0",
- "env_logger 0.7.1",
+ "env_logger",
  "error-support",
  "glean-build",
  "hex",
@@ -2739,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.2.1"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -2753,9 +2762,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.2.6"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2770,11 +2779,10 @@ checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
@@ -2801,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -2813,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -3041,9 +3049,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -3072,7 +3080,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3101,7 +3109,7 @@ dependencies = [
  "bitflags 1.3.2",
  "caseless",
  "dogear",
- "env_logger 0.7.1",
+ "env_logger",
  "error-support",
  "idna",
  "interrupt-support",
@@ -3144,7 +3152,7 @@ name = "places-integration-tests"
 version = "0.1.0"
 dependencies = [
  "dogear",
- "env_logger 0.7.1",
+ "env_logger",
  "parking_lot",
  "places",
  "rusqlite",
@@ -3246,7 +3254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c64d9ba0963cdcea2e1b2230fbae2bab30eb25a174be395c41e764bfb65dd62"
 dependencies = [
  "proc-macro2",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3323,7 +3331,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.26",
+ "syn 2.0.32",
  "tempfile",
  "which",
 ]
@@ -3338,7 +3346,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3367,7 +3375,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.2",
  "bincode",
- "env_logger 0.8.4",
+ "env_logger",
  "error-support",
  "hex",
  "lazy_static",
@@ -3387,12 +3395,6 @@ dependencies = [
  "viaduct",
  "viaduct-reqwest",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -3445,6 +3447,12 @@ dependencies = [
 [[package]]
 name = "rate-limiter"
 version = "0.1.0"
+
+[[package]]
+name = "raw-window-handle"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
 
 [[package]]
 name = "rayon"
@@ -3634,17 +3642,16 @@ dependencies = [
 
 [[package]]
 name = "rkv"
-version = "0.17.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6006704273063c72952370ad236b8d58556dcc4f99a95ced4d9ad40f3e80a69"
+checksum = "2c6d906922d99c677624d2042a93f89b2b7df0f6411032237d5d99a602c2487c"
 dependencies = [
  "arrayref",
  "bincode",
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "byteorder",
  "id-arena",
  "lazy_static",
- "lmdb-rkv",
  "log",
  "ordered-float",
  "paste",
@@ -3661,7 +3668,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
 dependencies = [
- "bitflags 2.3.1",
+ "bitflags 2.4.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -3846,7 +3853,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4020,7 +4027,7 @@ dependencies = [
 name = "sql-support"
 version = "0.1.0"
 dependencies = [
- "env_logger 0.7.1",
+ "env_logger",
  "ffi-support",
  "interrupt-support",
  "lazy_static",
@@ -4080,7 +4087,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "env_logger 0.7.1",
+ "env_logger",
  "error-support",
  "expect-test",
  "hex",
@@ -4112,9 +4119,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4139,7 +4146,7 @@ dependencies = [
  "anyhow",
  "base16",
  "base64 0.21.2",
- "env_logger 0.7.1",
+ "env_logger",
  "error-support",
  "ffi-support",
  "interrupt-support",
@@ -4201,7 +4208,7 @@ name = "tabs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger 0.8.4",
+ "env_logger",
  "error-support",
  "interrupt-support",
  "lazy_static",
@@ -4238,7 +4245,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
- "dirs",
+ "dirs 2.0.2",
  "winapi",
 ]
 
@@ -4409,7 +4416,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4467,7 +4474,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ac8060a61f8758a61562f6fb53ba3cbe1ca906f001df2e53cccddcdbee91e7c"
 dependencies = [
- "bitflags 2.3.1",
+ "bitflags 2.4.2",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4533,7 +4540,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4624,9 +4631,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -4645,9 +4652,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
@@ -4727,7 +4734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce082833f0fcaf6fc221fbab26720440daf99381f5a71e89b6e23375eb6ea770"
 dependencies = [
  "quote",
- "syn 2.0.26",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4759,7 +4766,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.26",
+ "syn 2.0.32",
  "toml",
  "uniffi_build",
  "uniffi_meta",
@@ -4822,13 +4829,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
  "serde",
 ]
@@ -4841,9 +4847,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "0.8.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
  "serde",
@@ -5083,13 +5089,19 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.5.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecad156490d6b620308ed411cfee90d280b3cbd13e189ea0d3fada8acc89158a"
+checksum = "97d1fa1e5c829b2bf9eb1e28fb950248b797cd6a04866fbdfa8bc31e5eef4c78"
 dependencies = [
+ "core-foundation",
+ "dirs 4.0.0",
+ "jni",
+ "log",
+ "ndk-context",
+ "objc",
+ "raw-window-handle",
+ "url",
  "web-sys",
- "widestring",
- "winapi",
 ]
 
 [[package]]
@@ -5097,7 +5109,7 @@ name = "webext-storage"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "env_logger 0.7.1",
+ "env_logger",
  "error-support",
  "ffi-support",
  "interrupt-support",
@@ -5159,12 +5171,6 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
 ]
-
-[[package]]
-name = "widestring"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
@@ -5473,4 +5479,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "components/suggest",
     "components/support/error",
     "components/support/error/tests",
+    "components/support/find-places-db",
     "components/support/guid",
     "components/support/interrupt",
     "components/support/jwcrypto",

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -18,7 +18,6 @@ the details of which are reproduced below.
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
-* [MIT License: matches](#mit-license-matches)
 * [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
@@ -514,8 +513,6 @@ The following text applies to code linked from these dependencies:
 [lazycell](https://github.com/indiv0/lazycell),
 [libc](https://github.com/rust-lang/libc),
 [linux-raw-sys](https://github.com/sunfishcode/linux-raw-sys),
-[lmdb-rkv-sys](https://github.com/mozilla/lmdb-rs.git),
-[lmdb-rkv](https://github.com/mozilla/lmdb-rs.git),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
 [mime](https://github.com/hyperium/mime),
@@ -1174,40 +1171,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: matches
-
-The following text applies to code linked from these dependencies:
-[matches](https://github.com/SimonSapin/rust-std-candidates)
-
-```
-Copyright (c) 2014-2016 Simon Sapin
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 
 ```
 -------------

--- a/components/autofill/Cargo.toml
+++ b/components/autofill/Cargo.toml
@@ -28,7 +28,7 @@ uniffi = { workspace = true }
 url = { version = "2.2", features = ["serde"] }
 
 [dev-dependencies]
-env_logger = { version = "0.7", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 libsqlite3-sys = { workspace = true }
 
 [build-dependencies]

--- a/components/logins/Cargo.toml
+++ b/components/logins/Cargo.toml
@@ -36,4 +36,4 @@ uniffi = { workspace = true, features = ["build"] }
 [dev-dependencies]
 more-asserts = "0.2"
 tempfile = "3.2.0"
-env_logger = { version = "0.7", default-features = false }
+env_logger = { version = "0.10", default-features = false }

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -26,10 +26,10 @@ serde_derive = "1"
 serde_json = "1"
 log = "0.4"
 thiserror = "1"
-url = "2.2"
-rkv = { version = "0.17", optional = true }
+url = "2.5"
+rkv = { version = "0.19", optional = true }
 jexl-eval = "0.2.2"
-uuid = { version = "0.8", features = ["serde", "v4"]}
+uuid = { version = "1.7", features = ["serde", "v4"]}
 sha2 = "^0.10"
 hex = "0.4"
 once_cell = "1"
@@ -46,6 +46,6 @@ glean-build = { path = "../external/glean/glean-core/build" }
 
 [dev-dependencies]
 viaduct-reqwest = { path = "../support/viaduct-reqwest" }
-env_logger = "0.7"
+env_logger = "0.10"
 clap = "2.33.3"
 tempfile = "3"

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -48,7 +48,7 @@ fn main() -> Result<()> {
     // To manually set the log level, you can set the `RUST_LOG` environment variable
     // Possible values are "info", "debug", "warn" and "error"
     // Check [`env_logger`](https://docs.rs/env_logger/) for more details
-    env_logger::from_env(Env::default().default_filter_or("info")).init();
+    env_logger::Builder::from_env(Env::default().default_filter_or("info")).init();
     viaduct_reqwest::use_reqwest_backend();
 
     // Initiate the matches for the command line arguments

--- a/components/places/Cargo.toml
+++ b/components/places/Cargo.toml
@@ -26,9 +26,9 @@ rusqlite = { workspace = true, features = ["functions", "window", "bundled", "un
 sql-support = { path = "../support/sql" }
 types = { path = "../support/types" }
 bitflags = "1.2"
-idna = "0.2"
+idna = "0.5"
 memchr = "2.3"
-dogear = "0.4"
+dogear = "0.5"
 interrupt-support = { path = "../support/interrupt" }
 error-support = { path = "../support/error" }
 sync-guid = { path = "../support/guid", features = ["rusqlite_support", "random"]}
@@ -39,7 +39,7 @@ uniffi = { workspace = true }
 [dev-dependencies]
 pretty_assertions = "0.6"
 tempfile = "3.1"
-env_logger = {version = "0.7", default-features = false}
+env_logger = {version = "0.10", default-features = false}
 sql-support = { path = "../support/sql" }
 
 [build-dependencies]

--- a/components/push/Cargo.toml
+++ b/components/push/Cargo.toml
@@ -27,7 +27,7 @@ types = { path = "../support/types" }
 uniffi = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
-env_logger = { version = "0.8", default-features = false, features = ["termcolor", "atty", "humantime"] }
+env_logger = { version = "0.10", default-features = false, features = ["humantime"] }
 mockito = "0.31"
 hex = "0.4"
 tempfile = "3.1.0"

--- a/components/suggest/Cargo.toml
+++ b/components/suggest/Cargo.toml
@@ -25,7 +25,7 @@ uniffi = { workspace = true }
 url = { version = "2.1", features = ["serde"] }
 
 [dev-dependencies]
-env_logger = { version = "0.7", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 expect-test = "1.4"
 hex = "0.4"
 rc_crypto = { path = "../support/rc_crypto" }

--- a/components/support/find-places-db/Cargo.toml
+++ b/components/support/find-places-db/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "find-places-db"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+dirs = "4"
+anyhow = "1.0"
+log = "0.4"

--- a/components/support/find-places-db/README.md
+++ b/components/support/find-places-db/README.md
@@ -1,0 +1,2 @@
+This crate is used only be examples and utilities to help you locate
+various places databases from any Desktop Firefoxes you have installed.

--- a/components/support/find-places-db/src/lib.rs
+++ b/components/support/find-places-db/src/lib.rs
@@ -1,0 +1,107 @@
+// Forked from https://github.com/thomcc/find-places-dbs, which was itself
+// originally in app-services, then split out for general-purpose use, but
+// then became unmaintained and publiched to crates.io without a Mozilla owner.
+// If we ever need to split it out again we should contact Thom, who I'm sure
+// would be happy to give us ownership of the crate.
+
+use anyhow::{bail, format_err, Result};
+use log::{debug, info, trace, warn};
+use std::{fs, path::PathBuf, process};
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PlacesLocation {
+    pub profile_name: String,
+    pub path: PathBuf,
+    pub db_size: u64,
+}
+
+impl PlacesLocation {
+    pub fn friendly_db_size(&self) -> String {
+        let sizes = [
+            (1024 * 1024 * 1024, "Gb"),
+            (1024 * 1024, "Mb"),
+            (1024, "Kb"),
+        ];
+        for (lim, suffix) in &sizes {
+            if self.db_size >= *lim {
+                return format!(
+                    "~{} {}",
+                    ((self.db_size as f64 / *lim as f64) * 10.0).round() / 10.0,
+                    suffix
+                );
+            }
+        }
+        format!("{} bytes", self.db_size)
+    }
+}
+
+pub fn get_all_places_dbs() -> Result<Vec<PlacesLocation>> {
+    let mut path = match dirs::home_dir() {
+        Some(dir) => dir,
+        None => bail!("No home directory found!"),
+    };
+    if cfg!(windows) {
+        path.extend(&["AppData", "Roaming", "Mozilla", "Firefox", "Profiles"]);
+    } else {
+        let out = String::from_utf8(process::Command::new("uname").args(["-s"]).output()?.stdout)?;
+        info!("Uname says: {:?}", out);
+        if out.trim() == "Darwin" {
+            // ~/Library/Application Support/Firefox/Profiles
+            path.extend(&["Library", "Application Support", "Firefox", "Profiles"]);
+        } else {
+            // I'm not actually sure if this is true for all non-macos unix likes.
+            path.extend(&[".mozilla", "firefox"]);
+        }
+    }
+    debug!("Using profile path: {:?}", path);
+    let mut res = fs::read_dir(path)?
+        .map(|entry_result| {
+            let entry = entry_result?;
+            trace!("Considering path {:?}", entry.path());
+            if !entry.path().is_dir() {
+                trace!("  Not dir: {:?}", entry.path());
+                return Ok(None);
+            }
+            let mut path = entry.path().to_owned();
+            let profile_name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_str()
+                .ok_or_else(|| {
+                    warn!("  Path has invalid UTF8: {:?}", path);
+                    format_err!("Path has invalid UTF8: {:?}", path)
+                })?
+                .into();
+            path.push("places.sqlite");
+            if !path.exists() {
+                return Ok(None);
+            }
+            let metadata = fs::metadata(&path)?;
+            let db_size = metadata.len();
+            Ok(Some(PlacesLocation {
+                profile_name,
+                path,
+                db_size,
+            }))
+        })
+        .filter_map(|result: Result<Option<PlacesLocation>>| match result {
+            Ok(val) => val,
+            Err(e) => {
+                debug!("Got error finding profile directory, skipping: {}", e);
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    res.sort_by(|a, b| b.db_size.cmp(&a.db_size));
+    Ok(res)
+}
+
+pub fn get_largest_places_db() -> Result<Option<PlacesLocation>> {
+    let all = get_all_places_dbs()?;
+    if all.is_empty() {
+        warn!("No places dbs!");
+        return Ok(None);
+    }
+    // Already sorted by size (descending)
+    Ok(Some(all.into_iter().next().unwrap()))
+}

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -40,4 +40,4 @@ uniffi = { workspace = true, features = ["build"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"
-jsonschema = { version = "0.13", default-features = false }
+jsonschema = { version = "0.17", default-features = false }

--- a/components/support/rc_crypto/Cargo.toml
+++ b/components/support/rc_crypto/Cargo.toml
@@ -14,8 +14,8 @@ hex = "0.4"
 thiserror = "1.0"
 error-support = { path = "../error" }
 nss = { path = "nss" }
-hawk = { version = "3.2", default-features = false, optional = true }
-ece = { version = "2.1", default-features = false, features = ["serializable-keys"], optional = true }
+hawk = { version = "4", default-features = false, optional = true }
+ece = { version = "2.3", default-features = false, features = ["serializable-keys"], optional = true }
 
 [dev-dependencies]
 

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -21,7 +21,7 @@ prettytable-rs = { version = "0.10", optional = true }
 rusqlite = { workspace = true, features = ["functions", "limits", "bundled", "unlock_notify"] }
 
 [dev-dependencies]
-env_logger = {version = "0.7", default-features = false}
+env_logger = {version = "0.10", default-features = false}
 
 [build-dependencies]
 nss_build_common = { path = "../rc_crypto/nss/nss_build_common" }

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -65,7 +65,7 @@ url = { version = "2.1", optional = true } # mozilla-central can't yet take 2.2 
 viaduct = { path = "../viaduct", optional = true }
 
 [dev-dependencies]
-env_logger = { version = "0.7", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -24,7 +24,7 @@ uniffi = { workspace = true }
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 
 [dev-dependencies]
-env_logger = { version = "0.8.0", default-features = false, features = ["termcolor", "atty", "humantime"] }
+env_logger = { version = "0.10.0", default-features = false, features = ["humantime"] }
 tempfile = "3.1"
 
 [build-dependencies]

--- a/components/webext-storage/Cargo.toml
+++ b/components/webext-storage/Cargo.toml
@@ -29,7 +29,7 @@ uniffi = { workspace = true }
 url = { version = "2.1", features = ["serde"] }
 
 [dev-dependencies]
-env_logger = { version = "0.7", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 tempfile = "3"
 # A *direct* dep on the -sys crate is required for our build.rs
 # to see the DEP_SQLITE3_LINK_TARGET env var that cargo sets

--- a/examples/cli-support/Cargo.toml
+++ b/examples/cli-support/Cargo.toml
@@ -11,12 +11,12 @@ fxa-client = { path = "../../components/fxa-client" }
 sync_manager = { path = "../../components/sync_manager" }
 log = "0.4"
 sync15 = { path = "../../components/sync15", features=["sync-client"] }
-url = "2.2"
-webbrowser = "0.5"
+url = "2"
+webbrowser = "0.8"
 # disable regex feature, as it's very costly for compile time and very rarely
 # used.
 
 [dependencies.env_logger]
-version = "0.7"
+version = "0.10"
 default-features = false
-features = ["termcolor", "atty", "humantime"]
+features = ["humantime"]

--- a/examples/places-autocomplete/Cargo.toml
+++ b/examples/places-autocomplete/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/autocomplete.rs"
 [dev-dependencies]
 places = { path = "../../components/places" }
 log = "0.4"
-url = "2.2"
+url = "2"
 anyhow = "1.0"
 interrupt-support = { path = "../../components/support/interrupt" }
 sql-support = { path = "../../components/support/sql" }
@@ -21,7 +21,7 @@ types = { path = "../../components/support/types" }
 clap = "2.33"
 tempfile = "3.1"
 rand = "0.8"
-find-places-db = "0.2"
+find-places-db = { path = "../../components/support/find-places-db" }
 rusqlite = { workspace = true, features = ["functions", "bundled"] }
 
 # While we don't have a replacement for termion on Windows yet (and thus

--- a/examples/places-utils/Cargo.toml
+++ b/examples/places-utils/Cargo.toml
@@ -23,11 +23,11 @@ serde = "1"
 serde_derive = "1"
 serde_json = "1"
 log = "0.4"
-url = "2.2"
+url = "2"
 cli-support = { path = "../cli-support" }
 structopt = "0.3"
 fxa-client = { path = "../../components/fxa-client" }
 tempfile = "3"
-find-places-db = "0.2"
+find-places-db = { path = "../../components/support/find-places-db" }
 anyhow = "1.0"
 ctrlc = "3.2.1"

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -14,7 +14,6 @@ the details of which are reproduced below.
 * [MIT License: generic-array](#mit-license-generic-array)
 * [MIT License: goblin](#mit-license-goblin)
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
-* [MIT License: matches](#mit-license-matches)
 * [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: nom](#mit-license-nom)
 * [MIT License: ordered-float](#mit-license-ordered-float)
@@ -474,8 +473,6 @@ The following text applies to code linked from these dependencies:
 [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
 [libc](https://github.com/rust-lang/libc),
 [linux-raw-sys](https://github.com/sunfishcode/linux-raw-sys),
-[lmdb-rkv-sys](https://github.com/mozilla/lmdb-rs.git),
-[lmdb-rkv](https://github.com/mozilla/lmdb-rs.git),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
 [mime](https://github.com/hyperium/mime),
@@ -989,40 +986,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: matches
-
-The following text applies to code linked from these dependencies:
-[matches](https://github.com/SimonSapin/rust-std-candidates)
-
-```
-Copyright (c) 2014-2016 Simon Sapin
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 
 ```
 -------------

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -253,14 +253,6 @@ the details of which are reproduced below.
     <url>https://github.com/sunfishcode/linux-raw-sys/blob/main/LICENSE-APACHE</url>
   </license>
   <license>
-    <name>Apache License 2.0: lmdb-rkv</name>
-    <url>https://github.com/mozilla/lmdb-rs/blob/master/LICENSE</url>
-  </license>
-  <license>
-    <name>Apache License 2.0: lmdb-rkv-sys</name>
-    <url>https://github.com/mozilla/lmdb-rs/blob/master/LICENSE</url>
-  </license>
-  <license>
     <name>Apache License 2.0: lock_api</name>
     <url>https://github.com/Amanieu/parking_lot/blob/master/LICENSE-APACHE</url>
   </license>
@@ -555,10 +547,6 @@ the details of which are reproduced below.
   <license>
     <name>MIT License: rusqlite</name>
     <url>https://github.com/rusqlite/rusqlite/blob/master/LICENSE</url>
-  </license>
-  <license>
-    <name>MIT License: matches</name>
-    <url>https://github.com/SimonSapin/rust-std-candidates/blob/master/LICENSE</url>
   </license>
   <license>
     <name>MIT License: mime_guess</name>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -18,7 +18,6 @@ the details of which are reproduced below.
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
 * [MIT License: libsqlite3-sys, rusqlite](#mit-license-libsqlite3-sys-rusqlite)
-* [MIT License: matches](#mit-license-matches)
 * [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
@@ -503,8 +502,6 @@ The following text applies to code linked from these dependencies:
 [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
 [lazycell](https://github.com/indiv0/lazycell),
 [libc](https://github.com/rust-lang/libc),
-[lmdb-rkv-sys](https://github.com/mozilla/lmdb-rs.git),
-[lmdb-rkv](https://github.com/mozilla/lmdb-rs.git),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
 [mime](https://github.com/hyperium/mime),
@@ -1153,40 +1150,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: matches
-
-The following text applies to code linked from these dependencies:
-[matches](https://github.com/SimonSapin/rust-std-candidates)
-
-```
-Copyright (c) 2014-2016 Simon Sapin
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 
 ```
 -------------

--- a/megazords/ios-rust/focus/DEPENDENCIES.md
+++ b/megazords/ios-rust/focus/DEPENDENCIES.md
@@ -16,7 +16,6 @@ the details of which are reproduced below.
 * [MIT License: h2](#mit-license-h2)
 * [MIT License: http-body](#mit-license-http-body)
 * [MIT License: hyper](#mit-license-hyper)
-* [MIT License: matches](#mit-license-matches)
 * [MIT License: mime_guess](#mit-license-mime_guess)
 * [MIT License: mio](#mit-license-mio)
 * [MIT License: nom](#mit-license-nom)
@@ -441,7 +440,6 @@ The following text applies to code linked from these dependencies:
 [block-buffer](https://github.com/RustCrypto/utils),
 [camino](https://github.com/camino-rs/camino),
 [cargo-platform](https://github.com/rust-lang/cargo),
-[cc](https://github.com/rust-lang/cc-rs),
 [cfg-if](https://github.com/alexcrichton/cfg-if),
 [chrono](https://github.com/chronotope/chrono),
 [core-foundation-sys](https://github.com/servo/core-foundation-rs),
@@ -483,8 +481,6 @@ The following text applies to code linked from these dependencies:
 [lalrpop-util](https://github.com/lalrpop/lalrpop),
 [lazy_static](https://github.com/rust-lang-nursery/lazy-static.rs),
 [libc](https://github.com/rust-lang/libc),
-[lmdb-rkv-sys](https://github.com/mozilla/lmdb-rs.git),
-[lmdb-rkv](https://github.com/mozilla/lmdb-rs.git),
 [lock_api](https://github.com/Amanieu/parking_lot),
 [log](https://github.com/rust-lang/log),
 [mime](https://github.com/hyperium/mime),
@@ -500,7 +496,6 @@ The following text applies to code linked from these dependencies:
 [percent-encoding](https://github.com/servo/rust-url/),
 [pin-project-lite](https://github.com/taiki-e/pin-project-lite),
 [pin-utils](https://github.com/rust-lang-nursery/pin-utils),
-[pkg-config](https://github.com/rust-lang/pkg-config-rs),
 [plain](https://github.com/randomites/plain),
 [proc-macro2](https://github.com/dtolnay/proc-macro2),
 [prost-derive](https://github.com/tokio-rs/prost),
@@ -1062,40 +1057,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
--------------
-## MIT License: matches
-
-The following text applies to code linked from these dependencies:
-[matches](https://github.com/SimonSapin/rust-std-candidates)
-
-```
-Copyright (c) 2014-2016 Simon Sapin
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 
 ```
 -------------

--- a/testing/separated/places-tests/Cargo.toml
+++ b/testing/separated/places-tests/Cargo.toml
@@ -17,8 +17,8 @@ types = { path = "../../../components/support/types" }
 places = { path = "../../../components/places" }
 sync15 = { path = "../../../components/sync15" }
 serde_json = "1.0"
-url = "2.2"
-dogear = "0.4"
+url = "2"
+dogear = "0.5"
 tempfile = "3.1"
-env_logger = { version = "0.7", default-features = false }
+env_logger = { version = "0.10", default-features = false }
 rusqlite = { workspace = true, features = ["functions", "bundled"] }

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -18,7 +18,7 @@ fxa-client = { path = "../../components/fxa-client" }
 sync-guid = { path = "../../components/support/guid", features = ["rusqlite_support", "random"]}
 interrupt-support = { path = "../../components/support/interrupt" }
 url = "2.2"
-env_logger = "0.7"
+env_logger = "0.10"
 log = "0.4"
 anyhow = "1.0"
 rand = "0.8"


### PR DESCRIPTION
This was largely done manually to try and bring app-services and mozilla-central closer together. With this patch we can vendor into mozilla-central, including when most of our mobile crates are built into libxul in the Android monorepo, oak.

This patch also re-forks find-places-db to avoid using a now orhpaned crate which no mozilla staff had access to update.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
