### PR TITLE
Update to Glean v60.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full Changelog](In progress)
 
+### Glean
+- Updated to v60.5.0 ([#6339](https://github.com/mozilla/application-services/pull/6339))
+
 # v130.0 (_2024-08-05_)
 
 ## ✨ What's New ✨

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glean-build"
-version = "14.3.0"
+version = "14.5.1"
 dependencies = [
  "xshell-venv",
 ]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinx-coroutines = "1.8.0"
 
 # Mozilla
 android-components = "128.0.2"
-glean = "60.4.0"
+glean = "60.5.0"
 rust-android-gradle = "0.9.4"
 
 # AndroidX

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -1165,7 +1165,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 60.4.0;
+				minimumVersion = 60.5.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "4bea990fdaaeea98b7855ce682bfefa6a5acc04b",
-        "version" : "60.4.0"
+        "revision" : "2185e2eea2d5ce272ff5c0e851eed42d52104ce4",
+        "version" : "60.5.0"
       }
     }
   ],


### PR DESCRIPTION
It seems at the moment we need to coordinate this again, as I'm running into build problems when updating it only in m-c (https://bugzilla.mozilla.org/show_bug.cgi?id=1911767)

I suspect this might be due to our removal of service-glean and thus the changed dependency tree, but I'm not sure.
Regardless, this seems like an easy thing and we can land that tomorrow with the next a-s nightly.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
