### PR TITLE
Add missing license headers

### DIFF
--- a/automation/cargo-update-pr.py
+++ b/automation/cargo-update-pr.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Purpose: Run cargo update and make a pull-request against main.
 # Dependencies: None

--- a/automation/check_protobuf_files_current.py
+++ b/automation/check_protobuf_files_current.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Purpose: Run cargo update and make a pull-request against main.
 # Dependencies: None

--- a/automation/kotlin-components-docs/gradle.properties
+++ b/automation/kotlin-components-docs/gradle.properties
@@ -1,1 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 org.gradle.jvmargs=-Xmx2g

--- a/automation/prepare-release.py
+++ b/automation/prepare-release.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Purpose: Prepare an Application-Services release
 # Dependencies: yaml

--- a/automation/publish_to_maven_local_if_modified.py
+++ b/automation/publish_to_maven_local_if_modified.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Purpose: Publish android packages to local maven repo, but only if changed since last publish.
 # Dependencies: None

--- a/automation/shared.py
+++ b/automation/shared.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 # Common code used by the automation python scripts.
 
 import subprocess

--- a/automation/smoke-test-android-components.py
+++ b/automation/smoke-test-android-components.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Purpose: Run android-components tests against this application-services working tree.
 # Dependencies: PyYAML

--- a/automation/smoke-test-fenix.py
+++ b/automation/smoke-test-fenix.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 
 # Purpose: Run Fenix tests against this application-services working tree.
 # Usage: ./automation/smoke-test-fenix.py

--- a/automation/smoke-test-fxios.py
+++ b/automation/smoke-test-fxios.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Purpose: Run Firefox-iOS tests against this application-services working tree.
 # Usage: ./automation/smoke-test-fxios.py

--- a/automation/tag-release.py
+++ b/automation/tag-release.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # Purpose: Tag an Application-Services release
 # Dependencies: yaml

--- a/components/as-ohttp-client/src/lib.rs
+++ b/components/as-ohttp-client/src/lib.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 extern crate bhttp;
 extern crate ohttp;
 extern crate rusqlite;

--- a/components/autofill/android/src/main/AndroidManifest.xml
+++ b/components/autofill/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/fxa-client/android/src/main/AndroidManifest.xml
+++ b/components/fxa-client/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/logins/android/src/main/AndroidManifest.xml
+++ b/components/logins/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/nimbus/android/src/main/AndroidManifest.xml
+++ b/components/nimbus/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/nimbus/src/metrics.rs
+++ b/components/nimbus/src/metrics.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use crate::{enrollment::ExperimentEnrollment, EnrolledFeature, EnrollmentStatus};
 use serde_derive::{Deserialize, Serialize};
 

