### PR TITLE
Recieves session token from application before oauth for user agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v124.0 (In progress)
 
+## ✨ What's New ✨
+
+### FxA Client
+- Added a new API `setUserData` that sets the user's session token, to prevent session token duplication and allow User Agent applications to support a signed in, but not verified state. ([#6111](https://github.com/mozilla/application-services/pull/6111))
+
 ## 🦊 What's Changed 🦊
 
 ### Webext-Storage

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
@@ -140,6 +140,19 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
     }
 
     /**
+     * Sets user data from the web content.
+     * NOTE: this is only useful for applications that are user agents
+     *       and require the user's session token
+     * @param userData: The user data including session token, email and uid
+     */
+    fun setUserData(
+        userData: UserData
+    ) {
+        this.inner.setUserData(userData)
+        tryPersistState()
+    }
+
+    /**
      * Authenticates the current account using the code and state parameters fetched from the
      * redirect URL reached after completing the sign in flow triggered by [beginOAuthFlow].
      *

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
@@ -146,7 +146,7 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
      * @param userData: The user data including session token, email and uid
      */
     fun setUserData(
-        userData: UserData
+        userData: UserData,
     ) {
         this.inner.setUserData(userData)
         tryPersistState()

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -113,7 +113,7 @@ open class FxAccountManager {
         FxALog.info("beginAuthentication")
         var scopes = scopes
         if scopes.isEmpty {
-            scopes = self.applicationScopes
+            scopes = applicationScopes
         }
         DispatchQueue.global().async {
             let result = self.updatingLatestAuthState { account in
@@ -143,7 +143,7 @@ open class FxAccountManager {
     ) {
         var scopes = scopes
         if scopes.isEmpty {
-            scopes = self.applicationScopes
+            scopes = applicationScopes
         }
         DispatchQueue.global().async {
             let result = self.updatingLatestAuthState { account in

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -90,7 +90,6 @@ open class FxAccountManager {
         return state == .authenticationProblem
     }
 
-
     /// Set the user data before completing their authentication
     public func setUserData(userData: UserData, completion: @escaping () -> Void) {
         DispatchQueue.global().async {
@@ -112,7 +111,10 @@ open class FxAccountManager {
         completionHandler: @escaping (Result<URL, Error>) -> Void
     ) {
         FxALog.info("beginAuthentication")
-        let scopes = if scopes.isEmpty { self.applicationScopes } else { scopes }
+        var scopes = scopes
+        if scopes.isEmpty {
+            scopes = self.applicationScopes
+        }
         DispatchQueue.global().async {
             let result = self.updatingLatestAuthState { account in
                 try account.beginOAuthFlow(
@@ -139,7 +141,10 @@ open class FxAccountManager {
         scopes: [String] = [],
         completionHandler: @escaping (Result<URL, Error>) -> Void
     ) {
-        let scopes = if scopes.isEmpty { self.applicationScopes } else { scopes }
+        var scopes = scopes
+        if scopes.isEmpty {
+            scopes = self.applicationScopes
+        }
         DispatchQueue.global().async {
             let result = self.updatingLatestAuthState { account in
                 try account.beginPairingFlow(

--- a/components/fxa-client/ios/FxAClient/FxAccountManager.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountManager.swift
@@ -90,6 +90,15 @@ open class FxAccountManager {
         return state == .authenticationProblem
     }
 
+
+    /// Set the user data before completing their authentication
+    public func setUserData(userData: UserData, completion: @escaping () -> Void) {
+        DispatchQueue.global().async {
+            self.account?.setUserData(userData: userData)
+            completion()
+        }
+    }
+
     /// Begins a new authentication flow.
     ///
     /// This function returns a URL string that the caller should open in a webview.
@@ -99,13 +108,15 @@ open class FxAccountManager {
     /// `finishAuthentication(...)` to complete the flow.
     public func beginAuthentication(
         entrypoint: String,
+        scopes: [String] = [],
         completionHandler: @escaping (Result<URL, Error>) -> Void
     ) {
         FxALog.info("beginAuthentication")
+        let scopes = if scopes.isEmpty { self.applicationScopes } else { scopes }
         DispatchQueue.global().async {
             let result = self.updatingLatestAuthState { account in
                 try account.beginOAuthFlow(
-                    scopes: self.applicationScopes,
+                    scopes: scopes,
                     entrypoint: entrypoint
                 )
             }
@@ -125,13 +136,15 @@ open class FxAccountManager {
     public func beginPairingAuthentication(
         pairingUrl: String,
         entrypoint: String,
+        scopes: [String] = [],
         completionHandler: @escaping (Result<URL, Error>) -> Void
     ) {
+        let scopes = if scopes.isEmpty { self.applicationScopes } else { scopes }
         DispatchQueue.global().async {
             let result = self.updatingLatestAuthState { account in
                 try account.beginPairingFlow(
                     pairingUrl: pairingUrl,
-                    scopes: self.applicationScopes,
+                    scopes: scopes,
                     entrypoint: entrypoint
                 )
             }

--- a/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
@@ -54,7 +54,7 @@ class PersistedFirefoxAccount {
 
     public func setUserData(userData: UserData) {
         defer { tryPersistState() }
-        self.inner.setUserData(userData: userData)
+        inner.setUserData(userData: userData)
     }
 
     public func beginOAuthFlow(

--- a/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
@@ -52,6 +52,11 @@ class PersistedFirefoxAccount {
         try inner.toJson()
     }
 
+    public func setUserData(userData: UserData) {
+        defer { tryPersistState() }
+        self.inner.setUserData(userData: userData)
+    }
+
     public func beginOAuthFlow(
         scopes: [String],
         entrypoint: String

--- a/components/fxa-client/src/auth.rs
+++ b/components/fxa-client/src/auth.rs
@@ -49,6 +49,13 @@ impl FirefoxAccount {
         self.internal.lock().get_auth_state()
     }
 
+    /// Sets the user data for a user agent
+    /// **Important**: This should only be used on user agents such as Firefox
+    /// that require the user's session token
+    pub fn set_user_data(&self, user_data: UserData) {
+        self.internal.lock().set_user_data(user_data)
+    }
+
     /// Initiate a web-based OAuth sign-in flow.
     ///
     /// This method initializes some internal state and then returns a URL at which the
@@ -290,4 +297,13 @@ pub enum FxaEvent {
     /// This is used for testing the auth/network retry code, since it hits the network and
     /// requires and auth token.
     CallGetProfile,
+}
+
+/// User data provided by the web content, meant to be consumed by user agents
+#[derive(Debug, Clone)]
+pub struct UserData {
+    pub(crate) session_token: String,
+    pub(crate) uid: String,
+    pub(crate) email: String,
+    pub(crate) verified: bool,
 }

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -138,6 +138,11 @@ interface FirefoxAccount {
   [Throws=FxaError]
   string to_json();
   
+  // Sets the users information based on the web content's login information
+  // This is intended to only be used by user agents (eg: Firefox) to set the users
+  // session token and tie it to the refresh token that will be issued at the end of the
+  // oauth flow.
+  void set_user_data(UserData user_data);
 
   // Initiate a web-based OAuth sign-in flow.
   //
@@ -1097,4 +1102,11 @@ interface FxaStateCheckerState {
   GetProfile();
   Complete(FxaState new_state);
   Cancel();
+};
+
+dictionary UserData {
+  string session_token;
+  string uid;
+  string email;
+  boolean verified;
 };

--- a/components/fxa-client/src/internal/state_manager.rs
+++ b/components/fxa-client/src/internal/state_manager.rs
@@ -165,7 +165,7 @@ impl StateManager {
         &mut self,
         scoped_keys: Vec<(String, ScopedKey)>,
         refresh_token: RefreshToken,
-        session_token: Option<String>,
+        new_session_token: Option<String>,
     ) {
         // When our keys change, we might need to re-register device capabilities with the server.
         // Ensure that this happens on the next call to ensure_capabilities.
@@ -175,8 +175,10 @@ impl StateManager {
             self.persisted_state.scoped_keys.insert(scope, key);
         }
         self.persisted_state.refresh_token = Some(refresh_token);
-        if let Some(session_token) = session_token {
-            self.persisted_state.session_token = Some(session_token)
+        // We prioritize the existing session token if we already have one, because we might have
+        // acquired a session token before the oauth flow
+        if let (None, Some(new_session_token)) = (self.session_token(), new_session_token) {
+            self.set_session_token(new_session_token)
         }
         self.persisted_state.logged_out_from_auth_issues = false;
         self.flow_store.clear();

--- a/components/fxa-client/src/internal/state_manager.rs
+++ b/components/fxa-client/src/internal/state_manager.rs
@@ -175,7 +175,9 @@ impl StateManager {
             self.persisted_state.scoped_keys.insert(scope, key);
         }
         self.persisted_state.refresh_token = Some(refresh_token);
-        self.persisted_state.session_token = session_token;
+        if let Some(session_token) = session_token {
+            self.persisted_state.session_token = Some(session_token)
+        }
         self.persisted_state.logged_out_from_auth_issues = false;
         self.flow_store.clear();
     }
@@ -250,6 +252,9 @@ impl StateManager {
         self.persisted_state.refresh_token = None;
         self.persisted_state.access_token_cache.clear();
     }
+    pub fn set_session_token(&mut self, token: String) {
+        self.persisted_state.session_token = Some(token)
+    }
 }
 
 #[cfg(test)]
@@ -260,10 +265,6 @@ impl StateManager {
 
     pub fn force_refresh_token(&mut self, token: RefreshToken) {
         self.persisted_state.refresh_token = Some(token)
-    }
-
-    pub fn force_session_token(&mut self, token: String) {
-        self.persisted_state.session_token = Some(token)
     }
 
     pub fn force_current_device_id(&mut self, device_id: impl Into<String>) {

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -53,7 +53,7 @@ use std::fmt;
 pub use sync15::DeviceType;
 use url::Url;
 
-pub use auth::{AuthorizationInfo, FxaEvent, FxaRustAuthState, FxaState};
+pub use auth::{AuthorizationInfo, FxaEvent, FxaRustAuthState, FxaState, UserData};
 pub use device::{AttachedClient, Device, DeviceCapability, DeviceConfig, LocalDevice};
 pub use error::{Error, FxaError};
 use parking_lot::Mutex;


### PR DESCRIPTION
Putting it up a little early, still needs:
- [x] unit tests,
- [x] fixing up swiftlint 
- [x] ios-tests
- [x] Two patches for iOS and Android
- [x] Changelog 

I'm adding those in a separate commit but I've tested this against both iOS and Android

## Context
User Agents such as Firefox iOS and Android, need access to a session token, this is so that they can issue access tokens, but also so they can load the settings page. This is a super power that usually only the web content would have.

Historically, well at least since the inception of the FxA client in Rust, the session token was delivered through a special OAuth scope. That works OK when the application is authenticating using pairing, however it leads to an interesting case when the application is authenticating using email/password. 

When signing in using email and password, the web content holds on to a session token, representing the web session the user just signed into, and additionally, the user agent would get a second session token through the special session scope. This leads to there being two seperate session tokens associated with the one authority (your firefox application). This easily reproducible, all you have to do is sign into Firefox Android or iOS using email and password, then go to manage account - you'll see two entries for the same device!

## This patch

This patch moves us so that we do what desktop does. Where desktop shares the same session token the content got when the user first signs in using email password
