### PR TITLE
Update gradle files to work in both app-services and mozilla-central

### DIFF
--- a/build-scripts/component-common.gradle
+++ b/build-scripts/component-common.gradle
@@ -12,22 +12,22 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    ndkVersion rootProject.ext.build.ndkVersion
-    compileSdkVersion rootProject.ext.build.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        ndkVersion config.ndkVersion
+        compileSdkVersion config.compileSdkVersion
+
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "LIBRARY_VERSION", "\"${rootProject.ext.library.version}\"")
+        buildConfigField("String", "LIBRARY_VERSION", "\"${config.componentsVersion}\"")
     }
 
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            consumerProguardFiles "$rootDir/proguard-rules-consumer-jna.pro"
+            consumerProguardFiles "$appServicesRootDir/proguard-rules-consumer-jna.pro"
         }
     }
 
@@ -39,7 +39,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(rootProject.ext.build.jvmTargetCompatibility)
+    jvmToolchain(rootProject.config.jvmTargetCompatibility)
 }
 
 dependencies {
@@ -103,24 +103,32 @@ ext.configureUniFFIBindgen = { crateName ->
     def generateUniffiBindings = tasks.register("generateUniffiBindings") {
         def megazordNative = configurations.getByName("megazordNative")
         doFirst {
-            def libraryPath = megazordNative.asFileTree.matching {
-                include "${nativeRustTarget}/libmegazord.*"
-            }.singleFile
+            if (gradle.hasProperty("mozconfig")) {
+                def libraryPath = "${mozconfig.topobjdir}/dist/bin/libmegazord.so"
+                megazordNative = "${mozconfig.topobjdir}/dist/host/bin/embedded-uniffi-bindgen"
+                exec {
+                    workingDir project.rootDir
+                    commandLine "${mozconfig.topobjdir}/dist/host/bin/embedded-uniffi-bindgen", 'generate', '--library', libraryPath, "--crate", crateName, '--language', 'kotlin', '--out-dir', uniffiOutDir.get()
+                }
+            } else {
+                def libraryPath = megazordNative.asFileTree.matching {
+                    include "${nativeRustTarget}/libmegazord.*"
+                }.singleFile
 
-            if (libraryPath == null) {
-                throw new GradleException("libmegazord dynamic library path not found")
+                if (libraryPath == null) {
+                    throw new GradleException("libmegazord dynamic library path not found")
+                }
+                exec {
+                    workingDir project.rootDir
+                    commandLine '/usr/bin/env', 'cargo', 'uniffi-bindgen', 'generate', '--library', libraryPath, "--crate", crateName, '--language', 'kotlin', '--out-dir', uniffiOutDir.get()
+                }
             }
-            exec {
-                workingDir project.rootDir
-                commandLine '/usr/bin/env', 'cargo', 'uniffi-bindgen', 'generate', '--library', libraryPath, "--crate", crateName, '--language', 'kotlin', '--out-dir', uniffiOutDir.get()
-            }
-
         }
         outputs.dir uniffiOutDir
         // Re-generate when the native megazord library is rebuilt
         inputs.files megazordNative
         // Re-generate if our uniffi-bindgen tooling changes.
-        inputs.dir "${project.rootDir}/tools/embedded-uniffi-bindgen/"
+        inputs.dir "${project.appServicesRootDir}/tools/embedded-uniffi-bindgen/"
     }
 
     afterEvaluate {
@@ -130,7 +138,9 @@ ext.configureUniFFIBindgen = { crateName ->
             def compileTask = tasks["compile${variantName}Kotlin"]
 
             compileTask.dependsOn(generateUniffiBindings)
-            variant.registerJavaGeneratingTask(generateUniffiBindings, megazordNative.singleFile)
+            if (!gradle.hasProperty("mozconfig")) { // XXX - needs uniffi-bindgen love in m-c
+                variant.registerJavaGeneratingTask(generateUniffiBindings, megazordNative.singleFile)
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,6 @@
 
 buildscript {
     ext.build = [
-        ndkVersion: "28.0.13004108", // Keep it in sync in TC Dockerfile.
-
         // In general, we should aim to keep these in sync with AC
         compileSdkVersion: 35,
         targetSdkVersion: 35,
@@ -200,8 +198,7 @@ ext.rustTargets += ext.nativeRustTarget
 ext.libsRootDir = useDownloadedLibs ? rootProject.buildDir : rootProject.rootDir
 
 subprojects {
-    group = "org.mozilla.appservices"
-    apply plugin: 'maven-publish'
+    // Note we apply some plugins to the subprojects in settings.gradle to help with the m-c migration.
 
     // Kotlin settings applicable to all modules.
     afterEvaluate{

--- a/components/autofill/android/build.gradle
+++ b/components/autofill/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.autofill'

--- a/components/crashtest/android/build.gradle
+++ b/components/crashtest/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.crashtest'

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -2,8 +2,8 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 ext.gleanNamespace = "mozilla.telemetry.glean"
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -2,8 +2,8 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -2,8 +2,8 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 ext.gleanYamlFiles = ["${project.projectDir}/../metrics.yaml"]
 ext.gleanNamespace = "mozilla.telemetry.glean"

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -2,9 +2,8 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/build-scripts/protobuf-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 ext.gleanNamespace = "mozilla.telemetry.glean"
 apply plugin: "org.mozilla.telemetry.glean-gradle-plugin"

--- a/components/push/android/build.gradle
+++ b/components/push/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.push'

--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.remotesettings'

--- a/components/suggest/android/build.gradle
+++ b/components/suggest/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.suggest'

--- a/components/support/android/build.gradle
+++ b/components/support/android/build.gradle
@@ -1,6 +1,6 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/build-scripts/protobuf-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/build-scripts/protobuf-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.native_support'

--- a/components/support/error/android/build.gradle
+++ b/components/support/error/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.errorsupport'

--- a/components/support/rust-log-forwarder/android/build.gradle
+++ b/components/support/rust-log-forwarder/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.rust_log_forwarder'

--- a/components/sync15/android/build.gradle
+++ b/components/sync15/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.sync15'

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -2,8 +2,8 @@ plugins {
     alias libs.plugins.gradle.python.envs
 }
 
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 // Needs to happen before `dependencies` in order for the variables
 // exposed by the plugin to be available for this project.

--- a/components/tabs/android/build.gradle
+++ b/components/tabs/android/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.remotetabs'

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -1,6 +1,6 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/build-scripts/protobuf-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/build-scripts/protobuf-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.httpconfig'

--- a/components/webext-storage/android/build.gradle
+++ b/components/webext-storage/android/build.gradle
@@ -1,7 +1,7 @@
 // TODO: Uncomment this code when webext-storage component is integrated in android
 
-// apply from: "$rootDir/build-scripts/component-common.gradle"
-// apply from: "$rootDir/publish.gradle"
+// apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+// apply from: "$appServicesRootDir/publish.gradle"
 
 // dependencies {
 //     // Part of the public API.

--- a/docs/howtos/upgrades/android.md
+++ b/docs/howtos/upgrades/android.md
@@ -18,7 +18,7 @@ This specifies what we use to build our code.
 Keep this in sync with the version Firefox Android is using.
 Update the version number in:
 
-* `build.gradle`
+* `settings.gradle`
 * `taskcluster/docker/linux/Dockerfile`
 
 ## Target / minimum versions
@@ -27,14 +27,14 @@ These control which devices the library is compatible with and control which ver
 Keep this in sync with the version Firefox Android is using.
 Update the version number in:
 
-* `build.gradle`
+* `settings.gradle`
 
 # Android NDK (Native Development Kit)
 
 The Android NDK is the toolset we use for cross-compiling our Rust code so that Firefox Android can dynamically link to it.
 
 * Update the version number in:
-  * `build.gradle` (search for `ndkVersion`)
+  * `settings.gradle` (search for `ndkVersion`)
   * `taskcluster/docker/linux/Dockerfile` (search for `ANDROID_NDK_VERSION`)
   * `components/support/rc_crypto/nss/nss_build_common/src/lib.rs` (search for `ANDROID_NDK_VERSION`)
 * Update these docs by replacing the old version with the new one:

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -1,19 +1,21 @@
 apply plugin: 'com.android.library'
-apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
 apply plugin: 'kotlin-android'
+
+if (!gradle.hasProperty("mozconfig")) {
+    apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
+}
 
 android {
     namespace 'org.mozilla.appservices.full_megazord'
 
-    ndkVersion rootProject.ext.build.ndkVersion
-    compileSdkVersion rootProject.ext.build.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion rootProject.ext.build['minSdkVersion']
-        targetSdkVersion rootProject.ext.build['targetSdkVersion']
+        ndkVersion config.ndkVersion
+        compileSdkVersion config.compileSdkVersion
+        minSdkVersion config.minSdkVersion
+        targetSdkVersion config.targetSdkVersion
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-        buildConfigField("String", "LIBRARY_VERSION", "\"${rootProject.ext.library.version}\"")
+        buildConfigField("String", "LIBRARY_VERSION", "\"${config.componentsVersion}\"")
     }
 
     buildTypes {
@@ -29,7 +31,7 @@ android {
 }
 
 kotlin {
-    jvmToolchain(rootProject.ext.build.jvmTargetCompatibility)
+    jvmToolchain(rootProject.config.jvmTargetCompatibility)
 }
 
 // Configurations are a somewhat mysterious Gradle concept.  For our purposes, we can treat them
@@ -70,66 +72,67 @@ dependencies {
     }
 }
 
-// Extract JNI dispatch libraries from the JAR into a directory, so that we can then package them
-// into our own megazord-desktopLibraries JAR.
-def extractLibJniDispatch = tasks.register("extractLibJniDispatch", Copy) {
-    from zipTree(configurations.jna.singleFile).matching {
-        include "**/libjnidispatch.*"
-    }
-    into layout.buildDirectory.dir("libjnidispatch").get()
-}
-
-def packageLibsForTest = tasks.register("packageLibsForTest", Jar) {
-    archiveBaseName = "full-megazord-libsForTests"
-
-    from extractLibJniDispatch
-    from layout.buildDirectory.dir("rustJniLibs/desktop")
-    dependsOn tasks["cargoBuild${rootProject.ext.nativeRustTarget.capitalize()}"]
-}
-
-def copyMegazordNative = tasks.register("copyMegazordNative", Copy) {
-    from layout.buildDirectory.dir("rustJniLibs/desktop")
-    into layout.buildDirectory.dir("megazordNative")
-}
-
-
-artifacts {
-    // Connect task output to the configurations
-    libsForTests(packageLibsForTest)
-    megazordNative(copyMegazordNative)
-}
-
-cargo {
-    // The directory of the Cargo.toml to build.
-    module = '..'
-
-    // The Android NDK API level to target.
-    apiLevel = rootProject.ext.build['minSdkVersion']
-
-    // Where Cargo writes its outputs.
-    targetDirectory = '../../../target'
-
-    libname = 'megazord'
-
-    // The Cargo targets to invoke.  The mapping from short name to target
-    // triple is defined by the `rust-android-gradle` plugin.
-    targets = rootProject.ext.rustTargets
-
-    // Perform release builds (which should have debug info, due to
-    // `debug = true` in Cargo.toml).
-    profile = "release"
-
-    exec = { spec, toolchain ->
-        rootProject.ext.cargoExec(spec, toolchain)
-        // Only used in the full megazord (that is, in this project) at build time.
-        spec.environment("MEGAZORD_VERSION", rootProject.ext.library.version)
+if (!gradle.hasProperty("mozconfig")) {
+    // Extract JNI dispatch libraries from the JAR into a directory, so that we can then package them
+    // into our own megazord-desktopLibraries JAR.
+    def extractLibJniDispatch = tasks.register("extractLibJniDispatch", Copy) {
+        from zipTree(configurations.jna.singleFile).matching {
+            include "**/libjnidispatch.*"
+        }
+        into layout.buildDirectory.dir("libjnidispatch").get()
     }
 
-    extraCargoBuildArguments = rootProject.ext.extraCargoBuildArguments
+    def packageLibsForTest = tasks.register("packageLibsForTest", Jar) {
+        archiveBaseName = "full-megazord-libsForTests"
 
-    // Add a build-id so that our code works with simpleperf
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1937916
-    generateBuildId = true
+        from extractLibJniDispatch
+        from layout.buildDirectory.dir("rustJniLibs/desktop")
+        dependsOn tasks["cargoBuild${rootProject.ext.nativeRustTarget.capitalize()}"]
+    }
+
+    def copyMegazordNative = tasks.register("copyMegazordNative", Copy) {
+        from layout.buildDirectory.dir("rustJniLibs/desktop")
+        into layout.buildDirectory.dir("megazordNative")
+    }
+
+    artifacts {
+        // Connect task output to configurations
+        libsForTests(packageLibsForTest)
+        megazordNative(copyMegazordNative)
+    }
+
+    cargo {
+        // The directory of the Cargo.toml to build.
+        module = '..'
+
+        // The Android NDK API level to target.
+        apiLevel = rootProject.config.minSdkVersion
+
+        // Where Cargo writes its outputs.
+        targetDirectory = '../../../target'
+
+        libname = 'megazord'
+
+        // The Cargo targets to invoke.  The mapping from short name to target
+        // triple is defined by the `rust-android-gradle` plugin.
+        targets = rootProject.ext.rustTargets
+
+        // Perform release builds (which should have debug info, due to
+        // `debug = true` in Cargo.toml).
+        profile = "release"
+
+        exec = { spec, toolchain ->
+            rootProject.ext.cargoExec(spec, toolchain)
+            // Only used in the full megazord (that is, in this project) at build time.
+            spec.environment("MEGAZORD_VERSION", config.componentsVersion)
+        }
+
+        extraCargoBuildArguments = rootProject.ext.extraCargoBuildArguments
+
+        // Add a build-id so that our code works with simpleperf
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=1937916
+        generateBuildId = true
+    }
 }
 
 afterEvaluate {
@@ -139,57 +142,61 @@ afterEvaluate {
         variant.productFlavors.each {
             productFlavor += "${it.name.capitalize()}"
         }
-        def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(tasks["cargoBuild"])
+        if (!gradle.hasProperty("mozconfig")) {
+            def buildType = "${variant.buildType.name.capitalize()}"
+            tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(tasks["cargoBuild"])
+        }
     }
 }
 
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 ext.configurePublish()
 
-afterEvaluate {
-    publishing {
-        publications {
-            // Publish a second package named `full-megazord-libsForTests` to Maven with the
-            // `libsForTests` output.  This contains the same content as our `libsForTests`
-            // configuration. Publishing it allows the android-components code to depend on it.
-            libsForTests(MavenPublication) {
-                artifact tasks['packageLibsForTest']
-                artifact file("${projectDir}/../DEPENDENCIES.md"), {
-                    extension "LICENSES.md"
-                }
-                pom {
-                    groupId = rootProject.ext.library.groupId
-                    artifactId = "${project.ext.artifactId}-libsForTests"
-                    description = project.ext.description
-                    // For mavenLocal publishing workflow, increment the version number every publish.
-                    version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
-                    packaging = "jar"
+if (!gradle.hasProperty("mozconfig")) {
+    afterEvaluate {
+        publishing {
+            publications {
+                // Publish a second package named `full-megazord-libsForTests` to Maven with the
+                // `libsForTests` output.  This contains the same content as our `libsForTests`
+                // configuration. Publishing it allows the android-components code to depend on it.
+                libsForTests(MavenPublication) {
+                    artifact tasks['packageLibsForTest']
+                    artifact file("${projectDir}/../DEPENDENCIES.md"), {
+                        extension "LICENSES.md"
+                    }
+                    pom {
+                        groupId = rootProject.config.componentsGroupId
+                        artifactId = "${project.ext.artifactId}-libsForTests"
+                        description = project.ext.description
+                        // For mavenLocal publishing workflow, increment the version number every publish.
+                        version = rootProject.config.componentsVersion + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
+                        packaging = "jar"
 
-                    licenses {
-                        license {
-                            name = libLicense
-                            url = libLicenseUrl
+                        licenses {
+                            license {
+                                name = libLicense
+                                url = libLicenseUrl
+                            }
+                        }
+
+                        developers {
+                            developer {
+                                name = 'Sync Team'
+                                email = 'sync-team@mozilla.com'
+                            }
+                        }
+
+                        scm {
+                            connection = libVcsUrl
+                            developerConnection = libVcsUrl
+                            url = libUrl
                         }
                     }
 
-                    developers {
-                        developer {
-                            name = 'Sync Team'
-                            email = 'sync-team@mozilla.com'
-                        }
-                    }
-
-                    scm {
-                        connection = libVcsUrl
-                        developerConnection = libVcsUrl
-                        url = libUrl
-                    }
+                    // This is never the publication we want to use when publishing a
+                    // parent project with us as a child `project()` dependency.
+                    alias = true
                 }
-
-                // This is never the publication we want to use when publishing a
-                // parent project with us as a child `project()` dependency.
-                alias = true
             }
         }
     }

--- a/publish.gradle
+++ b/publish.gradle
@@ -10,7 +10,7 @@ def libUrl = properties.libUrl
 def libVcsUrl = properties.libVcsUrl
 
 ext.configurePublish = {
-    def theGroupId = rootProject.ext.library.groupId
+    def theGroupId = rootProject.config.componentsGroupId
     def theArtifactId = project.ext.artifactId
     def theDescription = project.ext.description
 
@@ -42,7 +42,7 @@ ext.configurePublish = {
                     // For mavenLocal publishing workflow, increment the version number every publish.
                     // We only do this to the .pom file and not in $MEGAZORD_VERSION, because otherwise we
                     // would need to rebuild the megazord .so on every publish, even if nothing else had changed.
-                    version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
+                    version = rootProject.config.componentsVersion + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
                     packaging = "aar"
 
                     license {

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import org.yaml.snakeyaml.Yaml
 
-includeBuild('tools/nimbus-gradle-plugin') {
+// We prefer `appServicesRootDir` over `rootDir` to help us on the path to the monorepo.
+// (They are the same in app-services but different in moz-central)
+def maybeAppServicesRootDir = new File(rootDir, "services/app-services")
+def appServicesRootDir = maybeAppServicesRootDir.isDirectory() ? maybeAppServicesRootDir : rootDir;
+
+
+includeBuild("$appServicesRootDir/tools/nimbus-gradle-plugin") {
     dependencySubstitution {
         substitute module("org.mozilla.appservices:tooling-nimbus-gradle") using(project(':'))
     }
@@ -20,7 +26,7 @@ buildscript {
 
 rootProject.name = "appservices"
 
-def setupProject(name, projectProps) {
+def setupProject(name, projectProps, appServicesRootDir) {
     def path = projectProps.path
     def description = projectProps.description
     def artifactId = projectProps.artifactId
@@ -32,10 +38,14 @@ def setupProject(name, projectProps) {
 
     settings.include(":$name")
 
-    project(":$name").projectDir = new File(rootDir, path)
+    project(":$name").projectDir = new File(appServicesRootDir, path)
 
     // project(...) gives us a skeleton project that we can't set ext.* on
     gradle.beforeProject { project ->
+        // applying this plugin to our sub-projects here makes life much easier for m-c.
+        // Once in m-c, we can probably just remove all publishing capabilities from these crates entirely?
+        project.apply plugin: 'maven-publish'
+
         // However, the "afterProject" listener iterates over every project and gives us the actual project
         // So, once we filter for the project we care about, we can set whatever we want
         if (project.name == name) {
@@ -43,14 +53,19 @@ def setupProject(name, projectProps) {
             project.ext.artifactId = artifactId
             // Expose the rest of the project properties, mostly for validation reasons.
             project.ext.configProps = projectProps
+            project.ext.appServicesRootDir = appServicesRootDir
+
+            if (gradle.hasProperty("mozconfig")) {
+                project.buildDir = "${gradle.mozconfig.topobjdir}/gradle/build/app-services/android/$name"
+            }
         }
     }
 }
 
 def yaml = new Yaml()
-def buildconfig = yaml.load(new File(rootDir, '.buildconfig-android.yml').newInputStream())
+def buildconfig = yaml.load(new File(appServicesRootDir, '.buildconfig-android.yml').newInputStream())
 buildconfig.projects.each { project ->
-    setupProject(project.key, project.value)
+    setupProject(project.key, project.value, appServicesRootDir)
 }
 
 Properties localProperties = new Properties();
@@ -66,14 +81,20 @@ if (file('local.properties').canRead()) {
 
 def calcVersion(buildconfig) {
     def local = gradle.rootProject.findProperty("local")
-    def version = new File(rootDir, 'version.txt').getText().trim()
 
-    if (gradle.rootProject.hasProperty("nightlyVersion")) {
+    if (gradle.hasProperty("mozconfig")) {
+        // We are in m-c - XXX - this is temporary - once in m-c this will not be called, but this seems sane for now?
+        def buildid = file("${gradle.mozconfig.topobjdir}/buildid.h").getText('utf-8').split()[2]
+        return "${gradle.mozconfig.substs.MOZ_APP_VERSION}-${buildid}"
+    } else if (gradle.rootProject.hasProperty("nightlyVersion")) {
+        // We are in app-services but building a "nightly" version to be consumed by Fenix.
         return gradle.rootProject.nightlyVersion
     } else if(local) {
+        // We are doing a local publish
         return '0.0.1-SNAPSHOT'
     } else {
-        return version
+        // A normal build from app-services.
+        return new File(rootDir, 'version.txt').getText().trim()
     }
 }
 
@@ -85,17 +106,57 @@ def calcGroupId(buildconfig) {
     }
 }
 
+// This is a copy of the `Config` object used in moz-central (but with the addition of ndkVersion for UniFFI)
+// This is only used when not in mozilla-central - on m-c the existing Config class is used.
+// In the short term we should keep them in sync.
+// Once in moz-central we should remove this.
+class Config {
+    // This "componentsVersion" number is defined in "version.txt" and should follow
+    // semantic versioning (MAJOR.MINOR.PATCH). See https://semver.org/
+    public final String componentsVersion
+    public final String componentsGroupId
+    public final Integer jvmTargetCompatibility
+    public final Integer compileSdkVersion
+    public final Integer minSdkVersion
+    public final Integer targetSdkVersion
+    public final String ndkVersion
+
+    Config(
+            String componentsVersion,
+            String componentsGroupId,
+            Integer jvmTargetCompatibility,
+            Integer compileSdkVersion,
+            Integer minSdkVersion,
+            Integer targetSdkVersion,
+            String ndkVersion
+    ) {
+        this.componentsVersion = componentsVersion
+        this.componentsGroupId = componentsGroupId
+        this.jvmTargetCompatibility = jvmTargetCompatibility
+        this.compileSdkVersion = compileSdkVersion
+        this.minSdkVersion = minSdkVersion
+        this.targetSdkVersion = targetSdkVersion
+        this.ndkVersion = ndkVersion
+    }
+}
 
 gradle.projectsLoaded { ->
     // Wait until root project is "loaded" before we set "config"
     // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
     // gradle files. This means that they can just access "config.<value>", and it'll function properly
-    gradle.rootProject.ext.library = [
-        // You can use -Plocal=true to help with mavenLocal publishing workflow.
-        // It makes a fake version number that's smaller than any published version,
-        // which can be depended on specifically by the ./build-scripts/substitute-local-appservices.gradle
-        // but which is unlikely to be depended on by accident otherwise.
-        version: calcVersion(buildconfig),
-        groupId: calcGroupId(buildconfig),
-    ]
+    if (!gradle.hasProperty("mozconfig")) {
+        gradle.rootProject.ext.config = new Config(
+            // You can use -Plocal=true to help with mavenLocal publishing workflow.
+            // It makes a fake version number that's smaller than any published version,
+            // which can be depended on specifically by the ./build-scripts/substitute-local-appservices.gradle
+            // but which is unlikely to be depended on by accident otherwise.
+            calcVersion(buildconfig), // version,
+            calcGroupId(buildconfig), // componentsGroupId
+            17, // jvmTargetCompatibility,
+            35, // compileSdkVersion,
+            21, // minSdkVersion,
+            35, // targetSdkVersion,
+            "28.0.13004108", // ndkVersion - Keep it in sync in TC Dockerfile.
+        )
+    }
 }

--- a/tools/nimbus-gradle-plugin/build.gradle
+++ b/tools/nimbus-gradle-plugin/build.gradle
@@ -34,7 +34,7 @@ repositories {
 // any tokens (values wrapped in `@`s) with the value for that key in the tokens object.
 processResources {
     filter ReplaceTokens, tokens: [
-            'project.version': rootProject.ext.library.version
+            'project.version': rootProject.config.componentsVersion
     ]
 }
 
@@ -91,10 +91,10 @@ publishing {
             from components.java
 
             pom {
-                groupId = rootProject.ext.library.groupId
+                groupId = rootProject.config.componentsGroupId
                 artifactId = archivesBaseName
                 description = project.ext.description
-                version = rootProject.ext.library.version + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
+                version = rootProject.config.componentsVersion + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
 
                 licenses {
                     license {

--- a/tools/nimbus-gradle-plugin/settings.gradle
+++ b/tools/nimbus-gradle-plugin/settings.gradle
@@ -30,6 +30,7 @@ def calcVersion(buildconfig) {
 
 gradle.projectsLoaded { ->
     // Wait until root project is "loaded" before we set "config"
+    // XXX - there's no "config" here. This should be upgraded to use the same mechanism as the other components?
     // Note that since this is set on "rootProject.ext", it will be "in scope" during the evaluation of all projects'
     // gradle files. This means that they can just access "config.<value>", and it'll function properly
     gradle.rootProject.ext.library = [

--- a/tools/start-bindings/templates/build.gradle
+++ b/tools/start-bindings/templates/build.gradle
@@ -1,5 +1,5 @@
-apply from: "$rootDir/build-scripts/component-common.gradle"
-apply from: "$rootDir/publish.gradle"
+apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+apply from: "$appServicesRootDir/publish.gradle"
 
 android {
     namespace 'org.mozilla.appservices.{{ crate_name }}'


### PR DESCRIPTION
Newer version of #6530

There are 3 commits here, mainly as some might be more controversial than others:

* first commit is use `appServicesRootDir` rather than `rootDir`; no real functionality changes just a way so gradle works roughly the same in both places.
* second commit moves app-services to use the same shaped [`Config` object as m-c](https://searchfox.org/mozilla-central/rev/f53c09a22edc700ab1a9eaaf4da0f0dd9f11bff3/mobile/android/shared-settings.gradle#39-63). When app-services is in m-c, we end up using the `Config` object from m-c - the app-services version of this object is just for use in app-services so the same gradle code works in both places. Given some comments in the source it appears we maybe used to do that?
* Last commit is where some behaviour changes are implemented depending on whether we are in m-c or app-services. In particular, the code checks `gradle.hasProperty("mozconfig")` if it needs to do something different based on the location. For now, that means things like disabling the cargo-gradle plugin and changing how uniffi-bindgen is run, etc. The implemented behaviour should be correct in app-services, but might be less so in m-c for now (eg, currently we just disable uniffi-bindgen, whereas ultimately we obviously still need to run it, once I work out how!)

