### PR TITLE
One more fix for the taskcluster build.

### DIFF
--- a/taskcluster/scripts/nimbus-build.py
+++ b/taskcluster/scripts/nimbus-build.py
@@ -28,6 +28,10 @@ def main():
         [
             "cargo",
             "build",
+            # Need to specify both --package and --bin, or else cargo will enable the features for
+            # all binaries, which will probably lead to a failure when trying to build NSS.
+            "--package",
+            binary,
             "--bin",
             binary,
             "--release",


### PR DESCRIPTION
For some weird reason, the old command line was enabling the features for all binaries.  Since the remote settings CLI depends on rc_crypto, this was causing failures when trying to build NSS.  Adding the `-p` flag, fixes this.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
