### PR TITLE
nimbus-fml: Make the output deterministic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ### Suggest
 - Added support for Fakespot suggestions.
 
+## 🦊 What's Changed 🦊
+
+### Nimbus FML
+- The output order should be deterministic again ([#6283](https://github.com/mozilla/application-services/pull/6283))
+
 [Full Changelog](In progress)
 
 # v129.0 (_2024-07-08_)

--- a/components/support/nimbus-fml/src/client/mod.rs
+++ b/components/support/nimbus-fml/src/client/mod.rs
@@ -205,7 +205,7 @@ mod unit_tests {
         intermediate_representation::{FeatureDef, ModuleId, PropDef, TypeRef},
     };
     use serde_json::{json, Value};
-    use std::collections::HashMap;
+    use std::collections::{BTreeMap, HashMap};
 
     fn create_manifest() -> FeatureManifest {
         let fm_i = get_feature_manifest(
@@ -221,7 +221,7 @@ mod unit_tests {
                 metadata: Default::default(),
                 ..Default::default()
             }],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         get_feature_manifest(
@@ -238,7 +238,7 @@ mod unit_tests {
                 allow_coenrollment: true,
                 ..Default::default()
             }],
-            HashMap::from([(ModuleId::Local("test".into()), fm_i)]),
+            BTreeMap::from([(ModuleId::Local("test".into()), fm_i)]),
         )
     }
 

--- a/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/fixtures/intermediate_representation.rs
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use crate::intermediate_representation::{
     EnumDef, FeatureDef, FeatureManifest, ModuleId, ObjectDef, PropDef, TypeRef, VariantDef,
@@ -56,7 +56,7 @@ pub(crate) fn get_feature_manifest(
     obj_defs: Vec<ObjectDef>,
     enum_defs: Vec<EnumDef>,
     feature_defs: Vec<FeatureDef>,
-    all_imports: HashMap<ModuleId, FeatureManifest>,
+    all_imports: BTreeMap<ModuleId, FeatureManifest>,
 ) -> FeatureManifest {
     FeatureManifest {
         enum_defs: map_from(enum_defs, |e| e.name()),
@@ -90,7 +90,7 @@ pub(crate) fn get_one_prop_feature_manifest_with_imports(
     obj_defs: Vec<ObjectDef>,
     enum_defs: Vec<EnumDef>,
     prop: &PropDef,
-    all_imports: HashMap<ModuleId, FeatureManifest>,
+    all_imports: BTreeMap<ModuleId, FeatureManifest>,
 ) -> FeatureManifest {
     let mut fm = FeatureManifest {
         enum_defs: map_from(enum_defs, |e| e.name()),

--- a/components/support/nimbus-fml/src/intermediate_representation.rs
+++ b/components/support/nimbus-fml/src/intermediate_representation.rs
@@ -237,10 +237,10 @@ pub struct FeatureManifest {
     pub(crate) about: AboutBlock,
 
     #[serde(default)]
-    pub(crate) imported_features: HashMap<ModuleId, BTreeSet<String>>,
+    pub(crate) imported_features: BTreeMap<ModuleId, BTreeSet<String>>,
 
     #[serde(default)]
-    pub(crate) all_imports: HashMap<ModuleId, FeatureManifest>,
+    pub(crate) all_imports: BTreeMap<ModuleId, FeatureManifest>,
 }
 
 impl TypeFinder for FeatureManifest {
@@ -824,7 +824,7 @@ mod imports_tests {
             obj_defs,
             vec![],
             &prop,
-            HashMap::from([(ModuleId::Local("test".into()), fm_i)]),
+            BTreeMap::from([(ModuleId::Local("test".into()), fm_i)]),
         );
 
         let names: Vec<String> = fm.iter_all_object_defs().map(|(_, o)| o.name()).collect();
@@ -845,7 +845,7 @@ mod imports_tests {
             vec![],
             vec![],
             &prop,
-            HashMap::from([(ModuleId::Local("test".into()), fm_i)]),
+            BTreeMap::from([(ModuleId::Local("test".into()), fm_i)]),
         );
 
         let names: Vec<String> = fm
@@ -868,7 +868,7 @@ mod imports_tests {
                 name: "feature_i".into(),
                 ..Default::default()
             }],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         let fm = get_feature_manifest(
@@ -878,7 +878,7 @@ mod imports_tests {
                 name: "feature".into(),
                 ..Default::default()
             }],
-            HashMap::from([(ModuleId::Local("test".into()), fm_i)]),
+            BTreeMap::from([(ModuleId::Local("test".into()), fm_i)]),
         );
 
         let feature = fm.find_feature("feature_i");
@@ -905,7 +905,7 @@ mod imports_tests {
                     ..Default::default()
                 },
             ],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         let fm = get_feature_manifest(
@@ -923,7 +923,7 @@ mod imports_tests {
                     ..Default::default()
                 },
             ],
-            HashMap::from([(ModuleId::Local("test".into()), fm_i)]),
+            BTreeMap::from([(ModuleId::Local("test".into()), fm_i)]),
         );
 
         let coenrolling_features = fm.get_coenrolling_feature_ids();
@@ -948,7 +948,7 @@ mod imports_tests {
                 allow_coenrollment: false,
                 ..Default::default()
             }],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         let fm = get_feature_manifest(
@@ -966,7 +966,7 @@ mod imports_tests {
                     ..Default::default()
                 },
             ],
-            HashMap::from([(ModuleId::Local("test".into()), fm_i)]),
+            BTreeMap::from([(ModuleId::Local("test".into()), fm_i)]),
         );
 
         let coenrolling_features = fm.get_coenrolling_feature_ids();
@@ -991,7 +991,7 @@ mod imports_tests {
                 )],
                 ..Default::default()
             }],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         let fm = get_feature_manifest(
@@ -1006,7 +1006,7 @@ mod imports_tests {
                 )],
                 ..Default::default()
             }],
