### PR TITLE
Fixes for maven repositories when used in mozilla-central [ci full]

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -19,8 +19,26 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:2.2'
     }
-    repositories {
-        mavenCentral()
+
+    if (!gradle.root.hasProperty("mozconfig")) {
+        // in app-services
+        repositories {
+            mavenCentral()
+        }
+    } else {
+        // big copy/paste from mobile/android/shared-settings.gradle.
+        gradle.ext.mozconfig = gradle.root.mozconfig
+
+        repositories {
+            gradle.mozconfig.substs.GRADLE_MAVEN_REPOSITORIES.each { repository ->
+                maven {
+                    url = repository
+                    if (gradle.mozconfig.substs.ALLOW_INSECURE_GRADLE_REPOSITORIES) {
+                        allowInsecureProtocol = true
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/tools/nimbus-gradle-plugin/settings.gradle
+++ b/tools/nimbus-gradle-plugin/settings.gradle
@@ -7,8 +7,25 @@ buildscript {
     dependencies {
         classpath 'org.yaml:snakeyaml:2.2'
     }
-    repositories {
-        mavenCentral()
+    if (!gradle.root.hasProperty("mozconfig")) {
+        // in app-services
+        repositories {
+            mavenCentral()
+        }
+    } else {
+        // big copy/paste from mobile/android/shared-settings.gradle.
+        gradle.ext.mozconfig = gradle.root.mozconfig
+
+        repositories {
+            gradle.mozconfig.substs.GRADLE_MAVEN_REPOSITORIES.each { repository ->
+                maven {
+                    url = repository
+                    if (gradle.mozconfig.substs.ALLOW_INSECURE_GRADLE_REPOSITORIES) {
+                        allowInsecureProtocol = true
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This resolves the Android build problems I was seeing on CI in moz-central. Behaviour inside app-services should be identical.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
