### PR TITLE
Add DesktopRoots convenience property

### DIFF
--- a/components/places/ios/Places/Bookmark.swift
+++ b/components/places/ios/Places/Bookmark.swift
@@ -23,6 +23,12 @@ public enum BookmarkRoots {
         BookmarkRoots.ToolbarFolderGUID,
         BookmarkRoots.UnfiledFolderGUID,
     ])
+
+    public static let DesktopRoots = Set<String>([
+        BookmarkRoots.MenuFolderGUID,
+        BookmarkRoots.ToolbarFolderGUID,
+        BookmarkRoots.UnfiledFolderGUID,
+    ])
 }
 
 // Keeping `BookmarkNodeType` in the swift wrapper because the iOS code relies on the raw value of the variants of


### PR DESCRIPTION
### Description
- The iOS client regularly references the three desktop root folders (`BookmarkRoots.MenuFolderGUID`, `BookmarkRoots.ToolbarFolderGUID`, and `BookmarkRoots.UnfiledFolderGUID`) as a group to check for nested bookmarks in these locations. This adds a convenient way to refer to the desktop root folder GUIDS.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
