### PR TITLE
Bug 1879646 - Bump the Suggest database schema.

### DIFF
--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -6,8 +6,16 @@
 use rusqlite::{Connection, Transaction};
 use sql_support::open_database::{self, ConnectionInitializer};
 
-pub const VERSION: u32 = 12;
+/// The current database schema version.
+///
+/// For any changes to the schema [`SQL`], please make sure to:
+///
+///  1. Bump this version.
+///  2. Add a migration from the old version to the new version in
+///     [`SuggestConnectionInitializer::upgrade_from`].
+pub const VERSION: u32 = 13;
 
+/// The current Suggest database schema.
 pub const SQL: &str = "
     CREATE TABLE meta(
         key TEXT PRIMARY KEY,
@@ -132,10 +140,10 @@ impl ConnectionInitializer for SuggestConnectionInitializer {
 
     fn upgrade_from(&self, _db: &Transaction<'_>, version: u32) -> open_database::Result<()> {
         match version {
-            1..=11 => {
-                // These schema versions were used during development, and never
-                // shipped in any applications. Treat these databases as
-                // corrupt, so that they'll be replaced.
+            1..=12 => {
+                // Treat databases with these older schema versions as corrupt,
+                // so that they'll be replaced by a fresh, empty database with
+                // the current schema.
                 Err(open_database::Error::Corrupt)
             }
             _ => Err(open_database::Error::IncompatibleVersion(version)),

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -3935,10 +3935,10 @@ mod tests {
                     UnparsableRecords(
                         {
                             "clippy-2": UnparsableRecord {
-                                schema_version: 12,
+                                schema_version: 13,
                             },
                             "fancy-new-suggestions-1": UnparsableRecord {
-                                schema_version: 12,
+                                schema_version: 13,
                             },
                         },
                     ),
@@ -4004,10 +4004,10 @@ mod tests {
                     UnparsableRecords(
                         {
                             "clippy-2": UnparsableRecord {
-                                schema_version: 12,
+                                schema_version: 13,
                             },
                             "fancy-new-suggestions-1": UnparsableRecord {
-                                schema_version: 12,
+                                schema_version: 13,
                             },
                         },
                     ),
@@ -4111,10 +4111,10 @@ mod tests {
                     UnparsableRecords(
                         {
                             "clippy-2": UnparsableRecord {
-                                schema_version: 12,
+                                schema_version: 13,
                             },
                             "fancy-new-suggestions-1": UnparsableRecord {
-                                schema_version: 12,
+                                schema_version: 13,
                             },
                         },
                     ),
@@ -4200,7 +4200,7 @@ mod tests {
                     UnparsableRecords(
                         {
                             "invalid-attachment": UnparsableRecord {
-                                schema_version: 12,
+                                schema_version: 13,
                             },
                         },
                     ),


### PR DESCRIPTION
Bug 1878735 added a `yelp_custom_details` table to the schema. This commit bumps the schema version for that change, and adds a doc note for future schema changes.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
