### PR TITLE
 Bug 1894002 - use serde_path_to_error in relevancy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,6 +3548,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "sql-support",
  "thiserror",
  "uniffi",

--- a/components/relevancy/Cargo.toml
+++ b/components/relevancy/Cargo.toml
@@ -18,6 +18,7 @@ parking_lot = ">=0.11,<=0.12"
 rusqlite = { workspace = true, features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_path_to_error = "0.1"
 thiserror = "1.0"
 uniffi = { workspace = true }
 url = "2.5"

--- a/components/relevancy/src/error.rs
+++ b/components/relevancy/src/error.rs
@@ -33,8 +33,12 @@ pub enum Error {
     #[error("Remote Setting Error: {0}")]
     RemoteSettingsError(#[from] remote_settings::RemoteSettingsError),
 
-    #[error("Serde Json Error: {0}")]
-    SerdeJsonError(#[from] serde_json::Error),
+    #[error("Error parsing {type_name}: {error} ({path})")]
+    RemoteSettingsParseError {
+        type_name: String,
+        path: String,
+        error: serde_json::Error,
+    },
 
     #[error("Base64 Decode Error: {0}")]
     Base64DecodeError(String),
@@ -52,8 +56,17 @@ impl GetErrorHandling for Error {
     type ExternalError = RelevancyApiError;
 
     fn get_error_handling(&self) -> ErrorHandling<Self::ExternalError> {
-        ErrorHandling::convert(RelevancyApiError::Unexpected {
-            reason: self.to_string(),
-        })
+        match self {
+            Self::RemoteSettingsParseError { .. } => {
+                ErrorHandling::convert(RelevancyApiError::Unexpected {
+                    reason: self.to_string(),
+                })
+                .report_error("relevancy-remote-settings-parse-error")
+            }
+
+            _ => ErrorHandling::convert(RelevancyApiError::Unexpected {
+                reason: self.to_string(),
+            }),
+        }
     }
 }

--- a/components/relevancy/src/ingest.rs
+++ b/components/relevancy/src/ingest.rs
@@ -4,8 +4,8 @@
 
 use crate::db::RelevancyDao;
 use crate::rs::{
-    RelevancyAttachmentData, RelevancyRecord, RelevancyRemoteSettingsClient,
-    REMOTE_SETTINGS_COLLECTION,
+    from_json, from_json_slice, RelevancyAttachmentData, RelevancyRecord,
+    RelevancyRemoteSettingsClient, REMOTE_SETTINGS_COLLECTION,
 };
 use crate::url_hash::UrlHash;
 use crate::{Error, Interest, RelevancyDb, Result};
@@ -64,8 +64,7 @@ fn fetch_interest_data_inner(
 fn get_hash_urls(attachment_data: Vec<u8>) -> Result<Vec<UrlHash>> {
     let mut hash_urls = vec![];
 
-    let parsed_attachment_data =
-        serde_json::from_slice::<Vec<RelevancyAttachmentData>>(&attachment_data)?;
+    let parsed_attachment_data: Vec<RelevancyAttachmentData> = from_json_slice(&attachment_data)?;
 
     for attachment_data in parsed_attachment_data {
         let hash_url = STANDARD
@@ -82,7 +81,7 @@ fn get_hash_urls(attachment_data: Vec<u8>) -> Result<Vec<UrlHash>> {
 /// Extract Interest from the record info
 fn get_interest(record: &RemoteSettingsRecord) -> Result<Interest> {
     let record_fields: RelevancyRecord =
-        serde_json::from_value(serde_json::Value::Object(record.fields.clone()))?;
+        from_json(serde_json::Value::Object(record.fields.clone()))?;
     let custom_details = record_fields.record_custom_details;
     let category_code = custom_details.category_to_domains.category_code;
     Interest::try_from(category_code as u32)


### PR DESCRIPTION
 This gives us nicer errors since where the error happened in the JSON
 data.  "Unexpected null value" is not very useful, but if that's paired
 with `record_custom_details.category_to_domains.version` then you have
 a chance of figuring out the bug.

 Gave the error a more specific name and updated the error handling to
 report the error to sentry if we see it.  I don't think this affects
 desktop at all, but once we have this on mobile I think we'll want to
 surface these errors.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
