### PR TITLE
Bug 1928544 - For weather suggestions, don't match on airport codes or abbreviations when they're the only term in the query

### DIFF
--- a/components/suggest/src/weather.rs
+++ b/components/suggest/src/weather.rs
@@ -148,7 +148,7 @@ impl SuggestDao<'_> {
                     })
             })
             // Step 4: Discard matches that don't have the right combination of
-            // tokens or that are otherwise invalid. Along with step 1, this is
+            // tokens or that are otherwise invalid. Along with step 2, this is
             // the core of the matching logic. In general, allow a match if it
             // has (a) a city name typed in full or (b) a weather keyword at
             // least as long as the config's min keyword length, since that


### PR DESCRIPTION
In the original GeoNames data, each alternate name has an associated `iso_language` that indicates what kind of name it is. In addition to actual language codes, it can also be `"abbr"` for an abbreviation ("NY") and a handful of other values that all mean an airport code ("PDX"). We need to keep track of the `iso_language` per alternate so that we don't match on an abbreviation or airport code when it's the only term in the query. (Or, we could store an `is_abbreviation` in the RS data, but that's worse in the long term, and it's also good to be consistent with the original data where feasible IMO.)

I modified the schema and RS structs accordingly. In `DownloadedGeoname`, I changed the name of `alternate_names` to `alternate_names_2` because, while I'd like to uplift this change, it's not clear there's enough time. So we may need to support the old `alternate_names` on 133.

The other main change is to `filter_map_chunks()`: The filter-map function is now passed the chunk size, and weather uses it to tell whether the chunk is the last one in the query string.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
