### PR TITLE
[WIP] Added get_bytes_in_use function to webext-storage UDL

### DIFF
--- a/components/webext-storage/src/store.rs
+++ b/components/webext-storage/src/store.rs
@@ -119,9 +119,9 @@ impl WebExtStorageStore {
 
     /// Returns the bytes in use for the specified items (which can be null,
     /// a string, or an array)
-    pub fn get_bytes_in_use(&self, ext_id: &str, keys: JsonValue) -> Result<usize> {
+    pub fn get_bytes_in_use(&self, ext_id: &str, keys: JsonValue) -> Result<u64> {
         let db = self.db.lock();
-        api::get_bytes_in_use(&db, ext_id, keys)
+        Ok(api::get_bytes_in_use(&db, ext_id, keys)? as u64)
     }
 
     /// Returns a bridged sync engine for Desktop for this store.

--- a/components/webext-storage/src/webext-storage.udl
+++ b/components/webext-storage/src/webext-storage.udl
@@ -43,6 +43,9 @@ interface WebExtStorageStore {
     JsonValue get([ByRef] string ext_id, JsonValue keys);
 
     [Throws=WebExtStorageApiError]
+    u64 get_bytes_in_use([ByRef] string ext_id, JsonValue keys);
+
+    [Throws=WebExtStorageApiError]
     StorageChanges remove([ByRef] string ext_id, JsonValue keys);
 
     [Throws=WebExtStorageApiError]


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
