### PR TITLE
support: Extract `payload_support::shrink_to_fit`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3033,6 +3033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
+name = "payload-support"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4170,6 +4179,7 @@ dependencies = [
  "interrupt-support",
  "lazy_static",
  "log",
+ "payload-support",
  "rc_crypto",
  "serde",
  "serde_derive",
@@ -4231,6 +4241,7 @@ dependencies = [
  "interrupt-support",
  "lazy_static",
  "log",
+ "payload-support",
  "rusqlite",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "components/support/jwcrypto",
     "components/support/nimbus-cli",
     "components/support/nimbus-fml",
+    "components/support/payload",
     "components/support/rand_rccrypto",
     "components/support/rate-limiter",
     "components/support/restmail-client",

--- a/components/support/payload/Cargo.toml
+++ b/components/support/payload/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "payload-support"
+version = "0.1.0"
+authors = ["Sync Team <sync-team@mozilla.com>"]
+edition = "2021"
+license = "MPL-2.0"
+
+[dependencies]
+serde = "1"
+serde_derive = "1"
+serde_json = "1"

--- a/components/support/payload/src/lib.rs
+++ b/components/support/payload/src/lib.rs
@@ -1,0 +1,173 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use serde::Serialize;
+use std::{
+    io::{self, Write},
+    num::NonZeroUsize,
+};
+
+/// A quantity of items that can fit into a payload, accounting for
+/// serialization, encryption, and Base64-encoding overhead.
+pub enum Fit {
+    /// All items can fit into the payload.
+    All,
+
+    /// Some, but not all, items can fit into the payload without
+    /// exceeding the maximum payload size.
+    Some(NonZeroUsize),
+
+    /// The maximum payload size is too small to hold any items.
+    None,
+
+    /// The serialized size of the items couldn't be determined because of
+    /// a serialization error.
+    Err(serde_json::Error),
+}
+
+impl Fit {
+    /// If `self` is [`Fit::Some`], returns the number of items that can fit
+    /// into the payload without exceeding its maximum size. Otherwise,
+    /// returns `None`.
+    #[inline]
+    pub fn as_some(&self) -> Option<NonZeroUsize> {
+        match self {
+            Fit::Some(count) => Some(*count),
+            _ => None,
+        }
+    }
+}
+
+/// A writer that counts the number of bytes it's asked to write, and discards
+/// the data. Used to compute the serialized size of an item.
+#[derive(Clone, Copy, Default)]
+struct ByteCountWriter(usize);
+
+impl ByteCountWriter {
+    #[inline]
+    pub fn count(self) -> usize {
+        self.0
+    }
+}
+
+impl Write for ByteCountWriter {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0 += buf.len();
+        Ok(buf.len())
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Returns the size of the given value, in bytes, when serialized to JSON.
+pub fn compute_serialized_size<T: Serialize + ?Sized>(value: &T) -> serde_json::Result<usize> {
+    let mut w = ByteCountWriter::default();
+    serde_json::to_writer(&mut w, value)?;
+    Ok(w.count())
+}
+
+/// Calculates the maximum number of items that can fit within
+/// `max_payload_size` when serialized to JSON.
+pub fn try_fit_items<T: Serialize>(items: &[T], max_payload_size: usize) -> Fit {
+    let size = match compute_serialized_size(&items) {
+        Ok(size) => size,
+        Err(e) => return Fit::Err(e),
+    };
+    // See bug 535326 comment 8 for an explanation of the estimation
+    let max_serialized_size = match ((max_payload_size / 4) * 3).checked_sub(1500) {
+        Some(max_serialized_size) => max_serialized_size,
+        None => return Fit::None,
+    };
+    if size > max_serialized_size {
+        // Estimate a little more than the direct fraction to maximize packing
+        let mut cutoff = (items.len() * max_serialized_size - 1) / size + 1;
+        // Keep dropping off the last entry until the data fits.
+        while cutoff > 0 {
+            let size = match compute_serialized_size(&items[..cutoff]) {
+                Ok(size) => size,
+                Err(e) => return Fit::Err(e),
+            };
+            if size <= max_serialized_size {
+                break;
+            }
+            cutoff -= 1;
+        }
+        match NonZeroUsize::new(cutoff) {
+            Some(count) => Fit::Some(count),
+            None => Fit::None,
+        }
+    } else {
+        Fit::All
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_derive::Serialize;
+
+    #[derive(Serialize)]
+    struct CommandRecord {
+        #[serde(rename = "command")]
+        name: &'static str,
+        #[serde(default)]
+        args: &'static [Option<&'static str>],
+        #[serde(default, rename = "flowID", skip_serializing_if = "Option::is_none")]
+        flow_id: Option<&'static str>,
+    }
+
+    const COMMANDS: &[CommandRecord] = &[
+        CommandRecord {
+            name: "wipeEngine",
+            args: &[Some("bookmarks")],
+            flow_id: Some("flow"),
+        },
+        CommandRecord {
+            name: "resetEngine",
+            args: &[Some("history")],
+            flow_id: Some("flow"),
+        },
+        CommandRecord {
+            name: "logout",
+            args: &[],
+            flow_id: None,
+        },
+    ];
+
+    #[test]
+    fn test_compute_serialized_size() {
+        assert_eq!(compute_serialized_size(&1).unwrap(), 1);
+        assert_eq!(compute_serialized_size(&"hi").unwrap(), 4);
+        assert_eq!(
+            compute_serialized_size(&["hi", "hello", "bye"]).unwrap(),
+            20
+        );
+
+        let sizes = COMMANDS
+            .iter()
+            .map(|c| compute_serialized_size(c).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(sizes, &[61, 60, 30]);
+    }
+
+    #[test]
+    fn test_try_fit_items() {
+        // 4096 bytes is enough to fit all three commands.
+        assert!(matches!(try_fit_items(COMMANDS, 4096), Fit::All));
+
+        // `logout` won't fit within 2168 bytes.
+        assert_eq!(try_fit_items(COMMANDS, 2168).as_some().unwrap().get(), 2);
+
+        // `resetEngine` won't fit within 2084 bytes.
+        assert_eq!(try_fit_items(COMMANDS, 2084).as_some().unwrap().get(), 1);
+
+        // `wipeEngine` won't fit at all.
+        assert!(matches!(try_fit_items(COMMANDS, 1024), Fit::None));
+    }
+}

--- a/components/sync15/Cargo.toml
+++ b/components/sync15/Cargo.toml
@@ -51,6 +51,7 @@ base64 = { version = "0.21", optional = true }
 error-support = { path = "../support/error" }
 ffi-support = "0.4"
 interrupt-support = { path = "../support/interrupt" }
+payload-support = { path = "../support/payload" }
 lazy_static = "1.4"
 log = "0.4"
 rc_crypto = { path = "../support/rc_crypto", features = ["hawk"], optional = true }

--- a/components/sync15/src/clients_engine/ser.rs
+++ b/components/sync15/src/clients_engine/ser.rs
@@ -3,82 +3,25 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::error::Result;
+use payload_support::Fit;
 use serde::Serialize;
-use std::io::{self, Write};
-
-/// A writer that counts the number of bytes it's asked to write, and discards
-/// the data. Used to calculate the serialized size of the commands list.
-#[derive(Clone, Copy, Default)]
-pub struct WriteCount(usize);
-
-impl WriteCount {
-    #[inline]
-    pub fn len(self) -> usize {
-        self.0
-    }
-}
-
-impl Write for WriteCount {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.0 += buf.len();
-        Ok(buf.len())
-    }
-
-    #[inline]
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-/// Returns the size of the given value, in bytes, when serialized to JSON.
-fn compute_serialized_size<T: Serialize>(value: &T) -> Result<usize> {
-    let mut w = WriteCount::default();
-    serde_json::to_writer(&mut w, value)?;
-    Ok(w.len())
-}
 
 /// Truncates `list` to fit within `payload_size_max_bytes` when serialized to
 /// JSON.
 pub fn shrink_to_fit<T: Serialize>(list: &mut Vec<T>, payload_size_max_bytes: usize) -> Result<()> {
-    let size = compute_serialized_size(&list)?;
-    // See bug 535326 comment 8 for an explanation of the estimation
-    match ((payload_size_max_bytes / 4) * 3).checked_sub(1500) {
-        Some(max_serialized_size) => {
-            if size > max_serialized_size {
-                // Estimate a little more than the direct fraction to maximize packing
-                let cutoff = (list.len() * max_serialized_size - 1) / size + 1;
-                list.truncate(cutoff + 1);
-                // Keep dropping off the last entry until the data fits.
-                while compute_serialized_size(&list)? > max_serialized_size {
-                    if list.pop().is_none() {
-                        break;
-                    }
-                }
-            }
-            Ok(())
-        }
-        None => {
-            list.clear();
-            Ok(())
-        }
-    }
+    match payload_support::try_fit_items(list, payload_size_max_bytes) {
+        Fit::All => {}
+        Fit::Some(count) => list.truncate(count.get()),
+        Fit::None => list.clear(),
+        Fit::Err(e) => Err(e)?,
+    };
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::super::record::CommandRecord;
     use super::*;
-
-    #[test]
-    fn test_compute_serialized_size() {
-        assert_eq!(compute_serialized_size(&1).unwrap(), 1);
-        assert_eq!(compute_serialized_size(&"hi").unwrap(), 4);
-        assert_eq!(
-            compute_serialized_size(&["hi", "hello", "bye"]).unwrap(),
-            20
-        );
-    }
 
     #[test]
     fn test_shrink_to_fit() {
@@ -103,12 +46,6 @@ mod tests {
         // 4096 bytes is enough to fit all three commands.
         shrink_to_fit(&mut commands, 4096).unwrap();
         assert_eq!(commands.len(), 3);
-
-        let sizes = commands
-            .iter()
-            .map(|c| compute_serialized_size(c).unwrap())
-            .collect::<Vec<_>>();
-        assert_eq!(sizes, &[61, 60, 30]);
 
         // `logout` won't fit within 2168 bytes.
         shrink_to_fit(&mut commands, 2168).unwrap();

--- a/components/tabs/Cargo.toml
+++ b/components/tabs/Cargo.toml
@@ -10,6 +10,7 @@ exclude = ["/android", "/ios"]
 anyhow = "1.0"
 error-support = { path = "../support/error" }
 interrupt-support = { path = "../support/interrupt" }
+payload-support = { path = "../support/payload" }
 lazy_static = "1.4"
 log = "0.4"
 rusqlite = { workspace = true, features = ["bundled", "unlock_notify"] }

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -169,7 +169,6 @@ impl TabsStorage {
                 .collect();
             // Sort the tabs so when we trim tabs it's the oldest tabs
             sanitized_tabs.sort_by(|a, b| b.last_used.cmp(&a.last_used));
-            // If trimming the tab length failed for some reason, just return the untrimmed tabs
             trim_tabs_length(&mut sanitized_tabs, MAX_PAYLOAD_SIZE);
             return Some(sanitized_tabs);
         }
@@ -671,26 +670,12 @@ impl ToSql for CommandKind {
     }
 }
 
-// Trim the amount of tabs in a list to fit the specified memory size
+/// Trim the amount of tabs in a list to fit the specified memory size.
+/// If trimming the tab length fails for some reason, just return the untrimmed tabs.
 fn trim_tabs_length(tabs: &mut Vec<RemoteTab>, payload_size_max_bytes: usize) {
-    // Ported from https://searchfox.org/mozilla-central/rev/84fb1c4511312a0b9187f647d90059e3a6dd27f8/services/sync/modules/util.sys.mjs#422
-    // See bug 535326 comment 8 for an explanation of the estimation
-    let max_serialized_size = (payload_size_max_bytes / 4) * 3 - 1500;
-    let size = compute_serialized_size(tabs);
-    if size > max_serialized_size {
-        // Estimate a little more than the direct fraction to maximize packing
-        let cutoff = (tabs.len() * max_serialized_size) / size;
-        tabs.truncate(cutoff);
-
-        // Keep dropping off the last entry until the data fits.
-        while compute_serialized_size(tabs) > max_serialized_size {
-            tabs.pop();
-        }
+    if let Some(count) = payload_support::try_fit_items(tabs, payload_size_max_bytes).as_some() {
+        tabs.truncate(count.get());
     }
-}
-
-fn compute_serialized_size(v: &Vec<RemoteTab>) -> usize {
-    serde_json::to_string(v).unwrap_or_default().len()
 }
 
 // Similar to places/utils.js
@@ -728,6 +713,7 @@ fn is_url_syncable(url: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use payload_support::compute_serialized_size;
     use std::time::Duration;
 
     use super::*;
@@ -942,14 +928,14 @@ mod tests {
                 ..Default::default()
             });
         }
-        let tabs_mem_size = compute_serialized_size(&too_many_tabs);
+        let tabs_mem_size = compute_serialized_size(&too_many_tabs).unwrap();
         // ensure we are definitely over the payload limit
         assert!(tabs_mem_size > MAX_PAYLOAD_SIZE);
         // Add our over-the-limit tabs to the local state
         storage.update_local_state(too_many_tabs.clone());
         // prepare_local_tabs_for_upload did the trimming we needed to get under payload size
         let tabs_to_upload = &storage.prepare_local_tabs_for_upload().unwrap();
-        assert!(compute_serialized_size(tabs_to_upload) <= MAX_PAYLOAD_SIZE);
+        assert!(compute_serialized_size(tabs_to_upload).unwrap() <= MAX_PAYLOAD_SIZE);
     }
     // Helper struct to model what's stored in the DB
     struct TabsSQLRecord {


### PR DESCRIPTION
The tabs and clients engines use the same logic to truncate a list of
items to fit within a size limit when serialized to JSON, though
they handle failures differently: the tabs engine sends the complete
list of tabs; the clients engine clears the list of commands.

We'll reuse the same core logic to pack URLs for closed synced tabs
into multiple commands, so let's factor it out into a shared
support crate.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
