### PR TITLE
Support for a new "close inactive tabs" command.

### DIFF
--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
@@ -525,6 +525,21 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
     }
 
     /**
+     * Close all open and inactive tabs on another device.
+     *
+     * This performs network requests, and should not be used on the main thread.
+     *
+     * @param targetDeviceId The ID of the device on which the tabs are
+     * currently open.
+     */
+    fun closeInactiveTabs(targetDeviceId: String) {
+        withMetrics {
+            this.inner.closeInactiveTabs(targetDeviceId)
+        }
+    }
+
+
+    /**
      * Gather any telemetry which has been collected internally and return
      * the result as a JSON string.
      *

--- a/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
@@ -96,6 +96,8 @@ public class DeviceConstellation {
                     }
                 case let .closeTabs(urls):
                     try self.account.closeTabs(targetDeviceId: targetDeviceId, urls: urls)
+                case .closeInactiveTabs:
+                    try self.account.closeInactiveTabs(targetDeviceId: targetDeviceId)
                 }
             } catch {
                 FxALog.error("Error sending event to another device: \(error).")
@@ -165,4 +167,5 @@ public class DeviceConstellation {
 public enum DeviceEventOutgoing {
     case sendTab(title: String, url: String)
     case closeTabs(urls: [String])
+    case closeInactiveTabs
 }

--- a/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
@@ -195,6 +195,12 @@ class PersistedFirefoxAccount {
         }
     }
 
+    public func closeInactiveTabs(targetDeviceId: String) throws {
+        return try notifyAuthErrors {
+            try self.inner.closeInactiveTabs(targetDeviceId: targetDeviceId)
+        }
+    }
+
     public func getTokenServerEndpointURL() throws -> URL {
         return try URL(string: inner.getTokenServerEndpointUrl())!
     }

--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -243,6 +243,7 @@ pub struct Device {
 pub enum DeviceCapability {
     SendTab,
     CloseTabs,
+    CloseInactiveTabs,
 }
 
 /// A client connected to the user's account.

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -539,6 +539,12 @@ interface FirefoxAccount {
   [Throws=FxaError]
   void close_tabs([ByRef] string target_device_id, sequence<string> urls);
 
+  /// As above - but for closing all "inactive" tabs on the target and
+  /// the capability is [`CloseInactiveTabs`](DeviceCapability::CloseInactiveTabs)
+  ///
+  /// **💾 This method alters the persisted account state.**
+  [Throws=FxaError]
+  void close_inactive_tabs([ByRef] string target_device_id);
 
   // Get the URL at which to access the user's sync data.
   //
@@ -1002,6 +1008,7 @@ enum FxaRustAuthState {
 enum DeviceCapability {
   "SendTab",
   "CloseTabs",
+  "CloseInactiveTabs",
 };
 
 
@@ -1078,6 +1085,9 @@ interface IncomingDeviceCommand {
 
   /// Indicates that the sender wants to close one or more tabs on this device.
   TabsClosed(Device? sender, CloseTabsPayload payload);
+
+  /// Indicates that the sender wants to close all "inactive" tabs on this device.
+  InactiveTabsClosed(Device? sender);
 };
 
 // Machinery for dry-run testing of FxaAuthStateMachine

--- a/components/fxa-client/src/internal/close_inactive_tabs.rs
+++ b/components/fxa-client/src/internal/close_inactive_tabs.rs
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use super::{
+    commands::{
+        close_inactive_tabs::{self, CloseInactiveTabsPayload},
+        decrypt_command, encrypt_command, IncomingDeviceCommand, PrivateCommandKeys,
+    },
+    http_client::GetDeviceResponse,
+    scopes, telemetry, FirefoxAccount,
+};
+use crate::{Error, Result};
+
+impl FirefoxAccount {
+    pub fn close_inactive_tabs(&mut self, target_device_id: &str) -> Result<()> {
+        let devices = self.get_devices(false)?;
+        let target = devices
+            .iter()
+            .find(|d| d.id == target_device_id)
+            .ok_or_else(|| Error::UnknownTargetDevice(target_device_id.to_owned()))?;
+        let (payload, sent_telemetry) = CloseInactiveTabsPayload::new();
+        let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
+        let command_payload = encrypt_command(
+            oldsync_key,
+            target,
+            close_inactive_tabs::COMMAND_NAME,
+            &payload,
+        )?;
+        self.invoke_command(
+            close_inactive_tabs::COMMAND_NAME,
+            target,
+            &command_payload,
+            Some(close_inactive_tabs::COMMAND_TTL),
+        )?;
+        self.telemetry.record_command_sent(sent_telemetry);
+        Ok(())
+    }
+
+    pub(crate) fn handle_close_inactive_tabs_command(
+        &mut self,
+        sender: Option<GetDeviceResponse>,
+        payload: serde_json::Value,
+        reason: telemetry::ReceivedReason,
+    ) -> Result<IncomingDeviceCommand> {
+        let key: PrivateCommandKeys = match self.close_inactive_tabs_key() {
+            Some(s) => PrivateCommandKeys::deserialize(s)?,
+            None => {
+                return Err(Error::IllegalState(
+                    "Cannot find remote device keys. Has initialize_device been called before?",
+                ));
+            }
+        };
+        match decrypt_command(payload, &key) {
+            Ok(payload) => {
+                let recd_telemetry =
+                    telemetry::ReceivedCommand::for_close_inactive_tabs(&payload, reason);
+                self.telemetry.record_command_received(recd_telemetry);
+                Ok(IncomingDeviceCommand::InactiveTabsClosed { sender, payload })
+            }
+            Err(e) => {
+                log::warn!("Could not decrypt payload; resetting the command's keys.");
+                self.clear_close_inactive_tabs_keys();
+                self.reregister_current_capabilities()?;
+                Err(e)
+            }
+        }
+    }
+
+    pub(crate) fn load_or_generate_close_inactive_tabs_keys(
+        &mut self,
+    ) -> Result<PrivateCommandKeys> {
+        if let Some(s) = self.close_inactive_tabs_key() {
+            match PrivateCommandKeys::deserialize(s) {
+                Ok(keys) => return Ok(keys),
+                Err(_) => {
+                    error_support::report_error!(
+                        "fxaclient-close-inactive-tabs-key-deserialize",
+                        "Could not deserialize keys. Re-creating them."
+                    );
+                }
+            }
+        }
+        let keys = PrivateCommandKeys::from_random()?;
+        self.set_close_inactive_tabs_key(keys.serialize()?);
+        Ok(keys)
+    }
+
+    fn close_inactive_tabs_key(&self) -> Option<&str> {
+        self.state
+            .get_commands_data(close_inactive_tabs::COMMAND_NAME)
+    }
+
+    fn set_close_inactive_tabs_key(&mut self, key: String) {
+        self.state
+            .set_commands_data(close_inactive_tabs::COMMAND_NAME, key)
+    }
+
+    fn clear_close_inactive_tabs_keys(&mut self) {
+        self.state
+            .clear_commands_data(close_inactive_tabs::COMMAND_NAME);
+    }
+}

--- a/components/fxa-client/src/internal/commands/close_inactive_tabs.rs
+++ b/components/fxa-client/src/internal/commands/close_inactive_tabs.rs
@@ -1,0 +1,60 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::internal::telemetry;
+use serde_derive::*;
+
+pub const COMMAND_NAME: &str = "https://identity.mozilla.com/cmd/close-inactive-tabs/v1";
+pub const COMMAND_TTL: u64 = super::close_tabs::COMMAND_TTL;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CloseInactiveTabsPayload {
+    #[serde(rename = "flowID", default)]
+    pub flow_id: String,
+    #[serde(rename = "streamID", default)]
+    pub stream_id: String,
+}
+
+impl CloseInactiveTabsPayload {
+    pub fn new() -> (Self, telemetry::SentCommand) {
+        let sent_telemetry: telemetry::SentCommand =
+            telemetry::SentCommand::for_close_inactive_tabs();
+        (
+            CloseInactiveTabsPayload {
+                flow_id: sent_telemetry.flow_id.clone(),
+                stream_id: sent_telemetry.stream_id.clone(),
+            },
+            sent_telemetry,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::Result;
+
+    #[test]
+    fn test_empty_payload() -> Result<()> {
+        let empty = r#"{}"#;
+        let _: CloseInactiveTabsPayload = serde_json::from_str(empty)?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_payload() -> Result<()> {
+        let (payload, telem) = CloseInactiveTabsPayload::new();
+        let json = serde_json::to_string(&payload)?;
+        assert!(!json.is_empty());
+        assert_eq!(telem.flow_id.len(), 12);
+        assert_eq!(telem.stream_id.len(), 12);
+        assert_ne!(telem.flow_id, telem.stream_id);
+
+        let deserialized: CloseInactiveTabsPayload = serde_json::from_str(&json)?;
+        assert_eq!(deserialized, payload);
+
+        Ok(())
+    }
+}

--- a/components/fxa-client/src/internal/commands/mod.rs
+++ b/components/fxa-client/src/internal/commands/mod.rs
@@ -2,10 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+pub mod close_inactive_tabs;
 pub mod close_tabs;
 mod keys;
 pub mod send_tab;
 
+pub use close_inactive_tabs::CloseInactiveTabsPayload;
 pub use close_tabs::CloseTabsPayload;
 pub use send_tab::SendTabPayload;
 
@@ -27,6 +29,10 @@ pub enum IncomingDeviceCommand {
         sender: Option<Device>,
         payload: CloseTabsPayload,
     },
+    InactiveTabsClosed {
+        sender: Option<Device>,
+        payload: CloseInactiveTabsPayload,
+    },
 }
 
 impl TryFrom<IncomingDeviceCommand> for crate::IncomingDeviceCommand {
@@ -43,6 +49,11 @@ impl TryFrom<IncomingDeviceCommand> for crate::IncomingDeviceCommand {
                 crate::IncomingDeviceCommand::TabsClosed {
                     sender: sender.map(crate::Device::try_from).transpose()?,
                     payload: payload.into(),
+                }
+            }
+            IncomingDeviceCommand::InactiveTabsClosed { sender, .. } => {
+                crate::IncomingDeviceCommand::InactiveTabsClosed {
+                    sender: sender.map(crate::Device::try_from).transpose()?,
                 }
             }
         })

--- a/components/fxa-client/src/internal/mod.rs
+++ b/components/fxa-client/src/internal/mod.rs
@@ -21,6 +21,7 @@ use url::Url;
 
 #[cfg(feature = "integration_test")]
 pub mod auth;
+mod close_inactive_tabs;
 mod close_tabs;
 mod commands;
 pub mod config;

--- a/components/fxa-client/src/internal/telemetry.rs
+++ b/components/fxa-client/src/internal/telemetry.rs
@@ -50,6 +50,8 @@ pub enum Command {
     SendTab,
     #[serde(rename = "close_tabs")]
     CloseTabs,
+    #[serde(rename = "close_inactive_tabs")]
+    CloseInactiveTabs,
 }
 
 #[derive(Debug, Serialize)]
@@ -66,6 +68,10 @@ impl SentCommand {
 
     pub fn for_close_tabs() -> Self {
         Self::new(Command::CloseTabs)
+    }
+
+    pub fn for_close_inactive_tabs() -> Self {
+        Self::new(Command::CloseInactiveTabs)
     }
 
     fn new(command: Command) -> Self {
@@ -97,7 +103,19 @@ impl ReceivedCommand {
 
     pub fn for_close_tabs(payload: &commands::CloseTabsPayload, reason: ReceivedReason) -> Self {
         Self {
-            command: Command::SendTab,
+            command: Command::CloseTabs,
+            flow_id: payload.flow_id.clone(),
+            stream_id: payload.stream_id.clone(),
+            reason,
+        }
+    }
+
+    pub fn for_close_inactive_tabs(
+        payload: &commands::CloseInactiveTabsPayload,
+        reason: ReceivedReason,
+    ) -> Self {
+        Self {
+            command: Command::CloseInactiveTabs,
             flow_id: payload.flow_id.clone(),
             stream_id: payload.stream_id.clone(),
             reason,

--- a/components/fxa-client/src/push.rs
+++ b/components/fxa-client/src/push.rs
@@ -111,6 +111,14 @@ impl FirefoxAccount {
     pub fn close_tabs(&self, target_device_id: &str, urls: Vec<String>) -> ApiResult<()> {
         self.internal.lock().close_tabs(target_device_id, &urls)
     }
+
+    /// As above - but for closing all "inactive" tabs on the target and
+    /// the capability is [`CloseInactiveTabs`](DeviceCapability::CloseInactiveTabs)
+    /// **💾 This method alters the persisted account state.**
+    #[handle_error(Error)]
+    pub fn close_inactive_tabs(&self, target_device_id: &str) -> ApiResult<()> {
+        self.internal.lock().close_inactive_tabs(target_device_id)
+    }
 }
 
 /// Details of a web-push subscription endpoint.
@@ -203,6 +211,9 @@ pub enum IncomingDeviceCommand {
     TabsClosed {
         sender: Option<Device>,
         payload: CloseTabsPayload,
+    },
+    InactiveTabsClosed {
+        sender: Option<Device>,
     },
 }
 

--- a/examples/fxa-client/Cargo.toml
+++ b/examples/fxa-client/Cargo.toml
@@ -6,6 +6,10 @@ license = "MPL-2.0"
 edition = "2021"
 publish = false
 
+[[example]]
+name = "fxa-client"
+path = "src/fxa_client.rs"
+
 [dependencies]
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
 log = "0.4"

--- a/examples/fxa-client/src/fxa_client.rs
+++ b/examples/fxa-client/src/fxa_client.rs
@@ -8,8 +8,8 @@ mod send_tab;
 use std::fs;
 
 use clap::{Parser, Subcommand, ValueEnum};
-use cli_support::fxa_creds;
-use fxa_client::{FirefoxAccount, FxaConfig, FxaServer};
+use cli_support::{fxa_creds, init_logging};
+use fxa_client::{DeviceCapability, FirefoxAccount, FxaConfig, FxaServer};
 
 static CREDENTIALS_PATH: &str = "credentials.json";
 static CLIENT_ID: &str = "a2270f727f45f648";
@@ -61,11 +61,12 @@ enum Server {
 #[derive(Subcommand)]
 enum Command {
     Devices(devices::DeviceArgs),
-    SendTab(send_tab::SendTabArgs),
+    Send(send_tab::SendCommandArgs),
     Disconnect,
 }
 
 fn main() -> Result<()> {
+    init_logging();
     let cli = Cli::parse();
     viaduct_reqwest::use_reqwest_backend();
     if cli.log {
@@ -88,7 +89,7 @@ fn main() -> Result<()> {
     let account = load_account(&cli, scopes)?;
     match cli.command {
         Command::Devices(args) => devices::run(&account, args),
-        Command::SendTab(args) => send_tab::run(&account, args),
+        Command::Send(args) => send_tab::run(&account, args),
         Command::Disconnect => {
             account.disconnect();
             Ok(())
@@ -111,7 +112,13 @@ fn load_account(cli: &Cli, scopes: &[&str]) -> Result<FirefoxAccount> {
         client_id: CLIENT_ID.into(),
         token_server_url_override: None,
     };
-    fxa_creds::get_cli_fxa(config, CREDENTIALS_PATH, scopes).map(|cli| cli.account)
+    let acct = fxa_creds::get_cli_fxa(config, CREDENTIALS_PATH, scopes).map(|cli| cli.account)?;
+    acct.ensure_capabilities(vec![
+        DeviceCapability::SendTab,
+        DeviceCapability::CloseTabs,
+        DeviceCapability::CloseInactiveTabs,
+    ])?;
+    Ok(acct)
 }
 
 pub fn persist_fxa_state(acct: &FirefoxAccount) -> Result<()> {

--- a/examples/fxa-client/src/send_tab.rs
+++ b/examples/fxa-client/src/send_tab.rs
@@ -8,7 +8,7 @@ use fxa_client::{FirefoxAccount, IncomingDeviceCommand};
 use crate::{persist_fxa_state, Result};
 
 #[derive(Args)]
-pub struct SendTabArgs {
+pub struct SendCommandArgs {
     #[command(subcommand)]
     command: Command,
 }
@@ -18,7 +18,7 @@ enum Command {
     /// Perform a single poll for tabs sent to this device
     Poll,
     /// Send a tab to another device
-    Send {
+    SendTab {
         /// Device ID (use the `devices` command to list)
         device_id: String,
         title: String,
@@ -29,22 +29,25 @@ enum Command {
         device_id: String,
         urls: Vec<String>,
     },
+    /// Close all inactive taba on another device
+    CloseInactive { device_id: String },
 }
 
-pub fn run(account: &FirefoxAccount, args: SendTabArgs) -> Result<()> {
+pub fn run(account: &FirefoxAccount, args: SendCommandArgs) -> Result<()> {
     match args.command {
         Command::Poll => poll(account),
-        Command::Send {
+        Command::SendTab {
             device_id,
             title,
             url,
         } => send(account, device_id, title, url),
         Command::Close { device_id, urls } => close(account, device_id, urls),
+        Command::CloseInactive { device_id } => close_inactive(account, device_id),
     }
 }
 
 fn poll(account: &FirefoxAccount) -> Result<()> {
-    println!("Polling for send-tab events.  Ctrl-C to cancel");
+    println!("Polling for command events.  Ctrl-C to cancel");
     loop {
         let events = account.poll_device_commands().unwrap_or_default(); // Ignore 404 errors for now.
         persist_fxa_state(account)?;
@@ -60,7 +63,12 @@ fn poll(account: &FirefoxAccount) -> Result<()> {
                             None => println!("Tab received: {}", tab.url),
                         };
                     }
-                    IncomingDeviceCommand::TabsClosed { .. } => continue,
+                    IncomingDeviceCommand::TabsClosed { .. } => {
+                        println!("TabsClosed command received")
+                    }
+                    IncomingDeviceCommand::InactiveTabsClosed { .. } => {
+                        println!("InactiveTabsClosed command received")
+                    }
                 }
             }
         }
@@ -76,5 +84,11 @@ fn send(account: &FirefoxAccount, device_id: String, title: String, url: String)
 fn close(account: &FirefoxAccount, device_id: String, urls: Vec<String>) -> Result<()> {
     account.close_tabs(&device_id, urls)?;
     println!("Tabs closed!");
+    Ok(())
+}
+
+fn close_inactive(account: &FirefoxAccount, device_id: String) -> Result<()> {
+    account.close_inactive_tabs(&device_id)?;
+    println!("Inactive Tabs closed!");
     Ok(())
 }


### PR DESCRIPTION
The core foundation for `CloseInactiveTabs` - still to come:
* Teaching the tabs engine about the command
* Having Fenix support the command.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
