### PR TITLE
Remote settings caching support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Suggest
 - Added support for Fakespot suggestions.
 
+### Remote settings
+- Added cache support
+- Added builder API for constructing RemoteSettings instances
+
 ## 🦊 What's Changed 🦊
 
 ### Android

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,10 +3598,12 @@ name = "remote_settings"
 version = "0.1.0"
 dependencies = [
  "expect-test",
+ "log",
  "mockito",
  "parking_lot",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "uniffi",
  "url",

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["/android", "/ios"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = "0.4"
 uniffi = { workspace = true }
 thiserror = "1.0"
 serde = { version = "1", features=["derive"] }
@@ -29,3 +30,4 @@ mockito = "0.31"
 # We add the perserve_order feature to guarantee ordering of the keys in our
 # JSON objects as they get serialized/deserialized.
 serde_json = { version = "1", features = ["preserve_order"] }
+tempfile = "3.2.0"

--- a/components/remote_settings/src/cache.rs
+++ b/components/remote_settings/src/cache.rs
@@ -1,0 +1,259 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::{
+    collections::HashSet,
+    fs::{File, OpenOptions},
+    io::prelude::*,
+};
+
+use parking_lot::Mutex;
+
+use crate::{RemoteSettingsResponse, Result};
+
+/// Interface for caching remote settings data
+///
+/// This is implemented by the remote settings consumer, sometimes with foreign code via UniFFI.
+///
+/// This interface has no error handling.  Consumers should report any errors themselves.  If there
+/// is an error in `get()` simply return `None` and the remote settings client will re-fetch any
+/// data.
+pub trait RemoteSettingsCache: Send + Sync {
+    /// Update the cached value
+    fn store(&self, value: RemoteSettingsResponse);
+
+    /// Get the last value passed to `set`.
+    fn get(&self) -> Option<RemoteSettingsResponse>;
+}
+
+/// Merge a cached RemoteSettingsResponse and a newly downloaded one to get a merged reesponse
+///
+/// cached is a previously downloaded remote settings response (possibly run through merge_cache_and_response).
+/// new is a newly downloaded remote settings response (with `_expected` set to the last_modified
+/// time of the cached response).
+///
+/// This will merge the records from both responses, handle deletions/tombstones, and return a
+/// response that has:
+///   - The newest `last_modified_date`
+///   - A record list containing the newest version of all live records.  Deleted records will not
+///     be present in this list.
+///
+/// If everything is working properly, the returned value will exactly match what the server would
+/// have returned if there was no `_expected` param.
+pub fn merge_cache_and_response(
+    cached: RemoteSettingsResponse,
+    new: RemoteSettingsResponse,
+) -> RemoteSettingsResponse {
+    let new_record_ids = new
+        .records
+        .iter()
+        .map(|r| r.id.as_str())
+        .collect::<HashSet<&str>>();
+    // Start with any cached records that don't appear in new.
+    let mut records = cached
+        .records
+        .into_iter()
+        .filter(|r| !new_record_ids.contains(r.id.as_str()))
+        // deleted should always be false, check it just in case
+        .filter(|r| !r.deleted)
+        .collect::<Vec<_>>();
+    // Add all (non-deleted) records from new
+    records.extend(new.records.into_iter().filter(|r| !r.deleted));
+
+    RemoteSettingsResponse {
+        last_modified: new.last_modified,
+        records,
+    }
+}
+
+/// Implements RemoteSettingsCache by serializing data and writing it to a file
+pub struct RemoteSettingsCacheFile {
+    file: Mutex<File>,
+}
+
+impl RemoteSettingsCacheFile {
+    pub fn new(path: String) -> Result<Self> {
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path)?;
+        Ok(Self {
+            file: Mutex::new(file),
+        })
+    }
+
+    fn try_store(&self, value: RemoteSettingsResponse) -> Result<()> {
+        let mut file = self.file.lock();
+        file.rewind()?;
+        serde_json::to_writer(&mut *file, &value)?;
+        Ok(())
+    }
+
+    fn try_get(&self) -> Result<Option<RemoteSettingsResponse>> {
+        let mut file = self.file.lock();
+        if file.metadata()?.len() == 0 {
+            return Ok(None);
+        }
+        file.rewind()?;
+        Ok(serde_json::from_reader(&mut *file)?)
+    }
+}
+
+impl RemoteSettingsCache for RemoteSettingsCacheFile {
+    fn store(&self, value: RemoteSettingsResponse) {
+        if let Err(e) = self.try_store(value) {
+            log::warn!("Error writing remote settings cache: {e}");
+        }
+    }
+
+    fn get(&self) -> Option<RemoteSettingsResponse> {
+        match self.try_get() {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("Error reading remote settings cache: {e}");
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{RemoteSettingsRecord, RsJsonObject};
+
+    // Quick way to generate the fields data for our mock records
+    fn fields(data: &str) -> RsJsonObject {
+        let mut map = serde_json::Map::new();
+        map.insert("data".into(), data.into());
+        map
+    }
+
+    #[test]
+    fn test_combine_cache_and_response() {
+        let cached_response = RemoteSettingsResponse {
+            last_modified: 1000,
+            records: vec![
+                RemoteSettingsRecord {
+                    id: "a".into(),
+                    last_modified: 100,
+                    deleted: false,
+                    attachment: None,
+                    fields: fields("a"),
+                },
+                RemoteSettingsRecord {
+                    id: "b".into(),
+                    last_modified: 200,
+                    deleted: false,
+                    attachment: None,
+                    fields: fields("b"),
+                },
+                RemoteSettingsRecord {
+                    id: "c".into(),
+                    last_modified: 300,
+                    deleted: false,
+                    attachment: None,
+                    fields: fields("c"),
+                },
+            ],
+        };
+        let new_response = RemoteSettingsResponse {
+            last_modified: 2000,
+            records: vec![
+                // d is new
+                RemoteSettingsRecord {
+                    id: "d".into(),
+                    last_modified: 1300,
+                    deleted: false,
+                    attachment: None,
+                    fields: fields("d"),
+                },
+                // b was deleted
+                RemoteSettingsRecord {
+                    id: "b".into(),
+                    last_modified: 1200,
+                    deleted: true,
+                    attachment: None,
+                    fields: RsJsonObject::new(),
+                },
+                // a was updated
+                RemoteSettingsRecord {
+                    id: "a".into(),
+                    last_modified: 1100,
+                    deleted: false,
+                    attachment: None,
+                    fields: fields("a-with-new-data"),
+                },
+                // c was not modified, so it's not present in the new response
+            ],
+        };
+        let mut merged = merge_cache_and_response(cached_response, new_response);
+        // Sort the records to make the assertion easier
+        merged.records.sort_by_key(|r| r.id.clone());
+        assert_eq!(
+            merged,
+            RemoteSettingsResponse {
+                last_modified: 2000,
+                records: vec![
+                    // a was updated
+                    RemoteSettingsRecord {
+                        id: "a".into(),
+                        last_modified: 1100,
+                        deleted: false,
+                        attachment: None,
+                        fields: fields("a-with-new-data"),
+                    },
+                    RemoteSettingsRecord {
+                        id: "c".into(),
+                        last_modified: 300,
+                        deleted: false,
+                        attachment: None,
+                        fields: fields("c"),
+                    },
+                    RemoteSettingsRecord {
+                        id: "d".into(),
+                        last_modified: 1300,
+                        deleted: false,
+                        attachment: None,
+                        fields: fields("d")
+                    },
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn test_file_cache() {
+        let tempfile = tempfile::NamedTempFile::new().unwrap();
+        let path = tempfile.path().to_str().unwrap().to_string();
+
+        // Opening a new file
+        let cache = RemoteSettingsCacheFile::new(path.clone()).unwrap();
+        assert_eq!(cache.get(), None);
+        cache.store(RemoteSettingsResponse {
+            last_modified: 1000,
+            records: vec![],
+        });
+        assert_eq!(
+            cache.get(),
+            Some(RemoteSettingsResponse {
+                last_modified: 1000,
+                records: vec![],
+            })
+        );
+        drop(cache);
+
+        // Test opening an existing file
+        let cache = RemoteSettingsCacheFile::new(path.clone()).unwrap();
+        assert_eq!(
+            cache.get(),
+            Some(RemoteSettingsResponse {
+                last_modified: 1000,
+                records: vec![],
+            })
+        );
+    }
+}

--- a/components/remote_settings/src/error.rs
+++ b/components/remote_settings/src/error.rs
@@ -6,7 +6,7 @@
 pub enum RemoteSettingsError {
     #[error("JSON Error: {0}")]
     JSONError(#[from] serde_json::Error),
-    #[error("Error writing downloaded attachment: {0}")]
+    #[error("File error: {0}")]
     FileError(#[from] std::io::Error),
     /// An error has occurred while sending a request.
     #[error("Error sending request: {0}")]

--- a/components/remote_settings/src/remote_settings.udl
+++ b/components/remote_settings/src/remote_settings.udl
@@ -61,6 +61,8 @@ interface RemoteSettings {
     constructor(RemoteSettingsConfig remote_settings_config);
 
     // Fetch all records for the configuration this client was initialized with.
+    //
+    // If a cache was setup, this will use the cache optimize the network requests
     [Throws=RemoteSettingsError]
     RemoteSettingsResponse get_records();
 
@@ -69,7 +71,53 @@ interface RemoteSettings {
     [Throws=RemoteSettingsError]
     RemoteSettingsResponse get_records_since(u64 timestamp);
 
+    // Get records from the cache, if present
+    //
+    // This method will only check the cache and not make any network requests.
+    // If a cache was not setup, this will always return null.
+    RemoteSettingsResponse? get_cached_records();
+
+    // Sync records with the cache
+    //
+    // This method fetches new records from the server and updates the cache.
+    // If a cache was not setup, this is a no-op
+    [Throws=RemoteSettingsError]
+    void sync_cached_records();
+
     // Download an attachment with the provided id to the provided path.
     [Throws=RemoteSettingsError]
     void download_attachment_to_path(string attachment_id, string path);
+};
+
+// Builder object for constructing a RemoteSettings instance
+interface RemoteSettingsBuilder {
+    constructor();
+
+    [Self=ByArc]
+    RemoteSettingsBuilder collection_name(string collection_name);
+
+    [Self=ByArc]
+    RemoteSettingsBuilder server(RemoteSettingsServer server);
+
+    [Self=ByArc]
+    RemoteSettingsBuilder bucket_name(string bucket_name);
+
+    // Setup a cache that writes to a file.
+    // This is the simplest way to enable caching support.
+    [Self=ByArc, Throws=RemoteSettingsError]
+    RemoteSettingsBuilder cache_file(string path);
+
+    // Setup cache using a callback interface that implements RemoteSettingsCache
+    [Self=ByArc]
+    RemoteSettingsBuilder cache(RemoteSettingsCache cache);
+
+    [Throws=RemoteSettingsError]
+    RemoteSettings build();
+};
+
+// Consumer-supplied interface for storing cached values for `get_cached_records`
+[Trait]
+interface RemoteSettingsCache {
+    void store(RemoteSettingsResponse value);
+    RemoteSettingsResponse? get();
 };


### PR DESCRIPTION
Continued from #6295.  This is an attempt to expose the caching API to consumers.

Added a builder API for constructing RemoteSettings instances.  Gave the builder a couple ways to enable caching support:
  - Simple method: specify a cache path
  - Advance method: implement the RemoteSettingsCache callback interface

If a cache is supplied then:
  - get_records() will use the cache for efficient network requests
  - Consumers can use the `get_cached_records` and `sync_cached_records` for extra control over when we hit the network.  This is useful for settings where typically only want to get the setting from cache and not hit the network.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
