### PR TITLE
Bug 1937916 - Add build-id to Android builds

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinx-coroutines = "1.8.0"
 # Mozilla
 android-components = "133.0"
 glean = "63.0.0"
-rust-android-gradle = "0.9.5"
+rust-android-gradle = "0.9.6"
 
 # AndroidX
 androidx-annotation = "1.9.1"

--- a/megazords/full/android/build.gradle
+++ b/megazords/full/android/build.gradle
@@ -126,6 +126,10 @@ cargo {
     }
 
     extraCargoBuildArguments = rootProject.ext.extraCargoBuildArguments
+
+    // Add a build-id so that our code works with simpleperf
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1937916
+    generateBuildId = true
 }
 
 afterEvaluate {


### PR DESCRIPTION
Upgrade rust-android-gradle and set the `generateBuildId` flag.

See https://github.com/mozilla/rust-android-gradle/pull/159 for details.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
