### PR TITLE
Refactor fxa command encryption to avoid duplicated code

### DIFF
--- a/components/fxa-client/src/internal/commands/close_tabs.rs
+++ b/components/fxa-client/src/internal/commands/close_tabs.rs
@@ -2,35 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use rc_crypto::ece;
+use crate::internal::telemetry;
 use serde_derive::*;
-
-use crate::{internal::telemetry, Error, Result, ScopedKey};
-
-use super::{
-    super::device::Device,
-    send_tab::{PrivateSendTabKeysV1, PublicSendTabKeys, SendTabKeysPayload},
-};
 
 pub const COMMAND_NAME: &str = "https://identity.mozilla.com/cmd/close-uri/v1";
 // Note: matches REMOTE_COMMAND_TTL_MS in tabs storage.rs
 pub const COMMAND_TTL: u64 = 2 * 24 * 3600;
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct EncryptedCloseTabsPayload {
-    /// URL Safe Base 64 encrypted payload.
-    encrypted: String,
-}
-
-impl EncryptedCloseTabsPayload {
-    pub(crate) fn decrypt(self, keys: &PrivateSendTabKeysV1) -> Result<CloseTabsPayload> {
-        rc_crypto::ensure_initialized();
-        let encrypted = URL_SAFE_NO_PAD.decode(self.encrypted)?;
-        let decrypted = ece::decrypt(keys.p256key(), keys.auth_secret(), &encrypted)?;
-        Ok(serde_json::from_slice(&decrypted)?)
-    }
-}
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CloseTabsPayload {
@@ -59,31 +36,6 @@ impl CloseTabsPayload {
             sent_telemetry,
         )
     }
-
-    fn encrypt(&self, keys: PublicSendTabKeys) -> Result<EncryptedCloseTabsPayload> {
-        rc_crypto::ensure_initialized();
-        let bytes = serde_json::to_vec(&self)?;
-        let public_key = URL_SAFE_NO_PAD.decode(keys.public_key())?;
-        let auth_secret = URL_SAFE_NO_PAD.decode(keys.auth_secret())?;
-        let encrypted = ece::encrypt(&public_key, &auth_secret, &bytes)?;
-        let encrypted = URL_SAFE_NO_PAD.encode(encrypted);
-        Ok(EncryptedCloseTabsPayload { encrypted })
-    }
-}
-
-pub fn build_close_tabs_command(
-    scoped_key: &ScopedKey,
-    target: &Device,
-    payload: &CloseTabsPayload,
-) -> Result<serde_json::Value> {
-    let command = target
-        .available_commands
-        .get(COMMAND_NAME)
-        .ok_or(Error::UnsupportedCommand(COMMAND_NAME))?;
-    let bundle: SendTabKeysPayload = serde_json::from_str(command)?;
-    let public_keys = bundle.decrypt(scoped_key)?;
-    let encrypted_payload = payload.encrypt(public_keys)?;
-    Ok(serde_json::to_value(encrypted_payload)?)
 }
 
 #[cfg(test)]

