### PR TITLE
Bug 1950110 - Add search-config-v2 dump to remote settings Rust component, and update search-telemetry-v2.

### DIFF
--- a/components/remote_settings/dumps/main/search-config-v2.json
+++ b/components/remote_settings/dumps/main/search-config-v2.json
@@ -1,0 +1,8037 @@
+{
+  "data": [
+    {
+      "base": {
+        "aliases": [
+          "google"
+        ],
+        "classification": "general",
+        "name": "Google",
+        "partnerCode": "firefox-b-d",
+        "urls": {
+          "search": {
+            "base": "https://www.google.com/search",
+            "params": [
+              {
+                "name": "client",
+                "value": "{partnerCode}"
+              },
+              {
+                "experimentConfig": "google_channel_row",
+                "name": "channel"
+              },
+              {
+                "enterpriseValue": "entpr",
+                "name": "channel"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://www.google.com/complete/search",
+            "params": [
+              {
+                "name": "client",
+                "value": "firefox"
+              },
+              {
+                "experimentConfig": "search_rich_suggestions",
+                "name": "channel"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "trending": {
+            "base": "https://www.google.com/complete/search",
+            "method": "GET",
+            "params": [
+              {
+                "name": "client",
+                "value": "firefox"
+              },
+              {
+                "name": "channel",
+                "value": "ftr"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "7ace4aa1-e762-4f4b-87b9-b23b3c3a930b",
+      "identifier": "google",
+      "last_modified": 1738595538915,
+      "recordType": "engine",
+      "schema": 1738577315091,
+      "variants": [
+        {
+          "environment": {
+            "allRegionsAndLocales": true
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "channels": [
+                  "esr"
+                ]
+              },
+              "partnerCode": "firefox-b-e",
+              "telemetrySuffix": "b-e"
+            },
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android",
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "firefox-b-m",
+              "telemetrySuffix": "b-m"
+            }
+          ],
+          "telemetrySuffix": "b-d"
+        },
+        {
+          "environment": {
+            "regions": [
+              "ru",
+              "tr",
+              "by",
+              "kz"
+            ]
+          },
+          "telemetrySuffix": "com-nocodes",
+          "urls": {
+            "search": {
+              "params": []
+            }
+          }
+        },
+        {
+          "environment": {
+            "regions": [
+              "us"
+            ]
+          },
+          "partnerCode": "firefox-b-1-d",
+          "subVariants": [
+            {
+              "environment": {
+                "channels": [
+                  "esr"
+                ],
+                "regions": [
+                  "us"
+                ]
+              },
+              "partnerCode": "firefox-b-1-e",
+              "telemetrySuffix": "b-1-e"
+            },
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android",
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "firefox-b-1-m",
+              "telemetrySuffix": "b-1-m"
+            }
+          ],
+          "telemetrySuffix": "b-1-d",
+          "urls": {
+            "search": {
+              "params": [
+                {
+                  "name": "client",
+                  "value": "{partnerCode}"
+                },
+                {
+                  "experimentConfig": "google_channel_us",
+                  "name": "channel"
+                },
+                {
+                  "enterpriseValue": "entpr",
+                  "name": "channel"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "environment": {
+            "distributions": [
+              "canonical",
+              "canonical-001"
+            ]
+          },
+          "partnerCode": "ubuntu",
+          "telemetrySuffix": "canonical",
+          "urls": {
+            "search": {
+              "params": [
+                {
+                  "name": "client",
+                  "value": "{partnerCode}"
+                },
+                {
+                  "name": "channel",
+                  "value": "fs"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "environment": {
+            "distributions": [
+              "canonical-002"
+            ]
+          },
+          "partnerCode": "ubuntu-sn",
+          "telemetrySuffix": "ubuntu-sn",
+          "urls": {
+            "search": {
+              "params": [
+                {
+                  "name": "client",
+                  "value": "{partnerCode}"
+                },
+                {
+                  "name": "channel",
+                  "value": "fs"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "environment": {
+            "distributions": [
+              "mint-001"
+            ]
+          },
+          "partnerCode": "firefox-b-lm",
+          "telemetrySuffix": "b-lm"
+        },
+        {
+          "environment": {
+            "distributions": [
+              "mint-001"
+            ],
+            "regions": [
+              "us"
+            ]
+          },
+          "partnerCode": "firefox-b-1-lm",
+          "telemetrySuffix": "b-1-lm"
+        },
+        {
+          "environment": {
+            "distributions": [
+              "vivo-001"
+            ]
+          },
+          "partnerCode": "firefox-b-vv",
+          "telemetrySuffix": "b-vv"
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "พจนานุกรม ลองดู",
+        "urls": {
+          "search": {
+            "base": "https://dict.longdo.com/",
+            "params": [
+              {
+                "name": "src",
+                "value": "moz"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://search.longdo.com/Suggest/HeadSearch",
+            "params": [
+              {
+                "name": "ds",
+                "value": "head"
+              },
+              {
+                "name": "fxjson",
+                "value": "1"
+              }
+            ],
+            "searchTermParamName": "key"
+          }
+        }
+      },
+      "id": "fcc54178-e432-4d2b-820e-50f389bfb396",
+      "identifier": "longdo",
+      "last_modified": 1734364924962,
+      "recordType": "engine",
+      "schema": 1734352952859,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "th"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "general",
+        "name": "Ecosia",
+        "partnerCode": "mzl",
+        "urls": {
+          "search": {
+            "base": "https://www.ecosia.org/search",
+            "params": [
+              {
+                "name": "tt",
+                "value": "{partnerCode}"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://ac.ecosia.org/autocomplete",
+            "params": [
+              {
+                "name": "type",
+                "value": "list"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "e8e4a7e3-aead-43e3-887d-4064a186bd70",
+      "identifier": "ecosia",
+      "last_modified": 1734364924960,
+      "recordType": "engine",
+      "schema": 1734220806364,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "de"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "813cf1dd"
+            },
+            {
+              "environment": {
+                "applications": [
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "16eeffc4"
+            }
+          ]
+        },
+        {
+          "environment": {
+            "regions": [
+              "at",
+              "be",
+              "ch",
+              "de",
+              "es",
+              "it",
+              "nl",
+              "se"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "813cf1dd"
+            },
+            {
+              "environment": {
+                "applications": [
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "16eeffc4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "विकिपिडिया",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "विकिपिडिया (ne)",
+        "urls": {
+          "search": {
+            "base": "https://ne.wikipedia.org/wiki/विशेष:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ne.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "dd1c5a28-733d-46b4-ae5e-fff82f94aec9",
+      "identifier": "wikipedia-ne",
+      "last_modified": 1729004089310,
+      "recordType": "engine",
+      "schema": 1729002528998,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ne-NP"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "위키백과",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "위키백과 (ko)",
+        "urls": {
+          "search": {
+            "base": "https://ko.wikipedia.org/wiki/특수기능:찾기",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ko.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "831d7fed-79d2-4aac-9481-826300a03d65",
+      "identifier": "wikipedia-kr",
+      "last_modified": 1729004089308,
+      "recordType": "engine",
+      "schema": 1729002520757,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ko"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "विकिपीडिया",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "विकिपीडिया (hi)",
+        "urls": {
+          "search": {
+            "base": "https://hi.wikipedia.org/wiki/विशेष:खोज",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://hi.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "8fc18864-53e1-47b4-8730-2e67962c7b32",
+      "identifier": "wikipedia-hi",
+      "last_modified": 1729004089305,
+      "recordType": "engine",
+      "schema": 1729002511062,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "hi-IN"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "વિકિપીડિયા",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "વિકિપીડિયા (gu)",
+        "urls": {
+          "search": {
+            "base": "https://gu.wikipedia.org/wiki/વિશેષ:શોધ",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://gu.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "ede0b78c-500a-4d1b-8236-cd5e7ceee815",
+      "identifier": "wikipedia-gu",
+      "last_modified": 1729004089303,
+      "recordType": "engine",
+      "schema": 1729002508415,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "gu-IN"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipédia",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipédia (fr)",
+        "urls": {
+          "search": {
+            "base": "https://fr.wikipedia.org/wiki/Spécial:Recherche",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://fr.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "a0261c4c-7b60-42c5-b35b-00ab57c5fbc4",
+      "identifier": "wikipedia-fr",
+      "last_modified": 1729004089301,
+      "recordType": "engine",
+      "schema": 1729002502123,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ff",
+              "fr",
+              "son"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedie",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedie (cs)",
+        "urls": {
+          "search": {
+            "base": "https://cs.wikipedia.org/wiki/Speciální:Hledání",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://cs.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "2574b200-f878-4b0c-b7e0-49804b3f4b8e",
+      "identifier": "wikipedia-cz",
+      "last_modified": 1729004089298,
+      "recordType": "engine",
+      "schema": 1729002493066,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "cs"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "viquipèdia",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Viquipèdia (ca)",
+        "urls": {
+          "search": {
+            "base": "https://ca.wikipedia.org/wiki/Especial:Cerca",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ca.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "7ed640c7-bc86-45dc-b07a-f7d8b5a8e079",
+      "identifier": "wikipedia-ca",
+      "last_modified": 1729004089296,
+      "recordType": "engine",
+      "schema": 1729002490717,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ca",
+              "ca-valencia"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "উইকিপিডিয়া",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "উইকিপিডিয়া (bn)",
+        "urls": {
+          "search": {
+            "base": "https://bn.wikipedia.org/wiki/বিশেষ:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://bn.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "a0a95a2c-83b7-4507-a4e9-5632ca9825dd",
+      "identifier": "wikipedia-bn",
+      "last_modified": 1729004089294,
+      "recordType": "engine",
+      "schema": 1729002489104,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "bn",
+              "bn-BD",
+              "bn-IN"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "вікіпэдыя"
+        ],
+        "classification": "unknown",
+        "name": "Вікіпэдыя (be-tarask)",
+        "urls": {
+          "search": {
+            "base": "https://be-tarask.wikipedia.org/wiki/Спэцыяльныя:Пошук",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://be-tarask.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "d7cb9b4b-f53a-49ea-ae04-27172fb108e9",
+      "identifier": "wikipedia-be-tarask",
+      "last_modified": 1729004089292,
+      "recordType": "engine",
+      "schema": 1729002485955,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "be"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "вікіпедыя",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Вікіпедыя (be)",
+        "urls": {
+          "search": {
+            "base": "https://be.wikipedia.org/wiki/Адмысловае:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://be.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "5327659a-3b79-4071-95b5-b86f7cc25a25",
+      "identifier": "wikipedia-be",
+      "last_modified": 1729004089289,
+      "recordType": "engine",
+      "schema": 1729002480587,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "be"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "維基百科",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (zh)",
+        "urls": {
+          "search": {
+            "base": "https://zh.wikipedia.org/wiki/Special:搜索",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              },
+              {
+                "name": "variant",
+                "value": "zh-tw"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://zh.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "864df79e-c03d-47ee-aacf-06242cffe951",
+      "identifier": "wikipedia-zh-TW",
+      "last_modified": 1729004089287,
+      "recordType": "engine",
+      "schema": 1729002549717,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "zh-TW"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "维基百科",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "维基百科",
+        "urls": {
+          "search": {
+            "base": "https://zh.wikipedia.org/wiki/Special:搜索",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://zh.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "c0f736ce-c219-4388-a242-48168237e3f5",
+      "identifier": "wikipedia-zh-CN",
+      "last_modified": 1729004089284,
+      "recordType": "engine",
+      "schema": 1729002548615,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "zh-CN"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vikipediya",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vikipediya (uz)",
+        "urls": {
+          "search": {
+            "base": "https://uz.wikipedia.org/wiki/Maxsus:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://uz.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "1b07d255-6f2c-4e2d-a4b4-b0e99aae39e9",
+      "identifier": "wikipedia-uz",
+      "last_modified": 1729004089282,
+      "recordType": "engine",
+      "schema": 1729002547362,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "uz"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ویکیپیڈیا",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "ویکیپیڈیا (ur)",
+        "urls": {
+          "search": {
+            "base": "https://ur.wikipedia.org/wiki/خاص:تلاش",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ur.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "52a714ba-0471-47be-9557-fc5fe9c9ff50",
+      "identifier": "wikipedia-ur",
+      "last_modified": 1729004089279,
+      "recordType": "engine",
+      "schema": 1729002546136,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ur"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "вікіпедія",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Вікіпедія (uk)",
+        "urls": {
+          "search": {
+            "base": "https://uk.wikipedia.org/wiki/Спеціальна:Пошук",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://uk.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "3b65a693-177a-4bd2-9d66-8c038e005800",
+      "identifier": "wikipedia-uk",
+      "last_modified": 1729004089277,
+      "recordType": "engine",
+      "schema": 1729002544976,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "uk"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "วิกิพีเดีย",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "วิกิพีเดีย",
+        "urls": {
+          "search": {
+            "base": "https://th.wikipedia.org/wiki/พิเศษ:ค้นหา",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://th.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "5c7903a3-5a44-41a0-aac2-fc26fe8f8fe7",
+      "identifier": "wikipedia-th",
+      "last_modified": 1729004089275,
+      "recordType": "engine",
+      "schema": 1729002542224,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "th"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "వికీపీడియా",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "వికీపీడియా (te)",
+        "urls": {
+          "search": {
+            "base": "https://te.wikipedia.org/wiki/ప్రత్యేక:అన్వేషణ",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://te.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "391eb3c6-de7a-4aaf-8027-3ad1b8c3c00a",
+      "identifier": "wikipedia-te",
+      "last_modified": 1729004089273,
+      "recordType": "engine",
+      "schema": 1729002540762,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "te"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "விக்கிப்பீடியா",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "விக்கிப்பீடியா (ta)",
+        "urls": {
+          "search": {
+            "base": "https://ta.wikipedia.org/wiki/சிறப்பு:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ta.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "78ed73b5-4afd-467e-b7ee-c96658f345c6",
+      "identifier": "wikipedia-ta",
+      "last_modified": 1729004089270,
+      "recordType": "engine",
+      "schema": 1729002539071,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ta"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "википедија",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Википедија (sr)",
+        "urls": {
+          "search": {
+            "base": "https://sr.wikipedia.org/wiki/Посебно:Претражи",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://sr.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "d381964d-d1e3-4378-962c-6ac5b89161f8",
+      "identifier": "wikipedia-sr",
+      "last_modified": 1729004089268,
+      "recordType": "engine",
+      "schema": 1729002536927,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "sr"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedija",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedija (sl)",
+        "urls": {
+          "search": {
+            "base": "https://sl.wikipedia.org/wiki/Posebno:Iskanje",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://sl.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "887d2a1b-7275-4a4e-afa2-9157eb98a7d5",
+      "identifier": "wikipedia-sl",
+      "last_modified": 1729004089266,
+      "recordType": "engine",
+      "schema": 1729002535884,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "sl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipédia",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipédia (sk)",
+        "urls": {
+          "search": {
+            "base": "https://sk.wikipedia.org/wiki/Špeciálne:Hľadanie",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://sk.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "f9d77028-e386-4093-aacd-a8c2a56acbc0",
+      "identifier": "wikipedia-sk",
+      "last_modified": 1729004089264,
+      "recordType": "engine",
+      "schema": 1729002534892,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "sk"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "википедия",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Википедия (ru)",
+        "urls": {
+          "search": {
+            "base": "https://ru.wikipedia.org/wiki/Служебная:Поиск",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ru.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "8f2b997a-8bfe-436d-9393-b9abb52522ef",
+      "identifier": "wikipedia-ru",
+      "last_modified": 1729004089261,
+      "recordType": "engine",
+      "schema": 1729002532830,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ru"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipèdia",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipèdia (oc)",
+        "urls": {
+          "search": {
+            "base": "https://oc.wikipedia.org/wiki/Especial:Recèrca",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://oc.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "e3e2c4a1-4914-4a27-96f8-63fb6a90f490",
+      "identifier": "wikipedia-oc",
+      "last_modified": 1729004089259,
+      "recordType": "engine",
+      "schema": 1729002529878,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "oc"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "विकिपीडिया",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "विकिपीडिया (mr)",
+        "urls": {
+          "search": {
+            "base": "https://mr.wikipedia.org/wiki/विशेष:शोधा",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://mr.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "09f48c9b-b420-4312-8c60-aeb4358e0b97",
+      "identifier": "wikipedia-mr",
+      "last_modified": 1729004089257,
+      "recordType": "engine",
+      "schema": 1729002526927,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "mr"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "википедија",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Википедија (mk)",
+        "urls": {
+          "search": {
+            "base": "https://mk.wikipedia.org/wiki/Специјална:Барај",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://mk.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "a3aa8882-cbb0-4002-b0fc-b6ff5cdb9d92",
+      "identifier": "wikipedia-mk",
+      "last_modified": 1729004089255,
+      "recordType": "engine",
+      "schema": 1729002525972,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "mk"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vikipedeja",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vikipedeja (ltg)",
+        "urls": {
+          "search": {
+            "base": "https://ltg.wikipedia.org/wiki/Seviškuo:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ltg.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "52871fd0-a24a-443b-a2d4-17eb09951691",
+      "identifier": "wikipedia-ltg",
+      "last_modified": 1729004089252,
+      "recordType": "engine",
+      "schema": 1729002523991,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ltg"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ວິກິພີເດຍ",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "ວິກິພີເດຍ (lo)",
+        "urls": {
+          "search": {
+            "base": "https://lo.wikipedia.org/wiki/ພິເສດ:ຊອກຫາ",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://lo.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "515c4522-284d-468f-926a-eb7eb8a55e22",
+      "identifier": "wikipedia-lo",
+      "last_modified": 1729004089250,
+      "recordType": "engine",
+      "schema": 1729002521798,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "lo"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "វិគីភីឌា",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "វិគីភីឌា (km)",
+        "urls": {
+          "search": {
+            "base": "https://km.wikipedia.org/wiki/ពិសេស:ស្វែងរក",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://km.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "c8a7bec0-7f33-44e1-9521-363530993acc",
+      "identifier": "wikipedia-km",
+      "last_modified": 1729004089248,
+      "recordType": "engine",
+      "schema": 1729002518717,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "km"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "уикипедия",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Уикипедия (kk)",
+        "urls": {
+          "search": {
+            "base": "https://kk.wikipedia.org/wiki/Арнайы:Іздеу",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://kk.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "15f00a29-0d68-4ff1-89d1-5e58b95618b7",
+      "identifier": "wikipedia-kk",
+      "last_modified": 1729004089246,
+      "recordType": "engine",
+      "schema": 1729002517453,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "kk"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ვიკიპედია",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "ვიკიპედია (ka)",
+        "urls": {
+          "search": {
+            "base": "https://ka.wikipedia.org/wiki/სპეციალური:ძიება",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ka.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "ca784382-7beb-4a93-b211-745d4d71ec6c",
+      "identifier": "wikipedia-ka",
+      "last_modified": 1729004089244,
+      "recordType": "engine",
+      "schema": 1729002516520,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ka"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipédia",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipédia (hu)",
+        "urls": {
+          "search": {
+            "base": "https://hu.wikipedia.org/wiki/Speciális:Keresés",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://hu.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "9a10f883-2da7-4070-8a73-543153bdd52c",
+      "identifier": "wikipedia-hu",
+      "last_modified": 1729004089241,
+      "recordType": "engine",
+      "schema": 1729002514305,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "hu"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedija",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedija (hsb)",
+        "urls": {
+          "search": {
+            "base": "https://hsb.wikipedia.org/wiki/Specialnje:Pytać",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://hsb.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "5235d5f1-e04d-4ba3-b53b-35a8d09d2142",
+      "identifier": "wikipedia-hsb",
+      "last_modified": 1729004089239,
+      "recordType": "engine",
+      "schema": 1729002513214,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "hsb"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedija",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedija (hr)",
+        "urls": {
+          "search": {
+            "base": "https://hr.wikipedia.org/wiki/Posebno:Traži",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://hr.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "eb03a427-1f71-4df9-b609-a36064d2d0e2",
+      "identifier": "wikipedia-hr",
+      "last_modified": 1729004089237,
+      "recordType": "engine",
+      "schema": 1729002512016,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "hr"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ויקיפדיה",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "ויקיפדיה",
+        "urls": {
+          "search": {
+            "base": "https://he.wikipedia.org/wiki/מיוחד:חיפוש",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://he.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "f96aab0d-3562-445c-a70f-5805ea1d25fe",
+      "identifier": "wikipedia-he",
+      "last_modified": 1729004089235,
+      "recordType": "engine",
+      "schema": 1729002509714,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "he"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vikipetã",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vikipetã (gn)",
+        "urls": {
+          "search": {
+            "base": "https://gn.wikipedia.org/wiki/Mba'echĩchĩ:Buscar",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://gn.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "b66515df-d7b1-403c-b0df-22a5ce9dd07f",
+      "identifier": "wikipedia-gn",
+      "last_modified": 1729004089231,
+      "recordType": "engine",
+      "schema": 1729002506870,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "gn"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "uicipeid",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Uicipeid (gd)",
+        "urls": {
+          "search": {
+            "base": "https://gd.wikipedia.org/wiki/Sònraichte:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://gd.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "df26225d-6726-4630-94ce-7a398598139b",
+      "identifier": "wikipedia-gd",
+      "last_modified": 1729004089229,
+      "recordType": "engine",
+      "schema": 1729002505545,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "gd"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vicipéid",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vicipéid (ga)",
+        "urls": {
+          "search": {
+            "base": "https://ga.wikipedia.org/wiki/Speisialta:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ga.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "d8d0e94c-27e7-42b1-a5e2-b24198021234",
+      "identifier": "wikipedia-ga-IE",
+      "last_modified": 1729004089227,
+      "recordType": "engine",
+      "schema": 1729002504366,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ga-IE"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedy",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedy (fy)",
+        "urls": {
+          "search": {
+            "base": "https://fy.wikipedia.org/wiki/Wiki:Sykje",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://fy.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "4a6a7952-460d-4951-a011-9fc414f2569a",
+      "identifier": "wikipedia-fy-NL",
+      "last_modified": 1729004089224,
+      "recordType": "engine",
+      "schema": 1729002503250,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "fy-NL"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ویکی‌پدیا",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "ویکی‌پدیا (fa)",
+        "urls": {
+          "search": {
+            "base": "https://fa.wikipedia.org/wiki/ویژه:جستجو",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://fa.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "ce737d17-06f0-46f2-8c88-97f796ad88dc",
+      "identifier": "wikipedia-fa",
+      "last_modified": 1729004089222,
+      "recordType": "engine",
+      "schema": 1729002499436,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "fa"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vikipeedia",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vikipeedia (et)",
+        "urls": {
+          "search": {
+            "base": "https://et.wikipedia.org/wiki/Eri:Otsimine",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://et.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "87388ad0-c470-4a90-b79d-231e28b86eda",
+      "identifier": "wikipedia-et",
+      "last_modified": 1729004089220,
+      "recordType": "engine",
+      "schema": 1729002498372,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "et"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vikipedio",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vikipedio (eo)",
+        "urls": {
+          "search": {
+            "base": "https://eo.wikipedia.org/wiki/Specialaĵo:Serĉi",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://eo.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "25b42f42-d6e4-4193-be32-b4ca61cb55c7",
+      "identifier": "wikipedia-eo",
+      "last_modified": 1729004089218,
+      "recordType": "engine",
+      "schema": 1729002497291,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "eo"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedija",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedija (dsb)",
+        "urls": {
+          "search": {
+            "base": "https://dsb.wikipedia.org/wiki/Specialne:Pytaś",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://dsb.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "c8a9299d-c9d2-4bf3-8f94-812d38af35f7",
+      "identifier": "wikipedia-dsb",
+      "last_modified": 1729004089216,
+      "recordType": "engine",
+      "schema": 1729002494375,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "dsb"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wicipedia",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wicipedia (cy)",
+        "urls": {
+          "search": {
+            "base": "https://cy.wikipedia.org/wiki/Arbennig:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://cy.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "0df7934b-5903-4382-ae3d-d898ac0487aa",
+      "identifier": "wikipedia-cy",
+      "last_modified": 1729004089213,
+      "recordType": "engine",
+      "schema": 1729002491953,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "cy"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "уикипедия",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Уикипедия (bg)",
+        "urls": {
+          "search": {
+            "base": "https://bg.wikipedia.org/wiki/Специални:Търсене",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://bg.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "6324bcb4-9aad-4aa2-b10c-f320ae1242c3",
+      "identifier": "wikipedia-bg",
+      "last_modified": 1729004089211,
+      "recordType": "engine",
+      "schema": 1729002487482,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "bg"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vikipediya",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vikipediya (az)",
+        "urls": {
+          "search": {
+            "base": "https://az.wikipedia.org/wiki/Xüsusi:Axtar",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://az.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "2230b4af-8fdf-4aa0-a496-5178b25382ed",
+      "identifier": "wikipedia-az",
+      "last_modified": 1729004089209,
+      "recordType": "engine",
+      "schema": 1729002478197,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "az"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ويكيبيديا",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "ويكيبيديا (ar)",
+        "urls": {
+          "search": {
+            "base": "https://ar.wikipedia.org/wiki/خاص:بحث",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ar.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "3ed57e7f-df2a-4bb0-aecf-10327d5ff1ea",
+      "identifier": "wikipedia-ar",
+      "last_modified": 1729004089207,
+      "recordType": "engine",
+      "schema": 1729002476264,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ar"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "biquipedia",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Biquipedia (an)",
+        "urls": {
+          "search": {
+            "base": "https://an.wikipedia.org/wiki/Especial:Mirar",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://an.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "1c2173e4-1ad3-4347-900a-17f4103c6bbe",
+      "identifier": "wikipedia-an",
+      "last_modified": 1729004089205,
+      "recordType": "engine",
+      "schema": 1728896622109,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "an"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "βικιπαίδεια",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Βικιπαίδεια (el)",
+        "urls": {
+          "search": {
+            "base": "https://el.wikipedia.org/wiki/Ειδικό:Αναζήτηση",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://el.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "6ebc40f2-9307-4e58-8fd7-0e1a23b80723",
+      "identifier": "wikipedia-el",
+      "last_modified": 1729004089203,
+      "recordType": "engine",
+      "schema": 1729002495941,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "el"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ವಿಕಿಪೀಡಿಯ",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "ವಿಕಿಪೀಡಿಯ (kn)",
+        "urls": {
+          "search": {
+            "base": "https://kn.wikipedia.org/wiki/ವಿಶೇಷ:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://kn.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "ce510c56-9d5e-416c-aef0-277bfbaac464",
+      "identifier": "wikipedia-kn",
+      "last_modified": 1729004089200,
+      "recordType": "engine",
+      "schema": 1729002519733,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "kn"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vikipedija",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vikipedija (lt)",
+        "urls": {
+          "search": {
+            "base": "https://lt.wikipedia.org/wiki/Specialus:Paieška",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://lt.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "774990fb-aabc-4008-86d3-adf12f89ccd4",
+      "identifier": "wikipedia-lt",
+      "last_modified": 1729004089198,
+      "recordType": "engine",
+      "schema": 1729002522879,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "lt"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vikipēdija",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vikipēdija (lv)",
+        "urls": {
+          "search": {
+            "base": "https://lv.wikipedia.org/wiki/Special:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://lv.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "395b6c93-f7ff-47b8-b895-6f7bb99f9c56",
+      "identifier": "wikipedia-lv",
+      "last_modified": 1729004089196,
+      "recordType": "engine",
+      "schema": 1729002525117,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "lv"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ဝီကီပီးဒီးယား",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "ဝီကီပီးဒီးယား (my)",
+        "urls": {
+          "search": {
+            "base": "https://my.wikipedia.org/wiki/Special:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://my.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "0616dd06-2bfd-46f0-9870-832a1db8a622",
+      "identifier": "wikipedia-my",
+      "last_modified": 1729004089194,
+      "recordType": "engine",
+      "schema": 1729002527903,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "my"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "විකිපීඩියා",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "විකිපීඩියා (si)",
+        "urls": {
+          "search": {
+            "base": "https://si.wikipedia.org/wiki/විශේෂ:ගවේෂණය",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://si.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "6a54dc6e-623a-4839-afd7-224e06d7ba73",
+      "identifier": "wikipedia-si",
+      "last_modified": 1729004089191,
+      "recordType": "engine",
+      "schema": 1729002533949,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "si"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "vikipedi",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Vikipedi (tr)",
+        "urls": {
+          "search": {
+            "base": "https://tr.wikipedia.org/wiki/Özel:Ara",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://tr.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "8885ffbb-f450-4642-8204-ed9128b29e51",
+      "identifier": "wikipedia-tr",
+      "last_modified": 1729004089189,
+      "recordType": "engine",
+      "schema": 1729002543730,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "tr"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "վիքիպեդիա",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Վիքիպեդիա (hy)",
+        "urls": {
+          "search": {
+            "base": "https://hy.wikipedia.org/wiki/Սպասարկող:Որոնել",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://hy.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "c6286785-b61b-4288-aec1-9a7820c32694",
+      "identifier": "wikipedia-hy",
+      "last_modified": 1729004089187,
+      "recordType": "engine",
+      "schema": 1729002515482,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "hy-AM"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ਵਿਕੀਪੀਡੀਆ",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "ਵਿਕੀਪੀਡੀਆ (pa)",
+        "urls": {
+          "search": {
+            "base": "https://pa.wikipedia.org/wiki/ਖ਼ਾਸ:ਖੋਜੋ",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://pa.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "fa428a75-44d5-4f21-84bd-64935d483540",
+      "identifier": "wikipedia-pa",
+      "last_modified": 1729004089185,
+      "recordType": "engine",
+      "schema": 1729002530859,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "pa-IN"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipédia",
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipédia (pt)",
+        "urls": {
+          "search": {
+            "base": "https://pt.wikipedia.org/wiki/Especial:Pesquisar",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://pt.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "f2e04c1b-b19f-40d9-841d-9b48b7ba9da2",
+      "identifier": "wikipedia-pt",
+      "last_modified": 1729004089183,
+      "recordType": "engine",
+      "schema": 1729002531798,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "pt-BR",
+              "pt-PT"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (nb)",
+        "urls": {
+          "search": {
+            "base": "https://no.wikipedia.org/wiki/Spesial:Søk",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://no.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "607d401f-70cd-4810-b9b5-497d5a9489f6",
+      "identifier": "wikipedia-NO",
+      "last_modified": 1722952002234,
+      "recordType": "engine",
+      "schema": 1722848326841,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "nb-NO"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Reddit",
+        "urls": {
+          "search": {
+            "base": "https://www.reddit.com/search/",
+            "params": [],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "f2038189-6bfe-458b-b379-577fe9db4d51",
+      "identifier": "reddit",
+      "last_modified": 1718719100336,
+      "recordType": "engine",
+      "schema": 1718698475234,
+      "variants": [
+        {
+          "environment": {
+            "allRegionsAndLocales": true
+          },
+          "optional": true
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "ವಿಕ್ಷನರಿ (kn)",
+        "urls": {
+          "search": {
+            "base": "https://kn.wiktionary.org/wiki/ವಿಶೇಷ:Search",
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://kn.wiktionary.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              },
+              {
+                "name": "namespace",
+                "value": "0"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "a2b8eb91-dc15-4d98-8a1f-d7dced364111",
+      "identifier": "wiktionary-kn",
+      "last_modified": 1718719100333,
+      "recordType": "engine",
+      "schema": 1718698503954,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "kn"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "விக்சனரி (ta)",
+        "urls": {
+          "search": {
+            "base": "https://ta.wiktionary.org/wiki/சிறப்பு:Search",
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ta.wiktionary.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              },
+              {
+                "name": "namespace",
+                "value": "0"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "bcb9427b-c7c4-4665-9620-16ec5c0b304f",
+      "identifier": "wiktionary-ta",
+      "last_modified": 1718719100330,
+      "recordType": "engine",
+      "schema": 1718698508333,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ta"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "YouTube",
+        "urls": {
+          "search": {
+            "base": "https://www.youtube.com/results",
+            "params": [],
+            "searchTermParamName": "search_query"
+          }
+        }
+      },
+      "id": "05b6f528-bd00-4101-b107-b91d5f70b44b",
+      "identifier": "youtube",
+      "last_modified": 1718719100328,
+      "recordType": "engine",
+      "schema": 1718698509654,
+      "variants": [
+        {
+          "environment": {
+            "allRegionsAndLocales": true
+          },
+          "optional": true
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Salidzini.lv",
+        "partnerCode": "firefox-plugin",
+        "urls": {
+          "search": {
+            "base": "https://www.salidzini.lv/search.php",
+            "params": [
+              {
+                "name": "utm_source",
+                "value": "{partnerCode}"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://www.salidzini.lv/search_suggest_opensearch.php",
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "883c6f10-cac4-4dc0-b631-9a28cbadda49",
+      "identifier": "salidzinilv",
+      "last_modified": 1718719100324,
+      "recordType": "engine",
+      "schema": 1718698485230,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ltg",
+              "lv"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android",
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "firefox_mobile"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Am Faclair Beag",
+        "urls": {
+          "search": {
+            "base": "https://www.faclair.com/",
+            "searchTermParamName": "txtSearch"
+          }
+        }
+      },
+      "id": "d21e561b-64ae-4a33-b2f0-c4a490a5cf82",
+      "identifier": "faclair-beag",
+      "last_modified": 1718719100322,
+      "recordType": "engine",
+      "schema": 1718698465691,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "gd"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android",
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "urls": {
+                "search": {
+                  "base": "https://www.faclair.com/m"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "다음",
+        "urls": {
+          "search": {
+            "base": "https://search.daum.net/search",
+            "params": [
+              {
+                "name": "w",
+                "value": "tot"
+              },
+              {
+                "name": "nil_ch",
+                "value": "ffsr"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://suggest.search.daum.net/sushi/opensearch/pc",
+            "params": [
+              {
+                "name": "DA",
+                "value": "JU2"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "3330e927-6733-4239-9738-b41c5c460b11",
+      "identifier": "daum-kr",
+      "last_modified": 1718719100316,
+      "recordType": "engine",
+      "schema": 1718698358587,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ko"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "urls": {
+                "search": {
+                  "base": "https://m.search.daum.net/search"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Cốc Cốc",
+        "partnerCode": "firefox",
+        "urls": {
+          "search": {
+            "base": "https://coccoc.com/search",
+            "params": [
+              {
+                "name": "s",
+                "value": "ff"
+              },
+              {
+                "name": "utm_source",
+                "value": "{partnerCode}"
+              }
+            ],
+            "searchTermParamName": "query"
+          },
+          "suggestions": {
+            "base": "https://coccoc.com/composer/autocomplete",
+            "params": [
+              {
+                "name": "of",
+                "value": "b"
+              },
+              {
+                "name": "s",
+                "value": "ff"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "20104daa-cb8a-40b9-a8c5-2433f4476c3e",
+      "identifier": "coccoc",
+      "last_modified": 1718719100314,
+      "recordType": "engine",
+      "schema": 1718698356483,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "vi"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android",
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "ffmobile"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Seznam",
+        "partnerCode": "firefox",
+        "urls": {
+          "search": {
+            "base": "https://search.seznam.cz/",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "{partnerCode}"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://suggest.seznam.cz/fulltext_ff",
+            "searchTermParamName": "phrase"
+          }
+        }
+      },
+      "id": "b0cdb724-b7df-47d0-8ead-93aa0a8f60a2",
+      "identifier": "seznam-cz",
+      "last_modified": 1718719100311,
+      "recordType": "engine",
+      "schema": 1718698494927,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "cs"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android",
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "SearchBox"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "amazon"
+        ],
+        "classification": "unknown",
+        "name": "Amazon.co.jp",
+        "partnerCode": "mozillajapan-fx-22",
+        "urls": {
+          "search": {
+            "base": "https://www.amazon.co.jp/exec/obidos/external-search/",
+            "params": [
+              {
+                "name": "mode",
+                "value": "blended"
+              },
+              {
+                "name": "tag",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "field-keywords"
+          }
+        }
+      },
+      "id": "9d089e46-dc94-4d4f-8f17-cc07b59aa9e4",
+      "identifier": "amazon-jp",
+      "last_modified": 1718719100309,
+      "recordType": "engine",
+      "schema": 1718637175117,
+      "variants": [
+        {
+          "environment": {
+            "regions": [
+              "jp"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android",
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "moz-jp-mbl-22"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "amazon"
+        ],
+        "classification": "unknown",
+        "name": "Amazon.com",
+        "urls": {
+          "search": {
+            "base": "https://www.amazon.com/s",
+            "searchTermParamName": "k"
+          }
+        }
+      },
+      "id": "788a2ded-6872-4742-8115-c14dde7a18f9",
+      "identifier": "amazondotcom-us",
+      "last_modified": 1718719100307,
+      "notes": "Amazon.com (us only)",
+      "recordType": "engine",
+      "schema": 1718698346192,
+      "variants": [
+        {
+          "environment": {
+            "applications": [
+              "firefox"
+            ],
+            "regions": [
+              "us"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.at/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "5221-53469-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "16"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "8dee7454-6c6c-4b22-a411-4e474c7afbb3",
+      "identifier": "ebay-at",
+      "last_modified": 1718719100305,
+      "recordType": "engine",
+      "schema": 1718698368829,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "de",
+              "dsb",
+              "hsb"
+            ],
+            "regions": [
+              "at"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.com.au/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "705-53470-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "15"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "e5a64fe0-2cb9-4b22-83d3-4e529c3702a9",
+      "identifier": "ebay-au",
+      "last_modified": 1718719100302,
+      "recordType": "engine",
+      "schema": 1718698373814,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "cy",
+              "en-GB",
+              "en-US",
+              "gd"
+            ],
+            "regions": [
+              "au"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.befr.ebay.be/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "1553-53471-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "23"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "5f40614e-4fc6-4dee-a897-07b258e00820",
+      "identifier": "ebay-be",
+      "last_modified": 1718719100300,
+      "recordType": "engine",
+      "schema": 1718698383258,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "br",
+              "en-US",
+              "fr",
+              "wo",
+              "fy-NL",
+              "nl"
+            ],
+            "regions": [
+              "be"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.com/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "711-53200-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "0"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "d8b7ed81-00f3-478a-a835-dc0677d7190a",
+      "identifier": "ebay",
+      "last_modified": 1718719100298,
+      "recordType": "engine",
+      "schema": 1718698365997,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "en-US"
+            ],
+            "regions": [
+              "us"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "百度",
+          "baidu"
+        ],
+        "classification": "general",
+        "name": "百度",
+        "urls": {
+          "search": {
+            "base": "https://www.baidu.com/baidu",
+            "params": [
+              {
+                "name": "ie",
+                "value": "utf-8"
+              }
+            ],
+            "searchTermParamName": "wd"
+          },
+          "suggestions": {
+            "base": "https://www.baidu.com/su",
+            "params": [
+              {
+                "name": "ie",
+                "value": "utf-8"
+              },
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "wd"
+          }
+        }
+      },
+      "id": "ad58537f-f397-46ec-a1a8-935e12f0aab6",
+      "identifier": "baidu",
+      "last_modified": 1718719100295,
+      "recordType": "engine",
+      "schema": 1718698349444,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "zh-CN"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android",
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "urls": {
+                "search": {
+                  "base": "https://m.baidu.com/s",
+                  "params": [],
+                  "searchTermParamName": "word"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "qwant"
+        ],
+        "classification": "general",
+        "name": "Qwant",
+        "partnerCode": "brz-moz",
+        "urls": {
+          "search": {
+            "base": "https://www.qwant.com/",
+            "params": [
+              {
+                "name": "client",
+                "value": "{partnerCode}"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://api.qwant.com/api/suggest/",
+            "params": [
+              {
+                "name": "client",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "2e62746e-b90a-42ee-b0f2-9ed0e1e2eaf0",
+      "identifier": "qwant",
+      "last_modified": 1718719100293,
+      "recordType": "engine",
+      "schema": 1718698472747,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "fr"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "ff_android"
+            },
+            {
+              "environment": {
+                "applications": [
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "ff_ios"
+            }
+          ]
+        },
+        {
+          "environment": {
+            "regions": [
+              "be",
+              "ch",
+              "es",
+              "fr",
+              "it",
+              "nl"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "ff_android"
+            },
+            {
+              "environment": {
+                "applications": [
+                  "firefox-ios",
+                  "focus-ios"
+                ]
+              },
+              "partnerCode": "ff_ios"
+            }
+          ]
+        },
+        {
+          "environment": {
+            "distributions": [
+              "qwant-001",
+              "qwant-002"
+            ]
+          },
+          "partnerCode": "firefoxqwant",
+          "telemetrySuffix": "qwant"
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "bing"
+        ],
+        "classification": "general",
+        "name": "Bing",
+        "partnerCode": "MOZI",
+        "urls": {
+          "search": {
+            "base": "https://www.bing.com/search",
+            "params": [
+              {
+                "name": "pc",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "form",
+                "value": "MOZLBR"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://www.bing.com/osjson.aspx",
+            "params": [
+              {
+                "name": "form",
+                "value": "OSDJAS"
+              }
+            ],
+            "searchTermParamName": "query"
+          },
+          "trending": {
+            "base": "https://www.bing.com/osjson.aspx"
+          }
+        }
+      },
+      "id": "05645095-d26e-4f20-9137-f24a14a23f28",
+      "identifier": "bing",
+      "last_modified": 1718719100291,
+      "recordType": "engine",
+      "schema": 1718698353718,
+      "variants": [
+        {
+          "environment": {
+            "allRegionsAndLocales": true,
+            "applications": [
+              "firefox",
+              "firefox-android",
+              "firefox-ios"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "channels": [
+                  "esr"
+                ]
+              },
+              "partnerCode": "MOZR",
+              "telemetrySuffix": "esr"
+            },
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android"
+                ]
+              },
+              "partnerCode": "MOZB",
+              "urls": {
+                "search": {
+                  "params": [
+                    {
+                      "name": "pc",
+                      "value": "{partnerCode}"
+                    },
+                    {
+                      "name": "form",
+                      "value": "MOZMBA"
+                    }
+                  ],
+                  "searchTermParamName": "q"
+                }
+              }
+            },
+            {
+              "environment": {
+                "applications": [
+                  "firefox-ios"
+                ]
+              },
+              "partnerCode": "MOZW",
+              "urls": {
+                "search": {
+                  "params": [
+                    {
+                      "name": "pc",
+                      "value": "{partnerCode}"
+                    },
+                    {
+                      "name": "form",
+                      "value": "MOZWSB"
+                    }
+                  ],
+                  "searchTermParamName": "q"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "duckduckgo",
+          "ddg"
+        ],
+        "classification": "general",
+        "name": "DuckDuckGo",
+        "partnerCode": "ffab",
+        "urls": {
+          "search": {
+            "base": "https://duckduckgo.com/",
+            "params": [
+              {
+                "name": "t",
+                "value": "{partnerCode}"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://ac.duckduckgo.com/ac/",
+            "params": [
+              {
+                "name": "type",
+                "value": "list"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "04e99a38-13ee-47d8-8aa4-64482b3dea99",
+      "identifier": "ddg",
+      "last_modified": 1718719100285,
+      "recordType": "engine",
+      "schema": 1718698362015,
+      "variants": [
+        {
+          "environment": {
+            "allRegionsAndLocales": true
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "channels": [
+                  "esr"
+                ]
+              },
+              "partnerCode": "ftsa",
+              "telemetrySuffix": "esr"
+            }
+          ]
+        },
+        {
+          "environment": {
+            "allRegionsAndLocales": true,
+            "applications": [
+              "firefox-android",
+              "focus-android"
+            ]
+          },
+          "partnerCode": "fpas"
+        },
+        {
+          "environment": {
+            "allRegionsAndLocales": true,
+            "applications": [
+              "firefox-ios",
+              "focus-ios"
+            ]
+          },
+          "partnerCode": "ffip"
+        },
+        {
+          "environment": {
+            "distributions": [
+              "mint-001"
+            ]
+          },
+          "partnerCode": "lm",
+          "telemetrySuffix": "lm"
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.es/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "1185-53479-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "186"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "0592aedc-f4e5-4873-a8d4-da9482071613",
+      "identifier": "ebay-es",
+      "last_modified": 1718719100283,
+      "recordType": "engine",
+      "schema": 1718698418873,
+      "variants": [
+        {
+          "environment": {
+            "excludedRegions": [
+              "pl"
+            ],
+            "locales": [
+              "an",
+              "ast",
+              "ca",
+              "ca-valencia",
+              "es-ES",
+              "eu",
+              "gl"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.fr/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "709-53476-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "71"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "d327156c-dfc4-47f6-a620-3846a21144d9",
+      "identifier": "ebay-fr",
+      "last_modified": 1718719100280,
+      "recordType": "engine",
+      "schema": 1718698423588,
+      "variants": [
+        {
+          "environment": {
+            "excludedRegions": [
+              "be",
+              "ca",
+              "ch",
+              "pl"
+            ],
+            "locales": [
+              "br",
+              "fr",
+              "wo"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.ca/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "706-53473-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "2"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "336d7fa9-7579-4981-bfb0-024c6c5f977d",
+      "identifier": "ebay-ca",
+      "last_modified": 1718719100278,
+      "recordType": "engine",
+      "schema": 1718698388762,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "br",
+              "en-US",
+              "fr",
+              "wo"
+            ],
+            "regions": [
+              "ca"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        },
+        {
+          "environment": {
+            "excludedRegions": [
+              "pl"
+            ],
+            "locales": [
+              "en-CA"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.ch/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "5222-53480-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "193"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "8d8484a2-b856-4edd-93d7-c53a7aaca6e1",
+      "identifier": "ebay-ch",
+      "last_modified": 1718719100276,
+      "recordType": "engine",
+      "schema": 1718698406340,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "br",
+              "de",
+              "dsb",
+              "en-US",
+              "fr",
+              "hsb",
+              "wo"
+            ],
+            "regions": [
+              "ch"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        },
+        {
+          "environment": {
+            "excludedRegions": [
+              "pl"
+            ],
+            "locales": [
+              "rm"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.co.uk/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "710-53481-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "3"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "37f83917-8d6e-46d6-9d15-8e7779339d18",
+      "identifier": "ebay-uk",
+      "last_modified": 1718719100273,
+      "recordType": "engine",
+      "schema": 1718698449042,
+      "variants": [
+        {
+          "environment": {
+            "excludedRegions": [
+              "au",
+              "ie",
+              "pl"
+            ],
+            "locales": [
+              "cy",
+              "en-GB",
+              "gd"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        },
+        {
+          "environment": {
+            "locales": [
+              "en-US",
+              "sco"
+            ],
+            "regions": [
+              "gb"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.ie/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "5282-53468-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "205"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "0a9fed24-cd33-4293-bac8-eb26a285c9f1",
+      "identifier": "ebay-ie",
+      "last_modified": 1718719100271,
+      "recordType": "engine",
+      "schema": 1718698428556,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "cy",
+              "en-GB",
+              "en-US",
+              "gd"
+            ],
+            "regions": [
+              "ie"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        },
+        {
+          "environment": {
+            "excludedRegions": [
+              "pl"
+            ],
+            "locales": [
+              "ga-IE"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.de/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "707-53477-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "77"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "e991a5f7-616e-43b0-b349-7995b837a520",
+      "identifier": "ebay-de",
+      "last_modified": 1718719100269,
+      "recordType": "engine",
+      "schema": 1718698412277,
+      "variants": [
+        {
+          "environment": {
+            "excludedRegions": [
+              "at",
+              "ch",
+              "pl"
+            ],
+            "locales": [
+              "de",
+              "dsb",
+              "hsb"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.nl/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "1346-53482-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "146"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "670475c3-d56f-4f87-9834-ddb12d0e8cbd",
+      "identifier": "ebay-nl",
+      "last_modified": 1718719100266,
+      "recordType": "engine",
+      "schema": 1718698440696,
+      "variants": [
+        {
+          "environment": {
+            "excludedRegions": [
+              "be",
+              "pl"
+            ],
+            "locales": [
+              "fy-NL",
+              "nl"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        },
+        {
+          "environment": {
+            "locales": [
+              "en-US"
+            ],
+            "regions": [
+              "nl"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.it/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "724-53478-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "101"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "f36dd44c-ba5f-44e5-8b19-672eb1ed62fd",
+      "identifier": "ebay-it",
+      "last_modified": 1718719100264,
+      "recordType": "engine",
+      "schema": 1718698434710,
+      "variants": [
+        {
+          "environment": {
+            "excludedRegions": [
+              "pl"
+            ],
+            "locales": [
+              "fur",
+              "it",
+              "lij",
+              "sc"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "ebay"
+        ],
+        "classification": "unknown",
+        "name": "eBay",
+        "partnerCode": "5338192028",
+        "urls": {
+          "search": {
+            "base": "https://www.ebay.pl/sch/",
+            "params": [
+              {
+                "name": "toolid",
+                "value": "20004"
+              },
+              {
+                "name": "campid",
+                "value": "{partnerCode}"
+              },
+              {
+                "name": "mkevt",
+                "value": "1"
+              },
+              {
+                "name": "mkcid",
+                "value": "1"
+              },
+              {
+                "name": "mkrid",
+                "value": "4908-226936-19255-0"
+              }
+            ],
+            "searchTermParamName": "kw"
+          },
+          "suggestions": {
+            "base": "https://autosug.ebay.com/autosug",
+            "params": [
+              {
+                "name": "sId",
+                "value": "212"
+              },
+              {
+                "name": "fmt",
+                "value": "osr"
+              }
+            ],
+            "searchTermParamName": "kwd"
+          }
+        }
+      },
+      "id": "37f83917-8d6e-46d6-9d15-8e7779339d08",
+      "identifier": "ebay-pl",
+      "last_modified": 1718719100261,
+      "recordType": "engine",
+      "schema": 1718698443475,
+      "variants": [
+        {
+          "environment": {
+            "regions": [
+              "pl"
+            ]
+          },
+          "subVariants": [
+            {
+              "environment": {
+                "applications": [
+                  "firefox-android",
+                  "focus-android"
+                ]
+              },
+              "partnerCode": "5338791379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Wikiccionari (oc)",
+        "urls": {
+          "search": {
+            "base": "https://oc.wiktionary.org/wiki/Especial:Recèrca",
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://oc.wiktionary.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              },
+              {
+                "name": "namespace",
+                "value": "0"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "7c9d2fc3-1e6b-40f6-80ad-080bd94fe24b",
+      "identifier": "wiktionary-oc",
+      "last_modified": 1717416922458,
+      "recordType": "engine",
+      "schema": 1717411323291,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "oc"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "MercadoLibre Argentina",
+        "urls": {
+          "search": {
+            "base": "https://www.mercadolibre.com.ar/jm/search",
+            "searchTermParamName": "as_word"
+          }
+        }
+      },
+      "id": "8111d157-e064-40fa-993d-e1d972534754",
+      "identifier": "mercadolibre-ar",
+      "last_modified": 1717416922456,
+      "recordType": "engine",
+      "schema": 1717411267717,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "es-AR"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "id": "3e1fed64-5ec7-4b1c-bedc-741fe3c59bc3",
+      "last_modified": 1707833224345,
+      "orders": [
+        {
+          "environment": {
+            "distributions": [
+              "MozillaOnline"
+            ]
+          },
+          "order": [
+            "baidu",
+            "bing",
+            "google",
+            "wikipedia*"
+          ]
+        },
+        {
+          "environment": {
+            "distributions": [
+              "qwant-001",
+              "qwant-002"
+            ]
+          },
+          "order": [
+            "qwant",
+            "qwantjr"
+          ]
+        }
+      ],
+      "recordType": "engineOrders",
+      "schema": 1707824831520
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (en)",
+        "urls": {
+          "search": {
+            "base": "https://en.wikipedia.org/wiki/Special:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://en.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "7f6d23c2-191e-483e-af3a-ce6451e3a8dd",
+      "identifier": "wikipedia",
+      "last_modified": 1702906502744,
+      "recordType": "engine",
+      "schema": 1702901740904,
+      "variants": [
+        {
+          "environment": {
+            "allRegionsAndLocales": true,
+            "excludedLocales": [
+              "af",
+              "an",
+              "ar",
+              "ast",
+              "az",
+              "be",
+              "bg",
+              "bn",
+              "br",
+              "bs",
+              "ca",
+              "ca-valencia",
+              "cs",
+              "cy",
+              "da",
+              "de",
+              "dsb",
+              "el",
+              "eo",
+              "cak",
+              "es-AR",
+              "es-CL",
+              "es-ES",
+              "es-MX",
+              "trs",
+              "et",
+              "eu",
+              "fa",
+              "fi",
+              "fr",
+              "ff",
+              "son",
+              "fy-NL",
+              "ga-IE",
+              "gd",
+              "gl",
+              "gn",
+              "gu-IN",
+              "hi-IN",
+              "he",
+              "hr",
+              "hsb",
+              "hu",
+              "hy-AM",
+              "ia",
+              "id",
+              "is",
+              "ja",
+              "ja-JP-macos",
+              "ka",
+              "kab",
+              "kk",
+              "km",
+              "kn",
+              "ko",
+              "it",
+              "fur",
+              "sc",
+              "lij",
+              "lo",
+              "lt",
+              "ltg",
+              "lv",
+              "mk",
+              "mr",
+              "ms",
+              "my",
+              "nb-NO",
+              "ne-NP",
+              "nl",
+              "nn-NO",
+              "oc",
+              "pa-IN",
+              "pl",
+              "szl",
+              "pt-BR",
+              "pt-PT",
+              "rm",
+              "ro",
+              "ru",
+              "si",
+              "sk",
+              "sl",
+              "sq",
+              "sr",
+              "sv-SE",
+              "ta",
+              "te",
+              "th",
+              "tl",
+              "tr",
+              "uk",
+              "ur",
+              "uz",
+              "vi",
+              "wo",
+              "zh-CN",
+              "zh-TW"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (af)",
+        "urls": {
+          "search": {
+            "base": "https://af.wikipedia.org/wiki/Spesiaal:Soek",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://af.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "9dcc6d57-1b00-4cdc-bc11-d70593a3da30",
+      "identifier": "wikipedia-af",
+      "last_modified": 1702906502739,
+      "recordType": "engine",
+      "schema": 1702901741515,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "af"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (ast)",
+        "urls": {
+          "search": {
+            "base": "https://ast.wikipedia.org/wiki/Especial:Gueta",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ast.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "e5f07079-9153-4104-a8b9-a9d15ff75853",
+      "identifier": "wikipedia-ast",
+      "last_modified": 1702906502729,
+      "recordType": "engine",
+      "schema": 1702901743369,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ast"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (br)",
+        "urls": {
+          "search": {
+            "base": "https://br.wikipedia.org/wiki/Dibar:Klask",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://br.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "c9266f36-f954-44df-924b-a1c205f66d7c",
+      "identifier": "wikipedia-br",
+      "last_modified": 1702906502718,
+      "recordType": "engine",
+      "schema": 1702901745178,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "br"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (bs)",
+        "urls": {
+          "search": {
+            "base": "https://bs.wikipedia.org/wiki/Posebno:Pretraga",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://bs.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "c88785cc-48de-4f07-a40f-5d6564de3183",
+      "identifier": "wikipedia-bs",
+      "last_modified": 1702906502715,
+      "recordType": "engine",
+      "schema": 1702901745796,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "bs"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (da)",
+        "urls": {
+          "search": {
+            "base": "https://da.wikipedia.org/wiki/Speciel:Søgning",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://da.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "ae42fcaa-ddee-4212-acb9-8bc15d09a39d",
+      "identifier": "wikipedia-da",
+      "last_modified": 1702906502707,
+      "recordType": "engine",
+      "schema": 1702901746995,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "da"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (de)",
+        "urls": {
+          "search": {
+            "base": "https://de.wikipedia.org/wiki/Spezial:Suche",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://de.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "def1d4ba-b8c8-46c4-9800-134b989ca058",
+      "identifier": "wikipedia-de",
+      "last_modified": 1702906502704,
+      "recordType": "engine",
+      "schema": 1702901747613,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "de"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (eu)",
+        "urls": {
+          "search": {
+            "base": "https://eu.wikipedia.org/wiki/Berezi:Bilatu",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://eu.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "0d6704d1-3aed-420c-8c16-6aeefede499f",
+      "identifier": "wikipedia-eu",
+      "last_modified": 1702906502688,
+      "recordType": "engine",
+      "schema": 1702901750807,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "eu"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (fi)",
+        "urls": {
+          "search": {
+            "base": "https://fi.wikipedia.org/wiki/Toiminnot:Haku",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://fi.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "0820d593-6616-476a-ab3d-763c4d14dcc6",
+      "identifier": "wikipedia-fi",
+      "last_modified": 1702906502682,
+      "recordType": "engine",
+      "schema": 1702901752065,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "fi"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (gl)",
+        "urls": {
+          "search": {
+            "base": "https://gl.wikipedia.org/wiki/Especial:Procurar",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://gl.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "cd385c40-96bc-43c4-9f30-eff738828401",
+      "identifier": "wikipedia-gl",
+      "last_modified": 1702906502668,
+      "recordType": "engine",
+      "schema": 1702901754558,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "gl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (ia)",
+        "urls": {
+          "search": {
+            "base": "https://ia.wikipedia.org/wiki/Special:Recerca",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ia.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "6787b684-aa4f-48d2-9673-fce3b528c71c",
+      "identifier": "wikipedia-ia",
+      "last_modified": 1702906502647,
+      "recordType": "engine",
+      "schema": 1702901758249,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ia"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (id)",
+        "urls": {
+          "search": {
+            "base": "https://id.wikipedia.org/wiki/Istimewa:Pencarian",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://id.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "163da4a0-e59f-423a-bebc-3ec3bd68b941",
+      "identifier": "wikipedia-id",
+      "last_modified": 1702906502644,
+      "recordType": "engine",
+      "schema": 1702901758856,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "id"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (is)",
+        "urls": {
+          "search": {
+            "base": "https://is.wikipedia.org/wiki/Kerfissíða:Leit",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://is.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "26ca2f38-0472-45de-83fd-78d67aaecd22",
+      "identifier": "wikipedia-is",
+      "last_modified": 1702906502640,
+      "recordType": "engine",
+      "schema": 1702901759494,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "is"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (kab)",
+        "urls": {
+          "search": {
+            "base": "https://kab.wikipedia.org/wiki/Uslig:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://kab.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "e6f20ba5-3013-4b18-ad7a-351a64e62ec4",
+      "identifier": "wikipedia-kab",
+      "last_modified": 1702906502632,
+      "recordType": "engine",
+      "schema": 1702901760752,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "kab"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (lij)",
+        "urls": {
+          "search": {
+            "base": "https://lij.wikipedia.org/wiki/Speçiale:Riçerca",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://lij.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "5ec04310-966d-40da-af5b-f24383d40c8a",
+      "identifier": "wikipedia-lij",
+      "last_modified": 1702906502619,
+      "recordType": "engine",
+      "schema": 1702901763202,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "lij"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (ms)",
+        "urls": {
+          "search": {
+            "base": "https://ms.wikipedia.org/wiki/Khas:Gelintar",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ms.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "7039c888-4bd6-4b82-a164-ca3bfc93b24c",
+      "identifier": "wikipedia-ms",
+      "last_modified": 1702906502595,
+      "recordType": "engine",
+      "schema": 1702901767543,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ms"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (nl)",
+        "urls": {
+          "search": {
+            "base": "https://nl.wikipedia.org/wiki/Speciaal:Zoeken",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://nl.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "9e423eca-df00-4385-ab15-4e61bc220b05",
+      "identifier": "wikipedia-nl",
+      "last_modified": 1702906502588,
+      "recordType": "engine",
+      "schema": 1702901768793,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "nl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (rm)",
+        "urls": {
+          "search": {
+            "base": "https://rm.wikipedia.org/wiki/Spezial:Search",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://rm.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "4042df85-6b55-4a40-9c3f-ef74b05ef5be",
+      "identifier": "wikipedia-rm",
+      "last_modified": 1702906502581,
+      "recordType": "engine",
+      "schema": 1702901770011,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "rm"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (ro)",
+        "urls": {
+          "search": {
+            "base": "https://ro.wikipedia.org/wiki/Special:Căutare",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ro.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "c2f3213e-f43f-4776-b1cb-b70d8457b6c7",
+      "identifier": "wikipedia-ro",
+      "last_modified": 1702906502577,
+      "recordType": "engine",
+      "schema": 1702901770632,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ro"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (sq)",
+        "urls": {
+          "search": {
+            "base": "https://sq.wikipedia.org/wiki/Speciale:Kërkim",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://sq.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "bc8c03e7-747a-408c-a0ee-6598ca9fad4a",
+      "identifier": "wikipedia-sq",
+      "last_modified": 1702906502561,
+      "recordType": "engine",
+      "schema": 1702901773681,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "sq"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (sv)",
+        "urls": {
+          "search": {
+            "base": "https://sv.wikipedia.org/wiki/Special:Sök",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://sv.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "d0708bee-d246-4eb9-81ff-50d5947837ec",
+      "identifier": "wikipedia-sv-SE",
+      "last_modified": 1702906502555,
+      "recordType": "engine",
+      "schema": 1702901774920,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "sv-SE"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (tl)",
+        "urls": {
+          "search": {
+            "base": "https://tl.wikipedia.org/wiki/Natatangi:Maghanap",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://tl.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "d0c8b2f5-accc-45f4-adf4-a7377692869b",
+      "identifier": "wikipedia-tl",
+      "last_modified": 1702906502542,
+      "recordType": "engine",
+      "schema": 1702901777391,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "tl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (vi)",
+        "urls": {
+          "search": {
+            "base": "https://vi.wikipedia.org/wiki/Đặc_biệt:Tìm_kiếm",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://vi.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "5b6f0a3f-1f94-473d-8bcc-c48984523b0c",
+      "identifier": "wikipedia-vi",
+      "last_modified": 1702906502525,
+      "recordType": "engine",
+      "schema": 1702901780448,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "vi"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (wo)",
+        "urls": {
+          "search": {
+            "base": "https://wo.wikipedia.org/wiki/Jagleel:Ceet",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://wo.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "3f1ba3c7-23f1-4ca1-aa0c-623fcae80ddd",
+      "identifier": "wikipedia-wo",
+      "last_modified": 1702906502521,
+      "recordType": "engine",
+      "schema": 1702901781072,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "wo"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (es)",
+        "urls": {
+          "search": {
+            "base": "https://es.wikipedia.org/wiki/Especial:Buscar",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://es.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "82025e38-8eda-48c2-b844-2b5e7d489c34",
+      "identifier": "wikipedia-es",
+      "last_modified": 1702906502496,
+      "recordType": "engine",
+      "schema": 1702901785455,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "cak",
+              "es-AR",
+              "es-CL",
+              "es-ES",
+              "es-MX",
+              "trs"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (it)",
+        "urls": {
+          "search": {
+            "base": "https://it.wikipedia.org/wiki/Speciale:Ricerca",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://it.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "de65dd23-0d4b-4bf0-bd97-0f536e184ded",
+      "identifier": "wikipedia-it",
+      "last_modified": 1702906502476,
+      "recordType": "engine",
+      "schema": 1702901789119,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "fur",
+              "it",
+              "sc"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (ja)",
+        "urls": {
+          "search": {
+            "base": "https://ja.wikipedia.org/wiki/特別:検索",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://ja.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "a6bbf9df-acd4-47ea-9d26-6382b587c9c3",
+      "identifier": "wikipedia-ja",
+      "last_modified": 1702906502473,
+      "recordType": "engine",
+      "schema": 1702901789723,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ja",
+              "ja-JP-macos"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (nn)",
+        "urls": {
+          "search": {
+            "base": "https://nn.wikipedia.org/wiki/Spesial:Søk",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://nn.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "c3462c25-acc1-4003-a57b-3931bfacdce5",
+      "identifier": "wikipedia-NN",
+      "last_modified": 1702906502462,
+      "recordType": "engine",
+      "schema": 1702901792200,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "nn-NO"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "aliases": [
+          "wikipedia"
+        ],
+        "classification": "unknown",
+        "name": "Wikipedia (pl)",
+        "urls": {
+          "search": {
+            "base": "https://pl.wikipedia.org/wiki/Specjalna:Szukaj",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://pl.wikipedia.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "980cba80-0c46-4c05-8df0-aaea23d57732",
+      "identifier": "wikipedia-pl",
+      "last_modified": 1702906502453,
+      "recordType": "engine",
+      "schema": 1702901794065,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "pl",
+              "szl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Wolne Lektury",
+        "urls": {
+          "search": {
+            "base": "https://wolnelektury.pl/szukaj/",
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://wolnelektury.pl/katalog/jtags/",
+            "params": [
+              {
+                "name": "mozhint",
+                "value": "1"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "42348cb0-69a9-4451-8bd6-71bad5bc4e3f",
+      "identifier": "wolnelektury-pl",
+      "last_modified": 1702906502368,
+      "recordType": "engine",
+      "schema": 1702901811217,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "pl",
+              "szl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Allegro",
+        "urls": {
+          "search": {
+            "base": "https://allegro.pl/listing",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "string"
+          }
+        }
+      },
+      "id": "3cc3f699-284a-4320-b131-395d9b218ade",
+      "identifier": "allegro-pl",
+      "last_modified": 1702906502364,
+      "recordType": "engine",
+      "schema": 1702901811834,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "pl",
+              "szl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "GMX Suche",
+        "urls": {
+          "search": {
+            "base": "https://go.gmx.net/br/moz_search_web/",
+            "params": [
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://suggestplugin.ui-portal.de/s",
+            "params": [
+              {
+                "name": "brand",
+                "value": "gmx"
+              },
+              {
+                "name": "origin",
+                "value": "br_splugin_ff_sg"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "5240e0d8-8c2c-436b-b478-3fa0b506410f",
+      "identifier": "gmx-de",
+      "last_modified": 1702906502361,
+      "recordType": "engine",
+      "schema": 1702901812448,
+      "variants": [
+        {
+          "environment": {
+            "distributions": [
+              "gmx"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "GMX Shopping",
+        "urls": {
+          "search": {
+            "base": "https://shopping.gmx.net/",
+            "params": [
+              {
+                "name": "origin",
+                "value": "br_osd"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://shopping.gmx.net/suggest/ca/",
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "3a738904-cf8c-4d87-8972-ea98768d44f0",
+      "identifier": "gmx-shopping",
+      "last_modified": 1702906502357,
+      "recordType": "engine",
+      "schema": 1702901813066,
+      "variants": [
+        {
+          "environment": {
+            "distributions": [
+              "gmx"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "GMX Search",
+        "urls": {
+          "search": {
+            "base": "https://go.gmx.co.uk/br/moz_search_web/",
+            "params": [
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://suggestplugin.gmx.co.uk/s",
+            "params": [
+              {
+                "name": "brand",
+                "value": "gmxcouk"
+              },
+              {
+                "name": "origin",
+                "value": "moz_splugin_ff"
+              },
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "d5f10a5b-19b7-4214-9e84-be0b04d6414f",
+      "identifier": "gmx-en-GB",
+      "last_modified": 1702906502354,
+      "recordType": "engine",
+      "schema": 1702901813683,
+      "variants": [
+        {
+          "environment": {
+            "distributions": [
+              "gmxcouk"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "GMX - Búsqueda web",
+        "urls": {
+          "search": {
+            "base": "https://go.gmx.es/br/moz_search_web/",
+            "params": [
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://suggestplugin.gmx.es/s",
+            "params": [
+              {
+                "name": "brand",
+                "value": "gmxes"
+              },
+              {
+                "name": "origin",
+                "value": "moz_splugin_ff"
+              },
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "bdb578f4-6362-4789-911d-193c98ec5378",
+      "identifier": "gmx-es",
+      "last_modified": 1702906502351,
+      "recordType": "engine",
+      "schema": 1702901814287,
+      "variants": [
+        {
+          "environment": {
+            "distributions": [
+              "gmxes"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "GMX - Recherche web",
+        "urls": {
+          "search": {
+            "base": "https://go.gmx.fr/br/moz_search_web/",
+            "params": [
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://suggestplugin.gmx.fr/s",
+            "params": [
+              {
+                "name": "brand",
+                "value": "gmxfr"
+              },
+              {
+                "name": "origin",
+                "value": "moz_splugin_ff"
+              },
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "2b628809-284d-468a-831f-95dc479f30da",
+      "identifier": "gmx-fr",
+      "last_modified": 1702906502349,
+      "recordType": "engine",
+      "schema": 1702901814882,
+      "variants": [
+        {
+          "environment": {
+            "distributions": [
+              "gmxfr"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Qwant Junior",
+        "partnerCode": "firefoxqwant",
+        "urls": {
+          "search": {
+            "base": "https://www.qwantjunior.com/",
+            "params": [
+              {
+                "name": "client",
+                "value": "{partnerCode}"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://api.qwant.com/egp/suggest/",
+            "params": [
+              {
+                "name": "client",
+                "value": "opensearch"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "7996de41-caf5-4e52-8d96-4ee89ede5d5c",
+      "identifier": "qwantjr",
+      "last_modified": 1702906502346,
+      "recordType": "engine",
+      "schema": 1702901815498,
+      "variants": [
+        {
+          "environment": {
+            "distributions": [
+              "qwant-001",
+              "qwant-002"
+            ],
+            "locales": [
+              "fr"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "1&1 Suche",
+        "urls": {
+          "search": {
+            "base": "https://go.1und1.de/br/moz_search_web/",
+            "params": [
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://suggestplugin.ui-portal.de/s",
+            "params": [
+              {
+                "name": "brand",
+                "value": "1und1"
+              },
+              {
+                "name": "origin",
+                "value": "br_splugin_ff_sg"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "e870e51d-efed-41d3-8d65-f833ee8e9d96",
+      "identifier": "1und1",
+      "last_modified": 1702906502336,
+      "recordType": "engine",
+      "schema": 1702901817337,
+      "variants": [
+        {
+          "environment": {
+            "distributions": [
+              "1und1"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "WEB.DE Suche",
+        "urls": {
+          "search": {
+            "base": "https://go.web.de/br/moz_search_web/",
+            "params": [
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://suggestplugin.ui-portal.de/s",
+            "params": [
+              {
+                "name": "brand",
+                "value": "webde"
+              },
+              {
+                "name": "origin",
+                "value": "br_splugin_ff_sg"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "3d42fa9a-08ca-4057-b79d-917c576e2634",
+      "identifier": "webde",
+      "last_modified": 1702906502332,
+      "recordType": "engine",
+      "schema": 1702901817944,
+      "variants": [
+        {
+          "environment": {
+            "distributions": [
+              "webde"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "mail.com search",
+        "urls": {
+          "search": {
+            "base": "https://go.mail.com/br/moz_search_web/",
+            "params": [
+              {
+                "name": "enc",
+                "value": "UTF-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          },
+          "suggestions": {
+            "base": "https://search.mail.com/SuggestSearch/s",
+            "params": [
+              {
+                "name": "brand",
+                "value": "mailcom"
+              },
+              {
+                "name": "origin",
+                "value": "br_splugin_ff_sg"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "39375b5f-77bb-46cb-979d-345c002fe35f",
+      "identifier": "mailcom",
+      "last_modified": 1702906502329,
+      "recordType": "engine",
+      "schema": 1702901818560,
+      "variants": [
+        {
+          "environment": {
+            "distributions": [
+              "mail.com"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "charset": "EUC-JP",
+        "classification": "unknown",
+        "name": "楽天市場",
+        "urls": {
+          "search": {
+            "base": "https://pt.afl.rakuten.co.jp/c/013ca98b.cd7c5f0c/",
+            "params": [
+              {
+                "name": "sv",
+                "value": "2"
+              },
+              {
+                "name": "p",
+                "value": "0"
+              }
+            ],
+            "searchTermParamName": "sitem"
+          }
+        }
+      },
+      "id": "ab6f7178-b0be-452a-82f2-f5df8df2d836",
+      "identifier": "rakuten",
+      "last_modified": 1702906502326,
+      "recordType": "engine",
+      "schema": 1702901819182,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ja",
+              "ja-JP-macos"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Azerdict",
+        "urls": {
+          "search": {
+            "base": "https://azerdict.com/english/",
+            "searchTermParamName": "word"
+          }
+        }
+      },
+      "id": "786aa916-a331-4b0c-8099-85927dd87be8",
+      "identifier": "azerdict",
+      "last_modified": 1702906502323,
+      "recordType": "engine",
+      "schema": 1702901819798,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "az"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Ordbok",
+        "urls": {
+          "search": {
+            "base": "https://ordbok.uib.no/perl/ordbok.cgi",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Mozilla-search"
+              }
+            ],
+            "searchTermParamName": "OPP"
+          }
+        }
+      },
+      "id": "7ed2240b-b161-4b49-a7fe-35db89544f74",
+      "identifier": "bok-NO",
+      "last_modified": 1702906502320,
+      "recordType": "engine",
+      "schema": 1702901820444,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "nb-NO",
+              "nn-NO"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Ceneje.si",
+        "urls": {
+          "search": {
+            "base": "https://www.ceneje.si/search_new.aspx",
+            "params": [
+              {
+                "name": "FF-SearchBox",
+                "value": "1"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "5e515970-4129-48fc-b0d0-8a61c92903d2",
+      "identifier": "ceneji",
+      "last_modified": 1702906502317,
+      "recordType": "engine",
+      "schema": 1702901821058,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "sl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "EUdict Eng->Cro",
+        "urls": {
+          "search": {
+            "base": "https://eudict.com/",
+            "params": [
+              {
+                "name": "lang",
+                "value": "engcro"
+              }
+            ],
+            "searchTermParamName": "word"
+          }
+        }
+      },
+      "id": "8fe5af92-3b6d-4cbe-a736-4cad01a21efe",
+      "identifier": "eudict",
+      "last_modified": 1702906502306,
+      "recordType": "engine",
+      "schema": 1702901823499,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "hr"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Gule sider",
+        "urls": {
+          "search": {
+            "base": "https://www.gulesider.no/search",
+            "params": [
+              {
+                "name": "what",
+                "value": "all"
+              },
+              {
+                "name": "cmpid",
+                "value": "fre_partner_fire_gssbtop"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "0f9d78f8-e8ad-40be-8f50-b71d5da0f4cc",
+      "identifier": "gulesider-NO",
+      "last_modified": 1702906502300,
+      "recordType": "engine",
+      "schema": 1702901824715,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "nb-NO",
+              "nn-NO"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "LEO Eng-Deu",
+        "urls": {
+          "search": {
+            "base": "https://dict.leo.org/englisch-deutsch/{searchTerms}"
+          },
+          "suggestions": {
+            "base": "https://dict.leo.org/dictQuery/m-query/conf/ende/query.conf/strlist.json",
+            "params": [
+              {
+                "name": "sort",
+                "value": "PLa"
+              },
+              {
+                "name": "shortQuery",
+                "value": "undefined"
+              },
+              {
+                "name": "noDescription",
+                "value": "undefined"
+              },
+              {
+                "name": "noQueryURLs",
+                "value": "undefined"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "2669ab65-3d93-4432-a960-90413be80ae0",
+      "identifier": "leo_ende_de",
+      "last_modified": 1702906502297,
+      "recordType": "engine",
+      "schema": 1702901825311,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "de",
+              "dsb",
+              "hsb",
+              "rm"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Mapy.cz",
+        "urls": {
+          "search": {
+            "base": "https://www.mapy.cz/",
+            "params": [
+              {
+                "name": "sourceid",
+                "value": "Searchmodule_3"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "1ad708f0-5736-4f65-aeb4-31e5eca1c598",
+      "identifier": "mapy-cz",
+      "last_modified": 1702906502292,
+      "recordType": "engine",
+      "schema": 1702901826526,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "cs"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "MercadoLibre Chile",
+        "urls": {
+          "search": {
+            "base": "https://www.mercadolibre.cl/jm/search",
+            "searchTermParamName": "as_word"
+          }
+        }
+      },
+      "id": "5659791c-6637-4ba9-b46b-83f16df084cd",
+      "identifier": "mercadolibre-cl",
+      "last_modified": 1702906502286,
+      "recordType": "engine",
+      "schema": 1702901827757,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "es-CL"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "MercadoLibre Mexico",
+        "urls": {
+          "search": {
+            "base": "https://www.mercadolibre.com.mx/jm/search",
+            "searchTermParamName": "as_word"
+          }
+        }
+      },
+      "id": "162c9f26-f269-4b8e-b75f-01cf3c15e177",
+      "identifier": "mercadolibre-mx",
+      "last_modified": 1702906502283,
+      "recordType": "engine",
+      "schema": 1702901828372,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "es-MX"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "MercadoLivre",
+        "urls": {
+          "search": {
+            "base": "https://www.mercadolivre.com.br/jm/search",
+            "searchTermParamName": "as_word"
+          }
+        }
+      },
+      "id": "62453dfa-0d82-4961-b6e2-241647aa04b6",
+      "identifier": "mercadolivre",
+      "last_modified": 1702906502281,
+      "recordType": "engine",
+      "schema": 1702901829001,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "pt-BR"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "네이버",
+        "urls": {
+          "search": {
+            "base": "https://search.naver.com/search.naver",
+            "params": [
+              {
+                "name": "where",
+                "value": "nexearch"
+              },
+              {
+                "name": "frm",
+                "value": "ff"
+              },
+              {
+                "name": "sm",
+                "value": "oss"
+              },
+              {
+                "name": "ie",
+                "value": "utf8"
+              }
+            ],
+            "searchTermParamName": "query"
+          },
+          "suggestions": {
+            "base": "https://ac.search.naver.com/nx/ac",
+            "params": [
+              {
+                "name": "of",
+                "value": "os"
+              },
+              {
+                "name": "ie",
+                "value": "utf-8"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "88d22607-619b-4c7a-8708-bb0caef15e18",
+      "identifier": "naver-kr",
+      "last_modified": 1702906502278,
+      "recordType": "engine",
+      "schema": 1702901829625,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ko"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Odpiralni Časi",
+        "urls": {
+          "search": {
+            "base": "https://www.odpiralnicasi.com/spots",
+            "params": [
+              {
+                "name": "source",
+                "value": "1"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "2039744c-adce-459b-a547-e3dba931c2a0",
+      "identifier": "odpiralni",
+      "last_modified": 1702906502275,
+      "recordType": "engine",
+      "schema": 1702901830238,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "sl"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Pazaruvaj",
+        "urls": {
+          "search": {
+            "base": "https://www.pazaruvaj.com/CategorySearch.php",
+            "searchTermParamName": "st"
+          }
+        }
+      },
+      "id": "ddf4875a-61d4-4677-8aad-74fb3ef2e1df",
+      "identifier": "pazaruvaj",
+      "last_modified": 1702906502272,
+      "recordType": "engine",
+      "schema": 1702901830856,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "bg"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "charset": "ISO-8859-15",
+        "classification": "unknown",
+        "name": "Priberam",
+        "urls": {
+          "search": {
+            "base": "https://www.priberam.pt/dlpo/firefox.aspx",
+            "searchTermParamName": "pal"
+          }
+        }
+      },
+      "id": "4bc3282e-f318-443c-8b2f-c144205657d4",
+      "identifier": "priberam",
+      "last_modified": 1702906502270,
+      "recordType": "engine",
+      "schema": 1702901831479,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "pt-PT"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Prisjakt",
+        "urls": {
+          "search": {
+            "base": "https://www.prisjakt.nu/search",
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://www.prisjakt.nu/plugins/opensearch/suggestions.php",
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "e4f4c143-7b0a-4ae5-b461-cd22da9da90a",
+      "identifier": "prisjakt-sv-SE",
+      "last_modified": 1702906502267,
+      "recordType": "engine",
+      "schema": 1702901832077,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "sv-SE"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Readmoo 讀墨電子書",
+        "urls": {
+          "search": {
+            "base": "https://readmoo.com/search/keyword",
+            "params": [
+              {
+                "name": "pi",
+                "value": "0"
+              },
+              {
+                "name": "st",
+                "value": "true"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "f1570611-5dfa-4028-851c-fafaa8324bbd",
+      "identifier": "readmoo",
+      "last_modified": 1702906502264,
+      "recordType": "engine",
+      "schema": 1702901832677,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "zh-TW"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "Tyda.se",
+        "urls": {
+          "search": {
+            "base": "https://tyda.se/",
+            "searchTermParamName": "w"
+          }
+        }
+      },
+      "id": "511f0050-e322-456f-9f15-acafef69c898",
+      "identifier": "tyda-sv-SE",
+      "last_modified": 1702906502259,
+      "recordType": "engine",
+      "schema": 1702901833893,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "sv-SE"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "charset": "ISO-8859-2",
+        "classification": "unknown",
+        "name": "Vatera.hu",
+        "urls": {
+          "search": {
+            "base": "https://www.vatera.hu/listings/index.php",
+            "params": [
+              {
+                "name": "c",
+                "value": "0"
+              },
+              {
+                "name": "td",
+                "value": "on"
+              }
+            ],
+            "searchTermParamName": "q"
+          }
+        }
+      },
+      "id": "ede75b07-cdc0-485b-8a9c-8282f15c4ede",
+      "identifier": "vatera",
+      "last_modified": 1702906502256,
+      "recordType": "engine",
+      "schema": 1702901834503,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "hu"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "unknown",
+        "name": "విక్షనరీ (te)",
+        "urls": {
+          "search": {
+            "base": "https://te.wiktionary.org/wiki/ప్రత్యేక:అన్వేషణ",
+            "searchTermParamName": "search"
+          },
+          "suggestions": {
+            "base": "https://te.wiktionary.org/w/api.php",
+            "params": [
+              {
+                "name": "action",
+                "value": "opensearch"
+              },
+              {
+                "name": "namespace",
+                "value": "0"
+              }
+            ],
+            "searchTermParamName": "search"
+          }
+        }
+      },
+      "id": "45b4556e-8133-40c8-9a9b-63bc3ad91f53",
+      "identifier": "wiktionary-te",
+      "last_modified": 1702906502253,
+      "recordType": "engine",
+      "schema": 1702901835109,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "te"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "classification": "general",
+        "name": "Yahoo! JAPAN",
+        "partnerCode": "mozff",
+        "urls": {
+          "search": {
+            "base": "https://search.yahoo.co.jp/search",
+            "params": [
+              {
+                "name": "ei",
+                "value": "UTF-8"
+              },
+              {
+                "name": "fr",
+                "value": "{partnerCode}"
+              }
+            ],
+            "searchTermParamName": "p"
+          }
+        }
+      },
+      "id": "d45d4cf0-6ce3-4419-a160-ae2ada64c3e8",
+      "identifier": "yahoo-jp",
+      "last_modified": 1702906502248,
+      "recordType": "engine",
+      "schema": 1702901836360,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ja",
+              "ja-JP-macos"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "base": {
+        "charset": "EUC-JP",
+        "classification": "unknown",
+        "name": "Yahoo!オークション",
+        "urls": {
+          "search": {
+            "base": "https://auctions.yahoo.co.jp/search/search",
+            "params": [
+              {
+                "name": "ei",
+                "value": "EUC-JP"
+              },
+              {
+                "name": "fr",
+                "value": "mozff"
+              }
+            ],
+            "searchTermParamName": "p"
+          }
+        }
+      },
+      "id": "3d422460-2ea0-43df-b10d-2e8c9e42462d",
+      "identifier": "yahoo-jp-auctions",
+      "last_modified": 1702906502244,
+      "recordType": "engine",
+      "schema": 1702901836972,
+      "variants": [
+        {
+          "environment": {
+            "locales": [
+              "ja",
+              "ja-JP-macos"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "globalDefault": "google",
+      "id": "f3891684-2348-4e7a-9765-0c5d2d0ab1b9",
+      "last_modified": 1702906502241,
+      "recordType": "defaultEngines",
+      "schema": 1702901837584,
+      "specificDefaults": [
+        {
+          "default": "baidu",
+          "environment": {
+            "locales": [
+              "zh-CN"
+            ],
+            "regions": [
+              "cn"
+            ]
+          }
+        },
+        {
+          "default": "baidu",
+          "environment": {
+            "distributions": [
+              "MozillaOnline"
+            ]
+          }
+        },
+        {
+          "default": "1und1",
+          "environment": {
+            "distributions": [
+              "1und1"
+            ]
+          }
+        },
+        {
+          "default": "webde",
+          "environment": {
+            "distributions": [
+              "webde"
+            ]
+          }
+        },
+        {
+          "default": "mailcom",
+          "environment": {
+            "distributions": [
+              "mail.com"
+            ]
+          }
+        },
+        {
+          "default": "qwant",
+          "environment": {
+            "distributions": [
+              "qwant-001",
+              "qwant-002"
+            ]
+          }
+        },
+        {
+          "default": "gmx-de",
+          "environment": {
+            "distributions": [
+              "gmx"
+            ]
+          }
+        },
+        {
+          "default": "gmx-en-GB",
+          "environment": {
+            "distributions": [
+              "gmxcouk"
+            ]
+          }
+        },
+        {
+          "default": "gmx-es",
+          "environment": {
+            "distributions": [
+              "gmxes"
+            ]
+          }
+        },
+        {
+          "default": "gmx-fr",
+          "environment": {
+            "distributions": [
+              "gmxfr"
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "timestamp": 1738595538915
+}

--- a/components/remote_settings/dumps/main/search-telemetry-v2.json
+++ b/components/remote_settings/dumps/main/search-telemetry-v2.json
@@ -1,194 +1,6 @@
 {
   "data": [
     {
-      "codeParamName": "pc",
-      "components": [
-        {
-          "included": {
-            "children": [
-              {
-                "countChildren": true,
-                "selector": ".pa_item"
-              }
-            ],
-            "parent": {
-              "selector": ".adsMvCarousel"
-            },
-            "related": {
-              "selector": ".cr"
-            }
-          },
-          "type": "ad_carousel"
-        },
-        {
-          "excluded": {
-            "parent": {
-              "selector": "aside"
-            }
-          },
-          "included": {
-            "children": [
-              {
-                "selector": ".b_vlist2col",
-                "type": "ad_sitelink"
-              }
-            ],
-            "parent": {
-              "selector": ".sb_adTA"
-            }
-          },
-          "type": "ad_link"
-        },
-        {
-          "included": {
-            "children": [
-              {
-                "countChildren": true,
-                "selector": ".pa_item, .sb_adTA"
-              }
-            ],
-            "parent": {
-              "selector": "aside"
-            }
-          },
-          "type": "ad_sidebar"
-        },
-        {
-          "included": {
-            "children": [
-              {
-                "selector": "input[name='q']"
-              }
-            ],
-            "parent": {
-              "selector": "form#sb_form"
-            },
-            "related": {
-              "selector": "#sw_as"
-            }
-          },
-          "topDown": true,
-          "type": "incontent_searchbox"
-        },
-        {
-          "included": {
-            "children": [
-              {
-                "eventListeners": [
-                  {
-                    "action": "clicked_accept",
-                    "eventType": "click"
-                  }
-                ],
-                "selector": "button#bnp_btn_accept"
-              },
-              {
-                "eventListeners": [
-                  {
-                    "action": "clicked_reject",
-                    "eventType": "click"
-                  }
-                ],
-                "selector": "button#bnp_btn_reject"
-              },
-              {
-                "eventListeners": [
-                  {
-                    "action": "clicked_more_options",
-                    "eventType": "click"
-                  }
-                ],
-                "selector": "a#bnp_btn_preference"
-              }
-            ],
-            "parent": {
-              "selector": "div#bnp_cookie_banner"
-            }
-          },
-          "topDown": true,
-          "type": "cookie_banner"
-        },
-        {
-          "default": true,
-          "type": "ad_link"
-        }
-      ],
-      "domainExtraction": {
-        "ads": [
-          {
-            "method": "textContent",
-            "selectors": "#b_results .b_ad .b_attribution cite, .adsMvCarousel cite, aside cite"
-          }
-        ],
-        "nonAds": [
-          {
-            "method": "textContent",
-            "selectors": "#b_results .b_algo .b_attribution cite"
-          }
-        ]
-      },
-      "extraAdServersRegexps": [
-        "^https://www\\.bing\\.com/acli?c?k"
-      ],
-      "followOnCookies": [
-        {
-          "codeParamName": "PC",
-          "extraCodeParamName": "form",
-          "extraCodePrefixes": [
-            "QBRE"
-          ],
-          "host": "www.bing.com",
-          "name": "_SS"
-        },
-        {
-          "codeParamName": "PC",
-          "extraCodeParamName": "form",
-          "extraCodePrefixes": [
-            "QBRE"
-          ],
-          "host": "www.bing.com",
-          "name": "SRCHS"
-        }
-      ],
-      "id": "e1eec461-f1f3-40de-b94b-3b670b78108c",
-      "last_modified": 1731429440245,
-      "nonAdsLinkRegexps": [
-        "^https://www.bing.com/ck/a"
-      ],
-      "organicCodes": [],
-      "queryParamName": "q",
-      "queryParamNames": [
-        "q"
-      ],
-      "schema": 1730764806877,
-      "searchPageRegexp": "^https://www\\.bing\\.com/search",
-      "shoppingTab": {
-        "regexp": "^/shop?",
-        "selector": "#b-scopeListItem-shop a"
-      },
-      "taggedCodes": [
-        "MOZ2",
-        "MOZ4",
-        "MOZ5",
-        "MOZA",
-        "MOZB",
-        "MOZD",
-        "MOZE",
-        "MOZI",
-        "MOZL",
-        "MOZM",
-        "MOZO",
-        "MOZR",
-        "MOZT",
-        "MOZW",
-        "MOZX",
-        "MZSL01",
-        "MZSL02",
-        "MZSL03"
-      ],
-      "telemetryId": "bing"
-    },
-    {
       "adServerAttributes": [
         "rw"
       ],
@@ -423,7 +235,7 @@
       "ignoreLinkRegexps": [
         "^https?://consent\\.google\\.(?:.+)/d\\?continue\\="
       ],
-      "last_modified": 1724867833754,
+      "last_modified": 1738595471359,
       "nonAdsLinkQueryParamNames": [
         "url"
       ],
@@ -435,7 +247,10 @@
       "queryParamNames": [
         "q"
       ],
-      "schema": 1724630408117,
+      "schema": 1738577315189,
+      "searchPageMatches": [
+        "https://{host}/search*"
+      ],
       "searchPageRegexp": "^https://www\\.google\\.(?:.+)/search",
       "shoppingTab": {
         "inspectRegexpInSERP": true,
@@ -472,32 +287,42 @@
         "firefox-b-tinno",
         "firefox-b-pn-wt",
         "firefox-b-pn-wt-us",
+        "firefox-b-vv",
         "ubuntu",
         "ubuntu-sn"
       ],
       "telemetryId": "google"
     },
     {
-      "codeParamName": "client",
+      "codeParamName": "tt",
       "components": [
         {
           "included": {
             "children": [
               {
                 "countChildren": true,
-                "selector": "[data-slide-index]"
+                "selector": ".product-ads-carousel__item"
               }
             ],
             "parent": {
-              "selector": "[data-testid='pam.container']"
+              "selector": ".product-ads-carousel"
+            },
+            "related": {
+              "selector": ".snippet__control"
             }
           },
-          "type": "ad_image_row"
+          "type": "ad_carousel"
         },
         {
           "included": {
+            "children": [
+              {
+                "selector": ".result__extra-content .deep-links--descriptions",
+                "type": "ad_sitelink"
+              }
+            ],
             "parent": {
-              "selector": "[data-testid='adResult']"
+              "selector": ".ad-result"
             }
           },
           "type": "ad_link"
@@ -506,14 +331,14 @@
           "included": {
             "children": [
               {
-                "selector": "input[type='search']"
+                "selector": ".search-form__input, .search-form__submit"
               }
             ],
             "parent": {
-              "selector": "._1zdrb._1cR1n"
+              "selector": "form.search-form"
             },
             "related": {
-              "selector": "#search-suggestions"
+              "selector": ".search-form__suggestions"
             }
           },
           "topDown": true,
@@ -524,32 +349,65 @@
           "type": "ad_link"
         }
       ],
-      "defaultPageQueryParam": {
-        "key": "t",
-        "value": "web"
-      },
+      "expectedOrganicCodes": [],
       "extraAdServersRegexps": [
-        "^https://www\\.bing\\.com/acli?c?k",
-        "^https://api\\.qwant\\.com/v3/r/",
-        "^https://fdn\\.qwant\\.com/v3/r/"
+        "^https://www\\.bing\\.com/acli?c?k"
       ],
-      "filter_expression": "env.version|versionCompare(\"124.0a1\")>=0",
-      "followOnParamNames": [],
-      "id": "19c434a3-d173-4871-9743-290ac92a3f6b",
-      "isSPA": true,
-      "last_modified": 1713187389066,
+      "filter_expression": "env.version|versionCompare(\"110.0a1\")>=0",
+      "id": "9a487171-3a06-4647-8866-36250ec84f3a",
+      "last_modified": 1733951403249,
       "organicCodes": [],
       "queryParamName": "q",
       "queryParamNames": [
         "q"
       ],
-      "schema": 1712762409532,
-      "searchPageRegexp": "^https://www\\.qwant\\.com/",
-      "taggedCodes": [
-        "brz-moz",
-        "firefoxqwant"
+      "schema": 1733932318157,
+      "searchPageMatches": [
+        "https://www.ecosia.org/*"
       ],
-      "telemetryId": "qwant"
+      "searchPageRegexp": "^https://www\\.ecosia\\.org/",
+      "shoppingTab": {
+        "regexp": "/shopping?",
+        "selector": "nav li[data-test-id='search-navigation-item-shopping'] a"
+      },
+      "taggedCodes": [
+        "mzl",
+        "813cf1dd",
+        "16eeffc4"
+      ],
+      "telemetryId": "ecosia"
+    },
+    {
+      "codeParamName": "tn",
+      "extraAdServersRegexps": [
+        "^https?://www\\.baidu\\.com/baidu\\.php?"
+      ],
+      "followOnParamNames": [
+        "oq"
+      ],
+      "id": "19c434a3-d173-4871-9743-290ac92a3f6a",
+      "last_modified": 1733951403246,
+      "organicCodes": [],
+      "queryParamName": "wd",
+      "queryParamNames": [
+        "wd",
+        "word"
+      ],
+      "schema": 1733932317207,
+      "searchPageMatches": [
+        "https://m.baidu.com/s*",
+        "https://m.baidu.com/baidu*",
+        "https://www.baidu.com/s*",
+        "https://www.baidu.com/baidu*"
+      ],
+      "searchPageRegexp": "^https://(?:m|www)\\.baidu\\.com/(?:s|baidu)",
+      "taggedCodes": [
+        "monline_dg",
+        "monline_3_dg",
+        "monline_4_dg",
+        "monline_7_dg"
+      ],
+      "telemetryId": "baidu"
     },
     {
       "codeParamName": "t",
@@ -677,13 +535,16 @@
         "^https://www\\.amazon\\.(?:[a-z.]{2,24}).*(?:tag=duckduckgo-)"
       ],
       "id": "9dfd626b-26f2-4913-9d0a-27db6cb7d8ca",
-      "last_modified": 1706198445456,
+      "last_modified": 1733951403244,
       "organicCodes": [],
       "queryParamName": "q",
       "queryParamNames": [
         "q"
       ],
-      "schema": 1705363206938,
+      "schema": 1733932316283,
+      "searchPageMatches": [
+        "https://duckduckgo.com/*"
+      ],
       "searchPageRegexp": "^https://duckduckgo\\.com/",
       "shoppingTab": {
         "regexp": "&iax=shopping&ia=shopping",
@@ -709,61 +570,26 @@
       "telemetryId": "duckduckgo"
     },
     {
-      "codeParamName": "tn",
-      "extraAdServersRegexps": [
-        "^https?://www\\.baidu\\.com/baidu\\.php?"
-      ],
-      "followOnParamNames": [
-        "oq"
-      ],
-      "id": "19c434a3-d173-4871-9743-290ac92a3f6a",
-      "last_modified": 1698666532326,
-      "organicCodes": [],
-      "queryParamName": "wd",
-      "queryParamNames": [
-        "wd",
-        "word"
-      ],
-      "schema": 1698656464939,
-      "searchPageRegexp": "^https://(?:m|www)\\.baidu\\.com/(?:s|baidu)",
-      "taggedCodes": [
-        "monline_dg",
-        "monline_3_dg",
-        "monline_4_dg",
-        "monline_7_dg"
-      ],
-      "telemetryId": "baidu"
-    },
-    {
-      "codeParamName": "tt",
+      "codeParamName": "client",
       "components": [
         {
           "included": {
             "children": [
               {
                 "countChildren": true,
-                "selector": ".product-ads-carousel__item"
+                "selector": "[data-slide-index]"
               }
             ],
             "parent": {
-              "selector": ".product-ads-carousel"
-            },
-            "related": {
-              "selector": ".snippet__control"
+              "selector": "[data-testid='pam.container']"
             }
           },
-          "type": "ad_carousel"
+          "type": "ad_image_row"
         },
         {
           "included": {
-            "children": [
-              {
-                "selector": ".result__extra-content .deep-links--descriptions",
-                "type": "ad_sitelink"
-              }
-            ],
             "parent": {
-              "selector": ".ad-result"
+              "selector": "[data-testid='adResult']"
             }
           },
           "type": "ad_link"
@@ -772,14 +598,14 @@
           "included": {
             "children": [
               {
-                "selector": ".search-form__input, .search-form__submit"
+                "selector": "input[type='search']"
               }
             ],
             "parent": {
-              "selector": "form.search-form"
+              "selector": "._1zdrb._1cR1n"
             },
             "related": {
-              "selector": ".search-form__suggestions"
+              "selector": "#search-suggestions"
             }
           },
           "topDown": true,
@@ -790,31 +616,227 @@
           "type": "ad_link"
         }
       ],
-      "expectedOrganicCodes": [],
+      "defaultPageQueryParam": {
+        "key": "t",
+        "value": "web"
+      },
       "extraAdServersRegexps": [
-        "^https://www\\.bing\\.com/acli?c?k"
+        "^https://www\\.bing\\.com/acli?c?k",
+        "^https://api\\.qwant\\.com/v3/r/",
+        "^https://fdn\\.qwant\\.com/v3/r/"
       ],
-      "filter_expression": "env.version|versionCompare(\"110.0a1\")>=0",
-      "id": "9a487171-3a06-4647-8866-36250ec84f3a",
-      "last_modified": 1698666532324,
+      "filter_expression": "env.version|versionCompare(\"124.0a1\")>=0",
+      "followOnParamNames": [],
+      "id": "19c434a3-d173-4871-9743-290ac92a3f6b",
+      "isSPA": true,
+      "last_modified": 1733951403242,
       "organicCodes": [],
       "queryParamName": "q",
       "queryParamNames": [
         "q"
       ],
-      "schema": 1698656463945,
-      "searchPageRegexp": "^https://www\\.ecosia\\.org/",
+      "schema": 1733932315328,
+      "searchPageMatches": [
+        "https://www.qwant.com/*"
+      ],
+      "searchPageRegexp": "^https://www\\.qwant\\.com/",
+      "taggedCodes": [
+        "brz-moz",
+        "firefoxqwant"
+      ],
+      "telemetryId": "qwant"
+    },
+    {
+      "codeParamName": "pc",
+      "components": [
+        {
+          "included": {
+            "children": [
+              {
+                "countChildren": true,
+                "selector": ".pa_item"
+              }
+            ],
+            "parent": {
+              "selector": ".adsMvCarousel"
+            },
+            "related": {
+              "selector": ".cr"
+            }
+          },
+          "type": "ad_carousel"
+        },
+        {
+          "excluded": {
+            "parent": {
+              "selector": "aside"
+            }
+          },
+          "included": {
+            "children": [
+              {
+                "selector": ".b_vlist2col",
+                "type": "ad_sitelink"
+              }
+            ],
+            "parent": {
+              "selector": ".sb_adTA"
+            }
+          },
+          "type": "ad_link"
+        },
+        {
+          "included": {
+            "children": [
+              {
+                "countChildren": true,
+                "selector": ".pa_item, .sb_adTA"
+              }
+            ],
+            "parent": {
+              "selector": "aside"
+            }
+          },
+          "type": "ad_sidebar"
+        },
+        {
+          "included": {
+            "children": [
+              {
+                "selector": "input[name='q']"
+              }
+            ],
+            "parent": {
+              "selector": "form#sb_form"
+            },
+            "related": {
+              "selector": "#sw_as"
+            }
+          },
+          "topDown": true,
+          "type": "incontent_searchbox"
+        },
+        {
+          "included": {
+            "children": [
+              {
+                "eventListeners": [
+                  {
+                    "action": "clicked_accept",
+                    "eventType": "click"
+                  }
+                ],
+                "selector": "button#bnp_btn_accept"
+              },
+              {
+                "eventListeners": [
+                  {
+                    "action": "clicked_reject",
+                    "eventType": "click"
+                  }
+                ],
+                "selector": "button#bnp_btn_reject"
+              },
+              {
+                "eventListeners": [
+                  {
+                    "action": "clicked_more_options",
+                    "eventType": "click"
+                  }
+                ],
+                "selector": "a#bnp_btn_preference"
+              }
+            ],
+            "parent": {
+              "selector": "div#bnp_cookie_banner"
+            }
+          },
+          "topDown": true,
+          "type": "cookie_banner"
+        },
+        {
+          "default": true,
+          "type": "ad_link"
+        }
+      ],
+      "domainExtraction": {
+        "ads": [
+          {
+            "method": "textContent",
+            "selectors": "#b_results .b_ad .b_attribution cite, .adsMvCarousel cite, aside cite"
+          }
+        ],
+        "nonAds": [
+          {
+            "method": "textContent",
+            "selectors": "#b_results .b_algo .b_attribution cite"
+          }
+        ]
+      },
+      "extraAdServersRegexps": [
+        "^https://www\\.bing\\.com/acli?c?k"
+      ],
+      "followOnCookies": [
+        {
+          "codeParamName": "PC",
+          "extraCodeParamName": "form",
+          "extraCodePrefixes": [
+            "QBRE"
+          ],
+          "host": "www.bing.com",
+          "name": "_SS"
+        },
+        {
+          "codeParamName": "PC",
+          "extraCodeParamName": "form",
+          "extraCodePrefixes": [
+            "QBRE"
+          ],
+          "host": "www.bing.com",
+          "name": "SRCHS"
+        }
+      ],
+      "id": "e1eec461-f1f3-40de-b94b-3b670b78108c",
+      "last_modified": 1733951403237,
+      "nonAdsLinkRegexps": [
+        "^https://www.bing.com/ck/a"
+      ],
+      "organicCodes": [],
+      "queryParamName": "q",
+      "queryParamNames": [
+        "q"
+      ],
+      "schema": 1733820446478,
+      "searchPageMatches": [
+        "https://www.bing.com/search*"
+      ],
+      "searchPageRegexp": "^https://www\\.bing\\.com/search",
       "shoppingTab": {
-        "regexp": "/shopping?",
-        "selector": "nav li[data-test-id='search-navigation-item-shopping'] a"
+        "regexp": "^/shop?",
+        "selector": "#b-scopeListItem-shop a"
       },
       "taggedCodes": [
-        "mzl",
-        "813cf1dd",
-        "16eeffc4"
+        "MOZ2",
+        "MOZ4",
+        "MOZ5",
+        "MOZA",
+        "MOZB",
+        "MOZD",
+        "MOZE",
+        "MOZI",
+        "MOZL",
+        "MOZM",
+        "MOZO",
+        "MOZR",
+        "MOZT",
+        "MOZW",
+        "MOZX",
+        "MZSL01",
+        "MZSL02",
+        "MZSL03"
       ],
-      "telemetryId": "ecosia"
+      "telemetryId": "bing"
     }
   ],
-  "timestamp": 1731429440245
+  "timestamp": 1738595471359
 }

--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -85,9 +85,13 @@ struct RemoteSettingsClientInner<C> {
 }
 
 // Add your local packaged data you want to work with here
+//
+// To download the dump, run:
+//   $ cargo remote-settings dump-get --bucket main --collection-name <collection name>
 impl<C: ApiClient> RemoteSettingsClient<C> {
     // One line per bucket + collection
     packaged_collections! {
+        ("main", "search-config-v2"),
         ("main", "search-telemetry-v2"),
         ("main", "regions"),
     }


### PR DESCRIPTION
This adds the new dump and updates the existing search-telemetry-v2, no functional changes.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [X] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [X] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [X] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [X] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [X] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
