### PR TITLE
Doc generation improvements with UniFFI library mode

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,7 @@
 [alias]
 regen-protobufs = ["run", "--bin", "protobuf-gen", "tools/protobuf_files.toml"]
 uniffi-bindgen = ["run", "--package", "embedded-uniffi-bindgen", "--"]
+uniffi-bindgen-library-mode = ["run", "--package", "uniffi-bindgen-library-mode", "--"]
 dev-install = ["install", "asdev"]
 verify_env = ["asdev", "verify_env"]
 fxa = ["run", "-p", "examples-fxa-client", "--"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4710,12 +4710,13 @@ checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "uniffi"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31bff6daf87277a9014bcdefbc2842b0553392919d1096843c5aad899ca4588"
+checksum = "2db87def739fe4183947f8419d572d1849a4a09355eba4e988a2105cfd0ac6a7"
 dependencies = [
  "anyhow",
  "camino",
+ "cargo_metadata",
  "clap 4.2.2",
  "uniffi_bindgen",
  "uniffi_build",
@@ -4724,10 +4725,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi-bindgen-library-mode"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "camino",
+ "cargo_metadata",
+ "clap 4.2.2",
+ "uniffi",
+ "uniffi_bindgen",
+]
+
+[[package]]
 name = "uniffi_bindgen"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96061d7e01b185aa405f7c9b134741ab3e50cc6796a47d6fd8ab9a5364b5feed"
+checksum = "7a112599c9556d1581e4a3d72019a74c2c3e122cc27f4af12577a429c4d5e614"
 dependencies = [
  "anyhow",
  "askama",
@@ -4743,15 +4756,14 @@ dependencies = [
  "textwrap 0.16.1",
  "toml",
  "uniffi_meta",
- "uniffi_testing",
  "uniffi_udl",
 ]
 
 [[package]]
 name = "uniffi_build"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b86f9b221046af0c533eafe09ece04e2f1ded04ccdc9bba0ec09aec1c52bd"
+checksum = "e2b12684401d2a8508ca9c72a95bbc45906417e42fc80942abaf033bbf01aa33"
 dependencies = [
  "anyhow",
  "camino",
@@ -4760,9 +4772,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcfa22f55829d3aaa7acfb1c5150224188fe0f27c59a8a3eddcaa24d1ffbe58"
+checksum = "a22dbe67c1c957ac6e7611bdf605a6218aa86b0eebeb8be58b70ae85ad7d73dc"
 dependencies = [
  "quote",
  "syn 2.0.72",
@@ -4770,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3210d57d6ab6065ab47a2898dacdb7c606fd6a4156196831fa3bf82e34ac58a6"
+checksum = "5a0c35aaad30e3a9e6d4fe34e358d64dbc92ee09045b48591b05fc9f12e0905b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4785,9 +4797,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58691741080935437dc862122e68d7414432a11824ac1137868de46181a0bd2"
+checksum = "db66474c5c61b0f7afc3b4995fecf9b72b340daa5ca0ef3da7778d75eb5482ea"
 dependencies = [
  "bincode",
  "camino",
@@ -4803,9 +4815,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7663eacdbd9fbf4a88907ddcfe2e6fa85838eb6dc2418a7d91eebb3786f8e20b"
+checksum = "d898893f102e0e39b8bcb7e3d2188f4156ba280db32db9e8af1f122d057e9526"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4815,9 +4827,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f922465f7566f25f8fe766920205fdfa9a3fcdc209c6bfb7557f0b5bf45b04dd"
+checksum = "2c6aa4f0cf9d12172d84fc00a35a6c1f3522b526daad05ae739f709f6941b9b6"
 dependencies = [
  "anyhow",
  "camino",
@@ -4828,9 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef408229a3a407fafa4c36dc4f6ece78a6fb258ab28d2b64bddd49c8cb680f6"
+checksum = "6b044e9c519e0bb51e516ab6f6d8f4f4dcf900ce30d5ad07c03f924e2824f28e"
 dependencies = [
  "anyhow",
  "textwrap 0.16.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "megazords/ios-rust/focus",
     "tools/protobuf-gen",
     "tools/embedded-uniffi-bindgen",
+    "tools/uniffi-bindgen-library-mode",
     "automation/swift-components-docs",
 
     "examples/*/",
@@ -119,6 +120,7 @@ default-members = [
 #    "testing/sync-test",
     "tools/protobuf-gen",
     "tools/embedded-uniffi-bindgen",
+    "tools/uniffi-bindgen-library-mode",
     "examples/*/",
     "testing/separated/*/",
 ]
@@ -126,7 +128,7 @@ default-members = [
 [workspace.dependencies]
 rusqlite = "0.31.0"
 libsqlite3-sys = "0.28.0"
-uniffi = "0.28.0"
+uniffi = "0.28.1"
 
 [profile.release]
 opt-level = "s"

--- a/automation/kotlin-components-docs/generate_docs.sh
+++ b/automation/kotlin-components-docs/generate_docs.sh
@@ -10,24 +10,7 @@ KOTLIN_DIR="$WORKING_DIR/src/main/kotlin"
 
 # Generate Kotlin bindings using uniffi-bindgen
 CARGO=${CARGO:-cargo}  # Use the provided CARGO or fallback to cargo
-
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/remote_settings/src/remote_settings.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/error/src/errorsupport.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/rust-log-forwarder/src/rust_log_forwarder.udl" -l kotlin -o "$KOTLIN_DIR"
-
-# Repeat for other components
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/crashtest/src/crashtest.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/fxa-client/src/fxa_client.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/logins/src/logins.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/autofill/src/autofill.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/push/src/push.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/tabs/src/tabs.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/places/src/places.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/suggest/src/suggest.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync_manager/src/syncmanager.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync15/src/sync15.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/as-ohttp-client/src/as_ohttp_client.udl" -l kotlin -o "$KOTLIN_DIR"
+$CARGO uniffi-bindgen-library-mode android kotlin "$KOTLIN_DIR"
 
 # Generate documentation with increased memory
 (cd "$WORKING_DIR" && "$REPO_ROOT/gradlew" --max-workers=2 dokkaHtml -Dorg.gradle.vfs.watch=false)

--- a/automation/swift-components-docs/generate-swift-project.sh
+++ b/automation/swift-components-docs/generate-swift-project.sh
@@ -49,28 +49,9 @@ SWIFT_DIR="$WORKING_DIR/Sources/$FRAMEWORK_NAME"
 mkdir -p "$INCLUDE_DIR"
 
 # Generate Swift bindings and headers using uniffi-bindgen
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/remote_settings/src/remote_settings.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/error/src/errorsupport.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/rust-log-forwarder/src/rust_log_forwarder.udl" -l swift -o "$SWIFT_DIR"
+$CARGO uniffi-bindgen-library-mode ios swift "$SWIFT_DIR"
 
 # Move header files to the include directory
-mv "$SWIFT_DIR"/*.h "$INCLUDE_DIR"
-
-# Repeat for the other components if not focus
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/crashtest/src/crashtest.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/fxa-client/src/fxa_client.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/logins/src/logins.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/autofill/src/autofill.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/push/src/push.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/tabs/src/tabs.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/places/src/places.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/suggest/src/suggest.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync_manager/src/syncmanager.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync15/src/sync15.udl" -l swift -o "$SWIFT_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/as-ohttp-client/src/as_ohttp_client.udl" -l swift -o "$SWIFT_DIR"
-
-# Move the header files to the include directory
 mv "$SWIFT_DIR"/*.h "$INCLUDE_DIR"
 
 rm -rf "$WORKING_DIR"/Sources/"$FRAMEWORK_NAME"/*.modulemap

--- a/tools/uniffi-bindgen-library-mode/Cargo.toml
+++ b/tools/uniffi-bindgen-library-mode/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "uniffi-bindgen-library-mode"
+version = "0.1.0"
+authors = ["The Firefox Sync Developers <sync-team@mozilla.com>"]
+edition = "2021"
+license = "MPL-2.0"
+
+[dependencies]
+uniffi = { workspace = true, features = ["cli"] }
+uniffi_bindgen = { version = "0.28.1", features = ["cargo-metadata"] }
+clap = "4"
+cargo_metadata = "0.15"
+camino = "1"
+anyhow = "1"

--- a/tools/uniffi-bindgen-library-mode/README.md
+++ b/tools/uniffi-bindgen-library-mode/README.md
@@ -1,0 +1,39 @@
+# Embedded uniffi-bindgen for this workspace
+
+This crate exists entirely to support running `cargo uniffi-bindgen` in the workspace
+root and having it correctly execute the `uniffi-bindgen` command provided by the
+version of `uniffi_bindgen` that's in use in the workspace.
+
+Say what?
+
+OK, so exposing a crate to Kotlin or Swift via `uniffi` is done in two halves:
+
+* On the Rust side, the crate needs to depend on `uniffi` for runtime support code.
+* On the foreign-language side, we need to run `uniffi-bindgen` as part of the build
+  process to generate the language bindings.
+
+It's very important that both halves use the exact same version of UniFFI, and UniFFI
+will *try* to error out if it detects this. But if you *don't* detect it then using
+mismatched versions of UniFFI will lead to an inscrutable linker failure at runtime.
+
+The simple way to use UniFFI is for developers to `cargo install uniffi_bindgen`
+on their system and then use the `uniffi-bindgen` command-line tool during the build.
+But unfortunately, this makes it painful to bump the version of the `uniffi` crate
+used by the components, and it greatly complicates doing local development on UniFFI
+itself.
+
+This crate offers a more complicated way that is also more robust to UniFFI version
+changes.
+
+First, configure all UniFFI-using crates to use the `builtin-bindgen` feature
+of `uniffi_build`.
+
+Then, instead of running the system-installed `uniffi-bindgen`, run our handy
+`cargo uniffi-bindgen` alias, which delegates to this crate. This will execute
+the `uniffi-bindgen` command-line tool *provided by the version of UniFFI specified
+in this crate*, letting us avoid having to install and update `uniffi-bindgen` at
+the system level
+
+You'll still have to ensure that all crates in this workspace are using the
+same version of UniFFI, but that's much simpler than controlling what's installed
+on everybody's build machine.

--- a/tools/uniffi-bindgen-library-mode/src/main.rs
+++ b/tools/uniffi-bindgen-library-mode/src/main.rs
@@ -1,0 +1,234 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::{
+    env::consts::{DLL_PREFIX, DLL_SUFFIX},
+    fmt,
+    process::Command,
+};
+
+use anyhow::{bail, Result};
+use camino::Utf8PathBuf;
+use cargo_metadata::Metadata;
+use clap::{Parser, ValueEnum};
+use uniffi_bindgen::{
+    bindings::{KotlinBindingGenerator, PythonBindingGenerator, SwiftBindingGenerator},
+    cargo_metadata::CrateConfigSupplier,
+    library_mode::generate_bindings,
+};
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    #[arg(value_enum)]
+    megazord: Megazord,
+    #[arg(value_enum)]
+    language: Language,
+    out_dir: String,
+}
+
+#[derive(Clone, ValueEnum)]
+enum Megazord {
+    Android,
+    Ios,
+    IosFocus,
+    Cirrus,
+    NimbusExperimenter,
+}
+
+#[derive(Clone, ValueEnum)]
+enum Language {
+    Kotlin,
+    Swift,
+    Python,
+}
+
+fn main() {
+    if let Err(e) = run_uniffi_bindgen(Cli::parse()) {
+        eprintln!("{e}");
+        std::process::exit(1);
+    }
+}
+
+fn run_uniffi_bindgen(cli: Cli) -> Result<()> {
+    check_args(&cli)?;
+    // TODO: A lot of this code is copy-and-pasted from uniffi-bindgen.  The plan to fix this is to
+    // make an 0.28.2 release that exposes a public interface for this.
+    let metadata = cargo_metadata::MetadataCommand::new()
+        .exec()
+        .expect("error running cargo metadata");
+    let library_path = build_library(&metadata, &cli.megazord, &cli.language);
+    let config_supplier = CrateConfigSupplier::from(metadata);
+    match cli.language {
+        Language::Kotlin => {
+            generate_bindings(
+                &library_path,
+                None,
+                &KotlinBindingGenerator,
+                &config_supplier,
+                None,
+                &Utf8PathBuf::from(cli.out_dir),
+                false,
+            )?;
+        }
+        Language::Swift => {
+            generate_bindings(
+                &library_path,
+                None,
+                &SwiftBindingGenerator,
+                &config_supplier,
+                None,
+                &Utf8PathBuf::from(cli.out_dir),
+                false,
+            )?;
+        }
+        Language::Python => {
+            generate_bindings(
+                &library_path,
+                None,
+                &PythonBindingGenerator,
+                &config_supplier,
+                None,
+                &Utf8PathBuf::from(cli.out_dir),
+                false,
+            )?;
+        }
+    };
+    Ok(())
+}
+
+fn check_args(cli: &Cli) -> Result<()> {
+    match &cli.megazord {
+        Megazord::Ios | Megazord::IosFocus => match &cli.language {
+            Language::Swift => Ok(()),
+            _ => bail!("{} megazord is only compatible with swift", cli.megazord),
+        },
+        _ => match &cli.language {
+            Language::Swift => bail!("{} megazord is not compatible with swift", cli.megazord),
+            _ => Ok(()),
+        },
+    }
+}
+
+/// Build a megazord library and return the path to it
+fn build_library(metadata: &Metadata, megazord: &Megazord, language: &Language) -> Utf8PathBuf {
+    Command::new(env!("CARGO"))
+        .arg("build")
+        .arg("--release")
+        .arg("--package")
+        .arg(megazord.crate_name())
+        .spawn()
+        .expect("Error running cargo build")
+        .wait()
+        .expect("Error running cargo build");
+    let filename = match language {
+        // Swift uses static libs
+        Language::Swift => format!("lib{}.a", megazord.crate_name().replace('-', "_")),
+        // Everything else uses dynamic librarys
+        _ => format!(
+            "{}{}{}",
+            DLL_PREFIX,
+            megazord.crate_name().replace('-', "_"),
+            DLL_SUFFIX
+        ),
+    };
+    metadata
+        .workspace_root
+        .join("target")
+        .join("release")
+        .join(filename)
+}
+
+impl Megazord {
+    fn crate_name(&self) -> &'static str {
+        match self {
+            Self::Android => "megazord",
+            Self::Ios => "megazord_ios",
+            Self::IosFocus => "megazord_focus",
+            Self::Cirrus => "cirrus",
+            Self::NimbusExperimenter => "nimbus-experimenter",
+        }
+    }
+}
+
+impl fmt::Display for Megazord {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            Self::Android => "android",
+            Self::Ios => "ios",
+            Self::IosFocus => "ios-focus",
+            Self::Cirrus => "cirrus",
+            Self::NimbusExperimenter => "nimbus-experimenter",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+impl fmt::Display for Language {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            Self::Swift => "swift",
+            Self::Kotlin => "kotlin",
+            Self::Python => "python",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+//     for language in languages {
+//         // to help avoid mistakes we check the library is actually a cdylib, except
+//         // for swift where static libs are often used to extract the metadata.
+//         if !matches!(language, TargetLanguage::Swift) && !uniffi_bindgen::is_cdylib(library_path) {
+//             anyhow::bail!(
+//                 "Generate bindings for {language} requires a cdylib, but {library_path} was given"
+//             );
+//         }
+//
+//         // Type-bounds on trait implementations makes selecting between languages a bit tedious.
+//         match language {
+//             TargetLanguage::Kotlin => generate_bindings(
+//                 library_path,
+//                 crate_name.clone(),
+//                 &KotlinBindingGenerator,
+//                 &config_supplier,
+//                 cfo,
+//                 out_dir,
+//                 fmt,
+//             )?
+//             .len(),
+//             TargetLanguage::Python => generate_bindings(
+//                 library_path,
+//                 crate_name.clone(),
+//                 &PythonBindingGenerator,
+//                 &config_supplier,
+//                 cfo,
+//                 out_dir,
+//                 fmt,
+//             )?
+//             .len(),
+//             TargetLanguage::Ruby => generate_bindings(
+//                 library_path,
+//                 crate_name.clone(),
+//                 &RubyBindingGenerator,
+//                 &config_supplier,
+//                 cfo,
+//                 out_dir,
+//                 fmt,
+//             )?
+//             .len(),
+//             TargetLanguage::Swift => generate_bindings(
+//                 library_path,
+//                 crate_name.clone(),
+//                 &SwiftBindingGenerator,
+//                 &config_supplier,
+//                 cfo,
+//                 out_dir,
+//                 fmt,
+//             )?
+//             .len(),
+//         };
+//     }
+//     Ok(())
+// }
+//


### PR DESCRIPTION
Added a tool to run uniffi-bindgen in library mode.  One nice thing about this is that it's much easier to figure out the library path in Rust than a shell script.

Use that script to simplify the generate docs scripts.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
