### PR TITLE
Bug 1921925 - Factor out weather suggestions into their own file, move keywords to attachment, and simplify record

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ credentials.json
 .*.swp
 *.db-shm
 *.db-wal
+*~
 .vscode/
 
 # Android stuff.

--- a/components/suggest/src/config.rs
+++ b/components/suggest/src/config.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::rs::{DownloadedGlobalConfig, DownloadedWeatherData};
+use crate::rs::DownloadedGlobalConfig;
 
 /// Global Suggest configuration data.
 #[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq, uniffi::Record)]
@@ -25,12 +25,4 @@ impl From<&DownloadedGlobalConfig> for SuggestGlobalConfig {
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, uniffi::Enum)]
 pub enum SuggestProviderConfig {
     Weather { min_keyword_length: i32 },
-}
-
-impl From<&DownloadedWeatherData> for SuggestProviderConfig {
-    fn from(data: &DownloadedWeatherData) -> Self {
-        Self::Weather {
-            min_keyword_length: data.weather.min_keyword_length,
-        }
-    }
 }

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -25,8 +25,7 @@ use crate::{
     rs::{
         DownloadedAmoSuggestion, DownloadedAmpSuggestion, DownloadedAmpWikipediaSuggestion,
         DownloadedExposureSuggestion, DownloadedFakespotSuggestion, DownloadedMdnSuggestion,
-        DownloadedPocketSuggestion, DownloadedWeatherData, DownloadedWikipediaSuggestion, Record,
-        SuggestRecordId,
+        DownloadedPocketSuggestion, DownloadedWikipediaSuggestion, Record, SuggestRecordId,
     },
     schema::{clear_database, SuggestConnectionInitializer},
     suggestion::{cook_raw_suggestion_url, AmpSuggestionType, Suggestion},
@@ -714,42 +713,6 @@ impl<'a> SuggestDao<'a> {
         Ok(suggestions)
     }
 
-    /// Fetches weather suggestions
-    pub fn fetch_weather_suggestions(&self, query: &SuggestionQuery) -> Result<Vec<Suggestion>> {
-        // Weather keywords are matched by prefix but the query must be at least
-        // three chars long. Unlike the prefix matching of other suggestion
-        // types, the query doesn't need to contain the first full word.
-        if query.keyword.len() < 3 {
-            return Ok(vec![]);
-        }
-
-        let keyword_lowercased = &query.keyword.trim().to_lowercase();
-        let suggestions = self.conn.query_rows_and_then_cached(
-            r#"
-            SELECT
-              s.score
-            FROM
-              suggestions s
-            JOIN
-              keywords k
-              ON k.suggestion_id = s.id
-            WHERE
-              s.provider = :provider
-              AND (k.keyword BETWEEN :keyword AND :keyword || X'FFFF')
-             "#,
-            named_params! {
-                ":keyword": keyword_lowercased,
-                ":provider": SuggestionProvider::Weather
-            },
-            |row| -> Result<Suggestion> {
-                Ok(Suggestion::Weather {
-                    score: row.get::<_, f64>("score")?,
-                })
-            },
-        )?;
-        Ok(suggestions)
-    }
-
     /// Fetches fakespot suggestions
     pub fn fetch_fakespot_suggestions(&self, query: &SuggestionQuery) -> Result<Vec<Suggestion>> {
         self.conn.query_rows_and_then_cached(
@@ -1110,32 +1073,6 @@ impl<'a> SuggestDao<'a> {
         Ok(())
     }
 
-    /// Inserts weather record data into the database.
-    pub fn insert_weather_data(
-        &mut self,
-        record_id: &SuggestRecordId,
-        data: &DownloadedWeatherData,
-    ) -> Result<()> {
-        let mut suggestion_insert = SuggestionInsertStatement::new(self.conn)?;
-        let mut keyword_insert = KeywordInsertStatement::new(self.conn)?;
-        self.scope.err_if_interrupted()?;
-        let suggestion_id = suggestion_insert.execute(
-            record_id,
-            "",
-            "",
-            data.weather.score.unwrap_or(DEFAULT_SUGGESTION_SCORE),
-            SuggestionProvider::Weather,
-        )?;
-        for (index, keyword) in data.weather.keywords.iter().enumerate() {
-            keyword_insert.execute(suggestion_id, keyword, None, index)?;
-        }
-        self.put_provider_config(
-            SuggestionProvider::Weather,
-            &SuggestProviderConfig::from(data),
-        )?;
-        Ok(())
-    }
-
     /// Inserts exposure suggestion records data into the database.
     pub fn insert_exposure_suggestions(
         &mut self,
@@ -1413,10 +1350,10 @@ impl<'a> FullKeywordInserter<'a> {
 // for providers like Mdn, Pocket, and Weather, which have relatively small number of records
 // compared to Amp/Wikipedia.
 
-struct SuggestionInsertStatement<'conn>(rusqlite::Statement<'conn>);
+pub(crate) struct SuggestionInsertStatement<'conn>(rusqlite::Statement<'conn>);
 
 impl<'conn> SuggestionInsertStatement<'conn> {
-    fn new(conn: &'conn Connection) -> Result<Self> {
+    pub(crate) fn new(conn: &'conn Connection) -> Result<Self> {
         Ok(Self(conn.prepare(
             "INSERT INTO suggestions(
                  record_id,
@@ -1431,7 +1368,7 @@ impl<'conn> SuggestionInsertStatement<'conn> {
     }
 
     /// Execute the insert and return the `suggestion_id` for the new row
-    fn execute(
+    pub(crate) fn execute(
         &mut self,
         record_id: &SuggestRecordId,
         title: &str,
@@ -1631,10 +1568,10 @@ impl<'conn> ExposureInsertStatement<'conn> {
     }
 }
 
-struct KeywordInsertStatement<'conn>(rusqlite::Statement<'conn>);
+pub(crate) struct KeywordInsertStatement<'conn>(rusqlite::Statement<'conn>);
 
 impl<'conn> KeywordInsertStatement<'conn> {
-    fn new(conn: &'conn Connection) -> Result<Self> {
+    pub(crate) fn new(conn: &'conn Connection) -> Result<Self> {
         Ok(Self(conn.prepare(
             "INSERT INTO keywords(
                  suggestion_id,
@@ -1647,7 +1584,7 @@ impl<'conn> KeywordInsertStatement<'conn> {
         )?))
     }
 
-    fn new_with_or_ignore(conn: &'conn Connection) -> Result<Self> {
+    pub(crate) fn new_with_or_ignore(conn: &'conn Connection) -> Result<Self> {
         Ok(Self(conn.prepare(
             "INSERT OR IGNORE INTO keywords(
                  suggestion_id,
@@ -1660,7 +1597,7 @@ impl<'conn> KeywordInsertStatement<'conn> {
         )?))
     }
 
-    fn execute(
+    pub(crate) fn execute(
         &mut self,
         suggestion_id: i64,
         keyword: &str,

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -21,6 +21,7 @@ mod store;
 mod suggestion;
 #[cfg(test)]
 mod testing;
+mod weather;
 mod yelp;
 
 pub use config::{SuggestGlobalConfig, SuggestProviderConfig};

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -196,7 +196,7 @@ pub(crate) enum SuggestRecord {
     #[serde(rename = "mdn-suggestions")]
     Mdn,
     #[serde(rename = "weather")]
-    Weather(DownloadedWeatherData),
+    Weather,
     #[serde(rename = "configuration")]
     GlobalConfig(DownloadedGlobalConfig),
     #[serde(rename = "amp-mobile-suggestions")]
@@ -233,7 +233,7 @@ impl From<&SuggestRecord> for SuggestRecordType {
             SuggestRecord::Icon => Self::Icon,
             SuggestRecord::Mdn => Self::Mdn,
             SuggestRecord::Pocket => Self::Pocket,
-            SuggestRecord::Weather(_) => Self::Weather,
+            SuggestRecord::Weather => Self::Weather,
             SuggestRecord::Yelp => Self::Yelp,
             SuggestRecord::GlobalConfig(_) => Self::GlobalConfig,
             SuggestRecord::AmpMobile => Self::AmpMobile,
@@ -628,21 +628,6 @@ impl FullOrPrefixKeywords<String> {
     }
 }
 
-/// Weather data to ingest from a weather record
-#[derive(Clone, Debug, Deserialize)]
-pub(crate) struct DownloadedWeatherData {
-    pub weather: DownloadedWeatherDataInner,
-}
-#[derive(Clone, Debug, Deserialize)]
-pub(crate) struct DownloadedWeatherDataInner {
-    pub min_keyword_length: i32,
-    pub keywords: Vec<String>,
-    // Remote settings doesn't support floats in record JSON so we use a
-    // stringified float instead. If a float can't be parsed, this will be None.
-    #[serde(default, deserialize_with = "de_stringified_f64")]
-    pub score: Option<f64>,
-}
-
 /// Global Suggest configuration data to ingest from a configuration record
 #[derive(Clone, Debug, Deserialize)]
 pub(crate) struct DownloadedGlobalConfig {
@@ -653,13 +638,6 @@ pub(crate) struct DownloadedGlobalConfigInner {
     /// The maximum number of times the user can click "Show less frequently"
     /// for a suggestion in the UI.
     pub show_less_frequently_cap: i32,
-}
-
-fn de_stringified_f64<'de, D>(deserializer: D) -> std::result::Result<Option<f64>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    String::deserialize(deserializer).map(|s| s.parse().ok())
 }
 
 #[cfg(test)]

--- a/components/suggest/src/schema.rs
+++ b/components/suggest/src/schema.rs
@@ -17,8 +17,8 @@ use sql_support::{
 ///  1. Bump this version.
 ///  2. Add a migration from the old version to the new version in
 ///     [`SuggestConnectionInitializer::upgrade_from`].
-///    a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
-///       the migration.
+///     a. If suggestions should be re-ingested after the migration, call `clear_database()` inside
+///        the migration.
 pub const VERSION: u32 = 26;
 
 /// The current Suggest database schema.

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -631,7 +631,7 @@ where
                     },
                 )?;
             }
-            SuggestRecord::Weather(data) => dao.insert_weather_data(&record.id, data)?,
+            SuggestRecord::Weather => self.process_weather_record(dao, record, download_timer)?,
             SuggestRecord::GlobalConfig(config) => {
                 dao.put_global_config(&SuggestGlobalConfig::from(config))?
             }
@@ -673,7 +673,7 @@ where
         Ok(())
     }
 
-    fn download_attachment<T>(
+    pub(crate) fn download_attachment<T>(
         &self,
         dao: &mut SuggestDao,
         record: &Record,
@@ -856,24 +856,20 @@ impl SuggestStoreDbs {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use parking_lot::Once;
-    use serde_json::json;
-    use sql_support::ConnExt;
-
     use crate::{testing::*, SuggestionProvider};
 
     /// In-memory Suggest store for testing
-    struct TestStore {
+    pub(crate) struct TestStore {
         pub inner: SuggestStoreInner<MockRemoteSettingsClient>,
     }
 
     impl TestStore {
-        fn new(client: MockRemoteSettingsClient) -> Self {
+        pub fn new(client: MockRemoteSettingsClient) -> Self {
             static COUNTER: AtomicUsize = AtomicUsize::new(0);
             let db_path = format!(
                 "file:test_store_data_{}?mode=memory&cache=shared",
@@ -884,25 +880,25 @@ mod tests {
             }
         }
 
-        fn client_mut(&mut self) -> &mut MockRemoteSettingsClient {
+        pub fn client_mut(&mut self) -> &mut MockRemoteSettingsClient {
             &mut self.inner.settings_client
         }
 
-        fn read<T>(&self, op: impl FnOnce(&SuggestDao) -> Result<T>) -> Result<T> {
+        pub fn read<T>(&self, op: impl FnOnce(&SuggestDao) -> Result<T>) -> Result<T> {
             self.inner.dbs().unwrap().reader.read(op)
         }
 
-        fn count_rows(&self, table_name: &str) -> u64 {
+        pub fn count_rows(&self, table_name: &str) -> u64 {
             let sql = format!("SELECT count(*) FROM {table_name}");
             self.read(|dao| Ok(dao.conn.query_one(&sql)?))
                 .unwrap_or_else(|e| panic!("SQL error in count: {e}"))
         }
 
-        fn ingest(&self, constraints: SuggestIngestionConstraints) {
+        pub fn ingest(&self, constraints: SuggestIngestionConstraints) {
             self.inner.ingest(constraints).unwrap();
         }
 
-        fn fetch_suggestions(&self, query: SuggestionQuery) -> Vec<Suggestion> {
+        pub fn fetch_suggestions(&self, query: SuggestionQuery) -> Vec<Suggestion> {
             self.inner.query(query).unwrap().suggestions
         }
 
@@ -920,15 +916,6 @@ mod tests {
                 .fetch_provider_config(provider)
                 .expect("Error fetching provider config")
         }
-    }
-
-    fn before_each() {
-        static ONCE: Once = Once::new();
-        ONCE.call_once(|| {
-            env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace"))
-                .is_test(true)
-                .init();
-        });
     }
 
     /// Tests that `SuggestStore` is usable with UniFFI, which requires exposed
@@ -2044,112 +2031,6 @@ mod tests {
     }
 
     #[test]
-    fn weather() -> anyhow::Result<()> {
-        before_each();
-
-        let store = TestStore::new(MockRemoteSettingsClient::default().with_inline_record(
-            "weather",
-            "weather-1",
-            json!({
-                "weather": {
-                    "min_keyword_length": 3,
-                    "keywords": ["ab", "xyz", "weather"],
-                    "score": "0.24"
-                },
-            }),
-        ));
-        store.ingest(SuggestIngestionConstraints::all_providers());
-        // No match since the query doesn't match any keyword
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("xab")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("abx")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("xxyz")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("xyzx")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("weatherx")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("xweather")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("xwea")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("x   weather")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("   weather x")),
-            vec![]
-        );
-        // No match since the query is too short
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("xy")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("ab")),
-            vec![]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("we")),
-            vec![]
-        );
-        // Matches
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("xyz")),
-            vec![Suggestion::Weather { score: 0.24 },]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("wea")),
-            vec![Suggestion::Weather { score: 0.24 },]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("weat")),
-            vec![Suggestion::Weather { score: 0.24 },]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("weath")),
-            vec![Suggestion::Weather { score: 0.24 },]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("weathe")),
-            vec![Suggestion::Weather { score: 0.24 },]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("weather")),
-            vec![Suggestion::Weather { score: 0.24 },]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::weather("  weather  ")),
-            vec![Suggestion::Weather { score: 0.24 },]
-        );
-
-        assert_eq!(
-            store.fetch_provider_config(SuggestionProvider::Weather),
-            Some(SuggestProviderConfig::Weather {
-                min_keyword_length: 3,
-            })
-        );
-
-        Ok(())
-    }
-
-    #[test]
     fn fetch_global_config() -> anyhow::Result<()> {
         before_each();
 
@@ -2208,20 +2089,28 @@ mod tests {
     fn fetch_provider_config_other() -> anyhow::Result<()> {
         before_each();
 
-        let store = TestStore::new(MockRemoteSettingsClient::default().with_inline_record(
+        let store = TestStore::new(MockRemoteSettingsClient::default().with_record(
             "weather",
             "weather-1",
             json!({
-                "weather": {
-                    "min_keyword_length": 3,
-                    "keywords": ["weather"],
-                    "score": "0.24"
-                },
+                "min_keyword_length": 3,
+                "score": 0.24,
+                "keywords": []
             }),
         ));
         store.ingest(SuggestIngestionConstraints::all_providers());
+
+        // Sanity-check that the weather config was ingested.
+        assert_eq!(
+            store.fetch_provider_config(SuggestionProvider::Weather),
+            Some(SuggestProviderConfig::Weather {
+                min_keyword_length: 3,
+            })
+        );
+
         // Getting the config for a different provider should return None.
         assert_eq!(store.fetch_provider_config(SuggestionProvider::Amp), None);
+
         Ok(())
     }
 

--- a/components/suggest/src/testing/mod.rs
+++ b/components/suggest/src/testing/mod.rs
@@ -9,7 +9,11 @@ pub use client::{MockIcon, MockRemoteSettingsClient};
 pub use data::*;
 
 use crate::Suggestion;
+use parking_lot::Once;
 use serde_json::Value as JsonValue;
+
+pub use serde_json::json;
+pub use sql_support::ConnExt;
 
 /// Trait with utility functions for JSON handling in the tests
 pub trait JsonExt {
@@ -98,4 +102,13 @@ impl Suggestion {
             _ => panic!("has_location_sign only valid for yelp suggestions"),
         }
     }
+}
+
+pub fn before_each() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("trace"))
+            .is_test(true)
+            .init();
+    });
 }

--- a/components/suggest/src/weather.rs
+++ b/components/suggest/src/weather.rs
@@ -1,0 +1,226 @@
+use rusqlite::named_params;
+use serde::Deserialize;
+use sql_support::ConnExt;
+
+use crate::{
+    config::SuggestProviderConfig,
+    db::{KeywordInsertStatement, SuggestDao, SuggestionInsertStatement, DEFAULT_SUGGESTION_SCORE},
+    metrics::DownloadTimer,
+    provider::SuggestionProvider,
+    rs::{Client, Record, SuggestRecordId},
+    store::SuggestStoreInner,
+    suggestion::Suggestion,
+    Result, SuggestionQuery,
+};
+
+impl SuggestDao<'_> {
+    /// Fetches weather suggestions.
+    pub fn fetch_weather_suggestions(&self, query: &SuggestionQuery) -> Result<Vec<Suggestion>> {
+        // Weather keywords are matched by prefix but the query must be at least
+        // three chars long. Unlike the prefix matching of other suggestion
+        // types, the query doesn't need to contain the first full word.
+        if query.keyword.len() < 3 {
+            return Ok(vec![]);
+        }
+
+        let keyword_lowercased = &query.keyword.trim().to_lowercase();
+        let suggestions = self.conn.query_rows_and_then_cached(
+            r#"
+            SELECT
+              s.score
+            FROM
+              suggestions s
+            JOIN
+              keywords k
+              ON k.suggestion_id = s.id
+            WHERE
+              s.provider = :provider
+              AND (k.keyword BETWEEN :keyword AND :keyword || X'FFFF')
+            "#,
+            named_params! {
+                ":keyword": keyword_lowercased,
+                ":provider": SuggestionProvider::Weather
+            },
+            |row| -> Result<Suggestion> {
+                Ok(Suggestion::Weather {
+                    score: row.get::<_, f64>("score")?,
+                })
+            },
+        )?;
+        Ok(suggestions)
+    }
+
+    /// Inserts weather suggestions data into the database.
+    fn insert_weather_data(
+        &mut self,
+        record_id: &SuggestRecordId,
+        attachments: &[DownloadedWeatherAttachment],
+    ) -> Result<()> {
+        self.scope.err_if_interrupted()?;
+        let mut suggestion_insert = SuggestionInsertStatement::new(self.conn)?;
+        let mut keyword_insert = KeywordInsertStatement::new(self.conn)?;
+        for attachment in attachments {
+            let suggestion_id = suggestion_insert.execute(
+                record_id,
+                "",
+                "",
+                attachment.score.unwrap_or(DEFAULT_SUGGESTION_SCORE),
+                SuggestionProvider::Weather,
+            )?;
+            for (i, keyword) in attachment.keywords.iter().enumerate() {
+                keyword_insert.execute(suggestion_id, keyword, None, i)?;
+            }
+            self.put_provider_config(SuggestionProvider::Weather, &attachment.into())?;
+        }
+        Ok(())
+    }
+}
+
+impl<S> SuggestStoreInner<S>
+where
+    S: Client,
+{
+    /// Inserts a weather record into the database.
+    pub fn process_weather_record(
+        &self,
+        dao: &mut SuggestDao,
+        record: &Record,
+        download_timer: &mut DownloadTimer,
+    ) -> Result<()> {
+        self.download_attachment(dao, record, download_timer, |dao, record_id, data| {
+            dao.insert_weather_data(record_id, data)
+        })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct DownloadedWeatherAttachment {
+    pub keywords: Vec<String>,
+    pub min_keyword_length: i32,
+    pub score: Option<f64>,
+}
+
+impl From<&DownloadedWeatherAttachment> for SuggestProviderConfig {
+    fn from(a: &DownloadedWeatherAttachment) -> Self {
+        Self::Weather {
+            min_keyword_length: a.min_keyword_length,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{store::tests::TestStore, testing::*, SuggestIngestionConstraints};
+
+    #[test]
+    fn weather() -> anyhow::Result<()> {
+        before_each();
+
+        let store = TestStore::new(MockRemoteSettingsClient::default().with_record(
+            "weather",
+            "weather-1",
+            json!({
+                "keywords": ["ab", "xyz", "weather"],
+                "min_keyword_length": 3,
+                "score": 0.24
+            }),
+        ));
+
+        store.ingest(SuggestIngestionConstraints {
+            providers: Some(vec![SuggestionProvider::Weather]),
+            ..SuggestIngestionConstraints::all_providers()
+        });
+
+        // No match since the query doesn't match any keyword
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("xab")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("abx")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("xxyz")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("xyzx")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("weatherx")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("xweather")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("xwea")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("x   weather")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("   weather x")),
+            vec![]
+        );
+
+        // No match since the query is too short
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("xy")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("ab")),
+            vec![]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("we")),
+            vec![]
+        );
+
+        // Matches
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("xyz")),
+            vec![Suggestion::Weather { score: 0.24 },]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("wea")),
+            vec![Suggestion::Weather { score: 0.24 },]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("weat")),
+            vec![Suggestion::Weather { score: 0.24 },]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("weath")),
+            vec![Suggestion::Weather { score: 0.24 },]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("weathe")),
+            vec![Suggestion::Weather { score: 0.24 },]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("weather")),
+            vec![Suggestion::Weather { score: 0.24 },]
+        );
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::weather("  weather  ")),
+            vec![Suggestion::Weather { score: 0.24 },]
+        );
+
+        assert_eq!(
+            store.fetch_provider_config(SuggestionProvider::Weather),
+            Some(SuggestProviderConfig::Weather {
+                min_keyword_length: 3,
+            })
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This makes a few changes in preparation for city-based weather suggestions:

* Factor out most everything related to weather suggestions into `weather.rs`,
  including tests and structs for remote settings.
* Move weather keywords out of the RS record and into an attachment like all
  other suggestion types. (Weather suggestions aren't enabled by default so we
  don't need to worry about breaking changes.)
* Simplify the weather record by getting rid of the nested `weather` object.
  Just store our fields inline in the top-level record object.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
