### PR TITLE
Update ohttp to the same version in mozilla-central

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,8 +3263,8 @@ dependencies = [
 
 [[package]]
 name = "ohttp"
-version = "0.4.0"
-source = "git+https://github.com/martinthomson/ohttp.git?rev=fc3f4c787d1f6a6a87bf5194f7152cc906b02973"
+version = "0.5.1"
+source = "git+https://github.com/martinthomson/ohttp.git?rev=bf02e480d4722f9fba38a4245168d1a82f8fac6c#bf02e480d4722f9fba38a4245168d1a82f8fac6c"
 dependencies = [
  "bindgen",
  "byteorder",

--- a/components/as-ohttp-client/Cargo.toml
+++ b/components/as-ohttp-client/Cargo.toml
@@ -17,10 +17,10 @@ parking_lot = "0.12"
 rusqlite = { workspace = true, features = ["bundled"] }
 
 [dependencies.ohttp]
-version = "0.4"
+version = "0.5.1"
 default-features = false
 git = "https://github.com/martinthomson/ohttp.git"
-rev = "fc3f4c787d1f6a6a87bf5194f7152cc906b02973"
+rev = "bf02e480d4722f9fba38a4245168d1a82f8fac6c"
 features = ["client", "server", "app-svc", "external-sqlite"]
 
 [build-dependencies]


### PR DESCRIPTION
Updating this as one part of prep work for moving app-services into mozilla-central.

FWIW, m-c moving to 0.5.2 is going to cause issues with regex, so I didn't attempt to go there - we can follow to that once m-c goes there.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
