### PR TITLE
Adding SuggestBuilder.remote_settings_bucket_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # v129.0 (In progress)
 
+## ⚠️ Breaking Changes ⚠️
+
+### Suggest
+- Removed the deprecated `remote_settings_config` method.  No consumers were using this.
+
 ## ✨ What's New ✨
+
+### Suggest
+- Added the `SuggestStoreBuilder.remote_settings_bucket_name` as a way to specify the bucket name.
 
 [Full Changelog](In progress)
 

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -178,9 +178,8 @@ interface SuggestStoreBuilder {
     [Self=ByArc]
     SuggestStoreBuilder remote_settings_server(RemoteSettingsServer server);
 
-    // Deprecated: Use `remote_settings_server()` instead.
     [Self=ByArc]
-    SuggestStoreBuilder remote_settings_config(RemoteSettingsConfig config);
+    SuggestStoreBuilder remote_settings_bucket_name(string bucket_name);
 
     [Throws=SuggestApiError]
     SuggestStore build();


### PR DESCRIPTION
I just realized that the JS consumer wants to set the bucket name.  They currently use the `remote_settings_config` method to do this, but it's deprecated so we need to give them an alternative.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
