### PR TITLE
Update JNA to version 5.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext {
         kotlin_version = '1.9.22'
         kotlin_coroutines_version = '1.7.3'
-        jna_version = '5.13.0'
+        jna_version = '5.14.0'
         android_gradle_plugin_version = '8.0.2'
         android_components_version = '122.0'
         glean_version = '57.0.0'


### PR DESCRIPTION
We're hitting the same failures we had before with today's Glean bump PR in firefox-android. Looks like we need this bump after all!