### PR TITLE
Bug 1884434 - log a breadcrumb when check_internal_state is successful

### DIFF
--- a/components/fxa-client/src/state_machine/checker.rs
+++ b/components/fxa-client/src/state_machine/checker.rs
@@ -176,8 +176,9 @@ impl FxaStateMachineChecker {
                 inner.internal_state
             );
             inner.reported_error = true;
+        } else {
+            breadcrumb!("fxa-state-machine-checker: check_public_state successfull {state}");
         }
-        breadcrumb!("fxa-state-machine-checker: check_public_state successfull {state}");
     }
 
     /// Check the internal state
@@ -196,6 +197,8 @@ impl FxaStateMachineChecker {
                 inner.internal_state
             );
             inner.reported_error = true;
+        } else {
+            breadcrumb!("fxa-state-machine-checker: check_internal_state successfull {state}");
         }
     }
 }


### PR DESCRIPTION
I also updated the check_public_state breadcrumb code so that we don't output the successfull breadcrumb after a state mismatch.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
