### PR TITLE
chore: Update vendoring should error if a subprocess has an issue.

### DIFF
--- a/tools/update-moz-central-vendoring.py
+++ b/tools/update-moz-central-vendoring.py
@@ -4,6 +4,7 @@ import argparse
 import pathlib
 import re
 import subprocess
+import sys
 
 APP_SERVICES_DEPENDENCY_RE = re.compile(
     r'([\w-]+).*{\s*git\s*=\s*"https://github.com/mozilla/application-services"'
@@ -15,8 +16,8 @@ def main():
     moz_central_root = pathlib.Path(args.moz_central_dir)
     app_services_rev = get_app_services_rev()
     update_cargo_toml(moz_central_root / "Cargo.toml", app_services_rev)
-    subprocess.run(["./mach", "vendor", "rust"], cwd=moz_central_root)
-    subprocess.run(["./mach", "uniffi", "generate"], cwd=moz_central_root)
+    run_process(["./mach", "vendor", "rust"], cwd=moz_central_root)
+    run_process(["./mach", "uniffi", "generate"], cwd=moz_central_root)
 
     print("The vendoring was successful")
     print(" - If you saw a warning saying `There are 2 different versions of crate X`, then "
@@ -25,6 +26,12 @@ def main():
     print(" - Commit any changes and submit a phabricator patch")
     print()
     print("Details here: https://github.com/mozilla/application-services/blob/main/docs/howtos/vendoring-into-mozilla-central.md")
+
+def run_process(command, cwd):
+    result = subprocess.run(command, cwd=cwd)
+    if result.returncode != 0:
+        print("Vendoring failed, please see above errors", file=sys.stderr)
+        sys.exit(1)
 
 def parse_args():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
The current update-moz-central-vendoring.py script does not error if one of the sub-processes raises an error. This means that errors from the vendoring step can go unnoticed and the output would say that it was successful.

This is tools/harness only so shouldn't need a changelog nor tests.
 
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [X] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.