### PR TITLE
Properly close webext storage database close function

### DIFF
--- a/components/webext-storage/src/api.rs
+++ b/components/webext-storage/src/api.rs
@@ -438,8 +438,9 @@ mod tests {
     #[test]
     fn test_simple() -> Result<()> {
         let ext_id = "x";
-        let mut db = new_mem_db();
-        let tx = db.transaction()?;
+        let db = new_mem_db();
+        let conn = db.get_connection().expect("should retrieve connection");
+        let tx = conn.unchecked_transaction()?;
 
         // an empty store.
         for q in vec![JsonValue::Null, json!("foo"), json!(["foo"])].into_iter() {
@@ -529,8 +530,9 @@ mod tests {
     fn test_check_get_impl() -> Result<()> {
         // This is a port of checkGetImpl in test_ext_storage.js in Desktop.
         let ext_id = "x";
-        let mut db = new_mem_db();
-        let tx = db.transaction()?;
+        let db = new_mem_db();
+        let conn = db.get_connection().expect("should retrieve connection");
+        let tx = conn.unchecked_transaction()?;
 
         let prop = "test-prop";
         let value = "test-value";
@@ -584,8 +586,9 @@ mod tests {
     fn test_bug_1621162() -> Result<()> {
         // apparently Firefox, unlike Chrome, will not optimize the changes.
         // See bug 1621162 for more!
-        let mut db = new_mem_db();
-        let tx = db.transaction()?;
+        let db = new_mem_db();
+        let conn = db.get_connection().expect("should retrieve connection");
+        let tx = conn.unchecked_transaction()?;
         let ext_id = "xyz";
 
         set(&tx, ext_id, json!({"foo": "bar" }))?;
@@ -599,8 +602,9 @@ mod tests {
 
     #[test]
     fn test_quota_maxitems() -> Result<()> {
-        let mut db = new_mem_db();
-        let tx = db.transaction()?;
+        let db = new_mem_db();
+        let conn = db.get_connection().expect("should retrieve connection");
+        let tx = conn.unchecked_transaction()?;
         let ext_id = "xyz";
         for i in 1..SYNC_MAX_ITEMS + 1 {
             set(
@@ -619,8 +623,9 @@ mod tests {
 
     #[test]
     fn test_quota_bytesperitem() -> Result<()> {
-        let mut db = new_mem_db();
-        let tx = db.transaction()?;
+        let db = new_mem_db();
+        let conn = db.get_connection().expect("should retrieve connection");
+        let tx = conn.unchecked_transaction()?;
         let ext_id = "xyz";
         // A string 5 bytes less than the max. This should be counted as being
         // 3 bytes less than the max as the quotes are counted. Plus the length
@@ -645,8 +650,9 @@ mod tests {
 
     #[test]
     fn test_quota_bytes() -> Result<()> {
-        let mut db = new_mem_db();
-        let tx = db.transaction()?;
+        let db = new_mem_db();
+        let conn = db.get_connection().expect("should retrieve connection");
+        let tx = conn.unchecked_transaction()?;
         let ext_id = "xyz";
         let val = "x".repeat(SYNC_QUOTA_BYTES + 1);
 
@@ -682,8 +688,9 @@ mod tests {
 
     #[test]
     fn test_get_bytes_in_use() -> Result<()> {
-        let mut db = new_mem_db();
-        let tx = db.transaction()?;
+        let db = new_mem_db();
+        let conn = db.get_connection().expect("should retrieve connection");
+        let tx = conn.unchecked_transaction()?;
         let ext_id = "xyz";
 
         assert_eq!(get_bytes_in_use(&tx, ext_id, json!(null))?, 0);
@@ -714,8 +721,9 @@ mod tests {
 
     #[test]
     fn test_usage() {
-        let mut db = new_mem_db();
-        let tx = db.transaction().unwrap();
+        let db = new_mem_db();
+        let conn = db.get_connection().expect("should retrieve connection");
+        let tx = conn.unchecked_transaction().unwrap();
         // '{"a":"a","b":"bb","c":"ccc","n":999999}': 39 bytes
         set(&tx, "xyz", json!({ "a": "a" })).unwrap();
         set(&tx, "xyz", json!({ "b": "bb" })).unwrap();
@@ -727,7 +735,7 @@ mod tests {
 
         tx.commit().unwrap();
 
-        let usage = usage(&db).unwrap();
+        let usage = usage(conn).unwrap();
         let expect = [
             UsageInfo {
                 ext_id: "abc".to_string(),

--- a/components/webext-storage/src/migration.rs
+++ b/components/webext-storage/src/migration.rs
@@ -346,8 +346,9 @@ mod tests {
         init_source_db(path, f);
 
         // now migrate
-        let mut db = new_mem_db();
-        let tx = db.transaction().expect("tx should work");
+        let db = new_mem_db();
+        let conn = db.get_connection().expect("should retrieve connection");
+        let tx = conn.unchecked_transaction().expect("tx should work");
 
         let mi = migrate(&tx, &tmpdir.path().join("source.db")).expect("migrate should work");
         tx.commit().expect("should work");
@@ -384,17 +385,18 @@ mod tests {
     #[test]
     fn test_happy_paths() {
         // some real data.
-        let conn = do_migrate(HAPPY_PATH_MIGRATION_INFO, |c| {
+        let db = do_migrate(HAPPY_PATH_MIGRATION_INFO, |c| {
             c.execute_batch(HAPPY_PATH_SQL).expect("should populate")
         });
+        let conn = db.get_connection().expect("should retrieve connection");
 
         assert_has(
-            &conn,
+            conn,
             "{e7fefcf3-b39c-4f17-5215-ebfe120a7031}",
             json!({"userWelcomed": 1570659224457u64, "isWho": "4ec8109f"}),
         );
         assert_has(
-            &conn,
+            conn,
             "https-everywhere@eff.org",
             json!({"userRules": [], "ruleActiveStates": {}, "migration_version": 2}),
         );

--- a/components/webext-storage/src/sync/bridge.rs
+++ b/components/webext-storage/src/sync/bridge.rs
@@ -58,26 +58,30 @@ impl sync15::engine::BridgedEngine for BridgedEngine {
     fn last_sync(&self) -> Result<i64> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
-        Ok(get_meta(&db, LAST_SYNC_META_KEY)?.unwrap_or(0))
+        let conn = db.get_connection()?;
+        Ok(get_meta(conn, LAST_SYNC_META_KEY)?.unwrap_or(0))
     }
 
     fn set_last_sync(&self, last_sync_millis: i64) -> Result<()> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
-        put_meta(&db, LAST_SYNC_META_KEY, &last_sync_millis)?;
+        let conn = db.get_connection()?;
+        put_meta(conn, LAST_SYNC_META_KEY, &last_sync_millis)?;
         Ok(())
     }
 
     fn sync_id(&self) -> Result<Option<String>> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
-        Ok(get_meta(&db, SYNC_ID_META_KEY)?)
+        let conn = db.get_connection()?;
+        Ok(get_meta(conn, SYNC_ID_META_KEY)?)
     }
 
     fn reset_sync_id(&self) -> Result<String> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
-        let tx = db.unchecked_transaction()?;
+        let conn = db.get_connection()?;
+        let tx = conn.unchecked_transaction()?;
         let new_id = SyncGuid::random().to_string();
         self.do_reset(&tx)?;
         put_meta(&tx, SYNC_ID_META_KEY, &new_id)?;
@@ -88,11 +92,13 @@ impl sync15::engine::BridgedEngine for BridgedEngine {
     fn ensure_current_sync_id(&self, sync_id: &str) -> Result<String> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
-        let current: Option<String> = get_meta(&db, SYNC_ID_META_KEY)?;
+        let conn = db.get_connection()?;
+        let current: Option<String> = get_meta(conn, SYNC_ID_META_KEY)?;
         Ok(match current {
             Some(current) if current == sync_id => current,
             _ => {
-                let tx = db.unchecked_transaction()?;
+                let conn = db.get_connection()?;
+                let tx = conn.unchecked_transaction()?;
                 self.do_reset(&tx)?;
                 let result = sync_id.to_string();
                 put_meta(&tx, SYNC_ID_META_KEY, &result)?;
@@ -105,7 +111,8 @@ impl sync15::engine::BridgedEngine for BridgedEngine {
     fn sync_started(&self) -> Result<()> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
-        schema::create_empty_sync_temp_tables(&db)?;
+        let conn = db.get_connection()?;
+        schema::create_empty_sync_temp_tables(conn)?;
         Ok(())
     }
 
@@ -113,7 +120,8 @@ impl sync15::engine::BridgedEngine for BridgedEngine {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
         let signal = db.begin_interrupt_scope()?;
-        let tx = db.unchecked_transaction()?;
+        let conn = db.get_connection()?;
+        let tx = conn.unchecked_transaction()?;
         let incoming_content: Vec<_> = incoming_bsos
             .into_iter()
             .map(IncomingBso::into_content::<super::WebextRecord>)
@@ -127,8 +135,8 @@ impl sync15::engine::BridgedEngine for BridgedEngine {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
         let signal = db.begin_interrupt_scope()?;
-
-        let tx = db.unchecked_transaction()?;
+        let conn = db.get_connection()?;
+        let tx = conn.unchecked_transaction()?;
         let incoming = get_incoming(&tx)?;
         let actions = incoming
             .into_iter()
@@ -138,14 +146,15 @@ impl sync15::engine::BridgedEngine for BridgedEngine {
         stage_outgoing(&tx)?;
         tx.commit()?;
 
-        Ok(get_outgoing(&db, &signal)?.into())
+        Ok(get_outgoing(conn, &signal)?.into())
     }
 
     fn set_uploaded(&self, _server_modified_millis: i64, ids: &[SyncGuid]) -> Result<()> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
+        let conn = db.get_connection()?;
         let signal = db.begin_interrupt_scope()?;
-        let tx = db.unchecked_transaction()?;
+        let tx = conn.unchecked_transaction()?;
         record_uploaded(&tx, ids, &signal)?;
         tx.commit()?;
 
@@ -155,14 +164,16 @@ impl sync15::engine::BridgedEngine for BridgedEngine {
     fn sync_finished(&self) -> Result<()> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
-        schema::create_empty_sync_temp_tables(&db)?;
+        let conn = db.get_connection()?;
+        schema::create_empty_sync_temp_tables(conn)?;
         Ok(())
     }
 
     fn reset(&self) -> Result<()> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
-        let tx = db.unchecked_transaction()?;
+        let conn = db.get_connection()?;
+        let tx = conn.unchecked_transaction()?;
         self.do_reset(&tx)?;
         delete_meta(&tx, SYNC_ID_META_KEY)?;
         tx.commit()?;
@@ -172,7 +183,8 @@ impl sync15::engine::BridgedEngine for BridgedEngine {
     fn wipe(&self) -> Result<()> {
         let shared_db = self.thread_safe_storage_db()?;
         let db = shared_db.lock();
-        let tx = db.unchecked_transaction()?;
+        let conn = db.get_connection()?;
+        let tx = conn.unchecked_transaction()?;
         // We assume the meta table is only used by sync.
         tx.execute_batch(
             "DELETE FROM storage_sync_data; DELETE FROM storage_sync_mirror; DELETE FROM meta;",
@@ -195,7 +207,8 @@ mod tests {
     use crate::db::StorageDb;
     use sync15::engine::BridgedEngine;
 
-    fn query_count(conn: &StorageDb, table: &str) -> u32 {
+    fn query_count(db: &StorageDb, table: &str) -> u32 {
+        let conn = db.get_connection().expect("should retrieve connection");
         conn.query_row_and_then(&format!("SELECT COUNT(*) FROM {};", table), [], |row| {
             row.get::<_, u32>(0)
         })
@@ -207,12 +220,13 @@ mod tests {
         {
             let shared = engine.thread_safe_storage_db()?;
             let db = shared.lock();
-            db.execute(
+            let conn = db.get_connection().expect("should retrieve connection");
+            conn.execute(
                 "INSERT INTO storage_sync_data (ext_id, data, sync_change_counter)
                     VALUES ('ext-a', 'invalid-json', 2)",
                 [],
             )?;
-            db.execute(
+            conn.execute(
                 "INSERT INTO storage_sync_mirror (guid, ext_id, data)
                     VALUES ('guid', 'ext-a', '3')",
                 [],
@@ -234,10 +248,11 @@ mod tests {
         // A reset never wipes data...
         let shared = engine.thread_safe_storage_db()?;
         let db = shared.lock();
+        let conn = db.get_connection().expect("should retrieve connection");
         assert_eq!(query_count(&db, "storage_sync_data"), 1);
 
         // But did reset the change counter.
-        let cc = db.query_row_and_then(
+        let cc = conn.query_row_and_then(
             "SELECT sync_change_counter FROM storage_sync_data WHERE ext_id = 'ext-a';",
             [],
             |row| row.get::<_, u32>(0),
@@ -246,7 +261,7 @@ mod tests {
         // But did wipe the mirror...
         assert_eq!(query_count(&db, "storage_sync_mirror"), 0);
         // And the last_sync should have been wiped.
-        assert!(get_meta::<i64>(&db, LAST_SYNC_META_KEY)?.is_none());
+        assert!(get_meta::<i64>(conn, LAST_SYNC_META_KEY)?.is_none());
         Ok(())
     }
 
@@ -254,8 +269,9 @@ mod tests {
     fn assert_not_reset(engine: &super::BridgedEngine) -> Result<()> {
         let shared = engine.thread_safe_storage_db()?;
         let db = shared.lock();
+        let conn = db.get_connection().expect("should retrieve connection");
         assert_eq!(query_count(&db, "storage_sync_data"), 1);
-        let cc = db.query_row_and_then(
+        let cc = conn.query_row_and_then(
             "SELECT sync_change_counter FROM storage_sync_data WHERE ext_id = 'ext-a';",
             [],
             |row| row.get::<_, u32>(0),
@@ -263,7 +279,7 @@ mod tests {
         assert_eq!(cc, 2);
         assert_eq!(query_count(&db, "storage_sync_mirror"), 1);
         // And the last_sync should remain.
-        assert!(get_meta::<i64>(&db, LAST_SYNC_META_KEY)?.is_some());
+        assert!(get_meta::<i64>(conn, LAST_SYNC_META_KEY)?.is_some());
         Ok(())
     }
 
@@ -287,23 +303,25 @@ mod tests {
 
     #[test]
     fn test_reset() -> Result<()> {
-        let strong = new_mem_thread_safe_storage_db();
-        let engine = super::BridgedEngine::new(&strong);
+        let strong = &new_mem_thread_safe_storage_db();
+        let engine = super::BridgedEngine::new(strong);
 
         setup_mock_data(&engine)?;
-        put_meta(
-            &engine.thread_safe_storage_db()?.lock(),
-            SYNC_ID_META_KEY,
-            &"sync-id".to_string(),
-        )?;
+        {
+            let db = strong.lock();
+            let conn = db.get_connection()?;
+            put_meta(conn, SYNC_ID_META_KEY, &"sync-id".to_string())?;
+        }
 
         engine.reset()?;
         assert_reset(&engine)?;
-        // Only an explicit reset kills the sync-id, so check that here.
-        assert_eq!(
-            get_meta::<String>(&engine.thread_safe_storage_db()?.lock(), SYNC_ID_META_KEY)?,
-            None
-        );
+
+        {
+            let db = strong.lock();
+            let conn = db.get_connection()?;
+            // Only an explicit reset kills the sync-id, so check that here.
+            assert_eq!(get_meta::<String>(conn, SYNC_ID_META_KEY)?, None);
+        }
 
         Ok(())
     }
@@ -330,11 +348,13 @@ mod tests {
 
         setup_mock_data(&engine)?;
 
-        put_meta(
-            &engine.thread_safe_storage_db()?.lock(),
-            SYNC_ID_META_KEY,
-            &"old-id".to_string(),
-        )?;
+        {
+            let storage_db = &engine.thread_safe_storage_db()?;
+            let db = storage_db.lock();
+            let conn = db.get_connection()?;
+            put_meta(conn, SYNC_ID_META_KEY, &"old-id".to_string())?;
+        }
+
         assert_not_reset(&engine)?;
         assert_eq!(engine.sync_id()?, Some("old-id".to_string()));
 
@@ -354,11 +374,12 @@ mod tests {
         setup_mock_data(&engine)?;
         assert_not_reset(&engine)?;
 
-        put_meta(
-            &engine.thread_safe_storage_db()?.lock(),
-            SYNC_ID_META_KEY,
-            &"sync-id".to_string(),
-        )?;
+        {
+            let storage_db = &engine.thread_safe_storage_db()?;
+            let db = storage_db.lock();
+            let conn = db.get_connection()?;
+            put_meta(conn, SYNC_ID_META_KEY, &"sync-id".to_string())?;
+        }
 
         engine.ensure_current_sync_id("sync-id")?;
         // should not have reset.
@@ -372,11 +393,13 @@ mod tests {
         let engine = super::BridgedEngine::new(&strong);
 
         setup_mock_data(&engine)?;
-        put_meta(
-            &engine.thread_safe_storage_db()?.lock(),
-            SYNC_ID_META_KEY,
-            &"sync-id".to_string(),
-        )?;
+
+        {
+            let storage_db = &engine.thread_safe_storage_db()?;
+            let db = storage_db.lock();
+            let conn = db.get_connection()?;
+            put_meta(conn, SYNC_ID_META_KEY, &"sync-id".to_string())?;
+        }
 
         assert_eq!(engine.sync_id()?, Some("sync-id".to_string()));
         let new_id = engine.reset_sync_id()?;

--- a/components/webext-storage/src/sync/outgoing.rs
+++ b/components/webext-storage/src/sync/outgoing.rs
@@ -124,8 +124,9 @@ mod tests {
 
     #[test]
     fn test_simple() -> Result<()> {
-        let mut db = new_syncable_mem_db();
-        let tx = db.transaction()?;
+        let db = new_syncable_mem_db();
+        let conn = db.get_connection()?;
+        let tx = conn.unchecked_transaction()?;
 
         tx.execute_batch(
             r#"

--- a/components/webext-storage/src/sync/sync_tests.rs
+++ b/components/webext-storage/src/sync/sync_tests.rs
@@ -140,8 +140,9 @@ fn make_incoming_tombstone(guid: &Guid) -> IncomingContent<WebextRecord> {
 #[test]
 fn test_simple_outgoing_sync() -> Result<()> {
     // So we are starting with an empty local store and empty server store.
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data.clone())?;
     assert_eq!(do_sync(&tx, &[])?.len(), 1);
@@ -151,8 +152,9 @@ fn test_simple_outgoing_sync() -> Result<()> {
 
 #[test]
 fn test_simple_incoming_sync() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     let bridge_record = make_incoming(&Guid::new("guid"), "ext-id", &data);
     assert_eq!(do_sync(&tx, &[bridge_record])?.len(), 0);
@@ -166,8 +168,9 @@ fn test_simple_incoming_sync() -> Result<()> {
 fn test_outgoing_tombstone() -> Result<()> {
     // Tombstones are only kept when the mirror has that record - so first
     // test that, then arrange for the mirror to have the record.
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data.clone())?;
     assert_eq!(
@@ -197,8 +200,9 @@ fn test_outgoing_tombstone() -> Result<()> {
 fn test_incoming_tombstone_exists() -> Result<()> {
     // An incoming tombstone for a record we've previously synced (and thus
     // have data for)
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data.clone())?;
     assert_eq!(
@@ -224,8 +228,9 @@ fn test_incoming_tombstone_exists() -> Result<()> {
 
 #[test]
 fn test_incoming_tombstone_not_exists() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     // An incoming tombstone for something that's not anywhere locally.
     let guid = Guid::new("guid");
     let tombstone = make_incoming_tombstone(&guid);
@@ -242,8 +247,9 @@ fn test_incoming_tombstone_not_exists() -> Result<()> {
 
 #[test]
 fn test_reconciled() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", data)?;
     // Incoming payload with the same data
@@ -258,8 +264,9 @@ fn test_reconciled() -> Result<()> {
 /// identical to what is in the mirrored table.
 #[test]
 fn test_reconcile_with_null_payload() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", data.clone())?;
     // We try to push this change on the next sync.
@@ -278,8 +285,9 @@ fn test_reconcile_with_null_payload() -> Result<()> {
 
 #[test]
 fn test_accept_incoming_when_local_is_deleted() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     // We only record an extension as deleted locally if it has been
     // uploaded before being deleted.
     let data = json!({"key1": "key1-value"});
@@ -299,8 +307,9 @@ fn test_accept_incoming_when_local_is_deleted() -> Result<()> {
 
 #[test]
 fn test_accept_incoming_when_local_is_deleted_no_mirror() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", data)?;
     assert_eq!(do_sync(&tx, &[])?.len(), 1);
@@ -319,8 +328,9 @@ fn test_accept_incoming_when_local_is_deleted_no_mirror() -> Result<()> {
 
 #[test]
 fn test_accept_deleted_key_mirrored() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data)?;
     assert_eq!(do_sync(&tx, &[])?.len(), 1);
@@ -336,8 +346,9 @@ fn test_accept_deleted_key_mirrored() -> Result<()> {
 
 #[test]
 fn test_merged_no_mirror() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", data)?;
     // Incoming payload without 'key1' and some data for 'key2'.
@@ -355,8 +366,9 @@ fn test_merged_no_mirror() -> Result<()> {
 
 #[test]
 fn test_merged_incoming() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let old_data = json!({"key1": "key1-value", "key2": "key2-value", "doomed_key": "deletable"});
     set(&tx, "ext-id", old_data)?;
     assert_eq!(do_sync(&tx, &[])?.len(), 1);
@@ -385,8 +397,9 @@ fn test_merged_incoming() -> Result<()> {
 
 #[test]
 fn test_merged_with_null_payload() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let old_data = json!({"key1": "key1-value"});
     set(&tx, "ext-id", old_data.clone())?;
     // Push this change remotely.
@@ -409,8 +422,9 @@ fn test_merged_with_null_payload() -> Result<()> {
 
 #[test]
 fn test_deleted_mirrored_object_accept() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data)?;
     assert_eq!(do_sync(&tx, &[])?.len(), 1);
@@ -427,8 +441,9 @@ fn test_deleted_mirrored_object_accept() -> Result<()> {
 
 #[test]
 fn test_deleted_mirrored_object_merged() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     set(&tx, "ext-id", json!({"key1": "key1-value"}))?;
     assert_eq!(do_sync(&tx, &[])?.len(), 1);
     let guid = get_mirror_guid(&tx, "ext-id")?;
@@ -450,8 +465,9 @@ fn test_deleted_mirrored_object_merged() -> Result<()> {
 /// Like the above test, but with a mirrored tombstone.
 #[test]
 fn test_deleted_mirrored_tombstone_merged() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     // Sync some data so we can get the guid for this extension.
     set(&tx, "ext-id", json!({"key1": "key1-value"}))?;
     assert_eq!(do_sync(&tx, &[])?.len(), 1);
@@ -473,8 +489,9 @@ fn test_deleted_mirrored_tombstone_merged() -> Result<()> {
 
 #[test]
 fn test_deleted_not_mirrored_object_merged() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data)?;
     // Incoming payload with data deleted.
@@ -493,8 +510,9 @@ fn test_deleted_not_mirrored_object_merged() -> Result<()> {
 
 #[test]
 fn test_conflicting_incoming() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let data = json!({"key1": "key1-value", "key2": "key2-value"});
     set(&tx, "ext-id", data)?;
     // Incoming payload without 'key1' and conflicting for 'key2'.
@@ -517,8 +535,9 @@ fn test_conflicting_incoming() -> Result<()> {
 
 #[test]
 fn test_invalid_incoming() -> Result<()> {
-    let mut db = new_syncable_mem_db();
-    let tx = db.transaction()?;
+    let db = new_syncable_mem_db();
+    let conn = db.get_connection().expect("should retrieve connection");
+    let tx = conn.unchecked_transaction()?;
     let json = json!({"id": "id", "payload": json!("").to_string()});
     let bso = serde_json::from_value::<IncomingBso>(json).unwrap();
     let record = bso.into_content();


### PR DESCRIPTION
Fixed the db close function so that we are properly closing the database connection in preparation for exposing it to desktop.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
