### PR TITLE
Lock Swiftlint and Swiftformat to a version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,14 @@ jobs:
     executor: macos
     steps:
       - full-checkout
-      - run: brew install swiftlint swiftformat
+      - run: sudo gem install cocoapods
+      - run: pod init
+      - run: |
+          echo "platform :ios, '10.0'" > Podfile
+          echo "target 'CircleCI' do" >> Podfile
+          echo " pod 'SwiftLint', '0.53.9'" >> Podfile
+          echo " pod 'SwiftFormat/CLI', '0.53.10'" >> Podfile
+          echo "end" >> Podfile - run: pod install
       - run: ./automation/tests.py swiftlint
       - run: ./automation/tests.py swiftformat
   Check Rust formatting:


### PR DESCRIPTION
We've been bitten a couple of times where unrelated PRs start failing due to an upgrade with swiftlint/swiftformat. We should pin the version to prevent these issues and then in the future the upgrades + lint fixes can go together.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
