### PR TITLE
Relax chrono version requirement for nimbus-cli.

### DIFF
--- a/components/support/nimbus-cli/Cargo.toml
+++ b/components/support/nimbus-cli/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { version = "0.11.18", default-features = false, features = ["blocking
 serde_yaml = "0.9.21"
 percent-encoding = "2.3.0"
 copypasta = "0.8.2"
-chrono = "0.4.26"
+chrono = "0.4"
 axum = { version = "0.6.18", optional = true }
 tokio = { version = "1.29.1", optional = true, features = ["sync", "rt", "macros"] }
 tower = { version = "0.4.13", optional = true }


### PR DESCRIPTION
mozilla-central is on 0.4.19 and we'd like nimbus to work there without forcing m-c to upgrade.

All other chrono deps here use this loose version.
