### PR TITLE
Remote Settings: store full changesets instead of just records

### DIFF
--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -151,9 +151,15 @@ impl<C: ApiClient> RemoteSettingsClient<C> {
                 .get_last_modified_timestamp(&collection_url)?
                 .unwrap_or(0);
             if packaged_data.timestamp > cached_timestamp {
-                inner
-                    .storage
-                    .set_records(&collection_url, &packaged_data.data)?;
+                // Remove previously cached data (packaged data does not have tombstones like diff responses do).
+                inner.storage.empty()?;
+                // Insert new packaged data.
+                inner.storage.insert_collection_content(
+                    &collection_url,
+                    &packaged_data.data,
+                    packaged_data.timestamp,
+                    CollectionMetadata::default(),
+                )?;
                 return Ok(Some(self.filter_records(packaged_data.data)));
             }
         }
@@ -168,9 +174,14 @@ impl<C: ApiClient> RemoteSettingsClient<C> {
             (Some(cached_records), _) => Some(self.filter_records(cached_records)),
             // Case 3: sync_if_empty=true
             (None, true) => {
-                let records = inner.api_client.get_records(None)?;
-                inner.storage.set_records(&collection_url, &records)?;
-                Some(self.filter_records(records))
+                let changeset = inner.api_client.fetch_changeset(None)?;
+                inner.storage.insert_collection_content(
+                    &collection_url,
+                    &changeset.changes,
+                    changeset.timestamp,
+                    changeset.metadata,
+                )?;
+                Some(self.filter_records(changeset.changes))
             }
             // Case 4: Nothing to return
             (None, false) => None,
@@ -181,8 +192,13 @@ impl<C: ApiClient> RemoteSettingsClient<C> {
         let mut inner = self.inner.lock();
         let collection_url = inner.api_client.collection_url();
         let mtime = inner.storage.get_last_modified_timestamp(&collection_url)?;
-        let records = inner.api_client.get_records(mtime)?;
-        inner.storage.merge_records(&collection_url, &records)
+        let changeset = inner.api_client.fetch_changeset(mtime)?;
+        inner.storage.insert_collection_content(
+            &collection_url,
+            &changeset.changes,
+            changeset.timestamp,
+            changeset.metadata,
+        )
     }
 
     /// Downloads an attachment from [attachment_location]. NOTE: there are no guarantees about a
@@ -221,7 +237,7 @@ impl<C: ApiClient> RemoteSettingsClient<C> {
         }
 
         // Try to download the attachment because neither the storage nor the local data had it
-        let attachment = inner.api_client.get_attachment(&metadata.location)?;
+        let attachment = inner.api_client.fetch_attachment(&metadata.location)?;
 
         // Verify downloaded data
         if attachment.len() as u64 != metadata.size {
@@ -284,10 +300,10 @@ pub trait ApiClient {
     fn collection_url(&self) -> String;
 
     /// Fetch records from the server
-    fn get_records(&mut self, timestamp: Option<u64>) -> Result<Vec<RemoteSettingsRecord>>;
+    fn fetch_changeset(&mut self, timestamp: Option<u64>) -> Result<ChangesetResponse>;
 
     /// Fetch an attachment from the server
-    fn get_attachment(&mut self, attachment_location: &str) -> Result<Vec<u8>>;
+    fn fetch_attachment(&mut self, attachment_location: &str) -> Result<Vec<u8>>;
 
     /// Check if this client is pointing to the production server
     fn is_prod_server(&self) -> Result<bool>;
@@ -372,7 +388,7 @@ impl ApiClient for ViaductApiClient {
         self.endpoints.collection_url.to_string()
     }
 
-    fn get_records(&mut self, timestamp: Option<u64>) -> Result<Vec<RemoteSettingsRecord>> {
+    fn fetch_changeset(&mut self, timestamp: Option<u64>) -> Result<ChangesetResponse> {
         let mut url = self.endpoints.changeset_url.clone();
         // 0 is used as an arbitrary value for `_expected` because the current implementation does
         // not leverage push timestamps or polling from the monitor/changes endpoint. More
@@ -388,7 +404,7 @@ impl ApiClient for ViaductApiClient {
         let resp = self.make_request(url)?;
 
         if resp.is_success() {
-            Ok(resp.json::<ChangesetResponse>()?.changes)
+            Ok(resp.json::<ChangesetResponse>()?)
         } else {
             Err(Error::ResponseError(format!(
                 "status code: {}",
@@ -397,7 +413,7 @@ impl ApiClient for ViaductApiClient {
         }
     }
 
-    fn get_attachment(&mut self, attachment_location: &str) -> Result<Vec<u8>> {
+    fn fetch_attachment(&mut self, attachment_location: &str) -> Result<Vec<u8>> {
         let attachments_base_url = match &self.remote_state.attachments_base_url {
             Some(attachments_base_url) => attachments_base_url.to_owned(),
             None => {
@@ -706,9 +722,24 @@ struct RecordsResponse {
     data: Vec<RemoteSettingsRecord>,
 }
 
-#[derive(Deserialize, Serialize)]
-struct ChangesetResponse {
+#[derive(Clone, Deserialize, Serialize)]
+pub struct ChangesetResponse {
     changes: Vec<RemoteSettingsRecord>,
+    timestamp: u64,
+    metadata: CollectionMetadata,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+pub struct CollectionMetadata {
+    pub bucket: String,
+    pub signature: CollectionSignature,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+pub struct CollectionSignature {
+    pub signature: String,
+    /// X.509 certificate chain Url (x5u)
+    pub x5u: String,
 }
 
 /// A parsed Remote Settings record. Records can contain arbitrary fields, so clients
@@ -717,6 +748,7 @@ struct ChangesetResponse {
 pub struct RemoteSettingsRecord {
     pub id: String,
     pub last_modified: u64,
+    /// Tombstone flag (see https://remote-settings.readthedocs.io/en/latest/client-specifications.html#local-state)
     #[serde(default)]
     pub deleted: bool,
     pub attachment: Option<Attachment>,
@@ -1705,14 +1737,24 @@ mod test_new_client {
             attachment: None,
             fields: json!({"foo": "bar"}).as_object().unwrap().clone(),
         }];
+        let changeset = ChangesetResponse {
+            changes: records.clone(),
+            timestamp: 42,
+            metadata: CollectionMetadata {
+                bucket: "main".into(),
+                signature: CollectionSignature {
+                    signature: "b64sig".into(),
+                    x5u: "http://x5u.com".into(),
+                },
+            },
+        };
         api_client.expect_collection_url().returning(|| {
             "http://rs.example.com/v1/buckets/main/collections/test-collection".into()
         });
-        api_client.expect_get_records().returning({
-            let records = records.clone();
+        api_client.expect_fetch_changeset().returning({
             move |timestamp| {
                 assert_eq!(timestamp, None);
-                Ok(records.clone())
+                Ok(changeset.clone())
             }
         });
         api_client.expect_is_prod_server().returning(|| Ok(false));
@@ -1748,14 +1790,19 @@ mod jexl_tests {
             .unwrap()
             .clone(),
         }];
+        let changeset = ChangesetResponse {
+            changes: records.clone(),
+            timestamp: 42,
+            metadata: CollectionMetadata::default(),
+        };
         api_client.expect_collection_url().returning(|| {
             "http://rs.example.com/v1/buckets/main/collections/test-collection".into()
         });
-        api_client.expect_get_records().returning({
-            let records = records.clone();
+        api_client.expect_fetch_changeset().returning({
+            let changeset = changeset.clone();
             move |timestamp| {
                 assert_eq!(timestamp, None);
-                Ok(records.clone())
+                Ok(changeset.clone())
             }
         });
         api_client.expect_is_prod_server().returning(|| Ok(false));
@@ -1766,9 +1813,11 @@ mod jexl_tests {
         };
 
         let mut storage = Storage::new(":memory:".into()).expect("Error creating storage");
-        let _ = storage.set_records(
+        let _ = storage.insert_collection_content(
             "http://rs.example.com/v1/buckets/main/collections/test-collection",
             &records,
+            42,
+            CollectionMetadata::default(),
         );
 
         let rs_client = RemoteSettingsClient::new_from_parts(
@@ -1799,14 +1848,19 @@ mod jexl_tests {
             .unwrap()
             .clone(),
         }];
+        let changeset = ChangesetResponse {
+            changes: records.clone(),
+            timestamp: 42,
+            metadata: CollectionMetadata::default(),
+        };
         api_client.expect_collection_url().returning(|| {
             "http://rs.example.com/v1/buckets/main/collections/test-collection".into()
         });
-        api_client.expect_get_records().returning({
-            let records = records.clone();
+        api_client.expect_fetch_changeset().returning({
+            let changeset = changeset.clone();
             move |timestamp| {
                 assert_eq!(timestamp, None);
-                Ok(records.clone())
+                Ok(changeset.clone())
             }
         });
         api_client.expect_is_prod_server().returning(|| Ok(false));
@@ -1817,9 +1871,11 @@ mod jexl_tests {
         };
 
         let mut storage = Storage::new(":memory:".into()).expect("Error creating storage");
-        let _ = storage.set_records(
+        let _ = storage.insert_collection_content(
             "http://rs.example.com/v1/buckets/main/collections/test-collection",
             &records,
+            42,
+            CollectionMetadata::default(),
         );
 
         let rs_client = RemoteSettingsClient::new_from_parts(
@@ -1902,7 +1958,12 @@ mod cached_data_tests {
 
         let mut api_client = MockApiClient::new();
         let mut storage = Storage::new(":memory:".into())?;
-        storage.set_records(collection_url, &vec![old_record.clone()])?;
+        storage.insert_collection_content(
+            collection_url,
+            &vec![old_record.clone()],
+            42,
+            CollectionMetadata::default(),
+        )?;
 
         api_client
             .expect_collection_url()
@@ -1962,10 +2023,21 @@ mod cached_data_tests {
             attachment: None,
             fields: serde_json::Map::new(),
         }];
+        let changeset = ChangesetResponse {
+            changes: expected_records.clone(),
+            timestamp: 42,
+            metadata: CollectionMetadata {
+                bucket: "main".into(),
+                signature: CollectionSignature {
+                    signature: "b64sig".into(),
+                    x5u: "http://x5u.com".into(),
+                },
+            },
+        };
         api_client
-            .expect_get_records()
+            .expect_fetch_changeset()
             .withf(|timestamp| timestamp.is_none())
-            .returning(move |_| Ok(expected_records.clone()));
+            .returning(move |_| Ok(changeset.clone()));
 
         let rs_client =
             RemoteSettingsClient::new_from_parts(collection_name.to_string(), storage, api_client);
@@ -2012,7 +2084,7 @@ mod cached_data_tests {
         api_client.expect_is_prod_server().returning(|| Ok(true));
 
         // Since sync_if_empty is false, get_records should not be called
-        // No need to set expectation for api_client.get_records
+        // No need to set expectation for api_client.fetch_changeset
 
         let rs_client =
             RemoteSettingsClient::new_from_parts(collection_name.to_string(), storage, api_client);
@@ -2046,7 +2118,12 @@ mod cached_data_tests {
             attachment: None,
             fields: serde_json::Map::new(),
         }];
-        storage.set_records(&collection_url, &cached_records)?;
+        storage.insert_collection_content(
+            &collection_url,
+            &cached_records,
+            42,
+            CollectionMetadata::default(),
+        )?;
 
         api_client
             .expect_collection_url()
@@ -2082,7 +2159,12 @@ mod cached_data_tests {
 
         // Set up empty cached records
         let cached_records: Vec<RemoteSettingsRecord> = vec![];
-        storage.set_records(&collection_url, &cached_records)?;
+        storage.insert_collection_content(
+            &collection_url,
+            &cached_records,
+            42,
+            CollectionMetadata::default(),
+        )?;
 
         api_client
             .expect_collection_url()
@@ -2210,7 +2292,7 @@ mod test_packaged_metadata {
             .returning(move || collection_url.clone());
         api_client.expect_is_prod_server().returning(|| Ok(true));
         api_client
-            .expect_get_attachment()
+            .expect_fetch_attachment()
             .returning(move |_| Ok(mock_api_data.clone()));
 
         let rs_client =

--- a/components/remote_settings/src/storage.rs
+++ b/components/remote_settings/src/storage.rs
@@ -2,16 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+use crate::{
+    client::CollectionMetadata, client::CollectionSignature,
+    schema::RemoteSettingsConnectionInitializer, Attachment, RemoteSettingsRecord, Result,
+};
 use camino::Utf8PathBuf;
 use rusqlite::{params, Connection, OpenFlags, OptionalExtension, Transaction};
 use serde_json;
 use sha2::{Digest, Sha256};
 
 use sql_support::{open_database::open_database_with_flags, ConnExt};
-
-use crate::{
-    schema::RemoteSettingsConnectionInitializer, Attachment, RemoteSettingsRecord, Result,
-};
 
 /// Internal storage type
 ///
@@ -43,7 +43,7 @@ impl Storage {
     /// Get the last modified timestamp for the stored records
     ///
     /// Returns None if no records are stored or if `collection_url` does not match the
-    /// last `collection_url` passed to `set_records` / `merge_records`
+    /// last `collection_url` passed to `insert_collection_content`
     pub fn get_last_modified_timestamp(&self, collection_url: &str) -> Result<Option<u64>> {
         let mut stmt = self
             .conn
@@ -57,7 +57,7 @@ impl Storage {
     /// Get cached records for this collection
     ///
     /// Returns None if no records are stored or if `collection_url` does not match the `collection_url` passed
-    /// to `set_records`.
+    /// to `insert_collection_content`.
     pub fn get_records(
         &mut self,
         collection_url: &str,
@@ -83,6 +83,36 @@ impl Storage {
 
         tx.commit()?;
         result
+    }
+
+    /// Get cached metadata for this collection
+    ///
+    /// Returns None if no data is stored or if `collection_url` does not match the `collection_url` passed
+    /// to `insert_collection_content`.
+    pub fn get_collection_metadata(
+        &self,
+        collection_url: &str,
+    ) -> Result<Option<CollectionMetadata>> {
+        let mut stmt_metadata = self.conn.prepare(
+            "SELECT bucket, signature, x5u FROM collection_metadata WHERE collection_url = ?",
+        )?;
+
+        if let Some(metadata) = stmt_metadata
+            .query_row(params![collection_url], |row| {
+                Ok(CollectionMetadata {
+                    bucket: row.get(0).unwrap_or_default(),
+                    signature: CollectionSignature {
+                        signature: row.get(1).unwrap_or_default(),
+                        x5u: row.get(2).unwrap_or_default(),
+                    },
+                })
+            })
+            .optional()?
+        {
+            Ok(Some(metadata))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Get cached attachment data
@@ -120,30 +150,13 @@ impl Storage {
         }
     }
 
-    /// Set the list of records stored in the database, clearing out any previously stored records
-    pub fn set_records(
+    /// Set cached content for this collection.
+    pub fn insert_collection_content(
         &mut self,
         collection_url: &str,
         records: &[RemoteSettingsRecord],
-    ) -> Result<()> {
-        let tx = self.conn.transaction()?;
-
-        tx.execute("DELETE FROM records", [])?;
-        tx.execute("DELETE FROM collection_metadata", [])?;
-        let max_last_modified = Self::update_record_rows(&tx, collection_url, records)?;
-        Self::update_collection_metadata(&tx, collection_url, max_last_modified)?;
-        tx.commit()?;
-        Ok(())
-    }
-
-    /// Merge new records with records stored in the database
-    ///
-    /// Records with `deleted=false` will be inserted into the DB, replacing any previously stored
-    /// records with the same ID. Records with `deleted=true` will be removed.
-    pub fn merge_records(
-        &mut self,
-        collection_url: &str,
-        records: &[RemoteSettingsRecord],
+        last_modified: u64,
+        metadata: CollectionMetadata,
     ) -> Result<()> {
         let tx = self.conn.transaction()?;
 
@@ -159,8 +172,9 @@ impl Storage {
             "DELETE FROM collection_metadata where collection_url <> ?",
             [collection_url],
         )?;
-        let max_last_modified = Self::update_record_rows(&tx, collection_url, records)?;
-        Self::update_collection_metadata(&tx, collection_url, max_last_modified)?;
+
+        Self::update_record_rows(&tx, collection_url, records)?;
+        Self::update_collection_metadata(&tx, collection_url, last_modified, metadata)?;
         tx.commit()?;
         Ok(())
     }
@@ -198,11 +212,20 @@ impl Storage {
         tx: &Transaction<'_>,
         collection_url: &str,
         last_modified: u64,
+        metadata: CollectionMetadata,
     ) -> Result<()> {
         // Update the metadata
         tx.execute(
-            "INSERT OR REPLACE INTO collection_metadata (collection_url, last_modified) VALUES (?, ?)",
-            (collection_url, last_modified),
+            "INSERT OR REPLACE INTO collection_metadata \
+            (collection_url, last_modified, bucket, signature, x5u) \
+            VALUES (?, ?, ?, ?, ?)",
+            (
+                collection_url,
+                last_modified,
+                metadata.bucket,
+                metadata.signature.signature,
+                metadata.signature.x5u,
+            ),
         )?;
         Ok(())
     }
@@ -250,7 +273,10 @@ impl Storage {
 #[cfg(test)]
 mod tests {
     use super::Storage;
-    use crate::{Attachment, RemoteSettingsRecord, Result, RsJsonObject};
+    use crate::{
+        client::CollectionMetadata, client::CollectionSignature, Attachment, RemoteSettingsRecord,
+        Result, RsJsonObject,
+    };
     use sha2::{Digest, Sha256};
 
     #[test]
@@ -282,7 +308,12 @@ mod tests {
         ];
 
         // Set records
-        storage.set_records(collection_url, &records)?;
+        storage.insert_collection_content(
+            collection_url,
+            &records,
+            300,
+            CollectionMetadata::default(),
+        )?;
 
         // Get records
         let fetched_records = storage.get_records(collection_url)?;
@@ -295,7 +326,7 @@ mod tests {
 
         // Get last modified timestamp
         let last_modified = storage.get_last_modified_timestamp(collection_url)?;
-        assert_eq!(last_modified, Some(200));
+        assert_eq!(last_modified, Some(300));
 
         Ok(())
     }
@@ -324,7 +355,12 @@ mod tests {
         let collection_url = "https://example.com/api";
 
         // Set empty records
-        storage.set_records(collection_url, &Vec::<RemoteSettingsRecord>::default())?;
+        storage.insert_collection_content(
+            collection_url,
+            &Vec::<RemoteSettingsRecord>::default(),
+            42,
+            CollectionMetadata::default(),
+        )?;
 
         // Get records
         let fetched_records = storage.get_records(collection_url)?;
@@ -332,7 +368,7 @@ mod tests {
 
         // Get last modified timestamp when no records
         let last_modified = storage.get_last_modified_timestamp(collection_url)?;
-        assert_eq!(last_modified, Some(0));
+        assert_eq!(last_modified, Some(42));
 
         Ok(())
     }
@@ -519,7 +555,12 @@ mod tests {
             .expect("No attachment metadata for record");
 
         // Set records and attachment
-        storage.set_records(collection_url, &records)?;
+        storage.insert_collection_content(
+            collection_url,
+            &records,
+            42,
+            CollectionMetadata::default(),
+        )?;
         storage.set_attachment(collection_url, &metadata.location, attachment)?;
 
         // Verify they are stored
@@ -568,8 +609,12 @@ mod tests {
         }];
 
         // Set records for collection_url1
-        storage.set_records(collection_url1, &records_collection_url1)?;
-
+        storage.insert_collection_content(
+            collection_url1,
+            &records_collection_url1,
+            42,
+            CollectionMetadata::default(),
+        )?;
         // Verify records for collection_url1
         let fetched_records = storage.get_records(collection_url1)?;
         assert!(fetched_records.is_some());
@@ -578,7 +623,12 @@ mod tests {
         assert_eq!(fetched_records, records_collection_url1);
 
         // Set records for collection_url2, which will clear records for all collections
-        storage.set_records(collection_url2, &records_collection_url2)?;
+        storage.insert_collection_content(
+            collection_url2,
+            &records_collection_url2,
+            300,
+            CollectionMetadata::default(),
+        )?;
 
         // Verify that records for collection_url1 have been cleared
         let fetched_records = storage.get_records(collection_url1)?;
@@ -595,13 +645,13 @@ mod tests {
         let last_modified1 = storage.get_last_modified_timestamp(collection_url1)?;
         assert_eq!(last_modified1, None);
         let last_modified2 = storage.get_last_modified_timestamp(collection_url2)?;
-        assert_eq!(last_modified2, Some(200));
+        assert_eq!(last_modified2, Some(300));
 
         Ok(())
     }
 
     #[test]
-    fn test_storage_set_records() -> Result<()> {
+    fn test_storage_insert_collection_content() -> Result<()> {
         let mut storage = Storage::new(":memory:".into())?;
 
         let collection_url = "https://example.com/api";
@@ -617,7 +667,12 @@ mod tests {
         }];
 
         // Set initial records
-        storage.set_records(collection_url, &initial_records)?;
+        storage.insert_collection_content(
+            collection_url,
+            &initial_records,
+            42,
+            CollectionMetadata::default(),
+        )?;
 
         // Verify initial records
         let fetched_records = storage.get_records(collection_url)?;
@@ -635,7 +690,12 @@ mod tests {
                 .unwrap()
                 .clone(),
         }];
-        storage.set_records(collection_url, &updated_records)?;
+        storage.insert_collection_content(
+            collection_url,
+            &updated_records,
+            300,
+            CollectionMetadata::default(),
+        )?;
 
         // Verify updated records
         let fetched_records = storage.get_records(collection_url)?;
@@ -644,7 +704,7 @@ mod tests {
 
         // Verify last modified timestamp
         let last_modified = storage.get_last_modified_timestamp(collection_url)?;
-        assert_eq!(last_modified, Some(200));
+        assert_eq!(last_modified, Some(300));
 
         Ok(())
     }
@@ -738,14 +798,24 @@ mod tests {
         ];
 
         // Set initial records
-        storage.set_records(collection_url, &initial_records)?;
+        storage.insert_collection_content(
+            collection_url,
+            &initial_records,
+            1000,
+            CollectionMetadata::default(),
+        )?;
 
         // Verify initial records
         let fetched_records = storage.get_records(collection_url)?.unwrap();
         assert_eq!(fetched_records, initial_records);
 
         // Update records
-        storage.merge_records(collection_url, &updated_records)?;
+        storage.insert_collection_content(
+            collection_url,
+            &updated_records,
+            1300,
+            CollectionMetadata::default(),
+        )?;
 
         // Verify updated records
         let mut fetched_records = storage.get_records(collection_url)?.unwrap();
@@ -755,6 +825,42 @@ mod tests {
         // Verify last modified timestamp
         let last_modified = storage.get_last_modified_timestamp(collection_url)?;
         assert_eq!(last_modified, Some(1300));
+        Ok(())
+    }
+    #[test]
+    fn test_storage_get_collection_metadata() -> Result<()> {
+        let mut storage = Storage::new(":memory:".into())?;
+
+        let collection_url = "https://example.com/api";
+        let initial_records = vec![RemoteSettingsRecord {
+            id: "2".to_string(),
+            last_modified: 200,
+            deleted: false,
+            attachment: None,
+            fields: serde_json::json!({"key": "value2"})
+                .as_object()
+                .unwrap()
+                .clone(),
+        }];
+
+        // Set initial records
+        storage.insert_collection_content(
+            collection_url,
+            &initial_records,
+            1337,
+            CollectionMetadata {
+                bucket: "main".into(),
+                signature: CollectionSignature {
+                    signature: "b64encodedsig".into(),
+                    x5u: "http://15u/".into(),
+                },
+            },
+        )?;
+
+        let metadata = storage.get_collection_metadata(collection_url)?.unwrap();
+
+        assert_eq!(metadata.signature.signature, "b64encodedsig");
+        assert_eq!(metadata.signature.x5u, "http://15u/");
 
         Ok(())
     }


### PR DESCRIPTION
In order to prepare the work of signature verification, where we want to be able to assess data integrity/authenticity, we need to store collection metadata and timestamps.

Also, this PR fixes an issue where the timestamp was wrong in certain cases (empty collections, tombstones, etc.)

It is an internal change that does not require a CHANGELOG entry.

* [x] Refactoring
* [x] Storing
* [x] Retrieving 
* [x] Storage DB migration


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
