### PR TITLE
Desktop 128.1 release

### DIFF
--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -1027,6 +1027,18 @@ impl<'a> SuggestDao<'a> {
     /// the database.
     pub fn drop_suggestions(&mut self, record_id: &SuggestRecordId) -> Result<()> {
         self.conn.execute_cached(
+            "DELETE FROM keywords WHERE suggestion_id IN (SELECT id from suggestions WHERE record_id = :record_id)",
+            named_params! { ":record_id": record_id.as_str() },
+        )?;
+        self.conn.execute_cached(
+            "DELETE FROM full_keywords WHERE suggestion_id IN (SELECT id from suggestions WHERE record_id = :record_id)",
+            named_params! { ":record_id": record_id.as_str() },
+        )?;
+        self.conn.execute_cached(
+            "DELETE FROM prefix_keywords WHERE suggestion_id IN (SELECT id from suggestions WHERE record_id = :record_id)",
+            named_params! { ":record_id": record_id.as_str() },
+        )?;
+        self.conn.execute_cached(
             "DELETE FROM suggestions WHERE record_id = :record_id",
             named_params! { ":record_id": record_id.as_str() },
         )?;

--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -15,7 +15,7 @@ use sql_support::open_database::{self, ConnectionInitializer};
 ///     [`SuggestConnectionInitializer::upgrade_from`].
 ///    a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
 ///       the migration.
-pub const VERSION: u32 = 19;
+pub const VERSION: u32 = 20;
 
 /// The current Suggest database schema.
 pub const SQL: &str = "
@@ -26,17 +26,16 @@ CREATE TABLE meta(
 
 CREATE TABLE keywords(
     keyword TEXT NOT NULL,
-    suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
-    full_keyword_id INTEGER NULL REFERENCES full_keywords(id) ON DELETE SET NULL,
+    suggestion_id INTEGER NOT NULL,
+    full_keyword_id INTEGER NULL,
     rank INTEGER NOT NULL,
     PRIMARY KEY (keyword, suggestion_id)
 ) WITHOUT ROWID;
 
 -- full keywords are what we display to the user when a (partial) keyword matches
--- The FK to suggestion_id makes it so full keywords get deleted when the parent suggestion is deleted.
 CREATE TABLE full_keywords(
     id INTEGER PRIMARY KEY,
-    suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+    suggestion_id INTEGER NOT NULL,
     full_keyword TEXT NOT NULL
 );
 
@@ -45,7 +44,7 @@ CREATE TABLE prefix_keywords(
     keyword_suffix TEXT NOT NULL DEFAULT '',
     confidence INTEGER NOT NULL DEFAULT 0,
     rank INTEGER NOT NULL,
-    suggestion_id INTEGER NOT NULL REFERENCES suggestions(id) ON DELETE CASCADE,
+    suggestion_id INTEGER NOT NULL,
     PRIMARY KEY (keyword_prefix, keyword_suffix, suggestion_id)
 ) WITHOUT ROWID;
 
@@ -193,6 +192,41 @@ CREATE TABLE IF NOT EXISTS dismissed_suggestions (
                 )?;
                 Ok(())
             }
+            19 => {
+                // Clear the database since we're going to be dropping the keywords table and
+                // re-creating it
+                clear_database(tx)?;
+                tx.execute_batch(
+                    "
+-- Recreate the various keywords table to drop the foreign keys.
+DROP TABLE keywords;
+DROP TABLE full_keywords;
+DROP TABLE prefix_keywords;
+CREATE TABLE keywords(
+    keyword TEXT NOT NULL,
+    suggestion_id INTEGER NOT NULL,
+    full_keyword_id INTEGER NULL,
+    rank INTEGER NOT NULL,
+    PRIMARY KEY (keyword, suggestion_id)
+) WITHOUT ROWID;
+CREATE TABLE full_keywords(
+    id INTEGER PRIMARY KEY,
+    suggestion_id INTEGER NOT NULL,
+    full_keyword TEXT NOT NULL
+);
+CREATE TABLE prefix_keywords(
+    keyword_prefix TEXT NOT NULL,
+    keyword_suffix TEXT NOT NULL DEFAULT '',
+    confidence INTEGER NOT NULL DEFAULT 0,
+    rank INTEGER NOT NULL,
+    suggestion_id INTEGER NOT NULL,
+    PRIMARY KEY (keyword_prefix, keyword_suffix, suggestion_id)
+) WITHOUT ROWID;
+CREATE UNIQUE INDEX keywords_suggestion_id_rank ON keywords(suggestion_id, rank);
+                    ",
+                )?;
+                Ok(())
+            }
             _ => Err(open_database::Error::IncompatibleVersion(version)),
         }
     }
@@ -203,6 +237,9 @@ pub fn clear_database(db: &Connection) -> rusqlite::Result<()> {
     db.execute_batch(
         "
         DELETE FROM meta;
+        DELETE FROM keywords;
+        DELETE FROM full_keywords;
+        DELETE FROM prefix_keywords;
         DELETE FROM suggestions;
         DELETE FROM icons;
         DELETE FROM yelp_subjects;


### PR DESCRIPTION
I want to uplift the Suggest performance fix to Desktop, but it's complicated by the lack of a nightly process.

The 128 desktop beta is using app-services https://github.com/mozilla/application-services/commit/3ca067683c7546e34bc8cdbe820fbe8e4089939a.  This is about a dozen [commits](https://github.com/mozilla/application-services/commits/release-v128/?since=2024-05-30&until=2024-06-07) before our 128 release.  This means that if we just vendor in 128.1 to Desktop, we're going to be taking a bunch of commits that haven't been tested at all there, which seems pretty scary for an uplift.

Instead of that, I'm thinking we can make a branch that starts on https://github.com/mozilla/application-services/commit/3ca067683c7546e34bc8cdbe820fbe8e4089939a and has https://github.com/mozilla/application-services/commit/b57868178993306c3fb8eacc5447facab572a4f6 (the performance fix) cherry-picked in.  We can then vendor that commit on Desktop.  I called this branch `release-v128-desktop`, this PR contains the cherry-pick commit.

So my questions with this PR are:
  - Does this plan seem good?
  - Does the cherry-pick seem correct?