### PR TITLE
Bug 1854254 - nimbus-gradle-plugin: Overhaul the plugin to support lazy configuration.

### DIFF
--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusAssembleToolsTask.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusAssembleToolsTask.groovy
@@ -1,0 +1,209 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.appservices.tooling.nimbus
+
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.FileVisitDetails
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.LocalState
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+import javax.inject.Inject
+
+import groovy.transform.Immutable
+
+/**
+ * A task that fetches a prebuilt `nimbus-fml` binary for the current platform.
+ *
+ * Prebuilt binaries for all platforms are packaged into ZIP archives, and
+ * published to sources like `archive.mozilla.org` (for releases) or
+ * TaskCluster (for nightly builds).
+ *
+ * This task takes a variable number of inputs: a list of archive sources,
+ * and a list of glob patterns to find the binary for the current platform
+ * in the archive.
+ *
+ * The unzipped binary is this task's only output. This output is then used as
+ * an optional input to the `NimbusFmlCommandTask`s.
+ */
+@CacheableTask
+abstract class NimbusAssembleToolsTask extends DefaultTask {
+    @Inject
+    abstract ArchiveOperations getArchiveOperations()
+
+    @Nested
+    abstract FetchSpec getFetchSpec()
+
+    @Nested
+    abstract UnzipSpec getUnzipSpec()
+
+    /** The location of the fetched ZIP archive. */
+    @LocalState
+    abstract RegularFileProperty getArchiveFile()
+
+    /**
+     * The location of the fetched hash file, which contains the
+     * archive's checksum.
+     */
+    @LocalState
+    abstract RegularFileProperty getHashFile()
+
+    /** The location of the unzipped binary. */
+    @OutputFile
+    abstract RegularFileProperty getFmlBinary()
+
+    /**
+     * Configures the task to download the archive.
+     *
+     * @param action The configuration action.
+     */
+    void fetch(Action<FetchSpec> action) {
+        action.execute(fetchSpec)
+    }
+
+    /**
+     * Configures the task to extract the binary from the archive.
+     *
+     * @param action The configuration action.
+     */
+    void unzip(Action<UnzipSpec> action) {
+        action.execute(unzipSpec)
+    }
+
+    @TaskAction
+    void assembleTools() {
+        def sources = [fetchSpec, *fetchSpec.fallbackSources.get()].collect {
+            new Source(new URI(it.archive.get()), new URI(it.hash.get()))
+        }
+
+        def successfulSource = sources.find { it.trySaveArchiveTo(archiveFile.get().asFile) }
+        if (successfulSource == null) {
+            throw new GradleException("Couldn't fetch archive from any of: ${sources*.archiveURI.collect { "`$it`" }.join(', ')}")
+        }
+
+        // We get the checksum, although don't do anything with it yet;
+        // Checking it here would be able to detect if the zip file was tampered with
+        // in transit between here and the server.
+        // It won't detect compromise of the CI server.
+        try {
+            successfulSource.saveHashTo(hashFile.get().asFile)
+        } catch (IOException e) {
+            throw new GradleException("Couldn't fetch hash from `${successfulSource.hashURI}`", e)
+        }
+
+        def zipTree = archiveOperations.zipTree(archiveFile.get())
+        def visitedFilePaths = []
+        zipTree.matching {
+            include unzipSpec.includePatterns.get()
+        }.visit { FileVisitDetails details ->
+            if (!details.directory) {
+                if (visitedFilePaths.empty) {
+                    details.copyTo(fmlBinary.get().asFile)
+                    fmlBinary.get().asFile.setExecutable(true)
+                }
+                visitedFilePaths.add(details.relativePath)
+            }
+        }
+
+        if (visitedFilePaths.size() > 1) {
+            throw new GradleException("Ambiguous unzip spec matched ${visitedFilePaths.size()} files in archive: ${visitedFilePaths.collect { "`$it`" }.join(', ')}")
+        }
+    }
+
+    /**
+     * Specifies the source from which to fetch the archive and
+     * its hash file.
+     */
+    static abstract class FetchSpec extends SourceSpec {
+        @Inject
+        abstract ObjectFactory getObjectFactory()
+
+        @Nested
+        abstract ListProperty<SourceSpec> getFallbackSources()
+
+        /**
+         * Configures a fallback to try if the archive can't be fetched
+         * from this source.
+         *
+         * The task will try fallbacks in the order in which they're
+         * configured.
+         *
+         * @param action The configuration action.
+         */
+        void fallback(Action<SourceSpec> action) {
+            def spec = objectFactory.newInstance(SourceSpec)
+            action(spec)
+            fallbackSources.add(spec)
+        }
+    }
+
+    /** Specifies the URL of an archive and its hash file. */
+    static abstract class SourceSpec {
+        @Input
+        abstract Property<String> getArchive()
+
+        @Input
+        abstract Property<String> getHash()
+    }
+
+    /**
+     * Specifies which binary to extract from the fetched archive.
+     *
+     * The spec should only match one file in the archive. If the spec
+     * matches multiple files in the archive, the task will fail.
+     */
+    static abstract class UnzipSpec {
+        @Input
+        abstract ListProperty<String> getIncludePatterns()
+
+        /**
+         * Includes all files whose paths match the pattern.
+         *
+         * @param pattern An Ant-style glob pattern.
+         * @see org.gradle.api.tasks.util.PatternFilterable#include
+         */
+        void include(String pattern) {
+            includePatterns.add(pattern)
+        }
+    }
+
+    /** A helper to fetch an archive and its hash file. */
+    @Immutable
+    static class Source {
+        URI archiveURI
+        URI hashURI
+
+        boolean trySaveArchiveTo(File destination) {
+            try {
+                saveURITo(archiveURI, destination)
+                true
+            } catch (IOException ignored) {
+                false
+            }
+        }
+
+        void saveHashTo(File destination) {
+            saveURITo(hashURI, destination)
+        }
+
+        private static void saveURITo(URI source, File destination) {
+            source.toURL().withInputStream { from ->
+                destination.withOutputStream { out ->
+                    out << from
+                }
+            }
+        }
+    }
+}

