### PR TITLE
Truncate floats provided to bucketSample transform

### DIFF
--- a/components/nimbus/src/targeting.rs
+++ b/components/nimbus/src/targeting.rs
@@ -161,9 +161,7 @@ fn bucket_sample(args: &[Value]) -> anyhow::Result<Value> {
                 };
 
                 debug_assert!(n >= 0.0, "JEXL parser does not support negative values");
-                if n.fract() > 0.0 {
-                    Err(anyhow!("{} is not an integer", name))
-                } else if n > u32::MAX as f64 {
+                if n > u32::MAX as f64 {
                     Err(anyhow!("{} is out of range", name))
                 } else {
                     Ok(n as u32)

--- a/components/nimbus/src/tests/stateful/test_evaluator.rs
+++ b/components/nimbus/src/tests/stateful/test_evaluator.rs
@@ -405,28 +405,69 @@ fn test_targeting_is_already_enrolled() {
 #[test]
 fn test_bucket_sample() {
     let cases = [
-        (
-            "1.1",
-            "1000",
-            "1000",
-            Some(EnrollmentStatus::Error {
-                reason: "EvaluationError: Custom error: start is not an integer".into(),
-            }),
-        ),
+        ("1.1", "1000", "1000", None),
         (
             "0",
             "1.1",
             "1000",
-            Some(EnrollmentStatus::Error {
-                reason: "EvaluationError: Custom error: count is not an integer".into(),
+            Some(EnrollmentStatus::NotEnrolled {
+                reason: NotEnrolledReason::NotTargeted,
             }),
         ),
         (
             "0",
             "0",
             "1000.1",
+            Some(EnrollmentStatus::NotEnrolled {
+                reason: NotEnrolledReason::NotTargeted,
+            }),
+        ),
+        (
+            "4294967296",
+            "1",
+            "4294967297",
             Some(EnrollmentStatus::Error {
-                reason: "EvaluationError: Custom error: total is not an integer".into(),
+                reason: "EvaluationError: Custom error: start is out of range".into(),
+            }),
+        ),
+        (
+            "0",
+            "4294967296",
+            "4294967296",
+            Some(EnrollmentStatus::Error {
+                reason: "EvaluationError: Custom error: count is out of range".into(),
+            }),
+        ),
+        (
+            "0",
+            "0",
+            "4294967296",
+            Some(EnrollmentStatus::Error {
+                reason: "EvaluationError: Custom error: total is out of range".into(),
+            }),
+        ),
+        (
+            r#""hello""#,
+            "0",
+            "1000",
+            Some(EnrollmentStatus::Error {
+                reason: "EvaluationError: Custom error: start is not a number".into(),
+            }),
+        ),
+        (
+            "0",
+            r#""hello""#,
+            "1000",
+            Some(EnrollmentStatus::Error {
+                reason: "EvaluationError: Custom error: count is not a number".into(),
+            }),
+        ),
+        (
+            "0",
+            "1000",
+            r#""hello""#,
+            Some(EnrollmentStatus::Error {
+                reason: "EvaluationError: Custom error: total is not a number".into(),
             }),
         ),
     ];


### PR DESCRIPTION
The original implementation forbade floats and assumed that all inputs would be integers. However, the start param is most likely always going to be a floating point number in practice. We now support floats for the `start`, `count`, and `total` args and truncate them to u32.

Fixes bug 1877255

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
