### PR TITLE
Update Glean to v63.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 [Full Changelog](In progress)
 
+## 🦊 What's Changed 🦊
+
+### Glean
+- Updated to v63.0.0 ([bug 1933939](https://bugzilla.mozilla.org/show_bug.cgi?id=1933939))
+
 # v134.0 (_2023-11-25_)
 
 ## ✨ What's New ✨

--- a/components/sync_manager/android/src/test/java/mozilla/appservices/syncmanager/SyncTelemetryTest.kt
+++ b/components/sync_manager/android/src/test/java/mozilla/appservices/syncmanager/SyncTelemetryTest.kt
@@ -15,6 +15,7 @@ import mozilla.appservices.sync15.ProblemInfo
 import mozilla.appservices.sync15.SyncInfo
 import mozilla.appservices.sync15.SyncTelemetryPing
 import mozilla.appservices.sync15.ValidationInfo
+import mozilla.telemetry.glean.Glean
 import mozilla.telemetry.glean.testing.GleanTestRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -50,6 +51,15 @@ class SyncTelemetryTest {
     fun setup() {
         now = Date().asSeconds()
         pingCount = 0
+
+        // Due to recent changes in how upload enabled works, we need to register the custom
+        // Sync pings before they can be submitted properly.
+        Glean.registerPings(Pings.sync)
+        Glean.registerPings(Pings.bookmarksSync)
+        Glean.registerPings(Pings.loginsSync)
+        Glean.registerPings(Pings.creditcardsSync)
+        Glean.registerPings(Pings.addressesSync)
+        Glean.registerPings(Pings.tabsSync)
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinx-coroutines = "1.8.0"
 
 # Mozilla
 android-components = "133.0"
-glean = "62.0.0"
+glean = "63.0.0"
 rust-android-gradle = "0.9.4"
 
 # AndroidX

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.pbxproj
@@ -980,7 +980,7 @@
 			repositoryURL = "https://github.com/mozilla/glean-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 62.0.0;
+				minimumVersion = 63.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "94dc6b186acfc4720adc0bbb95f712b86bc82988e2b0c0a85e65eb1ae9a4af4c",
   "pins" : [
     {
       "identity" : "glean-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mozilla/glean-swift",
       "state" : {
-        "revision" : "5c614b4af5a1f1ffe23b46bd03696086d8ce9d0d",
-        "version" : "62.0.0"
+        "revision" : "be4fbca81f9e1da5f9b91e8bd245a8dee53cc57f",
+        "version" : "63.0.0"
       }
     }
   ],

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/NimbusTests.swift
@@ -10,8 +10,18 @@ import XCTest
 
 class NimbusTests: XCTestCase {
     override func setUp() {
+        // Due to recent changes in how upload enabled works, we need to register the custom
+        // Sync pings before they can collect data in tests, even here in Nimbus unfortunately.
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1935001 for more info.
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.sync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.historySync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.bookmarksSync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.loginsSync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.creditcardsSync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.addressesSync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.tabsSync)
+
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
     }
 
     func emptyExperimentJSON() -> String {

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
@@ -12,8 +12,19 @@ class SyncManagerTelemetryTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+
+        // Due to recent changes in how upload enabled works, we need to register the custom
+        // Sync pings before they can be submitted properly.
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.sync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.historySync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.bookmarksSync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.loginsSync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.creditcardsSync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.addressesSync)
+        Glean.shared.registerPings(GleanMetrics.Pings.shared.tabsSync)
+
         Glean.shared.resetGlean(clearStores: true)
-        Glean.shared.enableTestingMode()
+
         now = Int64(Date().timeIntervalSince1970) / BaseGleanSyncPing.MILLIS_PER_SEC
     }
 

--- a/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
+++ b/megazords/ios-rust/MozillaTestServices/MozillaTestServicesTests/SyncManagerTelemetryTests.swift
@@ -14,7 +14,8 @@ class SyncManagerTelemetryTests: XCTestCase {
         super.setUp()
 
         // Due to recent changes in how upload enabled works, we need to register the custom
-        // Sync pings before they can be submitted properly.
+        // Sync pings before they can collect data in tests.
+        // See https://bugzilla.mozilla.org/show_bug.cgi?id=1935001 for more info.
         Glean.shared.registerPings(GleanMetrics.Pings.shared.sync)
         Glean.shared.registerPings(GleanMetrics.Pings.shared.historySync)
         Glean.shared.registerPings(GleanMetrics.Pings.shared.bookmarksSync)


### PR DESCRIPTION
We reverted the update in #6520 to unblock A-S nightly updates on mozilla-central while the CI failures on Try caused by the v63.0.0 update are sorted out. Getting this submitted now so it's ready to re-land once they are.