### PR TITLE
fxa_client: Generalize incoming and outgoing command telemetry.

### DIFF
--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -674,11 +674,11 @@ interface FirefoxAccount {
   // It ensures that the expired token is removed and a fresh one generated.
   //
   void clear_access_token_cache();
-  
 
-  // Collect and return telemetry about send-tab attempts.
+
+  // Collect and return telemetry about incoming and outgoing device commands.
   //
-  // Applications that register the [`SendTab`](DeviceCapability::SendTab) capability
+  // Applications that have registered one or more [`DeviceCapability`]s
   // should also arrange to submit "sync ping" telemetry. Calling this method will
   // return a JSON string of telemetry data that can be incorporated into that ping.
   //
@@ -878,12 +878,12 @@ dictionary SendTabPayload {
   // A unique identifier to be included in send-tab metrics.
   //
   // The application should treat this as opaque.
-  string flow_id;
+  string flow_id = "";
 
   // A unique identifier to be included in send-tab metrics.
   //
   // The application should treat this as opaque.
-  string stream_id;
+  string stream_id = "";
 };
 
 // An individual entry in the navigation history of a sent tab.

--- a/components/fxa-client/src/internal/commands/send_tab.rs
+++ b/components/fxa-client/src/internal/commands/send_tab.rs
@@ -60,7 +60,7 @@ impl From<SendTabPayload> for crate::SendTabPayload {
 
 impl SendTabPayload {
     pub fn single_tab(title: &str, url: &str) -> (Self, telemetry::SentCommand) {
-        let sent_telemetry: telemetry::SentCommand = Default::default();
+        let sent_telemetry: telemetry::SentCommand = telemetry::SentCommand::for_send_tab();
         (
             SendTabPayload {
                 entries: vec![TabHistoryEntry {

--- a/components/fxa-client/src/internal/send_tab.rs
+++ b/components/fxa-client/src/internal/send_tab.rs
@@ -64,7 +64,7 @@ impl FirefoxAccount {
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
         let command_payload = send_tab::build_send_command(oldsync_key, target, &payload)?;
         self.invoke_command(send_tab::COMMAND_NAME, target, &command_payload)?;
-        self.telemetry.record_tab_sent(sent_telemetry);
+        self.telemetry.record_command_sent(sent_telemetry);
         Ok(())
     }
 
@@ -86,12 +86,8 @@ impl FirefoxAccount {
         match encrypted_payload.decrypt(&send_tab_key) {
             Ok(payload) => {
                 // It's an incoming tab, which we record telemetry for.
-                let recd_telemetry = telemetry::ReceivedCommand {
-                    flow_id: payload.flow_id.clone(),
-                    stream_id: payload.stream_id.clone(),
-                    reason,
-                };
-                self.telemetry.record_tab_received(recd_telemetry);
+                let recd_telemetry = telemetry::ReceivedCommand::for_send_tab(&payload, reason);
+                self.telemetry.record_command_received(recd_telemetry);
                 // The telemetry IDs escape to the consumer, but that's OK...
                 Ok(IncomingDeviceCommand::TabReceived { sender, payload })
             }


### PR DESCRIPTION
The FxA telemetry logic no longer assumes that the only command we report is Send Tab. We'll build on this to report telemetry for the Close Tabs command separately.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