--- a/components/fxa-client/src/internal/commands/keys.rs
+++ b/components/fxa-client/src/internal/commands/keys.rs
@@ -1,0 +1,211 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// All commands share the same structs for their crypto-keys.
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use super::super::device::Device;
+use super::super::scopes;
+use crate::{Error, Result, ScopedKey};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use rc_crypto::ece::{self, EcKeyComponents};
+use sync15::{EncryptedPayload, KeyBundle};
+
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) enum VersionedPrivateCommandKeys {
+    V1(PrivateCommandKeysV1),
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct PrivateCommandKeysV1 {
+    p256key: EcKeyComponents,
+    auth_secret: Vec<u8>,
+}
+pub(crate) type PrivateCommandKeys = PrivateCommandKeysV1;
+
+impl PrivateCommandKeys {
+    // We define this method so if someone attempts to serialize `PrivateCommandKeys` directly
+    // they actually get a serialization of `VersionedPrivateCommandKeys`, which is what we want,
+    // because the latter "tags" the version.
+    // We should work out how to clean this up to avoid these hacks.
+    pub(crate) fn serialize(&self) -> Result<String> {
+        Ok(serde_json::to_string(&VersionedPrivateCommandKeys::V1(
+            self.clone(),
+        ))?)
+    }
+
+    pub(crate) fn deserialize(s: &str) -> Result<Self> {
+        let versionned: VersionedPrivateCommandKeys = serde_json::from_str(s)?;
+        match versionned {
+            VersionedPrivateCommandKeys::V1(prv_key) => Ok(prv_key),
+        }
+    }
+}
+
+impl PrivateCommandKeys {
+    pub fn from_random() -> Result<Self> {
+        rc_crypto::ensure_initialized();
+        let (key_pair, auth_secret) = ece::generate_keypair_and_auth_secret()?;
+        Ok(Self {
+            p256key: key_pair.raw_components()?,
+            auth_secret: auth_secret.to_vec(),
+        })
+    }
+
+    pub fn p256key(&self) -> &EcKeyComponents {
+        &self.p256key
+    }
+
+    pub fn auth_secret(&self) -> &[u8] {
+        &self.auth_secret
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct CommandKeysPayload {
+    /// Hex encoded kid.
+    kid: String,
+    /// Base 64 encoded IV.
+    #[serde(rename = "IV")]
+    iv: String,
+    /// Hex encoded hmac.
+    hmac: String,
+    /// Base 64 encoded ciphertext.
+    ciphertext: String,
+}
+
+impl CommandKeysPayload {
+    fn decrypt(self, scoped_key: &ScopedKey) -> Result<PublicCommandKeys> {
+        let (ksync, kxcs) = extract_oldsync_key_components(scoped_key)?;
+        if hex::decode(self.kid)? != kxcs {
+            return Err(Error::MismatchedKeys);
+        }
+        let key = KeyBundle::from_ksync_bytes(&ksync)?;
+        let encrypted_payload = EncryptedPayload {
+            iv: self.iv,
+            hmac: self.hmac,
+            ciphertext: self.ciphertext,
+        };
+        Ok(encrypted_payload.decrypt_into(&key)?)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct PublicCommandKeys {
+    /// URL Safe Base 64 encoded push public key.
+    #[serde(rename = "publicKey")]
+    public_key: String,
+    /// URL Safe Base 64 encoded auth secret.
+    #[serde(rename = "authSecret")]
+    auth_secret: String,
+}
+
+impl PublicCommandKeys {
+    fn encrypt(&self, scoped_key: &ScopedKey) -> Result<CommandKeysPayload> {
+        let (ksync, kxcs) = extract_oldsync_key_components(scoped_key)?;
+        let key = KeyBundle::from_ksync_bytes(&ksync)?;
+        let encrypted_payload = EncryptedPayload::from_cleartext_payload(&key, &self)?;
+        Ok(CommandKeysPayload {
+            kid: hex::encode(kxcs),
+            iv: encrypted_payload.iv,
+            hmac: encrypted_payload.hmac,
+            ciphertext: encrypted_payload.ciphertext,
+        })
+    }
+    pub fn as_command_data(&self, scoped_key: &ScopedKey) -> Result<String> {
+        let encrypted_public_keys = self.encrypt(scoped_key)?;
+        Ok(serde_json::to_string(&encrypted_public_keys)?)
+    }
+    pub(crate) fn public_key(&self) -> &str {
+        &self.public_key
+    }
+    pub(crate) fn auth_secret(&self) -> &str {
+        &self.auth_secret
+    }
+}
+
+impl From<PrivateCommandKeys> for PublicCommandKeys {
+    fn from(internal: PrivateCommandKeys) -> Self {
+        Self {
+            public_key: URL_SAFE_NO_PAD.encode(internal.p256key.public_key()),
+            auth_secret: URL_SAFE_NO_PAD.encode(&internal.auth_secret),
+        }
+    }
+}
+
+fn extract_oldsync_key_components(oldsync_key: &ScopedKey) -> Result<(Vec<u8>, Vec<u8>)> {
+    if oldsync_key.scope != scopes::OLD_SYNC {
+        return Err(Error::IllegalState(
+            "Only oldsync scoped keys are supported at the moment.",
+        ));
+    }
+    let kxcs: &str = oldsync_key.kid.splitn(2, '-').collect::<Vec<_>>()[1];
+    let kxcs = URL_SAFE_NO_PAD.decode(kxcs)?;
+    let ksync = oldsync_key.key_bytes()?;
+    Ok((ksync, kxcs))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct EncryptedCommandPayload {
+    /// URL Safe Base 64 encrypted send-tab payload.
+    encrypted: String,
+}
+
+impl EncryptedCommandPayload {
+    pub(crate) fn decrypt<T: DeserializeOwned>(self, keys: &PrivateCommandKeys) -> Result<T> {
+        rc_crypto::ensure_initialized();
+        let encrypted = URL_SAFE_NO_PAD.decode(self.encrypted)?;
+        let decrypted = ece::decrypt(keys.p256key(), keys.auth_secret(), &encrypted)?;
+        Ok(serde_json::from_slice(&decrypted)?)
+    }
+}
+
+fn encrypt_payload<T: Serialize>(
+    payload: &T,
+    keys: PublicCommandKeys,
+) -> Result<EncryptedCommandPayload> {
+    rc_crypto::ensure_initialized();
+    let bytes = serde_json::to_vec(payload)?;
+    let public_key = URL_SAFE_NO_PAD.decode(keys.public_key())?;
+    let auth_secret = URL_SAFE_NO_PAD.decode(keys.auth_secret())?;
+    let encrypted = ece::encrypt(&public_key, &auth_secret, &bytes)?;
+    let encrypted = URL_SAFE_NO_PAD.encode(encrypted);
+    Ok(EncryptedCommandPayload { encrypted })
+}
+
+/// encrypt a command suitable for sending via a push message to another device.
+pub(crate) fn encrypt_command<T: Serialize>(
+    scoped_key: &ScopedKey,
+    target: &Device,
+    command: &'static str,
+    payload: &T,
+) -> Result<serde_json::Value> {
+    let public_keys = get_public_keys(scoped_key, target, command)?;
+    let encrypted_payload = encrypt_payload(payload, public_keys)?;
+    Ok(serde_json::to_value(encrypted_payload)?)
+}
+
+/// Get the public keys for a command for a device. These are encrypted in a device record.
+pub(crate) fn get_public_keys(
+    scoped_key: &ScopedKey,
+    target: &Device,
+    command: &'static str,
+) -> Result<PublicCommandKeys> {
+    let command = target
+        .available_commands
+        .get(command)
+        .ok_or(Error::UnsupportedCommand(command))?;
+    let bundle: CommandKeysPayload = serde_json::from_str(command)?;
+    bundle.decrypt(scoped_key)
+}
+
+/// decrypt a command sent from another device.
+pub(crate) fn decrypt_command<T: DeserializeOwned>(
+    v: serde_json::Value,
+    keys: &PrivateCommandKeys,
+) -> Result<T> {
+    let encrypted_payload: EncryptedCommandPayload = serde_json::from_value(v)?;
+    encrypted_payload.decrypt(keys)
+}

--- a/components/fxa-client/src/internal/commands/mod.rs
+++ b/components/fxa-client/src/internal/commands/mod.rs
@@ -3,10 +3,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 pub mod close_tabs;
+mod keys;
 pub mod send_tab;
 
 pub use close_tabs::CloseTabsPayload;
 pub use send_tab::SendTabPayload;
+
+pub(crate) use keys::{
+    decrypt_command, encrypt_command, get_public_keys, PrivateCommandKeys, PublicCommandKeys,
+};
 
 use super::device::Device;
 use crate::{Error, Result};

--- a/components/fxa-client/src/internal/commands/send_tab.rs
+++ b/components/fxa-client/src/internal/commands/send_tab.rs
@@ -2,42 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use super::super::telemetry;
 /// The Send Tab functionality is backed by Firefox Accounts device commands.
 /// A device shows it can handle "Send Tab" commands by advertising the "open-uri"
 /// command in its on own device record.
-/// This command data bundle contains a one-time generated `PublicSendTabKeys`
-/// (while keeping locally `PrivateSendTabKeys` containing the private key),
-/// wrapped by the account oldsync scope `kSync` to form a `SendTabKeysPayload`.
+/// This command data bundle contains a one-time generated `PublicCommandKeys`
+/// (while keeping locally `PrivateCommandKeys` containing the private key),
+/// wrapped by the account oldsync scope `kSync` to form a `CommandKeysPayload`.
 ///
-/// When a device sends a tab to another, it decrypts that `SendTabKeysPayload` using `kSync`,
+/// When a device sends a tab to another, it decrypts that `CommandKeysPayload` using `kSync`,
 /// uses the obtained public key to encrypt the `SendTabPayload` it created that
-/// contains the tab to send and finally forms the `EncryptedSendTabPayload` that is
+/// contains the tab to send and finally forms the encrypted payload that is
 /// then sent to the target device.
 use serde_derive::*;
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use rc_crypto::ece::{self, EcKeyComponents};
-use sync15::{EncryptedPayload, KeyBundle};
-
-use super::super::{device::Device, scopes, telemetry};
-use crate::{Error, Result, ScopedKey};
-
 pub const COMMAND_NAME: &str = "https://identity.mozilla.com/cmd/open-uri";
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct EncryptedSendTabPayload {
-    /// URL Safe Base 64 encrypted send-tab payload.
-    encrypted: String,
-}
-
-impl EncryptedSendTabPayload {
-    pub(crate) fn decrypt(self, keys: &PrivateSendTabKeysV1) -> Result<SendTabPayload> {
-        rc_crypto::ensure_initialized();
-        let encrypted = URL_SAFE_NO_PAD.decode(self.encrypted)?;
-        let decrypted = ece::decrypt(keys.p256key(), keys.auth_secret(), &encrypted)?;
-        Ok(serde_json::from_slice(&decrypted)?)
-    }
-}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SendTabPayload {
@@ -73,15 +52,6 @@ impl SendTabPayload {
             sent_telemetry,
         )
     }
-    fn encrypt(&self, keys: PublicSendTabKeys) -> Result<EncryptedSendTabPayload> {
-        rc_crypto::ensure_initialized();
-        let bytes = serde_json::to_vec(&self)?;
-        let public_key = URL_SAFE_NO_PAD.decode(keys.public_key())?;
-        let auth_secret = URL_SAFE_NO_PAD.decode(keys.auth_secret())?;
-        let encrypted = ece::encrypt(&public_key, &auth_secret, &bytes)?;
-        let encrypted = URL_SAFE_NO_PAD.encode(encrypted);
-        Ok(EncryptedSendTabPayload { encrypted })
-    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -97,155 +67,6 @@ impl From<TabHistoryEntry> for crate::TabHistoryEntry {
             url: e.url,
         }
     }
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) enum VersionnedPrivateSendTabKeys {
-    V1(PrivateSendTabKeysV1),
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-pub(crate) struct PrivateSendTabKeysV1 {
-    p256key: EcKeyComponents,
-    auth_secret: Vec<u8>,
-}
-pub(crate) type PrivateSendTabKeys = PrivateSendTabKeysV1;
-
-impl PrivateSendTabKeys {
-    // We define this method so the type-checker prevents us from
-    // trying to serialize `PrivateSendTabKeys` directly since
-    // `serde_json::to_string` would compile because both types derive
-    // `Serialize`.
-    pub(crate) fn serialize(&self) -> Result<String> {
-        Ok(serde_json::to_string(&VersionnedPrivateSendTabKeys::V1(
-            self.clone(),
-        ))?)
-    }
-
-    pub(crate) fn deserialize(s: &str) -> Result<Self> {
-        let versionned: VersionnedPrivateSendTabKeys = serde_json::from_str(s)?;
-        match versionned {
-            VersionnedPrivateSendTabKeys::V1(prv_key) => Ok(prv_key),
-        }
-    }
-}
-
-impl PrivateSendTabKeys {
-    pub fn from_random() -> Result<Self> {
-        rc_crypto::ensure_initialized();
-        let (key_pair, auth_secret) = ece::generate_keypair_and_auth_secret()?;
-        Ok(Self {
-            p256key: key_pair.raw_components()?,
-            auth_secret: auth_secret.to_vec(),
-        })
-    }
-
-    pub fn p256key(&self) -> &EcKeyComponents {
-        &self.p256key
-    }
-
-    pub fn auth_secret(&self) -> &[u8] {
-        &self.auth_secret
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub(crate) struct SendTabKeysPayload {
-    /// Hex encoded kid.
-    kid: String,
-    /// Base 64 encoded IV.
-    #[serde(rename = "IV")]
-    iv: String,
-    /// Hex encoded hmac.
-    hmac: String,
-    /// Base 64 encoded ciphertext.
-    ciphertext: String,
-}
-
-impl SendTabKeysPayload {
-    pub(crate) fn decrypt(self, scoped_key: &ScopedKey) -> Result<PublicSendTabKeys> {
-        let (ksync, kxcs) = extract_oldsync_key_components(scoped_key)?;
-        if hex::decode(self.kid)? != kxcs {
-            return Err(Error::MismatchedKeys);
-        }
-        let key = KeyBundle::from_ksync_bytes(&ksync)?;
-        let encrypted_payload = EncryptedPayload {
-            iv: self.iv,
-            hmac: self.hmac,
-            ciphertext: self.ciphertext,
-        };
-        Ok(encrypted_payload.decrypt_into(&key)?)
-    }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct PublicSendTabKeys {
-    /// URL Safe Base 64 encoded push public key.
-    #[serde(rename = "publicKey")]
-    public_key: String,
-    /// URL Safe Base 64 encoded auth secret.
-    #[serde(rename = "authSecret")]
-    auth_secret: String,
-}
-
-impl PublicSendTabKeys {
-    fn encrypt(&self, scoped_key: &ScopedKey) -> Result<SendTabKeysPayload> {
-        let (ksync, kxcs) = extract_oldsync_key_components(scoped_key)?;
-        let key = KeyBundle::from_ksync_bytes(&ksync)?;
-        let encrypted_payload = EncryptedPayload::from_cleartext_payload(&key, &self)?;
-        Ok(SendTabKeysPayload {
-            kid: hex::encode(kxcs),
-            iv: encrypted_payload.iv,
-            hmac: encrypted_payload.hmac,
-            ciphertext: encrypted_payload.ciphertext,
-        })
-    }
-    pub fn as_command_data(&self, scoped_key: &ScopedKey) -> Result<String> {
-        let encrypted_public_keys = self.encrypt(scoped_key)?;
-        Ok(serde_json::to_string(&encrypted_public_keys)?)
-    }
-    pub(crate) fn public_key(&self) -> &str {
-        &self.public_key
-    }
-    pub(crate) fn auth_secret(&self) -> &str {
-        &self.auth_secret
-    }
-}
-
-impl From<PrivateSendTabKeys> for PublicSendTabKeys {
-    fn from(internal: PrivateSendTabKeys) -> Self {
-        Self {
-            public_key: URL_SAFE_NO_PAD.encode(internal.p256key.public_key()),
-            auth_secret: URL_SAFE_NO_PAD.encode(&internal.auth_secret),
-        }
-    }
-}
-
-pub fn build_send_command(
-    scoped_key: &ScopedKey,
-    target: &Device,
-    send_tab_payload: &SendTabPayload,
-) -> Result<serde_json::Value> {
-    let command = target
-        .available_commands
-        .get(COMMAND_NAME)
-        .ok_or(Error::UnsupportedCommand(COMMAND_NAME))?;
-    let bundle: SendTabKeysPayload = serde_json::from_str(command)?;
-    let public_keys = bundle.decrypt(scoped_key)?;
-    let encrypted_payload = send_tab_payload.encrypt(public_keys)?;
-    Ok(serde_json::to_value(encrypted_payload)?)
-}
-
-fn extract_oldsync_key_components(oldsync_key: &ScopedKey) -> Result<(Vec<u8>, Vec<u8>)> {
-    if oldsync_key.scope != scopes::OLD_SYNC {
-        return Err(Error::IllegalState(
-            "Only oldsync scoped keys are supported at the moment.",
-        ));
-    }
-    let kxcs: &str = oldsync_key.kid.splitn(2, '-').collect::<Vec<_>>()[1];
-    let kxcs = URL_SAFE_NO_PAD.decode(kxcs)?;
-    let ksync = oldsync_key.key_bytes()?;
-    Ok((ksync, kxcs))
 }
 
 #[cfg(test)]

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -6,11 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 pub use super::http_client::{GetDeviceResponse as Device, PushSubscription};
 use super::{
-    commands::{
-        self,
-        send_tab::{PrivateSendTabKeys, PublicSendTabKeys},
-        IncomingDeviceCommand,
-    },
+    commands::{self, IncomingDeviceCommand, PrivateCommandKeys, PublicCommandKeys},
     http_client::{
         DeviceUpdateRequest, DeviceUpdateRequestBuilder, PendingCommand, UpdateDeviceResponse,
     },
@@ -348,7 +344,7 @@ impl FirefoxAccount {
     /// **💾 This method alters the persisted account state.**
     pub(crate) fn generate_command_data(&mut self, capability: DeviceCapability) -> Result<String> {
         let own_keys = self.load_or_generate_command_keys(capability)?;
-        let public_keys: PublicSendTabKeys = own_keys.into();
+        let public_keys: PublicCommandKeys = own_keys.into();
         let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
         public_keys.as_command_data(oldsync_key)
     }
@@ -356,7 +352,7 @@ impl FirefoxAccount {
     fn load_or_generate_command_keys(
         &mut self,
         capability: DeviceCapability,
-    ) -> Result<PrivateSendTabKeys> {
+    ) -> Result<PrivateCommandKeys> {
         match capability {
             DeviceCapability::SendTab => self.load_or_generate_send_tab_keys(),
             DeviceCapability::CloseTabs => self.load_or_generate_close_tabs_keys(),


### PR DESCRIPTION
I started looking into a `CloseInactiveTabs` command, and even though the actual payload is empty, it will still need an encrypted payload just for the metrics. This would duplicate yet more code, so I looked into refactoring the crypto into a `keys` module. Maybe the new module should be `crypto`?

We could go further, but this seems fine for now. We don't seem to have great tests for this, so I guess I should also make sure it works :)

Marking this as WIP for now - I'll see how it pans out with the new command - but I'd love feedback in the meantime.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
