### PR TITLE
Fixes for cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,7 +638,22 @@ dependencies = [
  "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
- "yaml-rust 0.3.5",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "atty",
+ "bitflags 1.3.2",
+ "clap_lex 0.2.4",
+ "indexmap 1.9.1",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.16.1",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -661,7 +676,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "bitflags 1.3.2",
- "clap_lex",
+ "clap_lex 0.4.1",
  "once_cell",
  "strsim 0.10.0",
 ]
@@ -676,6 +691,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.32",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1730,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -2633,7 +2657,7 @@ dependencies = [
  "anyhow",
  "askama",
  "cfg-if 1.0.0",
- "clap 2.34.0",
+ "clap 3.2.25",
  "console",
  "email_address",
  "glob",
@@ -2996,6 +3020,12 @@ checksum = "96bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "output_vt100"
@@ -3921,7 +3951,7 @@ dependencies = [
  "indexmap 1.9.1",
  "ryu",
  "serde",
- "yaml-rust 0.4.5",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -4323,6 +4353,12 @@ dependencies = [
  "unicode-linebreak",
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -5529,12 +5565,6 @@ checksum = "f43c2e9236bfd40d392b5ef2c073ef2719f7c69a758293cec4d8eff909a8917c"
 dependencies = [
  "xshell",
 ]
-
-[[package]]
-name = "yaml-rust"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e66366e18dc58b46801afbf2ca7661a9f59cc8c5962c29892b6039b4f86fa992"
 
 [[package]]
 name = "yaml-rust"

--- a/components/support/nimbus-fml/Cargo.toml
+++ b/components/support/nimbus-fml/Cargo.toml
@@ -14,7 +14,7 @@ uniffi-bindings = ["client-lib", "dep:uniffi"]
 name = "nimbus_fml"
 
 [dependencies]
-clap = {version = "2.34.0", features = ["yaml"]}
+clap = {version = "3", features = ["yaml"]}
 anyhow = "1.0.44"
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.8.21"

--- a/components/support/nimbus-fml/src/command_line/mod.rs
+++ b/components/support/nimbus-fml/src/command_line/mod.rs
@@ -57,26 +57,29 @@ where
     let matches = App::from_yaml(yaml).get_matches_from(args);
 
     Ok(match matches.subcommand() {
-        ("generate", Some(matches)) => {
-            CliCmd::Generate(create_generate_command_from_cli(matches, cwd)?)
-        }
-        ("generate-experimenter", Some(matches)) => CliCmd::GenerateExperimenter(
-            create_generate_command_experimenter_from_cli(matches, cwd)?,
-        ),
-        ("fetch", Some(matches)) => {
-            CliCmd::FetchFile(create_loader(matches, cwd)?, input_file(matches)?)
-        }
-        ("single-file", Some(matches)) => {
-            CliCmd::GenerateSingleFileManifest(create_single_file_from_cli(matches, cwd)?)
-        }
-        ("validate", Some(matches)) => {
-            CliCmd::Validate(create_validate_command_from_cli(matches, cwd)?)
-        }
-        ("channels", Some(matches)) => {
-            CliCmd::PrintChannels(create_print_channels_from_cli(matches, cwd)?)
-        }
-        ("info", Some(matches)) => CliCmd::PrintInfo(create_print_info_from_cli(matches, cwd)?),
-        (word, _) => unimplemented!("Command {} not implemented", word),
+        Some(subcommand) => match subcommand {
+            ("generate", matches) => {
+                CliCmd::Generate(create_generate_command_from_cli(matches, cwd)?)
+            }
+            ("generate-experimenter", matches) => CliCmd::GenerateExperimenter(
+                create_generate_command_experimenter_from_cli(matches, cwd)?,
+            ),
+            ("fetch", matches) => {
+                CliCmd::FetchFile(create_loader(matches, cwd)?, input_file(matches)?)
+            }
+            ("single-file", matches) => {
+                CliCmd::GenerateSingleFileManifest(create_single_file_from_cli(matches, cwd)?)
+            }
+            ("validate", matches) => {
+                CliCmd::Validate(create_validate_command_from_cli(matches, cwd)?)
+            }
+            ("channels", matches) => {
+                CliCmd::PrintChannels(create_print_channels_from_cli(matches, cwd)?)
+            }
+            ("info", matches) => CliCmd::PrintInfo(create_print_info_from_cli(matches, cwd)?),
+            (word, _) => unimplemented!("Command {} not implemented", word),
+        },
+        None => panic!("No subcommand given"),
     })
 }
 


### PR DESCRIPTION
- Update h2
- Switch nimbus-fml to clap v3.  It would be nice to upgrade it to v4, but this is simple and enough to fix the cargo audit warnings.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
