### PR TITLE
Update Kotlin to version 2.1.10 [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # v138.0 (In progress)
 
+## 🦊 What's Changed 🦊
+
+### Android
+- Upgraded Kotlin compiler from 1.9.24 to 2.1.10 ([#6640](https://github.com/mozilla/application-services/pull/6640))
+
 [Full Changelog](In progress)
 
 # v137.0 (_2025-03-03_)

--- a/build.gradle
+++ b/build.gradle
@@ -218,7 +218,7 @@ subprojects {
             }
         }
         tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-            kotlinOptions.allWarningsAsErrors = true
+            compilerOptions.allWarningsAsErrors = true
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,8 +11,8 @@ android-plugin = "8.8.2"
 protobuf = "4.29.0"
 
 # Kotlin
-kotlin-compiler = "1.9.24"
-kotlinx-coroutines = "1.8.0"
+kotlin-compiler = "2.1.10"
+kotlinx-coroutines = "1.10.1"
 
 # Mozilla
 android-components = "135.0.1"


### PR DESCRIPTION
We're almost ready to land this in mozilla-central, so let's do the same for A-S when ready.