### PR TITLE
Bug 1882381 - Switch to using the data path for the suggest DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 [Full Changelog](In progress)
 
+### Suggest
+- `SuggestStoreBuilder.cache_path` is now deprecated because we no longer use the cache path.
+
 # v124.0 (_2024-02-15_)
 
 ## 🦊 What's Changed 🦊

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -25,7 +25,7 @@ use crate::{
         DownloadedMdnSuggestion, DownloadedPocketSuggestion, DownloadedWeatherData,
         SuggestRecordId,
     },
-    schema::{SuggestConnectionInitializer, VERSION},
+    schema::{clear_database, SuggestConnectionInitializer, VERSION},
     store::{UnparsableRecord, UnparsableRecords},
     suggestion::{cook_raw_suggestion_url, AmpSuggestionType, Suggestion},
     Result, SuggestionQuery,
@@ -1250,12 +1250,7 @@ impl<'a> SuggestDao<'a> {
 
     /// Clears the database, removing all suggestions, icons, and metadata.
     pub fn clear(&mut self) -> Result<()> {
-        self.conn.execute_batch(
-            "DELETE FROM suggestions;
-             DELETE FROM icons;
-             DELETE FROM meta;",
-        )?;
-        Ok(())
+        Ok(clear_database(self.conn)?)
     }
 
     /// Returns the value associated with a metadata key.

--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -13,7 +13,9 @@ use sql_support::open_database::{self, ConnectionInitializer};
 ///  1. Bump this version.
 ///  2. Add a migration from the old version to the new version in
 ///     [`SuggestConnectionInitializer::upgrade_from`].
-pub const VERSION: u32 = 16;
+///    a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
+///       the migration.
+pub const VERSION: u32 = 17;
 
 /// The current Suggest database schema.
 pub const SQL: &str = "
@@ -121,6 +123,12 @@ pub const SQL: &str = "
         description TEXT NOT NULL,
         FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
     );
+
+    -- Just store the MD5 hash of the dismissed suggestion.  The collision rate is low and the
+    -- impact of a collision is not showing a suggestion, which is not that bad.
+    CREATE TABLE dismissed_suggestions (
+        url_hash INTEGER PRIMARY KEY
+    ) WITHOUT ROWID;
 ";
 
 /// Initializes an SQLite connection to the Suggest database, performing
@@ -149,7 +157,7 @@ impl ConnectionInitializer for SuggestConnectionInitializer {
         Ok(db.execute_batch(SQL)?)
     }
 
