### PR TITLE
Bug 1941655 - relax places DB constraints to what they were before bu…

### DIFF
--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -63,8 +63,10 @@ BEGIN
 
     SELECT throw('update: item without parent')
     WHERE NEW.guid <> 'root________'
-      AND NOT EXISTS(
-          SELECT 1 FROM moz_bookmarks WHERE id = NEW.parent);
+      AND NEW.parent IS NULL;
+-- bug 1941655, this seemingly more correct check causes obscure problems.
+--      AND NOT EXISTS(
+--          SELECT 1 FROM moz_bookmarks WHERE id = NEW.parent);
 
     SELECT throw(format('update: old type=%d; new=%d', OLD.type, NEW.type))
     WHERE OLD.type <> NEW.type;

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -560,6 +560,8 @@ mod tests {
                 e,
             );
 
+            // Bug 1941655 - we only guard against NULL parents, not missing ones.
+            /*
             let e = conn
                 .execute(
                     "UPDATE moz_bookmarks SET
@@ -573,6 +575,7 @@ mod tests {
                 "Expected error, got: {:?}",
                 e,
             );
+            */
         }
 
         // Invalid length guid


### PR DESCRIPTION
…g 1935797

This should restore the status quo. No new migration is necessary as only the triggers have changed and they are re-added each time the DB is opened. It would be great for people reviewing this to try and assure themselves the rules match what existed before 1935797, even though they continue to be expressed in a different way.

We then will want a new bug on file to dig deeper, but in the short term we should get this into Nightly, verify the errors go back down, then uplift to beta, and we need to do all this ASAP as the next merge is coming soon.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
