### PR TITLE
Revert Glean v63.0.0 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@
 
 [Full Changelog](In progress)
 
-## 🦊 What's Changed 🦊
-
-### Glean
-- Updated to v63.0.0 ([bug 1933939](https://bugzilla.mozilla.org/show_bug.cgi?id=1933939))
-
 # v134.0 (_2023-11-25_)
 
 ## ✨ What's New ✨

--- a/components/sync_manager/android/src/test/java/mozilla/appservices/syncmanager/SyncTelemetryTest.kt
+++ b/components/sync_manager/android/src/test/java/mozilla/appservices/syncmanager/SyncTelemetryTest.kt
@@ -6,7 +6,6 @@ package mozilla.appservices.syncmanager
 
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.work.testing.WorkManagerTestInitHelper
 import mozilla.appservices.sync15.EngineInfo
 import mozilla.appservices.sync15.FailureName
 import mozilla.appservices.sync15.FailureReason
@@ -16,9 +15,7 @@ import mozilla.appservices.sync15.ProblemInfo
 import mozilla.appservices.sync15.SyncInfo
 import mozilla.appservices.sync15.SyncTelemetryPing
 import mozilla.appservices.sync15.ValidationInfo
-import mozilla.telemetry.glean.Glean
-import mozilla.telemetry.glean.config.Configuration
-import org.junit.After
+import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -26,6 +23,7 @@ import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mozilla.appservices.syncmanager.GleanMetrics.Pings
@@ -42,6 +40,9 @@ private fun Date.asSeconds() = time / BaseGleanSyncPing.MILLIS_PER_SEC
 @RunWith(AndroidJUnit4::class)
 @Suppress("LargeClass")
 class SyncTelemetryTest {
+    @get:Rule
+    val gleanRule = GleanTestRule(ApplicationProvider.getApplicationContext())
+
     private var now: Long = 0
     private var pingCount = 0
 
@@ -49,32 +50,6 @@ class SyncTelemetryTest {
     fun setup() {
         now = Date().asSeconds()
         pingCount = 0
-
-        // Due to recent changes in how upload enabled works, we need to register the custom
-        // Sync pings before resetting Glean manually so they can be submitted properly. This
-        // replaces the use of the GleanTestRule until it can be updated to better support testing
-        // custom pings in libraries.
-        Glean.registerPings(Pings.sync)
-        Glean.registerPings(Pings.historySync)
-        Glean.registerPings(Pings.bookmarksSync)
-        Glean.registerPings(Pings.loginsSync)
-        Glean.registerPings(Pings.creditcardsSync)
-        Glean.registerPings(Pings.addressesSync)
-        Glean.registerPings(Pings.tabsSync)
-
-        // Glean will crash in tests without this line when not using the GleanTestRule.
-        WorkManagerTestInitHelper.initializeTestWorkManager(ApplicationProvider.getApplicationContext())
-        Glean.resetGlean(
-            context = ApplicationProvider.getApplicationContext(),
-            config = Configuration(),
-            clearStores = true,
-        )
-    }
-
-    @After
-    fun tearDown() {
-        // This closes the WorkManager database to help prevent leaking it during tests.
-        WorkManagerTestInitHelper.closeWorkDatabase()
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinx-coroutines = "1.8.0"
 
 # Mozilla
 android-components = "133.0"
-glean = "63.0.0"
+glean = "62.0.0"
 rust-android-gradle = "0.9.4"
 
 # AndroidX

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -980,7 +980,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 63.0.0;
+				minimumVersion = 62.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "94dc6b186acfc4720adc0bbb95f712b86bc82988e2b0c0a85e65eb1ae9a4af4c",
   "pins" : [
     {
       "identity" : "glean-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "be4fbca81f9e1da5f9b91e8bd245a8dee53cc57f",
-        "version" : "63.0.0"
+        "revision" : "5c614b4af5a1f1ffe23b46bd03696086d8ce9d0d",
+        "version" : "62.0.0"
       }
     }
   ],

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
@@ -10,18 +10,8 @@ import XCTest
 
 class NimbusTests: XCTestCase {
     override func setUp() {
-        // Due to recent changes in how upload enabled works, we need to register the custom
-        // Sync pings before they can collect data in tests, even here in Nimbus unfortunately.
-        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1935001 for more info.
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.sync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.historySync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.bookmarksSync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.loginsSync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.creditcardsSync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.addressesSync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.tabsSync)
-
         Glean.shared.resetGlean(clearStores: true)
+        Glean.shared.enableTestingMode()
     }
 
     func emptyExperimentJSON() -> String {

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
@@ -12,20 +12,8 @@ class SyncManagerTelemetryTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-
-        // Due to recent changes in how upload enabled works, we need to register the custom
-        // Sync pings before they can collect data in tests.
-        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1935001 for more info.
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.sync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.historySync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.bookmarksSync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.loginsSync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.creditcardsSync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.addressesSync)
-        Glean.shared.registerPings(GleanMetrics.Pings.shared.tabsSync)
-
         Glean.shared.resetGlean(clearStores: true)
-
+        Glean.shared.enableTestingMode()
         now = Int64(Date().timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC
     }
 


### PR DESCRIPTION
A-S nightly bumps have been blocked for about a week now due to issues getting passing CI on Try with the Glean v63 bump. In order to un-block those updates, I think we should revert this bump for now. Testing can continue on Try with one of the current builds that contains the bump and we can re-land and manually trigger new nightly builds again once all the kinks are worked out.