### PR TITLE
Bug 1907004: Chunk oversized "close tabs" commands into multiple device commands.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "mockall",
  "mockito",
  "parking_lot",
+ "payload-support",
  "rate-limiter",
  "rc_crypto",
  "serde",

--- a/components/fxa-client/Cargo.toml
+++ b/components/fxa-client/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "1.0"
 anyhow = "1.0"
 sync-guid = { path = "../support/guid", features = ["random"] }
 uniffi = { workspace = true }
+payload-support = { path = "../support/payload" }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
+++ b/components/fxa-client/android/src/main/java/mozilla/appservices/fxaclient/FxaClient.kt
@@ -517,12 +517,12 @@ class FxaClient(inner: FirefoxAccount, persistCallback: PersistCallback?) : Auto
      * @param targetDeviceId The ID of the device on which the tabs are
      * currently open.
      * @param urls The URLs of the tabs to close.
+     * @return The result of the operation.
      */
-    fun closeTabs(targetDeviceId: String, urls: List<String>) {
+    fun closeTabs(targetDeviceId: String, urls: List<String>): CloseTabsResult =
         withMetrics {
             this.inner.closeTabs(targetDeviceId, urls)
         }
-    }
 
     /**
      * Gather any telemetry which has been collected internally and return

--- a/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
+++ b/components/fxa-client/ios/FxAClient/FxAccountDeviceConstellation.swift
@@ -95,7 +95,7 @@ public class DeviceConstellation {
                         try self.account.sendSingleTab(targetDeviceId: targetDeviceId, title: title, url: url)
                     }
                 case let .closeTabs(urls):
-                    try self.account.closeTabs(targetDeviceId: targetDeviceId, urls: urls)
+                    _ = try self.account.closeTabs(targetDeviceId: targetDeviceId, urls: urls)
                 }
             } catch {
                 FxALog.error("Error sending event to another device: \(error).")

--- a/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
+++ b/components/fxa-client/ios/FxAClient/PersistedFirefoxAccount.swift
@@ -189,7 +189,7 @@ class PersistedFirefoxAccount {
         }
     }
 
-    public func closeTabs(targetDeviceId: String, urls: [String]) throws {
+    public func closeTabs(targetDeviceId: String, urls: [String]) throws -> CloseTabsResult {
         return try notifyAuthErrors {
             try self.inner.closeTabs(targetDeviceId: targetDeviceId, urls: urls)
         }

--- a/components/fxa-client/src/device.rs
+++ b/components/fxa-client/src/device.rs
@@ -266,3 +266,9 @@ pub struct AttachedClient {
     pub last_access_time: Option<i64>,
     pub scope: Option<Vec<String>>,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CloseTabsResult {
+    Ok,
+    TabsNotClosed { urls: Vec<String> },
+}

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use error_support::{convert_log_report_error, ErrorHandling, GetErrorHandling};
+use error_support::{ErrorHandling, GetErrorHandling};
 use rc_crypto::hawk;
 use std::string;
 
@@ -55,39 +55,6 @@ pub enum FxaError {
     /// A catch-all for other unspecified errors.
     #[error("other error: {0}")]
     Other(String),
-}
-
-/// Public error type thrown by device command-related
-/// [`FirefoxAccount`] operations.
-#[derive(Debug, thiserror::Error)]
-pub enum DeviceCommandError {
-    TabsNotClosed { urls: Vec<String> },
-    Account { error: FxaError },
-}
-
-impl DeviceCommandError {
-    /// Logs and reports an internal [`Error`] from a device command-related
-    /// operation, then converts the internal error to a public
-    /// [`DeviceCommandError`].
-    pub fn handle_error(error: Error) -> Self {
-        match error {
-            Error::TabsNotClosed { urls } => Self::TabsNotClosed { urls },
-            _ => Self::Account {
-                error: convert_log_report_error(error),
-            },
-        }
-    }
-}
-
-impl std::fmt::Display for DeviceCommandError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::TabsNotClosed { .. } => {
-                write!(f, "couldn't send one or more commands to close tabs")
-            }
-            Self::Account { error } => write!(f, "account error: {error}"),
-        }
-    }
 }
 
 /// FxA internal error type
@@ -226,9 +193,6 @@ pub enum Error {
 
     #[error("Internal error in the state machine: {0}")]
     StateMachineLogicError(String),
-
-    #[error("Some tabs weren't closed")]
-    TabsNotClosed { urls: Vec<String> },
 }
 
 // Define how our internal errors are handled and converted to external errors

--- a/components/fxa-client/src/error.rs
+++ b/components/fxa-client/src/error.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use error_support::{ErrorHandling, GetErrorHandling};
+use error_support::{convert_log_report_error, ErrorHandling, GetErrorHandling};
 use rc_crypto::hawk;
 use std::string;
 
@@ -55,6 +55,39 @@ pub enum FxaError {
     /// A catch-all for other unspecified errors.
     #[error("other error: {0}")]
     Other(String),
+}
+
+/// Public error type thrown by device command-related
+/// [`FirefoxAccount`] operations.
+#[derive(Debug, thiserror::Error)]
+pub enum DeviceCommandError {
+    TabsNotClosed { urls: Vec<String> },
+    Account { error: FxaError },
+}
+
+impl DeviceCommandError {
+    /// Logs and reports an internal [`Error`] from a device command-related
+    /// operation, then converts the internal error to a public
+    /// [`DeviceCommandError`].
+    pub fn handle_error(error: Error) -> Self {
+        match error {
+            Error::TabsNotClosed { urls } => Self::TabsNotClosed { urls },
+            _ => Self::Account {
+                error: convert_log_report_error(error),
+            },
+        }
+    }
+}
+
+impl std::fmt::Display for DeviceCommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TabsNotClosed { .. } => {
+                write!(f, "couldn't send one or more commands to close tabs")
+            }
+            Self::Account { error } => write!(f, "account error: {error}"),
+        }
+    }
 }
 
 /// FxA internal error type
@@ -193,6 +226,9 @@ pub enum Error {
 
     #[error("Internal error in the state machine: {0}")]
     StateMachineLogicError(String),
+
+    #[error("Some tabs weren't closed")]
+    TabsNotClosed { urls: Vec<String> },
 }
 
 // Define how our internal errors are handled and converted to external errors

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -91,6 +91,20 @@ enum FxaError {
 };
 
 
+/// An error type that carries additional information for
+/// device command-related [`FirefoxAccount`] operations.
+[Error]
+interface DeviceCommandError {
+  /// An error thrown if a device command to close one or more tabs
+  /// couldn't be sent. The caller should try to invoke
+  /// [`FirefoxAccount::close_tabs`] with the returned `urls` later.
+  TabsNotClosed(sequence<string> urls);
+
+  /// An error thrown if the operation failed for an
+  /// account-related reason.
+  Account(FxaError error);
+};
+
 
 // Object representing the signed-in state of an application.
 //
@@ -536,7 +550,7 @@ interface FirefoxAccount {
   ///
   /// If a device on the account has registered the [`CloseTabs`](DeviceCapability::CloseTabs)
   /// capability, this method can be used to close its tabs.
-  [Throws=FxaError]
+  [Throws=DeviceCommandError]
   void close_tabs([ByRef] string target_device_id, sequence<string> urls);
 
 

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -91,18 +91,30 @@ enum FxaError {
 };
 
 
-/// An error type that carries additional information for
-/// device command-related [`FirefoxAccount`] operations.
-[Error]
-interface DeviceCommandError {
-  /// An error thrown if a device command to close one or more tabs
-  /// couldn't be sent. The caller should try to invoke
-  /// [`FirefoxAccount::close_tabs`] with the returned `urls` later.
-  TabsNotClosed(sequence<string> urls);
+/// The result of invoking a "close tabs" command.
+///
+/// If [`FirefoxAccount::close_tabs`] is called with more URLs than can fit
+/// into a single command payload, the URLs will be chunked and sent in
+/// multiple commands.
+///
+/// Chunking breaks the atomicity of a "close tabs" command, but
+/// reduces the number of these commands that FxA sends to other devices.
+/// This is critical for platforms like iOS, where every command triggers a
+/// push message that must show a user-visible notification.
+[Enum]
+interface CloseTabsResult {
+  /// All URLs passed to [`FirefoxAccount::close_tabs`] were chunked and sent
+  /// in one or more device commands.
+  Ok();
 
-  /// An error thrown if the operation failed for an
-  /// account-related reason.
-  Account(FxaError error);
+  /// One or more URLs passed to [`FirefoxAccount::close_tabs`] couldn't be sent
+  /// in a device command. The caller can assume that:
+  ///
+  /// 1. Any URL in the returned list of `urls` was not sent, and
+  ///    should be retried.
+  /// 2. All other URLs that were passed to [`FirefoxAccount::close_tabs`], and
+  ///    that are _not_ in the list of `urls`, were chunked and sent.
+  TabsNotClosed(sequence<string> urls);
 };
 
 
@@ -550,8 +562,8 @@ interface FirefoxAccount {
   ///
   /// If a device on the account has registered the [`CloseTabs`](DeviceCapability::CloseTabs)
   /// capability, this method can be used to close its tabs.
-  [Throws=DeviceCommandError]
-  void close_tabs([ByRef] string target_device_id, sequence<string> urls);
+  [Throws=FxaError]
+  CloseTabsResult close_tabs([ByRef] string target_device_id, sequence<string> urls);
 
 
   // Get the URL at which to access the user's sync data.

--- a/components/fxa-client/src/internal/close_tabs.rs
+++ b/components/fxa-client/src/internal/close_tabs.rs
@@ -2,36 +2,100 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use std::mem;
+
+use payload_support::Fit;
+
 use super::{
     commands::{
         close_tabs::{self, CloseTabsPayload},
         decrypt_command, encrypt_command, IncomingDeviceCommand, PrivateCommandKeys,
     },
+    device::COMMAND_MAX_PAYLOAD_SIZE,
     http_client::GetDeviceResponse,
     scopes, telemetry, FirefoxAccount,
 };
 use crate::{Error, Result};
 
 impl FirefoxAccount {
-    pub fn close_tabs<T: AsRef<str>>(&mut self, target_device_id: &str, urls: &[T]) -> Result<()> {
+    pub fn close_tabs<T>(&mut self, target_device_id: &str, urls: Vec<T>) -> Result<()>
+    where
+        T: Into<String>,
+    {
         let devices = self.get_devices(false)?;
         let target = devices
             .iter()
             .find(|d| d.id == target_device_id)
             .ok_or_else(|| Error::UnknownTargetDevice(target_device_id.to_owned()))?;
-        let (payload, sent_telemetry) =
-            CloseTabsPayload::with_urls(urls.iter().map(|url| url.as_ref().to_owned()).collect());
-        let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
-        let command_payload =
-            encrypt_command(oldsync_key, target, close_tabs::COMMAND_NAME, &payload)?;
-        self.invoke_command(
-            close_tabs::COMMAND_NAME,
-            target,
-            &command_payload,
-            Some(close_tabs::COMMAND_TTL),
-        )?;
-        self.telemetry.record_command_sent(sent_telemetry);
-        Ok(())
+
+        let sent_telemetry = telemetry::SentCommand::for_close_tabs();
+        let mut urls_to_retry = Vec::new();
+
+        // Sort the URLs shortest to longest, so that we can at least make
+        // some forward progress, even if there's an oversized URL at the
+        // end that won't fit into a single command.
+        let mut urls: Vec<_> = urls.into_iter().map(Into::into).collect();
+        urls.sort_unstable_by_key(String::len);
+
+        while !urls.is_empty() {
+            // If we were asked to close more URLs than will fit in a
+            // single command, chunk the URLs into multiple commands,
+            // packing as many as we can into each. Do this until we've either
+            // drained and packed all the URLs, or we see an oversized URL
+            // that won't fit into a single command.
+            let chunk = match payload_support::try_fit_items(&urls, COMMAND_MAX_PAYLOAD_SIZE.get())
+            {
+                Fit::All => mem::take(&mut urls),
+                Fit::Some(count) => urls.drain(..count.get()).collect(),
+                Fit::None | Fit::Err(_) => {
+                    // Oversized URLs that won't fit into a single command, and
+                    // serialization errors, are permanent; retrying to send
+                    // these URLs won't help. But we want our consumers to keep
+                    // any pending closed URLs hidden from the user's synced
+                    // tabs list, until they're eventually sent (for temporary
+                    // errors; see below), or expire after some time
+                    // (for oversized URLs that can't ever be sent).
+                    urls_to_retry.append(&mut urls);
+                    break;
+                }
+            };
+
+            let sent_telemetry = sent_telemetry.clone_with_new_stream_id();
+            let payload = CloseTabsPayload::with_telemetry(&sent_telemetry, chunk);
+
+            let oldsync_key = self.get_scoped_key(scopes::OLD_SYNC)?;
+            let command_payload =
+                encrypt_command(oldsync_key, target, close_tabs::COMMAND_NAME, &payload)?;
+            let result = self.invoke_command(
+                close_tabs::COMMAND_NAME,
+                target,
+                &command_payload,
+                Some(close_tabs::COMMAND_TTL),
+            );
+            match result {
+                Ok(()) => {
+                    self.telemetry.record_command_sent(sent_telemetry);
+                }
+                Err(e) => {
+                    error_support::report_error!(
+                        "fxaclient-close-tabs-invoke",
+                        "Failed to send bulk Close Tabs command: {}",
+                        e
+                    );
+                    // Temporary error; if the consumer retries, we expect that
+                    // we _will_ eventually send these URLs.
+                    urls_to_retry.extend(payload.urls);
+                }
+            }
+        }
+
+        if urls_to_retry.is_empty() {
+            Ok(())
+        } else {
+            Err(Error::TabsNotClosed {
+                urls: urls_to_retry,
+            })
+        }
     }
 
     pub(crate) fn handle_close_tabs_command(
@@ -90,5 +154,405 @@ impl FirefoxAccount {
 
     fn clear_close_tabs_keys(&mut self) {
         self.state.clear_commands_data(close_tabs::COMMAND_NAME);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::{collections::HashSet, sync::Arc};
+
+    use mockall::predicate::{always, eq};
+    use serde_json::json;
+
+    use crate::{
+        internal::{
+            commands::PublicCommandKeys, config::Config, http_client::MockFxAClient,
+            oauth::RefreshToken, util, CachedResponse, FirefoxAccount,
+        },
+        ScopedKey,
+    };
+
+    /// An RAII helper that overrides the maximum command payload size
+    /// for testing, and restores the original size when dropped.
+    struct OverrideCommandMaxPayloadSize(usize);
+
+    impl OverrideCommandMaxPayloadSize {
+        pub fn with_new_size(new_size: usize) -> Self {
+            Self(COMMAND_MAX_PAYLOAD_SIZE.replace(new_size))
+        }
+    }
+
+    impl Drop for OverrideCommandMaxPayloadSize {
+        fn drop(&mut self) {
+            COMMAND_MAX_PAYLOAD_SIZE.set(self.0)
+        }
+    }
+
+    fn setup() -> FirefoxAccount {
+        let config = Config::stable_dev("12345678", "https://foo.bar");
+        let mut fxa = FirefoxAccount::with_config(config);
+        fxa.state.force_refresh_token(RefreshToken {
+            token: "refreshtok".to_owned(),
+            scopes: HashSet::default(),
+        });
+        fxa.state.insert_scoped_key(scopes::OLD_SYNC, ScopedKey {
+            kty: "oct".to_string(),
+            scope: "https://identity.mozilla.com/apps/oldsync".to_string(),
+            k: "kMtwpVC0ZaYFJymPza8rXK_0CgCp3KMwRStwGfBRBDtL6hXRDVJgQFaoOQ2dimw0Bko5WVv2gNTy7RX5zFYZHg".to_string(),
+            kid: "1542236016429-Ox1FbJfFfwTe5t-xq4v2hQ".to_string(),
+        });
+        fxa
+    }
+
+    // Quasi-integration tests that stub out _just_ enough of the
+    // machinery to send and respond to "close tabs" commands.
+
+    #[test]
+    fn test_close_tabs_send_one() -> Result<()> {
+        let _o = OverrideCommandMaxPayloadSize::with_new_size(2048);
+
+        let mut fxa = setup();
+        let close_tabs_keys = PrivateCommandKeys::from_random()?;
+        let devices = json!([
+            {
+                "id": "device0102",
+                "name": "Emerald",
+                "isCurrentDevice": false,
+                "location": {},
+                "availableCommands": {
+                    close_tabs::COMMAND_NAME: PublicCommandKeys::as_command_data(
+                        &close_tabs_keys.clone().into(),
+                        fxa.state.get_scoped_key(scopes::OLD_SYNC).unwrap(),
+                    )?,
+                },
+                "pushEndpointExpired": false,
+            },
+        ]);
+        fxa.devices_cache = Some(CachedResponse {
+            response: serde_json::from_value(devices)?,
+            cached_at: util::now(),
+            etag: "".into(),
+        });
+        fxa.set_close_tabs_key(close_tabs_keys.serialize()?);
+
+        let mut client = MockFxAClient::new();
+        client
+            .expect_invoke_command()
+            .once()
+            .with(
+                always(),
+                always(),
+                always(),
+                eq("device0102"),
+                always(),
+                always(),
+            )
+            .returning(|_, _, _, _, _, _| Ok(()));
+        fxa.set_client(Arc::new(client));
+
+        // Send one command.
+        fxa.close_tabs("device0102", vec!["https://example.com"])?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_close_tabs_send_two() -> Result<()> {
+        let _o = OverrideCommandMaxPayloadSize::with_new_size(2048);
+
+        let mut fxa = setup();
+        let close_tabs_keys = PrivateCommandKeys::from_random()?;
+        let devices = json!([
+            {
+                "id": "device0304",
+                "name": "Sapphire",
+                "isCurrentDevice": false,
+                "location": {},
+                "availableCommands": {
+                    close_tabs::COMMAND_NAME: PublicCommandKeys::as_command_data(
+                        &close_tabs_keys.clone().into(),
+                        fxa.state.get_scoped_key(scopes::OLD_SYNC).unwrap(),
+                    )?,
+                },
+                "pushEndpointExpired": false,
+            },
+        ]);
+        fxa.devices_cache = Some(CachedResponse {
+            response: serde_json::from_value(devices)?,
+            cached_at: util::now(),
+            etag: "".into(),
+        });
+        fxa.set_close_tabs_key(close_tabs_keys.serialize()?);
+
+        let mut client = MockFxAClient::new();
+        client
+            .expect_invoke_command()
+            .times(2)
+            .with(
+                always(),
+                always(),
+                always(),
+                eq("device0304"),
+                always(),
+                always(),
+            )
+            .returning(|_, _, _, _, _, _| Ok(()));
+        fxa.set_client(Arc::new(client));
+
+        // Send two commands.
+        fxa.close_tabs(
+            "device0304",
+            vec!["https://example.com", "https://example.org"],
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_close_tabs_all_fail() -> Result<()> {
+        let _o = OverrideCommandMaxPayloadSize::with_new_size(2048);
+
+        let mut fxa = setup();
+        let close_tabs_keys = PrivateCommandKeys::from_random()?;
+        let devices = json!([
+            {
+                "id": "device0506",
+                "name": "Ruby",
+                "isCurrentDevice": false,
+                "location": {},
+                "availableCommands": {
+                    close_tabs::COMMAND_NAME: PublicCommandKeys::as_command_data(
+                        &close_tabs_keys.clone().into(),
+                        fxa.state.get_scoped_key(scopes::OLD_SYNC).unwrap(),
+                    )?,
+                },
+                "pushEndpointExpired": false,
+            },
+        ]);
+        fxa.devices_cache = Some(CachedResponse {
+            response: serde_json::from_value(devices)?,
+            cached_at: util::now(),
+            etag: "".into(),
+        });
+        fxa.set_close_tabs_key(close_tabs_keys.serialize()?);
+
+        let mut client = MockFxAClient::new();
+        client
+            .expect_invoke_command()
+            .times(3)
+            .with(
+                always(),
+                always(),
+                always(),
+                eq("device0506"),
+                always(),
+                always(),
+            )
+            .returning(|_, _, _, _, _, _| {
+                Err(Error::RequestError(viaduct::Error::NetworkError(
+                    "Simulated error".to_owned(),
+                )))
+            });
+        fxa.set_client(Arc::new(client));
+
+        // Fail to send any commands.
+        match fxa.close_tabs(
+            "device0506",
+            vec![
+                "https://example.com",
+                "https://example.org",
+                "https://example.net",
+            ],
+        ) {
+            Err(Error::TabsNotClosed { urls }) => assert_eq!(
+                urls,
+                &[
+                    "https://example.com",
+                    "https://example.org",
+                    "https://example.net"
+                ]
+            ),
+            v => panic!("Wanted tabs not closed error; got {:?}", v),
+        };
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_close_tabs_one_fails() -> Result<()> {
+        let _o = OverrideCommandMaxPayloadSize::with_new_size(2048);
+
+        let mut fxa = setup();
+        let close_tabs_keys = PrivateCommandKeys::from_random()?;
+        let devices = json!([
+            {
+                "id": "device0708",
+                "name": "Agate",
+                "isCurrentDevice": false,
+                "location": {},
+                "availableCommands": {
+                    close_tabs::COMMAND_NAME: PublicCommandKeys::as_command_data(
+                        &close_tabs_keys.clone().into(),
+                        fxa.state.get_scoped_key(scopes::OLD_SYNC).unwrap(),
+                    )?,
+                },
+                "pushEndpointExpired": false,
+            },
+        ]);
+        fxa.devices_cache = Some(CachedResponse {
+            response: serde_json::from_value(devices)?,
+            cached_at: util::now(),
+            etag: "".into(),
+        });
+        fxa.set_close_tabs_key(close_tabs_keys.serialize()?);
+
+        let mut client = MockFxAClient::new();
+        client
+            .expect_invoke_command()
+            .times(3)
+            .with(
+                always(),
+                always(),
+                always(),
+                eq("device0708"),
+                always(),
+                always(),
+            )
+            // `.returning()` boxes its closure, so we need to capture
+            // the keys by `move`.
+            .returning(move |_, _, _, _, value, _| {
+                let payload: CloseTabsPayload = decrypt_command(value.clone(), &close_tabs_keys)?;
+                if payload.urls.iter().any(|url| url == "https://example.org") {
+                    Err(Error::RequestError(viaduct::Error::NetworkError(
+                        "Simulated error".to_owned(),
+                    )))
+                } else {
+                    Ok(())
+                }
+            });
+        fxa.set_client(Arc::new(client));
+
+        // Send two commands; fail to send one.
+        match fxa.close_tabs(
+            "device0708",
+            vec![
+                "https://example.com",
+                "https://example.org",
+                "https://example.net",
+            ],
+        ) {
+            Err(Error::TabsNotClosed { urls }) => assert_eq!(urls, &["https://example.org"]),
+            v => panic!("Wanted tabs not closed error; got {:?}", v),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_close_tabs_never_sent() -> Result<()> {
+        // Lower the maximum payload size such that we can't send
+        // any commands.
+        let _p = OverrideCommandMaxPayloadSize::with_new_size(0);
+
+        let mut fxa = setup();
+        let close_tabs_keys = PrivateCommandKeys::from_random()?;
+        let devices = json!([
+            {
+                "id": "device0910",
+                "name": "Amethyst",
+                "isCurrentDevice": false,
+                "location": {},
+                "availableCommands": {
+                    close_tabs::COMMAND_NAME: PublicCommandKeys::as_command_data(
+                        &close_tabs_keys.clone().into(),
+                        fxa.state.get_scoped_key(scopes::OLD_SYNC).unwrap(),
+                    )?,
+                },
+                "pushEndpointExpired": false,
+            },
+        ]);
+        fxa.devices_cache = Some(CachedResponse {
+            response: serde_json::from_value(devices)?,
+            cached_at: util::now(),
+            etag: "".into(),
+        });
+        fxa.set_close_tabs_key(close_tabs_keys.serialize()?);
+
+        let mut client = MockFxAClient::new();
+        client.expect_invoke_command().never().with(
+            always(),
+            always(),
+            always(),
+            eq("device0910"),
+            always(),
+            always(),
+        );
+        fxa.set_client(Arc::new(client));
+
+        match fxa.close_tabs("device0910", vec!["https://example.com"]) {
+            Err(Error::TabsNotClosed { urls }) => assert_eq!(urls, &["https://example.com"]),
+            v => panic!("Wanted tabs not closed error; got {:?}", v),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_close_tabs_two_per_command() -> Result<()> {
+        // Raise the maximum payload size to 2 URLs per command.
+        let _q = OverrideCommandMaxPayloadSize::with_new_size(2088);
+
+        let mut fxa = setup();
+        let close_tabs_keys = PrivateCommandKeys::from_random()?;
+        let devices = json!([
+            {
+                "id": "device1112",
+                "name": "Diamond",
+                "isCurrentDevice": false,
+                "location": {},
+                "availableCommands": {
+                    close_tabs::COMMAND_NAME: PublicCommandKeys::as_command_data(
+                        &close_tabs_keys.clone().into(),
+                        fxa.state.get_scoped_key(scopes::OLD_SYNC).unwrap(),
+                    )?,
+                },
+                "pushEndpointExpired": false,
+            },
+        ]);
+        fxa.devices_cache = Some(CachedResponse {
+            response: serde_json::from_value(devices)?,
+            cached_at: util::now(),
+            etag: "".into(),
+        });
+        fxa.set_close_tabs_key(close_tabs_keys.serialize()?);
+
+        let mut client = MockFxAClient::new();
+        client
+            .expect_invoke_command()
+            .times(2)
+            .with(
+                always(),
+                always(),
+                always(),
+                eq("device1112"),
+                always(),
+                always(),
+            )
+            .returning(|_, _, _, _, _, _| Ok(()));
+        fxa.set_client(Arc::new(client));
+
+        fxa.close_tabs(
+            "device1112",
+            vec![
+                "https://example.com/abcdefghi",
+                "https://example.org/jklmnopqr",
+                "https://example.net/stuvwxyza",
+                "https://example.edu/bcdefghij",
+            ],
+        )?;
+
+        Ok(())
     }
 }

--- a/components/fxa-client/src/internal/commands/close_tabs.rs
+++ b/components/fxa-client/src/internal/commands/close_tabs.rs
@@ -27,14 +27,15 @@ impl From<CloseTabsPayload> for crate::CloseTabsPayload {
 impl CloseTabsPayload {
     pub fn with_urls(urls: Vec<String>) -> (Self, telemetry::SentCommand) {
         let sent_telemetry: telemetry::SentCommand = telemetry::SentCommand::for_close_tabs();
-        (
-            CloseTabsPayload {
-                urls,
-                flow_id: sent_telemetry.flow_id.clone(),
-                stream_id: sent_telemetry.stream_id.clone(),
-            },
-            sent_telemetry,
-        )
+        (Self::with_telemetry(&sent_telemetry, urls), sent_telemetry)
+    }
+
+    pub fn with_telemetry(sent_telemetry: &telemetry::SentCommand, urls: Vec<String>) -> Self {
+        CloseTabsPayload {
+            urls,
+            flow_id: sent_telemetry.flow_id.clone(),
+            stream_id: sent_telemetry.stream_id.clone(),
+        }
     }
 }
 

--- a/components/fxa-client/src/internal/device.rs
+++ b/components/fxa-client/src/internal/device.rs
@@ -2,7 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    cell::Cell,
+    collections::{HashMap, HashSet},
+};
 
 pub use super::http_client::{GetDeviceResponse as Device, PushSubscription};
 use super::{
@@ -17,6 +20,14 @@ use sync15::DeviceType;
 
 // An devices response is considered fresh for `DEVICES_FRESHNESS_THRESHOLD` ms.
 const DEVICES_FRESHNESS_THRESHOLD: u64 = 60_000; // 1 minute
+
+thread_local! {
+    /// The maximum size, in bytes, of a command payload. The FxA server may
+    /// reject requests to invoke commands with payloads exceeding this size.
+    ///
+    /// Defaults to 16 KB; overridden in tests.
+    pub static COMMAND_MAX_PAYLOAD_SIZE: Cell<usize> = const { Cell::new(16 * 1024) }
+}
 
 /// The reason we are fetching commands.
 #[derive(Clone, Copy)]

--- a/components/fxa-client/src/internal/telemetry.rs
+++ b/components/fxa-client/src/internal/telemetry.rs
@@ -68,11 +68,19 @@ impl SentCommand {
         Self::new(Command::CloseTabs)
     }
 
+    pub fn clone_with_new_stream_id(&self) -> Self {
+        Self {
+            command: self.command,
+            flow_id: self.flow_id.clone(),
+            stream_id: Guid::random().into_string(),
+        }
+    }
+
     fn new(command: Command) -> Self {
         Self {
             command,
-            flow_id: Guid::random().to_string(),
-            stream_id: Guid::random().to_string(),
+            flow_id: Guid::random().into_string(),
+            stream_id: Guid::random().into_string(),
         }
     }
 }

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -55,7 +55,7 @@ use url::Url;
 
 pub use auth::{AuthorizationInfo, FxaEvent, FxaRustAuthState, FxaState, UserData};
 pub use device::{AttachedClient, Device, DeviceCapability, DeviceConfig, LocalDevice};
-pub use error::{Error, FxaError};
+pub use error::{DeviceCommandError, Error, FxaError};
 use parking_lot::Mutex;
 pub use profile::Profile;
 pub use push::{
@@ -74,6 +74,8 @@ pub use state_machine::checker::{
 pub type Result<T> = std::result::Result<T, Error>;
 /// Result returned by public-facing API functions
 pub type ApiResult<T> = std::result::Result<T, FxaError>;
+/// Result returned from a public device command-related function.
+pub type DeviceCommandResult<T> = std::result::Result<T, DeviceCommandError>;
 
 /// Object representing the signed-in state of an application.
 ///

--- a/components/fxa-client/src/lib.rs
+++ b/components/fxa-client/src/lib.rs
@@ -54,8 +54,10 @@ pub use sync15::DeviceType;
 use url::Url;
 
 pub use auth::{AuthorizationInfo, FxaEvent, FxaRustAuthState, FxaState, UserData};
-pub use device::{AttachedClient, Device, DeviceCapability, DeviceConfig, LocalDevice};
-pub use error::{DeviceCommandError, Error, FxaError};
+pub use device::{
+    AttachedClient, CloseTabsResult, Device, DeviceCapability, DeviceConfig, LocalDevice,
+};
+pub use error::{Error, FxaError};
 use parking_lot::Mutex;
 pub use profile::Profile;
 pub use push::{
@@ -74,8 +76,6 @@ pub use state_machine::checker::{
 pub type Result<T> = std::result::Result<T, Error>;
 /// Result returned by public-facing API functions
 pub type ApiResult<T> = std::result::Result<T, FxaError>;
-/// Result returned from a public device command-related function.
-pub type DeviceCommandResult<T> = std::result::Result<T, DeviceCommandError>;
 
 /// Object representing the signed-in state of an application.
 ///

--- a/components/fxa-client/src/push.rs
+++ b/components/fxa-client/src/push.rs
@@ -5,7 +5,10 @@
 use error_support::handle_error;
 use serde::{Deserialize, Serialize};
 
-use crate::{internal, ApiResult, Device, Error, FirefoxAccount, LocalDevice};
+use crate::{
+    internal, ApiResult, Device, DeviceCommandError, DeviceCommandResult, Error, FirefoxAccount,
+    LocalDevice,
+};
 
 impl FirefoxAccount {
     /// Set or update a push subscription endpoint for this device.
@@ -107,9 +110,11 @@ impl FirefoxAccount {
     ///
     /// If a device on the account has registered the [`CloseTabs`](DeviceCapability::CloseTabs)
     /// capability, this method can be used to close its tabs.
-    #[handle_error(Error)]
-    pub fn close_tabs(&self, target_device_id: &str, urls: Vec<String>) -> ApiResult<()> {
-        self.internal.lock().close_tabs(target_device_id, &urls)
+    pub fn close_tabs(&self, target_device_id: &str, urls: Vec<String>) -> DeviceCommandResult<()> {
+        self.internal
+            .lock()
+            .close_tabs(target_device_id, urls)
+            .map_err(DeviceCommandError::handle_error)
     }
 }
 

--- a/components/fxa-client/src/push.rs
+++ b/components/fxa-client/src/push.rs
@@ -5,10 +5,7 @@
 use error_support::handle_error;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    internal, ApiResult, Device, DeviceCommandError, DeviceCommandResult, Error, FirefoxAccount,
-    LocalDevice,
-};
+use crate::{internal, ApiResult, CloseTabsResult, Device, Error, FirefoxAccount, LocalDevice};
 
 impl FirefoxAccount {
     /// Set or update a push subscription endpoint for this device.
@@ -110,11 +107,13 @@ impl FirefoxAccount {
     ///
     /// If a device on the account has registered the [`CloseTabs`](DeviceCapability::CloseTabs)
     /// capability, this method can be used to close its tabs.
-    pub fn close_tabs(&self, target_device_id: &str, urls: Vec<String>) -> DeviceCommandResult<()> {
-        self.internal
-            .lock()
-            .close_tabs(target_device_id, urls)
-            .map_err(DeviceCommandError::handle_error)
+    #[handle_error(Error)]
+    pub fn close_tabs(
+        &self,
+        target_device_id: &str,
+        urls: Vec<String>,
+    ) -> ApiResult<CloseTabsResult> {
+        self.internal.lock().close_tabs(target_device_id, urls)
     }
 }
 


### PR DESCRIPTION
This PR:

* Introduces a new `CloseTabsResult` return type.
* Adds a `CloseTabsResult::TabsNotClosed` variant, which includes the URLs of any tabs that couldn't be sent in a "close tabs" command.
* Reworks `FirefoxAccount::close_tabs` to pack URLs that exceed the maximum payload size (16 KB by default) into multiple device commands.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
