### PR TITLE
Bug 1893086 - Port the potential impressions framework to the suggest component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glean-build"
-version = "13.0.0"
+version = "11.0.1"
 dependencies = [
  "xshell-venv",
 ]

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -33,6 +33,7 @@ pub struct SuggestionQuery {
     pub keyword: String,
     pub providers: Vec<SuggestionProvider>,
     pub limit: Option<i32>,
+    pub phantom_suggestion_type: Option<String>,
 }
 
 uniffi::include_scaffolding!("suggest");

--- a/components/suggest/src/provider.rs
+++ b/components/suggest/src/provider.rs
@@ -22,6 +22,7 @@ pub enum SuggestionProvider {
     Mdn = 6,
     Weather = 7,
     AmpMobile = 8,
+    Phantom = 9,
 }
 
 impl FromSql for SuggestionProvider {
@@ -45,6 +46,7 @@ impl SuggestionProvider {
             5 => Some(SuggestionProvider::Yelp),
             6 => Some(SuggestionProvider::Mdn),
             7 => Some(SuggestionProvider::Weather),
+            9 => Some(SuggestionProvider::Phantom),
             _ => None,
         }
     }
@@ -91,6 +93,9 @@ impl SuggestionProvider {
                     SuggestRecordType::Icon,
                     SuggestRecordType::GlobalConfig,
                 ]
+            }
+            SuggestionProvider::Phantom => {
+                vec![SuggestRecordType::Phantom, SuggestRecordType::GlobalConfig]
             }
         }
     }

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -49,7 +49,7 @@ pub(crate) const SUGGESTIONS_PER_ATTACHMENT: u64 = 200;
 
 /// A list of default record types to download if nothing is specified.
 /// This currently defaults to all of the record types.
-pub(crate) const DEFAULT_RECORDS_TYPES: [SuggestRecordType; 9] = [
+pub(crate) const DEFAULT_RECORDS_TYPES: [SuggestRecordType; 10] = [
     SuggestRecordType::Icon,
     SuggestRecordType::AmpWikipedia,
     SuggestRecordType::Amo,
@@ -59,6 +59,7 @@ pub(crate) const DEFAULT_RECORDS_TYPES: [SuggestRecordType; 9] = [
     SuggestRecordType::Weather,
     SuggestRecordType::GlobalConfig,
     SuggestRecordType::AmpMobile,
+    SuggestRecordType::Phantom,
 ];
 
 /// A trait for a client that downloads suggestions from Remote Settings.
@@ -114,6 +115,8 @@ pub(crate) enum SuggestRecord {
     GlobalConfig(DownloadedGlobalConfig),
     #[serde(rename = "amp-mobile-suggestions")]
     AmpMobile,
+    #[serde(rename = "phantom-suggestions")]
+    Phantom,
 }
 
 /// Enum for the different record types that can be consumed.
@@ -130,6 +133,7 @@ pub enum SuggestRecordType {
     Weather,
     GlobalConfig,
     AmpMobile,
+    Phantom,
 }
 
 impl From<SuggestRecord> for SuggestRecordType {
@@ -144,6 +148,7 @@ impl From<SuggestRecord> for SuggestRecordType {
             SuggestRecord::Yelp => Self::Yelp,
             SuggestRecord::GlobalConfig(_) => Self::GlobalConfig,
             SuggestRecord::AmpMobile => Self::AmpMobile,
+            SuggestRecord::Phantom => Self::Phantom,
         }
     }
 }
@@ -160,6 +165,7 @@ impl fmt::Display for SuggestRecordType {
             Self::Weather => write!(f, "weather"),
             Self::GlobalConfig => write!(f, "configuration"),
             Self::AmpMobile => write!(f, "amp-mobile-suggestions"),
+            Self::Phantom => write!(f, "phantom-suggestions"),
         }
     }
 }
@@ -408,6 +414,16 @@ pub(crate) struct DownloadedMdnSuggestion {
     pub description: String,
     pub keywords: Vec<String>,
     pub score: f64,
+}
+
+/// A phantom suggestion to ingest from an attachment
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct DownloadedPhantomSuggestion {
+    #[serde(rename = "type")]
+    pub phantom_type: String,
+    // TODO: Decide on a keywords strategy, see db.rs.
+    #[allow(dead_code)]
+    pub keywords: Vec<String>,
 }
 
 /// Weather data to ingest from a weather record

--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -15,7 +15,7 @@ use sql_support::open_database::{self, ConnectionInitializer};
 ///     [`SuggestConnectionInitializer::upgrade_from`].
 ///    a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
 ///       the migration.
