### PR TITLE
Prevent outgoing scrubbed credit card records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 ### Autofill
 - Replace `*-name` fields with a single `name` field for addresses.
+- Prevented outgoing syncs of scrubbed credit card records ([#6143](https://github.com/mozilla/application-services/pull/6143)).
 
 ## What's Fixed
 - It was possible for sync to apply a tombstone for places while a bookmark was still in the database. This would have resulted in foreign constraint SQLite error.

--- a/components/autofill/src/sync/credit_card/outgoing.rs
+++ b/components/autofill/src/sync/credit_card/outgoing.rs
@@ -34,10 +34,15 @@ impl ProcessOutgoingRecordImpl for OutgoingCreditCardsImpl {
             FROM credit_cards_data l
             LEFT JOIN credit_cards_mirror m
             ON l.guid = m.guid
-            WHERE sync_change_counter > 0
-                OR l.guid NOT IN (
-                    SELECT m.guid
-                    FROM credit_cards_mirror m
+            WHERE
+                l.cc_number_enc <> ''
+            AND
+                (
+                    sync_change_counter > 0 OR
+                    l.guid NOT IN (
+                        SELECT m.guid
+                        FROM credit_cards_mirror m
+                    )
                 )",
             common_cols = CREDIT_CARD_COMMON_COLS,
         );


### PR DESCRIPTION
Fixes two issues:

- Prevents the panic that was occurring in the common.rs/get_outgoing_records
- Updates the outgoing credit card logic to exclude outgoing scrubbed credit card records 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
