### PR TITLE
WIP: support keydb feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### `rc_crypto`
 - New low level bindings for functions for key generation with persistence, for listing persisted keys, and for wrapping and unwrapping to get at the key material of stored keys.
+- new feature `keydb` which enables key persistence via `nss::ensure_initialized_with_profile_dir`
 
 ## 🦊 What's Changed 🦊
 

--- a/components/support/rc_crypto/nss/Cargo.toml
+++ b/components/support/rc_crypto/nss/Cargo.toml
@@ -19,3 +19,4 @@ serde_derive = "1"
 [features]
 default = []
 gecko = ["nss_sys/gecko"]
+keydb = []

--- a/components/support/rc_crypto/nss/nss_sys/src/bindings/pk11pub.rs
+++ b/components/support/rc_crypto/nss/nss_sys/src/bindings/pk11pub.rs
@@ -9,6 +9,7 @@ extern "C" {
     pub fn PK11_FreeSlot(slot: *mut PK11SlotInfo);
     pub fn PK11_GetInternalSlot() -> *mut PK11SlotInfo;
     pub fn PK11_GetInternalKeySlot() -> *mut PK11SlotInfo;
+    pub fn PK11_NeedUserInit(slot: *mut PK11SlotInfo) -> PRBool;
     pub fn PK11_GenerateRandom(data: *mut c_uchar, len: c_int) -> SECStatus;
     pub fn PK11_FreeSymKey(key: *mut PK11SymKey);
     pub fn PK11_InitPin(

--- a/components/support/rc_crypto/nss/src/lib.rs
+++ b/components/support/rc_crypto/nss/src/lib.rs
@@ -17,3 +17,6 @@ pub mod pkixc;
 pub mod secport;
 pub use crate::error::{Error, ErrorKind, Result};
 pub use util::ensure_nss_initialized as ensure_initialized;
+
+#[cfg(feature = "keydb")]
+pub use util::ensure_nss_initialized_with_profile_dir as ensure_initialized_with_profile_dir;

--- a/components/support/rc_crypto/nss/src/pk11/slot.rs
+++ b/components/support/rc_crypto/nss/src/pk11/slot.rs
@@ -22,3 +22,11 @@ pub fn generate_random(data: &mut [u8]) -> Result<()> {
 pub(crate) fn get_internal_slot() -> Result<Slot> {
     unsafe { Slot::from_ptr(nss_sys::PK11_GetInternalSlot()) }
 }
+
+/// Safe wrapper around `PK11_GetInternalKeySlot` that
+/// de-allocates memory when the slot goes out of
+/// scope.
+#[cfg(feature = "keydb")]
+pub(crate) fn get_internal_key_slot() -> Result<Slot> {
+    unsafe { Slot::from_ptr(nss_sys::PK11_GetInternalKeySlot()) }
+}


### PR DESCRIPTION
This adds a feature `keydb` to rc_crypto's nss create, which enables the `ensure_initialized_with_profile_dir` initialize function. This configures NSS to use a profile and persist keys into key4.db.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
