### PR TITLE
Update the taskcluster commenting logic

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -212,8 +212,8 @@ tasks:
                                         $if: 'tasks_for == "cron"'
                                         then: '${cron.quoted_args}'
                                         else:
-                                            $if: 'tasks_for == "github-issue-comment"'
-                                            then: '--target-tasks-method=${event.taskcluster_comment}'
+                                            $if: 'tasks_for == "github-issue-comment" && event.taskcluster_comment == "ci full"'
+                                            then: '--target-tasks-method=pr-full'
                                             else: ''
                                     in:
                                       $if: 'tasks_for == "action"'


### PR DESCRIPTION
This will run all the tasks on `/taskcluster ci full` which matches handling of `[ci full]` in the PR title.
Before this change you had to use `/taskcluster pr-full`, which doesn't seem that intuitive.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