-            HashMap::from([(ModuleId::Local("test".into()), fm_i)]),
+            BTreeMap::from([(ModuleId::Local("test".into()), fm_i)]),
         );
 
         let json = fm.default_json();
@@ -1044,7 +1044,7 @@ mod feature_config_tests {
                 )],
                 ..Default::default()
             }],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         let result = fm.validate_feature_config("feature", json!({ "prop_1": "new value" }))?;
@@ -1067,7 +1067,7 @@ mod feature_config_tests {
                 )],
                 ..Default::default()
             }],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         let result = fm.validate_feature_config("feature-1", json!({ "prop_1": "new value" }));
@@ -1094,7 +1094,7 @@ mod feature_config_tests {
                 )],
                 ..Default::default()
             }],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         let result = fm.validate_feature_config("feature", json!({"prop": "new value"}));
@@ -1121,7 +1121,7 @@ mod feature_config_tests {
                 )],
                 ..Default::default()
             }],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         let result = fm.validate_feature_config(
@@ -1160,7 +1160,7 @@ mod feature_config_tests {
                 )],
                 ..Default::default()
             }],
-            HashMap::new(),
+            BTreeMap::new(),
         );
 
         let result = fm.validate_feature_config(

--- a/components/support/nimbus-fml/src/parser.rs
+++ b/components/support/nimbus-fml/src/parser.rs
@@ -223,7 +223,7 @@ impl Parser {
         &self,
         current: &FilePath,
         channel: Option<&str>,
-        imports: &mut HashMap<ModuleId, FeatureManifest>,
+        imports: &mut BTreeMap<ModuleId, FeatureManifest>,
         // includes: &mut HashSet<ModuleId>,
     ) -> Result<ModuleId> {
         let id = current.try_into()?;
@@ -253,7 +253,7 @@ impl Parser {
         // This loop does the work of merging the default blocks back into the imported manifests.
         // We'll then attach all the manifests to the root (i.e. the one we're generating code for today), in `imports`.
         // We associate only the feature ids with the manifest we're loading in this method.
-        let mut imported_feature_id_map = HashMap::new();
+        let mut imported_feature_id_map = BTreeMap::new();
 
         for block in &frontend.imports {
             // 1. Load the imported manifests in to the hash map.
@@ -328,7 +328,7 @@ impl Parser {
         &self,
         channel: Option<&str>,
     ) -> Result<FeatureManifest, FMLError> {
-        let mut manifests = HashMap::new();
+        let mut manifests = BTreeMap::new();
         let id = self.load_imports(&self.source, channel, &mut manifests)?;
         let mut fm = manifests
             .remove(&id)


### PR DESCRIPTION
Changed some HashMaps with BTreeMaps to ensure the order of the output is deterministic.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
  - It doesn't add new features, it changes a data type used here and there
  - Maybe it could be worth to include a test to check the output always follows a certain order, in case could you help me for that? :slightly_smiling_face: 
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
