### PR TITLE
Add NSS low-level bindings for dealing with primary password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # v136.0 (In progress)
 
+### `rc_crypto`
+- New low level bindings for dealing with primary password.
+
 [Full Changelog](In progress)
 
 # v135.0 (_2025-01-06_)

--- a/components/support/rc_crypto/nss/nss_sys/src/bindings/pk11pub.rs
+++ b/components/support/rc_crypto/nss/nss_sys/src/bindings/pk11pub.rs
@@ -9,6 +9,9 @@ extern "C" {
     pub fn PK11_FreeSlot(slot: *mut PK11SlotInfo);
     pub fn PK11_GetInternalSlot() -> *mut PK11SlotInfo;
     pub fn PK11_GetInternalKeySlot() -> *mut PK11SlotInfo;
+    pub fn PK11_NeedUserInit(slot: *mut PK11SlotInfo) -> PRBool;
+    pub fn PK11_NeedLogin(slot: *mut PK11SlotInfo) -> PRBool;
+    pub fn PK11_CheckUserPassword(slot: *mut PK11SlotInfo, password: *const c_char) -> SECStatus;
     pub fn PK11_GenerateRandom(data: *mut c_uchar, len: c_int) -> SECStatus;
     pub fn PK11_FreeSymKey(key: *mut PK11SymKey);
     pub fn PK11_InitPin(
@@ -41,6 +44,7 @@ extern "C" {
         isPerm: PRBool,
         wincx: *mut c_void,
     ) -> *mut PK11SymKey;
+    pub fn PK11_SetSymKeyNickname(key: *mut PK11SymKey, name: *const c_char) -> SECStatus;
     pub fn PK11_Derive(
         baseKey: *mut PK11SymKey,
         mechanism: CK_MECHANISM_TYPE,


### PR DESCRIPTION
This adds two low-level bindings to NSS for dealing with the primary password:
* `PK11_NeedLogin`: for checking wheather a primary password is set
* `PK11_CheckUserPassword`: for authorization with primary password

Additionally the following two low-level NSS bindings are added to deal with key persistence:
* `PK11_NeedUserInit`
* `PK11_SetSymKeyNickname`

Tested via [components/support/rc_crypto/nss/systest](../tree/main/components/support/rc_crypto/nss/systest).

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
