### PR TITLE
Add countBookmarksInTrees swift wrapper

### DIFF
--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -299,6 +299,37 @@ public class PlacesReadConnection {
         }
     }
 
+    /**
+     * Counts the number of bookmark items in the bookmark trees under the specified GUIDs.
+     * Empty folders, non-existing GUIDs and non-folder guids will return zero.
+     *
+     * - Parameter folderGuids: The guids of folders to query.
+     * - Returns: Count of all bookmark items (ie, not folders or separators) in all specified folders recursively.
+     * - Throws:
+     *     - `PlacesApiError.databaseInterrupted`: If a call is made to
+     *                                             `interrupt()` on this object
+     *                                             from another thread.
+     *     - `PlacesConnectionError.connUseAfterAPIClosed`: If the PlacesAPI that returned
+     *                                                      this connection object has
+     *                                                      been closed. This indicates
+     *                                                      API misuse.
+     *     - `PlacesApiError.databaseBusy`: If this query times out with a
+     *                                      SQLITE_BUSY error.
+     *     - `PlacesApiError.unexpected`: When an error that has not specifically
+     *                                    been exposed to Swift is encountered (for
+     *                                    example IO errors from the database code,
+     *                                    etc).
+     *     - `PlacesApiError.panic`: If the rust code panics while completing this
+     *                               operation. (If this occurs, please let us
+     *                               know).
+     */
+    open func countBookmarksInTrees(folderGuids: [Guid]) throws -> UInt32 {
+        return try queue.sync {
+            try self.checkApi()
+            return try self.conn.bookmarksCountBookmarksInTrees(folderGuids: folderGuids)
+        }
+    }
+
     open func getLatestHistoryMetadataForUrl(url: Url) throws -> HistoryMetadata? {
         return try queue.sync {
             try self.checkApi()

--- a/components/places/ios/Places/Places.swift
+++ b/components/places/ios/Places/Places.swift
@@ -323,10 +323,10 @@ public class PlacesReadConnection {
      *                               operation. (If this occurs, please let us
      *                               know).
      */
-    open func countBookmarksInTrees(folderGuids: [Guid]) throws -> UInt32 {
+    open func countBookmarksInTrees(folderGuids: [Guid]) throws -> Int {
         return try queue.sync {
             try self.checkApi()
-            return try self.conn.bookmarksCountBookmarksInTrees(folderGuids: folderGuids)
+            return try Int(self.conn.bookmarksCountBookmarksInTrees(folderGuids: folderGuids))
         }
     }
 

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/PlacesTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/PlacesTests.swift
@@ -253,6 +253,13 @@ class PlacesTests: XCTestCase {
         ], checkChildren: .onlyGUIDs)
     }
 
+    func testCountBookmarksInTrees() {
+        let db = api.getWriter()
+        let newFolderGUID = insertTree(db, parent: BookmarkRoots.MenuFolderGUID, tree: DummyTree0)
+        let bookmarkCount = try! db.countBookmarksInTrees(folderGuids: [newFolderGUID])
+        XCTAssertEqual(3, bookmarkCount)
+    }
+
     // MARK: history metadata tests
 
     func testDeleteVisitsFor() {


### PR DESCRIPTION
### Description
- Add `countBookmarksInTrees` wrapper function to `Places.swift` to help accomplish [FXIOS-9744: The desktop bookmarks folder is no longer displayed by default](https://mozilla-hub.atlassian.net/browse/FXIOS-9744)
- Swift equivalent to #5853

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
