### PR TITLE
Deprecate `RemoteSettingsConfig.server_url` in favor of a new, type-safe `RemoteSettingsConfig.server`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Suggest
 - Improved full keyword display for AMP suggestions
 - `SuggestStoreBuilder.cache_path` is now deprecated because we no longer use the cache path.
+- `SuggestStoreBuilder.remote_settings_config` is deprecated in favor of `remote_settings_server`, because `remote_settings_config` forced consumers that wanted to override the Remote Settings server to also specify the bucket and collection names.
 
 ### Remote Settings
 - `RemoteSettingsConfig.server_url` is deprecated in favor of `server`, which is a `RemoteSettingsServer` instead of a string.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 - Improved full keyword display for AMP suggestions
 - `SuggestStoreBuilder.cache_path` is now deprecated because we no longer use the cache path.
 
+### Remote Settings
+- `RemoteSettingsConfig.server_url` is deprecated in favor of `server`, which is a `RemoteSettingsServer` instead of a string.
+- The new `RemoteSettingsServer` type specifies the Remote Settings server to use.
+
 [Full Changelog](https://github.com/mozilla/application-services/compare/v124.0...v125.0)
 
 # v124.0 (_2024-02-15_)

--- a/components/nimbus/examples/experiment.rs
+++ b/components/nimbus/examples/experiment.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
             MetricsHandler,
         },
         AppContext, AvailableRandomizationUnits, EnrollmentStatus, NimbusClient,
-        NimbusTargetingHelper, RemoteSettingsConfig,
+        NimbusTargetingHelper, RemoteSettingsConfig, RemoteSettingsServer,
     };
     use std::collections::HashMap;
     use std::io::prelude::*;
