### PR TITLE
Bug 1930969 - Implement remaining environment matching in the search engine selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,6 +4504,7 @@ name = "search"
 version = "0.1.0"
 dependencies = [
  "error-support",
+ "firefox-versioning",
  "parking_lot",
  "serde",
  "serde_json",

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 uniffi = { version = "0.28.2" }
+firefox-versioning = { path = "../support/firefox-versioning" }
 
 [build-dependencies]
 uniffi = { version = "0.28.2", features = ["build"] }

--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -5,7 +5,10 @@
 //! This module defines the structures that we use for serde_json to parse
 //! the search configuration.
 
-use crate::{SearchApplicationName, SearchEngineClassification, SearchUrlParam};
+use crate::{
+    SearchApplicationName, SearchDeviceType, SearchEngineClassification, SearchUpdateChannel,
+    SearchUrlParam,
+};
 use serde::Deserialize;
 
 /// The list of possible submission methods for search engine urls.
@@ -134,12 +137,25 @@ pub(crate) struct JSONVariantEnvironment {
     /// A vector of applications that this applies to.
     #[serde(default)]
     pub applications: Vec<SearchApplicationName>,
-    // TODO: Implement these.
-    // pub channels: Option<Vec<String>,
-    // pub experiment: Option<String>,
-    // pub min_version: Option<String>,
-    // pub max_version: Option<String>,
-    // pub device_type: Option<String>,
+
+    /// A vector of release channels that this section applies to (not set = everywhere).
+    #[serde(default)]
+    pub channels: Vec<SearchUpdateChannel>,
+
+    /// The experiment that this section applies to.
+    #[serde(default)]
+    pub experiment: String,
+
+    /// The minimum application version this section applies to.
+    #[serde(default)]
+    pub min_version: String,
+
+    /// The maximum application version this section applies to.
+    #[serde(default)]
+    pub max_version: String,
+
+    #[serde(default)]
+    pub device_type: Vec<SearchDeviceType>,
 }
 
 /// Describes an individual variant of a search engine.

--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -96,7 +96,7 @@ pub(crate) struct JSONEngineBase {
 
 /// Specifies details of possible user environments that the engine or variant
 /// applies to.
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct JSONVariantEnvironment {
     /// Indicates that this section applies to all regions and locales. May be

--- a/components/search/src/environment_matching.rs
+++ b/components/search/src/environment_matching.rs
@@ -151,24 +151,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec![],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "FR".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when all_regions_and_locales is true"
@@ -182,24 +170,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec![],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when all_regions_and_locales is false (default) and no regions/locales are specified"
@@ -213,24 +189,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec![],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when all_regions_and_locales is true and the locale is excluded"
@@ -244,24 +208,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec![],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when all_regions_and_locales is true and the excluded locale is a different case"
@@ -275,24 +227,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec![],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when all_regions_and_locales is true and the locale is not excluded"
@@ -302,28 +242,15 @@ mod tests {
             !matches_user_environment(
                 &crate::JSONVariantEnvironment {
                     all_regions_and_locales: true,
-                    excluded_locales: vec![],
                     excluded_regions: vec!["us".to_string(), "fr".to_string()],
                     locales: vec![],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when all_regions_and_locales is true and the region is excluded"
@@ -337,24 +264,12 @@ mod tests {
                     excluded_regions: vec!["US".to_string(), "FR".to_string()],
                     locales: vec![],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when all_regions_and_locales is true and the excluded region is a different case"
@@ -368,24 +283,12 @@ mod tests {
                     excluded_regions: vec!["us".to_string()],
                     locales: vec![],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when all_regions_and_locales is true and the region is not excluded"
@@ -402,24 +305,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec!["en-gb".to_string(), "fi".to_string()],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the user locale matches one from the config"
@@ -433,24 +324,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec!["en-GB".to_string(), "FI".to_string()],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the user locale matches one from the config and is a different case"
@@ -464,24 +343,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec!["en-gb".to_string(), "en-ca".to_string()],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when the user locale does not match one from the config"
@@ -498,24 +365,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec![],
                     regions: vec!["gb".to_string(), "fr".to_string()],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the user region matches one from the config"
@@ -529,24 +384,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec![],
                     regions: vec!["GB".to_string(), "FR".to_string()],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the user region matches one from the config and is a different case"
@@ -560,24 +403,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec!["gb".to_string(), "ca".to_string()],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when the user region does not match one from the config"
@@ -594,24 +425,12 @@ mod tests {
                     excluded_regions: vec!["gb".to_string(), "ca".to_string()],
                     locales: vec!["en-gb".to_string(), "fi".to_string()],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the locale matches and the region is not excluded"
@@ -625,24 +444,12 @@ mod tests {
                     excluded_regions: vec!["gb".to_string(), "fr".to_string()],
                     locales: vec!["en-gb".to_string(), "fi".to_string()],
                     regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when the locale matches and the region is excluded"
@@ -659,24 +466,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec![],
                     regions: vec!["gb".to_string(), "fr".to_string()],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the region matches and the locale is not excluded"
@@ -690,24 +485,12 @@ mod tests {
                     excluded_regions: vec![],
                     locales: vec![],
                     regions: vec!["gb".to_string(), "fr".to_string()],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when the region matches and the locale is excluded"
@@ -719,29 +502,12 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
                     distributions: vec!["distro-1".to_string()],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
                     distribution_id: "distro-1".into(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the distribution matches one in the environment"
@@ -750,29 +516,12 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
                     distributions: vec!["distro-2".to_string(), "distro-3".to_string()],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
                     distribution_id: "distro-3".into(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the distribution matches one in the environment when there are multiple"
@@ -781,29 +530,12 @@ mod tests {
         assert!(
             !matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
                     distributions: vec!["distro-2".to_string(), "distro-3".to_string()],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
                     distribution_id: "distro-4".into(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when the distribution does not match any in the environment"
@@ -812,29 +544,15 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
                     regions: vec!["fr".to_string()],
                     distributions: vec!["distro-1".to_string(), "distro-2".to_string()],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
                     distribution_id: "distro-2".into(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the distribution and region matches the environment"
@@ -846,31 +564,15 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec!["fr".to_string()],
                     distributions: vec!["distro-1".to_string(), "distro-2".to_string()],
                     excluded_distributions: vec!["
                         distro-3".to_string(), "distro-4".to_string()
                     ],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
                     distribution_id: "distro-2".into(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the distribution matches the distribution list but not the excluded distributions"
@@ -879,29 +581,13 @@ mod tests {
         assert!(
             !matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec!["fr".to_string()],
                     distributions: vec!["distro-1".to_string(), "distro-2".to_string()],
                     excluded_distributions: vec!["distro-3".to_string(), "distro-4".to_string()],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
                     distribution_id: "distro-3".into(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when the distribution matches the the excluded distributions"
@@ -913,29 +599,12 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
                     applications: vec![SearchApplicationName::Firefox],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
                     app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the application name matches the one in the environment"
@@ -944,32 +613,15 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
                     applications: vec![
                         SearchApplicationName::FirefoxAndroid,
                         SearchApplicationName::Firefox
                     ],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: "distro-3".into(),
-                    experiment: String::new(),
                     app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the application name matches one in the environment when there are multiple"
@@ -978,32 +630,15 @@ mod tests {
         assert!(
             !matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
                     applications: vec![
                         SearchApplicationName::FirefoxAndroid,
                         SearchApplicationName::Firefox
                     ],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: "distro-4".into(),
-                    experiment: String::new(),
                     app_name: SearchApplicationName::FirefoxIos,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when the applications do not match the one in the environment"
@@ -1012,32 +647,18 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
                     regions: vec!["fr".to_string()],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
                     applications: vec![
                         SearchApplicationName::FirefoxAndroid,
                         SearchApplicationName::Firefox
                     ],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
                     app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the application name matches the one in the environment"
@@ -1049,29 +670,12 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
                     channels: vec![SearchUpdateChannel::Nightly],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
                     update_channel: SearchUpdateChannel::Nightly,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the channel matches one in the environment"
@@ -1080,29 +684,12 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
                     channels: vec![SearchUpdateChannel::Nightly, SearchUpdateChannel::Release],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
                     update_channel: SearchUpdateChannel::Release,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the channel matches one in the environment when there are multiple"
@@ -1111,19 +698,8 @@ mod tests {
         assert!(
             !matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
                     channels: vec![SearchUpdateChannel::Nightly],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
@@ -1142,29 +718,15 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
                     regions: vec!["fr".to_string()],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
                     channels: vec![SearchUpdateChannel::Default],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
                     update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the channel and region matches the environment"
@@ -1176,29 +738,12 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
                     experiment: "warp-drive".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Nightly,
-                    distribution_id: String::new(),
                     experiment: "warp-drive".to_string(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the experiment matches the one in the environment"
@@ -1207,29 +752,12 @@ mod tests {
         assert!(
             !matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
                     experiment: "warp-drive".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![SearchDeviceType::Smartphone],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
                     experiment: "cloak".to_string(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when the experiment does not match the one in the environment"
@@ -1238,29 +766,15 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
                     regions: vec!["fr".to_string()],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
                     experiment: "warp-drive".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
-                    device_type: vec![SearchDeviceType::Tablet],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
                     experiment: "warp-drive".to_string(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
-                    device_type: SearchDeviceType::Tablet,
+                    ..Default::default()
                 }
             ),
             "Should return true when the experiment and region matches the environment"
@@ -1269,84 +783,160 @@ mod tests {
 
     #[test]
     fn test_matches_user_environment_versions() {
-        fn match_version(
-            variant_min_version: &str,
-            variant_max_version: &str,
-            user_version: &str,
-        ) -> bool {
-            matches_user_environment(
+        assert!(
+            !matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: String::new(),
-                    channels: vec![],
-                    min_version: variant_min_version.to_string(),
-                    max_version: variant_max_version.to_string(),
-                    device_type: vec![],
+                    min_version: "43.0.0".to_string(),
+                    max_version: "".to_string(),
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Nightly,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: user_version.to_string(),
-                    device_type: SearchDeviceType::None,
+                    version: "42.0.0".to_string(),
+                    ..Default::default()
                 },
-            )
-        }
-
-        assert!(
-            !match_version("43.0.0", "", "42.0.0"),
+            ),
             "Should return false when the version is below the minimum"
         );
         assert!(
-            match_version("42.0.0", "", "42.0.0"),
+            matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "42.0.0".to_string(),
+                    max_version: "".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "42.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return true when the version is equal to the minimum"
         );
         assert!(
-            match_version("41.0.0", "", "42.0.0"),
+            matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "41.0.0".to_string(),
+                    max_version: "".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "42.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return true when the version is above the minimum"
         );
 
         assert!(
-            match_version("", "43.0.0", "42.0.0"),
+            matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "".to_string(),
+                    max_version: "43.0.0".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "42.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return true when the version is below the maximum"
         );
         assert!(
-            match_version("", "42.0.0", "42.0.0"),
+            matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "".to_string(),
+                    max_version: "42.0.0".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "42.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return true when the version is equal to the maximum"
         );
         assert!(
-            !match_version("", "41.0.0", "42.0.0"),
+            !matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "".to_string(),
+                    max_version: "41.0.0".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "42.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return false when the version is above the maximum"
         );
 
         assert!(
-            !match_version("41.0.0", "43.0.0", "2.0.0"),
+            !matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "41.0.0".to_string(),
+                    max_version: "43.0.0".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "2.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return false when the version is below the minimum and both are specified"
         );
         assert!(
-            match_version("41.0.0", "43.0.0", "41.0.0"),
+            matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "41.0.0".to_string(),
+                    max_version: "43.0.0".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "41.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return true when the version is equal to the minimum and both are specified"
         );
         assert!(
-            match_version("41.0.0", "43.0.0", "42.0.0"),
+            matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "41.0.0".to_string(),
+                    max_version: "43.0.0".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "42.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return true when the version is between the minimum and maximum"
         );
         assert!(
-            match_version("41.0.0", "43.0.0", "43.0.0"),
+            matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "41.0.0".to_string(),
+                    max_version: "43.0.0".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "43.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return true when the version is equal to the maximum and both are specified"
         );
         assert!(
-            !match_version("41.0.0", "43.0.0", "44.0.0"),
+            !matches_user_environment(
+                &crate::JSONVariantEnvironment {
+                    min_version: "41.0.0".to_string(),
+                    max_version: "43.0.0".to_string(),
+                    ..Default::default()
+                },
+                &SearchUserEnvironment {
+                    version: "44.0.0".to_string(),
+                    ..Default::default()
+                },
+            ),
             "Should return false when the version is above the maximum and both are specified"
         );
     }
@@ -1356,29 +946,12 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
                     device_type: vec![SearchDeviceType::None],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Nightly,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
                     device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return true when the device type matches one in the environment"
@@ -1387,29 +960,12 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
                     device_type: vec![SearchDeviceType::Smartphone, SearchDeviceType::Tablet],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Release,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
                     device_type: SearchDeviceType::Tablet,
+                    ..Default::default()
                 }
             ),
             "Should return true when the device type matches one in the environment when there are multiple"
@@ -1418,29 +974,12 @@ mod tests {
         assert!(
             !matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
-                    regions: vec![],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
                     device_type: vec![SearchDeviceType::Smartphone],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
-                    locale: "fi".into(),
-                    region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: "distro-4".into(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
                     device_type: SearchDeviceType::None,
+                    ..Default::default()
                 }
             ),
             "Should return false when the device type does not match any in the environment"
@@ -1449,29 +988,15 @@ mod tests {
         assert!(
             matches_user_environment(
                 &crate::JSONVariantEnvironment {
-                    all_regions_and_locales: false,
-                    excluded_locales: vec![],
-                    excluded_regions: vec![],
-                    locales: vec![],
                     regions: vec!["fr".to_string()],
-                    distributions: vec![],
-                    excluded_distributions: vec![],
-                    applications: vec![],
-                    experiment: "".to_string(),
-                    channels: vec![],
-                    min_version: "".to_string(),
-                    max_version: "".to_string(),
                     device_type: vec![SearchDeviceType::Tablet],
+                    ..Default::default()
                 },
                 &SearchUserEnvironment {
                     locale: "fi".into(),
                     region: "fr".into(),
-                    update_channel: SearchUpdateChannel::Default,
-                    distribution_id: String::new(),
-                    experiment: String::new(),
-                    app_name: SearchApplicationName::Firefox,
-                    version: String::new(),
                     device_type: SearchDeviceType::Tablet,
+                    ..Default::default()
                 }
             ),
             "Should return true when the device type and region matches the environment"

--- a/components/search/src/selector.rs
+++ b/components/search/src/selector.rs
@@ -217,6 +217,7 @@ mod tests {
             experiment: String::new(),
             app_name: SearchApplicationName::Firefox,
             version: String::new(),
+            device_type: SearchDeviceType::None,
         });
 
         assert!(
@@ -316,6 +317,7 @@ mod tests {
             experiment: String::new(),
             app_name: SearchApplicationName::Firefox,
             version: String::new(),
+            device_type: SearchDeviceType::None,
         });
 
         assert!(
@@ -483,6 +485,7 @@ mod tests {
             experiment: String::new(),
             app_name: SearchApplicationName::Firefox,
             version: String::new(),
+            device_type: SearchDeviceType::None,
         });
 
         assert!(
@@ -528,6 +531,7 @@ mod tests {
             experiment: String::new(),
             app_name: SearchApplicationName::FocusIos,
             version: String::new(),
+            device_type: SearchDeviceType::None,
         });
 
         assert!(
@@ -594,6 +598,7 @@ mod tests {
             experiment: String::new(),
             app_name: SearchApplicationName::Firefox,
             version: String::new(),
+            device_type: SearchDeviceType::None,
         });
 
         assert!(

--- a/components/search/src/types.rs
+++ b/components/search/src/types.rs
@@ -7,14 +7,16 @@
 use serde::Deserialize;
 
 /// The list of possible application names that are currently supported.
-#[derive(Clone, Debug, Deserialize, PartialEq, uniffi::Enum)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, uniffi::Enum)]
 #[serde(rename_all = "kebab-case")]
 pub enum SearchApplicationName {
-    Firefox = 1,
-    FirefoxAndroid = 2,
-    FirefoxIos = 3,
-    FocusAndroid = 4,
-    FocusIos = 5,
+    FirefoxAndroid = 1,
+    FirefoxIos = 2,
+    FocusAndroid = 3,
+    FocusIos = 4,
+    // The default doesn't really matter here, so we pick desktop.
+    #[default]
+    Firefox = 5,
 }
 
 impl SearchApplicationName {
@@ -31,7 +33,7 @@ impl SearchApplicationName {
 
 /// The list of possible update channels for a user's build.
 /// Use `default` for a self-build or an unknown channel.
-#[derive(Clone, Debug, Deserialize, PartialEq, uniffi::Enum)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, uniffi::Enum)]
 #[serde(rename_all = "lowercase")]
 pub enum SearchUpdateChannel {
     Nightly = 1,
@@ -39,21 +41,21 @@ pub enum SearchUpdateChannel {
     Beta = 3,
     Release = 4,
     Esr = 5,
-    #[serde(other)]
+    #[default]
     Default = 6,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, uniffi::Enum)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, uniffi::Enum)]
 #[serde(rename_all = "camelCase")]
 pub enum SearchDeviceType {
     Smartphone = 1,
     Tablet = 2,
-    #[serde(other)]
+    #[default]
     None = 3,
 }
 
 /// The user's environment that is used for filtering the search configuration.
-#[derive(Clone, Debug, uniffi::Record)]
+#[derive(Clone, Debug, uniffi::Record, Default)]
 pub struct SearchUserEnvironment {
     /// The current locale of the application that the user is using.
     pub locale: String,

--- a/components/search/src/types.rs
+++ b/components/search/src/types.rs
@@ -31,27 +31,25 @@ impl SearchApplicationName {
 
 /// The list of possible update channels for a user's build.
 /// Use `default` for a self-build or an unknown channel.
-#[derive(Clone, Debug, uniffi::Enum)]
+#[derive(Clone, Debug, Deserialize, PartialEq, uniffi::Enum)]
+#[serde(rename_all = "lowercase")]
 pub enum SearchUpdateChannel {
-    Default = 1,
-    Nightly = 2,
-    Aurora = 3,
-    Beta = 4,
-    Release = 5,
-    ESR = 6,
+    Nightly = 1,
+    Aurora = 2,
+    Beta = 3,
+    Release = 4,
+    Esr = 5,
+    #[serde(other)]
+    Default = 6,
 }
 
-impl SearchUpdateChannel {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            SearchUpdateChannel::Default => "default",
-            SearchUpdateChannel::Nightly => "nightly",
-            SearchUpdateChannel::Aurora => "aurora",
-            SearchUpdateChannel::Beta => "beta",
-            SearchUpdateChannel::Release => "release",
-            SearchUpdateChannel::ESR => "esr",
-        }
-    }
+#[derive(Clone, Debug, Deserialize, PartialEq, uniffi::Enum)]
+#[serde(rename_all = "camelCase")]
+pub enum SearchDeviceType {
+    Smartphone = 1,
+    Tablet = 2,
+    #[serde(other)]
+    None = 3,
 }
 
 /// The user's environment that is used for filtering the search configuration.
@@ -80,6 +78,9 @@ pub struct SearchUserEnvironment {
 
     /// The application version that the user is using.
     pub version: String,
+
+    /// The device type that the user is using.
+    pub device_type: SearchDeviceType,
 }
 
 /// Parameter definitions for search engine URLs. The name property is always


### PR DESCRIPTION
This implements the remaining environment matching in the search engine selector. This also gets the desktop `test_engine_selector_environment.js` passing.

Note that we do not add support for `optional` here, as that isn't really an environment variable and should be handled by the application itself according to what it does.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [X] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
