### PR TITLE
Adds raw FxA ID to sync telemetry

### DIFF
--- a/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncTelemetry.kt
+++ b/components/sync_manager/android/src/main/java/mozilla/appservices/syncmanager/SyncTelemetry.kt
@@ -47,7 +47,12 @@ object SyncTelemetry {
     @Suppress("LongParameterList")
     fun processSyncTelemetry(
         syncTelemetry: SyncTelemetryPing,
-
+        // Given our architecture, the uid has to come from the outside
+        // and can't be inside SyncTelemetryPing, because the sync manager does not
+        // know what the uid is.
+        // The default value is to prevent a breaking change and will be removed
+        // once downstream consumers pass the value in.
+        uid: String? = null,
         // The following are present to make this function testable. In tests, we need to "intercept"
         // values set in singleton ping objects before they're reset by a 'submit' call.
         submitGlobalPing: () -> Unit = { Pings.sync.submit() },
@@ -56,8 +61,11 @@ object SyncTelemetry {
         submitLoginsPing: () -> Unit = { Pings.loginsSync.submit() },
         submitCreditCardsPing: () -> Unit = { Pings.creditcardsSync.submit() },
         submitAddressesPing: () -> Unit = { Pings.addressesSync.submit() },
-        submitTabsPing: () -> Unit = { Pings.tabsSync.submit() },
+        submitTabsPing: () -> Unit = { Pings.tabsSync.submit()},
     ) {
+        uid?.let {
+            Sync.uid.set(it)
+        }
         syncTelemetry.syncs.forEach { syncInfo ->
             // Note that `syncUuid` is configured to be submitted in all of the sync pings (it's set
             // once, and will be attached by glean to history-sync, bookmarks-sync, and logins-sync pings).

--- a/components/sync_manager/ios/SyncManager/SyncManagerTelemetry.swift
+++ b/components/sync_manager/ios/SyncManager/SyncManagerTelemetry.swift
@@ -26,6 +26,7 @@ enum TelemetryReportingError: Error {
 }
 
 func processSyncTelemetry(syncTelemetry: RustSyncTelemetryPing,
+                          uid: String? = nil,
                           submitGlobalPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.sync.submit,
                           submitHistoryPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.historySync.submit,
                           submitBookmarksPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.bookmarksSync.submit,
@@ -33,6 +34,9 @@ func processSyncTelemetry(syncTelemetry: RustSyncTelemetryPing,
                           submitCreditCardsPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.creditcardsSync.submit,
                           submitTabsPing: (NoReasonCodes?) -> Void = GleanMetrics.Pings.shared.tabsSync.submit) throws
 {
+    if let uid = uid {
+        SyncMetrics.uid.set(uid)
+    }
     for syncInfo in syncTelemetry.syncs {
         _ = SyncMetrics.syncUuid.generateAndSet()
 

--- a/components/sync_manager/metrics.yaml
+++ b/components/sync_manager/metrics.yaml
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 ---
-
 $schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
 
 sync_v2:
@@ -53,6 +52,23 @@ sync_v2:
     notification_emails:
       - sync-team@mozilla.com
       - skhamis@mozilla.com
+    expires: never
+    lifetime: ping
+  uid:
+    type: string
+    description: >
+      The user's raw Firefox Account ID.
+    send_in_pings:
+      - sync
+    bugs: 
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1893727
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=1893727
+    data_sensitivity:
+      - interaction
+    notification_emails:
+      - sync-team@mozilla.com
+      - teshaq@mozilla.com
     expires: never
     lifetime: ping
 

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
@@ -54,6 +54,7 @@ class SyncManagerTelemetryTests: XCTestCase {
                                                                                                 message: "Synergies not aligned"))])
 
         func submitGlobalPing(_: NoReasonCodes?) {
+            XCTAssertEqual(SyncMetrics.uid.testGetValue(), "uid")
             XCTAssertEqual("Synergies not aligned", SyncMetrics.failureReason["other"].testGetValue())
             XCTAssertNotNil(globalSyncUuid)
             XCTAssertEqual(globalSyncUuid, SyncMetrics.syncUuid.testGetValue("sync"))
@@ -94,6 +95,7 @@ class SyncManagerTelemetryTests: XCTestCase {
         }
 
         try! processSyncTelemetry(syncTelemetry: syncTelemetry,
+                                  uid: "uid",
                                   submitGlobalPing: submitGlobalPing,
                                   submitHistoryPing: submitHistoryPing,
                                   submitLoginsPing: submitLoginsPing)
@@ -116,6 +118,7 @@ class SyncManagerTelemetryTests: XCTestCase {
                                                                    failureReason: nil)])
 
         func submitGlobalPing(_: NoReasonCodes?) {
+            XCTAssertEqual(SyncMetrics.uid.testGetValue(), "uid")
             XCTAssertNil(SyncMetrics.failureReason["other"].testGetValue())
             XCTAssertNotNil(globalSyncUuid)
             XCTAssertEqual(globalSyncUuid, SyncMetrics.syncUuid.testGetValue("sync"))
@@ -139,6 +142,7 @@ class SyncManagerTelemetryTests: XCTestCase {
         }
 
         try! processSyncTelemetry(syncTelemetry: syncTelemetry,
+                                  uid: "uid",
                                   submitGlobalPing: submitGlobalPing,
                                   submitHistoryPing: submitHistoryPing)
     }
@@ -165,6 +169,7 @@ class SyncManagerTelemetryTests: XCTestCase {
                                                                    failureReason: nil)])
 
         func submitGlobalPing(_: NoReasonCodes?) {
+            XCTAssertEqual(SyncMetrics.uid.testGetValue(), "uid")
             XCTAssertNil(SyncMetrics.failureReason["other"].testGetValue())
             XCTAssertNotNil(globalSyncUuid)
             XCTAssertEqual(globalSyncUuid, SyncMetrics.syncUuid.testGetValue("sync"))
@@ -188,6 +193,7 @@ class SyncManagerTelemetryTests: XCTestCase {
         }
 
         try! processSyncTelemetry(syncTelemetry: syncTelemetry,
+                                  uid: "uid",
                                   submitGlobalPing: submitGlobalPing,
                                   submitBookmarksPing: submitBookmarksPing)
     }
@@ -219,6 +225,7 @@ class SyncManagerTelemetryTests: XCTestCase {
                                                                    failureReason: nil)])
 
         func submitGlobalPing(_: NoReasonCodes?) {
+            XCTAssertEqual(SyncMetrics.uid.testGetValue(), "uid")
             XCTAssertNil(SyncMetrics.failureReason["other"].testGetValue())
             XCTAssertNotNil(globalSyncUuid)
             XCTAssertEqual(globalSyncUuid, SyncMetrics.syncUuid.testGetValue("sync"))
@@ -258,8 +265,28 @@ class SyncManagerTelemetryTests: XCTestCase {
         }
 
         try! processSyncTelemetry(syncTelemetry: syncTelemetry,
+                                  uid: "uid",
                                   submitGlobalPing: submitGlobalPing,
                                   submitCreditCardsPing: submitCreditCardsPing,
                                   submitTabsPing: submitTabsPing)
     }
+    
+    func testUidNotProvidedOK() {
+        let globalSyncUuid = UUID()
+        let syncTelemetry = RustSyncTelemetryPing(version: 1,
+                                                  uid: "abc123",
+                                                  events: [],
+                                                  syncs: [SyncInfo(at: now + 30,
+                                                                   took: 10000,
+                                                                   engines: [],
+                                                                   failureReason: nil)])
+
+        func submitGlobalPing(_: NoReasonCodes?) {
+            XCTAssertNil(SyncMetrics.uid.testGetValue())
+            XCTAssertNotNil(globalSyncUuid)
+        }
+        try! processSyncTelemetry(syncTelemetry: syncTelemetry,
+                                  submitGlobalPing: submitGlobalPing)
+    }
+    
 }


### PR DESCRIPTION
Still needs:
- [ ] Data review
- [ ] Tests for Kotlin code
- [ ] Verification that this is not a breaking change, or changes in iOS and Android that fix the breaking change
- [ ] Possibly adding the id to the other sync pings.

Data Review might take a while so keeping this in draft for now
