### PR TITLE
Generate static website docs from swift components

### DIFF
--- a/.github/workflows/swift-docs.yaml
+++ b/.github/workflows/swift-docs.yaml
@@ -1,0 +1,49 @@
+name: Generate Swift Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        run: |
+          RUSTUP_PLATFORM=x86_64-apple-darwin
+          RUSTUP_VERSION=1.27.0
+          curl -sfSL --retry 5 --retry-delay 10 -O "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_PLATFORM}/rustup-init"
+          chmod +x rustup-init
+          ./rustup-init -y --no-modify-path
+          rm rustup-init
+          echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $GITHUB_ENV
+          source $HOME/.cargo/env
+
+      - name: Set up Ruby environment
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Install Jazzy
+        run: gem install jazzy
+
+      - name: Run build script
+        run: |
+          cd ./automation/swift-components-docs
+          ./build.sh
+
+      - name: Deploy
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan swift-docs
+          git --work-tree automation/swift-components-docs/docs add --all
+          git --work-tree automation/swift-components-docs/docs commit -m "Deploy Swift docs"
+          git push origin HEAD:swift-docs --force

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,11 @@ cirrus.py
 fml.py
 *.dylib
 *.so
+
+# Build static website files
+automation/swift-components-docs/.build
+automation/swift-components-docs/docs
+automation/swift-components-docs/Sources/SwiftComponents/*.swift
+automation/swift-components-docs/Sources/SwiftComponents/include/*.h
+
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4160,6 +4160,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "swift_components_docs"
+version = "0.1.0"
+dependencies = [
+ "megazord_ios",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ members = [
     "megazords/ios-rust/focus",
     "tools/protobuf-gen",
     "tools/embedded-uniffi-bindgen",
+    "automation/swift-components-docs",
 
     "examples/*/",
     "testing/separated/*/",

--- a/automation/swift-components-docs/Cargo.toml
+++ b/automation/swift-components-docs/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "swift_components_docs"
+edition = "2021"
+version = "0.1.0"
+authors = ["Sync Team <sync-team@mozilla.com>"]
+license = "MPL-2.0"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+megazord_ios = { path = "../../megazords/ios-rust" }

--- a/automation/swift-components-docs/Package.swift
+++ b/automation/swift-components-docs/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.6
+import PackageDescription
+
+let package = Package(
+    name: "RustComponents",
+    targets: [
+        .target(
+            name: "SwiftComponents",
+            dependencies: [],
+            path: "Sources/SwiftComponents",
+            publicHeadersPath: "include", // SPM will look here for your module.modulemap
+            cSettings: [
+                .headerSearchPath("include"),
+                .define("MODULE_MAP", to: "include/module.modulemap")
+            ]
+        ),
+    ]
+)

--- a/automation/swift-components-docs/Sources/SwiftComponents/include/module.modulemap
+++ b/automation/swift-components-docs/Sources/SwiftComponents/include/module.modulemap
@@ -1,0 +1,19 @@
+module MozillaRustComponents {
+    header "suggestFFI.h"
+    header "as_ohttp_clientFFI.h"
+    header "autofillFFI.h"
+    header "crashtestFFI.h"
+    header "errorFFI.h"
+    header "fxa_clientFFI.h"
+    header "loginsFFI.h"
+    header "nimbusFFI.h"
+    header "placesFFI.h"
+    header "pushFFI.h"
+    header "remote_settingsFFI.h"
+    header "rustlogforwarderFFI.h"
+    header "sync15FFI.h"
+    header "syncmanagerFFI.h"
+    header "tabsFFI.h"
+
+    export *
+}

--- a/automation/swift-components-docs/build.sh
+++ b/automation/swift-components-docs/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Set the script to exit if any command fails
+set -e
+
+# Run the generate-swift-project.sh script
+echo "Running generate-swift-project.sh..."
+./generate-swift-project.sh
+
+# Run the build-static-website.sh script
+echo "Running generate-static-docs-website.sh..."
+./generate-static-docs-website.sh
+
+echo "All scripts executed successfully."
+

--- a/automation/swift-components-docs/generate-static-docs-website.sh
+++ b/automation/swift-components-docs/generate-static-docs-website.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Run jazzy with the --clean option
+jazzy --clean
+
+# Check if jazzy command was successful
+if jazzy --clean; then
+    echo "Documentation generated successfully and cleaned up previous output."
+else
+    echo "Failed to generate documentation."
+fi