--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusFeaturesTask.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusFeaturesTask.groovy
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.appservices.tooling.nimbus
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.LocalState
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.process.ExecSpec
+
+@CacheableTask
+abstract class NimbusFeaturesTask extends NimbusFmlCommandTask {
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract RegularFileProperty getInputFile()
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract ConfigurableFileCollection getRepoFiles()
+
+    @Input
+    abstract Property<String> getChannel()
+
+    @LocalState
+    abstract DirectoryProperty getCacheDir()
+
+    @OutputDirectory
+    abstract DirectoryProperty getOutputDir()
+
+    @Override
+    void configureFmlCommand(ExecSpec spec) {
+        spec.with {
+            args 'generate'
+
+            args '--language', 'kotlin'
+            args '--channel', channel.get()
+            args '--cache-dir', cacheDir.get()
+            for (File file : repoFiles) {
+                args '--repo-file', file
+            }
+
+            args inputFile.get().asFile
+            args outputDir.get().asFile
+        }
+    }
+}

--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusFmlCommandTask.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusFmlCommandTask.groovy
@@ -1,0 +1,93 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.appservices.tooling.nimbus
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+
+import javax.inject.Inject
+
+/**
+ * A base task to execute a `nimbus-fml` command.
+ *
+ * Subclasses can declare additional inputs and outputs, and override
+ * `configureFmlCommand` to set additional command arguments.
+ *
+ * This task requires either `applicationServicesDir` to be set, or
+ * the `fmlBinary` to exist. If `applicationServicesDir` is set,
+ * the task will run `nimbus-fml` from the Application Services repo;
+ * otherwise, it'll fall back to a prebuilt `fmlBinary`.
+ */
+abstract class NimbusFmlCommandTask extends DefaultTask {
+    public static final String APPSERVICES_FML_HOME = 'components/support/nimbus-fml'
+
+    @Inject
+    abstract ExecOperations getExecOperations()
+
+    @Inject
+    abstract ProjectLayout getProjectLayout()
+
+    @Input
+    abstract Property<String> getProjectDir()
+
+    @Input
+    @Optional
+    abstract Property<String> getApplicationServicesDir()
+
+    // `@InputFiles` instead of `@InputFile` because we don't want
+    // the task to fail if the `fmlBinary` file doesn't exist
+    // (https://github.com/gradle/gradle/issues/2016).
+    @InputFiles
+    @PathSensitive(PathSensitivity.NONE)
+    abstract RegularFileProperty getFmlBinary()
+
+    /**
+     * Configures the `nimbus-fml` command for this task.
+     *
+     * This method is invoked from the `@TaskAction` during the execution phase,
+     * and so has access to the final values of the inputs and outputs.
+     *
+     * @param spec The specification for the `nimbus-fml` command.
+     */
+    abstract void configureFmlCommand(ExecSpec spec)
+
+    @TaskAction
+    void execute() {
+        execOperations.exec { spec ->
+            spec.with {
+                // Absolutize `projectDir`, so that we can resolve our paths
+                // against it. If it's already absolute, it'll be used as-is.
+                def projectDir = projectLayout.projectDirectory.dir(projectDir.get())
+                def localAppServices = applicationServicesDir.getOrNull()
+                if (localAppServices == null) {
+                    if (!fmlBinary.get().asFile.exists()) {
+                        throw new GradleException("`nimbus-fml` wasn't downloaded and `nimbus.applicationServicesDir` isn't set")
+                    }
+                    workingDir projectDir
+                    commandLine fmlBinary.get().asFile
+                } else {
+                    def cargoManifest = projectDir.file("$localAppServices/$APPSERVICES_FML_HOME/Cargo.toml").asFile
+
+                    commandLine 'cargo'
+                    args 'run'
+                    args '--manifest-path', cargoManifest
+                    args '--'
+                }
+            }
+            configureFmlCommand(spec)
+        }
+    }
+}

