### PR TITLE
feat: store remote-settings attachments in local storage

### DIFF
--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -155,8 +155,6 @@ impl RemoteSettingsClient {
     /// this is that there is not much an application can do in this situation other than fall back
     /// to the same default handling as if records have not been synced.
     ///
-    /// TODO(Bug 1919141):
-    ///
     /// Application-services schedules regular dumps of the server data for specific collections.
     /// For these collections, `get_records` will never return None.  If you would like to add your
     /// collection to this list, please reach out to the DISCO team.
@@ -198,8 +196,8 @@ impl RemoteSettingsClient {
     ///   - This method will throw if there is a network or other error when fetching the
     ///     attachment data.
     #[handle_error(Error)]
-    pub fn get_attachment(&self, attachment_id: String) -> ApiResult<Vec<u8>> {
-        self.internal.get_attachment(&attachment_id)
+    pub fn get_attachment(&self, attachment_location: String) -> ApiResult<Vec<u8>> {
+        self.internal.get_attachment(&attachment_location)
     }
 }
 


### PR DESCRIPTION
Solves: https://bugzilla.mozilla.org/show_bug.cgi?id=1929659

Hooking up `attachments` to the `sqlite` storage in the remote-settings component. 

I also changed the name of the `Attachment` struct to `AttachmentMetadata`. I tried to do the same for the `RemoteSettingsRecord`, but we had to do some serialziation magic, and it seemed to cumbersome just for renaming things.

The idea is to be intentional that what's part of the `RemoteSettingsRecord` is not the `attachment` itself, but just the metadata for an `attachment`. The Remote Settings server response is calling it `attachment`, and therefore we adopt the name here as well.