### PR TITLE
Updated SuggestRemoteSettingsClient API

### DIFF
--- a/components/suggest/src/benchmarks/client.rs
+++ b/components/suggest/src/benchmarks/client.rs
@@ -2,9 +2,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{rs::SuggestRemoteSettingsClient, Result};
+use crate::{
+    rs::{
+        SuggestRemoteSettingsClient, SuggestRemoteSettingsRecord,
+        SuggestRemoteSettingsRecordRequest,
+    },
+    Result,
+};
 use parking_lot::Mutex;
-use remote_settings::{Client, GetItemsOptions, RemoteSettingsConfig, RemoteSettingsResponse};
+use remote_settings::{Client, RemoteSettingsConfig};
 use std::collections::HashMap;
 
 /// Remotes settings client that runs during the benchmark warm-up phase.
@@ -14,8 +20,8 @@ use std::collections::HashMap;
 /// [RemoteSettingsBenchmarkClient] implements [SuggestRemoteSettingsClient] by getting data from a HashMap rather than hitting the network.
 pub struct RemoteSettingsWarmUpClient {
     client: Client,
-    pub get_records_responses: Mutex<HashMap<GetItemsOptions, RemoteSettingsResponse>>,
-    pub get_attachment_responses: Mutex<HashMap<String, Vec<u8>>>,
+    pub get_records_responses:
+        Mutex<HashMap<SuggestRemoteSettingsRecordRequest, Vec<SuggestRemoteSettingsRecord>>>,
 }
 
 impl RemoteSettingsWarmUpClient {
@@ -29,7 +35,6 @@ impl RemoteSettingsWarmUpClient {
             })
             .unwrap(),
             get_records_responses: Mutex::new(HashMap::new()),
