### PR TITLE
Return non-zero exit code when symbol uploading fails

### DIFF
--- a/automation/symbols-generation/upload_symbols.py
+++ b/automation/symbols-generation/upload_symbols.py
@@ -80,7 +80,9 @@ def main():
     symbol_path = args[0]
     token_file = options.token_file
     shutil.make_archive(symbol_path , "zip", symbol_path)
-    upload_symbols(symbol_path + ".zip", token_file)
+    upload_success = upload_symbols(symbol_path + ".zip", token_file)
+    if not upload_success:
+        sys.exit(2)
 
 # run main if run directly
 if __name__ == "__main__":


### PR DESCRIPTION
This happened for the 131 release, but we didn't catch it because the python script exited successfully.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
