### PR TITLE
Chore: Use relative image paths in design doc

### DIFF
--- a/docs/design/components-strategy.md
+++ b/docs/design/components-strategy.md
@@ -9,20 +9,20 @@ On a high level, Firefox Sync has three main components:
     it **client side**
 
 Additionally, the token server assists in providing metadata to Firefox, so that it knows which sync server to communicate with.
-![Diagram showing on a high level, how Firefox sync interacts with Firefox Accounts and Sync Services](/diagrams/high-level-sync-ecosystem.png)
+![Diagram showing on a high level, how Firefox sync interacts with Firefox Accounts and Sync Services](../diagrams/high-level-sync-ecosystem.png)
 
 
 ## Multi-platform sync diagram
 Since we have multiple Firefox apps (Desktop, iOS, Android, Focus, etc) Firefox sync can sync across platforms. Allowing users
 to access their up-to-date data across apps and devices.
-![Diagram showing how firefox sync is a multi-platform feature](/diagrams/multi-platform-sync-diagram.png)
+![Diagram showing how firefox sync is a multi-platform feature](../diagrams/multi-platform-sync-diagram.png)
 
 
 ### Before: How sync was
 Before our Rust Components came to life, each application had its own implementation of the sync and FxA client protocols.
 This lead to duplicate logic across platforms. This was problematic since any modification to the sync or FxA client business logic
 would need to be modified in all implementations and the likelihood of errors was high.
-![Diagram showing how firefox sync used to be, with each platform having its own implementation](/diagrams/before-cross-components.png)
+![Diagram showing how firefox sync used to be, with each platform having its own implementation](../diagrams/before-cross-components.png)
 
 
 ### Now: Sync is starting to streamline its components
@@ -32,7 +32,7 @@ one Rust component (Web Extension Storage).
 
 The Rust components not only unify the different implementations of sync, they also provide a convenient local storage for the apps.
 In other words, the apps can use the components for storage, with or without syncing to the server.
-![Diagram showing how firefox sync is now, with iOS and Fenix platform sharing some implementations](/diagrams/now-cross-components.png)
+![Diagram showing how firefox sync is now, with iOS and Fenix platform sharing some implementations](../diagrams/now-cross-components.png)
 
 #### Current Status
 The following table has the status of each of our sync Rust Components
@@ -49,7 +49,7 @@ In an aspirational future, all the applications would use the same implementatio
 However, it's unlikely that we would migrate everything to use the Rust components since some implementations
 may not be prioritized, this is especially true for desktop which already has stable implementations.
 That said, we can get close to this future and minimize duplicate logic and the likelihood of errors.
-![Diagram showing how firefox sync should be, with all platforms using one implementation](/diagrams/future-cross-components.png)
+![Diagram showing how firefox sync should be, with all platforms using one implementation](../diagrams/future-cross-components.png)
 
 
 You can edit the diagrams in the following lucid chart (Note: Currently only Mozilla Employees can edit those diagrams): https://lucid.app/lucidchart/invitations/accept/inv_ab72e218-3ad9-4604-a7cd-7e0b0c259aa2


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.

Doh, fix my previous doc fix. Relatively path required for image linking.