### PR TITLE
feat: move versioning into its own support crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,6 +1523,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "firefox-versioning"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,6 +2705,7 @@ dependencies = [
  "ctor 0.2.8",
  "env_logger",
  "error-support",
+ "firefox-versioning",
  "glean-build",
  "hex",
  "jexl-eval",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ members = [
 
     "examples/*/",
     "testing/separated/*/",
+    "components/support/firefox-versioning",
 ]
 
 exclude = [

--- a/components/nimbus/Cargo.toml
+++ b/components/nimbus/Cargo.toml
@@ -17,7 +17,7 @@ name = "nimbus"
 default=["stateful"]
 rkv-safe-mode = ["dep:rkv"]
 stateful-uniffi-bindings = []
-stateful = ["rkv-safe-mode", "stateful-uniffi-bindings", "dep:remote_settings", "dep:regex"]
+stateful = ["rkv-safe-mode", "stateful-uniffi-bindings", "dep:remote_settings", "dep:regex", "dep:firefox-versioning"]
 
 [dependencies]
 anyhow = "1"
@@ -40,6 +40,7 @@ error-support = { path = "../support/error" }
 remote_settings = { path = "../remote_settings", optional = true }
 cfg-if = "1.0.0"
 regex = { version = "1.10.5", optional = true }
+firefox-versioning = { path = "../support/firefox-versioning", optional = true }
 
 [build-dependencies]
 uniffi = { workspace = true, features = ["build"] }

--- a/components/nimbus/src/error.rs
+++ b/components/nimbus/src/error.rs
@@ -8,6 +8,8 @@
 //! TODO: Implement proper error handling, this would include defining the error enum,
 //! impl std::error::Error using `thiserror` and ensuring all errors are handled appropriately
 
+#[cfg(feature = "stateful")]
+use firefox_versioning::error::VersionParsingError;
 use std::num::{ParseIntError, TryFromIntError};
 
 #[derive(Debug, thiserror::Error)]
@@ -104,6 +106,13 @@ pub enum CirrusClientError {
 impl<'a> From<jexl_eval::error::EvaluationError<'a>> for NimbusError {
     fn from(eval_error: jexl_eval::error::EvaluationError<'a>) -> Self {
         NimbusError::EvaluationError(eval_error.to_string())
+    }
+}
+
+#[cfg(feature = "stateful")]
+impl From<VersionParsingError> for NimbusError {
+    fn from(eval_error: VersionParsingError) -> Self {
+        NimbusError::VersionParsingError(eval_error.to_string())
     }
 }
 

--- a/components/nimbus/src/lib.rs
+++ b/components/nimbus/src/lib.rs
@@ -15,7 +15,6 @@ mod targeting;
 pub mod error;
 pub mod metrics;
 pub mod schema;
-pub mod versioning;
 
 pub use enrollment::{EnrolledFeature, EnrollmentStatus};
 pub use error::{NimbusError, Result};

--- a/components/nimbus/src/tests/helpers.rs
+++ b/components/nimbus/src/tests/helpers.rs
@@ -342,6 +342,7 @@ pub(crate) fn get_test_experiments() -> Vec<Experiment> {
     ]
 }
 
+#[cfg(feature = "stateful")]
 pub fn get_ios_rollout_experiment() -> Experiment {
     serde_json::from_value(json!(
     {

--- a/components/nimbus/src/tests/mod.rs
+++ b/components/nimbus/src/tests/mod.rs
@@ -10,7 +10,6 @@ mod test_evaluator;
 mod test_lib_bw_compat;
 mod test_sampling;
 mod test_schema;
-mod test_versioning;
 
 #[cfg(feature = "stateful")]
 mod stateful {

--- a/components/nimbus/src/tests/stateful/test_nimbus.rs
+++ b/components/nimbus/src/tests/stateful/test_nimbus.rs
@@ -917,6 +917,7 @@ fn delete_test_creation_date<P: AsRef<Path>>(path: P) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "stateful")]
 #[test]
 fn test_ios_rollout() -> Result<()> {
     let metrics = TestMetrics::new();
@@ -1645,6 +1646,7 @@ fn test_new_enrollment_in_targeting_mid_run() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "stateful")]
 #[test]
 fn test_recorded_context_recorded() -> Result<()> {
     let metrics = TestMetrics::new();

--- a/components/nimbus/src/tests/test_enrollment.rs
+++ b/components/nimbus/src/tests/test_enrollment.rs
@@ -10,12 +10,19 @@ use crate::{
     enrollment::*,
     error::Result,
     tests::helpers::{
-        get_ios_rollout_experiment, get_multi_feature_experiment, get_single_feature_experiment,
-        get_test_experiments, no_coenrolling_features,
+        get_multi_feature_experiment, get_single_feature_experiment, get_test_experiments,
+        no_coenrolling_features,
     },
     AppContext, AvailableRandomizationUnits, Branch, BucketConfig, Experiment, FeatureConfig,
     NimbusTargetingHelper, TargetingAttributes,
 };
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "stateful")] {
+        use crate::tests::helpers::get_ios_rollout_experiment;
+
+    }
+}
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
@@ -411,6 +418,7 @@ fn enrollment_evolver<'a>(
     EnrollmentsEvolver::new(aru, targeting_helper, ids)
 }
 
+#[cfg(feature = "stateful")]
 #[test]
 fn test_ios_rollout_experiment() -> Result<()> {
     let exp = &get_ios_rollout_experiment();

--- a/components/nimbus/src/tests/test_evaluator.rs
+++ b/components/nimbus/src/tests/test_evaluator.rs
@@ -109,6 +109,7 @@ fn test_geo_targeting_fails_properly() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "stateful")]
 #[test]
 fn test_minimum_version_targeting_passes() -> Result<()> {
     // Here's our valid jexl statement
@@ -121,6 +122,7 @@ fn test_minimum_version_targeting_passes() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "stateful")]
 #[test]
 fn test_minimum_version_targeting_fails() -> Result<()> {
     // Here's our valid jexl statement
@@ -138,6 +140,7 @@ fn test_minimum_version_targeting_fails() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "stateful")]
 #[test]
 fn test_targeting_specific_version() -> Result<()> {
     // Here's our valid jexl statement that targets **only** 96 versions
@@ -196,6 +199,7 @@ fn test_targeting_invalid_transform() -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "stateful")]
 #[test]
 fn test_targeting() {
     // Here's our valid jexl statement

--- a/components/nimbus/tests/test_message_helpers.rs
+++ b/components/nimbus/tests/test_message_helpers.rs
@@ -20,6 +20,7 @@ mod message_tests {
 
     use super::*;
 
+    #[cfg(feature = "stateful")]
     #[test]
     fn test_jexl_expression() -> Result<()> {
         let nimbus = common::new_test_client("jexl_test")?;

--- a/components/support/firefox-versioning/Cargo.toml
+++ b/components/support/firefox-versioning/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "firefox-versioning"
+version = "0.1.0"
+authors = ["Nimbus Team <project-nimbus@mozilla.com>"]
+license = "MPL-2.0"
+edition = "2021"
+
+[dependencies]
+serde_json = "1.0"
+thiserror = "1.0"

--- a/components/support/firefox-versioning/src/compare.rs
+++ b/components/support/firefox-versioning/src/compare.rs
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::error::VersionParsingError;
+use crate::version::Version;
+use serde_json::{json, Value};
+use std::convert::TryFrom;
+
+pub type Result<T, E = VersionParsingError> = std::result::Result<T, E>;
+
+pub fn version_compare(args: &[Value]) -> Result<Value> {
+    let curr_version = args.first().ok_or_else(|| {
+        VersionParsingError::ParseError("current version doesn't exist in jexl transform".into())
+    })?;
+    let curr_version = curr_version.as_str().ok_or_else(|| {
+        VersionParsingError::ParseError("current version in jexl transform is not a string".into())
+    })?;
+    let min_version = args.get(1).ok_or_else(|| {
+        VersionParsingError::ParseError("minimum version doesn't exist in jexl transform".into())
+    })?;
+    let min_version = min_version.as_str().ok_or_else(|| {
+        VersionParsingError::ParseError("minimum version is not a string in jexl transform".into())
+    })?;
+    let min_version = Version::try_from(min_version)?;
+    let curr_version = Version::try_from(curr_version)?;
+    Ok(json!(if curr_version > min_version {
+        1
+    } else if curr_version < min_version {
+        -1
+    } else {
+        0
+    }))
+}

--- a/components/support/firefox-versioning/src/error.rs
+++ b/components/support/firefox-versioning/src/error.rs
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/// The `VersioningError` indicates that a Firefox Version, being passed down as a `String`,
+/// cannot be parsed into a `Version`.
+///
+/// It can either be caused by a non-ASCII character or a integer overflow.
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum VersionParsingError {
+    /// Indicates that a number overflowed.
+    #[error("Overflow Error: {0}")]
+    Overflow(String),
+    /// Indicates a general parsing error.
+    #[error("Parsing Error: {0}")]
+    ParseError(String),
+}

--- a/components/support/firefox-versioning/src/lib.rs
+++ b/components/support/firefox-versioning/src/lib.rs
@@ -1,0 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+pub mod compare;
+pub mod error;
+pub mod version;

--- a/components/support/firefox-versioning/tests/test_versioning.rs
+++ b/components/support/firefox-versioning/tests/test_versioning.rs
@@ -2,8 +2,10 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use crate::versioning::*;
-use crate::{error::Result, NimbusError};
+use firefox_versioning::error::VersionParsingError;
+use firefox_versioning::version::{Version, VersionPart};
+
+pub type Result<T, E = VersionParsingError> = std::result::Result<T, E>;
 
 #[test]
 fn test_wild_card_to_version_part() -> Result<()> {
@@ -162,7 +164,7 @@ fn test_compare_wild_card() -> Result<()> {
 #[test]
 fn test_non_ascii_throws_error() -> Result<()> {
     let err = Version::try_from("92🥲.1.2pre").expect_err("Should have thrown error");
-    if let NimbusError::VersionParsingError(_) = err {
+    if let VersionParsingError::ParseError(_) = err {
         // Good!
     } else {
         panic!("Expected VersionParsingError, got {:?}", err)
@@ -178,7 +180,7 @@ fn test_version_number_parsing_overflows() -> Result<()> {
     // this is greater than i32::MAX, should return an error
     let err =
         VersionPart::try_from("2147483648").expect_err("Should throw error, it overflows an i32");
-    if let NimbusError::VersionParsingError(_) = err {
+    if let VersionParsingError::Overflow(_) = err {
         // OK
     } else {
         panic!("Expected a VersionParsingError, got {:?}", err)


### PR DESCRIPTION
Multiple components in application-services need to filter for the exact Firefox version. Instead of duplicating the code, we move it into its own support crate, which other components can now make use of.

Moves out of `Nimbus`:
- [x] `versioning.rs`
- [x] `tests/test_versioning.rs` 

Adds:
- [x] `components/support/versioning`
