### PR TITLE
EncryptorDecryptor Trait for Logins Component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 website/build
 target
 credentials.json
+logins.jwk
 *-engine.json
 *.db
 .*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,16 @@ pub fn add(&self, entry: LoginEntry) -> ApiResult<Login>
 pub fn add_or_update(&self, entry: LoginEntry) -> ApiResult<Login>
 ```
 
+New LoginsStore methods:
+```
+// Checking whether the database contains logins (does not utilize the `EncryptorDecryptor`):
+is_empty(&self) -> ApiResult<bool>
+// Checking for the Existence of Logins for a given base domain (also does not utilize the `EncryptorDecryptor`):
+has_logins_by_base_domain(&self, base_domain: &str) -> ApiResult<bool>
+```
+
 The crypto primitives `encrypt`, `decrypt`, `encrypt_struct` and `decrypt_struct` are not exposed anymore via UniFFI, as well as `EncryptedLogin` will not be exposed anymore. In addition we also do not expose the structs `RecordFields`, `LoginFields` and `SecureLoginFields` anymore.
 
-Checking for the Existence of Logins for a given Base Domain In order to check for the existence of stored logins for a given base domain, we provide an additional store method, has_logins_by_base_domain(&self, base_domain: &str), which does not utilize the `EncryptorDecryptor`.
 
 ##### SyncEngine
 The logins sync engine has been adapted for above EncryptorDecryptor trait and therefore does not support a `set_local_encryption_key` method anymore.

--- a/components/logins/README.md
+++ b/components/logins/README.md
@@ -89,7 +89,9 @@ To effectively work on the Logins component, you will need to be familiar with:
 
 ### Implementation Overview
 
-Logins implements encrypted storage for login records on top of NSS. The storage schema is based on the one
+Logins implements encrypted storage for login records on top of a consumer
+implemented EncryptorDecryptor, or via ManagedEncryptorDecryptor, using NSS
+based crypto algorithms (AES256-GCM). The storage schema is based on the one
 originally used in [Firefox for
 iOS](https://github.com/mozilla-mobile/firefox-ios/blob/faa6a2839abf4da2c54ff1b3291174b50b31ab2c/Storage/SQL/SQLiteLogins.swift),
 but with the following notable differences:

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -21,11 +21,12 @@ import org.mozilla.appservices.logins.GleanMetrics.LoginsStore as LoginsStoreMet
  * LoginStore.
  */
 
-class DatabaseLoginsStorage(dbPath: String) : AutoCloseable {
+class DatabaseLoginsStorage(dbPath: String, keyManager: KeyManager) : AutoCloseable {
     private var store: LoginStore
 
     init {
-        this.store = LoginStore(dbPath)
+        val encdec = createManagedEncdec(keyManager)
+        this.store = LoginStore(dbPath, encdec)
     }
 
     @Throws(LoginsApiException::class)
@@ -46,7 +47,7 @@ class DatabaseLoginsStorage(dbPath: String) : AutoCloseable {
     }
 
     @Throws(LoginsApiException::class)
-    fun get(id: String): EncryptedLogin? {
+    fun get(id: String): Login? {
         return readQueryCounters.measure {
             store.get(id)
         }
@@ -60,44 +61,44 @@ class DatabaseLoginsStorage(dbPath: String) : AutoCloseable {
     }
 
     @Throws(LoginsApiException::class)
-    fun list(): List<EncryptedLogin> {
+    fun list(): List<Login> {
         return readQueryCounters.measure {
             store.list()
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun getByBaseDomain(baseDomain: String): List<EncryptedLogin> {
+    fun getByBaseDomain(baseDomain: String): List<Login> {
         return readQueryCounters.measure {
             store.getByBaseDomain(baseDomain)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun findLoginToUpdate(look: LoginEntry, encryptionKey: String): Login? {
+    fun findLoginToUpdate(look: LoginEntry): Login? {
         return readQueryCounters.measure {
-            store.findLoginToUpdate(look, encryptionKey)
+            store.findLoginToUpdate(look)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun add(entry: LoginEntry, encryptionKey: String): EncryptedLogin {
+    fun add(entry: LoginEntry): Login {
         return writeQueryCounters.measure {
-            store.add(entry, encryptionKey)
+            store.add(entry)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun update(id: String, entry: LoginEntry, encryptionKey: String): EncryptedLogin {
+    fun update(id: String, entry: LoginEntry): Login {
         return writeQueryCounters.measure {
-            store.update(id, entry, encryptionKey)
+            store.update(id, entry)
         }
     }
 
     @Throws(LoginsApiException::class)
-    fun addOrUpdate(entry: LoginEntry, encryptionKey: String): EncryptedLogin {
+    fun addOrUpdate(entry: LoginEntry): Login {
         return writeQueryCounters.measure {
-            store.addOrUpdate(entry, encryptionKey)
+            store.addOrUpdate(entry)
         }
     }
 

--- a/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
+++ b/components/logins/android/src/main/java/mozilla/appservices/logins/DatabaseLoginsStorage.kt
@@ -61,9 +61,23 @@ class DatabaseLoginsStorage(dbPath: String, keyManager: KeyManager) : AutoClosea
     }
 
     @Throws(LoginsApiException::class)
+    fun isEmpty(): Boolean {
+        return readQueryCounters.measure {
+            store.isEmpty()
+        }
+    }
+
+    @Throws(LoginsApiException::class)
     fun list(): List<Login> {
         return readQueryCounters.measure {
             store.list()
+        }
+    }
+
+    @Throws(LoginsApiException::class)
+    fun hasLoginsByBaseDomain(baseDomain: String): Boolean {
+        return readQueryCounters.measure {
+            store.hasLoginsByBaseDomain(baseDomain)
         }
     }
 

--- a/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
+++ b/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
@@ -46,33 +46,25 @@ class DatabaseLoginsStorageTest {
 
         store.add(
             LoginEntry(
-                fields = LoginFields(
-                    origin = "https://www.example.com",
-                    httpRealm = "Something",
-                    usernameField = "users_name",
-                    passwordField = "users_password",
-                    formActionOrigin = null,
-                ),
-                secFields = SecureLoginFields(
-                    username = "Foobar2000",
-                    password = "hunter2",
-                ),
+                origin = "https://www.example.com",
+                httpRealm = "Something",
+                usernameField = "users_name",
+                passwordField = "users_password",
+                formActionOrigin = null,
+                username = "Foobar2000",
+                password = "hunter2",
             ),
         )
 
         store.add(
             LoginEntry(
-                fields = LoginFields(
-                    origin = "https://www.example.org",
-                    httpRealm = "",
-                    formActionOrigin = "https://www.example.org/login",
-                    usernameField = "users_name",
-                    passwordField = "users_password",
-                ),
-                secFields = SecureLoginFields(
-                    password = "MyVeryCoolPassword",
-                    username = "Foobar2000",
-                ),
+                origin = "https://www.example.org",
+                httpRealm = "",
+                formActionOrigin = "https://www.example.org/login",
+                usernameField = "users_name",
+                passwordField = "users_password",
+                password = "MyVeryCoolPassword",
+                username = "Foobar2000",
             ),
         )
 
@@ -93,17 +85,13 @@ class DatabaseLoginsStorageTest {
 
         val login = store.add(
             LoginEntry(
-                fields = LoginFields(
-                    origin = "https://www.example.com",
-                    httpRealm = "Something",
-                    usernameField = "users_name",
-                    passwordField = "users_password",
-                    formActionOrigin = null,
-                ),
-                secFields = SecureLoginFields(
-                    username = "Foobar2000",
-                    password = "hunter2",
-                ),
+                origin = "https://www.example.com",
+                httpRealm = "Something",
+                usernameField = "users_name",
+                passwordField = "users_password",
+                formActionOrigin = null,
+                username = "Foobar2000",
+                password = "hunter2",
             ),
         )
 
@@ -112,17 +100,13 @@ class DatabaseLoginsStorageTest {
 
         // N.B. this is invalid due to `formActionOrigin` being an invalid url.
         val invalid = LoginEntry(
-            fields = LoginFields(
-                origin = "https://test.example.com",
-                formActionOrigin = "not a url",
-                httpRealm = "",
-                usernameField = "users_name",
-                passwordField = "users_password",
-            ),
-            secFields = SecureLoginFields(
-                username = "Foobar2000",
-                password = "hunter2",
-            ),
+            origin = "https://test.example.com",
+            formActionOrigin = "not a url",
+            httpRealm = "",
+            usernameField = "users_name",
+            passwordField = "users_password",
+            username = "Foobar2000",
+            password = "hunter2",
         )
 
         try {
@@ -138,8 +122,8 @@ class DatabaseLoginsStorageTest {
         assertNull(LoginsStoreMetrics.readQueryCount.testGetValue())
         assertNull(LoginsStoreMetrics.readQueryErrorCount["storage_error"].testGetValue())
 
-        val record = store.get(login.record.id)!!
-        assertEquals(record.fields.origin, "https://www.example.com")
+        val record = store.get(login.id)!!
+        assertEquals(record.origin, "https://www.example.com")
 
         assertEquals(LoginsStoreMetrics.readQueryCount.testGetValue(), 1)
         assertNull(LoginsStoreMetrics.readQueryErrorCount["storage_error"].testGetValue())
@@ -153,13 +137,13 @@ class DatabaseLoginsStorageTest {
         val login = store.list()[0]
         // Wait 100ms so that touch is certain to change timeLastUsed.
         Thread.sleep(100)
-        store.touch(login.record.id)
+        store.touch(login.id)
 
-        val updatedLogin = store.get(login.record.id)
+        val updatedLogin = store.get(login.id)
 
         assertNotNull(updatedLogin)
-        assertEquals(login.record.timesUsed + 1, updatedLogin!!.record.timesUsed)
-        assert(updatedLogin.record.timeLastUsed > login.record.timeLastUsed)
+        assertEquals(login.timesUsed + 1, updatedLogin!!.timesUsed)
+        assert(updatedLogin.timeLastUsed > login.timeLastUsed)
 
         assertThrows(LoginsApiException.NoSuchRecord::class.java) { store.touch("abcdabcdabcd") }
 
@@ -171,11 +155,11 @@ class DatabaseLoginsStorageTest {
         val store = getTestStore()
         val login = store.list()[0]
 
-        assertNotNull(store.get(login.record.id))
-        assertTrue(store.delete(login.record.id))
-        assertNull(store.get(login.record.id))
-        assertFalse(store.delete(login.record.id))
-        assertNull(store.get(login.record.id))
+        assertNotNull(store.get(login.id))
+        assertTrue(store.delete(login.id))
+        assertNull(store.get(login.id))
+        assertFalse(store.delete(login.id))
+        assertNull(store.get(login.id))
 
         finishAndClose(store)
     }
@@ -189,8 +173,8 @@ class DatabaseLoginsStorageTest {
         test.wipeLocal()
         assertEquals(0, test.list().size)
 
-        assertNull(test.get(logins[0].record.id))
-        assertNull(test.get(logins[1].record.id))
+        assertNull(test.get(logins[0].id))
+        assertNull(test.get(logins[1].id))
 
         finishAndClose(test)
     }

--- a/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
+++ b/components/logins/android/src/test/java/mozilla/appservices/logins/DatabaseLoginsStorageTest.kt
@@ -32,13 +32,14 @@ class DatabaseLoginsStorageTest {
     @get:Rule
     val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
 
+    protected val encryptionKey = createKey()
+
     fun createTestStore(): DatabaseLoginsStorage {
         Megazord.init()
         val dbPath = dbFolder.newFile()
-        return DatabaseLoginsStorage(dbPath = dbPath.absolutePath)
+        val keyManager = createStaticKeyManager(key = encryptionKey)
+        return DatabaseLoginsStorage(dbPath = dbPath.absolutePath, keyManager = keyManager)
     }
-
-    protected val encryptionKey = createKey()
 
     protected fun getTestStore(): DatabaseLoginsStorage {
         val store = createTestStore()
@@ -57,7 +58,6 @@ class DatabaseLoginsStorageTest {
                     password = "hunter2",
                 ),
             ),
-            encryptionKey,
         )
 
         store.add(
@@ -74,7 +74,6 @@ class DatabaseLoginsStorageTest {
                     username = "Foobar2000",
                 ),
             ),
-            encryptionKey,
         )
 
         return store
@@ -106,7 +105,6 @@ class DatabaseLoginsStorageTest {
                     password = "hunter2",
                 ),
             ),
-            encryptionKey,
         )
 
         assertEquals(LoginsStoreMetrics.writeQueryCount.testGetValue(), 1)
@@ -128,7 +126,7 @@ class DatabaseLoginsStorageTest {
         )
 
         try {
-            store.add(invalid, encryptionKey)
+            store.add(invalid)
             fail("Should have thrown")
         } catch (e: LoginsApiException.InvalidRecord) {
             // All good.

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -17,8 +17,8 @@ open class LoginsStorage {
     private var store: LoginStore
     private let queue = DispatchQueue(label: "com.mozilla.logins-storage")
 
-    public init(databasePath: String) throws {
-        store = try LoginStore(path: databasePath)
+    public init(databasePath: String, keyManager: KeyManager) throws {
+        store = try LoginStore(path: databasePath, encdec: createManagedEncdec(keyManager: keyManager))
     }
 
     open func wipeLocal() throws {
@@ -47,36 +47,36 @@ open class LoginsStorage {
     /// then this throws `LoginStoreError.DuplicateGuid` if there is a collision
     ///
     /// Returns the `id` of the newly inserted record.
-    open func add(login: LoginEntry, encryptionKey: String) throws -> EncryptedLogin {
+    open func add(login: LoginEntry) throws -> Login {
         return try queue.sync {
-            try self.store.add(login: login, encryptionKey: encryptionKey)
+            try self.store.add(login: login)
         }
     }
 
     /// Update `login` in the database. If `login.id` does not refer to a known
     /// login, then this throws `LoginStoreError.NoSuchRecord`.
-    open func update(id: String, login: LoginEntry, encryptionKey: String) throws -> EncryptedLogin {
+    open func update(id: String, login: LoginEntry) throws -> Login {
         return try queue.sync {
-            try self.store.update(id: id, login: login, encryptionKey: encryptionKey)
+            try self.store.update(id: id, login: login)
         }
     }
 
     /// Get the record with the given id. Returns nil if there is no such record.
-    open func get(id: String) throws -> EncryptedLogin? {
+    open func get(id: String) throws -> Login? {
         return try queue.sync {
             try self.store.get(id: id)
         }
     }
 
     /// Get the entire list of records.
-    open func list() throws -> [EncryptedLogin] {
+    open func list() throws -> [Login] {
         return try queue.sync {
             try self.store.list()
         }
     }
 
     /// Get the list of records for some base domain.
-    open func getByBaseDomain(baseDomain: String) throws -> [EncryptedLogin] {
+    open func getByBaseDomain(baseDomain: String) throws -> [Login] {
         return try queue.sync {
             try self.store.getByBaseDomain(baseDomain: baseDomain)
         }

--- a/components/logins/ios/Logins/LoginsStorage.swift
+++ b/components/logins/ios/Logins/LoginsStorage.swift
@@ -68,10 +68,24 @@ open class LoginsStorage {
         }
     }
 
+    /// Check whether the database is empty.
+    open func isEmpty() throws -> Bool {
+        return try queue.sync {
+            try self.store.isEmpty()
+        }
+    }
+
     /// Get the entire list of records.
     open func list() throws -> [Login] {
         return try queue.sync {
             try self.store.list()
+        }
+    }
+
+    /// Check whether logins exist for some base domain.
+    open func hasLoginsByBaseDomain(baseDomain: String) throws -> Bool {
+        return try queue.sync {
+            try self.store.hasLoginsByBaseDomain(baseDomain: baseDomain)
         }
     }
 

--- a/components/logins/src/encryption.rs
+++ b/components/logins/src/encryption.rs
@@ -26,24 +26,154 @@
 // multiple layers, from the app saying "sync now" all the way down to the
 // low level sync code.
 // To make life a little easier, we do that via a struct.
+//
+// Consumers of the Login component have 3 options for setting up encryption:
+//    1. Implement EncryptorDecryptor directly
+//       eg `LoginStore::new(MyEncryptorDecryptor)`
+//    2. Implement KeyManager and use ManagedEncryptorDecryptor
+//       eg `LoginStore::new(ManagedEncryptorDecryptor::new(MyKeyManager))`
+//    3. Generate a single key and create a StaticKeyManager and use it together with
+//       ManagedEncryptorDecryptor
+//       eg `LoginStore::new(ManagedEncryptorDecryptor::new(StaticKeyManager { key: myKey }))`
+//
+//  You can implement EncryptorDecryptor directly to keep full control over the encryption
+//  algorithm. For example, on the desktop, this could make use of NSS's SecretDecoderRing to
+//  achieve transparent key management.
+//
+//  If the application wants to keep the current encryption, like Android and iOS, for example, but
+//  control the key management itself, the KeyManager can be implemented and the encryption can be
+//  done on the Rust side with the ManagedEncryptorDecryptor.
+//
+//  In tests or some command line tools, it can be practical to use a static key that does not
+//  change at runtime and is already present when the LoginsStore is initialized. In this case, it
+//  makes sense to use the provided StaticKeyManager.
 
 use crate::error::*;
+use std::sync::Arc;
 
-pub type EncryptorDecryptor = jwcrypto::EncryptorDecryptor<Error>;
+/// This is the generic EncryptorDecryptor trait, as handed over to the Store during initialization.
+/// Consumers can implement either this generic trait and bring in their own crypto, or leverage the
+/// ManagedEncryptorDecryptor below, which provides encryption algorithms out of the box.
+///
+/// Note that EncryptorDecryptor must not call any LoginStore methods. The login store can call out
+/// to the EncryptorDecryptor when it's internal mutex is held so calling back in to the LoginStore
+/// may deadlock.
+pub trait EncryptorDecryptor: Send + Sync {
+    fn encrypt(&self, cleartext: Vec<u8>) -> ApiResult<Vec<u8>>;
+    fn decrypt(&self, ciphertext: Vec<u8>) -> ApiResult<Vec<u8>>;
+}
 
-#[handle_error(Error)]
-pub fn create_canary(text: &str, key: &str) -> ApiResult<String> {
-    EncryptorDecryptor::new(key)?.create_canary(text)
+impl<T: EncryptorDecryptor> EncryptorDecryptor for Arc<T> {
+    fn encrypt(&self, clearbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
+        (**self).encrypt(clearbytes)
+    }
+
+    fn decrypt(&self, cipherbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
+        (**self).decrypt(cipherbytes)
+    }
+}
+
+/// The ManagedEncryptorDecryptor makes use of the NSS provided cryptographic algorithms. The
+/// ManagedEncryptorDecryptor uses a KeyManager for encryption key retrieval.
+pub struct ManagedEncryptorDecryptor {
+    key_manager: Arc<dyn KeyManager>,
+}
+
+impl ManagedEncryptorDecryptor {
+    pub fn new(key_manager: Arc<dyn KeyManager>) -> Self {
+        Self { key_manager }
+    }
+}
+
+impl EncryptorDecryptor for ManagedEncryptorDecryptor {
+    fn encrypt(&self, clearbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
+        let keybytes = self
+            .key_manager
+            .get_key()
+            .map_err(|_| LoginsApiError::MissingKey)?;
+        let key = std::str::from_utf8(&keybytes).map_err(|_| LoginsApiError::InvalidKey)?;
+
+        let encdec = jwcrypto::EncryptorDecryptor::new(key)
+            .map_err(|_: jwcrypto::EncryptorDecryptorError| LoginsApiError::InvalidKey)?;
+
+        let cleartext =
+            std::str::from_utf8(&clearbytes).map_err(|e| LoginsApiError::EncryptionFailed {
+                reason: e.to_string(),
+            })?;
+        encdec
+            .encrypt(cleartext, "encrypt SecureLoginFields")
+            .map_err(
+                |e: jwcrypto::EncryptorDecryptorError| LoginsApiError::EncryptionFailed {
+                    reason: e.to_string(),
+                },
+            )
+            .map(|text| text.into())
+    }
+
+    fn decrypt(&self, cipherbytes: Vec<u8>) -> ApiResult<Vec<u8>> {
+        let keybytes = self
+            .key_manager
+            .get_key()
+            .map_err(|_| LoginsApiError::MissingKey)?;
+        let key = std::str::from_utf8(&keybytes).map_err(|_| LoginsApiError::InvalidKey)?;
+
+        let encdec = jwcrypto::EncryptorDecryptor::new(key)
+            .map_err(|_: jwcrypto::EncryptorDecryptorError| LoginsApiError::InvalidKey)?;
+
+        let ciphertext =
+            std::str::from_utf8(&cipherbytes).map_err(|e| LoginsApiError::DecryptionFailed {
+                reason: e.to_string(),
+            })?;
+        encdec
+            .decrypt(ciphertext, "decrypt SecureLoginFields")
+            .map_err(
+                |e: jwcrypto::EncryptorDecryptorError| LoginsApiError::DecryptionFailed {
+                    reason: e.to_string(),
+                },
+            )
+            .map(|text| text.into())
+    }
+}
+
+/// Consumers can implement the KeyManager in combination with the ManagedEncryptorDecryptor to hand
+/// over the encryption key whenever encryption or decryption happens.
+pub trait KeyManager: Send + Sync {
+    fn get_key(&self) -> ApiResult<Vec<u8>>;
+}
+
+/// Last but not least we provide a StaticKeyManager, which can be
+/// used in cases where there is a single key during runtime, for example in tests.
+pub struct StaticKeyManager {
+    key: String,
+}
+
+impl StaticKeyManager {
+    pub fn new(key: String) -> Self {
+        Self { key }
+    }
+}
+
+impl KeyManager for StaticKeyManager {
+    #[handle_error(Error)]
+    fn get_key(&self) -> ApiResult<Vec<u8>> {
+        Ok(self.key.as_bytes().into())
+    }
 }
 
 #[handle_error(Error)]
+pub fn create_canary(text: &str, key: &str) -> ApiResult<String> {
+    jwcrypto::EncryptorDecryptor::new(key)?.create_canary(text)
+}
+
 pub fn check_canary(canary: &str, text: &str, key: &str) -> ApiResult<bool> {
-    EncryptorDecryptor::new(key)?.check_canary(canary, text)
+    let encdec = jwcrypto::EncryptorDecryptor::new(key)
+        .map_err(|_: jwcrypto::EncryptorDecryptorError| LoginsApiError::InvalidKey)?;
+    Ok(encdec.check_canary(canary, text).unwrap_or(false))
 }
 
 #[handle_error(Error)]
 pub fn create_key() -> ApiResult<String> {
-    EncryptorDecryptor::create_key()
+    jwcrypto::EncryptorDecryptor::create_key()
 }
 
 #[cfg(test)]
@@ -53,23 +183,17 @@ pub mod test_utils {
 
     lazy_static::lazy_static! {
         pub static ref TEST_ENCRYPTION_KEY: String = serde_json::to_string(&jwcrypto::Jwk::new_direct_key(Some("test-key".to_string())).unwrap()).unwrap();
-        pub static ref TEST_ENCRYPTOR: EncryptorDecryptor = EncryptorDecryptor::new(&TEST_ENCRYPTION_KEY).unwrap();
+        pub static ref TEST_ENCDEC: Arc<ManagedEncryptorDecryptor> = Arc::new(ManagedEncryptorDecryptor::new(Arc::new(StaticKeyManager { key: TEST_ENCRYPTION_KEY.clone() })));
     }
-    pub fn encrypt(value: &str) -> String {
-        TEST_ENCRYPTOR.encrypt(value, "test encrypt").unwrap()
-    }
-    pub fn decrypt(value: &str) -> String {
-        TEST_ENCRYPTOR.decrypt(value, "test decrypt").unwrap()
-    }
+
     pub fn encrypt_struct<T: Serialize>(fields: &T) -> String {
-        TEST_ENCRYPTOR
-            .encrypt_struct(fields, "test encrypt struct")
-            .unwrap()
+        let string = serde_json::to_string(fields).unwrap();
+        let cipherbytes = TEST_ENCDEC.encrypt(string.as_bytes().into()).unwrap();
+        std::str::from_utf8(&cipherbytes).unwrap().to_owned()
     }
     pub fn decrypt_struct<T: DeserializeOwned>(ciphertext: String) -> T {
-        TEST_ENCRYPTOR
-            .decrypt_struct(&ciphertext, "test decrypt struct")
-            .unwrap()
+        let jsonbytes = TEST_ENCDEC.decrypt(ciphertext.as_bytes().into()).unwrap();
+        serde_json::from_str(std::str::from_utf8(&jsonbytes).unwrap()).unwrap()
     }
 }
 
@@ -78,22 +202,65 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_encrypt() {
-        let ed = EncryptorDecryptor::new(&create_key().unwrap()).unwrap();
-        let cleartext = "secret";
-        let ciphertext = ed.encrypt(cleartext, "test encrypt").unwrap();
-        assert_eq!(ed.decrypt(&ciphertext, "test decrypt").unwrap(), cleartext);
-        let ed2 = EncryptorDecryptor::new(&create_key().unwrap()).unwrap();
+    fn test_static_key_manager() {
+        let key = create_key().unwrap();
+        let key_manager = StaticKeyManager { key: key.clone() };
+        assert_eq!(key.as_bytes(), key_manager.get_key().unwrap());
+    }
+
+    #[test]
+    fn test_managed_encdec_with_invalid_key() {
+        let key_manager = Arc::new(StaticKeyManager {
+            key: "bad_key".to_owned(),
+        });
+        let encdec = ManagedEncryptorDecryptor { key_manager };
         assert!(matches!(
-            ed2.decrypt(&ciphertext, "test decrypt").err().unwrap(),
-            Error::CryptoError(jwcrypto::EncryptorDecryptorError { description, .. })
-            if description == "test decrypt"
+            encdec.encrypt("secret".as_bytes().into()).err().unwrap(),
+            LoginsApiError::InvalidKey
+        ));
+    }
+
+    #[test]
+    fn test_managed_encdec_with_missing_key() {
+        struct MyKeyManager {}
+        impl KeyManager for MyKeyManager {
+            fn get_key(&self) -> ApiResult<Vec<u8>> {
+                Err(LoginsApiError::MissingKey)
+            }
+        }
+        let key_manager = Arc::new(MyKeyManager {});
+        let encdec = ManagedEncryptorDecryptor { key_manager };
+        assert!(matches!(
+            encdec.encrypt("secret".as_bytes().into()).err().unwrap(),
+            LoginsApiError::MissingKey
+        ));
+    }
+
+    #[test]
+    fn test_managed_encdec() {
+        let key = create_key().unwrap();
+        let key_manager = Arc::new(StaticKeyManager { key });
+        let encdec = ManagedEncryptorDecryptor { key_manager };
+        let cleartext = "secret";
+        let ciphertext = encdec.encrypt(cleartext.as_bytes().into()).unwrap();
+        assert_eq!(
+            encdec.decrypt(ciphertext.clone()).unwrap(),
+            cleartext.as_bytes()
+        );
+        let other_encdec = ManagedEncryptorDecryptor {
+            key_manager: Arc::new(StaticKeyManager {
+                key: create_key().unwrap(),
+            }),
+        };
+        assert!(matches!(
+            other_encdec.decrypt(ciphertext).err().unwrap(),
+            LoginsApiError::DecryptionFailed { reason: _ }
         ));
     }
 
     #[test]
     fn test_key_error() {
-        let storage_err = EncryptorDecryptor::new("bad-key").err().unwrap();
+        let storage_err = jwcrypto::EncryptorDecryptor::new("bad-key").err().unwrap();
         assert!(matches!(
             storage_err,
             Error::CryptoError(jwcrypto::EncryptorDecryptorError {
@@ -111,11 +278,12 @@ mod test {
         assert!(check_canary(&canary, CANARY_TEXT, &key).unwrap());
 
         let different_key = create_key().unwrap();
+        assert!(!check_canary(&canary, CANARY_TEXT, &different_key).unwrap());
+
+        let bad_key = "bad_key".to_owned();
         assert!(matches!(
-            check_canary(&canary, CANARY_TEXT, &different_key)
-                .err()
-                .unwrap(),
-            LoginsApiError::IncorrectKey
+            check_canary(&canary, CANARY_TEXT, &bad_key).err().unwrap(),
+            LoginsApiError::InvalidKey
         ));
     }
 }

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -30,42 +30,40 @@ namespace logins {
     EncryptorDecryptor create_managed_encdec(KeyManager key_manager);
 };
 
-/// The fields you can add or update.
-dictionary LoginFields {
+/// A login entry from the user, not linked to any database record.
+/// The add/update APIs input these.
+dictionary LoginEntry {
+    // login fields
     string origin;
     string? http_realm;
     string? form_action_origin;
     string username_field;
     string password_field;
-};
 
-/// Fields which are encrypted at rest.
-dictionary SecureLoginFields {
+    // secure login fields
     string password;
     string username;
 };
 
-/// Fields specific to database records
-dictionary RecordFields {
+/// A login stored in the database
+dictionary Login {
+    // record fields
     string id;
     i64 times_used;
     i64 time_created;
     i64 time_last_used;
     i64 time_password_changed;
-};
 
-/// A login entry from the user, not linked to any database record.
-/// The add/update APIs input these.
-dictionary LoginEntry {
-    LoginFields fields;
-    SecureLoginFields sec_fields;
-};
+    // login fields
+    string origin;
+    string? http_realm;
+    string? form_action_origin;
+    string username_field;
+    string password_field;
 
-/// A login stored in the database
-dictionary Login {
-    RecordFields record;
-    LoginFields fields;
-    SecureLoginFields sec_fields;
+    // secure login fields
+    string password;
+    string username;
 };
 
 /// These are the errors returned by our public API.

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -9,29 +9,25 @@ namespace logins {
     [Throws=LoginsApiError]
     string create_key();
 
-    /// Decrypt an `EncryptedLogin` to a `Login`
-    [Throws=LoginsApiError]
-    Login decrypt_login(EncryptedLogin login, [ByRef]string encryption_key);
-
-    /// Encrypt a `Login` to an `EncryptedLogin`
-    [Throws=LoginsApiError]
-    EncryptedLogin encrypt_login(Login login, [ByRef]string encryption_key);
-
-    /// Decrypt an encrypted `string` to `SecureLoginFields`
-    [Throws=LoginsApiError]
-    SecureLoginFields decrypt_fields(string sec_fields, [ByRef]string encryption_key);
-
-    /// Encrypt `SecureLoginFields` to an encrypted `string`
-    [Throws=LoginsApiError]
-    string encrypt_fields(SecureLoginFields sec_fields, [ByRef]string encryption_key);
-
-    /// Create a "canary" string, which can be used to test if the encryption key is still valid for the logins data
+    /// Create a "canary" string, which can be used to test if the encryption
+    //key is still valid for the logins data
     [Throws=LoginsApiError]
     string create_canary([ByRef]string text, [ByRef]string encryption_key);
 
-    /// Check that key is still valid using the output of `create_canary`.  `text` much match the text you initially passed to `create_canary()`
+    /// Check that key is still valid using the output of `create_canary`.
+    //`text` much match the text you initially passed to `create_canary()`
     [Throws=LoginsApiError]
     boolean check_canary([ByRef]string canary, [ByRef]string text, [ByRef]string encryption_key);
+
+    /// Utility function to create a StaticKeyManager to be used for the time
+    /// being until support lands for [trait implementation of an UniFFI
+    /// interface](https://mozilla.github.io/uniffi-rs/next/proc_macro/index.html#structs-implementing-traits)
+    /// in UniFFI. 
+    KeyManager create_static_key_manager(string key);
+
+    /// Similar to create_static_key_manager above, create a
+    /// ManagedEncryptorDecryptor by passing in a KeyManager
+    EncryptorDecryptor create_managed_encdec(KeyManager key_manager);
 };
 
 /// The fields you can add or update.
@@ -43,7 +39,7 @@ dictionary LoginFields {
     string password_field;
 };
 
-/// Fields available only while the encryption key is known.
+/// Fields which are encrypted at rest.
 dictionary SecureLoginFields {
     string password;
     string username;
@@ -59,7 +55,7 @@ dictionary RecordFields {
 };
 
 /// A login entry from the user, not linked to any database record.
-/// The add/update APIs input these, alongside an encryption key.
+/// The add/update APIs input these.
 dictionary LoginEntry {
     LoginFields fields;
     SecureLoginFields sec_fields;
@@ -72,15 +68,6 @@ dictionary Login {
     SecureLoginFields sec_fields;
 };
 
-/// An encrypted version of [Login].  This is what we return for all the "read"
-/// APIs - we never return the cleartext of encrypted fields.
-dictionary EncryptedLogin {
-    RecordFields record;
-    LoginFields fields;
-    /// ciphertext of a SecureLoginFields
-    string sec_fields;
-};
-
 /// These are the errors returned by our public API.
 [Error]
 interface LoginsApiError {
@@ -90,8 +77,17 @@ interface LoginsApiError {
     /// Asking to do something with a guid which doesn't exist.
     NoSuchRecord(string reason);
 
-    /// The encryption key supplied of the correct format, but not the correct key.
-    IncorrectKey();
+    /// Encryption key is missing.
+    MissingKey();
+
+    /// Encryption key is not valid.
+    InvalidKey();
+
+    /// encryption failed
+    EncryptionFailed(string reason);
+
+    /// decryption failed
+    DecryptionFailed(string reason);
 
     /// An operation was interrupted at the request of the consuming app.
     Interrupted(string reason);
@@ -107,19 +103,41 @@ interface LoginsApiError {
     UnexpectedLoginsApiError(string reason);
 };
 
+[Trait, WithForeign]
+interface EncryptorDecryptor {
+    [Throws=LoginsApiError]
+    bytes encrypt(bytes cleartext);
+
+    [Throws=LoginsApiError]
+    bytes decrypt(bytes ciphertext);
+};
+
+[Trait, WithForeign]
+interface KeyManager {
+    [Throws=LoginsApiError]
+    bytes get_key();
+};
+
+interface StaticKeyManager {
+    constructor(string key);
+};
+
+interface ManagedEncryptorDecryptor {
+    constructor(KeyManager key_manager);
+};
 
 interface LoginStore {
     [Throws=LoginsApiError]
-    constructor(string path);
+    constructor(string path, EncryptorDecryptor encdec);
 
     [Throws=LoginsApiError]
-    EncryptedLogin add(LoginEntry login, [ByRef]string encryption_key);
+    Login add(LoginEntry login);
 
     [Throws=LoginsApiError]
-    EncryptedLogin update([ByRef] string id, LoginEntry login, [ByRef]string encryption_key);
+    Login update([ByRef] string id, LoginEntry login);
 
     [Throws=LoginsApiError]
-    EncryptedLogin add_or_update(LoginEntry login, [ByRef]string encryption_key);
+    Login add_or_update(LoginEntry login);
 
     [Throws=LoginsApiError]
     boolean delete([ByRef] string id);
@@ -134,16 +152,19 @@ interface LoginStore {
     void touch([ByRef] string id);
 
     [Throws=LoginsApiError]
-    sequence<EncryptedLogin> list();
+    sequence<Login> list();
 
     [Throws=LoginsApiError]
-    sequence<EncryptedLogin> get_by_base_domain([ByRef] string base_domain);
+    sequence<Login> get_by_base_domain([ByRef] string base_domain);
 
     [Throws=LoginsApiError]
-    Login? find_login_to_update(LoginEntry look, [ByRef]string encryption_key);
+    boolean has_logins_by_base_domain([ByRef] string base_domain);
 
     [Throws=LoginsApiError]
-    EncryptedLogin? get([ByRef] string id);
+    Login? find_login_to_update(LoginEntry look);
+
+    [Throws=LoginsApiError]
+    Login? get([ByRef] string id);
 
     [Self=ByArc]
     void register_with_sync_manager();

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -150,6 +150,9 @@ interface LoginStore {
     void touch([ByRef] string id);
 
     [Throws=LoginsApiError]
+    boolean is_empty();
+
+    [Throws=LoginsApiError]
     sequence<Login> list();
 
     [Throws=LoginsApiError]

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -72,6 +72,11 @@ impl LoginStore {
     }
 
     #[handle_error(Error)]
+    pub fn is_empty(&self) -> ApiResult<bool> {
+        self.db.lock().get_all().map(|logins| logins.is_empty())
+    }
+
+    #[handle_error(Error)]
     pub fn list(&self) -> ApiResult<Vec<Login>> {
         self.db.lock().get_all().and_then(|logins| {
             logins

--- a/components/logins/src/sync/engine.rs
+++ b/components/logins/src/sync/engine.rs
@@ -719,43 +719,31 @@ mod tests {
         let store = LoginStore::new_in_memory(TEST_ENCDEC.clone()).unwrap();
 
         let to_add = LoginEntry {
-            fields: LoginFields {
-                form_action_origin: Some("https://www.example.com".into()),
-                origin: "http://not-relevant-here.com".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test".into(),
-                password: "test".into(),
-            },
+            form_action_origin: Some("https://www.example.com".into()),
+            origin: "http://not-relevant-here.com".into(),
+            username: "test".into(),
+            password: "test".into(),
+            ..Default::default()
         };
-        let first_id = store.add(to_add).expect("should insert first").record.id;
+        let first_id = store.add(to_add).expect("should insert first").id;
 
         let to_add = LoginEntry {
-            fields: LoginFields {
-                form_action_origin: Some("https://www.example1.com".into()),
-                origin: "http://not-relevant-here.com".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test1".into(),
-                password: "test1".into(),
-            },
+            form_action_origin: Some("https://www.example1.com".into()),
+            origin: "http://not-relevant-here.com".into(),
+            username: "test1".into(),
+            password: "test1".into(),
+            ..Default::default()
         };
-        let second_id = store.add(to_add).expect("should insert second").record.id;
+        let second_id = store.add(to_add).expect("should insert second").id;
 
         let to_add = LoginEntry {
-            fields: LoginFields {
-                http_realm: Some("http://some-realm.com".into()),
-                origin: "http://not-relevant-here.com".into(),
-                ..Default::default()
-            },
-            sec_fields: SecureLoginFields {
-                username: "test1".into(),
-                password: "test1".into(),
-            },
+            http_realm: Some("http://some-realm.com".into()),
+            origin: "http://not-relevant-here.com".into(),
+            username: "test1".into(),
+            password: "test1".into(),
+            ..Default::default()
         };
-        let no_form_origin_id = store.add(to_add).expect("should insert second").record.id;
+        let no_form_origin_id = store.add(to_add).expect("should insert second").id;
 
         let engine = LoginsSyncEngine::new(Arc::new(store)).unwrap();
 
@@ -840,15 +828,11 @@ mod tests {
                 .update(
                     "dummy_000001",
                     LoginEntry {
-                        fields: LoginFields {
-                            origin: "https://www.example2.com".into(),
-                            http_realm: Some("https://www.example2.com".into()),
-                            ..Default::default()
-                        },
-                        sec_fields: SecureLoginFields {
-                            username: "test".into(),
-                            password: "test".into(),
-                        },
+                        origin: "https://www.example2.com".into(),
+                        http_realm: Some("https://www.example2.com".into()),
+                        username: "test".into(),
+                        password: "test".into(),
+                        ..Default::default()
                     },
                 )
                 .unwrap();

--- a/components/logins/src/sync/update_plan.rs
+++ b/components/logins/src/sync/update_plan.rs
@@ -54,7 +54,7 @@ impl UpdatePlan {
         upstream: IncomingLogin,
         upstream_time: ServerTimestamp,
         server_now: ServerTimestamp,
-        encdec: &EncryptorDecryptor,
+        encdec: &dyn EncryptorDecryptor,
     ) -> Result<()> {
         let local_age = SystemTime::now()
             .duration_since(local.local_modified())
@@ -323,7 +323,7 @@ mod tests {
         get_server_modified, insert_encrypted_login, insert_login,
     };
     use crate::db::LoginDb;
-    use crate::encryption::test_utils::TEST_ENCRYPTOR;
+    use crate::encryption::test_utils::TEST_ENCDEC;
     use crate::login::test_utils::enc_login;
 
     fn inc_login(id: &str, password: &str) -> crate::sync::IncomingLogin {
@@ -470,7 +470,7 @@ mod tests {
                 upstream_login,
                 server_record_timestamp.try_into().unwrap(),
                 server_timestamp.try_into().unwrap(),
-                &TEST_ENCRYPTOR,
+                &*TEST_ENCDEC,
             )
             .unwrap();
         update_plan
@@ -536,7 +536,7 @@ mod tests {
                 upstream_login,
                 server_record_timestamp.try_into().unwrap(),
                 server_timestamp.try_into().unwrap(),
-                &TEST_ENCRYPTOR,
+                &*TEST_ENCDEC,
             )
             .unwrap();
         update_plan
@@ -607,7 +607,7 @@ mod tests {
                 upstream_login,
                 server_record_timestamp.try_into().unwrap(),
                 server_timestamp.try_into().unwrap(),
-                &TEST_ENCRYPTOR,
+                &*TEST_ENCDEC,
             )
             .unwrap();
         update_plan

--- a/testing/sync-test/src/auth.rs
+++ b/testing/sync-test/src/auth.rs
@@ -59,7 +59,9 @@ impl TestClient {
         };
 
         let key = create_key().unwrap();
-        let encdec = Arc::new(ManagedEncryptorDecryptor::new(Arc::new(StaticKeyManager::new(key.clone()))));
+        let encdec = Arc::new(ManagedEncryptorDecryptor::new(Arc::new(
+            StaticKeyManager::new(key.clone()),
+        )));
 
         Ok(Self {
             cli,

--- a/testing/sync-test/src/autofill.rs
+++ b/testing/sync-test/src/autofill.rs
@@ -74,8 +74,7 @@ pub fn add_credit_card(
 }
 
 pub fn scrub_credit_card(s: Arc<AutofillStore>) -> AutofillResult<()> {
-    AutofillStore::scrub_encrypted_data(s)
-        .expect("scrub_encrypted_data() to succeed");
+    AutofillStore::scrub_encrypted_data(s).expect("scrub_encrypted_data() to succeed");
     Ok(())
 }
 
@@ -257,7 +256,7 @@ pub fn get_test_group() -> TestGroup {
             ),
             (
                 "test_autofill_credit_cards_with_scrubbed_cards",
-                test_autofill_credit_cards_with_scrubbed_cards
+                test_autofill_credit_cards_with_scrubbed_cards,
             ),
         ],
     )

--- a/testing/sync-test/src/logins.rs
+++ b/testing/sync-test/src/logins.rs
@@ -4,7 +4,6 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 use crate::auth::TestClient;
 use crate::testing::TestGroup;
 use anyhow::Result;
-use logins::encryption::{create_key, EncryptorDecryptor};
 use logins::{
     ApiResult as LoginResult, Login, LoginEntry, LoginFields, LoginStore, SecureLoginFields,
 };
@@ -26,23 +25,17 @@ pub fn times_used_for_id(s: &LoginStore, id: &str) -> i64 {
         .times_used
 }
 
-pub fn add_login(s: &LoginStore, l: LoginEntry, key: &str) -> LoginResult<Login> {
-    let encrypted = s.add(l, key)?;
-    let fetched = s
-        .get(&encrypted.guid())?
-        .expect("Login we just added to exist");
-    let encdec = EncryptorDecryptor::new(key).unwrap();
-    Ok(fetched.decrypt(&encdec).unwrap())
+pub fn add_login(s: &LoginStore, l: LoginEntry) -> LoginResult<Login> {
+    let login = s.add(l)?;
+    let fetched = s.get(&login.guid())?.expect("Login we just added to exist");
+    Ok(fetched)
 }
 
-pub fn verify_login(s: &LoginStore, l: &Login, key: &str) {
-    let encdec = EncryptorDecryptor::new(key).unwrap();
+pub fn verify_login(s: &LoginStore, l: &Login) {
     let equivalent = s
         .get(&l.guid())
         .expect("get() to succeed")
-        .expect("Expected login to be present")
-        .decrypt(&encdec)
-        .expect("should decrypt");
+        .expect("Expected login to be present");
 
     assert_logins_equiv(&equivalent, l);
 }
@@ -58,35 +51,27 @@ pub fn verify_missing_login(s: &LoginStore, id: &str) {
 pub fn update_login<F: FnMut(&mut Login)>(
     s: &LoginStore,
     id: &str,
-    key: &str,
     mut callback: F,
 ) -> LoginResult<Login> {
-    let encdec = EncryptorDecryptor::new(key).unwrap();
-    let encrypted = s.get(id)?.expect("No such login!");
-    let mut login = encrypted.decrypt(&encdec).unwrap();
+    let mut login = s.get(id)?.expect("No such login!");
     callback(&mut login);
     let to_update = LoginEntry {
         fields: login.fields,
         sec_fields: login.sec_fields,
     };
-    s.update(id, to_update, key)?;
-    Ok(s.get(id)?
-        .expect("Just updated this")
-        .decrypt(&encdec)
-        .unwrap())
+    s.update(id, to_update)?;
+    Ok(s.get(id)?.expect("Just updated this"))
 }
 
-pub fn touch_login(s: &LoginStore, id: &str, times: usize, key: &str) -> LoginResult<Login> {
+pub fn touch_login(s: &LoginStore, id: &str, times: usize) -> LoginResult<Login> {
     for _ in 0..times {
         s.touch(id)?;
     }
-    let encdec = EncryptorDecryptor::new(key).unwrap();
-    Ok(s.get(id)?.unwrap().decrypt(&encdec).unwrap())
+    Ok(s.get(id)?.unwrap())
 }
 
-pub fn sync_logins(client: &mut TestClient, key: &str) -> Result<()> {
-    let mut local_encryption_keys = HashMap::new();
-    local_encryption_keys.insert("passwords".to_string(), key.to_string());
+pub fn sync_logins(client: &mut TestClient) -> Result<()> {
+    let local_encryption_keys = HashMap::new();
     client.sync(&["passwords".to_string()], local_encryption_keys)
 }
 
@@ -94,8 +79,6 @@ pub fn sync_logins(client: &mut TestClient, key: &str) -> Result<()> {
 
 fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Add some logins to client0");
-
-    let key = create_key().unwrap();
 
     let l0id = add_login(
         &c0.logins_store,
@@ -112,12 +95,11 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "hunter2".into(),
             },
         },
-        &key,
     )
     .expect("add l0")
     .guid();
 
-    let login0_c0 = touch_login(&c0.logins_store, &l0id, 2, &key).expect("touch0 c0");
+    let login0_c0 = touch_login(&c0.logins_store, &l0id, 2).expect("touch0 c0");
     assert_eq!(login0_c0.record.times_used, 3);
 
     let login1_c0 = add_login(
@@ -133,25 +115,24 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "sekret".into(),
             },
         },
-        &key,
     )
     .expect("add l1");
     let l1id = login1_c0.guid();
 
     log::info!("Syncing client0");
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0).expect("c0 sync to work");
 
     // Should be the same after syncing.
-    verify_login(&c0.logins_store, &login0_c0, &key);
-    verify_login(&c0.logins_store, &login1_c0, &key);
+    verify_login(&c0.logins_store, &login0_c0);
+    verify_login(&c0.logins_store, &login1_c0);
 
     log::info!("Syncing client1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1).expect("c1 sync to work");
 
     log::info!("Check state");
 
-    verify_login(&c1.logins_store, &login0_c0, &key);
-    verify_login(&c1.logins_store, &login1_c0, &key);
+    verify_login(&c1.logins_store, &login0_c0);
+    verify_login(&c1.logins_store, &login1_c0);
 
     assert_eq!(
         times_used_for_id(&c1.logins_store, &l0id),
@@ -162,31 +143,31 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Update logins");
 
     // Change login0 on both
-    update_login(&c1.logins_store, &l0id, &key, |l| {
+    update_login(&c1.logins_store, &l0id, |l| {
         l.sec_fields.password = "testtesttest".into();
     })
     .unwrap();
 
-    let login0_c0 = update_login(&c0.logins_store, &l0id, &key, |l| {
+    let login0_c0 = update_login(&c0.logins_store, &l0id, |l| {
         l.fields.username_field = "users_name".into();
     })
     .unwrap();
 
     // and login1 on remote.
-    let login1_c1 = update_login(&c1.logins_store, &l1id, &key, |l| {
+    let login1_c1 = update_login(&c1.logins_store, &l1id, |l| {
         l.sec_fields.username = "less_cool_username".into();
     })
     .unwrap();
 
     log::info!("Sync again");
 
-    sync_logins(c1, &key).expect("c1 sync 2");
-    sync_logins(c0, &key).expect("c0 sync 2");
+    sync_logins(c1).expect("c1 sync 2");
+    sync_logins(c0).expect("c0 sync 2");
 
     log::info!("Check state again");
 
     // Ensure the remotely changed password change made it through
-    verify_login(&c0.logins_store, &login1_c1, &key);
+    verify_login(&c0.logins_store, &login1_c1);
 
     // And that the conflicting one did too.
     verify_login(
@@ -202,7 +183,6 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
             },
             record: login0_c0.record,
         },
-        &key,
     );
 
     assert_eq!(
@@ -220,7 +200,6 @@ fn test_login_general(c0: &mut TestClient, c1: &mut TestClient) {
 
 fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Add some logins to client0");
-    let key = create_key().unwrap();
 
     let login0 = add_login(
         &c0.logins_store,
@@ -237,7 +216,6 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "hunter2".into(),
             },
         },
-        &key,
     )
     .expect("add l0");
     let l0id = login0.guid();
@@ -255,7 +233,6 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "sekret".into(),
             },
         },
-        &key,
     )
     .expect("add l1");
     let l1id = login1.guid();
@@ -273,7 +250,6 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "123454321".into(),
             },
         },
-        &key,
     )
     .expect("add l2");
     let l2id = login2.guid();
@@ -291,29 +267,28 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
                 password: "aaaaa".into(),
             },
         },
-        &key,
     )
     .expect("add l3");
     let l3id = login3.guid();
 
     log::info!("Syncing client0");
 
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0).expect("c0 sync to work");
 
     // Should be the same after syncing.
-    verify_login(&c0.logins_store, &login0, &key);
-    verify_login(&c0.logins_store, &login1, &key);
-    verify_login(&c0.logins_store, &login2, &key);
-    verify_login(&c0.logins_store, &login3, &key);
+    verify_login(&c0.logins_store, &login0);
+    verify_login(&c0.logins_store, &login1);
+    verify_login(&c0.logins_store, &login2);
+    verify_login(&c0.logins_store, &login3);
 
     log::info!("Syncing client1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1).expect("c1 sync to work");
 
     log::info!("Check state");
-    verify_login(&c1.logins_store, &login0, &key);
-    verify_login(&c1.logins_store, &login1, &key);
-    verify_login(&c1.logins_store, &login2, &key);
-    verify_login(&c1.logins_store, &login3, &key);
+    verify_login(&c1.logins_store, &login0);
+    verify_login(&c1.logins_store, &login1);
+    verify_login(&c1.logins_store, &login2);
+    verify_login(&c1.logins_store, &login3);
 
     // The 4 logins are for the for possible scenarios. All of them should result in the record
     // being deleted.
@@ -335,7 +310,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
 
     // case 3a. c0 modifies record (c1 will delete it after c0 syncs so the timestamps line up)
     log::info!("Updating {} on c0", l2id);
-    let login2_new = update_login(&c0.logins_store, &l2id, &key, |l| {
+    let login2_new = update_login(&c0.logins_store, &l2id, |l| {
         l.sec_fields.username = "foobar".into();
     })
     .unwrap();
@@ -345,30 +320,30 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
 
     // Sync c1
     log::info!("Syncing c1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1).expect("c1 sync to work");
     log::info!("Checking c1 state after sync");
 
     verify_missing_login(&c1.logins_store, &l0id);
     verify_missing_login(&c1.logins_store, &l1id);
-    verify_login(&c1.logins_store, &login2, &key);
+    verify_login(&c1.logins_store, &login2);
     verify_missing_login(&c1.logins_store, &l3id);
 
     log::info!("Update {} on c0", l3id);
     // 4b
-    update_login(&c0.logins_store, &l3id, &key, |l| {
+    update_login(&c0.logins_store, &l3id, |l| {
         l.sec_fields.password = "quux".into();
     })
     .unwrap();
 
     // Sync c0
     log::info!("Syncing c0");
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0).expect("c0 sync to work");
 
     log::info!("Checking c0 state after sync");
 
     verify_missing_login(&c0.logins_store, &l0id);
     verify_missing_login(&c0.logins_store, &l1id);
-    verify_login(&c0.logins_store, &login2_new, &key);
+    verify_login(&c0.logins_store, &login2_new);
     verify_missing_login(&c0.logins_store, &l3id);
 
     log::info!("Delete {} on c1", l2id);
@@ -376,14 +351,14 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
     assert!(c1.logins_store.delete(&l2id).expect("Delete should work"));
 
     log::info!("Syncing c1");
-    sync_logins(c1, &key).expect("c1 sync to work");
+    sync_logins(c1).expect("c1 sync to work");
 
     log::info!("{} should stay dead", l2id);
     // Ensure we didn't revive it.
     verify_missing_login(&c1.logins_store, &l2id);
 
     log::info!("Syncing c0");
-    sync_logins(c0, &key).expect("c0 sync to work");
+    sync_logins(c0).expect("c0 sync to work");
     log::info!("Should delete {}", l2id);
     verify_missing_login(&c0.logins_store, &l2id);
 }

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -5,10 +5,9 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 #![warn(rust_2018_idioms)]
 
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
-use std::{collections::HashSet, process};
 use std::sync::Arc;
+use std::{collections::HashSet, process};
 use structopt::StructOpt;
-
 
 mod auth;
 mod autofill;
@@ -78,7 +77,8 @@ pub fn run_test_group(opts: &Opts, group: TestGroup) {
     }
 
     let cfg = get_default_fxa_config();
-    let cli_fxa = get_cli_fxa(cfg, &opts.credential_file, &[SYNC_SCOPE]).expect("can't initialize cli");
+    let cli_fxa =
+        get_cli_fxa(cfg, &opts.credential_file, &[SYNC_SCOPE]).expect("can't initialize cli");
     let acct = Arc::new(cli_fxa);
 
     let mut user = TestUser::new(acct, 2).expect("Failed to get test user.");

--- a/testing/sync-test/src/sync15.rs
+++ b/testing/sync-test/src/sync15.rs
@@ -16,9 +16,7 @@ use std::cell::{Cell, RefCell};
 use std::mem;
 use sync15::bso::{IncomingBso, OutgoingBso};
 use sync15::client::{sync_multiple, MemoryCachedState};
-use sync15::engine::{
-    CollectionRequest, EngineSyncAssociation, SyncEngine,
-};
+use sync15::engine::{CollectionRequest, EngineSyncAssociation, SyncEngine};
 use sync15::{telemetry, ServerTimestamp};
 use sync_guid::Guid;
 
@@ -87,10 +85,10 @@ impl SyncEngine for TestEngine {
         // the RefCell.
         let temp: Vec<TestRecord> = mem::take(&mut *self.test_records.borrow_mut());
 
-        Ok(temp.into_iter()
-                .map(OutgoingBso::from_content_with_id)
-                .collect::<Result<_, _>>()?
-        )
+        Ok(temp
+            .into_iter()
+            .map(OutgoingBso::from_content_with_id)
+            .collect::<Result<_, _>>()?)
     }
 
     fn set_uploaded(


### PR DESCRIPTION
The encryption and decryption of credentials is outsourced to a [Foreign Trait](https://mozilla.github.io/uniffi-rs/0.27/foreign_traits.html) so that Android, desktop and iOS can each bring their own implementations of encryption, including key management. This makes the Logins API way simpler and cleaner. It is the first step in making AS-Logins desktop-ready.

The new `EncryptorDecryptor` trait replaces the current `EncryptorDecryptor` struct. Instead of using the `decrypt_struct` method, which involves serializing and deserializing the string to be encrypted, this trait uses only byte-based operations and serialization is up to the consumer.

We do not Uniffi-expose the crypto primitives `encrypt`, `decrypt`, `encrypt_struct` and `decrypt_struct` anymore. Also `EncryptedLogin` will not be exposed anymore.

A `ManagedEncryptorDecryptor` will provide an `EncryptorDecryptor` implementation which uses the currently used crypto methods, given a `KeyManager` implementation to ease adaption for mobile.


### BREAKING CHANGE

This commit introduces breaking changes to the Logins component:

During initialization, it receives an additional argument, a `EncryptorDecryptor` implementation. In addition, several `LoginsStore` API methods have been changed to not require an encryption key argument anymore, and return `Login` objects instead of `EncryptedLogin`.

Additionally, a new API method has been added to the LoginsStore, `has_logins_by_base_domain(&self, base_domain: &str)`, which can be used to check for the existence of a login for a given base domain.

### EncryptorDecryptor

With the introduction of the `EncryptorDecryptor` trait, encryption becomes transparent. That means, the LoginStore API receives some breaking changes as outlined above.  A `ManagedEncryptorDecryptor` will provide an `EncryptorDecryptor` implementation which uses the currently used crypto methods, given a `KeyManager` implementation. This eases adaption for mobile.  Furthermore, we provide a `StaticKeyManager` implementation, which can be used in tests and in cases where the key is - you name it - static.  Constructors Now an implementation of the above property must be passed to the constructors. To do this, the signatures are extended as follows:

```
pub fn new(path: impl AsRef<Path>, encdec: Arc<dyn EncryptorDecryptor>) -> ApiResult<Self>
pub fn new_from_db(db: LoginDb, encdec: Arc<dyn EncryptorDecryptor>) -> Self
pub fn new_in_memory(encdec: Arc<dyn EncryptorDecryptor>) -> ApiResult<Self>
```

### LoginStore API Methods
This allows the `LoginStore` API to be simplified as follows, making encryption transparent by eliminating the need to pass the key and allowing the methods to return decrypted login objects.

```
pub fn list(&self) -> ApiResult<Vec<Login>>
pub fn get(&self, id: &str) -> ApiResult<Option<Login>>
pub fn get_by_base_domain(&self, base_domain: &str) -> ApiResult<Vec<Login>>
pub fn find_login_to_update(&self, entry: LoginEntry) -> ApiResult<Option<Login>>
pub fn update(&self, id: &str, entry: LoginEntry) -> ApiResult<Login>
pub fn add(&self, entry: LoginEntry) -> ApiResult<Login>
pub fn add_or_update(&self, entry: LoginEntry) -> ApiResult<Login>
```

New LoginsStore methods:
```
// Checking whether the database contains logins (does not utilize the `EncryptorDecryptor`):
is_empty(&self) -> ApiResult<bool>
// Checking for the Existence of Logins for a given base domain (also does not utilize the `EncryptorDecryptor`):
has_logins_by_base_domain(&self, base_domain: &str) -> ApiResult<bool>
```


We will stop Uniffi-exposing the crypto primitives `encrypt`, `decrypt`, `encrypt_struct` and `decrypt_struct`. Also `EncryptedLogin` will not be exposed anymore. 

### SyncEngine
The logins sync engine has been adapted for above EncryptorDecryptor trait and therefore does not support `set_local_encryption_key` anymore.

### Flattened Login Struct

The current Login structure is nested:

```
Login {
  RecordFields record;
  LoginFields fields;
  SecureLoginFields sec_fields;
}
```

and thus exposes internal data structuring to the consumer. Since we make the encryption transparent for the consumer (Android, iOS, desktop) here, such a separation no longer makes sense here and above can be simplified to

```
Login {
    // record fields
    string id;
    i64 times_used;
    i64 time_created;
    i64 time_last_used;
    i64 time_password_changed;

    // login fields
    string origin;
    string? http_realm;
    string? form_action_origin;
    string username_field;
    string password_field;

    // secure login fields
    string password;
    string username;
}
```

The advantage of eliminating this separation lies, on the one hand, in the simplification of the API and the resulting easier use of the component, and on the other hand, in the easier changeability of the internal data structure. If, for example, we decide later to encrypt additional fields, such a change is possible without having to adapt the consumers.

So in addition to the changes mentioned above we will stop Uniffi-exposing the structs `RecordFields`, `LoginFields` and `SecureLoginFields`.

### Corresponding PR & Patch addressing breaking changes:

* **Android:** https://phabricator.services.mozilla.com/D232391
* **iOS:** https://github.com/mozilla-mobile/firefox-ios/pull/24108

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
