### PR TITLE
Fixup JEXL transform panic

### DIFF
--- a/components/nimbus/src/stateful/behavior.rs
+++ b/components/nimbus/src/stateful/behavior.rs
@@ -406,7 +406,12 @@ impl EventQueryType {
             }
         } as usize;
 
-        Ok((event, interval, usize::MAX, starting_bucket))
+        Ok((
+            event,
+            interval,
+            usize::MAX - starting_bucket,
+            starting_bucket,
+        ))
     }
 
     pub fn validate_arguments(&self, args: &[Value]) -> Result<(String, Interval, usize, usize)> {

--- a/components/nimbus/src/tests/stateful/test_evaluator.rs
+++ b/components/nimbus/src/tests/stateful/test_evaluator.rs
@@ -262,6 +262,11 @@ fn test_event_transform_last_seen_parameters() {
                 .to_string()
         })
     );
+
+    assert_eq!(
+        targeting("'app_cycle.foreground1'|eventLastSeen('Days', 2) > 1", &th),
+        None
+    );
 }
 
 #[test]

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/EventStoreTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/EventStoreTests.swift
@@ -77,4 +77,10 @@ final class EventStoreTests: XCTestCase {
             try helper.evalJexl(expression: "'\(eventId)'|eventLastSeen('Hours') == 48")
         )
     }
+
+    func testEventLastSeenRegression() async throws {
+        let jexl = try nimbus.createMessageHelper()
+        nimbus.events.recordEvent(eventId)
+        _ = try jexl.evalJexl(expression: "'\(eventId)'|eventLastSeen('Minutes', 1) == 1")
+    }
 }


### PR DESCRIPTION
Relates to [EXP-4367](https://mozilla-hub.atlassian.net/browse/EXP-4367).

According to [The Big O of Code Reviews](https://www.egorand.dev/the-big-o-of-code-reviews/), this is a O(_n_) change.

This finds and fixes a panic in the eventLastSeen transform argument handling.

TIL: JEXL transforms should never panic, as this poisons the mutex so that the JEXL evaluator doesn't function.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
