### PR TITLE
Upgrade Rust to 1.75 [ci full]

### DIFF
--- a/components/support/error/tests/returns_not_result.stderr
+++ b/components/support/error/tests/returns_not_result.stderr
@@ -9,3 +9,7 @@ error[E0308]: mismatched types
    = note: expected struct `String`
                 found enum `Result<String, ExternalError>`
    = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider using `Result::expect` to unwrap the `Result<String, ExternalError>` value, panicking if the value is a `Result::Err`
+   |
+39 |  #[handle_error(Error)].expect("REASON")
+   |                        +++++++++++++++++

--- a/components/support/error/tests/returns_result_but_incorrect_error.stderr
+++ b/components/support/error/tests/returns_result_but_incorrect_error.stderr
@@ -9,3 +9,7 @@ error[E0308]: mismatched types
    = note: expected enum `std::result::Result<String, ExternalError>`
               found enum `std::result::Result<_, OtherExternalError>`
    = note: this error originates in the attribute macro `handle_error` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: use the `?` operator to extract the `std::result::Result<_, OtherExternalError>` value, propagating a `Result::Err` value to the caller
+   |
+50 |  #[handle_error(Error)]?
+   |                        +

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -7,7 +7,7 @@
 #   supported and used in CI.
 
 [toolchain]
-channel = "1.74.0"
+channel = "1.75.0"
 targets = [
     "aarch64-linux-android",
     "armv7-linux-androideabi",


### PR DESCRIPTION
This was previously reverted due to some macosx issues here: https://github.com/mozilla/application-services/pull/6052
However we've now upgraded via: https://github.com/mozilla/application-services/pull/6073


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
