### PR TITLE
Bug 1889700 - interruption support for the Relevancy component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,6 +3538,7 @@ name = "relevancy"
 version = "0.1.0"
 dependencies = [
  "error-support",
+ "interrupt-support",
  "log",
  "md-5",
  "parking_lot",
@@ -4010,6 +4011,7 @@ dependencies = [
  "lazy_static",
  "log",
  "nss_build_common",
+ "parking_lot",
  "prettytable-rs",
  "rusqlite",
  "tempfile",

--- a/components/relevancy/Cargo.toml
+++ b/components/relevancy/Cargo.toml
@@ -9,6 +9,7 @@ exclude = ["/android", "/ios"]
 
 [dependencies]
 error-support = { path = "../support/error" }
+interrupt-support = { path = "../support/interrupt" }
 sql-support = { path = "../support/sql" }
 log = "0.4"
 md-5 = "0.10"

--- a/components/relevancy/src/db.rs
+++ b/components/relevancy/src/db.rs
@@ -8,31 +8,43 @@ use crate::{
     url_hash::{hash_url, UrlHash},
     Interest, InterestVector, Result,
 };
-use parking_lot::Mutex;
+use interrupt_support::SqlInterruptScope;
 use rusqlite::{Connection, OpenFlags};
-use sql_support::{open_database::open_database_with_flags, ConnExt};
-use std::path::{Path, PathBuf};
+use sql_support::{ConnExt, LazyDb};
+use std::path::Path;
 
 /// A thread-safe wrapper around an SQLite connection to the Relevancy database
 pub struct RelevancyDb {
-    db_path: PathBuf,
-    reader: Mutex<Option<Connection>>,
-    writer: Mutex<Option<Connection>>,
+    reader: LazyDb<RelevancyConnectionInitializer>,
+    writer: LazyDb<RelevancyConnectionInitializer>,
 }
 
 impl RelevancyDb {
     pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+        // Note: use `SQLITE_OPEN_READ_WRITE` for both read and write connections.
+        // Even if we're opening a read connection, we may need to do a write as part of the
+        // initialization process.
+        //
+        // The read-only nature of the connection is enforced by the fact that [RelevancyDb::read] uses a
+        // shared ref to the `RelevancyDao`.
+        let db_open_flags = OpenFlags::SQLITE_OPEN_URI
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_CREATE
+            | OpenFlags::SQLITE_OPEN_READ_WRITE;
         Ok(Self {
-            db_path: path.as_ref().to_owned(),
-            reader: Mutex::new(None),
-            writer: Mutex::new(None),
+            reader: LazyDb::new(path.as_ref(), db_open_flags, RelevancyConnectionInitializer),
+            writer: LazyDb::new(path.as_ref(), db_open_flags, RelevancyConnectionInitializer),
         })
     }
 
     pub fn close(&self) {
-        // This causes any open databases to be dropped, closing the connection.
-        *self.reader.lock() = None;
-        *self.writer.lock() = None;
+        self.reader.close(true);
+        self.writer.close(true);
+    }
+
+    pub fn interrupt(&self) {
+        self.reader.interrupt();
+        self.writer.interrupt();
     }
 
     #[cfg(test)]
@@ -45,45 +57,20 @@ impl RelevancyDb {
 
     /// Accesses the Suggest database in a transaction for reading.
     pub fn read<T>(&self, op: impl FnOnce(&RelevancyDao) -> Result<T>) -> Result<T> {
-        let mut reader_option = self.reader.lock();
-        let reader = match reader_option.as_mut() {
-            Some(reader) => reader,
-            None => reader_option.insert(self.open_database()?),
-        };
-        let tx = reader.transaction()?;
-        let dao = RelevancyDao::new(&tx);
+        let (mut conn, scope) = self.reader.lock()?;
+        let tx = conn.transaction()?;
+        let dao = RelevancyDao::new(&tx, scope);
         op(&dao)
     }
 
     /// Accesses the Suggest database in a transaction for reading and writing.
     pub fn read_write<T>(&self, op: impl FnOnce(&mut RelevancyDao) -> Result<T>) -> Result<T> {
-        let mut writer_option = self.writer.lock();
-        let writer = match writer_option.as_mut() {
-            Some(writer) => writer,
-            None => writer_option.insert(self.open_database()?),
-        };
-        let tx = writer.transaction()?;
-        let mut dao = RelevancyDao::new(&tx);
+        let (mut conn, scope) = self.writer.lock()?;
+        let tx = conn.transaction()?;
+        let mut dao = RelevancyDao::new(&tx, scope);
         let result = op(&mut dao)?;
         tx.commit()?;
         Ok(result)
-    }
-
-    fn open_database(&self) -> Result<Connection> {
-        // Note: use `SQLITE_OPEN_READ_WRITE` for both read and write connections.
-        // Even if we're opening a read connection, we may need to do a write as part of the
-        // initialization process.
-        //
-        // The read-only nature of the connection is enforced by the fact that [RelevancyDb::read] uses a
-        // shared ref to the `RelevancyDao`.
-        Ok(open_database_with_flags(
-            &self.db_path,
-            OpenFlags::SQLITE_OPEN_URI
-                | OpenFlags::SQLITE_OPEN_NO_MUTEX
-                | OpenFlags::SQLITE_OPEN_CREATE
-                | OpenFlags::SQLITE_OPEN_READ_WRITE,
-            &RelevancyConnectionInitializer,
-        )?)
     }
 }
 
@@ -94,11 +81,17 @@ impl RelevancyDb {
 /// reference (`&mut self`).
 pub struct RelevancyDao<'a> {
     pub conn: &'a Connection,
+    pub scope: SqlInterruptScope,
 }
 
 impl<'a> RelevancyDao<'a> {
-    fn new(conn: &'a Connection) -> Self {
-        Self { conn }
+    fn new(conn: &'a Connection, scope: SqlInterruptScope) -> Self {
+        Self { conn, scope }
+    }
+
+    /// Return Err(Interrupted) if we were interrupted
+    pub fn err_if_interrupted(&self) -> Result<()> {
+        Ok(self.scope.err_if_interrupted()?)
     }
 
     /// Associate a URL with an interest

--- a/components/relevancy/src/error.rs
+++ b/components/relevancy/src/error.rs
@@ -23,6 +23,9 @@ pub enum Error {
 
     #[error("Error fetching interest data")]
     FetchInterestDataError,
+
+    #[error("Interrupted")]
+    Interrupted(#[from] interrupt_support::Interrupted),
 }
 
 /// Result enum for the public API

--- a/components/relevancy/src/lib.rs
+++ b/components/relevancy/src/lib.rs
@@ -39,6 +39,10 @@ impl RelevancyStore {
         self.db.close()
     }
 
+    pub fn interrupt(&self) {
+        self.db.interrupt()
+    }
+
     /// Ingest top URLs to build the user's interest vector.
     ///
     /// Consumer should pass a list of the user's top URLs by frecency to this method.  It will

--- a/components/relevancy/src/populate_interests.rs
+++ b/components/relevancy/src/populate_interests.rs
@@ -5,6 +5,9 @@
 use crate::{url_hash::UrlHash, Error, Interest, RelevancyDb, Result};
 use std::io::{Cursor, Read};
 
+// Number of rows to write when inserting interest data before checking for interruption
+const WRITE_CHUNK_SIZE: usize = 100;
+
 pub fn ensure_interest_data_populated(db: &RelevancyDb) -> Result<()> {
     if !db.read(|dao| dao.need_to_load_url_interests())? {
         return Ok(());
@@ -17,8 +20,11 @@ pub fn ensure_interest_data_populated(db: &RelevancyDb) -> Result<()> {
         }
     };
     db.read_write(move |dao| {
-        for (url_hash, interest) in interest_data {
-            dao.add_url_interest(url_hash, interest)?;
+        for chunk in interest_data.chunks(WRITE_CHUNK_SIZE) {
+            for (url_hash, interest) in chunk {
+                dao.add_url_interest(*url_hash, *interest)?;
+            }
+            dao.err_if_interrupted()?;
         }
         Ok(())
     })
@@ -26,7 +32,8 @@ pub fn ensure_interest_data_populated(db: &RelevancyDb) -> Result<()> {
 
 /// Fetch the interest data
 fn fetch_interest_data() -> std::io::Result<Vec<(UrlHash, Interest)>> {
-    // TODO: this hack should be replaced with something that fetches from remote settings
+    // TODO: this hack should be replaced with something that fetches from remote settings.
+    // It should ideally check for interruption while fetching the data.
     let bytes = include_bytes!("../test-data");
     let mut reader = Cursor::new(&bytes);
     let mut data = vec![];

--- a/components/relevancy/src/relevancy.udl
+++ b/components/relevancy/src/relevancy.udl
@@ -14,7 +14,12 @@ interface RelevancyStore {
     constructor(string dbpath);
 
     // Close any open resources (for example databases)
+    //
+    // Calling `close` will interrupt any in-progress queries on other threads.
     void close();
+
+    // Interrupt any current database queries
+    void interrupt();
 
     // Ingest the top URLs by frequency to build up the user's interest vector
     [Throws=RelevancyApiError]

--- a/components/support/interrupt/src/sql.rs
+++ b/components/support/interrupt/src/sql.rs
@@ -120,3 +120,10 @@ impl Interruptee for SqlInterruptScope {
         self.was_interrupted()
     }
 }
+
+// Needed to allow Weak<SqlInterruptHandle> to be passed to `interrupt::register_interrupt`
+impl AsRef<SqlInterruptHandle> for SqlInterruptHandle {
+    fn as_ref(&self) -> &SqlInterruptHandle {
+        self
+    }
+}

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -17,6 +17,7 @@ interrupt-support = { path = "../interrupt" }
 ffi-support = "0.4"
 thiserror = "1.0"
 tempfile = "3.1.0"
+parking_lot = ">=0.11,<=0.12"
 prettytable-rs = { version = "0.10", optional = true }
 rusqlite = { workspace = true, features = ["functions", "limits", "bundled", "unlock_notify"] }
 

--- a/components/support/sql/src/lazy.rs
+++ b/components/support/sql/src/lazy.rs
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::open_database::{open_database_with_flags, ConnectionInitializer, Error};
+use interrupt_support::{register_interrupt, SqlInterruptHandle, SqlInterruptScope};
+use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
+use rusqlite::{Connection, OpenFlags};
+use std::{
+    path::{Path, PathBuf},
+    sync::{Arc, Weak},
+};
+
+/// Lazily-loaded database with interruption support
+///
+/// In addition to the [Self::interrupt] method, LazyDb also calls
+/// [interrupt_support::register_interrupt] on any opened database.  This means that if
+/// [interrupt_support::shutdown] is called it will interrupt this database if it's open and
+/// in-use.
+pub struct LazyDb<CI> {
+    path: PathBuf,
+    open_flags: OpenFlags,
+    connection_initializer: CI,
+    // Note: if you're going to lock both mutexes at once, make sure to lock the connection mutex
+    // first.  Otherwise, you risk creating a deadlock where two threads each hold one of the locks
+    // and is waiting for the other.
+    connection: Mutex<Option<Connection>>,
+    // It's important to use a separate mutex for the interrupt handle, since the whole point is to
+    // interrupt while another thread holds the connection mutex.  Since the only mutation is
+    // setting/unsetting the Arc, maybe this could be sped up by using something like
+    // `arc_swap::ArcSwap`, but that seems like overkill for our purposes. This mutex should rarely
+    // be contested and interrupt operations execute quickly.
+    interrupt_handle: Mutex<Option<Arc<SqlInterruptHandle>>>,
+}
+
+impl<CI: ConnectionInitializer> LazyDb<CI> {
+    /// Create a new LazyDb
+    ///
+    /// This does not open the connection and is non-blocking
+    pub fn new(path: &Path, open_flags: OpenFlags, connection_initializer: CI) -> Self {
+        Self {
+            path: path.to_owned(),
+            open_flags,
+            connection_initializer,
+            connection: Mutex::new(None),
+            interrupt_handle: Mutex::new(None),
+        }
+    }
+
+    /// Lock the database mutex and get a connection and interrupt scope.
+    ///
+    /// If the connection is closed, it will be opened.
+    ///
+    /// Calling `lock` again, or calling `close`, from the same thread while the mutex guard is
+    /// still alive will cause a deadlock.
+    pub fn lock(&self) -> Result<(MappedMutexGuard<'_, Connection>, SqlInterruptScope), Error> {
+        // Call get_conn first, then get_scope to ensure we acquire the locks in the correct order
+        let conn = self.get_conn()?;
+        let scope = self.get_scope(&conn)?;
+        Ok((conn, scope))
+    }
+
+    fn get_conn(&self) -> Result<MappedMutexGuard<'_, Connection>, Error> {
+        let mut guard = self.connection.lock();
+        // Open the database if it wasn't opened before.  Do this outside of the MutexGuard::map call to simplify the error handling
+        if guard.is_none() {
+            *guard = Some(open_database_with_flags(
+                &self.path,
+                self.open_flags,
+                &self.connection_initializer,
+            )?);
+        };
+        // Use MutexGuard::map to get a Connection rather than Option<Connection>.  The unwrap()
+        // call can't fail because of the previous code.
+        Ok(MutexGuard::map(guard, |conn_option| {
+            conn_option.as_mut().unwrap()
+        }))
+    }
+
+    fn get_scope(&self, conn: &Connection) -> Result<SqlInterruptScope, Error> {
+        let mut handle_guard = self.interrupt_handle.lock();
+        let result = match handle_guard.as_ref() {
+            Some(handle) => handle.begin_interrupt_scope(),
+            None => {
+                let handle = Arc::new(SqlInterruptHandle::new(conn));
+                register_interrupt(
+                    Arc::downgrade(&handle) as Weak<dyn AsRef<SqlInterruptHandle> + Send + Sync>
+                );
+                handle_guard.insert(handle).begin_interrupt_scope()
+            }
+        };
+        // If we see an Interrupted error when beginning the scope, it means that we're in shutdown
+        // mode.
+        result.map_err(|_| Error::Shutdown)
+    }
+
+    /// Close the database if it's open
+    ///
+    /// Pass interrupt=true to interrupt any in-progress queries before closing the database.
+    ///
+    /// Do not call `close` if you already have a lock on the database in the current thread, as
+    /// this will cause a deadlock.
+    pub fn close(&self, interrupt: bool) {
+        let mut interrupt_handle = self.interrupt_handle.lock();
+        if let Some(handle) = interrupt_handle.as_ref() {
+            if interrupt {
+                handle.interrupt();
+            }
+            *interrupt_handle = None;
+        }
+        // Drop the interrupt handle lock to avoid holding both locks at once.
+        drop(interrupt_handle);
+        *self.connection.lock() = None;
+    }
+
+    /// Interrupt any in-progress queries
+    pub fn interrupt(&self) {
+        if let Some(handle) = self.interrupt_handle.lock().as_ref() {
+            handle.interrupt();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::open_database::test_utils::TestConnectionInitializer;
+
+    fn open_test_db() -> LazyDb<TestConnectionInitializer> {
+        LazyDb::new(
+            Path::new(":memory:"),
+            OpenFlags::default(),
+            TestConnectionInitializer::new(),
+        )
+    }
+
+    #[test]
+    fn test_interrupt() {
+        let lazy_db = open_test_db();
+        let (_, scope) = lazy_db.lock().unwrap();
+        assert!(!scope.was_interrupted());
+        lazy_db.interrupt();
+        assert!(scope.was_interrupted());
+    }
+
+    #[test]
+    fn interrupt_before_db_is_opened_should_not_fail() {
+        let lazy_db = open_test_db();
+        lazy_db.interrupt();
+    }
+}

--- a/components/support/sql/src/lib.rs
+++ b/components/support/sql/src/lib.rs
@@ -10,14 +10,16 @@
 mod conn_ext;
 pub mod debug_tools;
 mod each_chunk;
+mod lazy;
 mod maybe_cached;
 pub mod open_database;
 mod repeat;
 
-pub use crate::conn_ext::*;
-pub use crate::each_chunk::*;
-pub use crate::maybe_cached::*;
-pub use crate::repeat::*;
+pub use conn_ext::*;
+pub use each_chunk::*;
+pub use lazy::*;
+pub use maybe_cached::*;
+pub use repeat::*;
 
 /// In PRAGMA foo='bar', `'bar'` must be a constant string (it cannot be a
 /// bound parameter), so we need to escape manually. According to


### PR DESCRIPTION
Added the `sql_support::LazyDb` struct.  This handles various details of a lazily-opened DB.  The main issue is connecting the dbs the interrupt code as their are opened.

Switched the relevancy code to using `LazyDb`, switched the `close` method to interrupt any in-progress queries before closing the DB, and added a manual `interrupt` function.  Also, if we expose the `interrupt_support::shutdown`, then we can have shutdown support for it.

"interrupt/shutdown" support means being able to interrupt SQL queries and also integrating with a cooperative interrupt system.  Added some simple code to check for interruption when we're populating the interest data.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
