### PR TITLE
Bug 1925601 - Fix the iOS build (again)

### DIFF
--- a/megazords/ios-rust/generate-files.sh
+++ b/megazords/ios-rust/generate-files.sh
@@ -27,4 +27,7 @@ CARGO="$HOME/.cargo/bin/cargo"
 
 # Hack to copy in the RustViaductFFI.h (https://bugzilla.mozilla.org/show_bug.cgi?id=1925601)
 cp "$THIS_DIR/../../components/viaduct/ios/RustViaductFFI.h" "$COMMON/Headers"
-awk '/MozillaRustComponents/ { print; print "    header \"RustViaductFFI.h\""; next }1' "$COMMON/Modules/module.modulemap"
+echo "original modulemap"
+cat "$COMMON/Modules/module.modulemap"
+TWEAKED_MODULEMAP=$(cat <(head -n1 "$COMMON/Modules/module.modulemap") <(echo "    header \"RustViaductFFI.h\"") <(tail -n +2 "$COMMON/Modules/module.modulemap"))
+echo "$TWEAKED_MODULEMAP" > "$COMMON/Modules/module.modulemap"


### PR DESCRIPTION
The last hack didn't fix the iOS build.  I looked through xcframework zip from the nightly build artifacts
(https://firefoxci.taskcluster-artifacts.net/dHGArzP3R0Cmwcr56RPQJA/0/public/build/nightly.json) and it seems like it was correctly copying the `RustViaductFFI.h` file, but not correctly updating module.modulemap.

The main issue was the `awk` command was printing out the updated contents to STDOUT, but not actually modifying `module.modulemap`.  I fixed that and also moved away from `awk`, since I'm worried about differences between gawk and nawk.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
