### PR TITLE
Bug 1945621 - Re‐enable missing‐parent checks and fix ON CONFLICT par…

### DIFF
--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -61,12 +61,15 @@ BEGIN
     WHERE NEW.guid = 'root________'
       AND NEW.parent IS NOT NULL;
 
-    SELECT throw('update: item without parent')
+    SELECT throw(format(
+        'update: nonexistent parent: old_parent=%d, new_parent=%d, operation=%q',
+        OLD.parent,
+        NEW.parent,
+        CASE WHEN NEW.syncChangeCounter > 0 THEN 'sync' ELSE 'user' END
+    ))
     WHERE NEW.guid <> 'root________'
-      AND NEW.parent IS NULL;
--- bug 1941655, this seemingly more correct check causes obscure problems.
---      AND NOT EXISTS(
---          SELECT 1 FROM moz_bookmarks WHERE id = NEW.parent);
+    AND NOT EXISTS(
+        SELECT 1 FROM moz_bookmarks WHERE id = NEW.parent);
 
     SELECT throw(format('update: old type=%d; new=%d', OLD.type, NEW.type))
     WHERE OLD.type <> NEW.type;

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -555,13 +555,12 @@ mod tests {
                 )
                 .expect_err("should fail to update folder with NULL parent");
             assert!(
-                e.to_string().contains("update: item without parent"),
+                e.to_string().contains("update: nonexistent parent"),
                 "Expected error, got: {:?}",
                 e,
             );
 
             // Bug 1941655 - we only guard against NULL parents, not missing ones.
-            /*
             let e = conn
                 .execute(
                     "UPDATE moz_bookmarks SET
@@ -571,11 +570,10 @@ mod tests {
                 )
                 .expect_err("should fail to update folder with nonexistent parent");
             assert!(
-                e.to_string().contains("update: item without parent"),
+                e.to_string().contains("update: nonexistent parent"),
                 "Expected error, got: {:?}",
                 e,
             );
-            */
         }
 
         // Invalid length guid


### PR DESCRIPTION
…ent logic


[Bug 1935797](https://bugzilla.mozilla.org/show_bug.cgi?id=1935797) added

    Instead of using CHECK constraints, we can create BEFORE INSERT and BEFORE UPDATE triggers on moz_bookmarks to enforce the invariants that we want. Unlike a CHECK constraint, a trigger gives us access to all values in the new row, and lets us fail an insert or update with a custom error message.

Which allowed issues like [bug 1876320](https://bugzilla.mozilla.org/show_bug.cgi?id=1876320) to have more specific debugging messages and allowed us to see more clearly in what exact constraint is failing. While it was technically "correct" in what the code was doing, it caused a spike of new issues like in [bug 1941655](https://bugzilla.mozilla.org/show_bug.cgi?id=1941655).

From :markh's comment in [bug 1941655](https://bugzilla.mozilla.org/show_bug.cgi?id=1941655)

    My best guess is that this is caused by this "ON CONFLICT" clause - note the lack of "parent" in that clause.
    I can reproduce something similar to this with these STR:
    Run our places-utils example to setup a DB with bookmarks via sync.
    Use a sqlite editor and locate a folder which has bookmarks.
    Delete the parent item (thus making the bookmarks tree invalid as items will reference a non-existing parent)
    Run places-utils again to sync.
    When doing this I get an error from the above-linked SQL about a conflict on guid - however, note the above clause is only for id. So if we modify the SQL such that guid is also handled (ie, copy the ON CONFLICT clause changing id to guid in the copy), and then we can get the same error we see.
    Naively, I tried changing the ON CONFLICT clause to include parent and set it to the root ID as described in the comments - this does allow the sync to complete without error, but causes tests to fail as the final tree is not what's expected - ie, the omission of parent appears intentional and that in this scenario, dogear has created a valid tree. IOW, it does appear that the condition here can be seen for real and does not imply the final bookmarks tree will be invalid.

So I think making a patch that deals with the parent in the ON CONFLICT as mentioned above, however with one slight difference.

What we should do is on conflict, we only update the parent if the new parent GUID actually exists in moz_bookmarks. This avoids referencing a non-existent parent, which would trigger an error. If the incoming parent is NULL or invalid, we keep the existing parent. That preserves any valid local parent info, and avoids forcing a fallback to the root prematurely. For newly inserted items (the "INSERT" path), we already set the parent to the root as a placeholder, and a later "fix up" step reattaches them to the correct parent once it's guaranteed to exist.




### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
