### PR TITLE
bug 1942364: switch to autograph gcp production for signing

### DIFF
--- a/taskcluster/app_services_taskgraph/transforms/signing.py
+++ b/taskcluster/app_services_taskgraph/transforms/signing.py
@@ -28,7 +28,7 @@ def build_upstream_artifacts(config, tasks):
                     "paths": publications_to_artifact_paths(
                         version, module_info["publications"]
                     ),
-                    "formats": ["autograph_gpg"],
+                    "formats": ["gcp_prod_autograph_gpg"],
                 }
             ]
         }


### PR DESCRIPTION
This needs to wait for https://github.com/mozilla-releng/scriptworker-scripts/pull/1123 to be deployed before it can be merged.