### PR TITLE
Update remote settings errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # v133.0 (In progress)
 
+## ⚠️ Breaking Changes ⚠️
+
+### Remote Settings
+- Updated Error hierarchy.  We don't need to update consumer code because the only consumer was
+  Android and it only caught exceptions using the base RemoteSettingsException class.
+
 ## 🦊 What's Changed 🦊
 
 ### Glean

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3610,6 +3610,7 @@ dependencies = [
 name = "remote_settings"
 version = "0.1.0"
 dependencies = [
+ "error-support",
  "expect-test",
  "log",
  "mockito",

--- a/components/nimbus/src/stateful/client/http_client.rs
+++ b/components/nimbus/src/stateful/client/http_client.rs
@@ -16,9 +16,9 @@
 use crate::error::Result;
 use crate::schema::parse_experiments;
 use crate::stateful::client::{Experiment, SettingsClient};
-use remote_settings::Client;
+use remote_settings::RemoteSettings;
 
-impl SettingsClient for Client {
+impl SettingsClient for RemoteSettings {
     fn get_experiments_metadata(&self) -> Result<String> {
         unimplemented!();
     }

--- a/components/nimbus/src/stateful/client/mod.rs
+++ b/components/nimbus/src/stateful/client/mod.rs
@@ -9,7 +9,7 @@ use crate::error::{NimbusError, Result};
 use crate::Experiment;
 use fs_client::FileSystemClient;
 use null_client::NullClient;
-use remote_settings::Client;
+use remote_settings::RemoteSettings;
 use remote_settings::RemoteSettingsConfig;
 
 pub(crate) fn create_client(
@@ -19,7 +19,7 @@ pub(crate) fn create_client(
         Some(config) => {
             assert!(config.server_url.is_none());
             let Some(remote_settings_server) = config.server.as_ref() else {
-                return Ok(Box::new(Client::new(config)?));
+                return Ok(Box::new(RemoteSettings::new(config)?));
             };
             let url = remote_settings_server.url()?;
             if url.scheme() == "file" {
@@ -32,7 +32,7 @@ pub(crate) fn create_client(
                 };
                 Box::new(FileSystemClient::new(path)?)
             } else {
-                Box::new(Client::new(config)?)
+                Box::new(RemoteSettings::new(config)?)
             }
         }
         // If no server is provided, then we still want Nimbus to work, but serving

--- a/components/relevancy/src/ingest.rs
+++ b/components/relevancy/src/ingest.rs
@@ -10,7 +10,9 @@ use crate::rs::{
 use crate::url_hash::UrlHash;
 use crate::{Error, Interest, RelevancyDb, Result};
 use base64::{engine::general_purpose::STANDARD, Engine};
-use remote_settings::{Client, RemoteSettingsConfig, RemoteSettingsRecord, RemoteSettingsServer};
+use remote_settings::{
+    RemoteSettings, RemoteSettingsConfig, RemoteSettingsRecord, RemoteSettingsServer,
+};
 
 // Number of rows to write when inserting interest data before checking for interruption
 const WRITE_CHUNK_SIZE: usize = 100;
@@ -33,7 +35,7 @@ pub fn ensure_interest_data_populated(db: &RelevancyDb) -> Result<()> {
 }
 
 fn fetch_interest_data() -> Result<Vec<(Interest, UrlHash)>> {
-    let rs = Client::new(RemoteSettingsConfig {
+    let rs = RemoteSettings::new(RemoteSettingsConfig {
         collection_name: REMOTE_SETTINGS_COLLECTION.to_string(),
         server: Some(RemoteSettingsServer::Prod),
         server_url: None,

--- a/components/relevancy/src/rs.rs
+++ b/components/relevancy/src/rs.rs
@@ -21,13 +21,15 @@ pub(crate) trait RelevancyRemoteSettingsClient {
     fn get_attachment(&self, location: &str) -> Result<Vec<u8>>;
 }
 
-impl RelevancyRemoteSettingsClient for remote_settings::Client {
+impl RelevancyRemoteSettingsClient for remote_settings::RemoteSettings {
     fn get_records(&self) -> Result<RemoteSettingsResponse> {
-        Ok(remote_settings::Client::get_records(self)?)
+        Ok(remote_settings::RemoteSettings::get_records(self)?)
     }
 
     fn get_attachment(&self, location: &str) -> Result<Vec<u8>> {
-        Ok(remote_settings::Client::get_attachment(self, location)?)
+        Ok(remote_settings::RemoteSettings::get_attachment(
+            self, location,
+        )?)
     }
 }
 

--- a/components/remote_settings/Cargo.toml
+++ b/components/remote_settings/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "1.0"
 serde = { version = "1", features=["derive"] }
 serde_json = "1"
 parking_lot = "0.12"
+error-support = { path = "../support/error" }
 viaduct = { path = "../viaduct" }
 url = "2.1" # mozilla-central can't yet take 2.2 (see bug 1734538)
 

--- a/components/remote_settings/src/config.rs
+++ b/components/remote_settings/src/config.rs
@@ -10,7 +10,7 @@
 
 use url::Url;
 
-use crate::Result;
+use crate::{ApiResult, Error, Result};
 
 /// Custom configuration for the client.
 /// Currently includes the following:
@@ -36,7 +36,17 @@ pub enum RemoteSettingsServer {
 }
 
 impl RemoteSettingsServer {
-    pub fn url(&self) -> Result<Url> {
+    /// Get the [url::Url] for this server
+    #[error_support::handle_error(Error)]
+    pub fn url(&self) -> ApiResult<Url> {
+        self.get_url()
+    }
+
+    /// Internal version of `url()`.
+    ///
+    /// The difference is that it uses `Error` instead of `ApiError`.  This is what we need to use
+    /// inside the crate.
+    pub(crate) fn get_url(&self) -> Result<Url> {
         Ok(match self {
             Self::Prod => Url::parse("https://firefox.settings.services.mozilla.com").unwrap(),
             Self::Stage => Url::parse("https://firefox.settings.services.allizom.org").unwrap(),

--- a/components/remote_settings/src/error.rs
+++ b/components/remote_settings/src/error.rs
@@ -2,8 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use error_support::{ErrorHandling, GetErrorHandling};
+
+pub type ApiResult<T> = std::result::Result<T, RemoteSettingsError>;
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Public error class, this is what we return to consumers
 #[derive(Debug, thiserror::Error)]
 pub enum RemoteSettingsError {
+    /// Network error while making a remote settings request
+    #[error("Remote settings unexpected error: {reason}")]
+    Network { reason: String },
+
+    /// The server has asked the client to backoff.
+    #[error("Server asked the client to back off ({seconds} seconds remaining)")]
+    Backoff { seconds: u64 },
+
+    #[error("Remote settings error: {reason}")]
+    Other { reason: String },
+}
+
+/// Internal error class, this is what we use inside this crate
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
     #[error("JSON Error: {0}")]
     JSONError(#[from] serde_json::Error),
     #[error("Error writing downloaded attachment: {0}")]
@@ -26,4 +47,31 @@ pub enum RemoteSettingsError {
     ConfigError(String),
 }
 
-pub type Result<T, E = RemoteSettingsError> = std::result::Result<T, E>;
+// Define how our internal errors are handled and converted to external errors
+// See `support/error/README.md` for how this works, especially the warning about PII.
+impl GetErrorHandling for Error {
+    type ExternalError = RemoteSettingsError;
+
+    fn get_error_handling(&self) -> ErrorHandling<Self::ExternalError> {
+        match self {
+            // Network errors are expected to happen in practice.  Let's log, but not report them.
+            Self::RequestError(viaduct::Error::NetworkError(e)) => {
+                ErrorHandling::convert(RemoteSettingsError::Network {
+                    reason: e.to_string(),
+                })
+                .log_warning()
+            }
+            // Backoff error shouldn't happen in practice, so let's report them for now.
+            // If these do happen in practice and we decide that there is a valid reason for them,
+            // then consider switching from reporting to Sentry to counting in Glean.
+            Self::BackoffError(seconds) => {
+                ErrorHandling::convert(RemoteSettingsError::Backoff { seconds: *seconds })
+                    .report_error("suggest-backoff")
+            }
+            _ => ErrorHandling::convert(RemoteSettingsError::Other {
+                reason: self.to_string(),
+            })
+            .report_error("logins-unexpected"),
+        }
+    }
+}

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -2,17 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-pub mod cache;
-pub mod error;
-pub use error::{RemoteSettingsError, Result};
 use std::{fs::File, io::prelude::Write};
+
+use error_support::handle_error;
+
+pub mod cache;
 pub mod client;
-pub use client::{
-    Attachment, Client, GetItemsOptions, RemoteSettingsRecord, RemoteSettingsResponse,
-    RsJsonObject, SortOrder,
-};
 pub mod config;
+pub mod error;
+
+pub use client::{Attachment, RemoteSettingsRecord, RemoteSettingsResponse, RsJsonObject};
 pub use config::{RemoteSettingsConfig, RemoteSettingsServer};
+pub use error::{ApiResult, RemoteSettingsError, Result};
+
+use client::Client;
+use error::Error;
 
 uniffi::include_scaffolding!("remote_settings");
 
@@ -22,28 +26,48 @@ pub struct RemoteSettings {
 }
 
 impl RemoteSettings {
-    pub fn new(config: RemoteSettingsConfig) -> Result<Self> {
+    #[handle_error(Error)]
+    pub fn new(config: RemoteSettingsConfig) -> ApiResult<Self> {
         Ok(RemoteSettings {
             config: config.clone(),
             client: Client::new(config)?,
         })
     }
 
-    pub fn get_records(&self) -> Result<RemoteSettingsResponse> {
+    #[handle_error(Error)]
+    pub fn get_records(&self) -> ApiResult<RemoteSettingsResponse> {
         let resp = self.client.get_records()?;
         Ok(resp)
     }
 
-    pub fn get_records_since(&self, timestamp: u64) -> Result<RemoteSettingsResponse> {
+    #[handle_error(Error)]
+    pub fn get_records_since(&self, timestamp: u64) -> ApiResult<RemoteSettingsResponse> {
         let resp = self.client.get_records_since(timestamp)?;
         Ok(resp)
     }
 
+    /// Fetches all records for a collection that can be found in the server,
+    /// bucket, and collection defined by the [ClientConfig] used to generate
+    /// this [Client]. This function will return the raw viaduct [Response].
+    #[handle_error(Error)]
+    pub fn get_records_raw(&self) -> ApiResult<viaduct::Response> {
+        self.client.get_records_raw()
+    }
+
+    /// Downloads an attachment from [attachment_location]. NOTE: there are no
+    /// guarantees about a maximum size, so use care when fetching potentially
+    /// large attachments.
+    #[handle_error(Error)]
+    pub fn get_attachment(&self, attachment_location: &str) -> ApiResult<Vec<u8>> {
+        self.client.get_attachment(attachment_location)
+    }
+
+    #[handle_error(Error)]
     pub fn download_attachment_to_path(
         &self,
         attachment_location: String,
         path: String,
-    ) -> Result<()> {
+    ) -> ApiResult<()> {
         let resp = self.client.get_attachment(&attachment_location)?;
         let mut file = File::create(path)?;
         file.write_all(&resp)?;

--- a/components/remote_settings/src/remote_settings.udl
+++ b/components/remote_settings/src/remote_settings.udl
@@ -44,15 +44,10 @@ dictionary Attachment {
 };
 
 [Error]
-enum RemoteSettingsError {
-    "JSONError",
-    "FileError",
-    "RequestError",
-    "UrlParsingError",
-    "BackoffError",
-    "ResponseError",
-    "AttachmentsUnsupportedError",
-    "ConfigError",
+interface RemoteSettingsError {
+    Network(string reason);
+    Backoff(u64 seconds);
+    Other(string reason);
 };
 
 interface RemoteSettings {

--- a/components/suggest/src/benchmarks/client.rs
+++ b/components/suggest/src/benchmarks/client.rs
@@ -21,7 +21,7 @@ impl RemoteSettingsBenchmarkClient {
     pub fn new() -> Result<Self> {
         let mut new_benchmark_client = Self::default();
         new_benchmark_client.fetch_data_with_client(
-            remote_settings::Client::new(remote_settings::RemoteSettingsConfig {
+            remote_settings::RemoteSettings::new(remote_settings::RemoteSettingsConfig {
                 server: None,
                 bucket_name: None,
                 collection_name: "quicksuggest".to_owned(),
@@ -30,7 +30,7 @@ impl RemoteSettingsBenchmarkClient {
             rs::Collection::Quicksuggest,
         )?;
         new_benchmark_client.fetch_data_with_client(
-            remote_settings::Client::new(remote_settings::RemoteSettingsConfig {
+            remote_settings::RemoteSettings::new(remote_settings::RemoteSettingsConfig {
                 server: None,
                 bucket_name: None,
                 collection_name: "fakespot-suggest-products".to_owned(),
@@ -43,7 +43,7 @@ impl RemoteSettingsBenchmarkClient {
 
     fn fetch_data_with_client(
         &mut self,
-        client: remote_settings::Client,
+        client: remote_settings::RemoteSettings,
         collection: rs::Collection,
     ) -> Result<()> {
         let response = client.get_records()?;

--- a/components/suggest/src/error.rs
+++ b/components/suggest/src/error.rs
@@ -104,16 +104,16 @@ impl GetErrorHandling for Error {
             // Do nothing for interrupted errors, this is just normal operation.
             Self::Interrupted(_) => ErrorHandling::convert(SuggestApiError::Interrupted),
             // Network errors are expected to happen in practice.  Let's log, but not report them.
-            Self::RemoteSettings(RemoteSettingsError::RequestError(
-                viaduct::Error::NetworkError(e),
-            )) => ErrorHandling::convert(SuggestApiError::Network {
-                reason: e.to_string(),
-            })
-            .log_warning(),
+            Self::RemoteSettings(RemoteSettingsError::Network { reason }) => {
+                ErrorHandling::convert(SuggestApiError::Network {
+                    reason: reason.clone(),
+                })
+                .log_warning()
+            }
             // Backoff error shouldn't happen in practice, so let's report them for now.
             // If these do happen in practice and we decide that there is a valid reason for them,
             // then consider switching from reporting to Sentry to counting in Glean.
-            Self::RemoteSettings(RemoteSettingsError::BackoffError(seconds)) => {
+            Self::RemoteSettings(RemoteSettingsError::Backoff { seconds }) => {
                 ErrorHandling::convert(SuggestApiError::Backoff { seconds: *seconds })
                     .report_error("suggest-backoff")
             }

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -74,8 +74,8 @@ pub(crate) trait Client {
 /// Implements the [Client] trait using a real remote settings client
 pub struct RemoteSettingsClient {
     // Create a separate client for each collection name
-    quicksuggest_client: remote_settings::Client,
-    fakespot_client: remote_settings::Client,
+    quicksuggest_client: remote_settings::RemoteSettings,
+    fakespot_client: remote_settings::RemoteSettings,
 }
 
 impl RemoteSettingsClient {
@@ -85,7 +85,7 @@ impl RemoteSettingsClient {
         server_url: Option<String>,
     ) -> Result<Self> {
         Ok(Self {
-            quicksuggest_client: remote_settings::Client::new(
+            quicksuggest_client: remote_settings::RemoteSettings::new(
                 remote_settings::RemoteSettingsConfig {
                     server: server.clone(),
                     bucket_name: bucket_name.clone(),
@@ -93,16 +93,18 @@ impl RemoteSettingsClient {
                     server_url: server_url.clone(),
                 },
             )?,
-            fakespot_client: remote_settings::Client::new(remote_settings::RemoteSettingsConfig {
-                server,
-                bucket_name,
-                collection_name: "fakespot-suggest-products".to_owned(),
-                server_url,
-            })?,
+            fakespot_client: remote_settings::RemoteSettings::new(
+                remote_settings::RemoteSettingsConfig {
+                    server,
+                    bucket_name,
+                    collection_name: "fakespot-suggest-products".to_owned(),
+                    server_url,
+                },
+            )?,
         })
     }
 
-    fn client_for_collection(&self, collection: Collection) -> &remote_settings::Client {
+    fn client_for_collection(&self, collection: Collection) -> &remote_settings::RemoteSettings {
         match collection {
             Collection::Fakespot => &self.fakespot_client,
             Collection::Quicksuggest => &self.quicksuggest_client,

--- a/components/support/nimbus-cli/src/sources/experiment_list.rs
+++ b/components/support/nimbus-cli/src/sources/experiment_list.rs
@@ -219,7 +219,7 @@ impl TryFrom<&ExperimentListSource> for Value {
                 endpoint,
                 is_preview,
             } => {
-                use remote_settings::{Client, RemoteSettingsConfig, RemoteSettingsServer};
+                use remote_settings::{RemoteSettings, RemoteSettingsConfig, RemoteSettingsServer};
                 viaduct_reqwest::use_reqwest_backend();
                 let collection_name = if *is_preview {
                     "nimbus-preview".to_string()
@@ -234,7 +234,7 @@ impl TryFrom<&ExperimentListSource> for Value {
                     bucket_name: None,
                     collection_name,
                 };
-                let client = Client::new(config)?;
+                let client = RemoteSettings::new(config)?;
 
                 let response = client.get_records_raw()?;
                 response.json::<Value>()?


### PR DESCRIPTION
Use fields inside the error enum, rather than the UniFFI "flat" errors which ignore the inner data.  This is prep for moving to proc-macros.

Switched to using error_support and define both internal and public error types.

Switch app-services consumers to using the `RemoteSettings` type rather than `Client`.  This way they're using the same public API as everyone else.  This required adding a couple more pub RemoteSettings methods that I didn't expose via UniFFI.  I didn't feel like adding new features to this client, because I'm hoping to replace it (#6378).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
