### PR TITLE
Remote settings: better message for ResponseError

### DIFF
--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -155,7 +155,10 @@ impl Client {
         if resp.is_success() {
             Ok(resp)
         } else {
-            Err(RemoteSettingsError::ResponseError(resp.text().to_string()))
+            Err(RemoteSettingsError::ResponseError(format!(
+                "status code: {}",
+                resp.status
+            )))
         }
     }
 


### PR DESCRIPTION
We're getting a handful of these in the suggest component, but the error message is not useful since the response text is blank.  Let's log the status code to understand these better.  Once we see the code, maybe we should add a new error variant to capture the specific error.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
