### PR TITLE
 Bug 1938924 - Add support for search-config-overrides-v2 to the Rust…

### DIFF
--- a/components/search/src/configuration_overrides_types.rs
+++ b/components/search/src/configuration_overrides_types.rs
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This module defines the structures that we use for serde_json to parse
+//! the search configuration overrides.
+
+use crate::JSONEngineUrls;
+use serde::Deserialize;
+
+/// Represents search configuration overrides record.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct JSONOverridesRecord {
+    /// This is the identifier of the search engine in search-config-v2 that this
+    /// record will override. It may be extended by telemetry_suffix.
+    pub identifier: String,
+
+    /// The partner code for the engine or variant. This will be inserted into
+    /// parameters which include '{partnerCode}
+    pub partner_code: String,
+
+    /// Suffix that is appended to the search engine identifier following a
+    /// dash, i.e. `<identifier>-<suffix>`. There should always be a suffix
+    /// supplied if the partner code is different.
+    pub telemetry_suffix: Option<String>,
+
+    /// The url used for reporting clicks.
+    pub click_url: String,
+
+    /// The URLs associated with the search engine.
+    //pub urls: JSONOverrideEngineUrls,
+    pub urls: JSONEngineUrls,
+}
+
+/// Represents the search configuration overrides as received from remote settings.
+#[derive(Debug, Deserialize)]
+pub(crate) struct JSONSearchConfigurationOverrides {
+    pub data: Vec<JSONOverridesRecord>,
+}

--- a/components/search/src/error.rs
+++ b/components/search/src/error.rs
@@ -17,8 +17,12 @@ use remote_settings::RemoteSettingsError;
 pub enum Error {
     #[error("Search configuration not specified")]
     SearchConfigNotSpecified,
-    #[error("No records received from remote settings")]
+    #[error("Search configuration overrides not specified")]
+    SearchConfigOverridesNotSpecified,
+    #[error("No search config v2 records received from remote settings")]
     SearchConfigNoRecords,
+    #[error("No search config overrides v2 records received from remote settings")]
+    SearchConfigOverridesNoRecords,
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
     #[error("Remote Settings error: {0}")]

--- a/components/search/src/lib.rs
+++ b/components/search/src/lib.rs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+mod configuration_overrides_types;
 mod configuration_types;
 mod environment_matching;
 mod error;

--- a/components/search/src/types.rs
+++ b/components/search/src/types.rs
@@ -209,6 +209,9 @@ pub struct SearchEngineDefinition {
     /// If the number is not specified, other methods of sorting may be relied
     /// upon (e.g. alphabetical).
     pub order_hint: Option<u32>,
+
+    /// The url used for reporting clicks.
+    pub click_url: Option<String>,
 }
 
 /// Details of the search engines to display to the user, generated as a result


### PR DESCRIPTION
… based search engine selector.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