-            get_attachment_responses: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -41,49 +46,34 @@ impl Default for RemoteSettingsWarmUpClient {
 }
 
 impl SuggestRemoteSettingsClient for RemoteSettingsWarmUpClient {
-    fn get_records_with_options(
+    fn get_records(
         &self,
-        options: &GetItemsOptions,
-    ) -> Result<RemoteSettingsResponse> {
-        let response = self.client.get_records_with_options(options)?;
+        request: SuggestRemoteSettingsRecordRequest,
+    ) -> Result<Vec<SuggestRemoteSettingsRecord>> {
+        let response =
+            <Client as SuggestRemoteSettingsClient>::get_records(&self.client, request.clone())?;
         self.get_records_responses
             .lock()
-            .insert(options.clone(), response.clone());
-        Ok(response)
-    }
-
-    fn get_attachment(&self, location: &str) -> Result<Vec<u8>> {
-        let response = self.client.get_attachment(location)?;
-        self.get_attachment_responses
-            .lock()
-            .insert(location.to_string(), response.clone());
+            .insert(request, response.clone());
         Ok(response)
     }
 }
 
 #[derive(Clone)]
 pub struct RemoteSettingsBenchmarkClient {
-    pub get_records_responses: HashMap<GetItemsOptions, RemoteSettingsResponse>,
-    pub get_attachment_responses: HashMap<String, Vec<u8>>,
+    pub get_records_responses:
+        HashMap<SuggestRemoteSettingsRecordRequest, Vec<SuggestRemoteSettingsRecord>>,
 }
 
 impl SuggestRemoteSettingsClient for RemoteSettingsBenchmarkClient {
-    fn get_records_with_options(
+    fn get_records(
         &self,
-        options: &GetItemsOptions,
-    ) -> Result<RemoteSettingsResponse> {
+        request: SuggestRemoteSettingsRecordRequest,
+    ) -> Result<Vec<SuggestRemoteSettingsRecord>> {
         Ok(self
             .get_records_responses
-            .get(options)
-            .unwrap_or_else(|| panic!("options not found: {options:?}"))
-            .clone())
-    }
-
-    fn get_attachment(&self, location: &str) -> Result<Vec<u8>> {
-        Ok(self
-            .get_attachment_responses
-            .get(location)
-            .unwrap_or_else(|| panic!("location not found: {location:?}"))
+            .get(&request)
+            .unwrap_or_else(|| panic!("options not found: {request:?}"))
             .clone())
     }
 }
@@ -92,7 +82,6 @@ impl From<RemoteSettingsWarmUpClient> for RemoteSettingsBenchmarkClient {
     fn from(warm_up_client: RemoteSettingsWarmUpClient) -> Self {
         Self {
             get_records_responses: warm_up_client.get_records_responses.into_inner(),
-            get_attachment_responses: warm_up_client.get_attachment_responses.into_inner(),
         }
     }
 }

--- a/components/suggest/src/benchmarks/ingest.rs
+++ b/components/suggest/src/benchmarks/ingest.rs
@@ -97,10 +97,15 @@ pub fn print_debug_ingestion_sizes() {
     let table_row_counts = store.table_row_counts();
     let client = store.into_settings_client();
     let total_attachment_size: usize = client
-        .get_attachment_responses
+        .get_records_responses
         .lock()
         .values()
-        .map(|data| data.len())
+        .flat_map(|records| {
+            records.iter().map(|r| match &r.attachment_data {
+                Some(d) => d.len(),
+                None => 0,
+            })
+        })
         .sum();
 
     println!(

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -7,7 +7,6 @@ use std::{collections::HashSet, path::Path, sync::Arc};
 
 use interrupt_support::{SqlInterruptHandle, SqlInterruptScope};
 use parking_lot::Mutex;
-use remote_settings::RemoteSettingsRecord;
 use rusqlite::{
     named_params,
     types::{FromSql, ToSql},
@@ -23,7 +22,7 @@ use crate::{
     rs::{
         DownloadedAmoSuggestion, DownloadedAmpSuggestion, DownloadedAmpWikipediaSuggestion,
         DownloadedMdnSuggestion, DownloadedPocketSuggestion, DownloadedWeatherData,
-        DownloadedWikipediaSuggestion, SuggestRecordId,
+        DownloadedWikipediaSuggestion, SuggestRecordId, SuggestRemoteSettingsRecord,
     },
     schema::{clear_database, SuggestConnectionInitializer},
     suggestion::{cook_raw_suggestion_url, AmpSuggestionType, Suggestion},
@@ -138,7 +137,7 @@ impl<'a> SuggestDao<'a> {
     pub fn handle_ingested_record(
         &mut self,
         last_ingest_key: &str,
-        record: &RemoteSettingsRecord,
+        record: &SuggestRemoteSettingsRecord,
     ) -> Result<()> {
         // Advance the last fetch time, so that we can resume
         // fetching after this record if we're interrupted.
@@ -148,7 +147,7 @@ impl<'a> SuggestDao<'a> {
     pub fn handle_deleted_record(
         &mut self,
         last_ingest_key: &str,
-        record: &RemoteSettingsRecord,
+        record: &SuggestRemoteSettingsRecord,
     ) -> Result<()> {
         let record_id = SuggestRecordId::from(&record.id);
         // Drop either the icon or suggestions, records only contain one or the other

--- a/components/suggest/src/error.rs
+++ b/components/suggest/src/error.rs
@@ -10,7 +10,7 @@ use remote_settings::RemoteSettingsError;
 /// type for private and crate-internal methods, and is never returned to the
 /// application.
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
+pub enum Error {
     #[error("Error opening database: {0}")]
     OpenDatabase(#[from] sql_support::open_database::Error),
 
@@ -22,6 +22,9 @@ pub(crate) enum Error {
 
     #[error("Error from Remote Settings: {0}")]
     RemoteSettings(#[from] RemoteSettingsError),
+
+    #[error("Remote settings record is missing an attachment (id: u64)")]
+    MissingAttachment(String),
 
     #[error("Operation interrupted")]
     Interrupted(#[from] interrupt_support::Interrupted),


### PR DESCRIPTION
Made the API more high-level and not just a copy of the remote settings client API.  It now inputs a `SuggestRemoteSettingsRecordRequest` which is specific to the kinds of requests we make.  It outputs a list of records linked to the attachment data.  This way:

  - It's simpler to mock up in the tests since the mocks can match the actual requests more directly.  I'm hoping to use this to simplify the store tests which have gotten really out of hand.
  - We abstract away some of the remote settings client details, which makes it easer to switch how we make requests in the future.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
