### PR TITLE
Make RemoteSettingsClient::get_attachment input a reference

### DIFF
--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -360,9 +360,10 @@ impl<C: ApiClient> RemoteSettingsClient<C> {
 
     /// Downloads an attachment from [attachment_location]. NOTE: there are no guarantees about a
     /// maximum size, so use care when fetching potentially large attachments.
-    pub fn get_attachment(&self, record: RemoteSettingsRecord) -> Result<Vec<u8>> {
+    pub fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
         let metadata = record
             .attachment
+            .as_ref()
             .ok_or_else(|| Error::RecordAttachmentMismatchError("No attachment metadata".into()))?;
 
         let mut inner = self.inner.lock();
@@ -2415,7 +2416,7 @@ mod test_packaged_metadata {
             fields: serde_json::json!({}).as_object().unwrap().clone(),
         };
 
-        let attachment_data = rs_client.get_attachment(record)?;
+        let attachment_data = rs_client.get_attachment(&record)?;
 
         // Verify we got the expected data
         let expected_data = std::fs::read(file_path)?;
@@ -2471,7 +2472,7 @@ mod test_packaged_metadata {
             fields: serde_json::json!({}).as_object().unwrap().clone(),
         };
 
-        let attachment_data = rs_client.get_attachment(record)?;
+        let attachment_data = rs_client.get_attachment(&record)?;
 
         // Verify we got the mock API data, not the packaged data
         assert_eq!(attachment_data, vec![1, 2, 3, 4, 5]);

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -200,7 +200,7 @@ impl RemoteSettingsClient {
     ///   - This method will throw if there is a network or other error when fetching the
     ///     attachment data.
     #[handle_error(Error)]
-    pub fn get_attachment(&self, record: RemoteSettingsRecord) -> ApiResult<Vec<u8>> {
+    pub fn get_attachment(&self, record: &RemoteSettingsRecord) -> ApiResult<Vec<u8>> {
         self.internal.get_attachment(record)
     }
 }


### PR DESCRIPTION
This won't change anything when it's called from UniFFI since we still need to copy the data to pass it over the FFI.  However, we're starting to use this client internally as well and this makes it so we can avoid a copy when calling the method from Rust.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
