### PR TITLE
Bug 1931963 - Add UniFFI bindings for fetch_geonames() in suggest

### DIFF
--- a/components/suggest/src/benchmarks/geoname.rs
+++ b/components/suggest/src/benchmarks/geoname.rs
@@ -18,7 +18,7 @@ pub struct FetchGeonamesArgs {
     query: &'static str,
     match_name_prefix: bool,
     geoname_type: Option<GeonameType>,
-    filter: Option<Vec<&'static Geoname>>,
+    filter: Option<Vec<Geoname>>,
 }
 
 pub struct IterationInput {
@@ -66,8 +66,7 @@ impl BenchmarkWithInput for GeonameBenchmark {
 }
 
 pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
-    static NY_STATE: std::sync::OnceLock<Geoname> = std::sync::OnceLock::new();
-    let ny_state = NY_STATE.get_or_init(|| Geoname {
+    let ny_state = Geoname {
         geoname_id: 8,
         name: "New York".to_string(),
         latitude: 43.00035,
@@ -75,7 +74,7 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
         country_code: "US".to_string(),
         admin1_code: "NY".to_string(),
         population: 19274244,
-    });
+    };
 
     vec![
         // no matches
@@ -388,7 +387,7 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                     query: "ny",
                     match_name_prefix: false,
                     geoname_type: None,
-                    filter: Some(vec![&ny_state]),
+                    filter: Some(vec![ny_state.clone()]),
                 },
                 should_match: true,
             }
@@ -402,7 +401,7 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                     query: "ny",
                     match_name_prefix: false,
                     geoname_type: Some(GeonameType::City),
-                    filter: Some(vec![&ny_state]),
+                    filter: Some(vec![ny_state.clone()]),
                 },
                 should_match: true,
             }
@@ -414,7 +413,7 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                     query: "ny",
                     match_name_prefix: false,
                     geoname_type: Some(GeonameType::Region),
-                    filter: Some(vec![&ny_state]),
+                    filter: Some(vec![ny_state.clone()]),
                 },
                 should_match: true,
             }
@@ -428,7 +427,7 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                     query: "ny",
                     match_name_prefix: true,
                     geoname_type: Some(GeonameType::City),
-                    filter: Some(vec![&ny_state]),
+                    filter: Some(vec![ny_state.clone()]),
                 },
                 should_match: true,
             }
@@ -440,7 +439,7 @@ pub fn all_benchmarks() -> Vec<(&'static str, GeonameBenchmark)> {
                     query: "ny",
                     match_name_prefix: true,
                     geoname_type: Some(GeonameType::Region),
-                    filter: Some(vec![&ny_state]),
+                    filter: Some(vec![ny_state.clone()]),
                 },
                 should_match: true,
             }

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -26,6 +26,7 @@ mod yelp;
 
 pub use config::{SuggestGlobalConfig, SuggestProviderConfig};
 pub use error::{Error, SuggestApiError};
+pub use geoname::{Geoname, GeonameMatch, GeonameType};
 pub use metrics::{LabeledTimingSample, SuggestIngestionMetrics};
 pub use provider::{SuggestionProvider, SuggestionProviderConstraints};
 pub use query::{QueryWithMetricsResult, SuggestionQuery};

--- a/components/suggest/src/provider.rs
+++ b/components/suggest/src/provider.rs
@@ -105,7 +105,7 @@ impl SuggestionProvider {
             Self::Wikipedia => vec![SuggestRecordType::AmpWikipedia],
             Self::Amo => vec![SuggestRecordType::Amo],
             Self::Pocket => vec![SuggestRecordType::Pocket],
-            Self::Yelp => vec![SuggestRecordType::Yelp],
+            Self::Yelp => vec![SuggestRecordType::Yelp, SuggestRecordType::Geonames],
             Self::Mdn => vec![SuggestRecordType::Mdn],
             Self::Weather => vec![SuggestRecordType::Weather, SuggestRecordType::Geonames],
             Self::AmpMobile => vec![SuggestRecordType::AmpMobile],


### PR DESCRIPTION
I didn't expect to be adding bindings for this, and there might be better ways to support the use case described in bug than exposing `fetch_geonames()` as is, but this works for now at least, and we need a fix for Firefox 134. Desktop will call this to validate cities and states returned by the Yelp ML model. Not only to validate but also to do prefix matching, since we can get that for free.

I considered adding a new function that matches both cities and regions at once so that desktop doesn't need to call into suggest twice and ideally so that we run only one SQL query. But I don't really like the idea of having a completely different code path for this. Or, it might be possible to rewrite the current function so it works that way. But that ends up getting a little messy pretty quickly, and the weather use case doesn't need it. So for now I did the simplest thing.

I also considered making geonames a full-fledged `SuggestionProvider` and `Suggestion`, but then we'd have to add more options to `SuggestionProviderConstraints` to support the `fetch_geonames()` params, and these aren't really standalone suggestions anyway.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
