### PR TITLE
Bug 1911903 - Fakespot keywords and product_type fields

### DIFF
--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -17,6 +17,7 @@ use sql_support::{open_database::open_database_with_flags, ConnExt};
 use crate::{
     config::{SuggestGlobalConfig, SuggestProviderConfig},
     error::RusqliteResultExt,
+    fakespot,
     keyword::full_keyword,
     pocket::{split_keyword, KeywordConfidence},
     provider::SuggestionProvider,
@@ -659,7 +660,9 @@ impl<'a> SuggestDao<'a> {
                 f.rating,
                 f.total_reviews,
                 i.data,
-                i.mimetype
+                i.mimetype,
+                f.keywords,
+                f.product_type
             FROM
                 suggestions s
             JOIN
@@ -678,10 +681,17 @@ impl<'a> SuggestDao<'a> {
             "#,
             (&query.fts_query(),),
             |row| {
+                let score = fakespot::FakespotScore::new(
+                    &query.keyword,
+                    row.get(9)?,
+                    row.get(10)?,
+                    row.get(2)?,
+                )
+                .as_suggest_score();
                 Ok(Suggestion::Fakespot {
                     title: row.get(0)?,
                     url: row.get(1)?,
-                    score: fakespot_suggestion_score(row.get(2)?),
+                    score,
                     fakespot_grade: row.get(3)?,
                     product_id: row.get(4)?,
                     rating: row.get(5)?,
@@ -1184,28 +1194,6 @@ impl<'a> FullKeywordInserter<'a> {
     }
 }
 
-/// Convert the score from the suggestions table for a Fakespot suggestion into the final score
-/// to use.
-///
-/// Fakespot suggestions have 2 different scores:
-///   - The Fakespot score comes from the Fakespot data set and is used to order Fakespot
-///     suggestions relative to each other.
-///   - The suggestion score is what we assign to the `Suggestion::Fakespot.score` field and is
-///     used by consumers to order suggestions of all types against each other.
-///
-/// This function calculates the suggestion score from the Fakespot score so that:
-///   - Suggestion scores for Fakespot suggestions are lower than Yelp suggestions
-///   - Suggestion scores for Fakespot suggestions are higher than all other suggestions
-///   - Suggestion scores for Fakespot suggestions reflect the Fakespot score, and ensure that
-///     Fakespot suggestions are correctly ordered against each other.
-///
-/// Since Yelp suggestions are always 0.25 and the next highest by suggestion type is MDN at
-/// 0.24, we pick a score that is 0.245 + the Fakespot score scaled down to [0, 0.001].
-#[inline(always)]
-fn fakespot_suggestion_score(fakespot_score: f64) -> f64 {
-    0.245 + fakespot_score / 1000.0
-}
-
 // ======================== Statement types ========================
 //
 // During ingestion we can insert hundreds of thousands of rows.  These types enable speedups by
@@ -1379,11 +1367,13 @@ impl<'conn> FakespotInsertStatement<'conn> {
                  suggestion_id,
                  fakespot_grade,
                  product_id,
+                 keywords,
+                 product_type,
                  rating,
                  total_reviews,
                  icon_id
              )
-             VALUES(?, ?, ?, ?, ?, ?)
+             VALUES(?, ?, ?, ?, ?, ?, ?, ?)
              ",
         )?))
     }
@@ -1402,6 +1392,8 @@ impl<'conn> FakespotInsertStatement<'conn> {
                 suggestion_id,
                 &fakespot.fakespot_grade,
                 &fakespot.product_id,
+                &fakespot.keywords.to_lowercase(),
+                &fakespot.product_type.to_lowercase(),
                 fakespot.rating,
                 fakespot.total_reviews,
                 icon_id,

--- a/components/suggest/src/fakespot.rs
+++ b/components/suggest/src/fakespot.rs
@@ -1,0 +1,225 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/// Fakespot-specific logic
+
+/// Score used to order Fakespot suggestions
+///
+/// FakespotScore contains several components, each in the range of [0, 1]
+pub struct FakespotScore {
+    /// Did the query match the `keywords` field exactly?
+    keywords_score: f64,
+    /// How well did the query match the `product_type` field?
+    product_type_score: f64,
+    /// Fakespot score from the RS data, this reflects the average review, number of reviews,
+    /// Fakespot grade, etc.
+    fakespot_score: f64,
+}
+
+impl FakespotScore {
+    pub fn new(query: &str, keywords: String, product_type: String, fakespot_score: f64) -> Self {
+        let query = query.to_lowercase();
+        let query_terms = split_terms(&query);
+        Self {
+            keywords_score: calc_keywords_score(&query_terms, &keywords),
+            product_type_score: calc_product_type_score(&query_terms, &product_type),
+            fakespot_score,
+        }
+    }
+
+    /// Convert a FakespotScore into the value to use in `Sugggestion::Fakespot::score`
+    ///
+    /// This converts FakespotScore into a single float that:
+    ///   - Is > 0.3 so that Fakespot suggestions are preferred to AMP ones
+    ///   - Reflects the Fakespot ordering:
+    ///     - Suggestions with higher keywords_score are greater
+    ///     - If keywords_score is tied, then suggestions with higher product_type_scores are greater
+    ///     - If both are tied, then suggestions with higher fakespot_score are greater
+    pub fn as_suggest_score(&self) -> f64 {
+        0.30 + (0.01 * self.keywords_score)
+            + (0.001 * self.product_type_score)
+            + (0.0001 * self.fakespot_score)
+    }
+}
+
+/// Split a string containing terms into a list of individual terms, normalized to lowercase
+fn split_terms(string: &str) -> Vec<&str> {
+    string.split_whitespace().collect()
+}
+
+fn calc_keywords_score(query_terms: &[&str], keywords: &str) -> f64 {
+    // Note: We can assume keywords is lower-case, since we do that during ingestion
+    let keyword_terms = split_terms(keywords);
+    if keyword_terms.is_empty() {
+        return 0.0;
+    }
+
+    if query_terms == keyword_terms {
+        1.0
+    } else {
+        0.0
+    }
+}
+
+fn calc_product_type_score(query_terms: &[&str], product_type: &str) -> f64 {
+    // Note: We can assume product_type is lower-case, since we do that during ingestion
+    let product_type_terms = split_terms(product_type);
+    if product_type_terms.is_empty() {
+        return 0.0;
+    }
+    let count = product_type_terms
+        .iter()
+        .filter(|t| query_terms.contains(t))
+        .count() as f64;
+    count / product_type_terms.len() as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct KeywordsTestCase {
+        keywords: &'static str,
+        query: &'static str,
+        expected: f64,
+    }
+
+    impl KeywordsTestCase {
+        fn test(&self) {
+            let actual =
+                calc_keywords_score(&split_terms(&self.query.to_lowercase()), self.keywords);
+            assert_eq!(
+                actual, self.expected,
+                "keywords: {} query: {} expected: {} actual: {actual}",
+                self.keywords, self.query, self.expected,
+            );
+        }
+    }
+
+    #[test]
+    fn test_keywords_score() {
+        // Keyword score 1.0 on exact matches, 0.0 otherwise
+        KeywordsTestCase {
+            keywords: "apple",
+            query: "apple",
+            expected: 1.0,
+        }
+        .test();
+        KeywordsTestCase {
+            keywords: "apple",
+            query: "android",
+            expected: 0.0,
+        }
+        .test();
+        KeywordsTestCase {
+            keywords: "apple",
+            query: "apple phone",
+            expected: 0.0,
+        }
+        .test();
+        // Empty keywords should always score 0.0
+        KeywordsTestCase {
+            keywords: "",
+            query: "",
+            expected: 0.0,
+        }
+        .test();
+        KeywordsTestCase {
+            keywords: "",
+            query: "apple",
+            expected: 0.0,
+        }
+        .test();
+        // Matching should be case insensitive
+        KeywordsTestCase {
+            keywords: "apple",
+            query: "Apple",
+            expected: 1.0,
+        }
+        .test();
+    }
+
+    struct ProductTypeTestCase {
+        query: &'static str,
+        product_type: &'static str,
+        expected: f64,
+    }
+    impl ProductTypeTestCase {
+        fn test(&self) {
+            let actual = calc_product_type_score(
+                &split_terms(&self.query.to_lowercase()),
+                self.product_type,
+            );
+            assert_eq!(
+                actual, self.expected,
+                "product_type: {} query: {} expected: {} actual: {actual}",
+                self.product_type, self.query, self.expected,
+            );
+        }
+    }
+
+    #[test]
+    fn test_product_type_score() {
+        // Product type scores based on the percentage of terms in the product type that are also
+        // present in the query
+        ProductTypeTestCase {
+            product_type: "standing desk",
+            query: "standing desk",
+            expected: 1.0,
+        }
+        .test();
+        ProductTypeTestCase {
+            product_type: "standing desk",
+            query: "desk",
+            expected: 0.5,
+        }
+        .test();
+        ProductTypeTestCase {
+            product_type: "standing desk",
+            query: "desk desk desk",
+            expected: 0.5,
+        }
+        .test();
+        ProductTypeTestCase {
+            product_type: "standing desk",
+            query: "standing",
+            expected: 0.5,
+        }
+        .test();
+        ProductTypeTestCase {
+            product_type: "standing desk",
+            query: "phone",
+            expected: 0.0,
+        }
+        .test();
+        // Extra terms in the query are ignored
+        ProductTypeTestCase {
+            product_type: "standing desk",
+            query: "standing desk for my office",
+            expected: 1.0,
+        }
+        .test();
+        // Empty product_type should always score 0.0
+        ProductTypeTestCase {
+            product_type: "",
+            query: "",
+            expected: 0.0,
+        }
+        .test();
+        // Matching should be case insensitive
+        ProductTypeTestCase {
+            product_type: "desk",
+            query: "Desk",
+            expected: 1.0,
+        }
+        .test();
+        // Extra spaces are ignored
+        ProductTypeTestCase {
+            product_type: "desk",
+            query: "  desk  ",
+            expected: 1.0,
+        }
+        .test();
+    }
+}

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -9,6 +9,7 @@ pub mod benchmarks;
 mod config;
 mod db;
 mod error;
+mod fakespot;
 mod keyword;
 mod metrics;
 pub mod pocket;

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -511,6 +511,8 @@ pub(crate) struct DownloadedMdnSuggestion {
 pub(crate) struct DownloadedFakespotSuggestion {
     pub fakespot_grade: String,
     pub product_id: String,
+    pub keywords: String,
+    pub product_type: String,
     pub rating: f64,
     pub score: f64,
     pub title: String,

--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -19,7 +19,7 @@ use sql_support::{
 ///     [`SuggestConnectionInitializer::upgrade_from`].
 ///    a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
 ///       the migration.
-pub const VERSION: u32 = 23;
+pub const VERSION: u32 = 24;
 
 /// The current Suggest database schema.
 pub const SQL: &str = "
@@ -93,6 +93,8 @@ CREATE TABLE fakespot_custom_details(
     suggestion_id INTEGER PRIMARY KEY,
     fakespot_grade TEXT NOT NULL,
     product_id TEXT NOT NULL,
+    keywords TEXT NOT NULL,
+    product_type TEXT NOT NULL,
     rating REAL NOT NULL,
     total_reviews INTEGER NOT NULL,
     icon_id TEXT,
@@ -356,6 +358,34 @@ CREATE VIRTUAL TABLE fakespot_fts USING FTS5(
   contentless_delete=1,
   tokenize=\"porter unicode61 remove_diacritics 2 tokenchars '''-'\"
 );
+                    ",
+                )?;
+                Ok(())
+            }
+            23 => {
+                // Drop all suggestions, then recreate the fakespot_custom_details table to add the
+                // `keywords` and `product_type` fields.
+                clear_database(tx)?;
+                tx.execute_batch(
+                    "
+DROP TABLE fakespot_custom_details;
+CREATE TABLE fakespot_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    fakespot_grade TEXT NOT NULL,
+    product_id TEXT NOT NULL,
+    keywords TEXT NOT NULL,
+    product_type TEXT NOT NULL,
+    rating REAL NOT NULL,
+    total_reviews INTEGER NOT NULL,
+    icon_id TEXT,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
+CREATE TRIGGER fakespot_ai AFTER INSERT ON fakespot_custom_details BEGIN
+  INSERT INTO fakespot_fts(rowid, title)
+    SELECT id, title
+    FROM suggestions
+    WHERE id = new.suggestion_id;
+END;
                     ",
                 )?;
                 Ok(())

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -106,12 +106,14 @@ impl Ord for Suggestion {
             Suggestion::Amp { score, .. }
             | Suggestion::Pocket { score, .. }
             | Suggestion::Amo { score, .. } => score,
+            Suggestion::Fakespot { score, .. } => score,
             _ => &DEFAULT_SUGGESTION_SCORE,
         };
         let b_score = match other {
             Suggestion::Amp { score, .. }
             | Suggestion::Pocket { score, .. }
             | Suggestion::Amo { score, .. } => score,
+            Suggestion::Fakespot { score, .. } => score,
             _ => &DEFAULT_SUGGESTION_SCORE,
         };
         b_score
@@ -172,6 +174,30 @@ impl Suggestion {
             | Self::Fakespot { icon, .. } => icon.as_deref(),
             _ => None,
         }
+    }
+}
+
+#[cfg(test)]
+/// Testing utilitise
+impl Suggestion {
+    pub fn with_fakespot_keyword_bonus(mut self) -> Self {
+        match &mut self {
+            Self::Fakespot { score, .. } => {
+                *score += 0.01;
+            }
+            _ => panic!("Not Suggestion::Fakespot"),
+        }
+        self
+    }
+
+    pub fn with_fakespot_product_type_bonus(mut self, bonus: f64) -> Self {
+        match &mut self {
+            Self::Fakespot { score, .. } => {
+                *score += 0.001 * bonus;
+            }
+            _ => panic!("Not Suggestion::Fakespot"),
+        }
+        self
     }
 }
 

--- a/components/suggest/src/testing/data.rs
+++ b/components/suggest/src/testing/data.rs
@@ -456,6 +456,8 @@ pub fn snowglobe_fakespot() -> JsonValue {
     json!({
         "fakespot_grade": "B",
         "product_id": "amazon-ABC",
+        "keywords": "",
+        "product_type": "snow globe",
         "rating": 4.7,
         "score": 0.8,
         "title": "Make Your Own Glitter Snow Globes",
@@ -472,9 +474,7 @@ pub fn snowglobe_suggestion() -> Suggestion {
         title: "Make Your Own Glitter Snow Globes".into(),
         total_reviews: 152,
         url: "http://amazon.com/dp/ABC".into(),
-        // The base score for Fakespot suggestions is 0.245, this should get an extra 0.0008 since
-        // the fakespot score is 0.8
-        score: 0.2458,
+        score: 0.3 + 0.00008,
         icon: Some("fakespot-icon-amazon-data".as_bytes().to_vec()),
         icon_mimetype: Some("image/png".into()),
     }
@@ -486,6 +486,8 @@ pub fn simpsons_fakespot() -> JsonValue {
         // Use a product ID that doesn't match the ingested icons to test what happens.  In this
         // case, icon and icon_mimetype for the returned Suggestion should both be None.
         "product_id": "vendorwithouticon-XYZ",
+        "keywords": "",
+        "product_type": "",
         "rating": 4.9,
         "score": 0.9,
         "title": "The Simpsons: Skinner's Sense of Snow (DVD)",
@@ -502,9 +504,7 @@ pub fn simpsons_suggestion() -> Suggestion {
         title: "The Simpsons: Skinner's Sense of Snow (DVD)".into(),
         total_reviews: 14000,
         url: "http://vendorwithouticon.com/dp/XYZ".into(),
-        // The base score for Fakespot suggestions is 0.245, this should get an extra 0.0009 since
-        // the fakespot score is 0.9.
-        score: 0.2459,
+        score: 0.3 + 0.00009,
         icon: None,
         icon_mimetype: None,
     }


### PR DESCRIPTION
Added support for ingesting these fields and using them to order the fakespot suggestions.  The fakespot scoring was getting complicated enough that I split it out into its own module.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
