### PR TITLE
Bug 1893086 - Port the potential impressions framework to the suggest component

### DIFF
--- a/components/suggest/src/benchmarks/query.rs
+++ b/components/suggest/src/benchmarks/query.rs
@@ -40,7 +40,7 @@ impl BenchmarkWithInput for QueryBenchmark {
         InputType(SuggestionQuery {
             providers: vec![self.provider],
             keyword: self.query.to_string(),
-            limit: None,
+            ..SuggestionQuery::default()
         })
     }
 

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -13,7 +13,7 @@ use rusqlite::{
     types::{FromSql, ToSql},
     Connection, OpenFlags, OptionalExtension,
 };
-use sql_support::{open_database::open_database_with_flags, ConnExt};
+use sql_support::{open_database::open_database_with_flags, repeat_sql_vars, ConnExt};
 
 use crate::{
     config::{SuggestGlobalConfig, SuggestProviderConfig},
@@ -24,8 +24,9 @@ use crate::{
     provider::SuggestionProvider,
     rs::{
         DownloadedAmoSuggestion, DownloadedAmpSuggestion, DownloadedAmpWikipediaSuggestion,
-        DownloadedFakespotSuggestion, DownloadedMdnSuggestion, DownloadedPocketSuggestion,
-        DownloadedWeatherData, DownloadedWikipediaSuggestion, Record, SuggestRecordId,
+        DownloadedExposureSuggestion, DownloadedFakespotSuggestion, DownloadedMdnSuggestion,
+        DownloadedPocketSuggestion, DownloadedWeatherData, DownloadedWikipediaSuggestion, Record,
+        SuggestRecordId,
     },
     schema::{clear_database, SuggestConnectionInitializer},
     suggestion::{cook_raw_suggestion_url, AmpSuggestionType, Suggestion},
@@ -805,6 +806,67 @@ impl<'a> SuggestDao<'a> {
         )
     }
 
+    /// Fetches exposure suggestions
+    pub fn fetch_exposure_suggestions(&self, query: &SuggestionQuery) -> Result<Vec<Suggestion>> {
+        // A single exposure suggestion can be spread across multiple remote
+        // settings records, for example if it has very many keywords. On ingest
+        // we will insert one row in `exposure_custom_details` and one row in
+        // `suggestions` per record, but that's only an implementation detail.
+        // Logically, and for consumers, there's only ever at most one exposure
+        // suggestion with a given exposure suggestion type.
+        //
+        // Why do insertions this way? It's how other suggestions work, and it
+        // lets us perform relational operations on suggestions, records, and
+        // keywords. For example, when a record is deleted we can look up its ID
+        // in `suggestions`, join the keywords table on the suggestion ID, and
+        // delete the keywords that were added by that record.
+
+        let Some(suggestion_types) = query
+            .provider_constraints
+            .as_ref()
+            .and_then(|c| c.exposure_suggestion_types.as_ref())
+        else {
+            return Ok(vec![]);
+        };
+
+        let keyword = query.keyword.to_lowercase();
+        let params = rusqlite::params_from_iter(
+            std::iter::once(&SuggestionProvider::Exposure as &dyn ToSql)
+                .chain(std::iter::once(&keyword as &dyn ToSql))
+                .chain(suggestion_types.iter().map(|t| t as &dyn ToSql)),
+        );
+        self.conn.query_rows_and_then_cached(
+            &format!(
+                r#"
+                    SELECT DISTINCT
+                      d.type
+                    FROM
+                      suggestions s
+                    JOIN
+                      exposure_custom_details d
+                      ON d.suggestion_id = s.id
+                    JOIN
+                      keywords k
+                      ON k.suggestion_id = s.id
+                    WHERE
+                      s.provider = ?
+                      AND k.keyword = ?
+                      AND d.type IN ({})
+                    ORDER BY
+                      d.type
+                    "#,
+                repeat_sql_vars(suggestion_types.len())
+            ),
+            params,
+            |row| -> Result<Suggestion> {
+                Ok(Suggestion::Exposure {
+                    suggestion_type: row.get("type")?,
+                    score: 1.0,
+                })
+            },
+        )
+    }
+
     /// Inserts all suggestions from a downloaded AMO attachment into
     /// the database.
     pub fn insert_amo_suggestions(
@@ -1055,6 +1117,39 @@ impl<'a> SuggestDao<'a> {
             SuggestionProvider::Weather,
             &SuggestProviderConfig::from(data),
         )?;
+        Ok(())
+    }
+
+    /// Inserts exposure suggestion records data into the database.
+    pub fn insert_exposure_suggestions(
+        &mut self,
+        record_id: &SuggestRecordId,
+        suggestion_type: &str,
+        suggestions: &[DownloadedExposureSuggestion],
+    ) -> Result<()> {
+        // `suggestion.keywords()` can yield duplicates for exposure
+        // suggestions, so ignore failures on insert in the uniqueness
+        // constraint on `(suggestion_id, keyword)`.
+        let mut keyword_insert = KeywordInsertStatement::new_with_or_ignore(self.conn)?;
+        let mut suggestion_insert = SuggestionInsertStatement::new(self.conn)?;
+        let mut exposure_insert = ExposureInsertStatement::new(self.conn)?;
+        for suggestion in suggestions {
+            self.scope.err_if_interrupted()?;
+            let suggestion_id = suggestion_insert.execute(
+                record_id,
+                "", // title, not used by exposure suggestions
+                "", // url, not used by exposure suggestions
+                DEFAULT_SUGGESTION_SCORE,
+                SuggestionProvider::Exposure,
+            )?;
+            exposure_insert.execute(suggestion_id, suggestion_type)?;
+
+            // Exposure suggestions don't use `rank` but `(suggestion_id, rank)`
+            // must be unique since there's an index on that tuple.
+            for (rank, keyword) in suggestion.keywords().enumerate() {
+                keyword_insert.execute(suggestion_id, &keyword, None, rank)?;
+            }
+        }
         Ok(())
     }
 
@@ -1498,12 +1593,47 @@ impl<'conn> FakespotInsertStatement<'conn> {
     }
 }
 
