### PR TITLE
fix: use library mode for kotlin docs

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -173,7 +173,34 @@ jobs:
           toolchain: stable
           override: true
 
+      - name: Build Dependencies
+        env:
+          NSS_DIR: ${{ github.workspace }}/libs/desktop/linux-x86-64/nss
+          NSS_STATIC: 1
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libclang-dev tcl ninja-build
+          
+          python3 -m venv venv
+          source venv/bin/activate
+          python3 -m pip install --upgrade pip setuptools six
+
+          # Clone the gyp repository
+          git clone https://chromium.googlesource.com/external/gyp.git tools/gyp
+          
+          # Navigate to gyp directory and install it
+          cd tools/gyp
+          python3 setup.py install
+          cd ../..
+
+          # Ensure the environment for desktop is correctly set up
+          # NSS for desktop has to be setup to build megazord
+          ./libs/verify-desktop-environment.sh
+
       - name: Build Kotlin docs
+        env:
+          NSS_DIR: ${{ github.workspace }}/libs/desktop/linux-x86-64/nss
+          NSS_STATIC: 1
         run: |
           cd ./automation/kotlin-components-docs
           chmod +x ./generate_docs.sh

--- a/automation/kotlin-components-docs/generate_docs.sh
+++ b/automation/kotlin-components-docs/generate_docs.sh
@@ -1,33 +1,33 @@
 #!/usr/bin/env bash
 
+# This script builds the Rust crate in its directory and generates Kotlin bindings,
+# using UniFFI in library mode.
+
+# Ensure script exits on errors or unset variables
+set -euo pipefail
+
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 REPO_ROOT="$( dirname "$( dirname "$THIS_DIR" )" )"
 WORKING_DIR=$THIS_DIR
-echo "Project root directory: $REPO_ROOT"
+CARGO="$HOME/.cargo/bin/cargo"
 
 # Set the documentation directory
 KOTLIN_DIR="$WORKING_DIR/src/main/kotlin"
 
-# Generate Kotlin bindings using uniffi-bindgen
-CARGO=${CARGO:-cargo}  # Use the provided CARGO or fallback to cargo
+# Build the Rust crate using Cargo
+echo "Building the Rust crate..."
+$CARGO build -p megazord --release
 
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/remote_settings/src/remote_settings.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/nimbus/src/nimbus.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/error/src/errorsupport.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/support/rust-log-forwarder/src/rust_log_forwarder.udl" -l kotlin -o "$KOTLIN_DIR"
+# Define the path to the generated Rust library
+LIBRARY_FILE="$REPO_ROOT/target/release/libmegazord.so"
+if [[ ! -f "$LIBRARY_FILE" ]]; then
+  echo "Error: Rust library not found at $LIBRARY_FILE"
+  exit 1
+fi
 
-# Repeat for other components
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/crashtest/src/crashtest.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/fxa-client/src/fxa_client.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/logins/src/logins.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/autofill/src/autofill.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/push/src/push.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/tabs/src/tabs.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/places/src/places.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/suggest/src/suggest.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync_manager/src/syncmanager.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/sync15/src/sync15.udl" -l kotlin -o "$KOTLIN_DIR"
-$CARGO uniffi-bindgen generate "$REPO_ROOT/components/as-ohttp-client/src/as_ohttp_client.udl" -l kotlin -o "$KOTLIN_DIR"
+# Generate Kotlin bindings, headers, and module map using uniffi-bindgen
+echo "Generating Kotlin bindings with uniffi-bindgen..."
+$CARGO uniffi-bindgen generate --library "$LIBRARY_FILE" --language kotlin --out-dir "$KOTLIN_DIR"
 
 # Generate documentation with increased memory
 (cd "$WORKING_DIR" && "$REPO_ROOT/gradlew" --max-workers=2 dokkaHtml -Dorg.gradle.vfs.watch=false)

--- a/automation/swift-components-docs/generate-swift-project.sh
+++ b/automation/swift-components-docs/generate-swift-project.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-#
+
 # This script builds the Rust crate in its directory and generates Swift bindings,
 # headers, and a module map using UniFFI in library mode.
 
-set -euo pipefail  # Ensure script exits on errors or unset variables
+# Ensure script exits on errors or unset variables
+set -euo pipefail
 
 FRAMEWORK_NAME="SwiftComponents"
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
@@ -18,10 +19,10 @@ mkdir -p "$INCLUDE_DIR"
 
 # Build the Rust crate using Cargo
 echo "Building the Rust crate..."
-$CARGO build -p megazord --release
+$CARGO build -p megazord_ios --release
 
 # Define the path to the generated Rust library
-LIBRARY_FILE="$REPO_ROOT/target/release/libmegazord.dylib"
+LIBRARY_FILE="$REPO_ROOT/target/release/libmegazord_ios.a"
 if [[ ! -f "$LIBRARY_FILE" ]]; then
   echo "Error: Rust library not found at $LIBRARY_FILE"
   exit 1

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -40,7 +40,7 @@
 - [Releases](howtos/releases.md)
   - [CI Publishing tools and flow](build-and-publish-pipeline.md)
   - [How to upgrade NSS](howtos/upgrading-nss-guide.md)
-- Rustdocs for components
+- [Rustdocs for components](rust-docs/index.html)
   - [as_ohttp_client](rust-docs/as_ohttp_client/index.html)
   - [autofill](rust-docs/autofill/index.html)
   - [crashtest](rust-docs/crashtest/index.html)


### PR DESCRIPTION
Using the `uniffi-bindgen` library mode to generate components. We updated `suggest` and `relevancy` and removed the `UDL` file. Therefore, both components are missing in the current published docs.