### PR TITLE
Bug 1919541 - Implement variant handling in the search engine selector.

### DIFF
--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -39,7 +39,7 @@ pub(crate) struct JSONEngineUrl {
     /// The PrePath and FilePath of the URL. May include variables for engines
     /// which have a variable FilePath, e.g. `{searchTerm}` for when a search
     /// term is within the path of the url.
-    pub base: String,
+    pub base: Option<String>,
 
     /// The HTTP method to use to send the request (`GET` or `POST`).
     /// If the engine definition has not specified the method, it defaults to GET.
@@ -160,9 +160,28 @@ pub(crate) struct JSONVariantEnvironment {
 
 /// Describes an individual variant of a search engine.
 #[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct JSONEngineVariant {
     /// Details of the possible user environments that this variant applies to.
     pub environment: JSONVariantEnvironment,
+
+    /// This search engine is presented as an option that the user may enable.
+    /// If not specified, defaults to false.
+    #[serde(default)]
+    pub optional: bool,
+
+    /// The partner code for the engine or variant. This will be inserted into
+    /// parameters which include '{partnerCode}'
+    pub partner_code: Option<String>,
+
+    /// Suffix that is appended to the search engine identifier following a dash,
+    /// i.e. `<identifier>-<suffix>`. There should always be a suffix supplied
+    /// if the partner code is different for a reason other than being on a
+    /// different platform.
+    pub telemetry_suffix: Option<String>,
+
+    /// The urls for this variant.
+    pub urls: Option<JSONEngineUrls>,
 }
 
 /// Represents an individual engine record in the configuration.

--- a/components/search/src/selector.rs
+++ b/components/search/src/selector.rs
@@ -359,6 +359,7 @@ mod tests {
                         classification: SearchEngineClassification::General,
                         identifier: "test2".to_string(),
                         name: "Test 2".to_string(),
+                        optional: false,
                         order_hint: None,
                         partner_code: String::new(),
                         telemetry_suffix: None,
@@ -372,6 +373,182 @@ mod tests {
                             suggestions: None,
                             trending: None
                         }
+                    }
+                ),
+                app_default_engine_id: Some("test1".to_string()),
+                app_private_default_engine_id: Some("test2".to_string())
+            }
+        )
+    }
+
+    #[test]
+    fn test_filter_engine_configuration_handles_basic_variants() {
+        let selector = Arc::new(SearchEngineSelector::new());
+
+        let config_result = Arc::clone(&selector).set_search_config(
+            json!({
+              "data": [
+                {
+                  "recordType": "engine",
+                  "identifier": "test1",
+                  "partnerCode": "star",
+                  "base": {
+                    "name": "Test 1",
+                    "classification": "general",
+                    "urls": {
+                      "search": {
+                        "base": "https://example.com/1",
+                        "method": "GET",
+                        "searchTermParamName": "q"
+                      },
+                      "suggestions": {
+                        "base": "https://example.com/suggestions",
+                        "method": "POST",
+                        "params": [{
+                          "name": "type",
+                          "value": "space",
+                        }],
+                        "searchTermParamName": "suggest"
+                      },
+                      "trending": {
+                        "base": "https://example.com/trending",
+                        "method": "GET",
+                        "params": [{
+                          "name": "area",
+                          "experimentConfig": "area-param",
+                        }]
+                      }
+                    }
+                  },
+                  "variants": [{
+                    "environment": {
+                      "allRegionsAndLocales": true
+                    },
+                  },
+                  {
+                    "environment": {
+                      "regions": ["FR"]
+                    },
+                    "urls": {
+                      "search": {
+                        "method": "POST",
+                        "params": [{
+                          "name": "mission",
+                          "value": "ongoing"
+                        }]
+                      }
+                    }
+                  }],
+                },
+                {
+                  "recordType": "engine",
+                  "identifier": "test2",
+                  "base": {
+                    "name": "Test 2",
+                    "classification": "general",
+                    "urls": {
+                      "search": {
+                        "base": "https://example.com/2",
+                        "method": "GET",
+                        "searchTermParamName": "search"
+                      }
+                    }
+                  },
+                  "variants": [{
+                    "environment": {
+                      "allRegionsAndLocales": true
+                    },
+                    "partnerCode": "ship",
+                    "telemetrySuffix": "E",
+                    "optional": true
+                  }],
+                },
+                {
+                  "recordType": "defaultEngines",
+                  "globalDefault": "test1",
+                  "globalDefaultPrivate": "test2"
+                }
+              ]
+            })
+            .to_string(),
+        );
+        assert!(
+            config_result.is_ok(),
+            "Should have set the configuration successfully. {:?}",
+            config_result
+        );
+
+        let result = selector.filter_engine_configuration(SearchUserEnvironment {
+            region: "FR".into(),
+            ..Default::default()
+        });
+
+        assert!(
+            result.is_ok(),
+            "Should have filtered the configuration without error. {:?}",
+            result
+        );
+        assert_eq!(
+            result.unwrap(),
+            RefinedSearchConfig {
+                engines: vec!(
+                    SearchEngineDefinition {
+                        charset: "UTF-8".to_string(),
+                        classification: SearchEngineClassification::General,
+                        identifier: "test1".to_string(),
+                        name: "Test 1".to_string(),
+                        urls: SearchEngineUrls {
+                            search: SearchEngineUrl {
+                                base: "https://example.com/1".to_string(),
+                                method: "POST".to_string(),
+                                params: vec![SearchUrlParam {
+                                    name: "mission".to_string(),
+                                    value: Some("ongoing".to_string()),
+                                    experiment_config: None
+                                }],
+                                search_term_param_name: Some("q".to_string())
+                            },
+                            suggestions: Some(SearchEngineUrl {
+                                base: "https://example.com/suggestions".to_string(),
+                                method: "POST".to_string(),
+                                params: vec![SearchUrlParam {
+                                    name: "type".to_string(),
+                                    value: Some("space".to_string()),
+                                    experiment_config: None
+                                }],
+                                search_term_param_name: Some("suggest".to_string())
+                            }),
+                            trending: Some(SearchEngineUrl {
+                                base: "https://example.com/trending".to_string(),
+                                method: "GET".to_string(),
+                                params: vec![SearchUrlParam {
+                                    name: "area".to_string(),
+                                    value: None,
+                                    experiment_config: Some("area-param".to_string())
+                                }],
+                                search_term_param_name: None
+                            })
+                        },
+                        ..Default::default()
+                    },
+                    SearchEngineDefinition {
+                        charset: "UTF-8".to_string(),
+                        classification: SearchEngineClassification::General,
+                        identifier: "test2".to_string(),
+                        name: "Test 2".to_string(),
+                        optional: true,
+                        partner_code: "ship".to_string(),
+                        telemetry_suffix: Some("E".to_string()),
+                        urls: SearchEngineUrls {
+                            search: SearchEngineUrl {
+                                base: "https://example.com/2".to_string(),
+                                method: "GET".to_string(),
+                                params: Vec::new(),
+                                search_term_param_name: Some("search".to_string())
+                            },
+                            ..Default::default()
+                        },
+                        ..Default::default()
                     }
                 ),
                 app_default_engine_id: Some("test1".to_string()),

--- a/components/search/src/types.rs
+++ b/components/search/src/types.rs
@@ -178,6 +178,11 @@ pub struct SearchEngineDefinition {
     /// The user visible name of the search engine.
     pub name: String,
 
+    /// This search engine is presented as an option that the user may enable.
+    /// The application should not include these in the default list of the
+    /// user's engines. If not supported, it should filter them out.
+    pub optional: bool,
+
     /// The partner code for the engine. This will be inserted into parameters
     /// which include `{partnerCode}`. May be the empty string.
     pub partner_code: String,


### PR DESCRIPTION
This implements handling for search engine variants within the selector. It does not handle sub-variants at this time, that will be handled in a follow-up.

No changelog/API entries as this isn't currently used anywhere.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [X] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
