### PR TITLE
Bug 1892324 - Add the "close tabs" device command to the FxA client

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
@@ -510,6 +510,21 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
     }
 
     /**
+     * Close one or more tabs that are currently open on another device.
+     *
+     * This performs network requests, and should not be used on the main thread.
+     *
+     * @param targetDeviceId The ID of the device on which the tabs are
+     * currently open.
+     * @param urls The URLs of the tabs to close.
+     */
+    fun closeTabs(targetDeviceId: String, urls: List<String>) {
+        withMetrics {
+            this.inner.closeTabs(targetDeviceId, urls)
+        }
+    }
+
+    /**
      * Gather any telemetry which has been collected internally and return
      * the result as a JSON string.
      *

--- a/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
@@ -94,6 +94,8 @@ public class DeviceConstellation {
                 case let .sendTab(title, url): do {
                         try self.account.sendSingleTab(targetDeviceId: targetDeviceId, title: title, url: url)
                     }
+                case let .closeTabs(urls):
+                    try self.account.closeTabs(targetDeviceId: targetDeviceId, urls: urls)
                 }
             } catch {
                 FxALog.error("Error sending event to another device: \(error).")
@@ -162,4 +164,5 @@ public class DeviceConstellation {
 
 public enum DeviceEventOutgoing {
     case sendTab(title: String, url: String)
+    case closeTabs(urls: [String])
 }

--- a/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
@@ -189,6 +189,12 @@ class PersistedFirefoxAccount {
         }
     }
 
+    public func closeTabs(targetDeviceId: String, urls: [String]) throws {
+        return try notifyAuthErrors {
+            try self.inner.closeTabs(targetDeviceId: targetDeviceId, urls: urls)
+        }
+    }
+
     public func getTokenServerEndpointURL() throws -> URL {
         return try URL(string: inner.getTokenServerEndpointUrl())!
     }

--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -239,11 +239,10 @@ pub struct Device {
 /// executing these commands are encapsulated as part of the FxA Client component,
 /// so consumers simply need to select which ones they want to support, and can
 /// use the variants of this enum to do so.
-///
-/// In practice, the only currently-supported command is the ability to receive a tab.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum DeviceCapability {
     SendTab,
+    CloseTabs,
 }
 
 /// A client connected to the user's account.

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -528,7 +528,17 @@ interface FirefoxAccount {
   //
   [Throws=FxaError]
   void send_single_tab([ByRef] string target_device_id, [ByRef] string title, [ByRef] string url );
-  
+
+
+  /// Use device commands to close one or more tabs on another device.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// If a device on the account has registered the [`CloseTabs`](DeviceCapability::CloseTabs)
+  /// capability, this method can be used to close its tabs.
+  [Throws=FxaError]
+  void close_tabs([ByRef] string target_device_id, sequence<string> urls);
+
 
   // Get the URL at which to access the user's sync data.
   //
@@ -886,6 +896,14 @@ dictionary SendTabPayload {
   string stream_id = "";
 };
 
+/// The payload sent when invoking a "close tabs" command.
+//
+dictionary CloseTabsPayload {
+
+  /// The URLs of the tabs to close.
+  sequence<string> urls;
+};
+
 // An individual entry in the navigation history of a sent tab.
 //
 dictionary TabHistoryEntry {
@@ -981,10 +999,9 @@ enum FxaRustAuthState {
 // so consumers simply need to select which ones they want to support, and can
 // use the variants of this enum to do so.
 //
-// In practice, the only currently-supported command is the ability to receive a tab.
-//
 enum DeviceCapability {
   "SendTab",
+  "CloseTabs",
 };
 
 
@@ -1058,6 +1075,9 @@ interface IncomingDeviceCommand {
 
   // Indicates that a tab has been sent to this device.
   TabReceived(Device? sender, SendTabPayload payload );
+
+  /// Indicates that the sender wants to close one or more tabs on this device.
+  TabsClosed(Device? sender, CloseTabsPayload payload);
 };
 
 // Machinery for dry-run testing of FxaAuthStateMachine

--- a/components/fxa-client/src/internal/close_tabs.rs
+++ b/components/fxa-client/src/internal/close_tabs.rs
@@ -25,7 +25,12 @@ impl FirefoxAccount {
         };
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
         let command_payload = close_tabs::build_close_tabs_command(oldsync_key, target, &payload)?;
-        self.invoke_command(close_tabs::COMMAND_NAME, target, &command_payload)?;
+        self.invoke_command(
+            close_tabs::COMMAND_NAME,
+            target,
+            &command_payload,
+            Some(close_tabs::COMMAND_TTL),
+        )?;
         Ok(())
     }
 

--- a/components/fxa-client/src/internal/close_tabs.rs
+++ b/components/fxa-client/src/internal/close_tabs.rs
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::{
+    commands::{
+        close_tabs::{self, CloseTabsPayload, EncryptedCloseTabsPayload},
+        send_tab::PrivateSendTabKeys,
+        IncomingDeviceCommand,
+    },
+    http_client::GetDeviceResponse,
+    scopes, FirefoxAccount,
+};
+use crate::{Error, Result};
+
+impl FirefoxAccount {
+    pub fn close_tabs<T: AsRef<str>>(&mut self, target_device_id: &str, urls: &[T]) -> Result<()> {
+        let devices = self.get_devices(false)?;
+        let target = devices
+            .iter()
+            .find(|d| d.id == target_device_id)
+            .ok_or_else(|| Error::UnknownTargetDevice(target_device_id.to_owned()))?;
+        let payload = CloseTabsPayload {
+            urls: urls.iter().map(|url| url.as_ref().to_owned()).collect(),
+        };
+        let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
+        let command_payload = close_tabs::build_close_tabs_command(oldsync_key, target, &payload)?;
+        self.invoke_command(close_tabs::COMMAND_NAME, target, &command_payload)?;
+        Ok(())
+    }
+
+    pub(crate) fn handle_close_tabs_command(
+        &mut self,
+        sender: Option<GetDeviceResponse>,
+        payload: serde_json::Value,
+    ) -> Result<IncomingDeviceCommand> {
+        let send_tab_key: PrivateSendTabKeys = match self.close_tabs_key() {
+            Some(s) => PrivateSendTabKeys::deserialize(s)?,
+            None => {
+                return Err(Error::IllegalState(
+                    "Cannot find Close Remote Tabs keys. Has initialize_device been called before?",
+                ));
+            }
+        };
+        let encrypted_payload: EncryptedCloseTabsPayload = serde_json::from_value(payload)?;
+        match encrypted_payload.decrypt(&send_tab_key) {
+            Ok(payload) => Ok(IncomingDeviceCommand::TabsClosed { sender, payload }),
+            Err(e) => {
+                log::warn!("Could not decrypt Close Remote Tabs payload. Diagnosing then resetting the Close Tabs keys.");
+                self.clear_close_tabs_keys();
+                self.reregister_current_capabilities()?;
+                Err(e)
+            }
+        }
+    }
+
+    pub(crate) fn load_or_generate_close_tabs_keys(&mut self) -> Result<PrivateSendTabKeys> {
+        if let Some(s) = self.close_tabs_key() {
+            match PrivateSendTabKeys::deserialize(s) {
+                Ok(keys) => return Ok(keys),
+                Err(_) => {
+                    error_support::report_error!(
+                        "fxaclient-close-tabs-key-deserialize",
+                        "Could not deserialize Close Remote Tabs keys. Re-creating them."
+                    );
+                }
+            }
+        }
+        let keys = PrivateSendTabKeys::from_random()?;
+        self.set_close_tabs_key(keys.serialize()?);
+        Ok(keys)
+    }
+
+    fn close_tabs_key(&self) -> Option<&str> {
+        self.state.get_commands_data(close_tabs::COMMAND_NAME)
+    }
+
+    fn set_close_tabs_key(&mut self, key: String) {
+        self.state.set_commands_data(close_tabs::COMMAND_NAME, key)
+    }
+
+    fn clear_close_tabs_keys(&mut self) {
+        self.state.clear_commands_data(close_tabs::COMMAND_NAME);
+    }
+}

--- a/components/fxa-client/src/internal/commands/close_tabs.rs
+++ b/components/fxa-client/src/internal/commands/close_tabs.rs
@@ -1,0 +1,98 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use rc_crypto::ece;
+use serde_derive::*;
+
+use crate::{Error, Result, ScopedKey};
+
+use super::{
+    super::device::Device,
+    send_tab::{PrivateSendTabKeysV1, PublicSendTabKeys, SendTabKeysPayload},
+};
+
+pub const COMMAND_NAME: &str = "https://identity.mozilla.com/cmd/close-uri/v1";
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EncryptedCloseTabsPayload {
+    /// URL Safe Base 64 encrypted payload.
+    encrypted: String,
+}
+
+impl EncryptedCloseTabsPayload {
+    pub(crate) fn decrypt(self, keys: &PrivateSendTabKeysV1) -> Result<CloseTabsPayload> {
+        rc_crypto::ensure_initialized();
+        let encrypted = URL_SAFE_NO_PAD.decode(self.encrypted)?;
+        let decrypted = ece::decrypt(keys.p256key(), keys.auth_secret(), &encrypted)?;
+        Ok(serde_json::from_slice(&decrypted)?)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CloseTabsPayload {
+    pub urls: Vec<String>,
+}
+
+impl From<CloseTabsPayload> for crate::CloseTabsPayload {
+    fn from(payload: CloseTabsPayload) -> Self {
+        crate::CloseTabsPayload { urls: payload.urls }
+    }
+}
+
+impl CloseTabsPayload {
+    fn encrypt(&self, keys: PublicSendTabKeys) -> Result<EncryptedCloseTabsPayload> {
+        rc_crypto::ensure_initialized();
+        let bytes = serde_json::to_vec(&self)?;
+        let public_key = URL_SAFE_NO_PAD.decode(keys.public_key())?;
+        let auth_secret = URL_SAFE_NO_PAD.decode(keys.auth_secret())?;
+        let encrypted = ece::encrypt(&public_key, &auth_secret, &bytes)?;
+        let encrypted = URL_SAFE_NO_PAD.encode(encrypted);
+        Ok(EncryptedCloseTabsPayload { encrypted })
+    }
+}
+
+pub fn build_close_tabs_command(
+    scoped_key: &ScopedKey,
+    target: &Device,
+    payload: &CloseTabsPayload,
+) -> Result<serde_json::Value> {
+    let command = target
+        .available_commands
+        .get(COMMAND_NAME)
+        .ok_or(Error::UnsupportedCommand(COMMAND_NAME))?;
+    let bundle: SendTabKeysPayload = serde_json::from_str(command)?;
+    let public_keys = bundle.decrypt(scoped_key)?;
+    let encrypted_payload = payload.encrypt(public_keys)?;
+    Ok(serde_json::to_value(encrypted_payload)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::Result;
+
+    #[test]
+    fn test_empty_payload() -> Result<()> {
+        let empty = r#"{ "urls": []}"#;
+        let payload: CloseTabsPayload = serde_json::from_str(empty)?;
+        assert!(payload.urls.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_payload() -> Result<()> {
+        let payload = CloseTabsPayload {
+            urls: vec!["https://www.mozilla.org".into()],
+        };
+        let json = serde_json::to_string(&payload)?;
+        assert!(!json.is_empty());
+        let deserialized: CloseTabsPayload = serde_json::from_str(&json)?;
+        assert_eq!(deserialized, payload);
+
+        Ok(())
+    }
+}

--- a/components/fxa-client/src/internal/commands/close_tabs.rs
+++ b/components/fxa-client/src/internal/commands/close_tabs.rs
@@ -14,6 +14,7 @@ use super::{
 };
 
 pub const COMMAND_NAME: &str = "https://identity.mozilla.com/cmd/close-uri/v1";
+pub const COMMAND_TTL: u64 = 2 * 24 * 3600;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EncryptedCloseTabsPayload {

--- a/components/fxa-client/src/internal/commands/mod.rs
+++ b/components/fxa-client/src/internal/commands/mod.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+pub mod close_tabs;
 pub mod send_tab;
+
+pub use close_tabs::CloseTabsPayload;
 pub use send_tab::SendTabPayload;
 
 use super::device::Device;
@@ -15,6 +18,10 @@ pub enum IncomingDeviceCommand {
         sender: Option<Device>,
         payload: SendTabPayload,
     },
+    TabsClosed {
+        sender: Option<Device>,
+        payload: CloseTabsPayload,
+    },
 }
 
 impl TryFrom<IncomingDeviceCommand> for crate::IncomingDeviceCommand {
@@ -23,6 +30,12 @@ impl TryFrom<IncomingDeviceCommand> for crate::IncomingDeviceCommand {
         Ok(match cmd {
             IncomingDeviceCommand::TabReceived { sender, payload } => {
                 crate::IncomingDeviceCommand::TabReceived {
+                    sender: sender.map(crate::Device::try_from).transpose()?,
+                    payload: payload.into(),
+                }
+            }
+            IncomingDeviceCommand::TabsClosed { sender, payload } => {
+                crate::IncomingDeviceCommand::TabsClosed {
                     sender: sender.map(crate::Device::try_from).transpose()?,
                     payload: payload.into(),
                 }

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -159,6 +159,7 @@ impl FirefoxAccount {
         command: &str,
         target: &Device,
         payload: &serde_json::Value,
+        ttl: Option<u64>,
     ) -> Result<()> {
         let refresh_token = self.get_refresh_token()?;
         self.client.invoke_command(
@@ -167,6 +168,7 @@ impl FirefoxAccount {
             command,
             &target.id,
             payload,
+            ttl,
         )
     }
 

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -264,7 +264,7 @@ impl FirefoxAccount {
                 self.handle_send_tab_command(sender, command_data.payload, telem_reason)
             }
             commands::close_tabs::COMMAND_NAME => {
-                self.handle_close_tabs_command(sender, command_data.payload)
+                self.handle_close_tabs_command(sender, command_data.payload, telem_reason)
             }
             _ => Err(Error::UnknownCommand(command_data.command)),
         }

--- a/components/fxa-client/src/internal/http_client.rs
+++ b/components/fxa-client/src/internal/http_client.rs
@@ -123,6 +123,7 @@ pub(crate) trait FxAClient {
         command: &str,
         target: &str,
         payload: &serde_json::Value,
+        ttl: Option<u64>,
     ) -> Result<()>;
     fn update_device_record<'a>(
         &self,
@@ -359,11 +360,13 @@ impl FxAClient for Client {
         command: &str,
         target: &str,
         payload: &serde_json::Value,
+        ttl: Option<u64>,
     ) -> Result<()> {
         let body = json!({
             "command": command,
             "target": target,
-            "payload": payload
+            "payload": payload,
+            "ttl": ttl,
         });
         let url = config.auth_url_path("v1/account/devices/invoke_command")?;
         let request = Request::post(url)

--- a/components/fxa-client/src/internal/mod.rs
+++ b/components/fxa-client/src/internal/mod.rs
@@ -21,6 +21,7 @@ use url::Url;
 
 #[cfg(feature = "integration_test")]
 pub mod auth;
+mod close_tabs;
 mod commands;
 pub mod config;
 pub mod device;

--- a/components/fxa-client/src/internal/send_tab.rs
+++ b/components/fxa-client/src/internal/send_tab.rs
@@ -16,17 +16,7 @@ use super::{
 use crate::{Error, Result};
 
 impl FirefoxAccount {
-    /// Generate the Send Tab command to be registered with the server.
-    ///
-    /// **💾 This method alters the persisted account state.**
-    pub(crate) fn generate_send_tab_command_data(&mut self) -> Result<String> {
-        let own_keys = self.load_or_generate_keys()?;
-        let public_keys: PublicSendTabKeys = own_keys.into();
-        let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
-        public_keys.as_command_data(oldsync_key)
-    }
-
-    fn load_or_generate_keys(&mut self) -> Result<PrivateSendTabKeys> {
+    pub(crate) fn load_or_generate_send_tab_keys(&mut self) -> Result<PrivateSendTabKeys> {
         if let Some(s) = self.send_tab_key() {
             match PrivateSendTabKeys::deserialize(s) {
                 Ok(keys) => return Ok(keys),

--- a/components/fxa-client/src/internal/send_tab.rs
+++ b/components/fxa-client/src/internal/send_tab.rs
@@ -53,7 +53,7 @@ impl FirefoxAccount {
         let (payload, sent_telemetry) = SendTabPayload::single_tab(title, url);
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
         let command_payload = send_tab::build_send_command(oldsync_key, target, &payload)?;
-        self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)?;
+        self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload, None)?;
         self.telemetry.record_command_sent(sent_telemetry);
         Ok(())
     }

--- a/components/fxa-client/src/internal/telemetry.rs
+++ b/components/fxa-client/src/internal/telemetry.rs
@@ -48,6 +48,8 @@ pub enum ReceivedReason {
 pub enum Command {
     #[serde(rename = "send_tab")]
     SendTab,
+    #[serde(rename = "close_tabs")]
+    CloseTabs,
 }
 
 #[derive(Debug, Serialize)]
@@ -60,6 +62,10 @@ pub struct SentCommand {
 impl SentCommand {
     pub fn for_send_tab() -> Self {
         Self::new(Command::SendTab)
+    }
+
+    pub fn for_close_tabs() -> Self {
+        Self::new(Command::CloseTabs)
     }
 
     fn new(command: Command) -> Self {
@@ -81,6 +87,15 @@ pub struct ReceivedCommand {
 
 impl ReceivedCommand {
     pub fn for_send_tab(payload: &commands::SendTabPayload, reason: ReceivedReason) -> Self {
+        Self {
+            command: Command::SendTab,
+            flow_id: payload.flow_id.clone(),
+            stream_id: payload.stream_id.clone(),
+            reason,
+        }
+    }
+
+    pub fn for_close_tabs(payload: &commands::CloseTabsPayload, reason: ReceivedReason) -> Self {
         Self {
             command: Command::SendTab,
             flow_id: payload.flow_id.clone(),

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -59,7 +59,8 @@ pub use error::{Error, FxaError};
 use parking_lot::Mutex;
 pub use profile::Profile;
 pub use push::{
-    AccountEvent, DevicePushSubscription, IncomingDeviceCommand, SendTabPayload, TabHistoryEntry,
+    AccountEvent, CloseTabsPayload, DevicePushSubscription, IncomingDeviceCommand, SendTabPayload,
+    TabHistoryEntry,
 };
 pub use token::{AccessTokenInfo, AuthorizationParameters, ScopedKey};
 

--- a/components/fxa-client/src/push.rs
+++ b/components/fxa-client/src/push.rs
@@ -100,6 +100,17 @@ impl FirefoxAccount {
             .lock()
             .send_single_tab(target_device_id, title, url)
     }
+
+    /// Use device commands to close one or more tabs on another device.
+    ///
+    /// **💾 This method alters the persisted account state.**
+    ///
+    /// If a device on the account has registered the [`CloseTabs`](DeviceCapability::CloseTabs)
+    /// capability, this method can be used to close its tabs.
+    #[handle_error(Error)]
+    pub fn close_tabs(&self, target_device_id: &str, urls: Vec<String>) -> ApiResult<()> {
+        self.internal.lock().close_tabs(target_device_id, &urls)
+    }
 }
 
 /// Details of a web-push subscription endpoint.
@@ -189,6 +200,10 @@ pub enum IncomingDeviceCommand {
         sender: Option<Device>,
         payload: SendTabPayload,
     },
+    TabsClosed {
+        sender: Option<Device>,
+        payload: CloseTabsPayload,
+    },
 }
 
 /// The payload sent when invoking a "send tab" command.
@@ -208,6 +223,12 @@ pub struct SendTabPayload {
     ///
     /// The application should treat this as opaque.
     pub stream_id: String,
+}
+
+/// The payload sent when invoking a "close tabs" command.
+#[derive(Debug)]
+pub struct CloseTabsPayload {
+    pub urls: Vec<String>,
 }
 
 /// An individual entry in the navigation history of a sent tab.

--- a/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncTelemetry.kt
+++ b/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncTelemetry.kt
@@ -453,6 +453,7 @@ object SyncTelemetry {
                         )
                         FxaTab.sent.record(extras)
                     }
+                    "close_tabs" -> Unit
                     else -> errors.add(InvalidTelemetryException.UnknownEvent(command))
                 }
             }
@@ -474,6 +475,7 @@ object SyncTelemetry {
                         )
                         FxaTab.received.record(extras)
                     }
+                    "close_tabs" -> Unit
                     else -> errors.add(InvalidTelemetryException.UnknownEvent(command))
                 }
             }

--- a/examples/fxa-client/src/send_tab.rs
+++ b/examples/fxa-client/src/send_tab.rs
@@ -24,6 +24,11 @@ enum Command {
         title: String,
         url: String,
     },
+    /// Close an open tab on another device
+    Close {
+        device_id: String,
+        urls: Vec<String>,
+    },
 }
 
 pub fn run(account: &FirefoxAccount, args: SendTabArgs) -> Result<()> {
@@ -34,6 +39,7 @@ pub fn run(account: &FirefoxAccount, args: SendTabArgs) -> Result<()> {
             title,
             url,
         } => send(account, device_id, title, url),
+        Command::Close { device_id, urls } => close(account, device_id, urls),
     }
 }
 
@@ -54,6 +60,7 @@ fn poll(account: &FirefoxAccount) -> Result<()> {
                             None => println!("Tab received: {}", tab.url),
                         };
                     }
+                    IncomingDeviceCommand::TabsClosed { .. } => continue,
                 }
             }
         }
@@ -63,5 +70,11 @@ fn poll(account: &FirefoxAccount) -> Result<()> {
 fn send(account: &FirefoxAccount, device_id: String, title: String, url: String) -> Result<()> {
     account.send_single_tab(&device_id, &title, &url)?;
     println!("Tab sent!");
+    Ok(())
+}
+
+fn close(account: &FirefoxAccount, device_id: String, urls: Vec<String>) -> Result<()> {
+    account.close_tabs(&device_id, urls)?;
+    println!("Tabs closed!");
     Ok(())
 }


### PR DESCRIPTION
This PR adds support for the "close tabs" command to our Rust FxA client. We'll use this new API in Firefox Android ([bug 1891157](https://bugzilla.mozilla.org/show_bug.cgi?id=1891157)) and iOS.

The implementation follows the same approach as our existing "send tab" command, down to the way we do encryption—I even kept the encryption key type names the same, to minimize churn.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
