### PR TITLE
Rework remote settings server URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Remote Settings
 - Updated Error hierarchy.  We don't need to update consumer code because the only consumer was
   Android and it only caught exceptions using the base RemoteSettingsException class.
+- Updated `RemoteSettingsServer::url()` to include the `v1/` path.  This makes the API match the JS
+  version.  This only affects Rust consumers, since this function is not exposed via UniFFI.
 
 ## 🦊 What's Changed 🦊
 

--- a/components/remote_settings/android/src/test/java/org/mozilla/appservices/remotesettings/RemoteSettingsTest.kt
+++ b/components/remote_settings/android/src/test/java/org/mozilla/appservices/remotesettings/RemoteSettingsTest.kt
@@ -83,7 +83,7 @@ class RemoteSettingsTest {
         val attachmentUrl = "${config.serverUrl}/attachments/$attachmentLocation"
         doFetch = { req ->
             when (req.url) {
-                "$topUrl/" -> {
+                "$topUrl/v1/" -> {
                     Response(
                         url = req.url,
                         status = 200,

--- a/components/remote_settings/src/config.rs
+++ b/components/remote_settings/src/config.rs
@@ -66,10 +66,21 @@ impl RemoteSettingsServer {
     /// inside the crate.
     pub(crate) fn get_url(&self) -> Result<Url> {
         Ok(match self {
-            Self::Prod => Url::parse("https://firefox.settings.services.mozilla.com").unwrap(),
-            Self::Stage => Url::parse("https://firefox.settings.services.allizom.org").unwrap(),
-            Self::Dev => Url::parse("https://remote-settings-dev.allizom.org").unwrap(),
-            Self::Custom { url } => Url::parse(url)?,
+            Self::Prod => Url::parse("https://firefox.settings.services.mozilla.com/v1")?,
+            Self::Stage => Url::parse("https://firefox.settings.services.allizom.org/v1")?,
+            Self::Dev => Url::parse("https://remote-settings-dev.allizom.org/v1")?,
+            Self::Custom { url } => {
+                let mut url = Url::parse(url)?;
+                // Custom URLs are weird and require a couple tricks for backwards compatibility.
+                // Normally we append `v1/` to match how this has historically worked.  However,
+                // don't do this for file:// schemes which normally don't make any sense, but it's
+                // what Nimbus uses to indicate they want to use the file-based client, rather than
+                // a remote-settings based one.
+                if url.scheme() != "file" {
+                    url = url.join("v1")?
+                }
+                url
+            }
         })
     }
 }


### PR DESCRIPTION
Let's update these to match the JS client:
https://github.com/mozilla-extensions/remote-settings-devtools/blob/15245fdb8e4fb5875a7866c7328ded6671ab466c/extension/experiments/remotesettings/api.js#L8-L11

This is a breaking change to the public API, but this API is not exposed via UniFFI and it's only used in 1 place:
https://github.com/mozilla/application-services/blob/50bf235b9a3a62a6b6749cd0bd7358d7b96a42e4/components/nimbus/src/stateful/client/mod.rs#L24-L35. AFAICT, the only affect this will have is that the error message will change slightly.

Also removed the `.unwrap()` calls.  It shouldn't matter because there's no way for `.join()` to fail, but it feels silly calling `unwrap()` from a function that returns a result.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
