### PR TITLE
Add `country` to weather suggestions

### DIFF
--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -81,6 +81,7 @@ pub enum Suggestion {
     Weather {
         city: Option<String>,
         region: Option<String>,
+        country: Option<String>,
         score: f64,
     },
     Fakespot {

--- a/components/suggest/src/weather.rs
+++ b/components/suggest/src/weather.rs
@@ -174,6 +174,7 @@ impl SuggestDao<'_> {
             .map(|(city, _, _)| Suggestion::Weather {
                 city: city.as_ref().map(|c| c.name.clone()),
                 region: city.as_ref().map(|c| c.admin1_code.clone()),
+                country: city.as_ref().map(|c| c.country_code.clone()),
                 score: w_cache.score,
             })
             .collect())
@@ -511,7 +512,8 @@ mod tests {
                 vec![Suggestion::Weather {
                     score: 0.24,
                     city: None,
-                    region: None
+                    region: None,
+                    country: None,
                 },]
             );
         }
@@ -553,7 +555,8 @@ mod tests {
                 vec![Suggestion::Weather {
                     score: 0.24,
                     city: None,
-                    region: None
+                    region: None,
+                    country: None,
                 },]
             );
         }
@@ -592,11 +595,13 @@ mod tests {
                     Suggestion::Weather {
                         city: Some("Waterloo".to_string()),
                         region: Some("IA".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                     Suggestion::Weather {
                         city: Some("Waterloo".to_string()),
                         region: Some("AL".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                 ],
@@ -606,6 +611,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Waterloo".to_string()),
                     region: Some("IA".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -614,6 +620,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Waterloo".to_string()),
                     region: Some("IA".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -622,6 +629,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Waterloo".to_string()),
                     region: Some("AL".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -630,6 +638,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Waterloo".to_string()),
                     region: Some("AL".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -640,6 +649,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -648,6 +658,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -656,6 +667,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -665,6 +677,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -673,6 +686,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -681,6 +695,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -689,6 +704,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -697,6 +713,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -705,6 +722,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -713,6 +731,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -721,6 +740,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Rochester".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -729,6 +749,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Rochester".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -737,6 +758,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Rochester".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -745,6 +767,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Rochester".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -753,6 +776,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Rochester".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -761,6 +785,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Rochester".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -769,6 +794,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Rochester".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -777,6 +803,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Rochester".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -785,6 +812,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -797,6 +825,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -805,6 +834,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -813,6 +843,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -821,6 +852,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -830,11 +862,13 @@ mod tests {
                     Suggestion::Weather {
                         city: Some("Waterloo".to_string()),
                         region: Some("IA".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                     Suggestion::Weather {
                         city: Some("Waterloo".to_string()),
                         region: Some("AL".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                 ],
@@ -845,11 +879,13 @@ mod tests {
                     Suggestion::Weather {
                         city: Some("Waterloo".to_string()),
                         region: Some("IA".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                     Suggestion::Weather {
                         city: Some("Waterloo".to_string()),
                         region: Some("AL".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                 ],
@@ -864,6 +900,7 @@ mod tests {
                     Suggestion::Weather {
                         city: Some("Long Name".to_string()),
                         region: Some("NY".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                 ],
@@ -876,11 +913,13 @@ mod tests {
                     Suggestion::Weather {
                         city: Some("Waterloo".to_string()),
                         region: Some("IA".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                     Suggestion::Weather {
                         city: Some("Waterloo".to_string()),
                         region: Some("AL".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                 ],
@@ -890,6 +929,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Waterloo".to_string()),
                     region: Some("IA".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -898,6 +938,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Waterloo".to_string()),
                     region: Some("IA".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -906,6 +947,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Waterloo".to_string()),
                     region: Some("IA".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -914,6 +956,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("Waterloo".to_string()),
                     region: Some("IA".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -922,6 +965,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -930,6 +974,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -938,6 +983,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -946,6 +992,7 @@ mod tests {
                 vec![Suggestion::Weather {
                     city: Some("New York City".to_string()),
                     region: Some("NY".to_string()),
+                    country: Some("US".to_string()),
                     score: 0.24,
                 }],
             ),
@@ -955,6 +1002,7 @@ mod tests {
                     Suggestion::Weather {
                         city: Some("Long Name".to_string()),
                         region: Some("NY".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                 ],
@@ -965,6 +1013,7 @@ mod tests {
                     Suggestion::Weather {
                         city: Some("Long Name".to_string()),
                         region: Some("NY".to_string()),
+                        country: Some("US".to_string()),
                         score: 0.24,
                     },
                 ],


### PR DESCRIPTION
I just saw that Merino expects a country to be passed along with city and region in weather requests. Rather than assuming "US" and hardcoding that in desktop, which would be fine for now, let's just go ahead and add the matching geoname's country code to `Suggestion::Weather`. It's a small change.

This doesn't modify query parsing at all. Country names still aren't supported in queries. We can cross that bridge if/when we come to it.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
