### PR TITLE
Disable bad swiftlint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -29,6 +29,8 @@ disabled_rules:
   - trailing_comma
   # It disagrees with swiftformat on this, and wants the opening braces to be on the same line in multiline declarations
   - opening_brace
+  # see discussion here https://github.com/realm/SwiftLint/issues/5263
+  - non_optional_string_data_conversion
 
 identifier_name:
   # Turn off it complaining about `id` or `let t = title`, etc, but keep


### PR DESCRIPTION
While https://github.com/mozilla/application-services/pull/6254 tries to fix the issue. Turns out the rule might be reversed in swiftlint mentioned by @linabutler https://github.com/mozilla/application-services/pull/6254#issuecomment-2138471699

https://github.com/realm/SwiftLint/pull/5601 has more discussion about the issues with the lint. For the sake of our PRs, lets just disable the rule for now (as we don't know when it'll get merged and version bumped). There's a broader discussion about locking swiftlint to prevent these kind of issues here https://bugzilla.mozilla.org/show_bug.cgi?id=1900934 but that'll take a little more discussion before we do anything substantial 

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
