### PR TITLE
Bug 1931373 - Add FTS matching data

### DIFF
--- a/components/suggest/src/query.rs
+++ b/components/suggest/src/query.rs
@@ -143,31 +143,38 @@ impl SuggestionQuery {
         }
     }
 
-    // Other Functionality
-
-    /// Parse the `keyword` field into a set of keywords.
-    ///
-    /// This is used when passing the keywords into an FTS search.  It:
-    ///   - Strips out any `():^*"` chars.  These are typically used for advanced searches, which
-    ///     we don't support and it would be weird to only support for FTS searches, which
-    ///     currently means Fakespot searches.
-    ///   - Splits on whitespace to get a list of individual keywords
-    ///
-    pub(crate) fn parse_keywords(&self) -> Vec<&str> {
-        self.keyword
-            .split([' ', '(', ')', ':', '^', '*', '"'])
-            .filter(|s| !s.is_empty())
-            .collect()
-    }
-
     /// Create an FTS query term for our keyword(s)
-    pub(crate) fn fts_query(&self) -> String {
-        let keywords = self.parse_keywords();
+    pub(crate) fn fts_query(&self) -> FtsQuery<'_> {
+        FtsQuery::new(&self.keyword)
+    }
+}
+
+pub struct FtsQuery<'a> {
+    pub match_arg: String,
+    pub match_arg_without_prefix_match: String,
+    pub is_prefix_query: bool,
+    keyword_terms: Vec<&'a str>,
+}
+
+impl<'a> FtsQuery<'a> {
+    fn new(keyword: &'a str) -> Self {
+        // Parse the `keyword` field into a set of keywords.
+        //
+        // This is used when passing the keywords into an FTS search.  It:
+        //   - Strips out any `():^*"` chars.  These are typically used for advanced searches, which
+        //     we don't support and it would be weird to only support for FTS searches.
+        //   - splits on whitespace to get a list of individual keywords
+        let keywords = Self::split_terms(keyword);
         if keywords.is_empty() {
-            return String::from(r#""""#);
+            return Self {
+                keyword_terms: keywords,
+                match_arg: String::from(r#""""#),
+                match_arg_without_prefix_match: String::from(r#""""#),
+                is_prefix_query: false,
+            };
         }
         // Quote each term from `query` and join them together
-        let mut fts_query = keywords
+        let mut sqlite_match = keywords
             .iter()
             .map(|keyword| format!(r#""{keyword}""#))
             .collect::<Vec<_>>()
@@ -175,11 +182,46 @@ impl SuggestionQuery {
         // If the input is > 3 characters, and there's no whitespace at the end.
         // We want to append a `*` char to the end to do a prefix match on it.
         let total_chars = keywords.iter().fold(0, |count, s| count + s.len());
-        let query_ends_in_whitespace = self.keyword.ends_with(' ');
-        if (total_chars > 3) && !query_ends_in_whitespace {
-            fts_query.push('*');
+        let query_ends_in_whitespace = keyword.ends_with(' ');
+        let prefix_match = (total_chars > 3) && !query_ends_in_whitespace;
+        let sqlite_match_without_prefix_match = sqlite_match.clone();
+        if prefix_match {
+            sqlite_match.push('*');
         }
-        fts_query
+        Self {
+            keyword_terms: keywords,
+            is_prefix_query: prefix_match,
+            match_arg: sqlite_match,
+            match_arg_without_prefix_match: sqlite_match_without_prefix_match,
+        }
+    }
+
+    /// Try to figure out if a FTS match required stemming
+    ///
+    /// To test this, we have to try to mimic the SQLite FTS logic. This code doesn't do it
+    /// perfectly, but it should return the correct result most of the time.
+    pub fn match_required_stemming(&self, title: &str) -> bool {
+        let title = title.to_lowercase();
+        let split_title = Self::split_terms(&title);
+
+        !self.keyword_terms.iter().enumerate().all(|(i, keyword)| {
+            split_title.iter().any(|title_word| {
+                let last_keyword = i == self.keyword_terms.len() - 1;
+
+                if last_keyword && self.is_prefix_query {
+                    title_word.starts_with(keyword)
+                } else {
+                    title_word == keyword
+                }
+            })
+        })
+    }
+
+    fn split_terms(phrase: &str) -> Vec<&str> {
+        phrase
+            .split([' ', '(', ')', ':', '^', '*', '"', ','])
+            .filter(|s| !s.is_empty())
+            .collect()
     }
 }
 
@@ -189,7 +231,7 @@ mod test {
 
     fn check_parse_keywords(input: &str, expected: Vec<&str>) {
         let query = SuggestionQuery::all_providers(input);
-        assert_eq!(query.parse_keywords(), expected);
+        assert_eq!(query.fts_query().keyword_terms, expected);
     }
 
     #[test]
@@ -207,7 +249,7 @@ mod test {
 
     fn check_fts_query(input: &str, expected: &str) {
         let query = SuggestionQuery::all_providers(input);
-        assert_eq!(query.fts_query(), expected);
+        assert_eq!(query.fts_query().match_arg, expected);
     }
 
     #[test]
@@ -233,5 +275,25 @@ mod test {
         check_fts_query("", r#""""#);
         check_fts_query(" ", r#""""#);
         check_fts_query("()", r#""""#);
+    }
+
+    #[test]
+    fn test_fts_query_match_required_stemming() {
+        // These don't require stemming, since each keyword matches a term in the title
+        assert!(!FtsQuery::new("running shoes").match_required_stemming("running shoes"));
+        assert!(
+            !FtsQuery::new("running shoes").match_required_stemming("new balance running shoes")
+        );
+        // Case changes shouldn't matter
+        assert!(!FtsQuery::new("running shoes").match_required_stemming("Running Shoes"));
+        // This doesn't require stemming, since `:` is not part of the word
+        assert!(!FtsQuery::new("running shoes").match_required_stemming("Running: Shoes"));
+        // This requires the keywords to be stemmed in order to match
+        assert!(FtsQuery::new("run shoes").match_required_stemming("running shoes"));
+        // This didn't require stemming, since the last keyword was a prefix match
+        assert!(!FtsQuery::new("running sh").match_required_stemming("running shoes"));
+        // This does require stemming (we know it wasn't a prefix match since there's not enough
+        // characters).
+        assert!(FtsQuery::new("run").match_required_stemming("running shoes"));
     }
 }

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -96,11 +96,24 @@ pub enum Suggestion {
         icon: Option<Vec<u8>>,
         icon_mimetype: Option<String>,
         score: f64,
+        // Details about the FTS match.  For performance reasons, this is only calculated for the
+        // result with the highest score.  We assume that only one that will be shown to the user
+        // and therefore the only one we'll collect metrics for.
+        match_info: Option<FtsMatchInfo>,
     },
     Exposure {
         suggestion_type: String,
         score: f64,
     },
+}
+
+/// Additional data about how an FTS match was made
+#[derive(Debug, Clone, PartialEq, uniffi::Record)]
+pub struct FtsMatchInfo {
+    /// Was this a prefix match (`water b` matched against `water bottle`)
+    pub prefix: bool,
+    /// Did the match require stemming? (`run shoes` matched against `running shoes`)
+    pub stemming: bool,
 }
 
 impl PartialOrd for Suggestion {
@@ -183,6 +196,13 @@ impl Suggestion {
             | Self::Fakespot { score, .. }
             | Self::Exposure { score, .. } => *score,
             Self::Wikipedia { .. } => DEFAULT_SUGGESTION_SCORE,
+        }
+    }
+
+    pub fn fts_match_info(&self) -> Option<&FtsMatchInfo> {
+        match self {
+            Self::Fakespot { match_info, .. } => match_info.as_ref(),
+            _ => None,
         }
     }
 }

--- a/components/suggest/src/testing/data.rs
+++ b/components/suggest/src/testing/data.rs
@@ -4,7 +4,7 @@
 
 //! Test data that we use in many tests
 
-use crate::{testing::MockIcon, Suggestion};
+use crate::{suggestion::FtsMatchInfo, testing::MockIcon, Suggestion};
 use serde_json::json;
 use serde_json::Value as JsonValue;
 
@@ -466,7 +466,7 @@ pub fn snowglobe_fakespot() -> JsonValue {
     })
 }
 
-pub fn snowglobe_suggestion() -> Suggestion {
+pub fn snowglobe_suggestion(match_info: Option<FtsMatchInfo>) -> Suggestion {
     Suggestion::Fakespot {
         fakespot_grade: "B".into(),
         product_id: "amazon-ABC".into(),
@@ -477,6 +477,7 @@ pub fn snowglobe_suggestion() -> Suggestion {
         score: 0.3 + 0.00008,
         icon: Some("fakespot-icon-amazon-data".as_bytes().to_vec()),
         icon_mimetype: Some("image/png".into()),
+        match_info,
     }
 }
 
@@ -496,7 +497,7 @@ pub fn simpsons_fakespot() -> JsonValue {
     })
 }
 
-pub fn simpsons_suggestion() -> Suggestion {
+pub fn simpsons_suggestion(match_info: Option<FtsMatchInfo>) -> Suggestion {
     Suggestion::Fakespot {
         fakespot_grade: "A".into(),
         product_id: "vendorwithouticon-XYZ".into(),
@@ -507,6 +508,7 @@ pub fn simpsons_suggestion() -> Suggestion {
         score: 0.3 + 0.00009,
         icon: None,
         icon_mimetype: None,
+        match_info,
     }
 }
 


### PR DESCRIPTION
Added extra data to `Suggestion::Fakespot` to capture how the FTS match was made.  The plan is to use this as a facet for our metrics to help us consider how to tune the matching logic (i.e. maybe we should not use stemming, maybe we should reqiure that terms are close together).

Added Suggest CLI flag to print out the full debug repr for suggestions. This provides an easy way to test the new functionality.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
