### PR TITLE
nimbus-gradle-plugin: Support absolute and relative paths.

### DIFF
--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -228,9 +228,9 @@ class NimbusPlugin implements Plugin<Project> {
             return !entry.directory && entry.name.contains(archOs)
         }.each { entry ->
             fmlPath.withOutputStream { out ->
-                def from = zipFile.getInputStream(entry)
-                out << from
-                from.close()
+                zipFile.getInputStream(entry).withStream { from ->
+                    out << from
+                }
             }
 
             fmlPath.setExecutable(true)
@@ -292,7 +292,7 @@ class NimbusPlugin implements Plugin<Project> {
     String getProjectVersion() {
         Properties props = new Properties()
         def stream = getClass().getResourceAsStream("/nimbus-gradle-plugin.properties")
-        props.load(stream)
+        stream.withStream { props.load(it) }
         return props.get("version")
     }
 

--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -93,7 +93,7 @@ abstract class NimbusPluginExtension {
     /**
      * The directory where downloaded files are or where they should be cached.
      *
-     * This defaults to `null`, in which case no cache directory will be used.
+     * If missing, this defaults to the Nimbus cache folder in the build directory.
      *
      * @return
      */
@@ -333,8 +333,7 @@ class NimbusPlugin implements Plugin<Project> {
 
             doFirst {
                 ensureDirExists(outputDir)
-                if (cacheDir != null)
-                    ensureDirExists(cacheDir)
+                ensureDirExists(cacheDir)
                 println("Nimbus FML generating Kotlin")
                 println("manifest        $inputFile")
                 println("cache dir       $cacheDir")
@@ -361,8 +360,7 @@ class NimbusPlugin implements Plugin<Project> {
             args "generate"
             args "--language", "kotlin"
             args "--channel", channel
-            if (cacheDir != null)
-                args "--cache-dir", cacheDir
+            args "--cache-dir", cacheDir
             for (File file : repoFiles) {
                 args "--repo-file", file
             }
@@ -403,8 +401,7 @@ class NimbusPlugin implements Plugin<Project> {
             group = "Nimbus"
 
             doFirst {
-                if (cacheDir != null)
-                    ensureDirExists(cacheDir)
+                ensureDirExists(cacheDir)
                 println("Nimbus FML: validating manifest")
                 println("manifest             $inputFile")
                 println("cache dir            $cacheDir")
@@ -424,8 +421,7 @@ class NimbusPlugin implements Plugin<Project> {
                 args "--"
             }
             args "validate"
-            if (cacheDir != null)
-                args "--cache-dir", cacheDir
+            args "--cache-dir", cacheDir
             for (File file : repoFiles) {
                 args "--repo-file", file
             }


### PR DESCRIPTION
Hi @jeddai! 👋🏼 

When I was fixing the [Fenix auto-publishing workflow](https://hg.mozilla.org/mozilla-central/rev/405fd04905cf) last week, I noticed that it didn't like absolute paths to the Application Services repo. I added a low-effort check that threw an exception for (Unix-style) absolute paths, but wanted to fix the issue for real.

I tracked down the bellyaching to how the Nimbus Gradle Plugin was resolving paths—and fixed it up in this PR so that it can handle both kinds of paths ☺️ I've tested this logic locally, and it works with both absolute and relative paths in `autoPublish.application-services.dir` now!

I think this is an O(n) change.

Here's an explanation of what I did, copied from the commit message:

* Use `project.file(...)` to resolve paths relative to the
  project directory, instead of the `File` constructor. The
  `.file()` method understands absolute paths.
* Use `project.layout.buildDirectory.dir(...)` to resolve
  paths relative to the build directory, instead of manually
  building the path from the deprecated `project.buildDir`
  property.
* Use `/` instead of `File.separator` for paths. This is the style
  that Gradle recommends, and it simplifies how we build path strings.
  The Java File APIs canonicalize `/` to `\` on Windows, so it's
  not necessary to use `File.separator` explicitly.

And, in a follow-up commit, I noticed a couple of places where we could use the Groovy `withReader` method.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
