### PR TITLE
Add appServicesRootDir attribute gradle should generally use instead …

### DIFF
--- a/components/autofill/android/build.gradle
+++ b/components/autofill/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.autofill'

--- a/components/crashtest/android/build.gradle
+++ b/components/crashtest/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.crashtest'

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -2,8 +2,8 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 ext.gleanNamespace = "mozilla.telemetry.glean"
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -2,8 +2,8 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -2,8 +2,8 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 ext.gleanYamlFiles = ["${project.projectDir}/../metrics.yaml"]
 ext.gleanNamespace = "mozilla.telemetry.glean"

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -2,9 +2,9 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/build-scripts/protobuf-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/build-scripts/protobuf-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 ext.gleanNamespace = "mozilla.telemetry.glean"
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.push'

--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.remotesettings'

--- a/components/suggest/android/build.gradle
+++ b/components/suggest/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.suggest'

--- a/components/support/android/build.gradle
+++ b/components/support/android/build.gradle
@@ -1,6 +1,6 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/build-scripts/protobuf-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/build-scripts/protobuf-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.native_support'

--- a/components/support/error/android/build.gradle
+++ b/components/support/error/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.errorsupport'

--- a/components/support/rust-log-forwarder/android/build.gradle
+++ b/components/support/rust-log-forwarder/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.rust_log_forwarder'

--- a/components/sync15/android/build.gradle
+++ b/components/sync15/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.sync15'

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -2,8 +2,8 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.

--- a/components/tabs/android/build.gradle
+++ b/components/tabs/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.remotetabs'

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -1,6 +1,6 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/build-scripts/protobuf-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/build-scripts/protobuf-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.httpconfig'

--- a/components/webext-storage/android/build.gradle
+++ b/components/webext-storage/android/build.gradle
@@ -1,7 +1,7 @@
 // TODO: Uncomment this code when webext-storage component is integrated in android
 
-// apply from: "$rootDir/build-scripts/component-common.gradle"
-// apply from: "$rootDir/publish.gradle"
+// apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+// apply from: "$appServicesRootDir/publish.gradle"
 
 // dependencies {
 //     // Part of the public API.

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -97,5 +97,5 @@ afterEvaluate {
     }
 }
 
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 ext.configurePublish()

--- a/settings.gradle
+++ b/settings.gradle
@@ -32,7 +32,12 @@ def setupProject(name, projectProps) {
 
     settings.include(":$name")
 
-    project(":$name").projectDir = new File(rootDir, path)
+    // We prefer `appServicesRootDir` over `rootDir` to help us on the path to the monorepo.
+    // (They are the same in app-services but different in moz-central)
+    def maybeAppServicesRootDir = new File(rootDir, "services/app-services")
+    def appServicesRootDir = maybeAppServicesRootDir.isDirectory() ? maybeAppServicesRootDir : rootDir;
+
+    project(":$name").projectDir = new File(appServicesRootDir, path)
 
     // project(...) gives us a skeleton project that we can't set ext.* on
     gradle.beforeProject { project ->
@@ -43,6 +48,7 @@ def setupProject(name, projectProps) {
             project.ext.artifactId = artifactId
             // Expose the rest of the project properties, mostly for validation reasons.
             project.ext.configProps = projectProps
+            project.ext.appServicesRootDir = appServicesRootDir
         }
     }
 }

--- a/tools/start-bindings/templates/build.gradle
+++ b/tools/start-bindings/templates/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.{{ crate_name }}'


### PR DESCRIPTION
…of rootDir.

The intent is that this will be the same as `rootDir` when in app-services, but magically turn into the root of the app-services tree once in mozilla-central.

The intent here is to avoid needing to touch these files after "vendoring" into m-c. @rvandermeulen does this make sense to you?