### PR TITLE
nimbus-gradle-plugin: Use `getArchOs()` as the path prefix when unzipping `nimbus-fml`.

### DIFF
--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusAssembleToolsTask.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusAssembleToolsTask.groovy
@@ -117,6 +117,10 @@ abstract class NimbusAssembleToolsTask extends DefaultTask {
             }
         }
 
+        if (visitedFilePaths.empty) {
+            throw new GradleException("Couldn't find any files in archive matching unzip spec: (${unzipSpec.includePatterns.get().collect { "`$it`" }.join(' | ')})")
+        }
+
         if (visitedFilePaths.size() > 1) {
             throw new GradleException("Ambiguous unzip spec matched ${visitedFilePaths.size()} files in archive: ${visitedFilePaths.collect { "`$it`" }.join(', ')}")
         }

--- a/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
+++ b/tools/nimbus-gradle-plugin/src/main/groovy/org/mozilla/appservices/tooling/nimbus/NimbusGradlePlugin.groovy
@@ -161,7 +161,7 @@ class NimbusPlugin implements Plugin<Project> {
             }
 
             unzip {
-                include "${getArchOs()}/release/nimbus-fml*"
+                include "${getArchOs()}*/release/nimbus-fml*"
             }
 
             onlyIf('`applicationServicesDir` == null') {


### PR DESCRIPTION
This fixes a regression from 9197c0bdce6b3be5c35feab0b01f8bffbb4fa6be. `NimbusAssembleToolsTask` wouldn't find `nimbus-fml` when run on an on an x86-64 Linux host, because `getArchOs()` returns `x86_64-unknown-linux` on that platform, while the directory in the archive is named `x86_64-unknown-linux-musl`. Using `getArchOs()` as the prefix fixes this for both x86-64 and ARM64 Linux hosts.

`NimbusAssembleToolsTask` now throws if no files match the unzip spec, to catch issues like this in the future.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
