### PR TITLE
Update NSS to version 3.100

### DIFF
--- a/libs/build-all.sh
+++ b/libs/build-all.sh
@@ -2,10 +2,10 @@
 
 set -euvx
 
-NSS="nss-3.99"
-NSS_ARCHIVE="nss-3.99-with-nspr-4.35.tar.gz"
-NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_99_RTM/src/${NSS_ARCHIVE}"
-NSS_SHA256="5f29fea64b3234b33a615b6df40469e239a4168ac0909106bd00e6490b274c31"
+NSS="nss-3.100"
+NSS_ARCHIVE="nss-3.100-with-nspr-4.35.tar.gz"
+NSS_URL="https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_100_RTM/src/${NSS_ARCHIVE}"
+NSS_SHA256="f806cee99be87d55f927e976316e1686b534b64f7a687ac05ba413da7e22d9ba"
 
 # End of configuration.
 

--- a/libs/build-nss-desktop.sh
+++ b/libs/build-nss-desktop.sh
@@ -63,7 +63,7 @@ if [[ "${CROSS_COMPILE_TARGET}" =~ "darwin" ]]; then
   else
     # From https://firefox-ci-tc.services.mozilla.com/tasks/index/app-services.cache.level-3.content.v1.nss-artifact/latest
     curl -sfSL --retry 5 --retry-delay 10 -O "https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/app-services.cache.level-3.content.v1.nss-artifact.latest/artifacts/public%2Fdist.tar.bz2"
-    SHA256="63ee96026b56ec37cff12a7b971eb8845c5b55c11a9d269ec8185ba4b67212cb"
+    SHA256="c17fa584f3fb488fe5668a71bbd4dd0a31c15d06fab83c70b8c2fc3eab2793f8"
     echo "${SHA256}  dist.tar.bz2" | shasum -a 256 -c - || exit 2
     tar xvjf dist.tar.bz2 && rm -rf dist.tar.bz2
     NSS_DIST_DIR=$(abspath "dist")

--- a/taskcluster/kinds/fetch/kind.yml
+++ b/taskcluster/kinds/fetch/kind.yml
@@ -37,6 +37,6 @@ tasks:
         description: fetches the built NSS artifacts from NSS CI
         fetch:
             type: static-url
-            url: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/Vop446DuRgWPdPX7VCvfkg/runs/0/artifacts/public/dist.tar.bz2
-            sha256: 63ee96026b56ec37cff12a7b971eb8845c5b55c11a9d269ec8185ba4b67212cb
-            size: 24241178
+            url: https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/ClU3bktrStaJTcJqipQP0w/runs/0/artifacts/public/dist.tar.bz2
+            sha256: c17fa584f3fb488fe5668a71bbd4dd0a31c15d06fab83c70b8c2fc3eab2793f8
+            size: 24315363


### PR DESCRIPTION
Changelog: https://hg.mozilla.org/projects/nss/pushloghtml?fromchange=NSS_3_99_RTM&tochange=NSS_3_100_RTM&branch=default
Firefox bump bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1891763