### PR TITLE
(DISCUSS) DISCO-2938 - return highlighted search matches

### DIFF
--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -692,7 +692,8 @@ impl<'a> SuggestDao<'a> {
                 f.rating,
                 f.total_reviews,
                 i.data,
-                i.mimetype
+                i.mimetype,
+                highlight(fakespot_fts, 0, '<b>', '</b>')
             FROM
                 suggestions s
             JOIN
@@ -721,6 +722,7 @@ impl<'a> SuggestDao<'a> {
                     total_reviews: row.get(6)?,
                     icon: row.get(7)?,
                     icon_mimetype: row.get(8)?,
+                    highlighted_title: row.get(9)?,
                 })
             },
         )

--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -19,7 +19,7 @@ use sql_support::{
 ///     [`SuggestConnectionInitializer::upgrade_from`].
 ///    a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
 ///       the migration.
-pub const VERSION: u32 = 23;
+pub const VERSION: u32 = 24;
 
 /// The current Suggest database schema.
 pub const SQL: &str = "
@@ -101,8 +101,6 @@ CREATE TABLE fakespot_custom_details(
 
 CREATE VIRTUAL TABLE IF NOT EXISTS fakespot_fts USING FTS5(
   title,
-  content='',
-  contentless_delete=1,
   tokenize=\"porter unicode61 remove_diacritics 2 tokenchars '''-'\"
 );
 
@@ -354,6 +352,19 @@ CREATE VIRTUAL TABLE fakespot_fts USING FTS5(
   title,
   content='',
   contentless_delete=1,
+  tokenize=\"porter unicode61 remove_diacritics 2 tokenchars '''-'\"
+);
+                    ",
+                )?;
+                Ok(())
+            }
+            23 => {
+                // Drop and re-create the fakespot_fts table to remove the content='' param
+                tx.execute_batch(
+                    "
+DROP TABLE fakespot_fts;
+CREATE VIRTUAL TABLE fakespot_fts USING FTS5(
+  title,
   tokenize=\"porter unicode61 remove_diacritics 2 tokenchars '''-'\"
 );
                     ",

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -2144,25 +2144,36 @@ mod tests {
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::fakespot("globe")),
-            vec![snowglobe_suggestion()],
+            vec![snowglobe_suggestion(
+                "Make Your Own Glitter Snow <b>Globes</b>"
+            )],
         );
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::fakespot("simpsons")),
-            vec![simpsons_suggestion()],
+            vec![simpsons_suggestion(
+                "The <b>Simpsons</b>: Skinner's Sense of Snow (DVD)"
+            )],
         );
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::fakespot("snow")),
-            vec![simpsons_suggestion(), snowglobe_suggestion()],
+            vec![
+                simpsons_suggestion("The Simpsons: Skinner's Sense of <b>Snow</b> (DVD)"),
+                snowglobe_suggestion("Make Your Own Glitter <b>Snow</b> Globes"),
+            ],
         );
         // Test FTS by using a query where the keywords are separated in the source text
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::fakespot("simpsons snow")),
-            vec![simpsons_suggestion()],
+            vec![simpsons_suggestion(
+                "The <b>Simpsons</b>: Skinner's Sense of <b>Snow</b> (DVD)"
+            )],
         );
         // Special characters should be stripped out
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::fakespot("simpsons + snow")),
-            vec![simpsons_suggestion()],
+            vec![simpsons_suggestion(
+                "The <b>Simpsons</b>: Skinner's Sense of <b>Snow</b> (DVD)"
+            )],
         );
 
         Ok(())
@@ -2184,15 +2195,21 @@ mod tests {
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::fakespot("simp")),
-            vec![simpsons_suggestion()],
+            vec![simpsons_suggestion(
+                "The <b>Simpsons</b>: Skinner's Sense of Snow (DVD)"
+            )],
         );
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::fakespot("simps")),
-            vec![simpsons_suggestion()],
+            vec![simpsons_suggestion(
+                "The <b>Simpsons</b>: Skinner's Sense of Snow (DVD)"
+            )],
         );
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::fakespot("simpson")),
-            vec![simpsons_suggestion()],
+            vec![simpsons_suggestion(
+                "The <b>Simpsons</b>: Skinner's Sense of Snow (DVD)"
+            )],
         );
 
         Ok(())

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -105,6 +105,7 @@ interface Suggestion {
         string url,
         sequence<u8>? icon,
         string? icon_mimetype,
+        string highlighted_title,
         f64 score
     );
 };

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -90,6 +90,7 @@ pub enum Suggestion {
         url: String,
         icon: Option<Vec<u8>>,
         icon_mimetype: Option<String>,
+        highlighted_title: String,
         score: f64,
     },
 }

--- a/components/suggest/src/testing/data.rs
+++ b/components/suggest/src/testing/data.rs
@@ -464,7 +464,7 @@ pub fn snowglobe_fakespot() -> JsonValue {
     })
 }
 
-pub fn snowglobe_suggestion() -> Suggestion {
+pub fn snowglobe_suggestion(highlighted_title: &str) -> Suggestion {
     Suggestion::Fakespot {
         fakespot_grade: "B".into(),
         product_id: "amazon-ABC".into(),
@@ -477,6 +477,7 @@ pub fn snowglobe_suggestion() -> Suggestion {
         score: 0.2458,
         icon: Some("fakespot-icon-amazon-data".as_bytes().to_vec()),
         icon_mimetype: Some("image/png".into()),
+        highlighted_title: highlighted_title.to_string(),
     }
 }
 
@@ -494,7 +495,7 @@ pub fn simpsons_fakespot() -> JsonValue {
     })
 }
 
-pub fn simpsons_suggestion() -> Suggestion {
+pub fn simpsons_suggestion(highlighted_title: &str) -> Suggestion {
     Suggestion::Fakespot {
         fakespot_grade: "A".into(),
         product_id: "vendorwithouticon-XYZ".into(),
@@ -507,6 +508,7 @@ pub fn simpsons_suggestion() -> Suggestion {
         score: 0.2459,
         icon: None,
         icon_mimetype: None,
+        highlighted_title: highlighted_title.to_string(),
     }
 }
 


### PR DESCRIPTION
In the last meeting we discussed the issue of results not being highlighted correctly because of stemming.  This is my attempt to try to fix that issue using the `highlight` function that FTS5 gives you.  I'm not totally sure if this is a good idea or not, I'd love feedback on it.

Some notes:
  - `highlight` doesn't work with a contentless table, so I disabled that.  This brings the size of the fakespot DB from ~3.6mb to 4mb.  The DB size for the other providers is ~20mb.  Seems like an acceptable tradeoff to me.
    - Maybe we could eventually use external content tables but that's harder to make work.  When I tried to do that I got SQLite errors when updating the data.  I haven't looked in to this, but I'm pretty sure it's related to deletion order.
  - I used `<b>` and `</b>` as the markers for the highlight, but we can switch that to whatever works for you or make it configurable.
  - My initial suggestion was to run the input through the stemming algorithm and return it to the component to use with its highlighting logic.  But, AFAICT, there's no way to do that with FTS5.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