@@ -218,7 +218,10 @@ fn main() -> Result<()> {
 
     // initiate the optional config
     let config = RemoteSettingsConfig {
-        server_url: Some(server_url.to_string()),
+        server: Some(RemoteSettingsServer::Custom {
+            url: server_url.to_string(),
+        }),
+        server_url: None,
         bucket_name: None,
         collection_name: collection_name.to_string(),
     };

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -31,7 +31,7 @@ cfg_if::cfg_if! {
 
         pub use stateful::nimbus_client::*;
         pub use stateful::matcher::AppContext;
-        pub use remote_settings::RemoteSettingsConfig;
+        pub use remote_settings::{RemoteSettingsConfig, RemoteSettingsServer};
     } else {
         pub mod stateless;
 

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -1,6 +1,9 @@
 [External="remote_settings"]
 typedef extern RemoteSettingsConfig;
 
+[External="remote_settings"]
+typedef extern RemoteSettingsServer;
+
 namespace nimbus {};
 dictionary AppContext {
     string app_name;

--- a/components/nimbus/tests/common/mod.rs
+++ b/components/nimbus/tests/common/mod.rs
@@ -10,7 +10,7 @@ use rkv::StoreOptions;
 use nimbus::{
     error::Result,
     metrics::{EnrollmentStatusExtraDef, MetricsHandler},
-    AppContext, NimbusClient, RemoteSettingsConfig,
+    AppContext, NimbusClient, RemoteSettingsConfig, RemoteSettingsServer,
 };
 
 pub struct NoopMetricsHandler;
@@ -58,7 +58,10 @@ fn new_test_client_internal(
     let url = Url::from_file_path(dir).expect("experiments dir should exist");
 
     let config = RemoteSettingsConfig {
-        server_url: Some(url.as_str().to_string()),
+        server: Some(RemoteSettingsServer::Custom {
+            url: url.as_str().to_string(),
+        }),
+        server_url: None,
         bucket_name: None,
         collection_name: "doesn't matter".to_string(),
     };

--- a/components/nimbus/tests/test_fs_client.rs
+++ b/components/nimbus/tests/test_fs_client.rs
@@ -14,7 +14,7 @@ mod common;
 #[test]
 fn test_simple() -> Result<()> {
     use common::NoopMetricsHandler;
-    use nimbus::{NimbusClient, RemoteSettingsConfig};
+    use nimbus::{NimbusClient, RemoteSettingsConfig, RemoteSettingsServer};
     use std::path::PathBuf;
     use url::Url;
 
@@ -26,7 +26,10 @@ fn test_simple() -> Result<()> {
     let url = Url::from_file_path(dir).expect("experiments dir should exist");
 
     let config = RemoteSettingsConfig {
-        server_url: Some(url.as_str().to_string()),
+        server: Some(RemoteSettingsServer::Custom {
+            url: url.as_str().to_string(),
+        }),
+        server_url: None,
         bucket_name: None,
         collection_name: "doesn't matter".to_string(),
     };

--- a/components/remote_settings/src/config.rs
+++ b/components/remote_settings/src/config.rs
@@ -3,19 +3,45 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 //! This module defines the custom configurations that consumers can set.
-//! Those configurations override default values and can be used to set a custom server url,
+//! Those configurations override default values and can be used to set a custom server,
 //! collection name, and bucket name.
 //! The purpose of the configuration parameters are to allow consumers an easy debugging option,
 //! and the ability to be explicit about the server.
 
+use url::Url;
+
+use crate::Result;
+
 /// Custom configuration for the client.
 /// Currently includes the following:
-/// - `server_url`: The optional url for the settings server. If not specified, the standard server will be used.
+/// - `server`: The Remote Settings server to use. If not specified, defaults to the production server (`RemoteSettingsServer::Prod`).
+/// - `server_url`: An optional custom Remote Settings server URL. Deprecated; please use `server` instead.
 /// - `bucket_name`: The optional name of the bucket containing the collection on the server. If not specified, the standard bucket will be used.
 /// - `collection_name`: The name of the collection for the settings server.
 #[derive(Debug, Clone)]
 pub struct RemoteSettingsConfig {
+    pub server: Option<RemoteSettingsServer>,
     pub server_url: Option<String>,
     pub bucket_name: Option<String>,
     pub collection_name: String,
+}
+
+/// The Remote Settings server that the client should use.
+#[derive(Debug, Clone)]
+pub enum RemoteSettingsServer {
+    Prod,
+    Stage,
+    Dev,
+    Custom { url: String },
+}
+
+impl RemoteSettingsServer {
+    pub fn url(&self) -> Result<Url> {
+        Ok(match self {
+            Self::Prod => Url::parse("https://firefox.settings.services.mozilla.com").unwrap(),
+            Self::Stage => Url::parse("https://firefox.settings.services.allizom.org").unwrap(),
+            Self::Dev => Url::parse("https://remote-settings-dev.allizom.org").unwrap(),
+            Self::Custom { url } => Url::parse(url)?,
+        })
+    }
 }

--- a/components/remote_settings/src/error.rs
+++ b/components/remote_settings/src/error.rs
@@ -22,6 +22,8 @@ pub enum RemoteSettingsError {
     ResponseError(String),
     #[error("This server doesn't support attachments")]
     AttachmentsUnsupportedError,
+    #[error("...")]
+    ConfigError(String),
 }
 
 pub type Result<T, E = RemoteSettingsError> = std::result::Result<T, E>;

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -11,7 +11,7 @@ pub use client::{
     RsJsonObject, SortOrder,
 };
 pub mod config;
-pub use config::RemoteSettingsConfig;
+pub use config::{RemoteSettingsConfig, RemoteSettingsServer};
 
 uniffi::include_scaffolding!("remote_settings");
 
@@ -70,7 +70,10 @@ mod test {
         .create();
 
         let config = RemoteSettingsConfig {
-            server_url: Some(mockito::server_url()),
+            server: Some(RemoteSettingsServer::Custom {
+                url: mockito::server_url(),
+            }),
+            server_url: None,
             bucket_name: Some(String::from("the-bucket")),
             collection_name: String::from("the-collection"),
         };
@@ -98,7 +101,10 @@ mod test {
         .create();
 
         let config = RemoteSettingsConfig {
-            server_url: Some(mockito::server_url()),
+            server: Some(RemoteSettingsServer::Custom {
+                url: mockito::server_url(),
+            }),
+            server_url: None,
             bucket_name: Some(String::from("the-bucket")),
             collection_name: String::from("the-collection"),
         };
@@ -119,7 +125,10 @@ mod test {
     fn test_download() {
         viaduct_reqwest::use_reqwest_backend();
         let config = RemoteSettingsConfig {
-            server_url: Some("http://localhost:8888".to_string()),
+            server: Some(RemoteSettingsServer::Custom {
+                url: "http://localhost:8888".into(),
+            }),
+            server_url: None,
             bucket_name: Some(String::from("the-bucket")),
             collection_name: String::from("the-collection"),
         };

--- a/components/remote_settings/src/remote_settings.udl
+++ b/components/remote_settings/src/remote_settings.udl
@@ -7,10 +7,19 @@ typedef string RsJsonObject;
 
 namespace remote_settings {};
 
+[Enum]
+interface RemoteSettingsServer {
+    Prod();
+    Stage();
+    Dev();
+    Custom(string url);
+};
+
 dictionary RemoteSettingsConfig {
     string collection_name;
     string? bucket_name = null;
     string? server_url = null;
+    RemoteSettingsServer? server = null;
 };
 
 dictionary RemoteSettingsResponse {
@@ -43,6 +52,7 @@ enum RemoteSettingsError {
     "BackoffError",
     "ResponseError",
     "AttachmentsUnsupportedError",
+    "ConfigError",
 };
 
 interface RemoteSettings {

--- a/components/suggest/src/benchmarks/client.rs
+++ b/components/suggest/src/benchmarks/client.rs
@@ -22,6 +22,7 @@ impl RemoteSettingsWarmUpClient {
     pub fn new() -> Self {
         Self {
             client: Client::new(RemoteSettingsConfig {
+                server: None,
                 server_url: None,
                 bucket_name: None,
                 collection_name: crate::rs::REMOTE_SETTINGS_COLLECTION.into(),

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-use remote_settings::RemoteSettingsConfig;
+use remote_settings::{RemoteSettingsConfig, RemoteSettingsServer};
 #[cfg(feature = "benchmark_api")]
 pub mod benchmarks;
 mod config;

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -13,7 +13,8 @@ use error_support::handle_error;
 use once_cell::sync::OnceCell;
 use parking_lot::Mutex;
 use remote_settings::{
-    self, GetItemsOptions, RemoteSettingsConfig, RemoteSettingsRecord, SortOrder,
+    self, GetItemsOptions, RemoteSettingsConfig, RemoteSettingsRecord, RemoteSettingsServer,
+    SortOrder,
 };
 use rusqlite::{
     types::{FromSql, ToSqlOutput},
@@ -50,6 +51,7 @@ pub struct SuggestStoreBuilder(Mutex<SuggestStoreBuilderInner>);
 #[derive(Default)]
 struct SuggestStoreBuilderInner {
     data_path: Option<String>,
+    remote_settings_server: Option<RemoteSettingsServer>,
     remote_settings_config: Option<RemoteSettingsConfig>,
 }
 
@@ -79,6 +81,11 @@ impl SuggestStoreBuilder {
         self
     }
 
+    pub fn remote_settings_server(self: Arc<Self>, server: RemoteSettingsServer) -> Arc<Self> {
+        self.0.lock().remote_settings_server = Some(server);
+        self
+    }
+
     #[handle_error(Error)]
     pub fn build(&self) -> SuggestApiResult<Arc<SuggestStore>> {
         let inner = self.0.lock();
@@ -86,14 +93,29 @@ impl SuggestStoreBuilder {
             .data_path
             .clone()
             .ok_or_else(|| Error::SuggestStoreBuilder("data_path not specified".to_owned()))?;
-        let settings_client =
-            remote_settings::Client::new(inner.remote_settings_config.clone().unwrap_or_else(
-                || RemoteSettingsConfig {
-                    server_url: None,
-                    bucket_name: None,
-                    collection_name: REMOTE_SETTINGS_COLLECTION.into(),
-                },
-            ))?;
+        let remote_settings_config = match (
+            inner.remote_settings_server.as_ref(),
+            inner.remote_settings_config.as_ref(),
+        ) {
+            (Some(server), None) => RemoteSettingsConfig {
+                server: Some(server.clone()),
+                server_url: None,
+                bucket_name: None,
+                collection_name: REMOTE_SETTINGS_COLLECTION.into(),
+            },
+            (None, Some(remote_settings_config)) => remote_settings_config.clone(),
+            (None, None) => RemoteSettingsConfig {
+                server: None,
+                server_url: None,
+                bucket_name: None,
+                collection_name: REMOTE_SETTINGS_COLLECTION.into(),
+            },
+            (Some(_), Some(_)) => Err(Error::SuggestStoreBuilder(
+                "can't specify both `remote_settings_server` and `remote_settings_config`"
+                    .to_owned(),
+            ))?,
+        };
+        let settings_client = remote_settings::Client::new(remote_settings_config)?;
         Ok(Arc::new(SuggestStore {
             inner: SuggestStoreInner::new(data_path, settings_client),
         }))
@@ -172,6 +194,7 @@ impl SuggestStore {
         let settings_client = || -> Result<_> {
             Ok(remote_settings::Client::new(
                 settings_config.unwrap_or_else(|| RemoteSettingsConfig {
+                    server: None,
                     server_url: None,
                     bucket_name: None,
                     collection_name: REMOTE_SETTINGS_COLLECTION.into(),

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -6,6 +6,9 @@
 [External="remote_settings"]
 typedef extern RemoteSettingsConfig;
 
+[External="remote_settings"]
+typedef extern RemoteSettingsServer;
+
 namespace suggest {
 
 boolean raw_suggestion_url_matches([ByRef] string raw_url, [ByRef] string url);

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -158,6 +158,10 @@ interface SuggestStoreBuilder {
     SuggestStoreBuilder cache_path(string path);
 
     [Self=ByArc]
+    SuggestStoreBuilder remote_settings_server(RemoteSettingsServer server);
+
+    // Deprecated: Use `remote_settings_server()` instead.
+    [Self=ByArc]
     SuggestStoreBuilder remote_settings_config(RemoteSettingsConfig config);
 
     [Throws=SuggestApiError]

--- a/components/support/nimbus-cli/src/sources/experiment_list.rs
+++ b/components/support/nimbus-cli/src/sources/experiment_list.rs
@@ -219,7 +219,7 @@ impl TryFrom<&ExperimentListSource> for Value {
                 endpoint,
                 is_preview,
             } => {
-                use remote_settings::{Client, RemoteSettingsConfig};
+                use remote_settings::{Client, RemoteSettingsConfig, RemoteSettingsServer};
                 viaduct_reqwest::use_reqwest_backend();
                 let collection_name = if *is_preview {
                     "nimbus-preview".to_string()
@@ -227,7 +227,10 @@ impl TryFrom<&ExperimentListSource> for Value {
                     "nimbus-mobile-experiments".to_string()
                 };
                 let config = RemoteSettingsConfig {
-                    server_url: Some(endpoint.clone()),
+                    server: Some(RemoteSettingsServer::Custom {
+                        url: endpoint.clone(),
+                    }),
+                    server_url: None,
                     bucket_name: None,
                     collection_name,
                 };


### PR DESCRIPTION
The `RemoteSettingsConfig.server_url` option has a couple of small pain points for consumers:

1. It forces them to hard-code the URLs for other environments (Fenix does this for stage [here](https://searchfox.org/mozilla-central/rev/e1e4a33e82ee1d278df238cf0896b7358a4bc359/mobile/android/fenix/app/src/main/java/org/mozilla/fenix/components/Core.kt#631-632) and [here](https://searchfox.org/mozilla-central/rev/e1e4a33e82ee1d278df238cf0896b7358a4bc359/mobile/android/focus-android/app/src/main/java/org/mozilla/focus/telemetry/GleanMetricsService.kt#65-66), for example). We can make things a bit smoother for these callers by having the Remote Settings component hard-code these URLs instead.
2. It forces other consumers of Remote Settings, like Suggest, to override _all_ config options—including the bucket and collection name—even if they just wanted to override the server URL. For example, if Fenix wanted to ingest suggestions from the staging server, it would need to also specify `collectionName: "quicksuggest"`, even though the collection name is an implementation detail of the Suggest component.

This PR tries to make that situation better by:

1. Introducing a new type, `RemoteSettingsServer`, that allows specifying a well-known (`Prod`, `Stage`, `Dev`) or `Custom` server.
2. Adding `RemoteSettingsServer.server` and `SuggestStoreBuilder.remote_settings_server()`.
3. Deprecating `RemoteSettingsConfig.server_url` and `SuggestStoreBuilder.remote_settings_config()`. These APIs are still available, but can't be used together with the new APIs—consumers must specify one or the other, or neither (to use the default `Prod` server), but not both.

This is the first step to wiring up Fenix's "use Remote Settings {production / stage} server" switch to Suggest ([bug 1889495](https://bugzilla.mozilla.org/show_bug.cgi?id=1889495)).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
