### PR TITLE
Bug 1876208 - API for dismissing suggestions

### DIFF
--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -26,7 +26,7 @@ pub(crate) type Result<T> = std::result::Result<T, error::Error>;
 pub type SuggestApiResult<T> = std::result::Result<T, error::SuggestApiError>;
 
 /// A query for suggestions to show in the address bar.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SuggestionQuery {
     pub keyword: String,
     pub providers: Vec<SuggestionProvider>,

--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -15,7 +15,7 @@ use sql_support::open_database::{self, ConnectionInitializer};
 ///     [`SuggestConnectionInitializer::upgrade_from`].
 ///    a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
 ///       the migration.
-pub const VERSION: u32 = 17;
+pub const VERSION: u32 = 18;
 
 /// The current Suggest database schema.
 pub const SQL: &str = "
@@ -124,10 +124,8 @@ pub const SQL: &str = "
         FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
     );
 
-    -- Just store the MD5 hash of the dismissed suggestion.  The collision rate is low and the
-    -- impact of a collision is not showing a suggestion, which is not that bad.
     CREATE TABLE dismissed_suggestions (
-        url_hash INTEGER PRIMARY KEY
+        url TEXT PRIMARY KEY
     ) WITHOUT ROWID;
 ";
 
@@ -170,6 +168,17 @@ impl ConnectionInitializer for SuggestConnectionInitializer {
                     "
                     CREATE TABLE dismissed_suggestions (
                         url_hash INTEGER PRIMARY KEY
+                    ) WITHOUT ROWID;",
+                    (),
+                )?;
+                Ok(())
+            }
+            17 => {
+                tx.execute(
+                    "
+                    DROP TABLE dismissed_suggestions;
+                    CREATE TABLE dismissed_suggestions (
+                        url TEXT PRIMARY KEY
                     ) WITHOUT ROWID;",
                     (),
                 )?;

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -123,6 +123,12 @@ interface SuggestStore {
     [Throws=SuggestApiError]
     sequence<Suggestion> query(SuggestionQuery query);
 
+    [Throws=SuggestApiError]
+    void dismiss_suggestion(string raw_suggestion_url);
+
+    [Throws=SuggestApiError]
+    void clear_dismissed_suggestions();
+
     void interrupt();
 
     [Throws=SuggestApiError]

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -109,6 +109,37 @@ impl Ord for Suggestion {
     }
 }
 
+impl Suggestion {
+    /// Get the URL for this suggestion, if present
+    pub fn url(&self) -> Option<&str> {
+        match self {
+            Self::Amp { url, .. }
+            | Self::Pocket { url, .. }
+            | Self::Wikipedia { url, .. }
+            | Self::Amo { url, .. }
+            | Self::Yelp { url, .. }
+            | Self::Mdn { url, .. } => Some(url),
+            _ => None,
+        }
+    }
+
+    /// Get the raw URL for this suggestion, if present
+    ///
+    /// This is the same as `url` except for Amp.  In that case, `url` is the URL after being
+    /// "cooked" using template interpolation, while `raw_url` is the URL template.
+    pub fn raw_url(&self) -> Option<&str> {
+        match self {
+            Self::Amp { raw_url: url, .. }
+            | Self::Pocket { url, .. }
+            | Self::Wikipedia { url, .. }
+            | Self::Amo { url, .. }
+            | Self::Yelp { url, .. }
+            | Self::Mdn { url, .. } => Some(url),
+            _ => None,
+        }
+    }
+}
+
 impl Eq for Suggestion {}
 /// Replaces all template parameters in a "raw" sponsored suggestion URL,
 /// producing a "cooked" URL with real values.


### PR DESCRIPTION
(This is on top of #5546, let's merge that one first)

Dismissed suggestion Urls are stored in the database and not returned again in subsequent queries.
    
This currently works with most providers, but not Yelp or Weather.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
