### PR TITLE
Starting new Remote Settings API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v132.0 (In progress)
 
+### Remote settings
+- Added `RemoteSettingsService` and `RemoteSettingsClient`.  These are a work in progress that will
+  eventually replace `RemoteSettings`.
+
 [Full Changelog](In progress)
 
 # v131.0 (_2024-08-30_)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,9 +470,9 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "camino"
-version = "1.0.9"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
  "serde",
 ]
@@ -3598,6 +3598,7 @@ dependencies = [
 name = "remote_settings"
 version = "0.1.0"
 dependencies = [
+ "camino",
  "expect-test",
  "log",
  "mockito",

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["/android", "/ios"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+camino = "1.1"
 log = "0.4"
 uniffi = { workspace = true }
 thiserror = "1.0"

--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -51,6 +51,19 @@ impl Client {
         })
     }
 
+    pub(crate) fn new_for_remote_settings_service(
+        server: RemoteSettingsServer,
+        bucket_name: String,
+        collection_name: String,
+    ) -> Result<Self> {
+        Ok(Self {
+            base_url: server.url()?,
+            bucket_name,
+            collection_name,
+            remote_state: Default::default(),
+        })
+    }
+
     /// Fetches all records for a collection that can be found in the server,
     /// bucket, and collection defined by the [ClientConfig] used to generate
     /// this [Client].

--- a/components/remote_settings/src/config.rs
+++ b/components/remote_settings/src/config.rs
@@ -18,12 +18,25 @@ use crate::Result;
 /// - `server_url`: An optional custom Remote Settings server URL. Deprecated; please use `server` instead.
 /// - `bucket_name`: The optional name of the bucket containing the collection on the server. If not specified, the standard bucket will be used.
 /// - `collection_name`: The name of the collection for the settings server.
+/// - `storage_dir`: Directory to store data in
 #[derive(Debug, Clone)]
 pub struct RemoteSettingsConfig {
     pub server: Option<RemoteSettingsServer>,
     pub server_url: Option<String>,
     pub bucket_name: Option<String>,
     pub collection_name: String,
+}
+
+/// Configuration for RemoteSettingsService
+///
+/// Once we move consumers away from the `RemoteSettings` API and to
+/// `RemoteSettingsService`/`RemoteSettingsClient`, we can remove the old config class and knock
+/// off the trailing `2`.
+#[derive(Debug, Clone)]
+pub struct RemoteSettingsConfig2 {
+    pub server: RemoteSettingsServer,
+    pub storage_dir: String,
+    pub bucket_name: Option<String>,
 }
 
 /// The Remote Settings server that the client should use.

--- a/components/remote_settings/src/remote_settings.udl
+++ b/components/remote_settings/src/remote_settings.udl
@@ -55,6 +55,10 @@ enum RemoteSettingsError {
     "ConfigError",
 };
 
+/// Remote settings client
+///
+/// Soft-deprecated.  We plan to move clients over to the new RemoteSettingsService and
+/// RemoteSettingsClient interfaces.
 interface RemoteSettings {
     /// Construct a new Remote Settings client with the given configuration.
     [Throws=RemoteSettingsError]
@@ -68,6 +72,53 @@ interface RemoteSettings {
     /// using the configuration this client was initialized with.
     [Throws=RemoteSettingsError]
     RemoteSettingsResponse get_records_since(u64 timestamp);
+
+    /// Download an attachment with the provided id to the provided path.
+    [Throws=RemoteSettingsError]
+    void download_attachment_to_path(string attachment_id, string path);
+};
+
+/// Stores application-level configuration data and constructs clients
+interface RemoteSettingsService {
+    constructor(RemoteSettingsConfig2 config);
+
+    /// Construct a new client with the configuration passed to the constructor
+    [Throws=RemoteSettingsError]
+    RemoteSettingsClient make_client(string collection_name);
+};
+
+/// Configuration for RemoteSettingsService
+///
+/// Once all clients have moved to the new API, we can remove the old RemoteSettingsConfig and
+/// rename this.
+dictionary RemoteSettingsConfig2 {
+    /// Server to use
+    RemoteSettingsServer server;
+    /// Directory to store data in.  Must be writable by the client.
+    string storage_dir;
+    /// Override bucket name ("main" by default, "preview" for preview collections)
+    string? bucket_name = null;
+};
+
+/// New remote settings client
+///
+/// This is a WIP matches the semantics of the official client more closely.  Once this is complete,
+/// we may decide to deprecate and remote the RemoteSettings class.
+interface RemoteSettingsClient {
+    /// Get the current set of records.
+    ///
+    /// If no records have been downloaded, this will return null.  Use `sync` to fetch the current
+    /// records from the server.
+    [Throws=RemoteSettingsError]
+    sequence<RemoteSettingsRecord>? get();
+
+    /// Sync records with the server.
+    [Throws=RemoteSettingsError]
+    void sync();
+
+    /// Sync records with the server if there are no records currently persisted.
+    [Throws=RemoteSettingsError]
+    void sync_if_empty();
 
     /// Download an attachment with the provided id to the provided path.
     [Throws=RemoteSettingsError]

--- a/components/remote_settings/src/storage.rs
+++ b/components/remote_settings/src/storage.rs
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use camino::Utf8Path;
+
+use crate::{RemoteSettingsRecord, Result};
+
+/// Storage container
+///
+/// This uses SQLite to store records and attachments in the database.
+pub struct Storage {}
+
+// TODO: actually implement these methods
+
+impl Storage {
+    pub fn new(_db_path: &Utf8Path) -> Result<Self> {
+        Ok(Self {})
+    }
+
+    /// Get all records currently in storage.
+    ///
+    /// Returns None if update_records has never been called.  Note: this is different from
+    /// update_records being called with 0 items.
+    pub fn get_records(&self) -> Result<Option<Vec<RemoteSettingsRecord>>> {
+        Ok(None)
+    }
+
+    /// Update the stored records
+    ///
+    /// records is a list of remote settings records downloaded from the server.  If any have
+    /// `deleted=true` then that record should be removed from storage.
+    pub fn update_records(
+        &self,
+        _records: Vec<RemoteSettingsRecord>,
+        _last_modified: u64,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    /// Get the last_modified time from the most recent call to [Self::update_records].
+    pub fn last_modified_time(&self) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    /// Get attachment data from storage
+    pub fn get_attachment_data(&self, _location: &str) -> Result<Option<Vec<u8>>> {
+        // Q: should we store attachment data directly in SQLite or put it in the filesystem?
+        todo!()
+    }
+
+    /// Store attachment data in storage
+    pub fn store_attachment_data(&self, _location: &str, _data: &[u8]) -> Result<()> {
+        todo!()
+    }
+}


### PR DESCRIPTION
Added the `RemoteSettingsService` and `RemoteSettingsClient` types. These provide the new remote settings API that we're hoping to implement. The goal is to match the API of the official client more closely.  The main changes are:
  - Downloaded data is stored locally
  - Getting/syncing records are split up into different operations to avoid hitting the network when getting settings values during startup.
  - Application-wide configuration is managed by `RemoteSettingsService`, which uses that to construct the clients.

This code is still a WIP.  The hope is that this outlines the general shape of the new API and the work that needs to be done.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