-    fn upgrade_from(&self, _db: &Transaction<'_>, version: u32) -> open_database::Result<()> {
+    fn upgrade_from(&self, tx: &Transaction<'_>, version: u32) -> open_database::Result<()> {
         match version {
             1..=15 => {
                 // Treat databases with these older schema versions as corrupt,
@@ -157,7 +165,159 @@ impl ConnectionInitializer for SuggestConnectionInitializer {
                 // the current schema.
                 Err(open_database::Error::Corrupt)
             }
+            16 => {
+                tx.execute(
+                    "
+                    CREATE TABLE dismissed_suggestions (
+                        url_hash INTEGER PRIMARY KEY
+                    ) WITHOUT ROWID;",
+                    (),
+                )?;
+                Ok(())
+            }
             _ => Err(open_database::Error::IncompatibleVersion(version)),
         }
+    }
+}
+
+/// Clears the database, removing all suggestions, icons, and metadata.
+pub fn clear_database(db: &Connection) -> rusqlite::Result<()> {
+    db.execute_batch(
+        "
+        DELETE FROM meta;
+        DELETE FROM suggestions;
+        DELETE FROM icons;
+        DELETE FROM yelp_subjects;
+        DELETE FROM yelp_modifiers;
+        DELETE FROM yelp_location_signs;
+        DELETE FROM yelp_custom_details;
+        ",
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use sql_support::open_database::test_utils::MigratedDatabaseFile;
+
+    // Snapshot of the v16 schema.  We use this to test that we can migrate from there to the
+    // current schema.
+    const V16_SCHEMA: &str = r#"
+    CREATE TABLE meta(
+        key TEXT PRIMARY KEY,
+        value NOT NULL
+    ) WITHOUT ROWID;
+
+    CREATE TABLE keywords(
+        keyword TEXT NOT NULL,
+        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+        full_keyword_id INTEGER NULL REFERENCES full_keywords(id) ON DELETE SET NULL,
+        rank INTEGER NOT NULL,
+        PRIMARY KEY (keyword, suggestion_id)
+    ) WITHOUT ROWID;
+
+    -- full keywords are what we display to the user when a (partial) keyword matches
+    -- The FK to suggestion_id makes it so full keywords get deleted when the parent suggestion is deleted.
+    CREATE TABLE full_keywords(
+        id INTEGER PRIMARY KEY,
+        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+        full_keyword TEXT NOT NULL
+    );
+
+    CREATE TABLE prefix_keywords(
+        keyword_prefix TEXT NOT NULL,
+        keyword_suffix TEXT NOT NULL DEFAULT '',
+        confidence INTEGER NOT NULL DEFAULT 0,
+        rank INTEGER NOT NULL,
+        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+        PRIMARY KEY (keyword_prefix, keyword_suffix, suggestion_id)
+    ) WITHOUT ROWID;
+
+    CREATE UNIQUE INDEX keywords_suggestion_id_rank ON keywords(suggestion_id, rank);
+
+    CREATE TABLE suggestions(
+        id INTEGER PRIMARY KEY,
+        record_id TEXT NOT NULL,
+        provider INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        url TEXT NOT NULL,
+        score REAL NOT NULL
+    );
+
+    CREATE TABLE amp_custom_details(
+        suggestion_id INTEGER PRIMARY KEY,
+        advertiser TEXT NOT NULL,
+        block_id INTEGER NOT NULL,
+        iab_category TEXT NOT NULL,
+        impression_url TEXT NOT NULL,
+        click_url TEXT NOT NULL,
+        icon_id TEXT NOT NULL,
+        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE wikipedia_custom_details(
+        suggestion_id INTEGER PRIMARY KEY REFERENCES suggestions(id) ON DELETE CASCADE,
+        icon_id TEXT NOT NULL
+    );
+
+    CREATE TABLE amo_custom_details(
+        suggestion_id INTEGER PRIMARY KEY,
+        description TEXT NOT NULL,
+        guid TEXT NOT NULL,
+        icon_url TEXT NOT NULL,
+        rating TEXT,
+        number_of_ratings INTEGER NOT NULL,
+        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+    );
+
+    CREATE INDEX suggestions_record_id ON suggestions(record_id);
+
+    CREATE TABLE icons(
+        id TEXT PRIMARY KEY,
+        data BLOB NOT NULL,
+        mimetype TEXT NOT NULL
+    ) WITHOUT ROWID;
+
+    CREATE TABLE yelp_subjects(
+        keyword TEXT PRIMARY KEY,
+        record_id TEXT NOT NULL
+    ) WITHOUT ROWID;
+
+    CREATE TABLE yelp_modifiers(
+        type INTEGER NOT NULL,
+        keyword TEXT NOT NULL,
+        record_id TEXT NOT NULL,
+        PRIMARY KEY (type, keyword)
+    ) WITHOUT ROWID;
+
+    CREATE TABLE yelp_location_signs(
+        keyword TEXT PRIMARY KEY,
+        need_location INTEGER NOT NULL,
+        record_id TEXT NOT NULL
+    ) WITHOUT ROWID;
+
+    CREATE TABLE yelp_custom_details(
+        icon_id TEXT PRIMARY KEY,
+        score REAL NOT NULL,
+        record_id TEXT NOT NULL
+    ) WITHOUT ROWID;
+
+    CREATE TABLE mdn_custom_details(
+        suggestion_id INTEGER PRIMARY KEY,
+        description TEXT NOT NULL,
+        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+    );
+
+    PRAGMA user_version=16;
+"#;
+
+    /// Test running all schema upgrades from V16, which was the first schema with a "real"
+    /// migration.
+    ///
+    /// If an upgrade fails, then this test will fail with a panic.
+    #[test]
+    fn test_all_upgrades() {
+        let db_file = MigratedDatabaseFile::new(SuggestConnectionInitializer, V16_SCHEMA);
+        db_file.run_all_upgrades();
     }
 }

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -144,6 +144,7 @@ interface SuggestStoreBuilder {
     [Self=ByArc]
     SuggestStoreBuilder data_path(string path);
 
+    // Deprecated: this is no longer used by the suggest component.
     [Self=ByArc]
     SuggestStoreBuilder cache_path(string path);
 

--- a/components/support/sql/src/open_database.rs
+++ b/components/support/sql/src/open_database.rs
@@ -278,6 +278,9 @@ pub mod test_utils {
             }
         }
 
+        /// Attempt to run all upgrades up to a specific version.
+        ///
+        /// This will result in a panic if an upgrade fails to run.
         pub fn upgrade_to(&self, version: u32) {
             let mut conn = self.open();
             let tx = conn.transaction().unwrap();
@@ -293,6 +296,9 @@ pub mod test_utils {
             tx.commit().unwrap();
         }
 
+        /// Attempt to run all upgrades
+        ///
+        /// This will result in a panic if an upgrade fails to run.
         pub fn run_all_upgrades(&self) {
             let current_version = get_schema_version(&self.open()).unwrap();
             for version in current_version..CI::END_VERSION {


### PR DESCRIPTION
- Use the `data_path` rather than `cache_path` for the suggest DB.  This is prep for for storing the suggestion dismissal data in the DB, which should not be reset on schema upgrades.
- Don't always drop and recreate the database when the schema upgrades.  Instead, I'm hoping we can use the code from `SuggestDao.clear` to delete the suggestion data so that we re-ingest it.
- Other than adding the `dismissed_suggestion` table, this doesn't implement any of the suggestion dismissal functionality.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
