### PR TITLE
Pass the right symbols directory to upload_android_symbols.sh

### DIFF
--- a/automation/upload_android_symbols.sh
+++ b/automation/upload_android_symbols.sh
@@ -17,5 +17,10 @@ fi
 
 SYMBOLS_DIR=${1}
 
+if [ ! -d "${SYMBOLS_DIR}" ]; then
+    echo "upload_android_symbols.sh: ${SYMBOLS_DIR} is not a directory"
+    exit 1
+fi
+
 pip3 install --user -r automation/symbols-generation/requirements.txt
 python3 automation/symbols-generation/upload_symbols.py "${SYMBOLS_DIR}" -t "$PWD/.symbols_upload_token"

--- a/taskcluster/kinds/upload-symbols/kind.yml
+++ b/taskcluster/kinds/upload-symbols/kind.yml
@@ -42,7 +42,7 @@ tasks:
     run:
       using: run-commands
       commands:
-        - [automation/upload_android_symbols.sh, crashreporter-symbols"]
+        - [automation/upload_android_symbols.sh, /builds/worker/fetches/crashreporter-symbols]
       dummy-secrets:
           by-level:
               '3': []


### PR DESCRIPTION
The command had a stray double quote after `crashreporter-symbols`, and wasn't pointing at $MOZ_FETCHES_DIR, so AFAICT it was not actually uploading anything.