### PR TITLE
update Nimbus to write targeting attributes after each individual enrollment

### DIFF
--- a/components/nimbus/src/stateful/enrollment.rs
+++ b/components/nimbus/src/stateful/enrollment.rs
@@ -18,7 +18,7 @@ impl<'a> EnrollmentsEvolver<'a> {
     /// Convenient wrapper around `evolve_enrollments` that fetches the current state of experiments,
     /// enrollments and user participation from the database.
     pub(crate) fn evolve_enrollments_in_db(
-        &self,
+        &mut self,
         db: &Database,
         writer: &mut Writer,
         next_experiments: &[Experiment],

--- a/components/nimbus/src/stateful/mod.rs
+++ b/components/nimbus/src/stateful/mod.rs
@@ -10,4 +10,5 @@ pub mod evaluator;
 pub mod matcher;
 pub mod nimbus_client;
 pub mod persistence;
+pub mod targeting;
 pub mod updating;

--- a/components/nimbus/src/stateful/targeting.rs
+++ b/components/nimbus/src/stateful/targeting.rs
@@ -1,0 +1,29 @@
+use crate::{
+    enrollment::ExperimentEnrollment, stateful::behavior::EventStore, NimbusTargetingHelper,
+    TargetingAttributes,
+};
+use std::sync::{Arc, Mutex};
+
+impl NimbusTargetingHelper {
+    pub(crate) fn with_targeting_attributes(
+        targeting_attributes: &TargetingAttributes,
+        event_store: Arc<Mutex<EventStore>>,
+    ) -> Self {
+        Self {
+            context: serde_json::to_value(targeting_attributes.clone()).unwrap(),
+            event_store,
+            targeting_attributes: Some(targeting_attributes.clone()),
+        }
+    }
+
+    pub(crate) fn update_enrollment(&mut self, enrollment: &ExperimentEnrollment) -> bool {
+        if let Some(ref mut targeting_attributes) = self.targeting_attributes {
+            targeting_attributes.update_enrollment(enrollment);
+
+            self.context = serde_json::to_value(targeting_attributes.clone()).unwrap();
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/components/nimbus/src/stateless/cirrus_client.rs
+++ b/components/nimbus/src/stateless/cirrus_client.rs
@@ -138,15 +138,19 @@ impl CirrusClient {
     ) -> Result<EnrollmentResponse> {
         let available_randomization_units =
             AvailableRandomizationUnits::with_user_id(user_id.as_str());
-        let ta = TargetingAttributes::new(self.app_context.clone(), request_context);
-        let th = NimbusTargetingHelper::new(ta);
+        let targeting_attributes =
+            TargetingAttributes::new(self.app_context.clone(), request_context);
+        let mut targeting_helper = NimbusTargetingHelper::new(targeting_attributes);
         let coenrolling_ids = self
             .coenrolling_feature_ids
             .iter()
             .map(|s| s.as_str())
             .collect();
-        let enrollments_evolver =
-            EnrollmentsEvolver::new(&available_randomization_units, &th, &coenrolling_ids);
+        let mut enrollments_evolver = EnrollmentsEvolver::new(
+            &available_randomization_units,
+            &mut targeting_helper,
+            &coenrolling_ids,
+        );
         let state = self.state.lock().unwrap();
 
         let (enrollments, events) = enrollments_evolver

--- a/components/nimbus/src/targeting.rs
+++ b/components/nimbus/src/targeting.rs
@@ -10,15 +10,18 @@ use serde_json::{json, Value};
 cfg_if::cfg_if! {
     if #[cfg(feature = "stateful")] {
         use anyhow::anyhow;
-        use crate::stateful::behavior::{EventStore, EventQueryType, query_event_store};
+        use crate::{TargetingAttributes, stateful::behavior::{EventStore, EventQueryType, query_event_store}};
         use std::sync::{Arc, Mutex};
     }
 }
 
+#[derive(Clone)]
 pub struct NimbusTargetingHelper {
     pub(crate) context: Value,
     #[cfg(feature = "stateful")]
     pub(crate) event_store: Arc<Mutex<EventStore>>,
+    #[cfg(feature = "stateful")]
+    pub(crate) targeting_attributes: Option<TargetingAttributes>,
 }
 
 impl NimbusTargetingHelper {
@@ -30,6 +33,8 @@ impl NimbusTargetingHelper {
             context: serde_json::to_value(context).unwrap(),
             #[cfg(feature = "stateful")]
             event_store,
+            #[cfg(feature = "stateful")]
+            targeting_attributes: None,
         }
     }
 
@@ -52,12 +57,12 @@ impl NimbusTargetingHelper {
             self.context.clone()
         };
 
-        #[cfg(feature = "stateful")]
-        let event_store = self.event_store.clone();
         Self {
             context,
             #[cfg(feature = "stateful")]
-            event_store,
+            event_store: self.event_store.clone(),
+            #[cfg(feature = "stateful")]
+            targeting_attributes: self.targeting_attributes.clone(),
         }
     }
 }

--- a/components/nimbus/src/tests/test_enrollment.rs
+++ b/components/nimbus/src/tests/test_enrollment.rs
@@ -404,7 +404,7 @@ fn local_ctx() -> (Uuid, AppContext, AvailableRandomizationUnits) {
 }
 
 fn enrollment_evolver<'a>(
-    targeting_helper: &'a NimbusTargetingHelper,
+    targeting_helper: &'a mut NimbusTargetingHelper,
     aru: &'a AvailableRandomizationUnits,
     ids: &'a HashSet<&str>,
 ) -> EnrollmentsEvolver<'a> {
@@ -421,9 +421,9 @@ fn test_ios_rollout_experiment() -> Result<()> {
         channel: "release".to_string(),
         ..app_ctx
     };
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let enrollment = evolver
         .evolve_enrollment::<Experiment>(true, None, Some(exp), None, &mut events)?
@@ -440,9 +440,9 @@ fn test_ios_rollout_experiment() -> Result<()> {
 fn test_evolver_new_experiment_enrolled() -> Result<()> {
     let exp = &get_test_experiments()[0];
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let enrollment = evolver
         .evolve_enrollment::<Experiment>(true, None, Some(exp), None, &mut events)?
@@ -462,9 +462,9 @@ fn test_evolver_new_experiment_not_enrolled() -> Result<()> {
     let mut exp = get_test_experiments()[0].clone();
     exp.bucket_config.count = 0; // Make the experiment bucketing fail.
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let enrollment = evolver
         .evolve_enrollment::<Experiment>(true, None, Some(&exp), None, &mut events)?
@@ -483,9 +483,9 @@ fn test_evolver_new_experiment_not_enrolled() -> Result<()> {
 fn test_evolver_new_experiment_globally_opted_out() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let enrollment = evolver
         .evolve_enrollment::<Experiment>(false, None, Some(&exp), None, &mut events)?
@@ -505,9 +505,9 @@ fn test_evolver_new_experiment_enrollment_paused() -> Result<()> {
     let mut exp = get_test_experiments()[0].clone();
     exp.is_enrollment_paused = true;
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let enrollment = evolver
         .evolve_enrollment::<Experiment>(true, None, Some(&exp), None, &mut events)?
@@ -526,9 +526,9 @@ fn test_evolver_new_experiment_enrollment_paused() -> Result<()> {
 fn test_evolver_experiment_update_not_enrolled_opted_out() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -555,9 +555,9 @@ fn test_evolver_experiment_update_not_enrolled_enrollment_paused() -> Result<()>
     let mut exp = get_test_experiments()[0].clone();
     exp.is_enrollment_paused = true;
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -584,9 +584,9 @@ fn test_evolver_experiment_update_not_enrolled_resuming_not_selected() -> Result
     let mut exp = get_test_experiments()[0].clone();
     exp.bucket_config.count = 0; // Make the experiment bucketing fail.
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -617,9 +617,9 @@ fn test_evolver_experiment_update_not_enrolled_resuming_not_selected() -> Result
 fn test_evolver_experiment_update_not_enrolled_resuming_selected() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -653,9 +653,9 @@ fn test_evolver_experiment_update_not_enrolled_resuming_selected() -> Result<()>
 fn test_evolver_experiment_update_enrolled_then_opted_out() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -696,9 +696,9 @@ fn test_evolver_experiment_update_enrolled_then_experiment_paused() -> Result<()
     let mut exp = get_test_experiments()[0].clone();
     exp.is_enrollment_paused = true;
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -736,9 +736,9 @@ fn test_evolver_experiment_update_enrolled_then_targeting_changed() -> Result<()
     let exp = get_test_experiments()[0].clone();
     let (_, mut app_ctx, aru) = local_ctx();
     app_ctx.app_name = "foobar".to_owned(); // Make the experiment targeting fail.
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -781,9 +781,9 @@ fn test_evolver_experiment_update_enrolled_then_targeting_changed() -> Result<()
 fn test_evolver_experiment_update_enrolled_then_bucketing_changed() -> Result<()> {
     let exp = get_bucketed_rollout("test-rollout", 0);
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -818,9 +818,9 @@ fn test_evolver_experiment_update_enrolled_then_bucketing_changed() -> Result<()
 #[test]
 fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
 
     let slug = "my-rollout";
 
@@ -879,9 +879,9 @@ fn test_rollout_unenrolls_when_bucketing_changes() -> Result<()> {
 #[test]
 fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> {
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
 
     let slug = "my-rollout";
 
@@ -957,9 +957,9 @@ fn test_rollout_unenrolls_then_reenrolls_when_bucketing_changes() -> Result<()> 
 fn test_experiment_does_not_reenroll_from_disqualified_not_selected_or_not_targeted() -> Result<()>
 {
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
 
     let slug_1 = "my-experiment-1";
     let slug_2 = "my-experiment-2";
@@ -1023,9 +1023,9 @@ fn test_evolver_experiment_update_enrolled_then_branches_changed() -> Result<()>
         },
     ];
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -1058,9 +1058,9 @@ fn test_evolver_experiment_update_enrolled_then_branch_disappears() -> Result<()
         features: None,
     }];
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -1099,9 +1099,9 @@ fn test_evolver_experiment_update_enrolled_then_branch_disappears() -> Result<()
 fn test_evolver_experiment_update_disqualified_then_opted_out() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -1134,9 +1134,9 @@ fn test_evolver_experiment_update_disqualified_then_opted_out() -> Result<()> {
 fn test_evolver_experiment_update_disqualified_then_bucketing_ok() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -1164,9 +1164,9 @@ fn test_evolver_feature_can_have_only_one_experiment() -> Result<()> {
     let _ = env_logger::try_init();
 
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     // Let's go from no experiments, to some experiments.
     let existing_experiments: Vec<Experiment> = vec![];
     let existing_enrollments: Vec<ExperimentEnrollment> = vec![];
@@ -1324,9 +1324,9 @@ fn test_evolver_experiment_not_enrolled_feature_conflict() -> Result<()> {
     let mut test_experiments = get_test_experiments();
     test_experiments.push(get_conflicting_experiment());
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = EnrollmentsEvolver::new(&aru, &th, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
     let (enrollments, events) =
         evolver.evolve_enrollments::<Experiment>(true, &[], &test_experiments, &[])?;
 
@@ -1386,9 +1386,9 @@ fn test_multi_feature_per_branch_conflict() -> Result<()> {
     let mut test_experiments = get_test_experiments();
     test_experiments.push(get_experiment_with_different_features_same_branch());
     let (_, app_ctx, aru) = local_ctx();
-    let targeting_attributes = app_ctx.into();
+    let mut targeting_attributes = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = EnrollmentsEvolver::new(&aru, &targeting_attributes, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_attributes, &ids);
     let (enrollments, events) =
         evolver.evolve_enrollments::<Experiment>(true, &[], &test_experiments, &[])?;
 
@@ -1426,9 +1426,9 @@ fn test_evolver_feature_id_reuse() -> Result<()> {
 
     let test_experiments = get_test_experiments();
     let (_, app_ctx, aru) = local_ctx();
-    let targeting_attributes = app_ctx.into();
+    let mut targeting_attributes = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = EnrollmentsEvolver::new(&aru, &targeting_attributes, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut targeting_attributes, &ids);
     let (enrollments, _) =
         evolver.evolve_enrollments::<Experiment>(true, &[], &test_experiments, &[])?;
 
@@ -1481,9 +1481,9 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
     let _ = env_logger::try_init();
 
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = EnrollmentsEvolver::new(&aru, &th, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
 
     let aboutwelcome_experiment = get_experiment_with_aboutwelcome_feature_branches();
     let newtab_experiment = get_experiment_with_newtab_feature_branches();
@@ -1781,9 +1781,9 @@ fn test_evolver_multi_feature_experiments() -> Result<()> {
 fn test_evolver_experiment_update_was_enrolled() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -2002,9 +2002,9 @@ fn test_map_features_by_feature_id_with_coenrolling_multifeature() -> Result<()>
 fn test_evolve_enrollments_with_coenrolling_features() -> Result<()> {
     let _ = env_logger::try_init();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = HashSet::from(["coenrolling"]);
-    let evolver = EnrollmentsEvolver::new(&aru, &th, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
 
     let exp1 = get_single_feature_experiment("exp1", "colliding", json!({"x": 1 }));
     let exp2 = get_single_feature_experiment("exp2", "coenrolling", json!({ "a": 1, "b": 2 }));
@@ -2070,9 +2070,9 @@ fn test_evolve_enrollments_with_coenrolling_features() -> Result<()> {
 fn test_evolve_enrollments_with_coenrolling_multi_features() -> Result<()> {
     let _ = env_logger::try_init();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = HashSet::from(["coenrolling"]);
-    let evolver = EnrollmentsEvolver::new(&aru, &th, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
 
     let exp1 = get_multi_feature_experiment(
         "exp1",
@@ -2257,9 +2257,9 @@ fn test_evolve_enrollments_error_handling() -> Result<()> {
 
     let _ = env_logger::try_init();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = EnrollmentsEvolver::new(&aru, &th, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
 
     // test that evolve_enrollments correctly handles the case where a
     // record without a previous enrollment gets dropped
@@ -2309,9 +2309,9 @@ fn test_evolve_enrollments_error_handling() -> Result<()> {
 fn test_evolve_enrollments_is_already_enrolled_targeting() -> Result<()> {
     let _ = env_logger::try_init();
     let (_, mut app_ctx, aru) = local_ctx();
-    let th = app_ctx.clone().into();
+    let mut th = app_ctx.clone().into();
     let ids = no_coenrolling_features();
-    let evolver = EnrollmentsEvolver::new(&aru, &th, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
 
     // The targeting for this experiment is
     // "app_id == 'org.mozilla.fenix' || is_already_enrolled"
@@ -2332,9 +2332,9 @@ fn test_evolve_enrollments_is_already_enrolled_targeting() -> Result<()> {
     // we change the app_id so the targeting will only target
     // against the `is_already_enrolled`
     app_ctx.app_id = "org.mozilla.bobo".into();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = EnrollmentsEvolver::new(&aru, &th, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
 
     // The user should still be enrolled, since the targeting is OR'ing the app_id == 'org.mozilla.fenix'
     // and the 'is_already_enrolled'
@@ -2358,9 +2358,9 @@ fn test_evolve_enrollments_is_already_enrolled_targeting() -> Result<()> {
 fn test_evolver_experiment_update_error() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -2390,9 +2390,9 @@ fn test_evolver_experiment_update_error() -> Result<()> {
 fn test_evolver_experiment_ended_was_enrolled() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -2426,9 +2426,9 @@ fn test_evolver_experiment_ended_was_enrolled() -> Result<()> {
 fn test_evolver_experiment_ended_was_disqualified() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -2462,9 +2462,9 @@ fn test_evolver_experiment_ended_was_disqualified() -> Result<()> {
 fn test_evolver_experiment_ended_was_not_enrolled() -> Result<()> {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: exp.slug.clone(),
@@ -2487,9 +2487,9 @@ fn test_evolver_experiment_ended_was_not_enrolled() -> Result<()> {
 #[test]
 fn test_evolver_garbage_collection_before_threshold() -> Result<()> {
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: "secure-gold".to_owned(),
@@ -2513,9 +2513,9 @@ fn test_evolver_garbage_collection_before_threshold() -> Result<()> {
 #[test]
 fn test_evolver_garbage_collection_after_threshold() -> Result<()> {
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let mut events = vec![];
     let existing_enrollment = ExperimentEnrollment {
         slug: "secure-gold".to_owned(),
@@ -2547,9 +2547,9 @@ fn test_evolver_new_experiment_enrollment_already_exists() {
         },
     };
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let res = evolver.evolve_enrollment::<Experiment>(
         true,
         None,
@@ -2564,9 +2564,9 @@ fn test_evolver_new_experiment_enrollment_already_exists() {
 fn test_evolver_existing_experiment_has_no_enrollment() {
     let exp = get_test_experiments()[0].clone();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let res = evolver.evolve_enrollment(true, Some(&exp), Some(&exp), None, &mut vec![]);
     assert!(res.is_err());
 }
@@ -2575,9 +2575,9 @@ fn test_evolver_existing_experiment_has_no_enrollment() {
 #[should_panic]
 fn test_evolver_no_experiments_no_enrollment() {
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     evolver
         .evolve_enrollment::<Experiment>(true, None, None, None, &mut vec![])
         .unwrap();
@@ -2617,9 +2617,9 @@ fn test_evolver_rollouts_do_not_conflict_with_experiments() -> Result<()> {
     let recipes = &[experiment, rollout];
 
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let (enrollments, events) =
         evolver.evolve_enrollments::<Experiment>(true, &[], recipes, &[])?;
     assert_eq!(enrollments.len(), 2);
@@ -2678,9 +2678,9 @@ fn test_evolver_rollouts_do_not_conflict_with_rollouts() -> Result<()> {
     let recipes = &[experiment, rollout, rollout2];
 
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
     let (enrollments, events) =
         evolver.evolve_enrollments::<Experiment>(true, &[], recipes, &[])?;
     assert_eq!(enrollments.len(), 3);
@@ -2903,9 +2903,9 @@ fn test_rollouts_end_to_end() -> Result<()> {
     let recipes = &[rollout, experiment];
 
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = no_coenrolling_features();
-    let evolver = enrollment_evolver(&th, &aru, &ids);
+    let mut evolver = enrollment_evolver(&mut th, &aru, &ids);
 
     let (enrollments, _events) =
         evolver.evolve_enrollments::<Experiment>(true, &[], recipes, &[])?;
@@ -3162,9 +3162,9 @@ fn test_sort_experiments_by_published_date() -> Result<()> {
 fn test_evolve_enrollments_ordering() -> Result<()> {
     let _ = env_logger::try_init();
     let (_, app_ctx, aru) = local_ctx();
-    let th = app_ctx.into();
+    let mut th = app_ctx.into();
     let ids = HashSet::new();
-    let evolver = EnrollmentsEvolver::new(&aru, &th, &ids);
+    let mut evolver = EnrollmentsEvolver::new(&aru, &mut th, &ids);
 
     let exp1 = get_single_feature_experiment("slug-1", "colliding-feature", json!({"x": 1 }))
         .patch(json!({"publishedDate": "2023-11-21T18:00:00Z"}));


### PR DESCRIPTION
O(_m_*_n_) change — opening as a draft for early feedback

I'm not super happy with how I've had to impl this, so if y'all have any better ideas please let me know.

There's a number of tests and a bit of logic missing as well — need to make sure all state transitions are covered and I'm pretty sure a few are missed with the current logic.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
