### PR TITLE
fix: add proper Rust doc comments to UDL files

### DIFF
--- a/components/as-ohttp-client/src/as_ohttp_client.udl
+++ b/components/as-ohttp-client/src/as_ohttp_client.udl
@@ -13,23 +13,23 @@ enum OhttpError {
     "DuplicateHeaders",
 };
 
-// The decrypted response from the Gateway/Target
+/// The decrypted response from the Gateway/Target
 dictionary OhttpResponse {
     u16 status_code;
     record<string, string> headers;
     sequence<u8> payload;
 };
 
-// Each OHTTP request-reply exchange needs to create an OhttpSession
-// object to manage encryption state.
+/// Each OHTTP request-reply exchange needs to create an OhttpSession
+/// object to manage encryption state.
 interface OhttpSession {
-    // Initialize encryption state based on specific Gateway key config
+    /// Initialize encryption state based on specific Gateway key config
     [Throws=OhttpError]
     constructor([ByRef] sequence<u8> config);
 
-    // Encapsulate an HTTP request as Binary HTTP and then encrypt that
-    // payload using HPKE. The caller is responsible for sending the
-    // resulting message to the Relay.
+    /// Encapsulate an HTTP request as Binary HTTP and then encrypt that
+    /// payload using HPKE. The caller is responsible for sending the
+    /// resulting message to the Relay.
     [Throws=OhttpError]
     sequence<u8> encapsulate([ByRef] string method,
                              [ByRef] string scheme,
@@ -38,9 +38,9 @@ interface OhttpSession {
                              record<string, string> headers,
                              [ByRef] sequence<u8> payload);
 
-    // Decypt and unpack the response from the Relay for the previously
-    // encapsulated request. You must use the same OhttpSession that
-    // generated the request message.
+    /// Decypt and unpack the response from the Relay for the previously
+    /// encapsulated request. You must use the same OhttpSession that
+    /// generated the request message.
     [Throws=OhttpError]
     OhttpResponse decapsulate([ByRef] sequence<u8> encoded);
 };
@@ -54,12 +54,12 @@ dictionary TestServerRequest {
     sequence<u8> payload;
 };
 
-// A testing interface for decrypting and responding to OHTTP messages. This
-// should only be used for testing.
+/// A testing interface for decrypting and responding to OHTTP messages. This
+/// should only be used for testing.
 interface OhttpTestServer {
     constructor();
 
-    // Return the unique encryption key config for this instance of test server.
+    /// Return the unique encryption key config for this instance of test server.
     sequence<u8> get_config();
 
     [Throws=OhttpError]

--- a/components/autofill/src/autofill.udl
+++ b/components/autofill/src/autofill.udl
@@ -1,21 +1,21 @@
 namespace autofill {
     // We expose the crypto primitives on the namespace
 
-    // Create a new, random, encryption key.
+    /// Create a new, random, encryption key.
     [Throws=AutofillApiError]
     string create_autofill_key();
 
-    // Encrypt an arbitrary string - `key` must have come from `create_key()`
+    /// Encrypt an arbitrary string - `key` must have come from `create_key()`
     [Throws=AutofillApiError]
     string encrypt_string(string key, string cleartext);
 
-    // Decrypt an arbitrary string - `key` must have come from `create_key()`
-    // and `ciphertext` must have come from `encrypt_string()`
+    /// Decrypt an arbitrary string - `key` must have come from `create_key()`
+    /// and `ciphertext` must have come from `encrypt_string()`
     [Throws=AutofillApiError]
     string decrypt_string(string key, string ciphertext);
 };
 
-// What you pass to create or update a credit-card.
+/// What you pass to create or update a credit-card.
 dictionary UpdatableCreditCardFields {
     string cc_name;
     string cc_number_enc;
@@ -25,7 +25,7 @@ dictionary UpdatableCreditCardFields {
     string cc_type;
 };
 
-// What you get back as a credit-card.
+/// What you get back as a credit-card.
 dictionary CreditCard {
     string guid;
     string cc_name;
@@ -41,7 +41,7 @@ dictionary CreditCard {
     i64 times_used;
 };
 
-// What you pass to create or update an address.
+/// What you pass to create or update an address.
 dictionary UpdatableAddressFields {
     string name;
     string organization;
@@ -55,7 +55,7 @@ dictionary UpdatableAddressFields {
     string email;
 };
 
-// What you get back as an address.
+/// What you get back as an address.
 dictionary Address {
     string guid;
     string name;

--- a/components/crashtest/src/crashtest.udl
+++ b/components/crashtest/src/crashtest.udl
@@ -10,43 +10,42 @@
 namespace crashtest {
     
     
-  // Trigger a hard abort inside the Rust code.
-  //
-  // This function simulates some kind of uncatchable illegal operation
-  // performed inside the Rust code. After calling this function you should
-  // expect your application to be halted with e.g. a `SIGABRT` or similar.
-  //
+  /// Trigger a hard abort inside the Rust code.
+  ///
+  /// This function simulates some kind of uncatchable illegal operation
+  /// performed inside the Rust code. After calling this function you should
+  /// expect your application to be halted with e.g. a `SIGABRT` or similar.
+  ///
   void trigger_rust_abort();
     
     
-  // Trigger a panic inside the Rust code.
-  //
-  // This function simulates the occurrence of an unexpected state inside
-  // the Rust code that causes it to panic. We build our Rust components to
-  // unwind on panic, so after calling this function through the foreign
-  // language bindings, you should expect it to intercept the panic translate
-  // it into some foreign-language-appropriate equivalent:
-  //
-  //  - In Kotlin, it will throw an exception.
-  //  - In Swift, it will fail with a `try!` runtime error.
-  //
+  /// Trigger a panic inside the Rust code.
+  ///
+  /// This function simulates the occurrence of an unexpected state inside
+  /// the Rust code that causes it to panic. We build our Rust components to
+  /// unwind on panic, so after calling this function through the foreign
+  /// language bindings, you should expect it to intercept the panic translate
+  /// it into some foreign-language-appropriate equivalent:
+  ///
+  ///  - In Kotlin, it will throw an exception.
+  ///  - In Swift, it will fail with a `try!` runtime error.
+  ///
   void trigger_rust_panic();
     
     
-  // Trigger an error inside the Rust code.
-  //
-  // This function simulates the occurrence of an expected error inside
-  // the Rust code. You should expect calling this function to throw the
-  // foreign-language representation of the [`CrashTestError`] class.
-  //
+  /// Trigger an error inside the Rust code.
+  ///
+  /// This function simulates the occurrence of an expected error inside
+  /// the Rust code. You should expect calling this function to throw the
+  /// foreign-language representation of the [`CrashTestError`] class.
+  ///
   [Throws=CrashTestError]
   void trigger_rust_error();
     
 };
 
 
-// An error that can be returned from Rust code.
-//
+/// An error that can be returned from Rust code.
 [Error]
 enum CrashTestError {
   "ErrorFromTheRustCode",

--- a/components/fxa-client/src/fxa_client.udl
+++ b/components/fxa-client/src/fxa_client.udl
@@ -1,92 +1,93 @@
-// # Firefox Accounts Client
-//
-// The fxa-client component lets applications integrate with the
-// [Firefox Accounts](https://mozilla.github.io/ecosystem-platform/docs/features/firefox-accounts/fxa-overview)
-// identity service. The shape of a typical integration would look
-// something like:
-//
-// * Out-of-band, register your application with the Firefox Accounts service,
-//   providing an OAuth `redirect_uri` controlled by your application and
-//   obtaining an OAuth `client_id`.
-//
-// * On application startup, create a [`FirefoxAccount`] object to represent the
-//   signed-in state of the application.
-//     * On first startup, a new [`FirefoxAccount`] can be created by calling
-//       [`FirefoxAccount::new`] and passing the application's `client_id`.
-//     * For subsequent startups the object can be persisted using the
-//       [`to_json`](FirefoxAccount::to_json) method and re-created by
-//       calling [`FirefoxAccount::from_json`].
-//
-// * When the user wants to sign in to your application, direct them through
-//   a web-based OAuth flow using [`begin_oauth_flow`](FirefoxAccount::begin_oauth_flow)
-//   or [`begin_pairing_flow`](FirefoxAccount::begin_pairing_flow); when they return
-//   to your registered `redirect_uri`, pass the resulting authorization state back to
-//   [`complete_oauth_flow`](FirefoxAccount::complete_oauth_flow) to sign them in.
-//
-// * Display information about the signed-in user by using the data from
-//   [`get_profile`](FirefoxAccount::get_profile).
-//
-// * Access account-related services on behalf of the user by obtaining OAuth
-//   access tokens via [`get_access_token`](FirefoxAccount::get_access_token).
-//
-// * If the user opts to sign out of the application, calling [`disconnect`](FirefoxAccount::disconnect)
-//   and then discarding any persisted account data.
+
 
 [External="sync15"]
 typedef extern DeviceType;
 
+/// # Firefox Accounts Client
+///
+/// The fxa-client component lets applications integrate with the
+/// [Firefox Accounts](https://mozilla.github.io/ecosystem-platform/docs/features/firefox-accounts/fxa-overview)
+/// identity service. The shape of a typical integration would look
+/// something like:
+///
+/// * Out-of-band, register your application with the Firefox Accounts service,
+///   providing an OAuth `redirect_uri` controlled by your application and
+///   obtaining an OAuth `client_id`.
+///
+/// * On application startup, create a [`FirefoxAccount`] object to represent the
+///   signed-in state of the application.
+///     * On first startup, a new [`FirefoxAccount`] can be created by calling
+///       [`FirefoxAccount::new`] and passing the application's `client_id`.
+///     * For subsequent startups the object can be persisted using the
+///       [`to_json`](FirefoxAccount::to_json) method and re-created by
+///       calling [`FirefoxAccount::from_json`].
+///
+/// * When the user wants to sign in to your application, direct them through
+///   a web-based OAuth flow using [`begin_oauth_flow`](FirefoxAccount::begin_oauth_flow)
+///   or [`begin_pairing_flow`](FirefoxAccount::begin_pairing_flow); when they return
+///   to your registered `redirect_uri`, pass the resulting authorization state back to
+///   [`complete_oauth_flow`](FirefoxAccount::complete_oauth_flow) to sign them in.
+///
+/// * Display information about the signed-in user by using the data from
+///   [`get_profile`](FirefoxAccount::get_profile).
+///
+/// * Access account-related services on behalf of the user by obtaining OAuth
+///   access tokens via [`get_access_token`](FirefoxAccount::get_access_token).
+///
+/// * If the user opts to sign out of the application, calling [`disconnect`](FirefoxAccount::disconnect)
+///   and then discarding any persisted account data.
 namespace fxa_client {
 };
 
 
 
-// Generic error type thrown by many [`FirefoxAccount`] operations.
-//
-// Precise details of the error are hidden from consumers, mostly due to limitations of
-// how we expose this API to other languages. The type of the error indicates how the
-// calling code should respond.
-//
+/// Generic error type thrown by many [`FirefoxAccount`] operations.
+///
+/// Precise details of the error are hidden from consumers, mostly due to limitations of
+/// how we expose this API to other languages. The type of the error indicates how the
+/// calling code should respond.
+///
 [Error]
 enum FxaError {
 
-  // Thrown when there was a problem with the authentication status of the account,
-  // such as an expired token. The application should [check its authorization status](
-  // FirefoxAccount::check_authorization_status) to see whether it has been disconnected,
-  // or retry the operation with a freshly-generated token.
+  /// Thrown when there was a problem with the authentication status of the account,
+  /// such as an expired token. The application should [check its authorization status](
+  /// FirefoxAccount::check_authorization_status) to see whether it has been disconnected,
+  /// or retry the operation with a freshly-generated token.
   "Authentication",
 
-  // Thrown if an operation fails due to network access problems.
-  // The application may retry at a later time once connectivity is restored.
+  /// Thrown if an operation fails due to network access problems.
+  /// The application may retry at a later time once connectivity is restored.
   "Network",
 
-  // Thrown if the application attempts to complete an OAuth flow when no OAuth flow has been initiated for that state.
-  // This may indicate a user who navigated directly to the OAuth `redirect_uri` for the application.
+  /// Thrown if the application attempts to complete an OAuth flow when no OAuth flow has been initiated for that state.
+  /// This may indicate a user who navigated directly to the OAuth `redirect_uri` for the application.
   "NoExistingAuthFlow",
 
-  // Thrown if the application attempts to complete an OAuth flow, but the state
-  // tokens returned from the Firefox Account server do not match with the ones
-  // expected by the client.
-  // This may indicate a stale OAuth flow, or potentially an attempted hijacking
-  // of the flow by an attacker. The signin attempt cannot be completed.
-  //
-  // **Note:** This error is currently only thrown in the Swift language bindings.
+  /// Thrown if the application attempts to complete an OAuth flow, but the state
+  /// tokens returned from the Firefox Account server do not match with the ones
+  /// expected by the client.
+  /// This may indicate a stale OAuth flow, or potentially an attempted hijacking
+  /// of the flow by an attacker. The signin attempt cannot be completed.
+  ///
+  /// **Note:** This error is currently only thrown in the Swift language bindings.
   "WrongAuthFlow",
 
-  // Origin mismatch when handling a pairing flow
-  //
-  // The most likely cause of this is that a user tried to pair together two firefox instances
-  // that are configured to use different servers.
+  /// Origin mismatch when handling a pairing flow
+  ///
+  /// The most likely cause of this is that a user tried to pair together two firefox instances
+  /// that are configured to use different servers.
   "OriginMismatch",
 
-  // The sync scoped key was missing in the server response
+  /// The sync scoped key was missing in the server response
   "SyncScopedKeyMissingInServerResponse",
 
-  // Thrown if there is a panic in the underlying Rust code.
-  //
-  // **Note:** This error is currently only thrown in the Kotlin language bindings.
+  /// Thrown if there is a panic in the underlying Rust code.
+  ///
+  /// **Note:** This error is currently only thrown in the Kotlin language bindings.
   "Panic",
 
-  // A catch-all for other unspecified errors.
+  /// A catch-all for other unspecified errors.
   "Other",
 };
 
@@ -118,440 +119,440 @@ interface CloseTabsResult {
 };
 
 
-// Object representing the signed-in state of an application.
-//
-// The `FirefoxAccount` object is the main interface provided by this crate.
-// It represents the signed-in state of an application that may be connected to
-// user's Firefox Account, and provides methods for inspecting the state of the
-// account and accessing other services on behalf of the user.
-//
+/// Object representing the signed-in state of an application.
+///
+/// The `FirefoxAccount` object is the main interface provided by this crate.
+/// It represents the signed-in state of an application that may be connected to
+/// user's Firefox Account, and provides methods for inspecting the state of the
+/// account and accessing other services on behalf of the user.
+///
 interface FirefoxAccount {
 
-  // Create a new [`FirefoxAccount`] instance, not connected to any account.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // This method constructs as new [`FirefoxAccount`] instance configured to connect
-  // the application to a user's account.
+  /// Create a new [`FirefoxAccount`] instance, not connected to any account.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// This method constructs as new [`FirefoxAccount`] instance configured to connect
+  /// the application to a user's account.
   constructor(FxaConfig config);
 
-  // Restore a [`FirefoxAccount`] instance from serialized state.
-  //
-  // Given a JSON string previously obtained from [`FirefoxAccount::to_json`], this
-  // method will deserialize it and return a live [`FirefoxAccount`] instance.
-  //
-  // **⚠️ Warning:** since the serialized state contains access tokens, you should
-  // not call `from_json` multiple times on the same data. This would result
-  // in multiple live objects sharing the same access tokens and is likely to
-  // produce unexpected behaviour.
-  //
+  /// Restore a [`FirefoxAccount`] instance from serialized state.
+  ///
+  /// Given a JSON string previously obtained from [`FirefoxAccount::to_json`], this
+  /// method will deserialize it and return a live [`FirefoxAccount`] instance.
+  ///
+  /// **⚠️ Warning:** since the serialized state contains access tokens, you should
+  /// not call `from_json` multiple times on the same data. This would result
+  /// in multiple live objects sharing the same access tokens and is likely to
+  /// produce unexpected behaviour.
+  ///
   [Throws=FxaError,Name=from_json]
   constructor([ByRef] string data);
   
 
-  // Save current state to a JSON string.
-  //
-  // This method serializes the current account state into a JSON string, which
-  // the application can use to persist the user's signed-in state across restarts.
-  // The application should call this method and update its persisted state after
-  // any potentially-state-changing operation.
-  //
-  // **⚠️ Warning:** the serialized state may contain encryption keys and access
-  // tokens that let anyone holding them access the user's data in Firefox Sync
-  // and/or other FxA services. Applications should take care to store the resulting
-  // data in a secure fashion, as appropriate for their target platform.
-  //
+  /// Save current state to a JSON string.
+  ///
+  /// This method serializes the current account state into a JSON string, which
+  /// the application can use to persist the user's signed-in state across restarts.
+  /// The application should call this method and update its persisted state after
+  /// any potentially-state-changing operation.
+  ///
+  /// **⚠️ Warning:** the serialized state may contain encryption keys and access
+  /// tokens that let anyone holding them access the user's data in Firefox Sync
+  /// and/or other FxA services. Applications should take care to store the resulting
+  /// data in a secure fashion, as appropriate for their target platform.
+  ///
   [Throws=FxaError]
   string to_json();
   
-  // Sets the users information based on the web content's login information
-  // This is intended to only be used by user agents (eg: Firefox) to set the users
-  // session token and tie it to the refresh token that will be issued at the end of the
-  // oauth flow.
+  /// Sets the users information based on the web content's login information
+  /// This is intended to only be used by user agents (eg: Firefox) to set the users
+  /// session token and tie it to the refresh token that will be issued at the end of the
+  /// oauth flow.
   void set_user_data(UserData user_data);
 
-  // Initiate a web-based OAuth sign-in flow.
-  //
-  // This method initializes some internal state and then returns a URL at which the
-  // user may perform a web-based authorization flow to connect the application to
-  // their account. The application should direct the user to the provided URL.
-  //
-  // When the resulting OAuth flow redirects back to the configured `redirect_uri`,
-  // the query parameters should be extracting from the URL and passed to the
-  // [`complete_oauth_flow`](FirefoxAccount::complete_oauth_flow) method to finalize
-  // the signin.
-  //
-  // # Arguments
-  //
-  //   - `scopes` - list of OAuth scopes to request.
-  //       - The requested scopes will determine what account-related data
-  //         the application is able to access.
-  //   - `entrypoint` - metrics identifier for UX entrypoint.
-  //       - This parameter is used for metrics purposes, to identify the
-  //         UX entrypoint from which the user triggered the signin request.
-  //         For example, the application toolbar, on the onboarding flow.
-  //   - `metrics` - optionally, additional metrics tracking parameters.
-  //       - These will be included as query parameters in the resulting URL.
-  //
+  /// Initiate a web-based OAuth sign-in flow.
+  ///
+  /// This method initializes some internal state and then returns a URL at which the
+  /// user may perform a web-based authorization flow to connect the application to
+  /// their account. The application should direct the user to the provided URL.
+  ///
+  /// When the resulting OAuth flow redirects back to the configured `redirect_uri`,
+  /// the query parameters should be extracting from the URL and passed to the
+  /// [`complete_oauth_flow`](FirefoxAccount::complete_oauth_flow) method to finalize
+  /// the signin.
+  ///
+  /// # Arguments
+  ///
+  ///   - `scopes` - list of OAuth scopes to request.
+  ///       - The requested scopes will determine what account-related data
+  ///         the application is able to access.
+  ///   - `entrypoint` - metrics identifier for UX entrypoint.
+  ///       - This parameter is used for metrics purposes, to identify the
+  ///         UX entrypoint from which the user triggered the signin request.
+  ///         For example, the application toolbar, on the onboarding flow.
+  ///   - `metrics` - optionally, additional metrics tracking parameters.
+  ///       - These will be included as query parameters in the resulting URL.
+  ///
   [Throws=FxaError]
   string begin_oauth_flow([ByRef] sequence<string> scopes, [ByRef] string entrypoint);
   
 
-  // Get the URL at which to begin a device-pairing signin flow.
-  //
-  // If the user wants to sign in using device pairing, call this method and then
-  // direct them to visit the resulting URL on an already-signed-in device. Doing
-  // so will trigger the other device to show a QR code to be scanned, and the result
-  // from said QR code can be passed to [`begin_pairing_flow`](FirefoxAccount::begin_pairing_flow).
-  //
+  /// Get the URL at which to begin a device-pairing signin flow.
+  ///
+  /// If the user wants to sign in using device pairing, call this method and then
+  /// direct them to visit the resulting URL on an already-signed-in device. Doing
+  /// so will trigger the other device to show a QR code to be scanned, and the result
+  /// from said QR code can be passed to [`begin_pairing_flow`](FirefoxAccount::begin_pairing_flow).
+  ///
   [Throws=FxaError]
   string get_pairing_authority_url();
   
 
-  // Initiate a device-pairing sign-in flow.
-  //
-  // Once the user has scanned a pairing QR code, pass the scanned value to this
-  // method. It will return a URL to which the application should redirect the user
-  // in order to continue the sign-in flow.
-  //
-  // When the resulting flow redirects back to the configured `redirect_uri`,
-  // the resulting OAuth parameters should be extracting from the URL and passed
-  // to [`complete_oauth_flow`](FirefoxAccount::complete_oauth_flow) to finalize
-  // the signin.
-  //
-  // # Arguments
-  //
-  //   - `pairing_url` - the URL scanned from a QR code on another device.
-  //   - `scopes` - list of OAuth scopes to request.
-  //       - The requested scopes will determine what account-related data
-  //         the application is able to access.
-  //   - `entrypoint` - metrics identifier for UX entrypoint.
-  //       - This parameter is used for metrics purposes, to identify the
-  //         UX entrypoint from which the user triggered the signin request.
-  //         For example, the application toolbar, on the onboarding flow.
-  //   - `metrics` - optionally, additional metrics tracking parameters.
-  //       - These will be included as query parameters in the resulting URL.
-  //
+  /// Initiate a device-pairing sign-in flow.
+  ///
+  /// Once the user has scanned a pairing QR code, pass the scanned value to this
+  /// method. It will return a URL to which the application should redirect the user
+  /// in order to continue the sign-in flow.
+  ///
+  /// When the resulting flow redirects back to the configured `redirect_uri`,
+  /// the resulting OAuth parameters should be extracting from the URL and passed
+  /// to [`complete_oauth_flow`](FirefoxAccount::complete_oauth_flow) to finalize
+  /// the signin.
+  ///
+  /// # Arguments
+  ///
+  ///   - `pairing_url` - the URL scanned from a QR code on another device.
+  ///   - `scopes` - list of OAuth scopes to request.
+  ///       - The requested scopes will determine what account-related data
+  ///         the application is able to access.
+  ///   - `entrypoint` - metrics identifier for UX entrypoint.
+  ///       - This parameter is used for metrics purposes, to identify the
+  ///         UX entrypoint from which the user triggered the signin request.
+  ///         For example, the application toolbar, on the onboarding flow.
+  ///   - `metrics` - optionally, additional metrics tracking parameters.
+  ///       - These will be included as query parameters in the resulting URL.
+  ///
   [Throws=FxaError]
   string begin_pairing_flow([ByRef] string pairing_url, [ByRef] sequence<string> scopes, [ByRef] string entrypoint);
   
 
-  // Complete an OAuth flow.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // At the conclusion of an OAuth flow, the user will be redirect to the
-  // application's registered `redirect_uri`. It should extract the `code`
-  // and `state` parameters from the resulting URL and pass them to this
-  // method in order to complete the sign-in.
-  //
-  // # Arguments
-  //
-  //   - `code` - the OAuth authorization code obtained from the redirect URI.
-  //   - `state` - the OAuth state parameter obtained from the redirect URI.
-  //
+  /// Complete an OAuth flow.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// At the conclusion of an OAuth flow, the user will be redirect to the
+  /// application's registered `redirect_uri`. It should extract the `code`
+  /// and `state` parameters from the resulting URL and pass them to this
+  /// method in order to complete the sign-in.
+  ///
+  /// # Arguments
+  ///
+  ///   - `code` - the OAuth authorization code obtained from the redirect URI.
+  ///   - `state` - the OAuth state parameter obtained from the redirect URI.
+  ///
   [Throws=FxaError]
   void complete_oauth_flow([ByRef] string code, [ByRef] string state );
   
 
-  // Check authorization status for this application.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications may call this method to check with the FxA server about the status
-  // of their authentication tokens. It returns an [`AuthorizationInfo`] struct
-  // with details about whether the tokens are still active.
-  //
+  /// Check authorization status for this application.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications may call this method to check with the FxA server about the status
+  /// of their authentication tokens. It returns an [`AuthorizationInfo`] struct
+  /// with details about whether the tokens are still active.
+  ///
   [Throws=FxaError]
   AuthorizationInfo check_authorization_status();
   
 
-  // Disconnect from the user's account.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // This method destroys any tokens held by the client, effectively disconnecting
-  // from the user's account. Applications should call this when the user opts to
-  // sign out.
-  //
-  // The persisted account state after calling this method will contain only the
-  // user's last-seen profile information, if any. This may be useful in helping
-  // the user to reconnnect to their account. If reconnecting to the same account
-  // is not desired then the application should discard the persisted account state.
-  //
+  /// Disconnect from the user's account.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// This method destroys any tokens held by the client, effectively disconnecting
+  /// from the user's account. Applications should call this when the user opts to
+  /// sign out.
+  ///
+  /// The persisted account state after calling this method will contain only the
+  /// user's last-seen profile information, if any. This may be useful in helping
+  /// the user to reconnnect to their account. If reconnecting to the same account
+  /// is not desired then the application should discard the persisted account state.
+  ///
   void disconnect();
 
-  // Update the state based on authentication issues.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Call this if you know there's an authentication / authorization issue that requires the
-  // user to re-authenticated.  It transitions the user to the [FxaRustAuthState.AuthIssues] state.
+  /// Update the state based on authentication issues.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Call this if you know there's an authentication / authorization issue that requires the
+  /// user to re-authenticated.  It transitions the user to the [FxaRustAuthState.AuthIssues] state.
   void on_auth_issues();
 
-  // Get the high-level authentication state of the client
-  //
-  // Deprecated: Use get_state() instead
+  /// Get the high-level authentication state of the client
+  ///
+  /// Deprecated: Use get_state() instead
   FxaRustAuthState get_auth_state();
 
-  // Get the current state
+  /// Get the current state
   FxaState get_state();
 
-  // Process an event (login, logout, etc).
-  //
-  // On success, update the current state and return it.
-  // On error, the current state will remain the same.
+  /// Process an event (login, logout, etc).
+  ///
+  /// On success, update the current state and return it.
+  /// On error, the current state will remain the same.
   [Throws=FxaError]
   FxaState process_event(FxaEvent event);
 
-  // Get profile information for the signed-in user, if any.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // This method fetches a [`Profile`] struct with information about the currently-signed-in
-  // user, either by using locally-cached profile information or by fetching fresh data from
-  // the server.
-  //
-  // # Arguments
-  //
-  //    - `ignore_cache` - if true, always hit the server for fresh profile information.
-  //
-  // # Notes
-  //
-  //    - Profile information is only available to applications that have been
-  //      granted the `profile` scope.
-  //    - There is currently no API for fetching cached profile information without
-  //      potentially hitting the server.
-  //    - If there is no signed-in user, this method will throw an
-  //      [`Authentication`](FxaError::Authentication) error.
-  //
+  /// Get profile information for the signed-in user, if any.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// This method fetches a [`Profile`] struct with information about the currently-signed-in
+  /// user, either by using locally-cached profile information or by fetching fresh data from
+  /// the server.
+  ///
+  /// # Arguments
+  ///
+  ///    - `ignore_cache` - if true, always hit the server for fresh profile information.
+  ///
+  /// # Notes
+  ///
+  ///    - Profile information is only available to applications that have been
+  ///      granted the `profile` scope.
+  ///    - There is currently no API for fetching cached profile information without
+  ///      potentially hitting the server.
+  ///    - If there is no signed-in user, this method will throw an
+  ///      [`Authentication`](FxaError::Authentication) error.
+  ///
   [Throws=FxaError]
   Profile get_profile( boolean ignore_cache );
   
 
-  // Create a new device record for this application.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // This method registered a device record for the application, providing basic metadata for
-  // the device along with a list of supported [Device Capabilities](DeviceCapability) for
-  // participating in the "device commands" ecosystem.
-  //
-  // Applications should call this method soon after a successful sign-in, to ensure
-  // they they appear correctly in the user's account-management pages and when discovered
-  // by other devices connected to the account.
-  //
-  // # Arguments
-  //
-  //    - `name` - human-readable display name to use for this application
-  //    - `device_type` - the [type](DeviceType) of device the application is installed on
-  //    - `supported_capabilities` - the set of [capabilities](DeviceCapability) to register
-  //       for this device in the "device commands" ecosystem.
-  //
-  // # Notes
-  //
-  //    - Device registration is only available to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Create a new device record for this application.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// This method registered a device record for the application, providing basic metadata for
+  /// the device along with a list of supported [Device Capabilities](DeviceCapability) for
+  /// participating in the "device commands" ecosystem.
+  ///
+  /// Applications should call this method soon after a successful sign-in, to ensure
+  /// they they appear correctly in the user's account-management pages and when discovered
+  /// by other devices connected to the account.
+  ///
+  /// # Arguments
+  ///
+  ///    - `name` - human-readable display name to use for this application
+  ///    - `device_type` - the [type](DeviceType) of device the application is installed on
+  ///    - `supported_capabilities` - the set of [capabilities](DeviceCapability) to register
+  ///       for this device in the "device commands" ecosystem.
+  ///
+  /// # Notes
+  ///
+  ///    - Device registration is only available to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   LocalDevice initialize_device([ByRef] string name,  DeviceType device_type,  sequence<DeviceCapability> supported_capabilities );
   
 
-  // Get the device id registered for this application.
-  //
-  // # Notes
-  //
-  //    - If the application has not registered a device record, this method will
-  //      throw an [`Other`](FxaError::Other) error.
-  //        - (Yeah...sorry. This should be changed to do something better.)
-  //    - Device metadata is only visible to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Get the device id registered for this application.
+  ///
+  /// # Notes
+  ///
+  ///    - If the application has not registered a device record, this method will
+  ///      throw an [`Other`](FxaError::Other) error.
+  ///        - (Yeah...sorry. This should be changed to do something better.)
+  ///    - Device metadata is only visible to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   string get_current_device_id();
   
 
-  // Get the list of devices registered on the user's account.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // This method returns a list of [`Device`] structs representing all the devices
-  // currently attached to the user's account (including the current device).
-  // The application might use this information to e.g. display a list of appropriate
-  // send-tab targets.
-  //
-  // # Arguments
-  //
-  //    - `ignore_cache` - if true, always hit the server for fresh profile information.
-  //
-  // # Notes
-  //
-  //    - Device metadata is only visible to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Get the list of devices registered on the user's account.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// This method returns a list of [`Device`] structs representing all the devices
+  /// currently attached to the user's account (including the current device).
+  /// The application might use this information to e.g. display a list of appropriate
+  /// send-tab targets.
+  ///
+  /// # Arguments
+  ///
+  ///    - `ignore_cache` - if true, always hit the server for fresh profile information.
+  ///
+  /// # Notes
+  ///
+  ///    - Device metadata is only visible to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   sequence<Device> get_devices( boolean ignore_cache );
   
 
-  // Get the list of all client applications attached to the user's account.
-  //
-  // This method returns a list of [`AttachedClient`] structs representing all the applications
-  // connected to the user's account. This includes applications that are registered as a device
-  // as well as server-side services that the user has connected.
-  //
-  // This information is really only useful for targeted messaging or marketing purposes,
-  // e.g. if the application wants to advertize a related product, but first wants to check
-  // whether the user is already using that product.
-  //
-  // # Notes
-  //
-  //    - Attached client metadata is only visible to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Get the list of all client applications attached to the user's account.
+  ///
+  /// This method returns a list of [`AttachedClient`] structs representing all the applications
+  /// connected to the user's account. This includes applications that are registered as a device
+  /// as well as server-side services that the user has connected.
+  ///
+  /// This information is really only useful for targeted messaging or marketing purposes,
+  /// e.g. if the application wants to advertize a related product, but first wants to check
+  /// whether the user is already using that product.
+  ///
+  /// # Notes
+  ///
+  ///    - Attached client metadata is only visible to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   sequence<AttachedClient> get_attached_clients();
   
 
-  // Update the display name used for this application instance.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // This method modifies the name of the current application's device record, as seen by
-  // other applications and in the user's account management pages.
-  //
-  // # Arguments
-  //
-  //    - `display_name` - the new name for the current device.
-  //
-  // # Notes
-  //
-  //    - Device registration is only available to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Update the display name used for this application instance.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// This method modifies the name of the current application's device record, as seen by
+  /// other applications and in the user's account management pages.
+  ///
+  /// # Arguments
+  ///
+  ///    - `display_name` - the new name for the current device.
+  ///
+  /// # Notes
+  ///
+  ///    - Device registration is only available to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   LocalDevice set_device_name([ByRef] string display_name );
   
 
-  // Clear any custom display name used for this application instance.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // This method clears the name of the current application's device record, causing other
-  // applications or the user's account management pages to have to fill in some sort of
-  // default name when displaying this device.
-  //
-  // # Notes
-  //
-  //    - Device registration is only available to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Clear any custom display name used for this application instance.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// This method clears the name of the current application's device record, causing other
+  /// applications or the user's account management pages to have to fill in some sort of
+  /// default name when displaying this device.
+  ///
+  /// # Notes
+  ///
+  ///    - Device registration is only available to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   void clear_device_name();
   
 
-  // Ensure that the device record has a specific set of capabilities.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // This method checks that the currently-registered device record is advertising the
-  // given set of capabilities in the FxA "device commands" ecosystem. If not, then it
-  // updates the device record to do so.
-  //
-  // Applications should call this method on each startup as a way to ensure that their
-  // expected set of capabilities is being accurately reflected on the FxA server, and
-  // to handle the rollout of new capabilities over time.
-  //
-  // # Arguments
-  //
-  //    - `supported_capabilities` - the set of [capabilities](DeviceCapability) to register
-  //       for this device in the "device commands" ecosystem.
-  //
-  // # Notes
-  //
-  //    - Device registration is only available to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Ensure that the device record has a specific set of capabilities.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// This method checks that the currently-registered device record is advertising the
+  /// given set of capabilities in the FxA "device commands" ecosystem. If not, then it
+  /// updates the device record to do so.
+  ///
+  /// Applications should call this method on each startup as a way to ensure that their
+  /// expected set of capabilities is being accurately reflected on the FxA server, and
+  /// to handle the rollout of new capabilities over time.
+  ///
+  /// # Arguments
+  ///
+  ///    - `supported_capabilities` - the set of [capabilities](DeviceCapability) to register
+  ///       for this device in the "device commands" ecosystem.
+  ///
+  /// # Notes
+  ///
+  ///    - Device registration is only available to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   LocalDevice ensure_capabilities( sequence<DeviceCapability> supported_capabilities );
   
 
-  // Set or update a push subscription endpoint for this device.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // This method registers the given webpush subscription with the FxA server, requesting
-  // that is send notifications in the event of any significant changes to the user's
-  // account. When the application receives a push message at the registered subscription
-  // endpoint, it should decrypt the payload and pass it to the [`handle_push_message`](
-  // FirefoxAccount::handle_push_message) method for processing.
-  //
-  // # Arguments
-  //
-  //    - `subscription` - the [`DevicePushSubscription`] details to register with the server.
-  //
-  // # Notes
-  //
-  //    - Device registration is only available to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Set or update a push subscription endpoint for this device.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// This method registers the given webpush subscription with the FxA server, requesting
+  /// that is send notifications in the event of any significant changes to the user's
+  /// account. When the application receives a push message at the registered subscription
+  /// endpoint, it should decrypt the payload and pass it to the [`handle_push_message`](
+  /// FirefoxAccount::handle_push_message) method for processing.
+  ///
+  /// # Arguments
+  ///
+  ///    - `subscription` - the [`DevicePushSubscription`] details to register with the server.
+  ///
+  /// # Notes
+  ///
+  ///    - Device registration is only available to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   LocalDevice set_push_subscription( DevicePushSubscription subscription );
 
 
-  // Process and respond to a server-delivered account update message
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications should call this method whenever they receive a push notification from the Firefox Accounts server.
-  // Such messages typically indicate a noteworthy change of state on the user's account, such as an update to their profile information
-  // or the disconnection of a client. The [`FirefoxAccount`] struct will update its internal state
-  // accordingly and return an individual [`AccountEvent`] struct describing the event, which the application
-  // may use for further processing.
-  //
-  // It's important to note if the event is [`AccountEvent::CommandReceived`], the caller should call
-  // [`FirefoxAccount::poll_device_commands`]
-  //
+  /// Process and respond to a server-delivered account update message
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications should call this method whenever they receive a push notification from the Firefox Accounts server.
+  /// Such messages typically indicate a noteworthy change of state on the user's account, such as an update to their profile information
+  /// or the disconnection of a client. The [`FirefoxAccount`] struct will update its internal state
+  /// accordingly and return an individual [`AccountEvent`] struct describing the event, which the application
+  /// may use for further processing.
+  ///
+  /// It's important to note if the event is [`AccountEvent::CommandReceived`], the caller should call
+  /// [`FirefoxAccount::poll_device_commands`]
+  ///
   [Throws=FxaError]
   AccountEvent handle_push_message([ByRef] string payload );
 
 
-  // Poll the server for any pending device commands.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications that have registered one or more [`DeviceCapability`]s with the server can use
-  // this method to check whether other devices on the account have sent them any commands.
-  // It will return a list of [`IncomingDeviceCommand`] structs for the application to process.
-  //
-  // # Notes
-  //
-  //    - Device commands are typically delivered via push message and the [`CommandReceived`](
-  //      AccountEvent::CommandReceived) event. Polling should only be used as a backup delivery
-  //      mechanism, f the application has reason to believe that push messages may have been missed.
-  //    - Device commands functionality is only available to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Poll the server for any pending device commands.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications that have registered one or more [`DeviceCapability`]s with the server can use
+  /// this method to check whether other devices on the account have sent them any commands.
+  /// It will return a list of [`IncomingDeviceCommand`] structs for the application to process.
+  ///
+  /// # Notes
+  ///
+  ///    - Device commands are typically delivered via push message and the [`CommandReceived`](
+  ///      AccountEvent::CommandReceived) event. Polling should only be used as a backup delivery
+  ///      mechanism, f the application has reason to believe that push messages may have been missed.
+  ///    - Device commands functionality is only available to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   sequence<IncomingDeviceCommand> poll_device_commands();
   
 
-  // Use device commands to send a single tab to another device.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // If a device on the account has registered the [`SendTab`](DeviceCapability::SendTab)
-  // capability, this method can be used to send it a tab.
-  //
-  // # Notes
-  //
-  //    - If the given device id does not existing or is not capable of receiving tabs,
-  //      this method will throw an [`Other`](FxaError::Other) error.
-  //        - (Yeah...sorry. This should be changed to do something better.)
-  //    - It is not currently possible to send a full [`SendTabPayload`] to another device,
-  //      but that's purely an API limitation that should go away in future.
-  //    - Device commands functionality is only available to applications that have been
-  //      granted the `https://identity.mozilla.com/apps/oldsync` scope.
-  //
+  /// Use device commands to send a single tab to another device.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// If a device on the account has registered the [`SendTab`](DeviceCapability::SendTab)
+  /// capability, this method can be used to send it a tab.
+  ///
+  /// # Notes
+  ///
+  ///    - If the given device id does not existing or is not capable of receiving tabs,
+  ///      this method will throw an [`Other`](FxaError::Other) error.
+  ///        - (Yeah...sorry. This should be changed to do something better.)
+  ///    - It is not currently possible to send a full [`SendTabPayload`] to another device,
+  ///      but that's purely an API limitation that should go away in future.
+  ///    - Device commands functionality is only available to applications that have been
+  ///      granted the `https:///identity.mozilla.com/apps/oldsync` scope.
+  ///
   [Throws=FxaError]
   void send_single_tab([ByRef] string target_device_id, [ByRef] string title, [ByRef] string url );
 
@@ -566,188 +567,188 @@ interface FirefoxAccount {
   CloseTabsResult close_tabs([ByRef] string target_device_id, sequence<string> urls);
 
 
-  // Get the URL at which to access the user's sync data.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
+  /// Get the URL at which to access the user's sync data.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
   [Throws=FxaError]
   string get_token_server_endpoint_url();
   
 
-  // Get a URL which shows a "successfully connceted!" message.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications can use this method after a successful signin, to redirect the
-  // user to a success message displayed in web content rather than having to
-  // implement their own native success UI.
-  //
+  /// Get a URL which shows a "successfully connceted!" message.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications can use this method after a successful signin, to redirect the
+  /// user to a success message displayed in web content rather than having to
+  /// implement their own native success UI.
+  ///
   [Throws=FxaError]
   string get_connection_success_url();
   
 
-  // Get a URL at which the user can manage their account and profile data.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications should link the user out to this URL from an appropriate place
-  // in their signed-in settings UI.
-  //
-  // # Arguments
-  //
-  //   - `entrypoint` - metrics identifier for UX entrypoint.
-  //       - This parameter is used for metrics purposes, to identify the
-  //         UX entrypoint from which the user followed the link.
-  //
+  /// Get a URL at which the user can manage their account and profile data.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications should link the user out to this URL from an appropriate place
+  /// in their signed-in settings UI.
+  ///
+  /// # Arguments
+  ///
+  ///   - `entrypoint` - metrics identifier for UX entrypoint.
+  ///       - This parameter is used for metrics purposes, to identify the
+  ///         UX entrypoint from which the user followed the link.
+  ///
   [Throws=FxaError]
   string get_manage_account_url([ByRef] string entrypoint );
   
 
-  // Get a URL at which the user can manage the devices connected to their account.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications should link the user out to this URL from an appropriate place
-  // in their signed-in settings UI. For example, "Manage your devices..." may be
-  // a useful link to place somewhere near the device list in the send-tab UI.
-  //
-  // # Arguments
-  //
-  //   - `entrypoint` - metrics identifier for UX entrypoint.
-  //       - This parameter is used for metrics purposes, to identify the
-  //         UX entrypoint from which the user followed the link.
-  //
+  /// Get a URL at which the user can manage the devices connected to their account.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications should link the user out to this URL from an appropriate place
+  /// in their signed-in settings UI. For example, "Manage your devices..." may be
+  /// a useful link to place somewhere near the device list in the send-tab UI.
+  ///
+  /// # Arguments
+  ///
+  ///   - `entrypoint` - metrics identifier for UX entrypoint.
+  ///       - This parameter is used for metrics purposes, to identify the
+  ///         UX entrypoint from which the user followed the link.
+  ///
   [Throws=FxaError]
   string get_manage_devices_url([ByRef] string entrypoint );
   
 
-  // Get a short-lived OAuth access token for the user's account.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications that need to access resources on behalf of the user must obtain an
-  // `access_token` in order to do so. For example, an access token is required when
-  // fetching the user's profile data, or when accessing their data stored in Firefox Sync.
-  //
-  // This method will obtain and return an access token bearing the requested scopes, either
-  // from a local cache of previously-issued tokens, or by creating a new one from the server.
-  //
-  // # Arguments
-  //
-  //    - `scope` - the OAuth scope to be granted by the token.
-  //        - This must be one of the scopes requested during the signin flow.
-  //        - Only a single scope is supported; for multiple scopes request multiple tokens.
-  //    - `ttl` - optionally, the time for which the token should be valid, in seconds.
-  //
-  // # Notes
-  //
-  //    - If the application receives an authorization error when trying to use the resulting
-  //      token, it should call [`clear_access_token_cache`](FirefoxAccount::clear_access_token_cache)
-  //      before requesting a fresh token.
-  //
+  /// Get a short-lived OAuth access token for the user's account.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications that need to access resources on behalf of the user must obtain an
+  /// `access_token` in order to do so. For example, an access token is required when
+  /// fetching the user's profile data, or when accessing their data stored in Firefox Sync.
+  ///
+  /// This method will obtain and return an access token bearing the requested scopes, either
+  /// from a local cache of previously-issued tokens, or by creating a new one from the server.
+  ///
+  /// # Arguments
+  ///
+  ///    - `scope` - the OAuth scope to be granted by the token.
+  ///        - This must be one of the scopes requested during the signin flow.
+  ///        - Only a single scope is supported; for multiple scopes request multiple tokens.
+  ///    - `ttl` - optionally, the time for which the token should be valid, in seconds.
+  ///
+  /// # Notes
+  ///
+  ///    - If the application receives an authorization error when trying to use the resulting
+  ///      token, it should call [`clear_access_token_cache`](FirefoxAccount::clear_access_token_cache)
+  ///      before requesting a fresh token.
+  ///
   [Throws=FxaError]
   AccessTokenInfo get_access_token([ByRef] string scope,  optional i64? ttl = null);
 
-  // Get the session token for the user's account, if one is available.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications that function as a web browser may need to hold on to a session token
-  // on behalf of Firefox Accounts web content. This method exists so that they can retrieve
-  // it an pass it back to said web content when required.
-  //
-  // # Notes
-  //
-  //    - Please do not attempt to use the resulting token to directly make calls to the
-  //      Firefox Accounts servers! All account management functionality should be performed
-  //      in web content.
-  //    - A session token is only available to applications that have requested the
-  //      `https://identity.mozilla.com/tokens/session` scope.
-  //
+  /// Get the session token for the user's account, if one is available.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications that function as a web browser may need to hold on to a session token
+  /// on behalf of Firefox Accounts web content. This method exists so that they can retrieve
+  /// it an pass it back to said web content when required.
+  ///
+  /// # Notes
+  ///
+  ///    - Please do not attempt to use the resulting token to directly make calls to the
+  ///      Firefox Accounts servers! All account management functionality should be performed
+  ///      in web content.
+  ///    - A session token is only available to applications that have requested the
+  ///      `https:///identity.mozilla.com/tokens/session` scope.
+  ///
   [Throws=FxaError]
   string get_session_token();
   
 
-  // Update the stored session token for the user's account.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications that function as a web browser may need to hold on to a session token
-  // on behalf of Firefox Accounts web content. This method exists so that said web content
-  // signals that it has generated a new session token, the stored value can be updated
-  // to match.
-  //
-  // # Arguments
-  //
-  //    - `session_token` - the new session token value provided from web content.
-  //
+  /// Update the stored session token for the user's account.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications that function as a web browser may need to hold on to a session token
+  /// on behalf of Firefox Accounts web content. This method exists so that said web content
+  /// signals that it has generated a new session token, the stored value can be updated
+  /// to match.
+  ///
+  /// # Arguments
+  ///
+  ///    - `session_token` - the new session token value provided from web content.
+  ///
   [Throws=FxaError]
   void handle_session_token_change([ByRef] string session_token );
   
 
-  // Create a new OAuth authorization code using the stored session token.
-  //
-  // When a signed-in application receives an incoming device pairing request, it can
-  // use this method to grant the request and generate a corresponding OAuth authorization
-  // code. This code would then be passed back to the connecting device over the
-  // pairing channel (a process which is not currently supported by any code in this
-  // component).
-  //
-  // # Arguments
-  //
-  //    - `params` - the OAuth parameters from the incoming authorization request
-  //
+  /// Create a new OAuth authorization code using the stored session token.
+  ///
+  /// When a signed-in application receives an incoming device pairing request, it can
+  /// use this method to grant the request and generate a corresponding OAuth authorization
+  /// code. This code would then be passed back to the connecting device over the
+  /// pairing channel (a process which is not currently supported by any code in this
+  /// component).
+  ///
+  /// # Arguments
+  ///
+  ///    - `params` - the OAuth parameters from the incoming authorization request
+  ///
   [Throws=FxaError]
   string authorize_code_using_session_token( AuthorizationParameters params );
   
 
-  // Clear the access token cache in response to an auth failure.
-  //
-  // **💾 This method alters the persisted account state.**
-  //
-  // Applications that receive an authentication error when trying to use an access token,
-  // should call this method before creating a new token and retrying the failed operation.
-  // It ensures that the expired token is removed and a fresh one generated.
-  //
+  /// Clear the access token cache in response to an auth failure.
+  ///
+  /// **💾 This method alters the persisted account state.**
+  ///
+  /// Applications that receive an authentication error when trying to use an access token,
+  /// should call this method before creating a new token and retrying the failed operation.
+  /// It ensures that the expired token is removed and a fresh one generated.
+  ///
   void clear_access_token_cache();
 
 
-  // Collect and return telemetry about incoming and outgoing device commands.
-  //
-  // Applications that have registered one or more [`DeviceCapability`]s
-  // should also arrange to submit "sync ping" telemetry. Calling this method will
-  // return a JSON string of telemetry data that can be incorporated into that ping.
-  //
-  // Sorry, this is not particularly carefully documented because it is intended
-  // as a stop-gap until we get native Glean support. If you know how to submit
-  // a sync ping, you'll know what to do with the contents of the JSON string.
-  //
+  /// Collect and return telemetry about incoming and outgoing device commands.
+  ///
+  /// Applications that have registered one or more [`DeviceCapability`]s
+  /// should also arrange to submit "sync ping" telemetry. Calling this method will
+  /// return a JSON string of telemetry data that can be incorporated into that ping.
+  ///
+  /// Sorry, this is not particularly carefully documented because it is intended
+  /// as a stop-gap until we get native Glean support. If you know how to submit
+  /// a sync ping, you'll know what to do with the contents of the JSON string.
+  ///
   [Throws=FxaError]
   string gather_telemetry();
 
-  // Used by the application to test auth token issues
+  /// Used by the application to test auth token issues
   void simulate_network_error();
 
-  // Used by the application to test auth token issues
+  /// Used by the application to test auth token issues
   void simulate_temporary_auth_token_issue();
 
-  // Used by the application to test auth token issues
+  /// Used by the application to test auth token issues
   void simulate_permanent_auth_token_issue();
 };
 
 dictionary FxaConfig {
-    // FxaServer to connect with
+    /// FxaServer to connect with
     FxaServer server;
-    // Registered OAuth client id of the application.
+    /// Registered OAuth client id of the application.
     string client_id;
-    // `redirect_uri` - the registered OAuth redirect URI of the application.
+    /// `redirect_uri` - the registered OAuth redirect URI of the application.
     string redirect_uri;
-    //  URL for the user's Sync Tokenserver. This can be used to support users who self-host their
-    //  sync data. If `None` then it will default to the Mozilla-hosted Sync server.
+    ///  URL for the user's Sync Tokenserver. This can be used to support users who self-host their
+    ///  sync data. If `None` then it will default to the Mozilla-hosted Sync server.
     string? token_server_url_override = null;
 };
 
-// FxA server to connect to
+/// FxA server to connect to
 [Enum]
 interface FxaServer {
     Release();
@@ -758,86 +759,86 @@ interface FxaServer {
     Custom(string url);
 };
 
-// Information about the authorization state of the application.
-//
-// This struct represents metadata about whether the application is currently
-// connected to the user's account.
-//
+/// Information about the authorization state of the application.
+///
+/// This struct represents metadata about whether the application is currently
+/// connected to the user's account.
+///
 dictionary AuthorizationInfo {
   boolean active;
 };
 
-// An OAuth access token, with its associated keys and metadata.
-//
-// This struct represents an FxA OAuth access token, which can be used to access a resource
-// or service on behalf of the user. For example, accessing the user's data in Firefox Sync
-// an access token for the scope `https://identity.mozilla.com/apps/sync` along with the
-// associated encryption key.
-//
+/// An OAuth access token, with its associated keys and metadata.
+///
+/// This struct represents an FxA OAuth access token, which can be used to access a resource
+/// or service on behalf of the user. For example, accessing the user's data in Firefox Sync
+/// an access token for the scope `https:///identity.mozilla.com/apps/sync` along with the
+/// associated encryption key.
+///
 dictionary AccessTokenInfo {
 
-  // The scope of access granted by token.
+  /// The scope of access granted by token.
   string scope;
 
-  // The access token itself.
-  //
-  // This is the value that should be included in the `Authorization` header when
-  // accessing an OAuth protected resource on behalf of the user.
+  /// The access token itself.
+  ///
+  /// This is the value that should be included in the `Authorization` header when
+  /// accessing an OAuth protected resource on behalf of the user.
   string token;
 
-  // The client-side encryption key associated with this scope.
-  //
-  // **⚠️ Warning:** the value of this field should never be revealed outside of the
-  // application. For example, it should never to sent to a server or logged in a log file.
+  /// The client-side encryption key associated with this scope.
+  ///
+  /// **⚠️ Warning:** the value of this field should never be revealed outside of the
+  /// application. For example, it should never to sent to a server or logged in a log file.
   ScopedKey? key;
 
-  // The expiry time of the token, in seconds.
-  //
-  // This is the timestamp at which the token is set to expire, in seconds since
-  // unix epoch. Note that it is a signed integer, for compatibility with languages
-  // that do not have an unsigned integer type.
-  //
-  // This timestamp is for guidance only. Access tokens are not guaranteed to remain
-  // value for any particular lengthof time, and consumers should be prepared to handle
-  // auth failures even if the token has not yet expired.
+  /// The expiry time of the token, in seconds.
+  ///
+  /// This is the timestamp at which the token is set to expire, in seconds since
+  /// unix epoch. Note that it is a signed integer, for compatibility with languages
+  /// that do not have an unsigned integer type.
+  ///
+  /// This timestamp is for guidance only. Access tokens are not guaranteed to remain
+  /// value for any particular lengthof time, and consumers should be prepared to handle
+  /// auth failures even if the token has not yet expired.
   i64 expires_at;
 };
 
-// A cryptographic key associated with an OAuth scope.
-//
-// Some OAuth scopes have a corresponding client-side encryption key that is required
-// in order to access protected data. This struct represents such key material in a
-// format compatible with the common "JWK" standard.
-//
+/// A cryptographic key associated with an OAuth scope.
+///
+/// Some OAuth scopes have a corresponding client-side encryption key that is required
+/// in order to access protected data. This struct represents such key material in a
+/// format compatible with the common "JWK" standard.
+///
 dictionary ScopedKey {
 
-  // The type of key.
-  //
-  // In practice for FxA, this will always be string string "oct" (short for "octal")
-  // to represent a raw symmetric key.
+  /// The type of key.
+  ///
+  /// In practice for FxA, this will always be string string "oct" (short for "octal")
+  /// to represent a raw symmetric key.
   string kty;
 
-  // The OAuth scope with which this key is associated.
+  /// The OAuth scope with which this key is associated.
   string scope;
 
-  // The key material, as base64-url-encoded bytes.
-  //
-  // **⚠️ Warning:** the value of this field should never be revealed outside of the
-  // application. For example, it should never to sent to a server or logged in a log file.
+  /// The key material, as base64-url-encoded bytes.
+  ///
+  /// **⚠️ Warning:** the value of this field should never be revealed outside of the
+  /// application. For example, it should never to sent to a server or logged in a log file.
   string k;
 
-  // An opaque unique identifier for this key.
-  //
-  // Unlike the `k` field, this value is not secret and may be revealed to the server.
+  /// An opaque unique identifier for this key.
+  ///
+  /// Unlike the `k` field, this value is not secret and may be revealed to the server.
   string kid;
 };
 
-// Parameters provided in an incoming OAuth request.
-//
-// This struct represents parameters obtained from an incoming OAuth request - that is,
-// the values that an OAuth client would append to the authorization URL when initiating
-// an OAuth sign-in flow.
-//
+/// Parameters provided in an incoming OAuth request.
+///
+/// This struct represents parameters obtained from an incoming OAuth request - that is,
+/// the values that an OAuth client would append to the authorization URL when initiating
+/// an OAuth sign-in flow.
+///
 dictionary AuthorizationParameters {
   string client_id;
   sequence<string> scope;
@@ -848,12 +849,12 @@ dictionary AuthorizationParameters {
   string? keys_jwk;
 };
 
-// A device connected to the user's account.
-//
-// This struct provides metadata about a device connected to the user's account.
-// This data would typically be used to display e.g. the list of candidate devices
-// in a "send tab" menu.
-//
+/// A device connected to the user's account.
+///
+/// This struct provides metadata about a device connected to the user's account.
+/// This data would typically be used to display e.g. the list of candidate devices
+/// in a "send tab" menu.
+///
 dictionary Device {
   string id;
   string display_name;
@@ -865,17 +866,17 @@ dictionary Device {
   i64? last_access_time;
 };
 
-// Device configuration
+/// Device configuration
 dictionary DeviceConfig {
   string name;
   DeviceType device_type;
   sequence<DeviceCapability> capabilities;
 };
 
-// Local device that's connecting to FxA
-//
-// This is returned by the device update methods and represents the server's view of the local
-// device.
+/// Local device that's connecting to FxA
+///
+/// This is returned by the device update methods and represents the server's view of the local
+/// device.
 dictionary LocalDevice {
   string id;
   string display_name;
@@ -885,69 +886,69 @@ dictionary LocalDevice {
   boolean push_endpoint_expired;
 };
 
-// Details of a web-push subscription endpoint.
-//
-// This struct encapsulates the details of a web-push subscription endpoint,
-// including all the information necessary to send a notification to its owner.
-// Devices attached to the user's account may register one of these in order
-// to receive timely updates about account-related events.
-//
-// Managing a web-push subscription is outside of the scope of this component.
-//
+/// Details of a web-push subscription endpoint.
+///
+/// This struct encapsulates the details of a web-push subscription endpoint,
+/// including all the information necessary to send a notification to its owner.
+/// Devices attached to the user's account may register one of these in order
+/// to receive timely updates about account-related events.
+///
+/// Managing a web-push subscription is outside of the scope of this component.
+///
 dictionary DevicePushSubscription {
   string endpoint;
   string public_key;
   string auth_key;
 };
 
-// The payload sent when invoking a "send tab" command.
-//
+/// The payload sent when invoking a "send tab" command.
+///
 dictionary SendTabPayload {
 
-  // The navigation history of the sent tab.
-  //
-  // The last item in this list represents the page to be displayed,
-  // while earlier items may be included in the navigation history
-  // as a convenience to the user.
+  /// The navigation history of the sent tab.
+  ///
+  /// The last item in this list represents the page to be displayed,
+  /// while earlier items may be included in the navigation history
+  /// as a convenience to the user.
   sequence<TabHistoryEntry> entries;
 
-  // A unique identifier to be included in send-tab metrics.
-  //
-  // The application should treat this as opaque.
+  /// A unique identifier to be included in send-tab metrics.
+  ///
+  /// The application should treat this as opaque.
   string flow_id = "";
 
-  // A unique identifier to be included in send-tab metrics.
-  //
-  // The application should treat this as opaque.
+  /// A unique identifier to be included in send-tab metrics.
+  ///
+  /// The application should treat this as opaque.
   string stream_id = "";
 };
 
 /// The payload sent when invoking a "close tabs" command.
-//
+///
 dictionary CloseTabsPayload {
 
   /// The URLs of the tabs to close.
   sequence<string> urls;
 };
 
-// An individual entry in the navigation history of a sent tab.
-//
+/// An individual entry in the navigation history of a sent tab.
+///
 dictionary TabHistoryEntry {
   string title;
   string url;
 };
 
-// A client connected to the user's account.
-//
-// This struct provides metadata about a client connected to the user's account.
-// Unlike the [`Device`] struct, "clients" encompasses both client-side and server-side
-// applications - basically anything where the user is able to sign in with their
-// Firefox Account.
-//
-//
-// This data would typically be used for targeted messaging purposes, catering the
-// contents of the message to what other applications the user has on their account.
-//
+/// A client connected to the user's account.
+///
+/// This struct provides metadata about a client connected to the user's account.
+/// Unlike the [`Device`] struct, "clients" encompasses both client-side and server-side
+/// applications - basically anything where the user is able to sign in with their
+/// Firefox Account.
+///
+///
+/// This data would typically be used for targeted messaging purposes, catering the
+/// contents of the message to what other applications the user has on their account.
+///
 dictionary AttachedClient {
   string? client_id;
   string? device_id;
@@ -959,34 +960,34 @@ dictionary AttachedClient {
   sequence<string>? scope;
 };
 
-// Information about the user that controls a Firefox Account.
-//
-// This struct represents details about the user themselves, and would typically be
-// used to customize account-related UI in the browser so that it is personalize
-// for the current user.
-//
+/// Information about the user that controls a Firefox Account.
+///
+/// This struct represents details about the user themselves, and would typically be
+/// used to customize account-related UI in the browser so that it is personalize
+/// for the current user.
+///
 dictionary Profile {
 
-  // The user's account uid
-  //
-  // This is an opaque immutable unique identifier for their account.
+  /// The user's account uid
+  ///
+  /// This is an opaque immutable unique identifier for their account.
   string uid;
 
-  // The user's current primary email address.
-  //
-  // Note that unlike the `uid` field, the email address may change over time.
+  /// The user's current primary email address.
+  ///
+  /// Note that unlike the `uid` field, the email address may change over time.
   string email;
 
-  // The user's preferred textual display name.
+  /// The user's preferred textual display name.
   string? display_name;
 
-  // The URL of a profile picture representing the user.
-  //
-  // All accounts have a corresponding profile picture. If the user has not
-  // provided one then a default image is used.
+  /// The URL of a profile picture representing the user.
+  ///
+  /// All accounts have a corresponding profile picture. If the user has not
+  /// provided one then a default image is used.
   string avatar;
 
-  // Whether the `avatar` URL represents the default avatar image.
+  /// Whether the `avatar` URL represents the default avatar image.
   boolean is_default_avatar;
 };
 
@@ -1017,99 +1018,99 @@ enum FxaRustAuthState {
   "AuthIssues",
 };
 
-// A "capability" offered by a device.
-//
-// In the FxA ecosystem, connected devices may advertize their ability to respond
-// to various "commands" that can be invoked by other devices. The details of
-// executing these commands are encapsulated as part of the FxA Client component,
-// so consumers simply need to select which ones they want to support, and can
-// use the variants of this enum to do so.
-//
+/// A "capability" offered by a device.
+///
+/// In the FxA ecosystem, connected devices may advertize their ability to respond
+/// to various "commands" that can be invoked by other devices. The details of
+/// executing these commands are encapsulated as part of the FxA Client component,
+/// so consumers simply need to select which ones they want to support, and can
+/// use the variants of this enum to do so.
+///
 enum DeviceCapability {
   "SendTab",
   "CloseTabs",
 };
 
 
-// An event that happened on the user's account.
-//
-// If the application has registered a [`DevicePushSubscription`] as part of its
-// device record, then the Firefox Accounts server can send push notifications
-// about important events that happen on the user's account. This enum represents
-// the different kinds of event that can occur.
-//
+/// An event that happened on the user's account.
+///
+/// If the application has registered a [`DevicePushSubscription`] as part of its
+/// device record, then the Firefox Accounts server can send push notifications
+/// about important events that happen on the user's account. This enum represents
+/// the different kinds of event that can occur.
+///
 [Enum]
 interface AccountEvent {
 
-  // Sent when another device has invoked a command for this device to execute.
-  //
-  // When receiving this event, the application should inspect the contained
-  // command and react appropriately.
+  /// Sent when another device has invoked a command for this device to execute.
+  ///
+  /// When receiving this event, the application should inspect the contained
+  /// command and react appropriately.
   CommandReceived(IncomingDeviceCommand command );
 
-  // Sent when the user has modified their account profile information.
-  //
-  // When receiving this event, the application should request fresh profile
-  // information by calling [`get_profile`](FirefoxAccount::get_profile) with
-  // `ignore_cache` set to true, and update any profile information displayed
-  // in its UI.
-  //
+  /// Sent when the user has modified their account profile information.
+  ///
+  /// When receiving this event, the application should request fresh profile
+  /// information by calling [`get_profile`](FirefoxAccount::get_profile) with
+  /// `ignore_cache` set to true, and update any profile information displayed
+  /// in its UI.
+  ///
   ProfileUpdated();
 
-  // Sent when when there has been a change in authorization status.
-  //
-  // When receiving this event, the application should check whether it is
-  // still connected to the user's account by calling [`check_authorization_status`](
-  // FirefoxAccount::check_authorization_status), and updating its UI as appropriate.
-  //
+  /// Sent when when there has been a change in authorization status.
+  ///
+  /// When receiving this event, the application should check whether it is
+  /// still connected to the user's account by calling [`check_authorization_status`](
+  /// FirefoxAccount::check_authorization_status), and updating its UI as appropriate.
+  ///
   AccountAuthStateChanged();
 
-  // Sent when the user deletes their Firefox Account.
-  //
-  // When receiving this event, the application should act as though the user had
-  // signed out, discarding any persisted account state.
+  /// Sent when the user deletes their Firefox Account.
+  ///
+  /// When receiving this event, the application should act as though the user had
+  /// signed out, discarding any persisted account state.
   AccountDestroyed();
 
-  // Sent when a new device connects to the user's account.
-  //
-  // When receiving this event, the application may use it to trigger an update
-  // of any UI that shows the list of connected devices. It may also show the
-  // user an informational notice about the new device, as a security measure.
+  /// Sent when a new device connects to the user's account.
+  ///
+  /// When receiving this event, the application may use it to trigger an update
+  /// of any UI that shows the list of connected devices. It may also show the
+  /// user an informational notice about the new device, as a security measure.
   DeviceConnected(string device_name );
 
-  // Sent when a device disconnects from the user's account.
-  //
-  // When receiving this event, the application may use it to trigger an update
-  // of any UI that shows the list of connected devices.
+  /// Sent when a device disconnects from the user's account.
+  ///
+  /// When receiving this event, the application may use it to trigger an update
+  /// of any UI that shows the list of connected devices.
   DeviceDisconnected(string device_id, boolean is_local_device );
 
-  // An unknown event, most likely an event the client doesn't support yet.
-  //
-  // When receiving this event, the application should gracefully ignore it.
+  /// An unknown event, most likely an event the client doesn't support yet.
+  ///
+  /// When receiving this event, the application should gracefully ignore it.
   Unknown();
 };
 
 
-// A command invoked by another device.
-//
-// This enum represents all possible commands that can be invoked on
-// the device. It is the responsibility of the application to interpret
-// each command.
-//
+/// A command invoked by another device.
+///
+/// This enum represents all possible commands that can be invoked on
+/// the device. It is the responsibility of the application to interpret
+/// each command.
+///
 [Enum]
 interface IncomingDeviceCommand {
 
-  // Indicates that a tab has been sent to this device.
+  /// Indicates that a tab has been sent to this device.
   TabReceived(Device? sender, SendTabPayload payload );
 
   /// Indicates that the sender wants to close one or more tabs on this device.
   TabsClosed(Device? sender, CloseTabsPayload payload);
 };
 
-// Machinery for dry-run testing of FxaAuthStateMachine
-//
-// Remove this once we've migrated the firefox-android and firefox-ios code to using FxaAuthStateMachine
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1867793
+/// Machinery for dry-run testing of FxaAuthStateMachine
+///
+/// Remove this once we've migrated the firefox-android and firefox-ios code to using FxaAuthStateMachine
+/// https:///bugzilla.mozilla.org/show_bug.cgi?id=1867793
 
 interface FxaStateMachineChecker {
   constructor();

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -3,38 +3,38 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 namespace logins {
-    // We expose the crypto primitives on the namespace
+    /// We expose the crypto primitives on the namespace
 
-    // Create a new, random, encryption key.
+    /// Create a new, random, encryption key.
     [Throws=LoginsApiError]
     string create_key();
 
-    // Decrypt an `EncryptedLogin` to a `Login`
+    /// Decrypt an `EncryptedLogin` to a `Login`
     [Throws=LoginsApiError]
     Login decrypt_login(EncryptedLogin login, [ByRef]string encryption_key);
 
-    // Encrypt a `Login` to an `EncryptedLogin`
+    /// Encrypt a `Login` to an `EncryptedLogin`
     [Throws=LoginsApiError]
     EncryptedLogin encrypt_login(Login login, [ByRef]string encryption_key);
 
-    // Decrypt an encrypted `string` to `SecureLoginFields`
+    /// Decrypt an encrypted `string` to `SecureLoginFields`
     [Throws=LoginsApiError]
     SecureLoginFields decrypt_fields(string sec_fields, [ByRef]string encryption_key);
 
-    // Encrypt `SecureLoginFields` to an encrypted `string`
+    /// Encrypt `SecureLoginFields` to an encrypted `string`
     [Throws=LoginsApiError]
     string encrypt_fields(SecureLoginFields sec_fields, [ByRef]string encryption_key);
 
-    // Create a "canary" string, which can be used to test if the encryption key is still valid for the logins data
+    /// Create a "canary" string, which can be used to test if the encryption key is still valid for the logins data
     [Throws=LoginsApiError]
     string create_canary([ByRef]string text, [ByRef]string encryption_key);
 
-    // Check that key is still valid using the output of `create_canary`.  `text` much match the text you initially passed to `create_canary()`
+    /// Check that key is still valid using the output of `create_canary`.  `text` much match the text you initially passed to `create_canary()`
     [Throws=LoginsApiError]
     boolean check_canary([ByRef]string canary, [ByRef]string text, [ByRef]string encryption_key);
 };
 
-// The fields you can add or update.
+/// The fields you can add or update.
 dictionary LoginFields {
     string origin;
     string? http_realm;
@@ -43,13 +43,13 @@ dictionary LoginFields {
     string password_field;
 };
 
-// Fields available only while the encryption key is known.
+/// Fields available only while the encryption key is known.
 dictionary SecureLoginFields {
     string password;
     string username;
 };
 
-// Fields specific to database records
+/// Fields specific to database records
 dictionary RecordFields {
     string id;
     i64 times_used;
@@ -58,51 +58,52 @@ dictionary RecordFields {
     i64 time_password_changed;
 };
 
-// A login entry from the user, not linked to any database record.
-// The add/update APIs input these, alongside an encryption key.
+/// A login entry from the user, not linked to any database record.
+/// The add/update APIs input these, alongside an encryption key.
 dictionary LoginEntry {
     LoginFields fields;
     SecureLoginFields sec_fields;
 };
 
-// A login stored in the database
+/// A login stored in the database
 dictionary Login {
     RecordFields record;
     LoginFields fields;
     SecureLoginFields sec_fields;
 };
 
-// An encrypted version of [Login].  This is what we return for all the "read"
-// APIs - we never return the cleartext of encrypted fields.
+/// An encrypted version of [Login].  This is what we return for all the "read"
+/// APIs - we never return the cleartext of encrypted fields.
 dictionary EncryptedLogin {
     RecordFields record;
     LoginFields fields;
-    string sec_fields; // ciphertext of a SecureLoginFields
+    /// ciphertext of a SecureLoginFields
+    string sec_fields;
 };
 
-// These are the errors returned by our public API.
+/// These are the errors returned by our public API.
 [Error]
 interface LoginsApiError {
-    // The login data supplied is invalid. The reason will indicate what's wrong with it.
+    /// The login data supplied is invalid. The reason will indicate what's wrong with it.
     InvalidRecord(string reason);
 
-    // Asking to do something with a guid which doesn't exist.
+    /// Asking to do something with a guid which doesn't exist.
     NoSuchRecord(string reason);
 
-    // The encryption key supplied of the correct format, but not the correct key.
+    /// The encryption key supplied of the correct format, but not the correct key.
     IncorrectKey();
 
-    // An operation was interrupted at the request of the consuming app.
+    /// An operation was interrupted at the request of the consuming app.
     Interrupted(string reason);
 
-    // Sync reported that authentication failed and the user should re-enter their FxA password.
+    /// Sync reported that authentication failed and the user should re-enter their FxA password.
     // TODO: remove this at the same time as remove the sync() method in favour of the SyncManager.
     SyncAuthInvalid(string reason);
 
-    // something internal went wrong which doesn't have a public error value
-    // because the consuming app can not reasonably take any action to resolve it.
-    // The underlying error will have been logged and reported.
-    // (ideally would just be `Unexpected`, but that would be a breaking change)
+    /// something internal went wrong which doesn't have a public error value
+    /// because the consuming app can not reasonably take any action to resolve it.
+    /// The underlying error will have been logged and reported.
+    /// (ideally would just be `Unexpected`, but that would be a breaking change)
     UnexpectedLoginsApiError(string reason);
 };
 

--- a/components/nimbus/src/cirrus.udl
+++ b/components/nimbus/src/cirrus.udl
@@ -29,11 +29,11 @@ interface CirrusClient {
     [Throws=NimbusError]
     constructor(string app_context, MetricsHandler metrics_handler, sequence<string> coenrolling_feature_ids);
 
-    // Handles an enrollment request string and returns an enrollment response string.
+    /// Handles an enrollment request string and returns an enrollment response string.
     [Throws=NimbusError]
     string handle_enrollment(string request);
 
-    // Sets the experiments list in the CirrusClient's internal state.
+    /// Sets the experiments list in the CirrusClient's internal state.
     [Throws=NimbusError]
     void set_experiments(string experiments);
 };

--- a/components/nimbus/src/nimbus.udl
+++ b/components/nimbus/src/nimbus.udl
@@ -64,8 +64,8 @@ enum EnrollmentChangeEventType {
 
 callback interface MetricsHandler {
     void record_enrollment_statuses(sequence<EnrollmentStatusExtraDef> enrollment_status_extras);
-    // Feature activation is the pre-cursor to feature exposure: it is defined as the first time
-    // the feature configuration is asked for.
+    /// Feature activation is the pre-cursor to feature exposure: it is defined as the first time
+    /// the feature configuration is asked for.
     void record_feature_activation(FeatureExposureExtraDef event);
 
     void record_feature_exposure(FeatureExposureExtraDef event);
@@ -127,154 +127,154 @@ interface NimbusClient {
         MetricsHandler metrics_handler
     );
 
-    // Initializes the database and caches enough information so that the
-    // non-blocking API functions (eg, `get_experiment_branch()`) can
-    // return accurate results rather than throwing a "not initialized" error.
-    // It's not strictly necessary to call this function - any function that
-    // wants to use the database will implicitly initialize too - this exists
-    // so that the consuming application can have confidence the non-blocking
-    // functions will return data instead of returning an error, and will do
-    // the minimum amount of work to achieve that.
+    /// Initializes the database and caches enough information so that the
+    /// non-blocking API functions (eg, `get_experiment_branch()`) can
+    /// return accurate results rather than throwing a "not initialized" error.
+    /// It's not strictly necessary to call this function - any function that
+    /// wants to use the database will implicitly initialize too - this exists
+    /// so that the consuming application can have confidence the non-blocking
+    /// functions will return data instead of returning an error, and will do
+    /// the minimum amount of work to achieve that.
     [Throws=NimbusError]
     void initialize();
 
-    // Returns the branch allocated for a given slug or id.
+    /// Returns the branch allocated for a given slug or id.
     [Throws=NimbusError]
     string? get_experiment_branch(string id);
 
     [Throws=NimbusError]
     string? get_feature_config_variables(string feature_id);
 
-    // Returns a list of experiment branches for a given experiment ID.
+    /// Returns a list of experiment branches for a given experiment ID.
     [Throws=NimbusError]
     sequence<ExperimentBranch> get_experiment_branches(string experiment_slug);
 
-    // Returns a list of experiments this user is enrolled in.
+    /// Returns a list of experiments this user is enrolled in.
     [Throws=NimbusError]
     sequence<EnrolledExperiment> get_active_experiments();
 
-    // Records a Glean event that this feature has been exposed.
-    // If the feature is not involved in an experiment, then the event is suppressed.
-    // If the feature is only involved in a rollout, then the event is suppressed.
-    // If the feature is involved in an experiment, then record the experiment slug
-    // and branch.
-    // If the feature is involved in an experiment and a rollout, then record only the
-    // experiment slug and branch.
-    // If the slug is specified, then use this as the experiment, and use it to look up
-    // the branch. This is useful for coenrolling features.
+    /// Records a Glean event that this feature has been exposed.
+    /// If the feature is not involved in an experiment, then the event is suppressed.
+    /// If the feature is only involved in a rollout, then the event is suppressed.
+    /// If the feature is involved in an experiment, then record the experiment slug
+    /// and branch.
+    /// If the feature is involved in an experiment and a rollout, then record only the
+    /// experiment slug and branch.
+    /// If the slug is specified, then use this as the experiment, and use it to look up
+    /// the branch. This is useful for coenrolling features.
     void record_feature_exposure(string feature_id, string? slug);
 
-    // Records a Glean event that this feature configuration is malformed.
-    // Accepts a part_id to give the experiment owner or feature implementer
-    // clues where to look.
-    // The Glean event will always fire, but the content of that event will
-    // vary depending on whether then feature is part of an experiment or rollout
-    // or not.
+    /// Records a Glean event that this feature configuration is malformed.
+    /// Accepts a part_id to give the experiment owner or feature implementer
+    /// clues where to look.
+    /// The Glean event will always fire, but the content of that event will
+    /// vary depending on whether then feature is part of an experiment or rollout
+    /// or not.
     void record_malformed_feature_config(string feature_id, string part_id);
 
-    // Returns a list of experiments for this `app_name`, as specified in the `AppContext`.
-    // It is not intended to be used to be used for user facing applications.
+    /// Returns a list of experiments for this `app_name`, as specified in the `AppContext`.
+    /// It is not intended to be used to be used for user facing applications.
     [Throws=NimbusError]
     sequence<AvailableExperiment> get_available_experiments();
 
-    // Getter and setter for user's participation in all experiments.
-    // Possible values are:
-    // * `true`: the user will not enroll in new experiments, and opt out of all existing ones.
-    // * `false`: experiments proceed as usual.
+    /// Getter and setter for user's participation in all experiments.
+    /// Possible values are:
+    /// * `true`: the user will not enroll in new experiments, and opt out of all existing ones.
+    /// * `false`: experiments proceed as usual.
     [Throws=NimbusError]
     boolean get_global_user_participation();
 
     [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> set_global_user_participation(boolean opt_in);
 
-    // Fetches the list of experiments from the server. This does not affect the list
-    // of active experiments or experiment enrolment.
-    // Fetched experiments are not applied until `apply_pending_updates()` is called.
+    /// Fetches the list of experiments from the server. This does not affect the list
+    /// of active experiments or experiment enrolment.
+    /// Fetched experiments are not applied until `apply_pending_updates()` is called.
     [Throws=NimbusError]
     void fetch_experiments();
 
-    // Toggles the enablement of the fetch. If `false`, then calling `fetch_experiments`
-    // returns immediately, having not done any fetching from remote settings.
-    // This is only useful for QA, and should not be used in production: use
-    // `set_global_user_participation` instead.
+    /// Toggles the enablement of the fetch. If `false`, then calling `fetch_experiments`
+    /// returns immediately, having not done any fetching from remote settings.
+    /// This is only useful for QA, and should not be used in production: use
+    /// `set_global_user_participation` instead.
     [Throws=NimbusError]
     void set_fetch_enabled(boolean flag);
 
     [Throws=NimbusError]
     boolean is_fetch_enabled();
 
-    // Apply the updated experiments from the last fetch.
-    // After calling this, the list of active experiments might change
-    // (there might be new experiments, or old experiments might have expired).
+    /// Apply the updated experiments from the last fetch.
+    /// After calling this, the list of active experiments might change
+    /// (there might be new experiments, or old experiments might have expired).
     [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> apply_pending_experiments();
 
-    // A convenience method for apps to set the experiments from a local source
-    // for either testing, or before the first fetch has finished.
-    //
-    // Experiments set with this method are not applied until `apply_pending_updates()` is called.
+    /// A convenience method for apps to set the experiments from a local source
+    /// for either testing, or before the first fetch has finished.
+    ///
+    /// Experiments set with this method are not applied until `apply_pending_updates()` is called.
     [Throws=NimbusError]
     void set_experiments_locally(string experiments_json);
 
-    // These are test-only functions and should never be exposed to production
-    // users, as they mess with the "statistical requirements" of the SDK.
+    /// These are test-only functions and should never be exposed to production
+    /// users, as they mess with the "statistical requirements" of the SDK.
 
-    // Reset the enrollments and experiments in the database to an empty state.
+    /// Reset the enrollments and experiments in the database to an empty state.
     [Throws=NimbusError]
     void reset_enrollments();
 
-    // Opt in to a specific branch on a specific experiment. Useful for
-    // developers to test their app's interaction with the experiment.
+    /// Opt in to a specific branch on a specific experiment. Useful for
+    /// developers to test their app's interaction with the experiment.
     [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> opt_in_with_branch(string experiment_slug, string branch);
 
-    // Opt out of a specific experiment.
+    /// Opt out of a specific experiment.
     [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> opt_out(string experiment_slug);
 
-    // Reset internal state in response to application-level telemetry reset.
-    //
-    // Consumers should call this method when the user resets the telemetry state of the
-    // consuming application, such as by opting out of submitting telemetry. It resets the
-    // internal state of the Nimbus client to create a clean break between data collected
-    // before and after the reset, including:
-    //
-    //    * clearing any unique identifiers used internally, so they will reset to
-    //      new random values on next use.
-    //    * accepting new randomization units, based on application-level ids that
-    //      may have also changed.
-    //    * disqualifying this client out of any active experiments, to avoid submitting
-    //      misleading incomplete data.
-    //
+    /// Reset internal state in response to application-level telemetry reset.
+    ///
+    /// Consumers should call this method when the user resets the telemetry state of the
+    /// consuming application, such as by opting out of submitting telemetry. It resets the
+    /// internal state of the Nimbus client to create a clean break between data collected
+    /// before and after the reset, including:
+    ///
+    ///    * clearing any unique identifiers used internally, so they will reset to
+    ///      new random values on next use.
+    ///    * accepting new randomization units, based on application-level ids that
+    ///      may have also changed.
+    ///    * disqualifying this client out of any active experiments, to avoid submitting
+    ///      misleading incomplete data.
+    ///
     [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> reset_telemetry_identifiers();
 
-    // This provides low level access to the targeting machinery for other uses by the application (e.g. messages)
-    // Additional parameters can be added via the optional JSON object. This allows for many JEXL expressions
-    // to be run across the same context.
+    /// This provides low level access to the targeting machinery for other uses by the application (e.g. messages)
+    /// Additional parameters can be added via the optional JSON object. This allows for many JEXL expressions
+    /// to be run across the same context.
     [Throws=NimbusError]
     NimbusTargetingHelper create_targeting_helper(optional JsonObject? additional_context = null);
 
-    // This provides a unified String interpolation library which exposes the application context.
-    // It's first use is in the messaging helper, to add extra parameters to URLs.
+    /// This provides a unified String interpolation library which exposes the application context.
+    /// It's first use is in the messaging helper, to add extra parameters to URLs.
     [Throws=NimbusError]
     NimbusStringHelper create_string_helper(optional JsonObject? additional_context = null);
 
-    // Records an event for the purposes of behavioral targeting.
-    // This function is used to record and persist data used for the behavioral
-    // targeting such as "core-active" user targeting.
+    /// Records an event for the purposes of behavioral targeting.
+    /// This function is used to record and persist data used for the behavioral
+    /// targeting such as "core-active" user targeting.
     [Throws=NimbusError]
     void record_event(string event_id, optional i64 count = 1);
 
-    // Records an event as if it were in the past.
-    // This, and `advance_event_time` are useful for testing.
-    // `seconds_ago` must be positive.
+    /// Records an event as if it were in the past.
+    /// This, and `advance_event_time` are useful for testing.
+    /// `seconds_ago` must be positive.
     [Throws=NimbusError]
     void record_past_event(string event_id, i64 seconds_ago, optional i64 count = 1);
 
-    // Advances what the event store thinks is now.
-    // This, and `record_past_event` are useful for testing.
-    // `by_seconds` must be positive.
+    /// Advances what the event store thinks is now.
+    /// This, and `record_past_event` are useful for testing.
+    /// `by_seconds` must be positive.
     [Throws=NimbusError]
     void advance_event_time(i64 by_seconds);
 
@@ -286,18 +286,18 @@ interface NimbusClient {
 };
 
 interface NimbusTargetingHelper {
-    // Execute the given jexl expression and evaluate against the existing targeting parameters and context passed to
-    // the helper at construction.
+    /// Execute the given jexl expression and evaluate against the existing targeting parameters and context passed to
+    /// the helper at construction.
     [Throws=NimbusError]
     boolean eval_jexl(string expression);
 };
 
 interface NimbusStringHelper {
-    // Take the given template and find patterns that match the regular expression `{\w+}`.
-    // Any matches are used as keys into the application context, the `additional_context` or the special case `uuid`.
+    /// Take the given template and find patterns that match the regular expression `{\w+}`.
+    /// Any matches are used as keys into the application context, the `additional_context` or the special case `uuid`.
     string string_format(string template, optional string? uuid = null);
 
-    // Generates an optional UUID to be passed into the `string_format` method.
-    // If the return is not null, then it should be recorded with Glean as a UuidMetricType.
+    /// Generates an optional UUID to be passed into the `string_format` method.
+    /// If the return is not null, then it should be recorded with Glean as a UuidMetricType.
     string? get_uuid(string template);
 };

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -61,8 +61,8 @@ interface PlacesConnection {
     [Throws=PlacesApiError]
     sequence<SearchResult> query_autocomplete(string search, i32 limit);
 
-    // `url` is a `string` and not a `URL` because `accept_result`
-    // handles malformed urls
+    /// `url` is a `string` and not a `URL` because `accept_result`
+    /// handles malformed urls
     [Throws=PlacesApiError]
     void accept_result(string search_string, string url);
 
@@ -196,10 +196,10 @@ interface PlacesConnection {
     [Throws=PlacesApiError]
     Guid bookmarks_insert(InsertableBookmarkItem bookmark);
 
-    // Counts the number of bookmarks in the bookmark tree under the specified GUID. Does not count
-    // the passed item, so an empty folder will return zero, as will a non-existing GUID or the
-    // guid of a non-folder item.
-    // Counts only bookmark items - ie, sub-folders and separators are not counted.
+    /// Counts the number of bookmarks in the bookmark tree under the specified GUID. Does not count
+    /// the passed item, so an empty folder will return zero, as will a non-existing GUID or the
+    /// guid of a non-folder item.
+    /// Counts only bookmark items - ie, sub-folders and separators are not counted.
     [Throws=PlacesApiError]
     u32 bookmarks_count_bookmarks_in_trees([ByRef] sequence<Guid> folder_guids);
 
@@ -207,14 +207,13 @@ interface PlacesConnection {
     HistoryMigrationResult places_history_import_from_ios(string db_path, i64 last_sync_timestamp);
 };
 
-/**
- * Frecency threshold options for fetching top frecent sites. Requests a page that was visited
- * with a frecency score greater or equal to the value associated with the enums
- */
+
+/// Frecency threshold options for fetching top frecent sites. Requests a page that was visited
+/// with a frecency score greater or equal to the value associated with the enums
 enum FrecencyThresholdOption {
-// Returns all visited pages. The frecency score is 0
+   /// Returns all visited pages. The frecency score is 0
   "None",
-// Skip visited pages that were only visited once. The frecency score is 101
+   /// Skip visited pages that were only visited once. The frecency score is 101
   "SkipOneTimePages",
 };
 
@@ -234,18 +233,18 @@ dictionary SearchResult {
 // Everything below is from the crate::storage::history_metadata module...
 
 enum DocumentType {
-     // A page that isn't described by any other more specific types.
+     /// A page that isn't described by any other more specific types.
     "Regular",
-    // A media page.
+    /// A media page.
     "Media",
 };
 
 // Mimics https://searchfox.org/mozilla-central/rev/57f94ca1d57ab745242daafc8926690377579b83/toolkit/components/places/nsINavHistoryService.idl#922
 enum VisitType {
-    // This transition type means the user followed a link.
+    /// This transition type means the user followed a link.
     "Link",
-    // This transition type means that the user typed the page's URL in the
-    // URL bar or selected it from UI (URL bar autocomplete results, etc)
+    /// This transition type means that the user typed the page's URL in the
+    /// URL bar or selected it from UI (URL bar autocomplete results, etc)
     "Typed",
     "Bookmark",
     "Embed",
@@ -254,11 +253,11 @@ enum VisitType {
     "Download",
     "FramedLink",
     "Reload",
-     // Internal visit type used for meta data updates. Doesn't represent an actual page visit
+     /// Internal visit type used for meta data updates. Doesn't represent an actual page visit
     "UpdatePlace",
 };
 
-// This is used as an "input" to the api.
+/// This is used as an "input" to the api.
 dictionary HistoryMetadataObservation {
     string url;
     string? referrer_url = null;
@@ -268,7 +267,7 @@ dictionary HistoryMetadataObservation {
     string? title = null;
 };
 
-// This is what is returned.
+/// This is what is returned.
 dictionary HistoryMetadata {
     string url;
     string? title;
@@ -310,10 +309,8 @@ dictionary HistoryVisitInfosWithBound {
     i64 offset;
 };
 
-/**
- * Encapsulates either information about a visit to a page, or meta information about the page,
- * or both. Use [VisitType.UPDATE_PLACE] to differentiate an update from a visit.
- */
+/// Encapsulates either information about a visit to a page, or meta information about the page,
+/// or both. Use [VisitType.UPDATE_PLACE] to differentiate an update from a visit.
 dictionary VisitObservation {
     Url url;
     string? title = null;
@@ -327,7 +324,7 @@ dictionary VisitObservation {
     Url? preview_image_url = null;
 };
 
-// Exists just to convince uniffi to generate `liftSequence*` helpers!
+/// Exists just to convince uniffi to generate `liftSequence*` helpers!
 dictionary Dummy {
     sequence<HistoryMetadata>? md;
 };
@@ -401,7 +398,7 @@ dictionary BookmarkUpdateInfo {
 
 // Structs for inserting new bookmark items.
 
-// Where the item should be placed.
+/// Where the item should be placed.
 [Enum]
 interface BookmarkPosition {
     Specific(u32 pos);

--- a/components/push/src/push.udl
+++ b/components/push/src/push.udl
@@ -4,166 +4,166 @@
 
 namespace push {};
 
-// Object representing the PushManager used to manage subscriptions
-//
-// The `PushManager` object is the main interface provided by this crate
-// it allow consumers to manage push subscriptions. It exposes methods that
-// interact with the [`autopush server`](https://autopush.readthedocs.io/en/latest/)
-// and persists state representing subscriptions.
+/// Object representing the PushManager used to manage subscriptions
+///
+/// The `PushManager` object is the main interface provided by this crate
+/// it allow consumers to manage push subscriptions. It exposes methods that
+/// interact with the [`autopush server`](https:///autopush.readthedocs.io/en/latest/)
+/// and persists state representing subscriptions.
 interface PushManager {
-    // Creates a new [`PushManager`] object, not subscribed to any
-    // channels
-    //
-    // # Arguments
-    //
-    //   - `config`: The PushConfiguration for the PushManager
-    //
-    // # Errors
-    // Returns an error in the following cases:
-    //   - PushManager is unable to open the `database_path` given
+    /// Creates a new [`PushManager`] object, not subscribed to any
+    /// channels
+    ///
+    /// # Arguments
+    ///
+    ///   - `config`: The PushConfiguration for the PushManager
+    ///
+    /// # Errors
+    /// Returns an error in the following cases:
+    ///   - PushManager is unable to open the `database_path` given
     [Throws=PushApiError]
     constructor(PushConfiguration config);
 
-    // Subscribes to a new channel and gets the Subscription Info block
-    //
-    // # Arguments
-    //   - `scope` - Site scope string
-    //   - `server_key` - optional VAPID public key to "lock" subscriptions (defaults to "" for no key)
-    //
-    // # Returns
-    // A Subscription response that includes the following:
-    //   - A URL that can be used to deliver push messages
-    //   - A cryptographic key that can be used to encrypt messages
-    //     that would then be decrypted using the [`PushManager::decrypt`] function
-    //
-    // # Errors
-    // Returns an error in the following cases:
-    //   - PushManager was unable to access its persisted storage
-    //   - An error occurred sending a subscription request to the autopush server
-    //   - An error occurred generating or deserializing the cryptographic keys
+    /// Subscribes to a new channel and gets the Subscription Info block
+    ///
+    /// # Arguments
+    ///   - `scope` - Site scope string
+    ///   - `server_key` - optional VAPID public key to "lock" subscriptions (defaults to "" for no key)
+    ///
+    /// # Returns
+    /// A Subscription response that includes the following:
+    ///   - A URL that can be used to deliver push messages
+    ///   - A cryptographic key that can be used to encrypt messages
+    ///     that would then be decrypted using the [`PushManager::decrypt`] function
+    ///
+    /// # Errors
+    /// Returns an error in the following cases:
+    ///   - PushManager was unable to access its persisted storage
+    ///   - An error occurred sending a subscription request to the autopush server
+    ///   - An error occurred generating or deserializing the cryptographic keys
     [Throws=PushApiError]
     SubscriptionResponse subscribe([ByRef] string scope, [ByRef] optional string? app_server_sey = null);
 
 
-    // Retrieves an existing push subscription
-    //
-    // # Arguments
-    //   - `scope` - Site scope string
-    //
-    // # Returns
-    // A Subscription response that includes the following:
-    //   - A URL that can be used to deliver push messages
-    //   - A cryptographic key that can be used to encrypt messages
-    //     that would then be decrypted using the [`PushManager::decrypt`] function
-    //
-    // # Errors
-    // Returns an error in the following cases:
-    //   - PushManager was unable to access its persisted storage
-    //   - An error occurred generating or deserializing the cryptographic keys
+    /// Retrieves an existing push subscription
+    ///
+    /// # Arguments
+    ///   - `scope` - Site scope string
+    ///
+    /// # Returns
+    /// A Subscription response that includes the following:
+    ///   - A URL that can be used to deliver push messages
+    ///   - A cryptographic key that can be used to encrypt messages
+    ///     that would then be decrypted using the [`PushManager::decrypt`] function
+    ///
+    /// # Errors
+    /// Returns an error in the following cases:
+    ///   - PushManager was unable to access its persisted storage
+    ///   - An error occurred generating or deserializing the cryptographic keys
     [Throws=PushApiError]
     SubscriptionResponse? get_subscription([ByRef] string scope);
 
-    // Unsubscribe from given scope, ending that subscription for the user.
-    //
-    // # Arguments
-    //   - `scope` - The scope for the channel to remove
-    //
-    // # Returns
-    // Returns a boolean. Boolean is False if the subscription was already
-    // terminated in the past.
-    //
-    // # Errors
-    // Returns an error in the following cases:
-    //   - An error occurred sending an unsubscribe request to the autopush server
-    //   - An error occurred accessing the PushManager's persisted storage
+    /// Unsubscribe from given scope, ending that subscription for the user.
+    ///
+    /// # Arguments
+    ///   - `scope` - The scope for the channel to remove
+    ///
+    /// # Returns
+    /// Returns a boolean. Boolean is False if the subscription was already
+    /// terminated in the past.
+    ///
+    /// # Errors
+    /// Returns an error in the following cases:
+    ///   - An error occurred sending an unsubscribe request to the autopush server
+    ///   - An error occurred accessing the PushManager's persisted storage
     [Throws=PushApiError]
     boolean unsubscribe([ByRef] string scope);
 
-    // Unsubscribe all channels for the user
-    //
-    // # Errors
-    // Returns an error in the following cases:
-    //   - The PushManager does not contain a valid UAID
-    //   - An error occurred sending an unsubscribe request to the autopush server
-    //   - An error occurred accessing the PushManager's persisted storage
+    /// Unsubscribe all channels for the user
+    ///
+    /// # Errors
+    /// Returns an error in the following cases:
+    ///   - The PushManager does not contain a valid UAID
+    ///   - An error occurred sending an unsubscribe request to the autopush server
+    ///   - An error occurred accessing the PushManager's persisted storage
     [Throws=PushApiError]
     void unsubscribe_all();
 
-    // Updates the Native OS push registration ID.
-    //
-    // # Arguments:
-    //   - `new_token` - the new Native OS push registration ID
-    //
-    // # Errors
-    // Return an error in the following cases:
-    //   - The PushManager does not contain a valid UAID
-    //   - An error occurred sending an update request to the autopush server
-    //   - An error occurred accessing the PushManager's persisted storage
+    /// Updates the Native OS push registration ID.
+    ///
+    /// # Arguments:
+    ///   - `new_token` - the new Native OS push registration ID
+    ///
+    /// # Errors
+    /// Return an error in the following cases:
+    ///   - The PushManager does not contain a valid UAID
+    ///   - An error occurred sending an update request to the autopush server
+    ///   - An error occurred accessing the PushManager's persisted storage
     [Throws=PushApiError]
     void update([ByRef] string registration_token);
 
-    // Verifies the connection state
-    //
-    // **NOTE**: This does not resubscribe to any channels
-    // it only returns the list of channels that the client should
-    // re-subscribe to.
-    //
-    // # Returns
-    // Returns a list of [`PushSubscriptionChanged`]
-    // indicating the channels the consumer the client should re-subscribe
-    // to. If the list is empty, the client's connection was verified
-    // successfully, and the client does not need to resubscribe
-    //
-    // # Errors
-    // Return an error in the following cases:
-    //   - The PushManager does not contain a valid UAID
-    //   - An error occurred sending an channel list retrieval request to the autopush server
-    //   - An error occurred accessing the PushManager's persisted storage
+    /// Verifies the connection state
+    ///
+    /// **NOTE**: This does not resubscribe to any channels
+    /// it only returns the list of channels that the client should
+    /// re-subscribe to.
+    ///
+    /// # Returns
+    /// Returns a list of [`PushSubscriptionChanged`]
+    /// indicating the channels the consumer the client should re-subscribe
+    /// to. If the list is empty, the client's connection was verified
+    /// successfully, and the client does not need to resubscribe
+    ///
+    /// # Errors
+    /// Return an error in the following cases:
+    ///   - The PushManager does not contain a valid UAID
+    ///   - An error occurred sending an channel list retrieval request to the autopush server
+    ///   - An error occurred accessing the PushManager's persisted storage
     [Throws=PushApiError]
     sequence<PushSubscriptionChanged> verify_connection(optional boolean force_verify = false);
 
-    // Decrypts a raw push message.
-    //
-    // This accepts the content of a Push Message (from websocket or via Native Push systems).
-    // # Arguments:
-    //   - `payload`: The Push payload as received by the client from Push.
-    //
-    // # Returns
-    // Decrypted message body
-    //
-    // # Errors
-    // Returns an error in the following cases:
-    //   - The PushManager does not contain a valid UAID
-    //   - There are no records associated with the UAID the [`PushManager`] contains
-    //   - An error occurred while decrypting the message
-    //   - An error occurred accessing the PushManager's persisted storage
+    /// Decrypts a raw push message.
+    ///
+    /// This accepts the content of a Push Message (from websocket or via Native Push systems).
+    /// # Arguments:
+    ///   - `payload`: The Push payload as received by the client from Push.
+    ///
+    /// # Returns
+    /// Decrypted message body
+    ///
+    /// # Errors
+    /// Returns an error in the following cases:
+    ///   - The PushManager does not contain a valid UAID
+    ///   - There are no records associated with the UAID the [`PushManager`] contains
+    ///   - An error occurred while decrypting the message
+    ///   - An error occurred accessing the PushManager's persisted storage
     [Throws=PushApiError]
     DecryptResponse decrypt(record<DOMString, string> payload);
 };
 
-// Key Information that can be used to encrypt payloads
+/// Key Information that can be used to encrypt payloads
 dictionary KeyInfo {
     string auth;
     string p256dh;
 };
 
-// Subscription Information, the endpoint to send push messages to and
-// the key information that can be used to encrypt payloads
+/// Subscription Information, the endpoint to send push messages to and
+/// the key information that can be used to encrypt payloads
 dictionary SubscriptionInfo {
     string endpoint;
     KeyInfo keys;
 };
 
-// The subscription response object returned from [`PushManager::subscribe`]
+/// The subscription response object returned from [`PushManager::subscribe`]
 dictionary SubscriptionResponse {
     string channel_id;
     SubscriptionInfo subscription_info;
 };
 
-// An dictionary describing the push subscription that changed, the caller
-// will receive a list of [`PushSubscriptionChanged`] when calling
-// [`PushManager::verify_connection`], one entry for each channel that the
-// caller should resubscribe to
+/// An dictionary describing the push subscription that changed, the caller
+/// will receive a list of [`PushSubscriptionChanged`] when calling
+/// [`PushManager::verify_connection`], one entry for each channel that the
+/// caller should resubscribe to
 dictionary PushSubscriptionChanged {
     string channel_id;
     string scope;
@@ -174,8 +174,8 @@ dictionary DecryptResponse {
     string scope;
 };
 
-// The main Error returned from the Push component, each
-// variant describes a different error
+/// The main Error returned from the Push component, each
+/// variant describes a different error
 [Error]
 enum PushApiError {
     "UAIDNotRecognizedError",
@@ -185,14 +185,14 @@ enum PushApiError {
     "InternalError"
 };
 
-// The types of supported native bridges.
-//
-// FCM = Google Android Firebase Cloud Messaging
-// ADM = Amazon Device Messaging for FireTV
-// APNS = Apple Push Notification System for iOS
-//
-// Please contact services back-end for any additional bridge protocols.
-//
+/// The types of supported native bridges.
+///
+/// FCM = Google Android Firebase Cloud Messaging
+/// ADM = Amazon Device Messaging for FireTV
+/// APNS = Apple Push Notification System for iOS
+///
+/// Please contact services back-end for any additional bridge protocols.
+///
 enum BridgeType {
     "Fcm",
     "Adm",
@@ -208,9 +208,9 @@ dictionary PushConfiguration {
     u64? verify_connection_rate_limiter;
 };
 
-// Supported protocols for push
-// "Https" is default, and "Http" is only
-//  supported  for tests
+/// Supported protocols for push
+/// "Https" is default, and "Http" is only
+///  supported  for tests
 enum PushHttpProtocol {
     "Https",
     "Http"

--- a/components/relevancy/src/relevancy.udl
+++ b/components/relevancy/src/relevancy.udl
@@ -7,32 +7,32 @@ interface RelevancyApiError {
 
 // Top-level class for the Relevancy component
 interface RelevancyStore {
-    // Construct a new RelevancyStore
-    //
-    // This is non-blocking since databases and other resources are lazily opened.
+    /// Construct a new RelevancyStore
+    ///
+    /// This is non-blocking since databases and other resources are lazily opened.
     constructor(string dbpath);
 
-    // Close any open resources (for example databases)
-    //
-    // Calling `close` will interrupt any in-progress queries on other threads.
+    /// Close any open resources (for example databases)
+    ///
+    /// Calling `close` will interrupt any in-progress queries on other threads.
     void close();
 
-    // Interrupt any current database queries
+    /// Interrupt any current database queries
     void interrupt();
 
-    // Ingest the top URLs by frequency to build up the user's interest vector
+    /// Ingest the top URLs by frequency to build up the user's interest vector
     [Throws=RelevancyApiError]
     InterestVector ingest(sequence<string> top_urls);
 
-    // Calculate metrics for the user's interest vector in order to measure how strongly we're
-    // identifying interests.  See the `InterestMetrics` struct for details.
+    /// Calculate metrics for the user's interest vector in order to measure how strongly we're
+    /// identifying interests.  See the `InterestMetrics` struct for details.
     [Throws=RelevancyApiError]
     InterestMetrics calculate_metrics();
 
-    // Get the interest vector for the user.
-    //
-    // This is intended to be show to the user in an `about:` page so that users can judge if it
-    // feels correct.
+    /// Get the interest vector for the user.
+    ///
+    /// This is intended to be show to the user in an `about:` page so that users can judge if it
+    /// feels correct.
     [Throws=RelevancyApiError]
     InterestVector user_interest_vector();
 };
@@ -60,37 +60,37 @@ enum Interest {
     "Inconclusive",
 };
 
-// Interest metrics that we want to send to Glean as part of the validation process.  These contain
-// the cosine similarity when comparing the user's interest against various interest vectors that
-// consumers may use.
-//
-// Cosine similarly was chosen because it seems easy to calculate.  This was then matched against
-// some semi-plausible real-world interest vectors that consumers might use.  This is all up for
-// debate and we may decide to switch to some other metrics.
-//
-// Similarity values are transformed to integers by multiplying the floating point value by 1000 and
-// rounding.  This is to make them compatible with Glean's distribution metrics.
+/// Interest metrics that we want to send to Glean as part of the validation process.  These contain
+/// the cosine similarity when comparing the user's interest against various interest vectors that
+/// consumers may use.
+///
+/// Cosine similarly was chosen because it seems easy to calculate.  This was then matched against
+/// some semi-plausible real-world interest vectors that consumers might use.  This is all up for
+/// debate and we may decide to switch to some other metrics.
+///
+/// Similarity values are transformed to integers by multiplying the floating point value by 1000 and
+/// rounding.  This is to make them compatible with Glean's distribution metrics.
 dictionary InterestMetrics {
-    // Similarity between the user's interest vector and an interest vector where the element for
-    // the user's top interest is copied, but all other interests are set to zero.  This measures
-    // the highest possible similarity with consumers that used interest vectors with a single
-    // interest set.
+    /// Similarity between the user's interest vector and an interest vector where the element for
+    /// the user's top interest is copied, but all other interests are set to zero.  This measures
+    /// the highest possible similarity with consumers that used interest vectors with a single
+    /// interest set.
     u32 top_single_interest_similarity;
 
-    // The same as before, but the top 2 interests are copied. This measures the highest possible
-    // similarity with consumers that used interest vectors with a two interests (note: this means
-    // they would need to choose the user's top two interests and have the exact same proportion
-    // between them as the user).
+    /// The same as before, but the top 2 interests are copied. This measures the highest possible
+    /// similarity with consumers that used interest vectors with a two interests (note: this means
+    /// they would need to choose the user's top two interests and have the exact same proportion
+    /// between them as the user).
     u32 top_2interest_similarity;
 
-    // The same as before, but the top 3 interests are copied.
+    /// The same as before, but the top 3 interests are copied.
     u32 top_3interest_similarity;
 };
 
-// Vector storing a count value for each interest
-//
-// Here "vector" refers to the mathematical object, not a Rust `Vec`.  It always has a fixed
-// number of elements.
+/// Vector storing a count value for each interest
+///
+/// Here "vector" refers to the mathematical object, not a Rust `Vec`.  It always has a fixed
+/// number of elements.
 dictionary InterestVector {
     u32 animals;
     u32 arts;

--- a/components/remote_settings/src/remote_settings.udl
+++ b/components/remote_settings/src/remote_settings.udl
@@ -56,20 +56,20 @@ enum RemoteSettingsError {
 };
 
 interface RemoteSettings {
-    // Construct a new Remote Settings client with the given configuration.
+    /// Construct a new Remote Settings client with the given configuration.
     [Throws=RemoteSettingsError]
     constructor(RemoteSettingsConfig remote_settings_config);
 
-    // Fetch all records for the configuration this client was initialized with.
+    /// Fetch all records for the configuration this client was initialized with.
     [Throws=RemoteSettingsError]
     RemoteSettingsResponse get_records();
 
-    // Fetch all records added to the server since the provided timestamp,
-    // using the configuration this client was initialized with.
+    /// Fetch all records added to the server since the provided timestamp,
+    /// using the configuration this client was initialized with.
     [Throws=RemoteSettingsError]
     RemoteSettingsResponse get_records_since(u64 timestamp);
 
-    // Download an attachment with the provided id to the provided path.
+    /// Download an attachment with the provided id to the provided path.
     [Throws=RemoteSettingsError]
     void download_attachment_to_path(string attachment_id, string path);
 };

--- a/components/suggest/src/suggest.udl
+++ b/components/suggest/src/suggest.udl
@@ -17,9 +17,9 @@ boolean raw_suggestion_url_matches([ByRef] string raw_url, [ByRef] string url);
 
 [Error]
 interface SuggestApiError {
-    // An operation was interrupted by calling `SuggestStore.interrupt()`
+    /// An operation was interrupted by calling `SuggestStore.interrupt()`
     Interrupted();
-    // The server requested a backoff after too many requests
+    /// The server requested a backoff after too many requests
     Backoff(u64 seconds);
     Network(string reason);
     Other(string reason);
@@ -124,42 +124,42 @@ dictionary SuggestionQuery {
 dictionary SuggestIngestionConstraints {
     sequence<SuggestionProvider>? providers = null;
     SuggestionProviderConstraints? provider_constraints = null;
-    // Only ingest if the table `suggestions` is empty.
-    //
-    // This is indented to handle periodic updates.  Consumers can schedule an ingest with
-    // `empty_only=true` on startup and a regular ingest with `empty_only=false` to run on a long periodic schedule (maybe
-    // once a day). This allows ingestion to normally be run at a slow, periodic rate.  However, if
-    // there is a schema upgrade that causes the database to be thrown away, then the
-    // `empty_only=true` ingestion that runs on startup will repopulate it.
+    /// Only ingest if the table `suggestions` is empty.
+    ///
+    /// This is indented to handle periodic updates.  Consumers can schedule an ingest with
+    /// `empty_only=true` on startup and a regular ingest with `empty_only=false` to run on a long periodic schedule (maybe
+    /// once a day). This allows ingestion to normally be run at a slow, periodic rate.  However, if
+    /// there is a schema upgrade that causes the database to be thrown away, then the
+    /// `empty_only=true` ingestion that runs on startup will repopulate it.
     boolean empty_only = false;
 };
 
-// Some providers manage multiple suggestion subtypes. Queries, ingests, and
-// other operations on those providers must be constrained to a desired subtype.
+/// Some providers manage multiple suggestion subtypes. Queries, ingests, and
+/// other operations on those providers must be constrained to a desired subtype.
 dictionary SuggestionProviderConstraints {
-    // `Exposure` provider - For each desired exposure suggestion type, this
-    // should contain the value of the `suggestion_type` field of its remote
-    // settings record(s).
+    /// `Exposure` provider - For each desired exposure suggestion type, this
+    /// should contain the value of the `suggestion_type` field of its remote
+    /// settings record(s).
     sequence<string>? exposure_suggestion_types = null;
 };
 
 dictionary SuggestIngestionMetrics {
-    // Samples for the `suggest.ingestion_time` metric
+    /// Samples for the `suggest.ingestion_time` metric
     sequence<LabeledTimingSample> ingestion_times;
-    // Samples for the `suggest.ingestion_download_time` metric
+    /// Samples for the `suggest.ingestion_download_time` metric
     sequence<LabeledTimingSample> download_times;
 };
 
 dictionary QueryWithMetricsResult {
     sequence<Suggestion> suggestions;
-    // Samples for the `suggest.query_time` metric
+    /// Samples for the `suggest.query_time` metric
     sequence<LabeledTimingSample> query_times;
 };
 
-/// A single sample for a labeled timing distribution metric
+//// A single sample for a labeled timing distribution metric
 dictionary LabeledTimingSample {
     string label;
-    // Time in microseconds
+    /// Time in microseconds
     u64 value;
 };
 
@@ -196,10 +196,10 @@ interface SuggestStore {
     [Throws=SuggestApiError]
     void clear_dismissed_suggestions();
 
-    // Interrupt operations
-    //
-    // This is optional for backwards compatibility, but this is deprecated.  Consumers should
-    // update their code to pass in a InterruptKind value.
+    /// Interrupt operations
+    ///
+    /// This is optional for backwards compatibility, but this is deprecated.  Consumers should
+    /// update their code to pass in a InterruptKind value.
     void interrupt(optional InterruptKind? kind = null);
 
     [Throws=SuggestApiError]
@@ -221,7 +221,7 @@ interface SuggestStoreBuilder {
     [Self=ByArc]
     SuggestStoreBuilder data_path(string path);
 
-    // Deprecated: this is no longer used by the suggest component.
+    /// Deprecated: this is no longer used by the suggest component.
     [Self=ByArc]
     SuggestStoreBuilder cache_path(string path);
 
@@ -231,11 +231,11 @@ interface SuggestStoreBuilder {
     [Self=ByArc]
     SuggestStoreBuilder remote_settings_bucket_name(string bucket_name);
 
-    // Add an sqlite3 extension to load
-    //
-    // library_name should be the name of the library without any extension, for example `libmozsqlite3`.
-    // entrypoint should be the entry point, for example `sqlite3_fts5_init`.  If `null` (the default)
-    // entry point will be used (see https://sqlite.org/loadext.html for details).
+    /// Add an sqlite3 extension to load
+    ///
+    /// library_name should be the name of the library without any extension, for example `libmozsqlite3`.
+    /// entrypoint should be the entry point, for example `sqlite3_fts5_init`.  If `null` (the default)
+    /// entry point will be used (see https://sqlite.org/loadext.html for details).
     [Self=ByArc]
     SuggestStoreBuilder load_extension(string library_name, string? entrypoint);
 

--- a/components/support/error/src/errorsupport.udl
+++ b/components/support/error/src/errorsupport.udl
@@ -3,10 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 namespace errorsupport {
-    // Set the global error reporter.  This is typically done early in startup.
+    /// Set the global error reporter.  This is typically done early in startup.
     void set_application_error_reporter(ApplicationErrorReporter error_reporter);
-    // Unset the global error reporter.  This is typically done at shutdown for
-    // platforms that want to cleanup references like Desktop.
+    /// Unset the global error reporter.  This is typically done at shutdown for
+    /// platforms that want to cleanup references like Desktop.
     void unset_application_error_reporter();
 };
 

--- a/components/support/interrupt/src/interrupt_support.udl
+++ b/components/support/interrupt/src/interrupt_support.udl
@@ -1,5 +1,5 @@
 namespace interrupt_support {
-    // Enter shutdown mode, causing all current and future interruptible operations to be interrupted.
+    /// Enter shutdown mode, causing all current and future interruptible operations to be interrupted.
     void shutdown();
 };
 

--- a/components/support/nimbus-fml/src/fml.udl
+++ b/components/support/nimbus-fml/src/fml.udl
@@ -27,11 +27,11 @@ dictionary FmlLoaderConfig {
 };
 
 interface FmlClient {
-    // Constructs a new FmlClient object.
-    //
-    // Definitions of the parameters are as follows:
-    // - `manifest_path`: The path (relative to the current working directory) to the fml.yml that should be loaded.
-    // - `channel`: The channel that should be loaded for the manifest.
+    /// Constructs a new FmlClient object.
+    ///
+    /// Definitions of the parameters are as follows:
+    /// - `manifest_path`: The path (relative to the current working directory) to the fml.yml that should be loaded.
+    /// - `channel`: The channel that should be loaded for the manifest.
     [Throws=FMLError]
     constructor(string manifest, string channel);
 
@@ -41,28 +41,28 @@ interface FmlClient {
     [Name=new_with_config, Throws=FMLError]
     constructor(string manifest, string channel, FmlLoaderConfig config);
 
-    // Validates a supplied list of feature configurations. The valid configurations will be merged into the manifest's
-    // default feature JSON, and invalid configurations will be returned as a list of their respective errors.
+    /// Validates a supplied list of feature configurations. The valid configurations will be merged into the manifest's
+    /// default feature JSON, and invalid configurations will be returned as a list of their respective errors.
     [Throws=FMLError]
     MergedJsonWithErrors merge(record<DOMString, JsonObject> feature_configs);
 
-    // Returns the default feature JSON for the loaded FML's selected channel.
+    /// Returns the default feature JSON for the loaded FML's selected channel.
     [Throws=FMLError]
     string get_default_json();
 
-    // Returns a list of feature ids that support coenrollment.
+    /// Returns a list of feature ids that support coenrollment.
     [Throws=FMLError]
     sequence<string> get_coenrolling_feature_ids();
 
-    // Returns a list of feature ids.
+    /// Returns a list of feature ids.
     sequence<string> get_feature_ids();
 
-    // Returns a description of the given feature.
-    // If no feature exists, returns None.
+    /// Returns a description of the given feature.
+    /// If no feature exists, returns None.
     FmlFeatureDescriptor? get_feature_descriptor(string id);
 
-    // Returns a description of the given feature.
-    // If no feature exists, returns None.
+    /// Returns a description of the given feature.
+    /// If no feature exists, returns None.
     sequence<FmlFeatureDescriptor> get_feature_descriptors();
 
     FmlFeatureInspector? get_feature_inspector(string id);
@@ -92,91 +92,91 @@ dictionary DocumentationLink {
 };
 
 interface FmlFeatureInspector {
-    // Parses the string and returns a list of errors.
-    // Current implementation will only return one error.
+    /// Parses the string and returns a list of errors.
+    /// Current implementation will only return one error.
     sequence<FmlEditorError>? get_errors(string src);
 
-    // Returns the default JSON for the feature for this channel.
+    /// Returns the default JSON for the feature for this channel.
     [Throws=FMLError]
     JsonObject get_default_json();
 
     [Throws=FMLError]
     sequence<FmlFeatureExample> get_examples();
 
-    // Returns a 8 digit hex hash of the structure of the feature.
-    //
-    // This is suitable for tracking over time.
-    //
-    // This is a truncated SHA256 hash which takes in to consideration
-    // the name and types of all the variables in this feature, and nested
-    // objects, as well as the variants of enums.
-    //
-    // It does not take into consideration the default values for this
-    // feature, ordering of fields or variables or enum variants, or
-    // documentation, so as to remain stable despite superficial changes
-    // to the feature's configuration.
-    //
-    // If this hash changes for a given feature then it is almost
-    // certain that the code which uses this configuration will also have
-    // changed.
+    /// Returns a 8 digit hex hash of the structure of the feature.
+    ///
+    /// This is suitable for tracking over time.
+    ///
+    /// This is a truncated SHA256 hash which takes in to consideration
+    /// the name and types of all the variables in this feature, and nested
+    /// objects, as well as the variants of enums.
+    ///
+    /// It does not take into consideration the default values for this
+    /// feature, ordering of fields or variables or enum variants, or
+    /// documentation, so as to remain stable despite superficial changes
+    /// to the feature's configuration.
+    ///
+    /// If this hash changes for a given feature then it is almost
+    /// certain that the code which uses this configuration will also have
+    /// changed.
     string get_schema_hash();
 
-    // Returns a 8 digit hex hash of the default values for the feature.
-    //
-    // This is suitable for tracking over time.
-    //
-    // This is likely to change more frequently than the structure hash.
-    //
-    // It should be noted that the any changes to the structure hash will
-    // necessitate a change to this value, but not vice versa.
+    /// Returns a 8 digit hex hash of the default values for the feature.
+    ///
+    /// This is suitable for tracking over time.
+    ///
+    /// This is likely to change more frequently than the structure hash.
+    ///
+    /// It should be noted that the any changes to the structure hash will
+    /// necessitate a change to this value, but not vice versa.
     string get_defaults_hash();
 };
 
 dictionary FmlEditorError {
-    // The error to display to the user.
+    /// The error to display to the user.
     string message;
 
-    // The span within the text where the error was found.
+    /// The span within the text where the error was found.
     CursorSpan error_span;
 
-    // The error token, the text to highlight.
-    // The text string should coincide within the error_span. If not, then
-    // the error should be considered as out of date.
+    /// The error token, the text to highlight.
+    /// The text string should coincide within the error_span. If not, then
+    /// the error should be considered as out of date.
     string? highlight;
 
-    // A list of corrections that the user could take.
+    /// A list of corrections that the user could take.
     sequence<CorrectionCandidate> corrections;
 
-    // Deprecated: zero indexed line number for the error. Use error_span.from.line instead.
+    /// Deprecated: zero indexed line number for the error. Use error_span.from.line instead.
     u32 line;
-    // Deprecated: zero indexed column number for the error. Use error_span.from.col instead.
+    /// Deprecated: zero indexed column number for the error. Use error_span.from.col instead.
     u32 col;
 };
 
-// The span of an error, or insertion into the editor text.
+/// The span of an error, or insertion into the editor text.
 dictionary CursorSpan {
     CursorPosition from;
     CursorPosition to;
 };
 
 dictionary CursorPosition {
-    // zero indexed line number.
+    /// zero indexed line number.
     u32 line;
-    // zero indexed column number for the error.
+    /// zero indexed column number for the error.
     u32 col;
 };
 
 dictionary CorrectionCandidate {
-    // The string that should be inserted into the source
+    /// The string that should be inserted into the source
     string           insert;
-    // The short display name to represent the fix.
+    /// The short display name to represent the fix.
     string?          display_name;
 
-    // Insertion span. If None, then the error's error_span should be used.
+    /// Insertion span. If None, then the error's error_span should be used.
     CursorSpan?        insertion_span;
 
-    // The final position of the cursor after the insertion has taken place.
-    // If None, then should be left to the editor to decide.
+    /// The final position of the cursor after the insertion has taken place.
+    /// If None, then should be left to the editor to decide.
     CursorPosition?   cursor_at;
 };
 

--- a/components/support/rust-log-forwarder/src/rust_log_forwarder.udl
+++ b/components/support/rust-log-forwarder/src/rust_log_forwarder.udl
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 namespace rust_log_forwarder {
-    // Set the logger to forward to.
-    //
-    // Pass in null to disable logging.
+    /// Set the logger to forward to.
+    ///
+    /// Pass in null to disable logging.
     void set_logger(AppServicesLogger? logger);
-    // Set the maximum log level filter.  Records below this level will not be sent to the logger.
+    /// Set the maximum log level filter.  Records below this level will not be sent to the logger.
     void set_max_level(Level level);
 };
 
@@ -21,7 +21,7 @@ enum Level {
 
 dictionary Record {
     Level level;
-    // The target field from the Rust log crate.  Usually the Rust module name, however log! calls can manually override the target name.
+    /// The target field from the Rust log crate.  Usually the Rust module name, however log! calls can manually override the target name.
     string target;
     string message;
 };

--- a/components/sync15/src/sync15.udl
+++ b/components/sync15/src/sync15.udl
@@ -2,15 +2,15 @@
 
 // This exists purely to expose types used by other components.
 namespace sync15 {
+
 };
 
-// Enumeration for the different types of device.
-//
-// Firefox Accounts separates devices into broad categories for display purposes,
-// such as distinguishing a desktop PC from a mobile phone. Upon signin, the
-// application should inspect the device it is running on and select an appropriate
-// [`DeviceType`] to include in its device registration record.
-//
+/// Enumeration for the different types of device.
+///
+/// Firefox Accounts separates devices into broad categories for display purposes,
+/// such as distinguishing a desktop PC from a mobile phone. Upon signin, the
+/// application should inspect the device it is running on and select an appropriate
+/// [`DeviceType`] to include in its device registration record.
 enum DeviceType {
   "Desktop",
   "Mobile",

--- a/components/sync_manager/src/syncmanager.udl
+++ b/components/sync_manager/src/syncmanager.udl
@@ -21,27 +21,27 @@ enum SyncManagerError {
 };
 
 dictionary SyncParams {
-    // Why are we performing this sync?
+    /// Why are we performing this sync?
     SyncReason reason;
-    // Which engines should we sync?
+    /// Which engines should we sync?
     SyncEngineSelection engines;
-    // Which engines should be enabled in the "account global" list (for
-    // example, if the UI was used to change an engine's state since the last
-    // sync).
+    /// Which engines should be enabled in the "account global" list (for
+    /// example, if the UI was used to change an engine's state since the last
+    /// sync).
     record<DOMString, boolean> enabled_changes;
-    // Keys to encrypt/decrypt data from local database files.  These are
-    // separate from the key we use to encrypt the sync payload as a whole.
+    /// Keys to encrypt/decrypt data from local database files.  These are
+    /// separate from the key we use to encrypt the sync payload as a whole.
     record<DOMString, string> local_encryption_keys;
-    // Authorization for the sync server
+    /// Authorization for the sync server
     SyncAuthInfo auth_info;
-    // An opaque string, as returned in the previous sync's SyncResult and
-    // persisted to disk, or null if no such state is available. This includes
-    // information such as the list of engines previously enabled, certain
-    // server timestamps and GUIDs etc. If this value isn't correctly persisted
-    // and round-tripped, each sync may look like a "first sync".
+    /// An opaque string, as returned in the previous sync's SyncResult and
+    /// persisted to disk, or null if no such state is available. This includes
+    /// information such as the list of engines previously enabled, certain
+    /// server timestamps and GUIDs etc. If this value isn't correctly persisted
+    /// and round-tripped, each sync may look like a "first sync".
     string? persisted_state;
-    // Information about the current device, such as its name, formfactor and
-    // FxA device ID.
+    /// Information about the current device, such as its name, formfactor and
+    /// FxA device ID.
     DeviceSettings device_settings;
 };
 
@@ -74,25 +74,25 @@ dictionary DeviceSettings {
 };
 
 dictionary SyncResult {
-    // Result from the sync server
+    /// Result from the sync server
     ServiceStatus status;
-    // Engines that synced successfully
+    /// Engines that synced successfully
     sequence<string> successful;
-    // Maps the names of engines that failed to sync to the reason why
+    /// Maps the names of engines that failed to sync to the reason why
     record<DOMString, string> failures;
-    // State that should be persisted to disk and supplied to the sync method
-    // on the next sync (See SyncParams.persisted_state).
+    /// State that should be persisted to disk and supplied to the sync method
+    /// on the next sync (See SyncParams.persisted_state).
     string persisted_state;
-    // The list of engines which are marked as "declined" (ie, disabled) on the
-    // sync server. The list of declined engines is global to the account
-    // rather than to the device. Apps should use this after every sync to
-    // update the local state (ie, to ensure that their Sync UI correctly
-    // reflects what engines are enabled and disabled), because these could
-    // change after every sync.
+    /// The list of engines which are marked as "declined" (ie, disabled) on the
+    /// sync server. The list of declined engines is global to the account
+    /// rather than to the device. Apps should use this after every sync to
+    /// update the local state (ie, to ensure that their Sync UI correctly
+    /// reflects what engines are enabled and disabled), because these could
+    /// change after every sync.
     sequence<string>? declined;
-    // Earliest time that the next sync should happen at
+    /// Earliest time that the next sync should happen at
     timestamp? next_sync_allowed_at;
-    // JSON string encoding a `SyncTelemetryPing` object
+    /// JSON string encoding a `SyncTelemetryPing` object
     string? telemetry_json;
 };
 
@@ -108,13 +108,13 @@ enum ServiceStatus {
 interface SyncManager {
     constructor();
 
-    // Disconnect engines from sync, deleting/resetting the sync-related data
+    /// Disconnect engines from sync, deleting/resetting the sync-related data
     void disconnect();
 
-    // Perform a sync.  See [SyncParams] and [SyncResult] for details on how this works
+    /// Perform a sync.  See [SyncParams] and [SyncResult] for details on how this works
     [Throws=SyncManagerError]
     SyncResult sync(SyncParams params);
 
-    // Get a list of engine names available for syncing
+    /// Get a list of engine names available for syncing
     sequence<string> get_available_engines();
 };

--- a/components/tabs/src/tabs.udl
+++ b/components/tabs/src/tabs.udl
@@ -42,7 +42,7 @@ dictionary RemoteTabRecord {
     string title;
     sequence<string> url_history;
     string? icon;
-    // Number of ms since the unix epoch (as reported by the client's clock)
+    /// Number of ms since the unix epoch (as reported by the client's clock)
     i64 last_used;
     boolean inactive = false;
 };
@@ -51,7 +51,7 @@ dictionary ClientRemoteTabs {
     string client_id;
     string client_name;
     DeviceType device_type;
-    // Number of ms since the unix epoch (as reported by the server's clock)
+    /// Number of ms since the unix epoch (as reported by the server's clock)
     i64 last_modified;
     sequence<RemoteTabRecord> remote_tabs;
 };
@@ -94,11 +94,11 @@ dictionary PendingCommand {
     Timestamp? time_sent;
 };
 
-// Note the canonical docs for this are in https://searchfox.org/mozilla-central/source/services/interfaces/mozIBridgedSyncEngine.idl
-// It's only actually used in desktop, but it's fine to expose this everywhere.
-// NOTE: all timestamps here are milliseconds.
+/// Note the canonical docs for this are in https://searchfox.org/mozilla-central/source/services/interfaces/mozIBridgedSyncEngine.idl
+/// It's only actually used in desktop, but it's fine to expose this everywhere.
+/// NOTE: all timestamps here are milliseconds.
 interface TabsBridgedEngine {
-    //readonly attribute long storageVersion;
+    // readonly attribute long storageVersion;
     // readonly attribute boolean allowSkippedRecord;
 
     // XXX - better logging story than this?


### PR DESCRIPTION
So that the docs are being rendered properly, UDL files have to adhere to the Rust commenting style (`//` for internal comments, `///` for Rust doc comments, which will be rendered when creating documentation).

We use `uniffi` to create language documentation out of the UDL file, and put it here for:
* Swift: https://mozilla.github.io/application-services/swift/index.html
* Kotlin: https://mozilla.github.io/application-services/kotlin/index.html