### PR TITLE
Use LEFT JOIN for yelp_custom_detail SQL

### DIFF
--- a/components/suggest/src/yelp.rs
+++ b/components/suggest/src/yelp.rs
@@ -219,7 +219,7 @@ impl<'a> SuggestDao<'a> {
               i.data, y.score
             FROM
               yelp_custom_details y
-            JOIN
+            LEFT JOIN
               icons i
               ON y.icon_id = i.id
             LIMIT


### PR DESCRIPTION
Currently, we are using `JOIN` to combine the icon data, but in that case, if there is no record in icons  table, the `SELECT` returned no results. Due to this, tests on JS side has failed.
https://github.com/mozilla/application-services/blob/main/components/suggest/src/yelp.rs#L222
To resolve this, we use `LEFT JOIN` to set `NULL` if no data, instead.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumeLr applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
