### PR TITLE
Implement Eq, Ord, and Hash on GetItemOptions

### DIFF
--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -346,7 +346,7 @@ where
             for unparsable_ids in all_unparsable_ids.chunks(UNPARSABLE_IDS_PER_REQUEST) {
                 let mut options = GetItemsOptions::new();
                 for unparsable_id in unparsable_ids {
-                    options.eq("id", *unparsable_id);
+                    options.filter_eq("id", *unparsable_id);
                 }
                 let records_chunk = self
                     .settings_client
@@ -388,7 +388,7 @@ where
         // so that we can eventually resume downloading where we left off.
         options.sort("last_modified", SortOrder::Ascending);
 
-        options.eq("type", ingest_record_type.to_string());
+        options.filter_eq("type", ingest_record_type.to_string());
 
         // Get the last ingest value. This is the max of the last_ingest_keys
         // that are in the database.
@@ -397,7 +397,7 @@ where
         {
             // Only download changes since our last ingest. If our last ingest
             // was interrupted, we'll pick up where we left off.
-            options.gt("last_modified", last_ingest.to_string());
+            options.filter_gt("last_modified", last_ingest.to_string());
         }
 
         if let Some(max_suggestions) = constraints.max_suggestions {


### PR DESCRIPTION
A side issue here is that there are inherint methods with the same method names as these traits. This is normally not a big deal because inherent methods have a higher precedence than trait methods. However, the methods also take `&mut self` and which has a lower precedent than `&self` and this rule as a higher precedence (meta-precedence?) than the other rule.

I prefixed the inherint method names with `filter_` and everything seems to work okay.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
