### PR TITLE
Bug 1930984 - Implement default search engine selection on the search engine selector.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4505,6 +4505,7 @@ version = "0.1.0"
 dependencies = [
  "error-support",
  "firefox-versioning",
+ "once_cell",
  "parking_lot",
  "serde",
  "serde_json",

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -17,3 +17,6 @@ firefox-versioning = { path = "../support/firefox-versioning" }
 
 [build-dependencies]
 uniffi = { version = "0.28.2", features = ["build"] }
+
+[dev-dependencies]
+once_cell = "1.18.0"

--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -182,12 +182,43 @@ pub(crate) struct JSONEngineRecord {
     pub variants: Vec<JSONEngineVariant>,
 }
 
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct JSONSpecificDefaultRecord {
+    /// The identifier of the engine that will be used as the application default
+    /// for the associated environment. If the entry is suffixed with a star,
+    /// matching is applied on a "starts with" basis.
+    #[serde(default)]
+    pub default: String,
+
+    /// The identifier of the engine that will be used as the application default
+    /// in private mode for the associated environment. If the entry is suffixed
+    /// with a star, matching is applied on a "starts with" basis.
+    #[serde(default)]
+    pub default_private: String,
+
+    /// The specific environment to match for this record.
+    pub environment: JSONVariantEnvironment,
+}
+
 /// Represents the default engines record.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct JSONDefaultEnginesRecord {
+    /// The identifier of the engine that will be used as the application default
+    /// if no other engines are specified as default.
     pub global_default: String,
-    pub global_default_private: Option<String>,
+
+    /// The identifier of the engine that will be used as the application default
+    /// in private mode if no other engines are specified as default.
+    #[serde(default)]
+    pub global_default_private: String,
+
+    /// The specific environment filters to set a different default engine. The
+    /// array is ordered, when multiple entries match on environments, the later
+    /// entry will override earlier entries.
+    #[serde(default)]
+    pub specific_defaults: Vec<JSONSpecificDefaultRecord>,
 }
 
 /// Represents the engine orders record.

--- a/components/search/src/types.rs
+++ b/components/search/src/types.rs
@@ -155,7 +155,7 @@ impl SearchEngineClassification {
 }
 
 /// A definition for an individual search engine to be presented to the user.
-#[derive(Debug, uniffi::Record, PartialEq)]
+#[derive(Debug, uniffi::Record, PartialEq, Clone)]
 pub struct SearchEngineDefinition {
     /// A list of aliases for this engine.
     pub aliases: Vec<String>,
@@ -217,11 +217,13 @@ pub struct RefinedSearchConfig {
     pub engines: Vec<SearchEngineDefinition>,
 
     /// The identifier of the engine that should be used for the application
-    /// default engine.
-    pub app_default_engine_id: String,
+    /// default engine. If this is undefined, an error has occurred, and the
+    /// application should either default to the first engine in the engines
+    /// list or otherwise handle appropriately.
+    pub app_default_engine_id: Option<String>,
 
     /// If specified, the identifier of the engine that should be used for the
     /// application default engine in private browsing mode.
     /// Only desktop uses this currently.
-    pub app_default_private_engine_id: Option<String>,
+    pub app_private_default_engine_id: Option<String>,
 }


### PR DESCRIPTION
This adds handling of the default search engines from the search configuration.

This changes the object returned by `filter_engine_configuration` to use an `Option` for `app_default_engine_id` as that allows us to highlight there may have been an issue with the configuration - in theory, this should never happen, but just in case, I'd rather the application had potential to be aware of it.

No API/changelog necessary as this isn't currently used.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [X] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
