### PR TITLE
Removing nss dependency from sql-support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4796,7 +4796,6 @@ dependencies = [
  "interrupt-support",
  "lazy_static",
  "log",
- "nss_build_common",
  "parking_lot",
  "rusqlite",
  "tempfile",

--- a/components/support/sql/Cargo.toml
+++ b/components/support/sql/Cargo.toml
@@ -24,6 +24,3 @@ rusqlite = { version = "0.31.0", features = ["functions", "limits", "bundled", "
 
 [dev-dependencies]
 env_logger = {version = "0.10", default-features = false}
-
-[build-dependencies]
-nss_build_common = { path = "../rc_crypto/nss/nss_build_common" }


### PR DESCRIPTION
We stopped using this in 4bc525e8eec13f0ec91a9397e7e622128cf6e6ff, but the build-dependency was never removed.  It's now causing taskcluster build issues with nimbus-cli.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
