### PR TITLE
Switch Android tests from junit 4 to junit-vintage [ci full]

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ androidx-test-runner = "1.6.1"
 androidx-test-work = "2.9.0"
 
 # Third Party Testing
-junit = "4.13.2"
+junit = "5.11.0"
 mockito = "5.12.0"
 robolectric = "4.13"
 
@@ -85,7 +85,7 @@ test-runner = { group = "androidx.test", name = "runner", version.ref = "android
 test-work = { group = "androidx.work", name = "work-testing", version.ref = "androidx-test-work" }
 
 # Third Party Testing
-junit = { group = "junit", name = "junit", version.ref = "junit" }
+junit = { group = "org.junit.vintage", name = "junit-vintage-engine", version.ref = "junit" }
 mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ androidx-test-work = "2.9.0"
 
 # Third Party Testing
 junit = "5.11.0"
-mockito = "5.12.0"
+mockito = "5.13.0"
 robolectric = "4.13"
 
 # Miscellaneous Gradle plugins


### PR DESCRIPTION
This is a useful first step to migrating to junit 5 as it allows you to switch to version 5 without having to rewrite every test en masse at the same time.