### PR TITLE
build: upgrade `rusqlite` 0.30.0 → 0.31.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,17 +19,6 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "ahash"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
@@ -1772,23 +1761,23 @@ name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
-dependencies = [
- "ahash 0.7.6",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
- "hashbrown 0.12.1",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2129,7 +2118,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
- "ahash 0.8.7",
+ "ahash",
  "anyhow",
  "base64",
  "bytecount",
@@ -2226,9 +2215,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3661,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
  "bitflags 2.4.2",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ default-members = [
 ]
 
 [workspace.dependencies]
-rusqlite = "0.30.0"
-libsqlite3-sys = "0.27.0"
+rusqlite = "0.31.0"
+libsqlite3-sys = "0.28.0"
 uniffi = "0.27.1"
 
 [profile.release]

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -596,7 +596,8 @@ The following text applies to code linked from these dependencies:
 [windows_x86_64_gnu](https://github.com/microsoft/windows-rs),
 [windows_x86_64_msvc](https://github.com/microsoft/windows-rs),
 [xshell-macros](https://github.com/matklad/xshell),
-[xshell](https://github.com/matklad/xshell)
+[xshell](https://github.com/matklad/xshell),
+[zerocopy](https://github.com/google/zerocopy)
 
 ```
                               Apache License

--- a/megazords/full/DEPENDENCIES.md
+++ b/megazords/full/DEPENDENCIES.md
@@ -537,7 +537,8 @@ The following text applies to code linked from these dependencies:
 [windows_x86_64_gnu](https://github.com/microsoft/windows-rs),
 [windows_x86_64_msvc](https://github.com/microsoft/windows-rs),
 [xshell-macros](https://github.com/matklad/xshell),
-[xshell](https://github.com/matklad/xshell)
+[xshell](https://github.com/matklad/xshell),
+[zerocopy](https://github.com/google/zerocopy)
 
 ```
                               Apache License

--- a/megazords/full/android/dependency-licenses.xml
+++ b/megazords/full/android/dependency-licenses.xml
@@ -505,6 +505,10 @@ the details of which are reproduced below.
     <url>https://github.com/matklad/xshell/blob/master/LICENSE-APACHE</url>
   </license>
   <license>
+    <name>Apache License 2.0: zerocopy</name>
+    <url>https://github.com/google/zerocopy/blob/main/LICENSE-APACHE</url>
+  </license>
+  <license>
     <name>MIT License: aho-corasick</name>
     <url>https://github.com/BurntSushi/aho-corasick/blob/master/LICENSE-MIT</url>
   </license>

--- a/megazords/ios-rust/DEPENDENCIES.md
+++ b/megazords/ios-rust/DEPENDENCIES.md
@@ -575,7 +575,8 @@ The following text applies to code linked from these dependencies:
 [vcpkg](https://github.com/mcgoo/vcpkg-rs),
 [version_check](https://github.com/SergioBenitez/version_check),
 [xshell-macros](https://github.com/matklad/xshell),
-[xshell](https://github.com/matklad/xshell)
+[xshell](https://github.com/matklad/xshell),
+[zerocopy](https://github.com/google/zerocopy)
 
 ```
                               Apache License


### PR DESCRIPTION
This PR is intended to unblock duplicate dependencies that would be introduced as new versions of `ahash` and `hashbrown` in [Firefox bug 1893057](https://bugzilla.mozilla.org/show_bug.cgi?id=1893057).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This upgrades what I presume is a well-vetted dependency (though I'm not familiar with it). Assuming coverage in CI, I'll leave it to maintainer judgment on whether testing is sufficient.
- [x] **Changelog**: Will address this shortly.
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - ~~Any new dependencies are accompanied by a summary of the due dilligence applied in selecting them.~~

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
