### PR TITLE
Uses m1 runners for circle ci because x86 is deprecated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
           command: |
             SCCACHE_VERSION=v0.2.15
             if [ "$(uname)" == "Darwin" ]; then
-              SCCACHE="sccache-${SCCACHE_VERSION}-x86_64-apple-darwin"
+              SCCACHE="sccache-${SCCACHE_VERSION}-aarch64-apple-darwin"
             else
               SCCACHE="sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl"
             fi
@@ -72,9 +72,9 @@ commands:
       - run:
           name: Install Rust
           command: |
-            RUSTUP_PLATFORM=x86_64-apple-darwin
-            RUSTUP_VERSION=1.24.1
-            RUSTUP_SHA256=d53e8000c8663e1704a2071f7042be917bc90cbc89c11e11c5dfdcb35b84c00e
+            RUSTUP_PLATFORM=aarch64-apple-darwin
+            RUSTUP_VERSION=1.27.0
+            RUSTUP_SHA256=c30c180297a0053dcb8932ed43d365f0c9005abd847375f7ed5799a761ea81e5
             curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"
             echo "${RUSTUP_SHA256} *rustup-init" | shasum -a 256 -c -
             chmod +x rustup-init
@@ -116,6 +116,7 @@ commands:
     steps:
       # this is a problem with Mac OSX?
       - run: pip install --ignore-installed six
+      - run: pip install --upgrade setuptools
       - run:
           name: Install NSS build system dependencies
           command: |
@@ -155,9 +156,9 @@ commands:
       - restore_cache:
           name: Restore sccache cache
           keys:
-          # We have multiple keys to increase the chance of a cache hit
-          # in case the Cargo.lock is updated, we still want to retrieve
-          # some cache
+            # We have multiple keys to increase the chance of a cache hit
+            # in case the Cargo.lock is updated, we still want to retrieve
+            # some cache
             - sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "Cargo.lock" }}
             - sccache-cache-stable-{{ arch }}-{{ .Environment.CIRCLE_JOB }}
             - sccache-cache-stable-{{ arch }}
@@ -185,6 +186,10 @@ commands:
   setup-ios-environment:
     steps:
       - run:
+          name: Install rosetta
+          ## FIXME: https://bugzilla.mozilla.org/show_bug.cgi?id=1901618
+          command: /usr/sbin/softwareupdate --install-rosetta --agree-to-license
+      - run:
           name: Toggle brew auto-updates
           command: |
             if [ -z "${CIRCLE_TAG}" ]; then
@@ -204,8 +209,8 @@ executors:
       - image: cimg/rust:1.53.0
   macos:
     macos:
-      xcode: 14.3.1
-    resource_class: macos.x86.medium.gen2
+      xcode: "15.1"
+    resource_class: macos.m1.medium.gen1
 
 jobs:
   Check Swift formatting:

--- a/automation/run_ios_tests.sh
+++ b/automation/run_ios_tests.sh
@@ -5,10 +5,10 @@ set -euvx
 ./megazords/ios-rust/build-xcframework.sh --build-profile release
 set -o pipefail && \
 xcodebuild \
-  -workspace ./megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace \
+  -workspace megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace \
   -scheme MozillaTestServices \
   -sdk iphonesimulator \
-  -destination 'platform=iOS Simulator,name=iPhone 14' \
+  -destination 'platform=iOS Simulator,name=iPhone 15' \
   test | \
 tee raw_xcodetest.log | \
 xcpretty && exit "${PIPESTATUS[0]}"

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -1090,14 +1090,14 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.org.MozillaTestServicesTests;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.MozillaTestServicesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
@@ -1111,14 +1111,14 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 43AQ936H96;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.org.MozillaTestServicesTests;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.MozillaTestServicesTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
See https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718 for deprecation notice


We would get rid of our circle dependency soon once we move away to moz-central but for now this should fix breakage eg: https://github.com/mozilla/application-services/pull/6213
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
