### PR TITLE
Make the relevancy constructor infallible

### DIFF
--- a/components/relevancy/src/db.rs
+++ b/components/relevancy/src/db.rs
@@ -20,7 +20,7 @@ pub struct RelevancyDb {
 }
 
 impl RelevancyDb {
-    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+    pub fn new(path: impl AsRef<Path>) -> Self {
         // Note: use `SQLITE_OPEN_READ_WRITE` for both read and write connections.
         // Even if we're opening a read connection, we may need to do a write as part of the
         // initialization process.
@@ -31,10 +31,10 @@ impl RelevancyDb {
             | OpenFlags::SQLITE_OPEN_NO_MUTEX
             | OpenFlags::SQLITE_OPEN_CREATE
             | OpenFlags::SQLITE_OPEN_READ_WRITE;
-        Ok(Self {
+        Self {
             reader: LazyDb::new(path.as_ref(), db_open_flags, RelevancyConnectionInitializer),
             writer: LazyDb::new(path.as_ref(), db_open_flags, RelevancyConnectionInitializer),
-        })
+        }
     }
 
     pub fn close(&self) {
@@ -52,7 +52,7 @@ impl RelevancyDb {
         use std::sync::atomic::{AtomicU32, Ordering};
         static COUNTER: AtomicU32 = AtomicU32::new(0);
         let count = COUNTER.fetch_add(1, Ordering::Relaxed);
-        Self::new(format!("file:test{count}.sqlite?mode=memory&cache=shared")).unwrap()
+        Self::new(format!("file:test{count}.sqlite?mode=memory&cache=shared"))
     }
 
     /// Accesses the Suggest database in a transaction for reading.

--- a/components/relevancy/src/lib.rs
+++ b/components/relevancy/src/lib.rs
@@ -28,11 +28,10 @@ pub struct RelevancyStore {
 
 /// Top-level API for the Relevancy component
 impl RelevancyStore {
-    #[handle_error(Error)]
-    pub fn new(db_path: String) -> ApiResult<Self> {
-        Ok(Self {
-            db: RelevancyDb::new(db_path)?,
-        })
+    pub fn new(db_path: String) -> Self {
+        Self {
+            db: RelevancyDb::new(db_path),
+        }
     }
 
     pub fn close(&self) {

--- a/components/relevancy/src/relevancy.udl
+++ b/components/relevancy/src/relevancy.udl
@@ -10,7 +10,6 @@ interface RelevancyStore {
     // Construct a new RelevancyStore
     //
     // This is non-blocking since databases and other resources are lazily opened.
-    [Throws=RelevancyApiError]
     constructor(string dbpath);
 
     // Close any open resources (for example databases)


### PR DESCRIPTION
After the switch to lazy DB construction, it was actually was infallible in practice.  We just need to update the type signatures to reflect that.

The only drawback I can see is that this restricts us from adding operations that could fail to the constructor in the future, but that seems okay to me.  I think we can always be lazy about the operation and defer the failure to when we actually try to open the DB.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