-pub const VERSION: u32 = 19;
+pub const VERSION: u32 = 20;
 
 /// The current Suggest database schema.
 pub const SQL: &str = "
@@ -124,6 +124,14 @@ CREATE TABLE mdn_custom_details(
     FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
 );
 
+CREATE TABLE phantom_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    type TEXT NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX phantom_custom_details_type ON phantom_custom_details(type);
+
 CREATE TABLE dismissed_suggestions (
     url TEXT PRIMARY KEY
 ) WITHOUT ROWID;
@@ -190,6 +198,19 @@ CREATE TABLE dismissed_suggestions (
 CREATE TABLE IF NOT EXISTS dismissed_suggestions (
     url TEXT PRIMARY KEY
 ) WITHOUT ROWID;",
+                )?;
+                Ok(())
+            }
+            19 => {
+                tx.execute(
+                    "
+CREATE TABLE phantom_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    type TEXT NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
+CREATE INDEX phantom_custom_details_type ON phantom_custom_details(type);",
+                    (),
                 )?;
                 Ok(())
             }

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -34,6 +34,7 @@ enum SuggestionProvider {
     "Mdn",
     "Weather",
     "AmpMobile",
+    "Phantom",
 };
 
 [Enum]
@@ -95,12 +96,18 @@ interface Suggestion {
     Weather(
         f64 score
     );
+    Phantom(
+        string phantom_type,
+        string matched_keyword,
+        f64 score
+    );
 };
 
 dictionary SuggestionQuery {
     string keyword;
     sequence<SuggestionProvider> providers;
     i32? limit = null;
+    string? phantom_suggestion_type;
 };
 
 dictionary SuggestIngestionConstraints {

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -81,6 +81,11 @@ pub enum Suggestion {
     Weather {
         score: f64,
     },
+    Phantom {
+        phantom_type: String,
+        matched_keyword: String,
+        score: f64,
+    },
 }
 
 impl PartialOrd for Suggestion {
@@ -91,20 +96,9 @@ impl PartialOrd for Suggestion {
 
 impl Ord for Suggestion {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let a_score = match self {
-            Suggestion::Amp { score, .. }
-            | Suggestion::Pocket { score, .. }
-            | Suggestion::Amo { score, .. } => score,
-            _ => &DEFAULT_SUGGESTION_SCORE,
-        };
-        let b_score = match other {
-            Suggestion::Amp { score, .. }
-            | Suggestion::Pocket { score, .. }
-            | Suggestion::Amo { score, .. } => score,
-            _ => &DEFAULT_SUGGESTION_SCORE,
-        };
-        b_score
-            .partial_cmp(a_score)
+        other
+            .score()
+            .partial_cmp(&self.score())
             .unwrap_or(std::cmp::Ordering::Equal)
     }
 }
@@ -136,6 +130,20 @@ impl Suggestion {
             | Self::Yelp { url, .. }
             | Self::Mdn { url, .. } => Some(url),
             _ => None,
+        }
+    }
+
+    /// Get the score for this suggestion.
+    pub fn score(&self) -> f64 {
+        match self {
+            Self::Amp { score, .. }
+            | Self::Pocket { score, .. }
+            | Self::Amo { score, .. }
+            | Self::Yelp { score, .. }
+            | Self::Mdn { score, .. }
+            | Self::Weather { score, .. }
+            | Self::Phantom { score, .. } => *score,
+            Self::Wikipedia { .. } => DEFAULT_SUGGESTION_SCORE,
         }
     }
 }


### PR DESCRIPTION
Please see https://bugzilla.mozilla.org/show_bug.cgi?id=1893086 for details. Notes:

* I'm not sure who to request review from these days, so please forward the request if you'd like!
* This leaves a keyword-matching strategy as a to-do. I think we'll want to use fts5 but I'm not sure. I'd like to do that as a follow-up.
* This modifies `SuggestionQuery`, which breaks most existing tests in store.rs. To prevent that from happening again in the future as much as possible, I added a `SuggestionQueryBuilder` and a couple macros.
* `SuggestionQueryBuilder` isn't exposed to consumers. Should it be? I tried adding it to the udl but that requires `Arc`-ifying it, which makes it a pain to use in tests (I think?). Can we do that later if it turns out to be helpful?
* Since this does modify `SuggestionQuery`, do I need to do something to avoid breaking mobile? I read the breaking changes info but tbh I don't understand it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
