### PR TITLE
update getLocaleTag in Nimbus swift to be public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v135.0 (In progress)
 
+### Nimbus SDK ⛅️🔬🔭
+- Updated `getLocaleTag` to be publicly accessible ([#6510](https://github.com/mozilla/application-services/pull/6510))
+
 [Full Changelog](In progress)
 
 # v134.0 (_2023-11-25_)

--- a/components/nimbus/ios/Nimbus/Utils/Utils.swift
+++ b/components/nimbus/ios/Nimbus/Utils/Utils.swift
@@ -83,7 +83,7 @@ func timestampNanos() -> UInt64 {
 /// to indicate "undetermined".
 ///
 /// - returns: a locale string that supports custom injected locale/languages.
-func getLocaleTag() -> String {
+public func getLocaleTag() -> String {
     if NSLocale.current.languageCode == nil {
         return "und"
     } else {


### PR DESCRIPTION
This needs to be public for calculating the RecordedNimbusContext attributes in Firefox iOS

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
