### PR TITLE
Suggest - switch to using `error_support`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   bindings](https://bugzilla.mozilla.org/show_bug.cgi?id=1874030). This also
   affects the Swift bindings, since Swift enforces argument ordering.
 
+### Suggest
+- Added more error variants to `SuggestApiError`
+
 ## What's Fixed
 - It was possible for sync to apply a tombstone for places while a bookmark was still in the database. This would have resulted in foreign constraint SQLite error.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,6 +4081,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "env_logger 0.7.1",
+ "error-support",
  "expect-test",
  "hex",
  "interrupt-support",
@@ -4095,6 +4096,7 @@ dependencies = [
  "thiserror",
  "uniffi",
  "url",
+ "viaduct",
 ]
 
 [[package]]

--- a/components/suggest/Cargo.toml
+++ b/components/suggest/Cargo.toml
@@ -17,7 +17,9 @@ remote_settings = { path = "../remote_settings" }
 rusqlite = { workspace = true, features = ["functions", "bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+error-support = { path = "../support/error" }
 sql-support = { path = "../support/sql" }
+viaduct = { path = "../viaduct" }
 thiserror = "1"
 uniffi = { workspace = true }
 url = { version = "2.1", features = ["serde"] }

--- a/components/suggest/src/error.rs
+++ b/components/suggest/src/error.rs
@@ -3,6 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+use error_support::{ErrorHandling, GetErrorHandling};
+use remote_settings::RemoteSettingsError;
+
 /// A list of errors that are internal to the component. This is the error
 /// type for private and crate-internal methods, and is never returned to the
 /// application.
@@ -18,7 +21,7 @@ pub(crate) enum Error {
     Json(#[from] serde_json::Error),
 
     #[error("Error from Remote Settings: {0}")]
-    RemoteSettings(#[from] remote_settings::RemoteSettingsError),
+    RemoteSettings(#[from] RemoteSettingsError),
 
     #[error("Operation interrupted")]
     Interrupted(#[from] interrupt_support::Interrupted),
@@ -29,15 +32,45 @@ pub(crate) enum Error {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum SuggestApiError {
+    #[error("Network error: {reason}")]
+    Network { reason: String },
+    // The server requested a backoff after too many requests
+    #[error("Backoff")]
+    Backoff { seconds: u64 },
+    // The application interrupted a request
+    #[error("Interrupted")]
+    Interrupted,
     #[error("Other error: {reason}")]
     Other { reason: String },
 }
 
-impl From<Error> for SuggestApiError {
-    /// Converts an internal component error to a public application error.
-    fn from(error: Error) -> Self {
-        Self::Other {
-            reason: error.to_string(),
+// Define how our internal errors are handled and converted to external errors
+// See `support/error/README.md` for how this works, especially the warning about PII.
+impl GetErrorHandling for Error {
+    type ExternalError = SuggestApiError;
+
+    fn get_error_handling(&self) -> ErrorHandling<Self::ExternalError> {
+        match self {
+            // Do nothing for interrupted errors, this is just normal operation.
+            Self::Interrupted(_) => ErrorHandling::convert(SuggestApiError::Interrupted),
+            // Network errors are expected to happen in practice.  Let's log, but not report them.
+            Self::RemoteSettings(RemoteSettingsError::RequestError(
+                viaduct::Error::NetworkError(e),
+            )) => ErrorHandling::convert(SuggestApiError::Network {
+                reason: e.to_string(),
+            })
+            .log_warning(),
+            // Backoff error shouldn't happen in practice, so let's report them for now.
+            // If these do happen in practice and we decide that there is a valid reason for them,
+            // then consider switching from reporting to Sentry to counting in Glean.
+            Self::RemoteSettings(RemoteSettingsError::BackoffError(seconds)) => {
+                ErrorHandling::convert(SuggestApiError::Backoff { seconds: *seconds })
+                    .report_error("suggest-backoff")
+            }
+            _ => ErrorHandling::convert(SuggestApiError::Other {
+                reason: self.to_string(),
+            })
+            .report_error("suggest-unexpected"),
         }
     }
 }

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -8,6 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use error_support::handle_error;
 use once_cell::sync::OnceCell;
 use remote_settings::{
     self, GetItemsOptions, RemoteSettingsConfig, RemoteSettingsRecord, SortOrder,
@@ -22,6 +23,7 @@ use crate::{
     db::{
         ConnectionType, SuggestDao, SuggestDb, LAST_INGEST_META_KEY, UNPARSABLE_RECORDS_META_KEY,
     },
+    error::Error,
     rs::{
         SuggestAttachment, SuggestRecord, SuggestRecordId, SuggestRemoteSettingsClient,
         REMOTE_SETTINGS_COLLECTION, SUGGESTIONS_PER_ATTACHMENT,
@@ -97,6 +99,7 @@ pub(crate) struct UnparsableRecord {
 
 impl SuggestStore {
     /// Creates a Suggest store.
+    #[handle_error(Error)]
     pub fn new(
         path: &str,
         settings_config: Option<RemoteSettingsConfig>,
@@ -116,8 +119,9 @@ impl SuggestStore {
     }
 
     /// Queries the database for suggestions.
+    #[handle_error(Error)]
     pub fn query(&self, query: SuggestionQuery) -> SuggestApiResult<Vec<Suggestion>> {
-        Ok(self.inner.query(query)?)
+        self.inner.query(query)
     }
 
     /// Interrupts any ongoing queries.
@@ -130,13 +134,15 @@ impl SuggestStore {
     }
 
     /// Ingests new suggestions from Remote Settings.
+    #[handle_error(Error)]
     pub fn ingest(&self, constraints: SuggestIngestionConstraints) -> SuggestApiResult<()> {
-        Ok(self.inner.ingest(constraints)?)
+        self.inner.ingest(constraints)
     }
 
     /// Removes all content from the database.
+    #[handle_error(Error)]
     pub fn clear(&self) -> SuggestApiResult<()> {
-        Ok(self.inner.clear()?)
+        self.inner.clear()
     }
 }
 

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -14,6 +14,11 @@ boolean raw_suggestion_url_matches([ByRef] string raw_url, [ByRef] string url);
 
 [Error]
 interface SuggestApiError {
+    // An operation was interrupted by calling `SuggestStore.interrupt()`
+    Interrupted();
+    // The server requested a backoff after too many requests
+    Backoff(u64 seconds);
+    Network(string reason);
     Other(string reason);
 };
 


### PR DESCRIPTION
Start using `error_support` for internal -> external error conversion.

Added SuggestApiError variants for network errors and interrupted operations.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
