### PR TITLE
Bug 1947694 - Add an API to the SearchEngineSelector to allow using the RemoteSettingService directly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,15 +4543,19 @@ dependencies = [
 name = "search"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "error-support",
  "firefox-versioning",
+ "mockito",
  "once_cell",
  "parking_lot",
  "pretty_assertions",
+ "remote_settings",
  "serde",
  "serde_json",
  "thiserror 1.0.31",
  "uniffi",
+ "viaduct-reqwest",
 ]
 
 [[package]]

--- a/components/remote_settings/src/service.rs
+++ b/components/remote_settings/src/service.rs
@@ -63,7 +63,12 @@ impl RemoteSettingsService {
         context: Option<RemoteSettingsContext>,
     ) -> Result<Arc<RemoteSettingsClient>> {
         let mut inner = self.inner.lock();
-        let storage = Storage::new(inner.storage_dir.join(format!("{collection_name}.sql")))?;
+        // Allow using in-memory databases for testing of external crates.
+        let storage = if inner.storage_dir == ":memory:" {
+            Storage::new(inner.storage_dir.clone())?
+        } else {
+            Storage::new(inner.storage_dir.join(format!("{collection_name}.sql")))?
+        };
 
         let client = Arc::new(RemoteSettingsClient::new(
             inner.base_url.clone(),
@@ -83,7 +88,14 @@ impl RemoteSettingsService {
         #[allow(unused_variables)] context: Option<RemoteSettingsContext>,
     ) -> Result<Arc<RemoteSettingsClient>> {
         let mut inner = self.inner.lock();
-        let storage = Storage::new(inner.storage_dir.join(format!("{collection_name}.sql")))?;
+        // Allow using in-memory databases for testing of external crates.
+        let storage = if inner.storage_dir == ":memory:" {
+            Storage::new(Utf8PathBuf::from(
+                "file:remote-settings-{collection-name}?mode=memory&cache=shared".to_string(),
+            ))?
+        } else {
+            Storage::new(inner.storage_dir.join(format!("{collection_name}.sql")))?
+        };
         let client = Arc::new(RemoteSettingsClient::new(
             inner.base_url.clone(),
             inner.bucket_name.clone(),

--- a/components/search/Cargo.toml
+++ b/components/search/Cargo.toml
@@ -7,8 +7,10 @@ readme = "README.md"
 license = "MPL-2.0"
 
 [dependencies]
+env_logger = { version = "0.10.0", default-features = false, optional = true }
 error-support = { path = "../support/error" }
 parking_lot = ">=0.11,<=0.12"
+remote_settings = { path = "../remote_settings" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
@@ -19,5 +21,12 @@ firefox-versioning = { path = "../support/firefox-versioning" }
 uniffi = { version = "0.28.2", features = ["build"] }
 
 [dev-dependencies]
+env_logger = { version = "0.10.0", default-features = false, features = ["humantime"] }
 once_cell = "1.18.0"
+mockito = "0.31"
 pretty_assertions = "0.6"
+viaduct-reqwest = { path = "../support/viaduct-reqwest" }
+
+[features]
+# Enable `env_logger`. Only works on non-Android non-iOS targets.
+enable_env_logger = ["env_logger"]

--- a/components/search/src/error.rs
+++ b/components/search/src/error.rs
@@ -8,6 +8,8 @@
 /// exposed to your application, which should handle them as needed.
 use error_support::{ErrorHandling, GetErrorHandling};
 
+use remote_settings::RemoteSettingsError;
+
 /// A list of errors that are internal to the component. This is the error
 /// type for private and crate-internal methods, and is never returned to the
 /// application.
@@ -15,8 +17,12 @@ use error_support::{ErrorHandling, GetErrorHandling};
 pub enum Error {
     #[error("Search configuration not specified")]
     SearchConfigNotSpecified,
+    #[error("No records received from remote settings")]
+    SearchConfigNoRecords,
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
+    #[error("Remote Settings error: {0}")]
+    RemoteSettings(#[from] RemoteSettingsError),
 }
 
 // #[non_exhaustive]


### PR DESCRIPTION


### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