--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusValidateTask.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusValidateTask.groovy
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.appservices.tooling.nimbus
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.LocalState
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.process.ExecSpec
+
+@CacheableTask
+abstract class NimbusValidateTask extends NimbusFmlCommandTask {
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract RegularFileProperty getInputFile()
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    abstract ConfigurableFileCollection getRepoFiles()
+
+    @LocalState
+    abstract DirectoryProperty getCacheDir()
+
+    @Override
+    void configureFmlCommand(ExecSpec spec) {
+        spec.with {
+            args 'validate'
+
+            args '--cache-dir', cacheDir.get()
+            for (File file : repoFiles) {
+                args '--repo-file', file
+            }
+
+            args inputFile.get()
+        }
+    }
+}


### PR DESCRIPTION
This is a substantial refactor of the plugin that should fix issues like bug 1854254 and bug 1856461, and speed up FML generation. These bugs had the same underlying cause: the plugin was trying to configure its tasks without observing the Gradle build lifecycle, leading to inconsistencies and accidental interdependencies.

Further, because the old tasks didn't declare their inputs or outputs, Gradle couldn't "see" the full task graph, causing too much or too little to be rebuilt. The easiest way to force Gradle to pick up the changes used to be a full clobber.

This commit resolves all those issues by:

* Adopting Gradle's lazy configuration API [1], which lets Gradle track inputs and outputs, and avoids ordering issues caused by realizing the task graph at the wrong time [2].
* Adopting the new Android Gradle Plugin `SourceDirectories` API that supports lazy configuration [3].
* Adding task classes and custom types to help with naming and configuring inputs and outputs.

[1]: https://docs.gradle.org/current/userguide/lazy_configuration.html
[2]: https://docs.gradle.org/current/userguide/task_configuration_avoidance.html
[3]: https://developer.android.com/reference/tools/gradle-api/8.4/com/android/build/api/variant/SourceDirectories

This is definitely a big change, and I'm really sorry about that—it was tough to migrate the plugin incrementally, with how it was structured. I did test it in various configurations locally, and it's working like a charm! 🎉 The public `NimbusExtension` API also works exactly the same way as it does now.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