--- a/components/places/android/src/main/AndroidManifest.xml
+++ b/components/places/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/push/android/src/main/AndroidManifest.xml
+++ b/components/push/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/relevancy/src/bin/generate-test-data.rs
+++ b/components/relevancy/src/bin/generate-test-data.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use relevancy::{
     url_hash::{hash_url, UrlHash},
     Interest,

--- a/components/relevancy/src/ranker.rs
+++ b/components/relevancy/src/ranker.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use std::cmp::max;
 
 use crate::interest::{Interest, InterestVector};

--- a/components/remote_settings/android/src/main/AndroidManifest.xml
+++ b/components/remote_settings/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/suggest/android/src/main/AndroidManifest.xml
+++ b/components/suggest/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/suggest/benches/benchmark_all.rs
+++ b/components/suggest/benches/benchmark_all.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use criterion::{
     criterion_group, criterion_main, measurement::Measurement, BatchSize, BenchmarkGroup, Criterion,
 };

--- a/components/support/android/src/main/AndroidManifest.xml
+++ b/components/support/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/support/error/android/src/main/AndroidManifest.xml
+++ b/components/support/error/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/support/find-places-db/src/lib.rs
+++ b/components/support/find-places-db/src/lib.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 // Forked from https://github.com/thomcc/find-places-dbs, which was itself
 // originally in app-services, then split out for general-purpose use, but
 // then became unmaintained and published to crates.io without a Mozilla owner.

--- a/components/support/nimbus-cli/assets/index.html
+++ b/components/support/nimbus-cli/assets/index.html
@@ -1,3 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <html>
     <head>
         <title>nimbus-cli test server</title>

--- a/components/support/nimbus-cli/assets/li-template.html
+++ b/components/support/nimbus-cli/assets/li-template.html
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <li><a href="{url}" id="{platform}-latest">Click for {platform}</a></li>

--- a/components/support/nimbus-cli/assets/script.js
+++ b/components/support/nimbus-cli/assets/script.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 function onReload() {
     const uaString = window.navigator.userAgent.toLowerCase();
     let el;

--- a/components/support/nimbus-cli/assets/style.css
+++ b/components/support/nimbus-cli/assets/style.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 .wrapper {
     height: 100%;
     width: 100%;

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/EnumTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/EnumTemplate.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 {% import "macros.kt" as kt %}
 {% let inner = self.inner() %}
 {% let class_name = inner.name()|class_name %}

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/FeatureTemplate.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 {%- import "macros.kt" as kt %}
 {%- let inner = self.inner() %}
 

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/ImportedModuleInitializationTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/ImportedModuleInitializationTemplate.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 {%- import "macros.kt" as kt %}
 {%- let variables = "variables" %}
 {%- let prefs = "prefs" %}

--- a/components/support/nimbus-fml/src/backends/kotlin/templates/ObjectTemplate.kt
+++ b/components/support/nimbus-fml/src/backends/kotlin/templates/ObjectTemplate.kt
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 {%- import "macros.kt" as kt %}
 {%- let inner = self.inner() %}
 {%- let class_name = inner.name()|class_name %}

--- a/components/support/rust-log-forwarder/android/src/main/AndroidManifest.xml
+++ b/components/support/rust-log-forwarder/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/sync15/android/src/main/AndroidManifest.xml
+++ b/components/sync15/android/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>
 

--- a/components/sync_manager/android/src/main/AndroidManifest.xml
+++ b/components/sync_manager/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/sync_manager/src/types.rs
+++ b/components/sync_manager/src/types.rs
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 use std::collections::HashMap;
 use std::time::SystemTime;
 use sync15::DeviceType;

--- a/components/tabs/android/src/main/AndroidManifest.xml
+++ b/components/tabs/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/components/viaduct/android/src/main/AndroidManifest.xml
+++ b/components/viaduct/android/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>
 

--- a/components/webext-storage/android/src/main/AndroidManifest.xml
+++ b/components/webext-storage/android/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.mozilla.appservices.webextstorage" />

--- a/docs/shared/a-s.css
+++ b/docs/shared/a-s.css
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /* Style the tab */
 .tabbar {
     overflow: hidden;

--- a/docs/shared/tabs.js
+++ b/docs/shared/tabs.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 /**
  * Returns true if browser supports HTML5 localStorage.
  */

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 # Project-wide Gradle settings.
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip

--- a/megazords/full/android/src/main/AndroidManifest.xml
+++ b/megazords/full/android/src/main/AndroidManifest.xml
@@ -1,1 +1,5 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"/>

--- a/taskcluster/scripts/build-and-test-swift.py
+++ b/taskcluster/scripts/build-and-test-swift.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from collections import namedtuple
 import argparse

--- a/taskcluster/scripts/deps-complete.py
+++ b/taskcluster/scripts/deps-complete.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import json
 import os

--- a/taskcluster/scripts/nimbus-build.py
+++ b/taskcluster/scripts/nimbus-build.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import argparse
 import subprocess

--- a/taskcluster/scripts/setup-branch-build-firefox-android.py
+++ b/taskcluster/scripts/setup-branch-build-firefox-android.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import argparse
 import os

--- a/taskcluster/scripts/setup-branch-build-firefox-ios.py
+++ b/taskcluster/scripts/setup-branch-build-firefox-ios.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import argparse
 import os

--- a/tools/clean-gradle-autopublish.py
+++ b/tools/clean-gradle-autopublish.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from configparser import RawConfigParser
 from pathlib import Path

--- a/tools/clean.py
+++ b/tools/clean.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 """
 Clean the world.
 

--- a/tools/loc_summary.py
+++ b/tools/loc_summary.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #
 # This is a simple script to generate some summary lines-of-code metrics.
 # Use it like this:

--- a/tools/nimbus-gradle-plugin/src/main/resources/nimbus-gradle-plugin.properties
+++ b/tools/nimbus-gradle-plugin/src/main/resources/nimbus-gradle-plugin.properties
@@ -1,1 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 version=@project.version@

--- a/tools/update-moz-central-vendoring.py
+++ b/tools/update-moz-central-vendoring.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import argparse
 import pathlib


### PR DESCRIPTION
These are all cases where the mozilla-central linter will pick up missing license headers and are automatically fixed by that linter. I did a brief check and it looks like these are all files where we should/can have license headers.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [X] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
