### PR TITLE
Update sql support crate to temporarily not depend on prettytable-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4779,7 +4779,6 @@ dependencies = [
  "log",
  "nss_build_common",
  "parking_lot",
- "prettytable-rs",
  "rusqlite",
  "tempfile",
  "thiserror 1.0.31",

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -8,7 +8,8 @@ license = "MPL-2.0"
 [features]
 default = []
 ### The debug-tools feature brings in utilities to help with debugging.
-debug-tools = ["dep:prettytable-rs", "rusqlite/column_decltype"]
+# "dep:prettytable-rs" temp removed for moz-central integration.
+debug-tools = ["rusqlite/column_decltype"]
 
 [dependencies]
 log = "0.4"
@@ -17,7 +18,8 @@ interrupt-support = { path = "../interrupt" }
 thiserror = "1.0"
 tempfile = "3.1.0"
 parking_lot = ">=0.11,<=0.12"
-prettytable-rs = { version = "0.10", optional = true }
+# disable for m-c :(
+# prettytable-rs = { version = "0.10", optional = true }
 rusqlite = { workspace = true, features = ["functions", "limits", "bundled", "unlock_notify"] }
 
 [dev-dependencies]

--- a/components/support/sql/src/lib.rs
+++ b/components/support/sql/src/lib.rs
@@ -8,7 +8,16 @@
 //! A crate with various sql/sqlcipher helpers.
 
 mod conn_ext;
-pub mod debug_tools;
+
+// XXX - temporarily disable our debug_tools, to avoid pulling in:
+// prettytable-rs = { version = "0.10", optional = true }
+// while vendoring into m-c :(
+pub mod debug_tools {
+    pub fn define_debug_functions(_c: &rusqlite::Connection) -> rusqlite::Result<()> {
+        Ok(())
+    }
+}
+
 mod each_chunk;
 mod lazy;
 mod maybe_cached;

--- a/examples/places-utils/src/places-utils.rs
+++ b/examples/places-utils/src/places-utils.rs
@@ -217,11 +217,14 @@ fn delete_history(db: &PlacesDb) -> Result<()> {
     Ok(())
 }
 
-fn show_stats(db: &PlacesDb) -> Result<()> {
-    db.execute("ANALYZE;", [])?;
-    println!("Left most column in `stat` is the record count in the table/index");
-    println!("See the sqlite docs for `sqlite_stat1` for more info.");
-    sql_support::debug_tools::print_query(db, "SELECT * from sqlite_stat1")?;
+fn show_stats(_db: &PlacesDb) -> Result<()> {
+    println!(
+        "Sorry - this has been temporarily enabled to avoid bringing our pretty-printer into m-c"
+    );
+    // db.execute("ANALYZE;", [])?;
+    // println!("Left most column in `stat` is the record count in the table/index");
+    // println!("See the sqlite docs for `sqlite_stat1` for more info.");
+    // sql_support::debug_tools::print_query(db, "SELECT * from sqlite_stat1")?;
     Ok(())
 }
 


### PR DESCRIPTION
prettytable-rs drags in dependencies we don't want in m-c (or, at least, which we
don't want to audit at this stage). We should work out an alternative, but this seems
fine in the short term.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
