### PR TITLE
chore: Revert two typo fixes in DEPENDENCIES.md since it is auto-generated.

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2235,7 +2235,7 @@ The following text applies to code linked from these dependencies:
  * The implementation was written so as to conform with Netscapes SSL.
  *
  * This library is free for commercial and non-commercial use as long as
- * the following conditions are adhered to.  The following conditions
+ * the following conditions are aheared to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
@@ -2260,7 +2260,7 @@ The following text applies to code linked from these dependencies:
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the routines from the library
+ *    The word 'cryptographic' can be left out if the rouines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
@@ -2278,7 +2278,7 @@ The following text applies to code linked from these dependencies:
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * The licence and distribution terms for any publicly available version or
+ * The licence and distribution terms for any publically available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
  * [including the GNU Public Licence.]


### PR DESCRIPTION
As requested by @linabutler, I've reverted the changes in the auto-generated `DEPENDENCIES.md`, introduced in #6251.

I apologies @linabutler and @mhammond I misunderstood you in 6251, I thought since the PR was merged that there was no action needed.... 
