### PR TITLE
FxaError::Other error should show a description of the other error

### DIFF
--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -53,8 +53,8 @@ pub enum FxaError {
     #[error("panic in native code")]
     Panic,
     /// A catch-all for other unspecified errors.
-    #[error("other error")]
-    Other,
+    #[error("other error: {0}")]
+    Other(String),
 }
 
 /// FxA internal error type
@@ -216,14 +216,15 @@ impl GetErrorHandling for Error {
             Error::UnknownOAuthState => {
                 ErrorHandling::convert(FxaError::NoExistingAuthFlow).log_warning()
             }
-            Error::BackoffError(_) => {
-                ErrorHandling::convert(FxaError::Other).report_error("fxa-client-backoff")
-            }
+            Error::BackoffError(_) => ErrorHandling::convert(FxaError::Other(self.to_string()))
+                .report_error("fxa-client-backoff"),
             Error::InvalidStateTransition(_) | Error::StateMachineLogicError(_) => {
-                ErrorHandling::convert(FxaError::Other).report_error("fxa-state-machine-error")
+                ErrorHandling::convert(FxaError::Other(self.to_string()))
+                    .report_error("fxa-state-machine-error")
             }
             Error::OriginMismatch(_) => ErrorHandling::convert(FxaError::OriginMismatch),
-            _ => ErrorHandling::convert(FxaError::Other).report_error("fxa-client-other-error"),
+            _ => ErrorHandling::convert(FxaError::Other(self.to_string()))
+                .report_error("fxa-client-other-error"),
         }
     }
 }


### PR DESCRIPTION
When testing out commands etc, I'd see an error shown as `Error: other error`. After this patch it will be the far more helpful `Error: other error: Device target is unknown (Device ID: 1234)`

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
