### PR TITLE
Suggest - add a data path field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 
 ### Suggest
 - Added more error variants to `SuggestApiError`
+- Added `SuggestStoreBuilder` to create `SuggestStore` instances.
+- `SuggestStore` now stores a data path.  This is the path to the SQLite database that should
+  persist when the cache is cleared.
 
 ## What's Fixed
 - It was possible for sync to apply a tombstone for places while a bookmark was still in the database. This would have resulted in foreign constraint SQLite error.

--- a/components/suggest/src/error.rs
+++ b/components/suggest/src/error.rs
@@ -25,6 +25,9 @@ pub(crate) enum Error {
 
     #[error("Operation interrupted")]
     Interrupted(#[from] interrupt_support::Interrupted),
+
+    #[error("SuggestStoreBuilder {0}")]
+    SuggestStoreBuilder(String),
 }
 
 /// The error type for all Suggest component operations. These errors are

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -17,7 +17,7 @@ mod yelp;
 
 pub use error::SuggestApiError;
 pub use provider::SuggestionProvider;
-pub use store::{SuggestIngestionConstraints, SuggestStore};
+pub use store::{SuggestIngestionConstraints, SuggestStore, SuggestStoreBuilder};
 pub use suggestion::{raw_suggestion_url_matches, Suggestion};
 
 pub(crate) type Result<T> = std::result::Result<T, error::Error>;

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -106,3 +106,19 @@ interface SuggestStore {
     [Throws=SuggestApiError]
     void clear();
 };
+
+interface SuggestStoreBuilder {
+    constructor();
+
+    [Self=ByArc]
+    SuggestStoreBuilder data_path(string path);
+
+    [Self=ByArc]
+    SuggestStoreBuilder cache_path(string path);
+
+    [Self=ByArc]
+    SuggestStoreBuilder remote_settings_config(RemoteSettingsConfig config);
+
+    [Throws=SuggestApiError]
+    SuggestStore build();
+};


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1876208 points out that we need a permanent database to store user dismissal data -- one that won't be deleted when the cache is cleared.

`SuggestStoreInner` stores the new field, but doesn't actually use it yet.  Let's wait until the consumer code is updated before that.

I added this capability using a builder object for two reasons:
  - This allows us to keep the current constructor to avoid any breaking changes while consumers adapt to the new system.
  - It forces consumers to specify `cache_path` or `data_path`.  If the constructor inputted 2 strings it would be easy to mix them up and hard to notice.

Lastly, input paths as owned strings rather than refs.  I think this avoids an extra copy.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
