### PR TITLE
Fix the path to the megazord symbols when uploading

### DIFF
--- a/automation/symbols-generation/upload_symbols.py
+++ b/automation/symbols-generation/upload_symbols.py
@@ -65,6 +65,7 @@ def upload_symbols(zip_file, token_file):
         return True
 
     print("Upload symbols failed: {0}".format(r), file=sys.stderr)
+    print(r.text, file=sys.stderr)
     return False
 
 def main():

--- a/taskcluster/kinds/module-build/kind.yml
+++ b/taskcluster/kinds/module-build/kind.yml
@@ -8,7 +8,6 @@ loader: app_services_taskgraph.loader.build_config:loader
 
 transforms:
   - app_services_taskgraph.transforms.worker:transforms
-  - app_services_taskgraph.transforms.secrets:transforms
   - app_services_taskgraph.transforms.module_build:transforms
   - taskgraph.transforms.run:transforms
   - taskgraph.transforms.task:transforms
@@ -38,19 +37,6 @@ task-defaults:
       - ':{module_name}:assembleRelease'
       - ':{module_name}:publish'
       - ':{module_name}:checkMavenArtifacts'
-    dummy-secrets:
-        by-level:
-            '3': []
-            default:
-                - content: "faketoken"
-                  path: .symbols_upload_token
-    secrets:
-        by-level:
-            '3':
-                - name: project/application-services/symbols-token
-                  key: token
-                  path: .symbols_upload_token
-            default: []
     using: gradlew
     use-caches: true
 

--- a/taskcluster/kinds/upload-symbols/kind.yml
+++ b/taskcluster/kinds/upload-symbols/kind.yml
@@ -42,7 +42,7 @@ tasks:
     run:
       using: run-commands
       commands:
-        - [automation/upload_android_symbols.sh, /builds/worker/fetches/crashreporter-symbols]
+        - [automation/upload_android_symbols.sh, /builds/worker/fetches/crashreporter-symbols/crashreporter-symbols]
       dummy-secrets:
           by-level:
               '3': []


### PR DESCRIPTION
fetch-content extracts our symbols archive one directory deeper than I expected, so this fixes commit 37a76bb30d9fb35941cced8a56f66df17d0038ca's fix.

It also adds some more debugging info to the upload_symbols script in case of failure, and removes upload-symbols-related config from the module-build tasks.