### PR TITLE
Updating the fxa-client example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,6 +1004,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1406,8 @@ dependencies = [
  "clap 4.2.2",
  "cli-support",
  "fxa-client",
+ "log",
+ "simple_logger",
  "sync15",
  "url",
  "viaduct-reqwest",
@@ -2787,6 +2798,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,6 +3215,12 @@ checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
 dependencies = [
  "plotters-backend",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3852,18 +3875,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3968,6 +3991,18 @@ name = "similar"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
+
+[[package]]
+name = "simple_logger"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+dependencies = [
+ "colored",
+ "log",
+ "time",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "siphasher"
@@ -4356,20 +4391,36 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.11"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
+ "deranged",
+ "itoa 1.0.9",
  "libc",
+ "num-conv",
  "num_threads",
+ "powerfmt",
+ "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinytemplate"

--- a/examples/autofill-utils/src/autofill-utils.rs
+++ b/examples/autofill-utils/src/autofill-utils.rs
@@ -11,7 +11,7 @@ use autofill::db::{
 };
 use autofill::encryption::{create_autofill_key, EncryptorDecryptor};
 use autofill::error::Error;
-use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
+use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
 use cli_support::prompt::{prompt_string, prompt_usize};
 use interrupt_support::NeverInterrupts; // XXX need a real interruptee!
 use std::sync::Arc;
@@ -357,7 +357,7 @@ fn run_sync(
     wait: u64,
 ) -> Result<()> {
     // XXX - need to add interrupts
-    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file)?;
+    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file, &[SYNC_SCOPE])?;
 
     if wipe_all {
         Sync15StorageClient::new(cli_fxa.client_init.clone())?.wipe_all_remote()?;

--- a/examples/fxa-client/Cargo.toml
+++ b/examples/fxa-client/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 
 [dependencies]
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
+log = "0.4"
+simple_logger = "4"
 clap = {version = "4.2", features = ["derive"]}
 cli-support = { path = "../cli-support" }
 fxa-client = { path = "../../components/fxa-client" }

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -4,7 +4,7 @@
 
 #![warn(rust_2018_idioms)]
 
-use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
+use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
 use interrupt_support::Interruptee;
 use places::storage::bookmarks::{
     json_tree::{
@@ -237,7 +237,7 @@ fn sync(
 ) -> Result<()> {
     use_reqwest_backend();
 
-    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file)?;
+    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &cred_file, &[SYNC_SCOPE])?;
 
     if wipe_all {
         Sync15StorageClient::new(cli_fxa.client_init.clone())?.wipe_all_remote()?;

--- a/examples/sync-pass/src/sync-pass.rs
+++ b/examples/sync-pass/src/sync-pass.rs
@@ -6,7 +6,9 @@
 #![warn(rust_2018_idioms)]
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use cli_support::fxa_creds::{get_account_and_token, get_cli_fxa, get_default_fxa_config};
+use cli_support::fxa_creds::{
+    get_account_and_token, get_cli_fxa, get_default_fxa_config, SYNC_SCOPE,
+};
 use cli_support::prompt::{prompt_char, prompt_string, prompt_usize};
 use logins::encryption::{create_key, EncryptorDecryptor};
 use logins::{
@@ -475,12 +477,12 @@ fn main() -> Result<()> {
             }
             'S' | 's' => {
                 log::info!("Syncing!");
-                let (_, token_info) = get_account_and_token(get_default_fxa_config(), cred_file)?;
+                let (_, token_info) = get_account_and_token(get_default_fxa_config(), cred_file, &[SYNC_SCOPE])?;
                 let sync_key = URL_SAFE_NO_PAD.encode(
                     token_info.key.unwrap().key_bytes()?,
                 );
                 // TODO: allow users to use stage/etc.
-                let cli_fxa = get_cli_fxa(get_default_fxa_config(), cred_file)?;
+                let cli_fxa = get_cli_fxa(get_default_fxa_config(), cred_file, &[SYNC_SCOPE])?;
                 match do_sync(
                     Arc::clone(&store),
                     cli_fxa.client_init.key_id.clone(),

--- a/examples/tabs-sync/src/tabs-sync.rs
+++ b/examples/tabs-sync/src/tabs-sync.rs
@@ -5,7 +5,9 @@
 #![warn(rust_2018_idioms)]
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use cli_support::fxa_creds::{get_account_and_token, get_cli_fxa, get_default_fxa_config};
+use cli_support::fxa_creds::{
+    get_account_and_token, get_cli_fxa, get_default_fxa_config, SYNC_SCOPE,
+};
 use cli_support::prompt::{prompt_char, prompt_string};
 use interrupt_support::NeverInterrupts;
 use std::path::Path;
@@ -100,10 +102,11 @@ fn main() -> Result<()> {
     cli_support::init_logging();
     let opts = Opts::from_args();
 
-    let (_, token_info) = get_account_and_token(get_default_fxa_config(), &opts.creds_file)?;
+    let (_, token_info) =
+        get_account_and_token(get_default_fxa_config(), &opts.creds_file, &[SYNC_SCOPE])?;
     let sync_key = URL_SAFE_NO_PAD.encode(token_info.key.unwrap().key_bytes()?);
 
-    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &opts.creds_file)?;
+    let cli_fxa = get_cli_fxa(get_default_fxa_config(), &opts.creds_file, &[SYNC_SCOPE])?;
     let device_id = cli_fxa.account.get_current_device_id()?;
 
     let store = Arc::new(TabsStore::new(Path::new(&opts.db_path)));

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -4,7 +4,7 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
-use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config};
+use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
 use std::{collections::HashSet, process};
 use std::sync::Arc;
 use structopt::StructOpt;
@@ -78,7 +78,7 @@ pub fn run_test_group(opts: &Opts, group: TestGroup) {
     }
 
     let cfg = get_default_fxa_config();
-    let cli_fxa = get_cli_fxa(cfg, &opts.credential_file).expect("can't initialize cli");
+    let cli_fxa = get_cli_fxa(cfg, &opts.credential_file, &[SYNC_SCOPE]).expect("can't initialize cli");
     let acct = Arc::new(cli_fxa);
 
     let mut user = TestUser::new(acct, 2).expect("Failed to get test user.");


### PR DESCRIPTION
Added flags to:
  - Request the session scope.
  - Control how log messages get printed to the console.

Updated the code to re-authenticated using the existing data rather than throwing it away and starting from scratch.

These changes make it possible to repro
https://bugzilla.mozilla.org/show_bug.cgi?id=1887071

- run `cargo run -- --log -d devices` with fresh credentials.
  - Any command should do, but I used `devices`
  - The client should ask you to login and paste your credentials
  - You should see the device list printed out
- In a browser session, change your FxA password
- run `cargo run -- --log -d devices` again
  - The client should tell you there was an auth-problem and ask you to reauthenticate.
  - After you paste the reauthentication URL you should see an error printed out

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