--- a/automation/swift-components-docs/generate-swift-project.sh
+++ b/automation/swift-components-docs/generate-swift-project.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# This script builds the Rust crate in its directory and generates Swift bindings, headers, and a module map.
+
+FRAMEWORK_NAME="SwiftComponents"
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+REPO_ROOT="$( dirname "$( dirname "$THIS_DIR" )" )"
+WORKING_DIR=$THIS_DIR
+
+MANIFEST_PATH="$WORKING_DIR/Cargo.toml"
+
+if [[ ! -f "$MANIFEST_PATH" ]]; then
+  echo "Could not locate Cargo.toml in $MANIFEST_PATH"
+  exit 1
+fi
+
+CRATE_NAME=$(grep --max-count=1 '^name =' "$MANIFEST_PATH" | cut -d '"' -f 2)
+if [[ -z "$CRATE_NAME" ]]; then
+  echo "Could not determine crate name from $MANIFEST_PATH"
+  exit 1
+fi
+
+# Helper to run the cargo build command in a controlled environment.
+# It's important that we don't let environment variables from the user's default
+# desktop build environment leak into the iOS build, otherwise it might e.g.
+# link against the desktop build of NSS.
+
+CARGO="$HOME/.cargo/bin/cargo"
+LIBS_DIR="$REPO_ROOT/libs"
+
+cargo_build () {
+  LIBS_DIR="$REPO_ROOT/libs/ios/arm64"
+
+  env -i \
+    NSS_STATIC=1 \
+    NSS_DIR="$LIBS_DIR/nss" \
+    PATH="${PATH}"
+}
+
+set -euvx
+
+cargo_build aarch64-apple-ios
+
+# Create directories for Swift files, headers, and module map
+INCLUDE_DIR="$WORKING_DIR/Sources/$FRAMEWORK_NAME/include"
+SWIFT_DIR="$WORKING_DIR/Sources/$FRAMEWORK_NAME"
+
+mkdir -p "$INCLUDE_DIR"
+
+# Generate Swift bindings and headers using uniffi-bindgen
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/remote_settings/src/remote_settings.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/error/src/errorsupport.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/rust-log-forwarder/src/rust_log_forwarder.udl" -l swift -o "$SWIFT_DIR"
+
+# Move header files to the include directory
+mv "$SWIFT_DIR"/*.h "$INCLUDE_DIR"
+
+# Repeat for the other components if not focus
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/crashtest/src/crashtest.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/fxa-client/src/fxa_client.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/logins/src/logins.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/autofill/src/autofill.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/push/src/push.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/tabs/src/tabs.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/places/src/places.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/suggest/src/suggest.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync_manager/src/syncmanager.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync15/src/sync15.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen generate "$REPO_ROOT/components/as-ohttp-client/src/as_ohttp_client.udl" -l swift -o "$SWIFT_DIR"
+
+# Move the header files to the include directory
+mv "$SWIFT_DIR"/*.h "$INCLUDE_DIR"
+
+rm -rf "$WORKING_DIR"/Sources/"$FRAMEWORK_NAME"/*.modulemap
+
+echo "Successfully generated Swift bindings, headers, and module map."

--- a/automation/swift-components-docs/src/lib.rs
+++ b/automation/swift-components-docs/src/lib.rs
@@ -1,0 +1,8 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#![allow(unknown_lints)]
+#![warn(rust_2018_idioms)]
+
+pub use megazord_ios::*;

--- a/megazords/ios-rust/Cargo.toml
+++ b/megazords/ios-rust/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Sync Team <sync-team@mozilla.com>"]
 license = "MPL-2.0"
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 rust-log-forwarder = { path = "../../components/support/rust-log-forwarder" }


### PR DESCRIPTION
This PR is a first step in building static-website docs for the Swift components produced by `application-services`. 

It adds a new folder inside `automation`. Inside, we build a new Swift project, with all the `.swift` and `.h` files from the output of `uniffi-bindgen`. We have to manipulate a few things to make it work, and provide a fixed `module.modulemap` and `Package.swift`.

In the end, we use `jazzy` to generate the documentation.


## Feedback

I decided to move this to this repo instead of `rust-components-swift`, because it feels closer to the source, and we really just need the output of `uniffi-bindgen` to build this. No `Xcframework` or `Xcodeproject` needed.

## Outcome (local)
<img width="1007" alt="Screenshot 2024-08-29 at 09 26 25" src="https://github.com/user-attachments/assets/12057ea1-2825-4547-83c9-88febb0cb067">

