### PR TITLE
Bug 1938922 - Implement sub-variant handling in the search engine selector.

### DIFF
--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -81,6 +81,7 @@ pub(crate) struct JSONEngineBase {
     /// The classification of search engine according to the main search types
     /// (e.g. general, shopping, travel, dictionary). Currently, only marking as
     /// a general search engine is supported.
+    #[serde(default)]
     pub classification: SearchEngineClassification,
 
     /// The user visible name for the search engine.
@@ -182,6 +183,15 @@ pub(crate) struct JSONEngineVariant {
 
     /// The urls for this variant.
     pub urls: Option<JSONEngineUrls>,
+
+    /// This section describes subvariations of this search engine that may occur
+    /// depending on the user's environment. The last subvariant that matches
+    /// the user's environment will be applied to the engine.
+    ///
+    /// Note: sub-variants are only supported in a top-level variant. You cannot
+    /// have nested sub-variants.
+    #[serde(default)]
+    pub sub_variants: Vec<JSONEngineVariant>,
 }
 
 /// Represents an individual engine record in the configuration.

--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -59,7 +59,7 @@ pub(crate) struct JSONEngineUrl {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct JSONEngineUrls {
     /// The URL to use for searches.
-    pub search: JSONEngineUrl,
+    pub search: Option<JSONEngineUrl>,
 
     /// The URL to use for suggestions.
     pub suggestions: Option<JSONEngineUrl>,

--- a/components/search/src/filter.rs
+++ b/components/search/src/filter.rs
@@ -40,7 +40,7 @@ impl JSONEngineUrl {
 impl From<JSONEngineUrls> for SearchEngineUrls {
     fn from(urls: JSONEngineUrls) -> Self {
         Self {
-            search: urls.search.into(),
+            search: urls.search.unwrap_or_default().into(),
             suggestions: urls.suggestions.map(|suggestions| suggestions.into()),
             trending: urls.trending.map(|trending| trending.into()),
         }
@@ -65,7 +65,7 @@ impl JSONEngineUrls {
     /// `preferred` object.
     fn merge(original: Self, preferred: JSONEngineUrls) -> Self {
         Self {
-            search: JSONEngineUrl::merge(original.search, preferred.search),
+            search: JSONEngineUrls::maybe_merge_urls(original.search, preferred.search),
             suggestions: JSONEngineUrls::maybe_merge_urls(
                 original.suggestions,
                 preferred.suggestions,
@@ -264,12 +264,12 @@ mod tests {
                 name: "Test".to_string(),
                 partner_code: None,
                 urls: JSONEngineUrls {
-                    search: JSONEngineUrl {
+                    search: Some(JSONEngineUrl {
                         base: Some("https://example.com".to_string()),
                         method: None,
                         params: None,
                         search_term_param_name: None,
-                    },
+                    }),
                     suggestions: None,
                     trending: None,
                 },
@@ -319,7 +319,7 @@ mod tests {
         name: "Test".to_string(),
         partner_code: Some("firefox".to_string()),
         urls: JSONEngineUrls {
-            search: JSONEngineUrl {
+            search: Some(JSONEngineUrl {
                 base: Some("https://example.com".to_string()),
                 method: Some(crate::JSONEngineMethod::Post),
                 params: Some(vec![SearchUrlParam {
@@ -328,7 +328,7 @@ mod tests {
                     experiment_config: None,
                 }]),
                 search_term_param_name: Some("baz".to_string()),
-            },
+            }),
             suggestions: Some(JSONEngineUrl {
                 base: Some("https://example.com/suggestions".to_string()),
                 method: Some(crate::JSONEngineMethod::Get),
@@ -431,7 +431,7 @@ mod tests {
                 partner_code: Some("trek".to_string()),
                 telemetry_suffix: Some("star".to_string()),
                 urls: Some(JSONEngineUrls {
-                    search: JSONEngineUrl {
+                    search: Some(JSONEngineUrl {
                         base: Some("https://example.com/variant".to_string()),
                         method: Some(JSONEngineMethod::Get),
                         params: Some(vec![SearchUrlParam {
@@ -440,7 +440,7 @@ mod tests {
                             experiment_config: None,
                         }]),
                         search_term_param_name: Some("ship".to_string()),
-                    },
+                    }),
                     suggestions: Some(JSONEngineUrl {
                         base: Some("https://example.com/suggestions-variant".to_string()),
                         method: Some(JSONEngineMethod::Get),

--- a/components/search/src/filter.rs
+++ b/components/search/src/filter.rs
@@ -22,17 +22,19 @@ impl From<JSONEngineUrl> for SearchEngineUrl {
     }
 }
 
-impl JSONEngineUrl {
-    /// Merges two `JSONEngineUrl` objects, preferring the values from the
-    /// `preferred` object.
-    fn merge(original: Self, preferred: Self) -> Self {
-        Self {
-            base: preferred.base.or(original.base),
-            method: preferred.method.or(original.method),
-            params: preferred.params.or(original.params),
-            search_term_param_name: preferred
-                .search_term_param_name
-                .or(original.search_term_param_name),
+impl SearchEngineUrl {
+    fn merge(&mut self, preferred: &JSONEngineUrl) {
+        if let Some(base) = &preferred.base {
+            self.base = base.clone();
+        }
+        if let Some(method) = &preferred.method {
+            self.method = method.as_str().to_string();
+        }
+        if let Some(params) = &preferred.params {
+            self.params = params.clone();
+        }
+        if let Some(search_term_param_name) = &preferred.search_term_param_name {
+            self.search_term_param_name = Some(search_term_param_name.clone());
         }
     }
 }
@@ -47,46 +49,49 @@ impl From<JSONEngineUrls> for SearchEngineUrls {
     }
 }
 
-impl JSONEngineUrls {
-    fn maybe_merge_urls(
-        original_url: Option<JSONEngineUrl>,
-        preferred_url: Option<JSONEngineUrl>,
-    ) -> Option<JSONEngineUrl> {
-        match (&original_url, &preferred_url) {
-            (Some(original), Some(preferred)) => {
-                Some(JSONEngineUrl::merge(original.clone(), preferred.clone()))
-            }
-            (None, Some(preferred)) => Some(preferred.clone()),
-            _ => original_url.clone(),
+impl SearchEngineUrls {
+    fn merge(&mut self, preferred: &JSONEngineUrls) {
+        if let Some(search_url) = &preferred.search {
+            self.search.merge(search_url);
         }
-    }
-
-    /// Merges two `JSONEngineUrl` objects, preferring the values from the
-    /// `preferred` object.
-    fn merge(original: Self, preferred: JSONEngineUrls) -> Self {
-        Self {
-            search: JSONEngineUrls::maybe_merge_urls(original.search, preferred.search),
-            suggestions: JSONEngineUrls::maybe_merge_urls(
-                original.suggestions,
-                preferred.suggestions,
-            ),
-            trending: JSONEngineUrls::maybe_merge_urls(original.trending, preferred.trending),
+        if let Some(suggestions_url) = &preferred.suggestions {
+            match &mut self.suggestions {
+                Some(suggestion) => suggestion.merge(suggestions_url),
+                None => self.suggestions = Some(suggestions_url.clone().into()),
+            };
+        }
+        if let Some(trending_url) = &preferred.trending {
+            match &mut self.trending {
+                Some(trend) => trend.merge(trending_url),
+                None => self.suggestions = Some(trending_url.clone().into()),
+            };
         }
     }
 }
 
 impl SearchEngineDefinition {
+    fn merge_variant(&mut self, variant: &JSONEngineVariant) {
+        if !self.optional {
+            self.optional = variant.optional;
+        }
+        if let Some(partner_code) = &variant.partner_code {
+            self.partner_code = partner_code.clone();
+        }
+        if let Some(telemetry_suffix) = &variant.telemetry_suffix {
+            self.telemetry_suffix = telemetry_suffix.clone();
+        }
+        if let Some(urls) = &variant.urls {
+            self.urls.merge(urls);
+        }
+    }
+
     pub(crate) fn from_configuration_details(
         identifier: &str,
         base: JSONEngineBase,
-        variant: JSONEngineVariant,
+        variant: &JSONEngineVariant,
+        sub_variant: &Option<JSONEngineVariant>,
     ) -> SearchEngineDefinition {
-        let urls: JSONEngineUrls = match variant.urls {
-            Some(urls) => JSONEngineUrls::merge(base.urls, urls),
-            None => base.urls,
-        };
-
-        SearchEngineDefinition {
+        let mut engine_definition = SearchEngineDefinition {
             aliases: base.aliases.unwrap_or_default(),
             charset: base.charset.unwrap_or_else(|| "UTF-8".to_string()),
             classification: base.classification,
@@ -94,13 +99,17 @@ impl SearchEngineDefinition {
             name: base.name,
             optional: variant.optional,
             order_hint: None,
-            partner_code: variant
-                .partner_code
-                .or(base.partner_code)
-                .unwrap_or_default(),
-            telemetry_suffix: variant.telemetry_suffix,
-            urls: urls.into(),
+            partner_code: base.partner_code.unwrap_or_default(),
+            telemetry_suffix: String::new(),
+            urls: base.urls.into(),
+        };
+
+        engine_definition.merge_variant(variant);
+        if let Some(sub_variant) = sub_variant {
+            engine_definition.merge_variant(sub_variant);
         }
+
+        engine_definition
     }
 }
 
@@ -159,8 +168,23 @@ fn maybe_extract_engine_config(
         .rev()
         .find(|r| matches_user_environment(&r.environment, user_environment));
 
+    let mut matching_sub_variant = None;
+    if let Some(variant) = &matching_variant {
+        matching_sub_variant = variant
+            .sub_variants
+            .iter()
+            .rev()
+            .find(|r| matches_user_environment(&r.environment, user_environment))
+            .cloned();
+    }
+
     matching_variant.map(|variant| {
-        SearchEngineDefinition::from_configuration_details(&identifier, base, variant)
+        SearchEngineDefinition::from_configuration_details(
+            &identifier,
+            base,
+            &variant,
+            &matching_sub_variant,
+        )
     })
 }
 
@@ -274,7 +298,7 @@ mod tests {
                     trending: None,
                 },
             },
-            JSONEngineVariant {
+            &JSONEngineVariant {
                 environment: JSONVariantEnvironment {
                     all_regions_and_locales: true,
                     ..Default::default()
@@ -283,7 +307,9 @@ mod tests {
                 partner_code: None,
                 telemetry_suffix: None,
                 urls: None,
+                sub_variants: vec![],
             },
+            &None,
         );
 
         assert_eq!(
@@ -297,7 +323,7 @@ mod tests {
                 name: "Test".to_string(),
                 optional: false,
                 order_hint: None,
-                telemetry_suffix: None,
+                telemetry_suffix: String::new(),
                 urls: SearchEngineUrls {
                     search: SearchEngineUrl {
                         base: "https://example.com".to_string(),
@@ -357,7 +383,7 @@ mod tests {
         let result = SearchEngineDefinition::from_configuration_details(
             "test",
             Lazy::force(&ENGINE_BASE).clone(),
-            JSONEngineVariant {
+            &JSONEngineVariant {
                 environment: JSONVariantEnvironment {
                     all_regions_and_locales: true,
                     ..Default::default()
@@ -366,7 +392,9 @@ mod tests {
                 partner_code: None,
                 telemetry_suffix: None,
                 urls: None,
+                sub_variants: vec![],
             },
+            &None,
         );
 
         assert_eq!(
@@ -380,7 +408,7 @@ mod tests {
                 name: "Test".to_string(),
                 optional: false,
                 order_hint: None,
-                telemetry_suffix: None,
+                telemetry_suffix: String::new(),
                 urls: SearchEngineUrls {
                     search: SearchEngineUrl {
                         base: "https://example.com".to_string(),
@@ -422,7 +450,7 @@ mod tests {
         let result = SearchEngineDefinition::from_configuration_details(
             "test",
             Lazy::force(&ENGINE_BASE).clone(),
-            JSONEngineVariant {
+            &JSONEngineVariant {
                 environment: JSONVariantEnvironment {
                     all_regions_and_locales: true,
                     ..Default::default()
@@ -462,7 +490,9 @@ mod tests {
                         search_term_param_name: Some("trend".to_string()),
                     }),
                 }),
+                sub_variants: vec![],
             },
+            &None,
         );
 
         assert_eq!(
@@ -476,7 +506,7 @@ mod tests {
                 name: "Test".to_string(),
                 optional: true,
                 order_hint: None,
-                telemetry_suffix: Some("star".to_string()),
+                telemetry_suffix: "star".to_string(),
                 urls: SearchEngineUrls {
                     search: SearchEngineUrl {
                         base: "https://example.com/variant".to_string(),
@@ -507,6 +537,149 @@ mod tests {
                             experiment_config: None,
                         }],
                         search_term_param_name: Some("trend".to_string()),
+                    })
+                }
+            }
+        )
+    }
+
+    #[test]
+    fn test_from_configuration_details_merges_sub_variants() {
+        let result = SearchEngineDefinition::from_configuration_details(
+            "test",
+            Lazy::force(&ENGINE_BASE).clone(),
+            &JSONEngineVariant {
+                environment: JSONVariantEnvironment {
+                    all_regions_and_locales: true,
+                    ..Default::default()
+                },
+                optional: true,
+                partner_code: Some("trek".to_string()),
+                telemetry_suffix: Some("star".to_string()),
+                urls: Some(JSONEngineUrls {
+                    search: Some(JSONEngineUrl {
+                        base: Some("https://example.com/variant".to_string()),
+                        method: Some(JSONEngineMethod::Get),
+                        params: Some(vec![SearchUrlParam {
+                            name: "variant".to_string(),
+                            value: Some("test variant".to_string()),
+                            experiment_config: None,
+                        }]),
+                        search_term_param_name: Some("ship".to_string()),
+                    }),
+                    suggestions: Some(JSONEngineUrl {
+                        base: Some("https://example.com/suggestions-variant".to_string()),
+                        method: Some(JSONEngineMethod::Get),
+                        params: Some(vec![SearchUrlParam {
+                            name: "suggest-variant".to_string(),
+                            value: Some("sugg test variant".to_string()),
+                            experiment_config: None,
+                        }]),
+                        search_term_param_name: Some("variant".to_string()),
+                    }),
+                    trending: Some(JSONEngineUrl {
+                        base: Some("https://example.com/trending-variant".to_string()),
+                        method: Some(JSONEngineMethod::Get),
+                        params: Some(vec![SearchUrlParam {
+                            name: "trend-variant".to_string(),
+                            value: Some("trend test variant".to_string()),
+                            experiment_config: None,
+                        }]),
+                        search_term_param_name: Some("trend".to_string()),
+                    }),
+                }),
+                // This would be the list of sub-variants for this part of the
+                // configuration, however it is not used as the actual sub-variant
+                // to be merged is passed as the third argument to
+                // `from_configuration_details`.
+                sub_variants: vec![],
+            },
+            &Some(JSONEngineVariant {
+                environment: JSONVariantEnvironment {
+                    all_regions_and_locales: true,
+                    ..Default::default()
+                },
+                optional: true,
+                partner_code: Some("trek2".to_string()),
+                telemetry_suffix: Some("star2".to_string()),
+                urls: Some(JSONEngineUrls {
+                    search: Some(JSONEngineUrl {
+                        base: Some("https://example.com/subvariant".to_string()),
+                        method: Some(JSONEngineMethod::Get),
+                        params: Some(vec![SearchUrlParam {
+                            name: "subvariant".to_string(),
+                            value: Some("test subvariant".to_string()),
+                            experiment_config: None,
+                        }]),
+                        search_term_param_name: Some("shuttle".to_string()),
+                    }),
+                    suggestions: Some(JSONEngineUrl {
+                        base: Some("https://example.com/suggestions-subvariant".to_string()),
+                        method: Some(JSONEngineMethod::Get),
+                        params: Some(vec![SearchUrlParam {
+                            name: "suggest-subvariant".to_string(),
+                            value: Some("sugg test subvariant".to_string()),
+                            experiment_config: None,
+                        }]),
+                        search_term_param_name: Some("subvariant".to_string()),
+                    }),
+                    trending: Some(JSONEngineUrl {
+                        base: Some("https://example.com/trending-subvariant".to_string()),
+                        method: Some(JSONEngineMethod::Get),
+                        params: Some(vec![SearchUrlParam {
+                            name: "trend-subvariant".to_string(),
+                            value: Some("trend test subvariant".to_string()),
+                            experiment_config: None,
+                        }]),
+                        search_term_param_name: Some("subtrend".to_string()),
+                    }),
+                }),
+                sub_variants: vec![],
+            }),
+        );
+
+        assert_eq!(
+            result,
+            SearchEngineDefinition {
+                aliases: vec!["foo".to_string(), "bar".to_string()],
+                charset: "ISO-8859-15".to_string(),
+                classification: SearchEngineClassification::Unknown,
+                identifier: "test".to_string(),
+                partner_code: "trek2".to_string(),
+                name: "Test".to_string(),
+                optional: true,
+                order_hint: None,
+                telemetry_suffix: "star2".to_string(),
+                urls: SearchEngineUrls {
+                    search: SearchEngineUrl {
+                        base: "https://example.com/subvariant".to_string(),
+                        method: "GET".to_string(),
+                        params: vec![SearchUrlParam {
+                            name: "subvariant".to_string(),
+                            value: Some("test subvariant".to_string()),
+                            experiment_config: None,
+                        }],
+                        search_term_param_name: Some("shuttle".to_string()),
+                    },
+                    suggestions: Some(SearchEngineUrl {
+                        base: "https://example.com/suggestions-subvariant".to_string(),
+                        method: "GET".to_string(),
+                        params: vec![SearchUrlParam {
+                            name: "suggest-subvariant".to_string(),
+                            value: Some("sugg test subvariant".to_string()),
+                            experiment_config: None,
+                        }],
+                        search_term_param_name: Some("subvariant".to_string()),
+                    }),
+                    trending: Some(SearchEngineUrl {
+                        base: "https://example.com/trending-subvariant".to_string(),
+                        method: "GET".to_string(),
+                        params: vec![SearchUrlParam {
+                            name: "trend-subvariant".to_string(),
+                            value: Some("trend test subvariant".to_string()),
+                            experiment_config: None,
+                        }],
+                        search_term_param_name: Some("subtrend".to_string()),
                     })
                 }
             }

--- a/components/search/src/types.rs
+++ b/components/search/src/types.rs
@@ -188,8 +188,9 @@ pub struct SearchEngineDefinition {
     pub partner_code: String,
 
     /// Optional suffix that is appended to the search engine identifier
-    /// following a dash, i.e. `<identifier>-<suffix>`
-    pub telemetry_suffix: Option<String>,
+    /// following a dash, i.e. `<identifier>-<suffix>`. If it is an empty string
+    /// no dash should be appended.
+    pub telemetry_suffix: String,
 
     /// The URLs associated with the search engine.
     pub urls: SearchEngineUrls,


### PR DESCRIPTION
Implements sub-variant handling in the search engine selector. Not yet used by any code, so no breaking API changes to worry about.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [X] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
