### PR TITLE
Explicitly use the minSdkVersion for setting the NDK API level [ci full]

### DIFF
--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -58,7 +58,7 @@ cargo {
     module = '..'
 
     // The Android NDK API level to target.
-    apiLevel = 21
+    apiLevel = rootProject.ext.build['minSdkVersion']
 
     // Where Cargo writes its outputs.
     targetDirectory = '../../../target'


### PR DESCRIPTION
I can't see any reason we *wouldn't* want these to be in sync, so let's make the relationship explicit. Companion Glean PR: https://github.com/mozilla/glean/pull/2747