### PR TITLE
Bug 1905769 - Suggest API for loading sqlite3 extensions

### DIFF
--- a/components/suggest/Cargo.toml
+++ b/components/suggest/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 once_cell = "1.5"
 parking_lot = ">=0.11,<=0.12"
 remote_settings = { path = "../remote_settings" }
-rusqlite = { workspace = true, features = ["functions", "bundled"] }
+rusqlite = { workspace = true, features = ["functions", "bundled", "load_extension"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 error-support = { path = "../support/error" }

--- a/components/suggest/src/benchmarks/ingest.rs
+++ b/components/suggest/src/benchmarks/ingest.rs
@@ -27,6 +27,7 @@ impl IngestBenchmark {
         let temp_dir = tempfile::tempdir().unwrap();
         let store = SuggestStoreInner::new(
             temp_dir.path().join("warmup.sqlite"),
+            vec![],
             RemoteSettingsWarmUpClient::new(),
         );
         store.benchmark_ingest_records_by_type(record_type);
@@ -52,7 +53,7 @@ impl BenchmarkWithInput for IngestBenchmark {
             "db{}.sqlite",
             DB_FILE_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
-        let store = SuggestStoreInner::new(data_path, self.client.clone());
+        let store = SuggestStoreInner::new(data_path, vec![], self.client.clone());
         store.ensure_db_initialized();
         if self.reingest {
             store.force_reingest(self.record_type);
@@ -148,6 +149,7 @@ pub fn print_debug_ingestion_sizes() {
     viaduct_reqwest::use_reqwest_backend();
     let store = SuggestStoreInner::new(
         "file:debug_ingestion_sizes?mode=memory&cache=shared",
+        vec![],
         RemoteSettingsWarmUpClient::new(),
     );
     store

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -69,6 +69,12 @@ impl From<ConnectionType> for OpenFlags {
     }
 }
 
+#[derive(Default, Clone)]
+pub struct Sqlite3Extension {
+    pub library: String,
+    pub entry_point: Option<String>,
+}
+
 /// A thread-safe wrapper around an SQLite connection to the Suggest database,
 /// and its interrupt handle.
 pub(crate) struct SuggestDb {
@@ -85,8 +91,16 @@ pub(crate) struct SuggestDb {
 impl SuggestDb {
     /// Opens a read-only or read-write connection to a Suggest database at the
     /// given path.
-    pub fn open(path: impl AsRef<Path>, type_: ConnectionType) -> Result<Self> {
-        let conn = open_database_with_flags(path, type_.into(), &SuggestConnectionInitializer)?;
+    pub fn open(
+        path: impl AsRef<Path>,
+        extensions_to_load: &[Sqlite3Extension],
+        type_: ConnectionType,
+    ) -> Result<Self> {
+        let conn = open_database_with_flags(
+            path,
+            type_.into(),
+            &SuggestConnectionInitializer::new(extensions_to_load),
+        )?;
         Ok(Self::with_connection(conn))
     }
 

--- a/components/suggest/src/suggest-fakespot.udl
+++ b/components/suggest/src/suggest-fakespot.udl
@@ -191,6 +191,13 @@ interface SuggestStoreBuilder {
     [Self=ByArc]
     SuggestStoreBuilder remote_settings_bucket_name(string bucket_name);
 
+    // Add an sqlite3 extension to load
+    //
+    // library_name should be the name of the library without any extension, for example `libmozsqlite3`.
+    // entrypoint should be the entry point, for example `sqlite3_fts5_init`
+    [Self=ByArc]
+    SuggestStoreBuilder load_extension(string library_name, string? entrypoint);
+
     [Throws=SuggestApiError]
     SuggestStore build();
 };

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -181,6 +181,14 @@ interface SuggestStoreBuilder {
     [Self=ByArc]
     SuggestStoreBuilder remote_settings_bucket_name(string bucket_name);
 
+    // Add an sqlite3 extension to load
+    //
+    // library_name should be the name of the library without any extension, for example `libmozsqlite3`.
+    // entrypoint should be the entry point, for example `sqlite3_fts5_init`.  If `null` the default
+    // entry point will be used (see https://sqlite.org/loadext.html for details).
+    [Self=ByArc]
+    SuggestStoreBuilder load_extension(string library_name, string? entrypoint);
+
     [Throws=SuggestApiError]
     SuggestStore build();
 };


### PR DESCRIPTION
Added a method on `SuggestStoreBuilder` to load an SQLite3 extension. This will be needed to enable FTS5 on Desktop.  It shouldn't be needed on Android/iOS, since FTS5 is normally loaded by default.

I tested this with a simple .so file that I downloaded myself.  However, I couldn't figure out a good way to check in this code.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
