### PR TITLE
Bug 1889440 - Fixing the suggest database migration

### DIFF
--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -15,118 +15,118 @@ use sql_support::open_database::{self, ConnectionInitializer};
 ///     [`SuggestConnectionInitializer::upgrade_from`].
 ///    a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
 ///       the migration.
-pub const VERSION: u32 = 18;
+pub const VERSION: u32 = 19;
 
 /// The current Suggest database schema.
 pub const SQL: &str = "
-    CREATE TABLE meta(
-        key TEXT PRIMARY KEY,
-        value NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE meta(
+    key TEXT PRIMARY KEY,
+    value NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE keywords(
-        keyword TEXT NOT NULL,
-        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
-        full_keyword_id INTEGER NULL REFERENCES full_keywords(id) ON DELETE SET NULL,
-        rank INTEGER NOT NULL,
-        PRIMARY KEY (keyword, suggestion_id)
-    ) WITHOUT ROWID;
+CREATE TABLE keywords(
+    keyword TEXT NOT NULL,
+    suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+    full_keyword_id INTEGER NULL REFERENCES full_keywords(id) ON DELETE SET NULL,
+    rank INTEGER NOT NULL,
+    PRIMARY KEY (keyword, suggestion_id)
+) WITHOUT ROWID;
 
-    -- full keywords are what we display to the user when a (partial) keyword matches
-    -- The FK to suggestion_id makes it so full keywords get deleted when the parent suggestion is deleted.
-    CREATE TABLE full_keywords(
-        id INTEGER PRIMARY KEY,
-        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
-        full_keyword TEXT NOT NULL
-    );
+-- full keywords are what we display to the user when a (partial) keyword matches
+-- The FK to suggestion_id makes it so full keywords get deleted when the parent suggestion is deleted.
+CREATE TABLE full_keywords(
+    id INTEGER PRIMARY KEY,
+    suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+    full_keyword TEXT NOT NULL
+);
 
-    CREATE TABLE prefix_keywords(
-        keyword_prefix TEXT NOT NULL,
-        keyword_suffix TEXT NOT NULL DEFAULT '',
-        confidence INTEGER NOT NULL DEFAULT 0,
-        rank INTEGER NOT NULL,
-        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
-        PRIMARY KEY (keyword_prefix, keyword_suffix, suggestion_id)
-    ) WITHOUT ROWID;
+CREATE TABLE prefix_keywords(
+    keyword_prefix TEXT NOT NULL,
+    keyword_suffix TEXT NOT NULL DEFAULT '',
+    confidence INTEGER NOT NULL DEFAULT 0,
+    rank INTEGER NOT NULL,
+    suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+    PRIMARY KEY (keyword_prefix, keyword_suffix, suggestion_id)
+) WITHOUT ROWID;
 
-    CREATE UNIQUE INDEX keywords_suggestion_id_rank ON keywords(suggestion_id, rank);
+CREATE UNIQUE INDEX keywords_suggestion_id_rank ON keywords(suggestion_id, rank);
 
-    CREATE TABLE suggestions(
-        id INTEGER PRIMARY KEY,
-        record_id TEXT NOT NULL,
-        provider INTEGER NOT NULL,
-        title TEXT NOT NULL,
-        url TEXT NOT NULL,
-        score REAL NOT NULL
-    );
+CREATE TABLE suggestions(
+    id INTEGER PRIMARY KEY,
+    record_id TEXT NOT NULL,
+    provider INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    url TEXT NOT NULL,
+    score REAL NOT NULL
+);
 
-    CREATE TABLE amp_custom_details(
-        suggestion_id INTEGER PRIMARY KEY,
-        advertiser TEXT NOT NULL,
-        block_id INTEGER NOT NULL,
-        iab_category TEXT NOT NULL,
-        impression_url TEXT NOT NULL,
-        click_url TEXT NOT NULL,
-        icon_id TEXT NOT NULL,
-        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
-    );
+CREATE TABLE amp_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    advertiser TEXT NOT NULL,
+    block_id INTEGER NOT NULL,
+    iab_category TEXT NOT NULL,
+    impression_url TEXT NOT NULL,
+    click_url TEXT NOT NULL,
+    icon_id TEXT NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
 
-    CREATE TABLE wikipedia_custom_details(
-        suggestion_id INTEGER PRIMARY KEY REFERENCES suggestions(id) ON DELETE CASCADE,
-        icon_id TEXT NOT NULL
-    );
+CREATE TABLE wikipedia_custom_details(
+    suggestion_id INTEGER PRIMARY KEY REFERENCES suggestions(id) ON DELETE CASCADE,
+    icon_id TEXT NOT NULL
+);
 
-    CREATE TABLE amo_custom_details(
-        suggestion_id INTEGER PRIMARY KEY,
-        description TEXT NOT NULL,
-        guid TEXT NOT NULL,
-        icon_url TEXT NOT NULL,
-        rating TEXT,
-        number_of_ratings INTEGER NOT NULL,
-        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
-    );
+CREATE TABLE amo_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    description TEXT NOT NULL,
+    guid TEXT NOT NULL,
+    icon_url TEXT NOT NULL,
+    rating TEXT,
+    number_of_ratings INTEGER NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
 
-    CREATE INDEX suggestions_record_id ON suggestions(record_id);
+CREATE INDEX suggestions_record_id ON suggestions(record_id);
 
-    CREATE TABLE icons(
-        id TEXT PRIMARY KEY,
-        data BLOB NOT NULL,
-        mimetype TEXT NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE icons(
+    id TEXT PRIMARY KEY,
+    data BLOB NOT NULL,
+    mimetype TEXT NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE yelp_subjects(
-        keyword TEXT PRIMARY KEY,
-        record_id TEXT NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE yelp_subjects(
+    keyword TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE yelp_modifiers(
-        type INTEGER NOT NULL,
-        keyword TEXT NOT NULL,
-        record_id TEXT NOT NULL,
-        PRIMARY KEY (type, keyword)
-    ) WITHOUT ROWID;
+CREATE TABLE yelp_modifiers(
+    type INTEGER NOT NULL,
+    keyword TEXT NOT NULL,
+    record_id TEXT NOT NULL,
+    PRIMARY KEY (type, keyword)
+) WITHOUT ROWID;
 
-    CREATE TABLE yelp_location_signs(
-        keyword TEXT PRIMARY KEY,
-        need_location INTEGER NOT NULL,
-        record_id TEXT NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE yelp_location_signs(
+    keyword TEXT PRIMARY KEY,
+    need_location INTEGER NOT NULL,
+    record_id TEXT NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE yelp_custom_details(
-        icon_id TEXT PRIMARY KEY,
-        score REAL NOT NULL,
-        record_id TEXT NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE yelp_custom_details(
+    icon_id TEXT PRIMARY KEY,
+    score REAL NOT NULL,
+    record_id TEXT NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE mdn_custom_details(
-        suggestion_id INTEGER PRIMARY KEY,
-        description TEXT NOT NULL,
-        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
-    );
+CREATE TABLE mdn_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    description TEXT NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
 
-    CREATE TABLE dismissed_suggestions (
-        url TEXT PRIMARY KEY
-    ) WITHOUT ROWID;
+CREATE TABLE dismissed_suggestions (
+    url TEXT PRIMARY KEY
+) WITHOUT ROWID;
 ";
 
 /// Initializes an SQLite connection to the Suggest database, performing
@@ -166,9 +166,9 @@ impl ConnectionInitializer for SuggestConnectionInitializer {
             16 => {
                 tx.execute(
                     "
-                    CREATE TABLE dismissed_suggestions (
-                        url_hash INTEGER PRIMARY KEY
-                    ) WITHOUT ROWID;",
+CREATE TABLE dismissed_suggestions (
+    url_hash INTEGER PRIMARY KEY
+) WITHOUT ROWID;",
                     (),
                 )?;
                 Ok(())
@@ -176,11 +176,20 @@ impl ConnectionInitializer for SuggestConnectionInitializer {
             17 => {
                 tx.execute(
                     "
-                    DROP TABLE dismissed_suggestions;
-                    CREATE TABLE dismissed_suggestions (
-                        url TEXT PRIMARY KEY
-                    ) WITHOUT ROWID;",
+DROP TABLE dismissed_suggestions;
+CREATE TABLE dismissed_suggestions (
+    url TEXT PRIMARY KEY
+) WITHOUT ROWID;",
                     (),
+                )?;
+                Ok(())
+            }
+            18 => {
+                tx.execute_batch(
+                    "
+CREATE TABLE IF NOT EXISTS dismissed_suggestions (
+    url TEXT PRIMARY KEY
+) WITHOUT ROWID;",
                 )?;
                 Ok(())
             }
@@ -212,112 +221,112 @@ mod test {
     // Snapshot of the v16 schema.  We use this to test that we can migrate from there to the
     // current schema.
     const V16_SCHEMA: &str = r#"
-    CREATE TABLE meta(
-        key TEXT PRIMARY KEY,
-        value NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE meta(
+    key TEXT PRIMARY KEY,
+    value NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE keywords(
-        keyword TEXT NOT NULL,
-        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
-        full_keyword_id INTEGER NULL REFERENCES full_keywords(id) ON DELETE SET NULL,
-        rank INTEGER NOT NULL,
-        PRIMARY KEY (keyword, suggestion_id)
-    ) WITHOUT ROWID;
+CREATE TABLE keywords(
+    keyword TEXT NOT NULL,
+    suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+    full_keyword_id INTEGER NULL REFERENCES full_keywords(id) ON DELETE SET NULL,
+    rank INTEGER NOT NULL,
+    PRIMARY KEY (keyword, suggestion_id)
+) WITHOUT ROWID;
 
-    -- full keywords are what we display to the user when a (partial) keyword matches
-    -- The FK to suggestion_id makes it so full keywords get deleted when the parent suggestion is deleted.
-    CREATE TABLE full_keywords(
-        id INTEGER PRIMARY KEY,
-        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
-        full_keyword TEXT NOT NULL
-    );
+-- full keywords are what we display to the user when a (partial) keyword matches
+-- The FK to suggestion_id makes it so full keywords get deleted when the parent suggestion is deleted.
+CREATE TABLE full_keywords(
+    id INTEGER PRIMARY KEY,
+    suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+    full_keyword TEXT NOT NULL
+);
 
-    CREATE TABLE prefix_keywords(
-        keyword_prefix TEXT NOT NULL,
-        keyword_suffix TEXT NOT NULL DEFAULT '',
-        confidence INTEGER NOT NULL DEFAULT 0,
-        rank INTEGER NOT NULL,
-        suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
-        PRIMARY KEY (keyword_prefix, keyword_suffix, suggestion_id)
-    ) WITHOUT ROWID;
+CREATE TABLE prefix_keywords(
+    keyword_prefix TEXT NOT NULL,
+    keyword_suffix TEXT NOT NULL DEFAULT '',
+    confidence INTEGER NOT NULL DEFAULT 0,
+    rank INTEGER NOT NULL,
+    suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+    PRIMARY KEY (keyword_prefix, keyword_suffix, suggestion_id)
+) WITHOUT ROWID;
 
-    CREATE UNIQUE INDEX keywords_suggestion_id_rank ON keywords(suggestion_id, rank);
+CREATE UNIQUE INDEX keywords_suggestion_id_rank ON keywords(suggestion_id, rank);
 
-    CREATE TABLE suggestions(
-        id INTEGER PRIMARY KEY,
-        record_id TEXT NOT NULL,
-        provider INTEGER NOT NULL,
-        title TEXT NOT NULL,
-        url TEXT NOT NULL,
-        score REAL NOT NULL
-    );
+CREATE TABLE suggestions(
+    id INTEGER PRIMARY KEY,
+    record_id TEXT NOT NULL,
+    provider INTEGER NOT NULL,
+    title TEXT NOT NULL,
+    url TEXT NOT NULL,
+    score REAL NOT NULL
+);
 
-    CREATE TABLE amp_custom_details(
-        suggestion_id INTEGER PRIMARY KEY,
-        advertiser TEXT NOT NULL,
-        block_id INTEGER NOT NULL,
-        iab_category TEXT NOT NULL,
-        impression_url TEXT NOT NULL,
-        click_url TEXT NOT NULL,
-        icon_id TEXT NOT NULL,
-        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
-    );
+CREATE TABLE amp_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    advertiser TEXT NOT NULL,
+    block_id INTEGER NOT NULL,
+    iab_category TEXT NOT NULL,
+    impression_url TEXT NOT NULL,
+    click_url TEXT NOT NULL,
+    icon_id TEXT NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
 
-    CREATE TABLE wikipedia_custom_details(
-        suggestion_id INTEGER PRIMARY KEY REFERENCES suggestions(id) ON DELETE CASCADE,
-        icon_id TEXT NOT NULL
-    );
+CREATE TABLE wikipedia_custom_details(
+    suggestion_id INTEGER PRIMARY KEY REFERENCES suggestions(id) ON DELETE CASCADE,
+    icon_id TEXT NOT NULL
+);
 
-    CREATE TABLE amo_custom_details(
-        suggestion_id INTEGER PRIMARY KEY,
-        description TEXT NOT NULL,
-        guid TEXT NOT NULL,
-        icon_url TEXT NOT NULL,
-        rating TEXT,
-        number_of_ratings INTEGER NOT NULL,
-        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
-    );
+CREATE TABLE amo_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    description TEXT NOT NULL,
+    guid TEXT NOT NULL,
+    icon_url TEXT NOT NULL,
+    rating TEXT,
+    number_of_ratings INTEGER NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
 
-    CREATE INDEX suggestions_record_id ON suggestions(record_id);
+CREATE INDEX suggestions_record_id ON suggestions(record_id);
 
-    CREATE TABLE icons(
-        id TEXT PRIMARY KEY,
-        data BLOB NOT NULL,
-        mimetype TEXT NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE icons(
+    id TEXT PRIMARY KEY,
+    data BLOB NOT NULL,
+    mimetype TEXT NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE yelp_subjects(
-        keyword TEXT PRIMARY KEY,
-        record_id TEXT NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE yelp_subjects(
+    keyword TEXT PRIMARY KEY,
+    record_id TEXT NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE yelp_modifiers(
-        type INTEGER NOT NULL,
-        keyword TEXT NOT NULL,
-        record_id TEXT NOT NULL,
-        PRIMARY KEY (type, keyword)
-    ) WITHOUT ROWID;
+CREATE TABLE yelp_modifiers(
+    type INTEGER NOT NULL,
+    keyword TEXT NOT NULL,
+    record_id TEXT NOT NULL,
+    PRIMARY KEY (type, keyword)
+) WITHOUT ROWID;
 
-    CREATE TABLE yelp_location_signs(
-        keyword TEXT PRIMARY KEY,
-        need_location INTEGER NOT NULL,
-        record_id TEXT NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE yelp_location_signs(
+    keyword TEXT PRIMARY KEY,
+    need_location INTEGER NOT NULL,
+    record_id TEXT NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE yelp_custom_details(
-        icon_id TEXT PRIMARY KEY,
-        score REAL NOT NULL,
-        record_id TEXT NOT NULL
-    ) WITHOUT ROWID;
+CREATE TABLE yelp_custom_details(
+    icon_id TEXT PRIMARY KEY,
+    score REAL NOT NULL,
+    record_id TEXT NOT NULL
+) WITHOUT ROWID;
 
-    CREATE TABLE mdn_custom_details(
-        suggestion_id INTEGER PRIMARY KEY,
-        description TEXT NOT NULL,
-        FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
-    );
+CREATE TABLE mdn_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    description TEXT NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
 
-    PRAGMA user_version=16;
+PRAGMA user_version=16;
 "#;
 
     /// Test running all schema upgrades from V16, which was the first schema with a "real"
@@ -328,5 +337,6 @@ mod test {
     fn test_all_upgrades() {
         let db_file = MigratedDatabaseFile::new(SuggestConnectionInitializer, V16_SCHEMA);
         db_file.run_all_upgrades();
+        db_file.assert_schema_matches_new_database();
     }
 }

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -5021,10 +5021,10 @@ mod tests {
                     UnparsableRecords(
                         {
                             "clippy-2": UnparsableRecord {
-                                schema_version: 18,
+                                schema_version: 19,
                             },
                             "fancy-new-suggestions-1": UnparsableRecord {
-                                schema_version: 18,
+                                schema_version: 19,
                             },
                         },
                     ),
@@ -5093,10 +5093,10 @@ mod tests {
                     UnparsableRecords(
                         {
                             "clippy-2": UnparsableRecord {
-                                schema_version: 18,
+                                schema_version: 19,
                             },
                             "fancy-new-suggestions-1": UnparsableRecord {
-                                schema_version: 18,
+                                schema_version: 19,
                             },
                         },
                     ),
@@ -5292,10 +5292,10 @@ mod tests {
                     UnparsableRecords(
                         {
                             "clippy-2": UnparsableRecord {
-                                schema_version: 18,
+                                schema_version: 19,
                             },
                             "fancy-new-suggestions-1": UnparsableRecord {
-                                schema_version: 18,
+                                schema_version: 19,
                             },
                         },
                     ),
@@ -5381,7 +5381,7 @@ mod tests {
                     UnparsableRecords(
                         {
                             "invalid-attachment": UnparsableRecord {
-                                schema_version: 18,
+                                schema_version: 19,
                             },
                         },
                     ),


### PR DESCRIPTION
The previous migration failed because I was passing 2 statements to `execute()`, but that will only run one.  I should have used `execute_batch`.  Added a new migration that should fix things and also won't break things for users where we created a fresh v18 database that did have the `dismissed_suggestions` table.

Added a test to check if the schemas of a fresh database and an upgraded database are the same.  Hopefully this prevents the next issue like this.  Updated the SQL so that it doesn't have any leading spaces.  This makes the comparision easier.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
