### PR TITLE
Switch from JCenter to MavenCentral [ci full]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ plugins {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             name "Mozilla"
             url "https://maven.mozilla.org/maven2"

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ buildscript {
         classpath 'org.yaml:snakeyaml:2.2'
     }
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/tools/nimbus-gradle-plugin/build.gradle
+++ b/tools/nimbus-gradle-plugin/build.gradle
@@ -19,7 +19,7 @@ gradlePlugin {
 
 repositories {
     google()
-    jcenter()
+    mavenCentral()
     maven {
         name "Mozilla"
         url "https://maven.mozilla.org/maven2"

--- a/tools/nimbus-gradle-plugin/settings.gradle
+++ b/tools/nimbus-gradle-plugin/settings.gradle
@@ -8,7 +8,7 @@ buildscript {
         classpath 'org.yaml:snakeyaml:2.2'
     }
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
JCenter has been sunset. See <https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/>.

### Pull Request checklist ###
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes
- [x] **Quality**: This PR builds and tests run cleanly
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
     - This PR doesn't change any code.
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
     - I don't think this change is interesting to library users. But I'd be happy to add a changelog entry in case someone disagrees.
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)

Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1866339