+struct ExposureInsertStatement<'conn>(rusqlite::Statement<'conn>);
+
+impl<'conn> ExposureInsertStatement<'conn> {
+    fn new(conn: &'conn Connection) -> Result<Self> {
+        Ok(Self(conn.prepare(
+            "INSERT INTO exposure_custom_details(
+                 suggestion_id,
+                 type
+             )
+             VALUES(?, ?)
+             ",
+        )?))
+    }
+
+    fn execute(&mut self, suggestion_id: i64, suggestion_type: &str) -> Result<()> {
+        self.0
+            .execute((suggestion_id, suggestion_type))
+            .with_context("exposure insert")?;
+        Ok(())
+    }
+}
+
 struct KeywordInsertStatement<'conn>(rusqlite::Statement<'conn>);
 
 impl<'conn> KeywordInsertStatement<'conn> {
     fn new(conn: &'conn Connection) -> Result<Self> {
         Ok(Self(conn.prepare(
             "INSERT INTO keywords(
+                 suggestion_id,
+                 keyword,
+                 full_keyword_id,
+                 rank
+             )
+             VALUES(?, ?, ?, ?)
+             ",
+        )?))
+    }
+
+    fn new_with_or_ignore(conn: &'conn Connection) -> Result<Self> {
+        Ok(Self(conn.prepare(
+            "INSERT OR IGNORE INTO keywords(
                  suggestion_id,
                  keyword,
                  full_keyword_id,

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -26,7 +26,7 @@ mod yelp;
 pub use config::{SuggestGlobalConfig, SuggestProviderConfig};
 pub use error::SuggestApiError;
 pub use metrics::{LabeledTimingSample, SuggestIngestionMetrics};
-pub use provider::SuggestionProvider;
+pub use provider::{SuggestionProvider, SuggestionProviderConstraints};
 pub use query::{QueryWithMetricsResult, SuggestionQuery};
 pub use store::{InterruptKind, SuggestIngestionConstraints, SuggestStore, SuggestStoreBuilder};
 pub use suggestion::{raw_suggestion_url_matches, Suggestion};

--- a/components/suggest/src/provider.rs
+++ b/components/suggest/src/provider.rs
@@ -12,6 +12,17 @@ use rusqlite::{
 
 use crate::rs::SuggestRecordType;
 
+/// Record types from these providers will be ingested when consumers do not
+/// specify providers in `SuggestIngestionConstraints`.
+pub(crate) const DEFAULT_INGEST_PROVIDERS: [SuggestionProvider; 6] = [
+    SuggestionProvider::Amp,
+    SuggestionProvider::Wikipedia,
+    SuggestionProvider::Amo,
+    SuggestionProvider::Yelp,
+    SuggestionProvider::Mdn,
+    SuggestionProvider::AmpMobile,
+];
+
 /// A provider is a source of search suggestions.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 #[repr(u8)]
@@ -25,6 +36,7 @@ pub enum SuggestionProvider {
     Weather = 7,
     AmpMobile = 8,
     Fakespot = 9,
+    Exposure = 10,
 }
 
 impl fmt::Display for SuggestionProvider {
@@ -39,6 +51,7 @@ impl fmt::Display for SuggestionProvider {
             Self::Weather => write!(f, "weather"),
             Self::AmpMobile => write!(f, "ampmobile"),
             Self::Fakespot => write!(f, "fakespot"),
+            Self::Exposure => write!(f, "exposure"),
         }
     }
 }
@@ -54,7 +67,7 @@ impl FromSql for SuggestionProvider {
 }
 
 impl SuggestionProvider {
-    pub fn all() -> [Self; 9] {
+    pub fn all() -> [Self; 10] {
         [
             Self::Amp,
             Self::Wikipedia,
@@ -65,36 +78,39 @@ impl SuggestionProvider {
             Self::Weather,
             Self::AmpMobile,
             Self::Fakespot,
+            Self::Exposure,
         ]
     }
 
     #[inline]
     pub(crate) fn from_u8(v: u8) -> Option<Self> {
         match v {
-            1 => Some(SuggestionProvider::Amp),
-            2 => Some(SuggestionProvider::Wikipedia),
-            3 => Some(SuggestionProvider::Amo),
-            4 => Some(SuggestionProvider::Pocket),
-            5 => Some(SuggestionProvider::Yelp),
-            6 => Some(SuggestionProvider::Mdn),
-            7 => Some(SuggestionProvider::Weather),
-            8 => Some(SuggestionProvider::AmpMobile),
-            9 => Some(SuggestionProvider::Fakespot),
+            1 => Some(Self::Amp),
+            2 => Some(Self::Wikipedia),
+            3 => Some(Self::Amo),
+            4 => Some(Self::Pocket),
+            5 => Some(Self::Yelp),
+            6 => Some(Self::Mdn),
+            7 => Some(Self::Weather),
+            8 => Some(Self::AmpMobile),
+            9 => Some(Self::Fakespot),
+            10 => Some(Self::Exposure),
             _ => None,
         }
     }
 
     pub(crate) fn record_type(&self) -> SuggestRecordType {
         match self {
-            SuggestionProvider::Amp => SuggestRecordType::AmpWikipedia,
-            SuggestionProvider::Wikipedia => SuggestRecordType::AmpWikipedia,
-            SuggestionProvider::Amo => SuggestRecordType::Amo,
-            SuggestionProvider::Pocket => SuggestRecordType::Pocket,
-            SuggestionProvider::Yelp => SuggestRecordType::Yelp,
-            SuggestionProvider::Mdn => SuggestRecordType::Mdn,
-            SuggestionProvider::Weather => SuggestRecordType::Weather,
-            SuggestionProvider::AmpMobile => SuggestRecordType::AmpMobile,
-            SuggestionProvider::Fakespot => SuggestRecordType::Fakespot,
+            Self::Amp => SuggestRecordType::AmpWikipedia,
+            Self::Wikipedia => SuggestRecordType::AmpWikipedia,
+            Self::Amo => SuggestRecordType::Amo,
+            Self::Pocket => SuggestRecordType::Pocket,
+            Self::Yelp => SuggestRecordType::Yelp,
+            Self::Mdn => SuggestRecordType::Mdn,
+            Self::Weather => SuggestRecordType::Weather,
+            Self::AmpMobile => SuggestRecordType::AmpMobile,
+            Self::Fakespot => SuggestRecordType::Fakespot,
+            Self::Exposure => SuggestRecordType::Exposure,
         }
     }
 }
@@ -103,4 +119,9 @@ impl ToSql for SuggestionProvider {
     fn to_sql(&self) -> RusqliteResult<ToSqlOutput<'_>> {
         Ok(ToSqlOutput::from(*self as u8))
     }
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct SuggestionProviderConstraints {
+    pub exposure_suggestion_types: Option<Vec<String>>,
 }

--- a/components/suggest/src/query.rs
+++ b/components/suggest/src/query.rs
@@ -2,13 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::{LabeledTimingSample, Suggestion, SuggestionProvider};
+use crate::{LabeledTimingSample, Suggestion, SuggestionProvider, SuggestionProviderConstraints};
 
 /// A query for suggestions to show in the address bar.
 #[derive(Clone, Debug, Default)]
 pub struct SuggestionQuery {
     pub keyword: String,
     pub providers: Vec<SuggestionProvider>,
+    pub provider_constraints: Option<SuggestionProviderConstraints>,
     pub limit: Option<i32>,
 }
 
@@ -24,7 +25,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.to_string(),
             providers: Vec::from(SuggestionProvider::all()),
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -32,7 +33,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.to_string(),
             providers,
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -50,7 +51,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.into(),
             providers: vec![SuggestionProvider::Amp],
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -58,7 +59,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.into(),
             providers: vec![SuggestionProvider::Wikipedia],
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -66,7 +67,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.into(),
             providers: vec![SuggestionProvider::AmpMobile],
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -74,7 +75,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.into(),
             providers: vec![SuggestionProvider::Amo],
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -82,7 +83,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.into(),
             providers: vec![SuggestionProvider::Pocket],
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -90,7 +91,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.into(),
             providers: vec![SuggestionProvider::Yelp],
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -98,7 +99,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.into(),
             providers: vec![SuggestionProvider::Mdn],
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -106,7 +107,7 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.into(),
             providers: vec![SuggestionProvider::Fakespot],
-            limit: None,
+            ..Self::default()
         }
     }
 
@@ -114,7 +115,20 @@ impl SuggestionQuery {
         Self {
             keyword: keyword.into(),
             providers: vec![SuggestionProvider::Weather],
-            limit: None,
+            ..Self::default()
+        }
+    }
+
+    pub fn exposure(keyword: &str, suggestion_types: &[&str]) -> Self {
+        Self {
+            keyword: keyword.into(),
+            providers: vec![SuggestionProvider::Exposure],
+            provider_constraints: Some(SuggestionProviderConstraints {
+                exposure_suggestion_types: Some(
+                    suggestion_types.iter().map(|s| s.to_string()).collect(),
+                ),
+            }),
+            ..Self::default()
         }
     }
 

--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -19,7 +19,7 @@ use sql_support::{
 ///     [`SuggestConnectionInitializer::upgrade_from`].
 ///    a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
 ///       the migration.
-pub const VERSION: u32 = 25;
+pub const VERSION: u32 = 26;
 
 /// The current Suggest database schema.
 pub const SQL: &str = "
@@ -170,6 +170,13 @@ CREATE TABLE mdn_custom_details(
     description TEXT NOT NULL,
     FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
 );
+
+CREATE TABLE exposure_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    type TEXT NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
+CREATE INDEX exposure_custom_details_type ON exposure_custom_details(type);
 
 CREATE TABLE dismissed_suggestions (
     url TEXT PRIMARY KEY
@@ -419,6 +426,20 @@ CREATE TABLE ingested_records(
     last_modified INTEGER NOT NULL,
     PRIMARY KEY (id, collection)
 ) WITHOUT ROWID;
+                    ",
+                )?;
+                Ok(())
+            }
+            25 => {
+                // Create the exposure suggestions table and index.
+                tx.execute_batch(
+                    "
+CREATE TABLE exposure_custom_details(
+    suggestion_id INTEGER PRIMARY KEY,
+    type TEXT NOT NULL,
+    FOREIGN KEY(suggestion_id) REFERENCES suggestions(id) ON DELETE CASCADE
+);
+CREATE INDEX exposure_custom_details_type ON exposure_custom_details(type);
                     ",
                 )?;
                 Ok(())

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -35,6 +35,7 @@ enum SuggestionProvider {
     "Weather",
     "AmpMobile",
     "Fakespot",
+    "Exposure",
 };
 
 [Enum]
@@ -107,16 +108,22 @@ interface Suggestion {
         string? icon_mimetype,
         f64 score
     );
+    Exposure(
+        string suggestion_type,
+        f64 score
+    );
 };
 
 dictionary SuggestionQuery {
     string keyword;
     sequence<SuggestionProvider> providers;
+    SuggestionProviderConstraints? provider_constraints = null;
     i32? limit = null;
 };
 
 dictionary SuggestIngestionConstraints {
     sequence<SuggestionProvider>? providers = null;
+    SuggestionProviderConstraints? provider_constraints = null;
     // Only ingest if the table `suggestions` is empty.
     //
     // This is indented to handle periodic updates.  Consumers can schedule an ingest with
@@ -125,6 +132,15 @@ dictionary SuggestIngestionConstraints {
     // there is a schema upgrade that causes the database to be thrown away, then the
     // `empty_only=true` ingestion that runs on startup will repopulate it.
     boolean empty_only = false;
+};
+
+// Some providers manage multiple suggestion subtypes. Queries, ingests, and
+// other operations on those providers must be constrained to a desired subtype.
+dictionary SuggestionProviderConstraints {
+    // `Exposure` provider - For each desired exposure suggestion type, this
+    // should contain the value of the `suggestion_type` field of its remote
+    // settings record(s).
+    sequence<string>? exposure_suggestion_types = null;
 };
 
 dictionary SuggestIngestionMetrics {

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -92,6 +92,10 @@ pub enum Suggestion {
         icon_mimetype: Option<String>,
         score: f64,
     },
+    Exposure {
+        suggestion_type: String,
+        score: f64,
+    },
 }
 
 impl PartialOrd for Suggestion {
@@ -102,22 +106,9 @@ impl PartialOrd for Suggestion {
 
 impl Ord for Suggestion {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        let a_score = match self {
-            Suggestion::Amp { score, .. }
-            | Suggestion::Pocket { score, .. }
-            | Suggestion::Amo { score, .. } => score,
-            Suggestion::Fakespot { score, .. } => score,
-            _ => &DEFAULT_SUGGESTION_SCORE,
-        };
-        let b_score = match other {
-            Suggestion::Amp { score, .. }
-            | Suggestion::Pocket { score, .. }
-            | Suggestion::Amo { score, .. } => score,
-            Suggestion::Fakespot { score, .. } => score,
-            _ => &DEFAULT_SUGGESTION_SCORE,
-        };
-        b_score
-            .partial_cmp(a_score)
+        other
+            .score()
+            .partial_cmp(&self.score())
             .unwrap_or(std::cmp::Ordering::Equal)
     }
 }
@@ -160,9 +151,9 @@ impl Suggestion {
             | Self::Wikipedia { title, .. }
             | Self::Amo { title, .. }
             | Self::Yelp { title, .. }
-            | Self::Mdn { title, .. } => title,
-            Self::Weather { .. } => "weather",
-            Self::Fakespot { title, .. } => title,
+            | Self::Mdn { title, .. }
+            | Self::Fakespot { title, .. } => title,
+            _ => "untitled",
         }
     }
 
@@ -173,6 +164,20 @@ impl Suggestion {
             | Self::Yelp { icon, .. }
             | Self::Fakespot { icon, .. } => icon.as_deref(),
             _ => None,
+        }
+    }
+
+    pub fn score(&self) -> f64 {
+        match self {
+            Self::Amp { score, .. }
+            | Self::Pocket { score, .. }
+            | Self::Amo { score, .. }
+            | Self::Yelp { score, .. }
+            | Self::Mdn { score, .. }
+            | Self::Weather { score, .. }
+            | Self::Fakespot { score, .. }
+            | Self::Exposure { score, .. } => *score,
+            Self::Wikipedia { .. } => DEFAULT_SUGGESTION_SCORE,
         }
     }
 }

--- a/components/suggest/src/testing/mod.rs
+++ b/components/suggest/src/testing/mod.rs
@@ -43,6 +43,7 @@ impl Suggestion {
             Self::Weather { score, .. } => score,
             Self::Wikipedia { .. } => panic!("with_score not valid for wikipedia suggestions"),
             Self::Fakespot { score, .. } => score,
+            Self::Exposure { score, .. } => score,
         };
         *current_score = score;
         self

--- a/examples/suggest-cli/src/main.rs
+++ b/examples/suggest-cli/src/main.rs
@@ -186,7 +186,7 @@ fn query(
             None => SuggestionProvider::all().to_vec(),
         },
         keyword: input,
-        limit: None,
+        ..SuggestionQuery::default()
     };
     let mut results = store
         .query_with_metrics(query)


### PR DESCRIPTION
This is a redo of #6211 and has some substantial changes from that, but overall it's very similar. It implements a new type of suggestion called exposure suggestions. In #6211 they were called phantom suggestions, but I think "exposure" is a better name.

In summary, exposure suggestions can be matched on a subtype in addition to being matched on keyword. (The subtype is called `exposure_suggestion_type` throughout this commit.) Exposure suggestions in remote settings define a subtype, and suggest consumers pass in a subtype at query time to match suggestions only of that subtype. No code changes are required to support new subtypes. Exposure suggestions are intended to be used with telemetry implemented in the consumer to quickly and easily test potential exposures of hypothetical suggestion types.

Differences between this commit and #6211:

* As mentioned, rename "phantom" to "exposure"
* Implement a keyword-matching strategy instead of leaving it as a to-do (more on this below)
* Add `exposure_suggestion_type` to ingest constraints so consumers don't have to ingest all exposure suggestions, only the subtype they're interested in. This is parallel to how consumers pass in `exposure_suggestion_type` at query time. The way this works is, RS records for exposure suggestions are expected to have a `exposure_suggestion_type` inline field, and we pass the type in the RS request.
* Don't include a `matched_keyword` in the suggestion returned to the consumer. I found we don't actually need it.

### Keyword-matching strategy

The strategy is informed by the first two use cases for potential exposures on desktop, translation and VPN suggestions. In both cases, we have a large list of keywords and prefixes of those keywords. Prefix keywords don't necessarily start with the first word, unlike AMO, Pocket, and other suggestion types that use the `prefix_keywords` table. So at query time, we don't know how to break down a query into a prefix and a rest-of-the-query in order to do the lookup.

This commit expects all keywords for an exposure suggestion, including prefix keywords, to be defined in the remote settings data, and it ingests them into the `keywords` table. At query time, it does a simple lookup into that table, like how AMP suggestions work. It doesn't keep track of "full keywords" like AMP does (in the `full_keywords` table) since they don't matter here. For exposure suggestions, keywords are just keywords, prefix or not.

The format of the keywords in the RS data is a little novel. The keywords list can contain full keyword strings for keywords that don't have prefixes. It can also contain tuples, which are used as a compact way to represent a starting prefix keyword and all the other keywords associated with that prefix. There's a code comment in rs.rs above `FullOrPrefixKeywords` that explains, and `test_exposure_keywords` in that file has examples.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
