### PR TITLE
nimbus: Replace `serverUrl` with `RemoteSettingsServer` in bindings.

### DIFF
--- a/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
+++ b/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import mozilla.appservices.remotesettings.RemoteSettingsConfig
+import mozilla.appservices.remotesettings.RemoteSettingsServer
 import mozilla.telemetry.glean.Glean
 import org.json.JSONObject
 import org.mozilla.experiments.nimbus.GleanMetrics.NimbusEvents
@@ -158,7 +159,7 @@ open class Nimbus(
         // Initialize Nimbus
         val remoteSettingsConfig = server?.let {
             RemoteSettingsConfig(
-                serverUrl = it.url.toString(),
+                server = RemoteSettingsServer.Custom(it.url.toString()),
                 collectionName = it.collection,
             )
         }

--- a/components/nimbus/ios/Nimbus/NimbusCreate.swift
+++ b/components/nimbus/ios/Nimbus/NimbusCreate.swift
@@ -94,7 +94,7 @@ public extension Nimbus {
         let remoteSettings = server.map { server -> RemoteSettingsConfig in
             RemoteSettingsConfig(
                 collectionName: server.collection,
-                serverUrl: server.url.absoluteString
+                server: .custom(url: server.url.absoluteString)
             )
         }
         let nimbusClient = try NimbusClient(


### PR DESCRIPTION
#6191 added an [assertion](https://github.com/mozilla/application-services/blob/94d15144656f2fa49e3de385bb1ec07da446d6e4/components/nimbus/src/stateful/client/mod.rs#L20) to the `create_client` function in Nimbus, to check that it wasn't using the (now-deprecated) `config.server_url` property.

But I missed that `create_client` was indirectly called from [Swift](https://github.com/mozilla/application-services/blob/94d15144656f2fa49e3de385bb1ec07da446d6e4/components/nimbus/ios/Nimbus/NimbusCreate.swift#L97) and [Kotlin](https://github.com/mozilla/application-services/blob/94d15144656f2fa49e3de385bb1ec07da446d6e4/components/nimbus/android/src/main/java/org/mozilla/experiments/nimbus/Nimbus.kt#L161) code, and those call sites still passed `serverUrl`. I think these uses would have tripped the assertion I added.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
