### PR TITLE
Bug 1945621 - Run check for users to re-parent orphaned bookmarks and…

### DIFF
--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -62,9 +62,7 @@ BEGIN
       AND NEW.parent IS NOT NULL;
 
     SELECT throw(format(
-        'update: nonexistent parent: old_parent=%d, new_parent=%d, operation=%q',
-        OLD.parent,
-        NEW.parent,
+        'update: item without parent: operation=%q',
         CASE WHEN NEW.syncChangeCounter > 0 THEN 'sync' ELSE 'user' END
     ))
     WHERE NEW.guid <> 'root________'

--- a/components/places/sql/create_shared_triggers.sql
+++ b/components/places/sql/create_shared_triggers.sql
@@ -61,7 +61,12 @@ BEGIN
     WHERE NEW.guid = 'root________'
       AND NEW.parent IS NOT NULL;
 
-    SELECT throw('update: item without parent')
+    SELECT throw(format(
+        'update: nonexistent parent: old_parent=%d, new_parent=%d, operation=%q',
+        OLD.parent,
+        NEW.parent,
+        CASE WHEN NEW.syncChangeCounter > 0 THEN 'sync' ELSE 'user' END
+    ))
     WHERE NEW.guid <> 'root________'
       AND NEW.parent IS NULL;
 -- bug 1941655, this seemingly more correct check causes obscure problems.

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -555,7 +555,7 @@ mod tests {
                 )
                 .expect_err("should fail to update folder with NULL parent");
             assert!(
-                e.to_string().contains("update: nonexistent parent"),
+                e.to_string().contains("update: item without parent"),
                 "Expected error, got: {:?}",
                 e,
             );
@@ -571,7 +571,7 @@ mod tests {
                 )
                 .expect_err("should fail to update folder with nonexistent parent");
             assert!(
-                e.to_string().contains("update: nonexistent parent"),
+                e.to_string().contains("update: item without parent"),
                 "Expected error, got: {:?}",
                 e,
             );

--- a/components/places/src/db/schema.rs
+++ b/components/places/src/db/schema.rs
@@ -555,7 +555,7 @@ mod tests {
                 )
                 .expect_err("should fail to update folder with NULL parent");
             assert!(
-                e.to_string().contains("update: item without parent"),
+                e.to_string().contains("update: nonexistent parent"),
                 "Expected error, got: {:?}",
                 e,
             );
@@ -571,7 +571,7 @@ mod tests {
                 )
                 .expect_err("should fail to update folder with nonexistent parent");
             assert!(
-                e.to_string().contains("update: item without parent"),
+                e.to_string().contains("update: nonexistent parent"),
                 "Expected error, got: {:?}",
                 e,
             );

--- a/components/support/error/src/lib.rs
+++ b/components/support/error/src/lib.rs
@@ -44,6 +44,8 @@ pub use reporting::{
     report_breadcrumb, report_error_to_app, set_application_error_reporter,
     unset_application_error_reporter, ApplicationErrorReporter,
 };
+// These are exposed specifically for tests
+pub use reporting::{ArcReporterAdapter, TestErrorReporter};
 
 pub use error_support_macros::handle_error;
 


### PR DESCRIPTION
… log outcome


[Bug 1935797](https://bugzilla.mozilla.org/show_bug.cgi?id=1935797) added

Instead of using CHECK constraints, we can create BEFORE INSERT and BEFORE UPDATE triggers on moz_bookmarks to enforce the invariants that we want. Unlike a CHECK constraint, a trigger gives us access to all values in the new row, and lets us fail an insert or update with a custom error message.

Which allowed issues like [bug 1876320](https://bugzilla.mozilla.org/show_bug.cgi?id=1876320) to have more specific debugging messages and allowed us to see more clearly in what exact constraint is failing. While it was technically "correct" in what the code was doing, it caused a spike of new issues like in [bug 1941655](https://bugzilla.mozilla.org/show_bug.cgi?id=1941655).

From :markh's comment in [bug 1941655](https://bugzilla.mozilla.org/show_bug.cgi?id=1941655)

> My best guess is that this is caused by this "ON CONFLICT" clause - note the lack of "parent" in that clause.
> I can reproduce something similar to this with these STR:
Run our places-utils example to setup a DB with bookmarks via sync.
Use a sqlite editor and locate a folder which has bookmarks.
Delete the parent item (thus making the bookmarks tree invalid as items will reference a non-existing parent)
Run places-utils again to sync.
When doing this I get an error from the above-linked SQL about a conflict on guid - however, note the above clause is only for id. So if we modify the SQL such that guid is also handled (ie, copy the ON CONFLICT clause changing id to guid in the copy), and then we can get the same error we see.
Naively, I tried changing the ON CONFLICT clause to include parent and set it to the root ID as described in the comments - this does allow the sync to complete without error, but causes tests to fail as the final tree is not what's expected - ie, the omission of parent appears intentional and that in this scenario, dogear has created a valid tree. IOW, it does appear that the condition here can be seen for real and does not imply the final bookmarks tree will be invalid.


To continue testing the above theory. I think adding better logging and telemetry might be the next small step to figuring out what is going on. Dogear technically still does the right thing but mainly operates on syncing bookmarks. This patch hopes to do a couple of things:

1. Add better logging around the `ON CONFLICT` part of the code, since we've relaxed the trigger, we've seen an uptick of `UNIQUE CONSTRAINT: moz_bookmarks.guid`. Thus more logging around the guid should help here.
2. Check for any orphaned bookmarks that somehow already exist in the tree, we expect this to be relatively low to (1) but a potential hit.


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
