### PR TITLE
Disco 2821 - Add a score API for relevancy

### DIFF
--- a/components/relevancy/src/lib.rs
+++ b/components/relevancy/src/lib.rs
@@ -13,6 +13,7 @@ mod db;
 mod error;
 mod ingest;
 mod interest;
+mod ranker;
 mod rs;
 mod schema;
 pub mod url_hash;
@@ -20,6 +21,7 @@ pub mod url_hash;
 pub use db::RelevancyDb;
 pub use error::{ApiResult, Error, RelevancyApiError, Result};
 pub use interest::{Interest, InterestVector};
+pub use ranker::score;
 
 use error_support::handle_error;
 

--- a/components/relevancy/src/ranker.rs
+++ b/components/relevancy/src/ranker.rs
@@ -1,0 +1,115 @@
+use std::cmp::max;
+
+use crate::interest::{Interest, InterestVector};
+
+/// Calculate score for a piece of categorized content based on a user interest vector.
+///
+/// This scoring function is of the following properties:
+///   - The score ranges from 0.0 to 1.0
+///   - The score is monotonically increasing for the accumulated interest count
+///
+/// Params:
+///   - `interest_vector`: a user interest vector that can be fetched via
+///     `RelevancyStore::user_interest_vector()`.
+///   - `content_categories`: a list of categories (interests) of the give content.
+/// Return:
+//   - A score ranges in [0, 1].
+pub fn score(interest_vector: InterestVector, content_categories: Vec<Interest>) -> f64 {
+    let n = content_categories
+        .iter()
+        .fold(0, |acc, &category| acc + interest_vector[category]);
+
+    // Apply base 10 logarithm to the accumulated count so its hyperbolic tangent is more
+    // evenly distributed in [0, 1]. Note that `max(n, 1)` is used to avoid negative scores.
+    (max(n, 1) as f64).log10().tanh()
+}
+
+#[cfg(test)]
+mod test {
+    use crate::interest::{Interest, InterestVector};
+
+    use super::*;
+
+    const EPSILON: f64 = 1e-10;
+    const SUBEPSILON: f64 = 1e-6;
+
+    #[test]
+    fn test_score_lower_bound() {
+        // Empty interest vector yields score 0.
+        let s = score(InterestVector::default(), vec![Interest::Food]);
+        let delta = (s - 0_f64).abs();
+
+        assert!(delta < EPSILON);
+
+        // No overlap also yields score 0.
+        let s = score(
+            InterestVector {
+                animals: 10,
+                ..InterestVector::default()
+            },
+            vec![Interest::Food],
+        );
+        let delta = (s - 0_f64).abs();
+
+        assert!(delta < EPSILON);
+    }
+
+    #[test]
+    fn test_score_upper_bound() {
+        let score = score(
+            InterestVector {
+                animals: 1_000_000_000,
+                ..InterestVector::default()
+            },
+            vec![Interest::Animals],
+        );
+        let delta = (score - 1.0_f64).abs();
+
+        // Can get very close to the upper bound 1.0 but not over.
+        assert!(delta < SUBEPSILON);
+    }
+
+    #[test]
+    fn test_score_monotonic() {
+        let l = score(
+            InterestVector {
+                animals: 1,
+                ..InterestVector::default()
+            },
+            vec![Interest::Animals],
+        );
+
+        let r = score(
+            InterestVector {
+                animals: 5,
+                ..InterestVector::default()
+            },
+            vec![Interest::Animals],
+        );
+
+        assert!(l < r);
+    }
+
+    #[test]
+    fn test_score_multi_categories() {
+        let l = score(
+            InterestVector {
+                animals: 100,
+                food: 100,
+                ..InterestVector::default()
+            },
+            vec![Interest::Animals, Interest::Food],
+        );
+
+        let r = score(
+            InterestVector {
+                animals: 200,
+                ..InterestVector::default()
+            },
+            vec![Interest::Animals],
+        );
+        let delta = (l - r).abs();
+
+        assert!(delta < EPSILON);
+    }
+}

--- a/components/relevancy/src/relevancy.udl
+++ b/components/relevancy/src/relevancy.udl
@@ -1,4 +1,14 @@
-namespace relevancy { };
+namespace relevancy {
+  // Calculate score for a piece of categorized content based on a user interest vector.
+  //
+  // Params:
+  //   - `interest_vector`: a user interest vector that can be fetched via
+  //     `RelevancyStore::user_interest_vector()`.
+  //   - `content_categories`: a list of categories (interests) of the give content.
+  // Return:
+  //   - A score ranges in [0, 1].
+  double score(InterestVector interest_vector, sequence<Interest> content_categories);
+};
 
 [Error]
 interface RelevancyApiError {


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.

This adds a score API to the relevancy component.

Note:
- For simplicity, I opted to implement this as a stateless function instead of adding it as a method to `RelevancyStore`. Meaning that the consumer needs to provide both the user interest vector and the content categories for scoring. The former should be accessible through either `RelevancyStore::ingest()` or `RelevancyStore::user_interest_vector()`. The latter can be specified directly by the content provider.
- The score is implemented using a simple sigmoid function for now. See the code for more details.
- This is slightly different from the original design, in particular, it doesn't provide the ranking directly. The consumer needs to score all the content one by one (optionally, merge the score result with other scores) and rank all the candidates by themselves. I don't think that's too bad for them for the experimentation phase. We can add more ranking capabilities later as we go.