### PR TITLE
Add ability for the tabs engine to close db connection

### DIFF
--- a/components/tabs/src/error.rs
+++ b/components/tabs/src/error.rs
@@ -50,6 +50,9 @@ pub enum Error {
 
     #[error("Error opening database: {0}")]
     OpenDatabaseError(#[from] sql_support::open_database::Error),
+
+    #[error("Unexpected connection state")]
+    UnexpectedConnectionState,
 }
 
 // Define how our internal errors are handled and converted to external errors
@@ -85,6 +88,12 @@ impl GetErrorHandling for Error {
                 reason: e.to_string(),
             })
             .report_error("tabs-open-database-error"),
+            Self::UnexpectedConnectionState => {
+                ErrorHandling::convert(TabsApiError::UnexpectedTabsError {
+                    reason: "Unexpected connection state".to_string(),
+                })
+                .report_error("tabs-unexpected-connection-state")
+            }
         }
     }
 }

--- a/components/tabs/src/storage.rs
+++ b/components/tabs/src/storage.rs
@@ -57,6 +57,12 @@ pub struct ClientRemoteTabs {
     pub remote_tabs: Vec<RemoteTab>,
 }
 
+pub(crate) enum DbConnection {
+    Created,
+    Open(Connection),
+    Closed,
+}
+
 // Tabs has unique requirements for storage:
 // * The "local_tabs" exist only so we can sync them out. There's no facility to
 //   query "local tabs", so there's no need to store these persistently - ie, they
@@ -72,7 +78,7 @@ pub struct ClientRemoteTabs {
 pub struct TabsStorage {
     local_tabs: RefCell<Option<Vec<RemoteTab>>>,
     db_path: PathBuf,
-    db_connection: Option<Connection>,
+    db_connection: DbConnection,
 }
 
 impl TabsStorage {
@@ -80,7 +86,18 @@ impl TabsStorage {
         Self {
             local_tabs: RefCell::default(),
             db_path: db_path.as_ref().to_path_buf(),
-            db_connection: None,
+            db_connection: DbConnection::Created,
+        }
+    }
+
+    pub fn close(&mut self) {
+        if let DbConnection::Open(conn) =
+            std::mem::replace(&mut self.db_connection, DbConnection::Closed)
+        {
+            if let Err(err) = conn.close() {
+                // Log the error, but continue with shutdown
+                log::error!("Failed to close the connection: {:?}", err);
+            }
         }
     }
 
@@ -93,8 +110,10 @@ impl TabsStorage {
 
     /// If a DB file exists, open and return it.
     pub fn open_if_exists(&mut self) -> Result<Option<&Connection>> {
-        if let Some(ref existing) = self.db_connection {
-            return Ok(Some(existing));
+        match self.db_connection {
+            DbConnection::Open(ref conn) => return Ok(Some(conn)),
+            DbConnection::Closed => return Ok(None),
+            DbConnection::Created => {}
         }
         let flags = OpenFlags::SQLITE_OPEN_NO_MUTEX
             | OpenFlags::SQLITE_OPEN_URI
@@ -105,8 +124,11 @@ impl TabsStorage {
             &crate::schema::TabsMigrationLogic,
         ) {
             Ok(conn) => {
-                self.db_connection = Some(conn);
-                Ok(self.db_connection.as_ref())
+                self.db_connection = DbConnection::Open(conn);
+                match self.db_connection {
+                    DbConnection::Open(ref conn) => Ok(Some(conn)),
+                    _ => unreachable!("impossible value"),
+                }
             }
             Err(open_database::Error::SqlError(rusqlite::Error::SqliteFailure(code, _)))
                 if code.code == rusqlite::ErrorCode::CannotOpen =>
@@ -119,8 +141,10 @@ impl TabsStorage {
 
     /// Open and return the DB, creating it if necessary.
     pub fn open_or_create(&mut self) -> Result<&Connection> {
-        if let Some(ref existing) = self.db_connection {
-            return Ok(existing);
+        match self.db_connection {
+            DbConnection::Open(ref conn) => return Ok(conn),
+            DbConnection::Closed => return Err(Error::UnexpectedConnectionState),
+            DbConnection::Created => {}
         }
         let flags = OpenFlags::SQLITE_OPEN_NO_MUTEX
             | OpenFlags::SQLITE_OPEN_URI
@@ -131,8 +155,11 @@ impl TabsStorage {
             flags,
             &crate::schema::TabsMigrationLogic,
         )?;
-        self.db_connection = Some(conn);
-        Ok(self.db_connection.as_ref().unwrap())
+        self.db_connection = DbConnection::Open(conn);
+        match self.db_connection {
+            DbConnection::Open(ref conn) => Ok(conn),
+            _ => unreachable!("We just set to Open, this should be impossible."),
+        }
     }
 
     pub fn update_local_state(&mut self, local_state: Vec<RemoteTab>) {
@@ -1530,5 +1557,32 @@ mod tests {
             .contains(&("device-1".to_string(), "https://example1.com".to_string())));
         assert!(remaining_commands
             .contains(&("device-2".to_string(), "https://example3.com".to_string())));
+    }
+
+    #[test]
+    fn test_close_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_close_connection.db");
+        let mut storage = TabsStorage::new(db_path);
+
+        // Open the connection
+        storage.open_or_create().unwrap();
+
+        // Verify that the connection is open
+        assert!(matches!(storage.db_connection, DbConnection::Open(_)));
+
+        // Close the connection
+        storage.close();
+
+        // Verify that the connection is closed
+        assert!(matches!(storage.db_connection, DbConnection::Closed));
+
+        // Attempt to reopen the connection should fail
+        let result = storage.open_or_create();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            Error::UnexpectedConnectionState
+        ));
     }
 }

--- a/components/tabs/src/store.rs
+++ b/components/tabs/src/store.rs
@@ -24,6 +24,13 @@ impl TabsStore {
         }
     }
 
+    // Closes connection to the tabs DB, this is named slightly
+    // different since Kotlin implements AutoClosable and doesn't
+    // want us using close
+    pub fn close_connection(&self) {
+        self.storage.lock().unwrap().close()
+    }
+
     pub fn set_local_tabs(&self, local_state: Vec<RemoteTab>) {
         self.storage.lock().unwrap().update_local_state(local_state);
     }

--- a/components/tabs/src/tabs.udl
+++ b/components/tabs/src/tabs.udl
@@ -23,6 +23,8 @@ interface TabsApiError {
 interface TabsStore {
     constructor(string path);
 
+    void close_connection();
+
     sequence<ClientRemoteTabs> get_all();
 
     void set_local_tabs(sequence<RemoteTabRecord> remote_tabs);


### PR DESCRIPTION
This is mainly a fix for the issue that came up in trying to land https://bugzilla.mozilla.org/show_bug.cgi?id=1911626. Which is happening because we don't properly close the tabs DB connection in the browser mochitest thus causing the error in the bug.

This exposes the ability to call `close` on the tab store during shutdown and ensure that we don't hit this issue.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
