### PR TITLE
fix: increase timeout for nimbus ios test for CI 

### DIFF
--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
@@ -179,7 +179,7 @@ class NimbusTests: XCTestCase {
             return self.minimalExperimentJSON()
         }
 
-        let finishedNormally = job.joinOrTimeout(timeout: 1.0)
+        let finishedNormally = job.joinOrTimeout(timeout: 4.0)
         XCTAssertTrue(finishedNormally)
 
         let noExperiments = nimbus.getActiveExperiments()


### PR DESCRIPTION
This test is flaky, and fails every now and then. My assumption is that it's because of the timeout. Locally, it runs through, and on some PRs as well. Just every now and then, the CI takes longer than expected.