### PR TITLE
Create the storage dir in the remote settings client

### DIFF
--- a/components/remote_settings/src/service.rs
+++ b/components/remote_settings/src/service.rs
@@ -40,6 +40,9 @@ impl RemoteSettingsService {
     /// This is typically done early in the application-startup process
     pub fn new(storage_dir: String, config: RemoteSettingsConfig2) -> Result<Self> {
         let storage_dir = storage_dir.into();
+        if storage_dir != ":memory:" {
+            std::fs::create_dir(&storage_dir)?;
+        }
         let base_url = config
             .server
             .unwrap_or(RemoteSettingsServer::Prod)

--- a/examples/cli-support/src/lib.rs
+++ b/examples/cli-support/src/lib.rs
@@ -44,12 +44,11 @@ pub fn cli_data_path(filename: &str) -> String {
 
 fn data_path(relative_path: Option<&str>) -> PathBuf {
     let dir = workspace_root_dir().join(".cli-data");
-    let dir = match relative_path {
+
+    match relative_path {
         None => dir,
         Some(relative_path) => dir.join(relative_path),
-    };
-    std::fs::create_dir_all(&dir).expect("Error creating dir {dir:?}");
-    dir
+    }
 }
 
 pub fn workspace_root_dir() -> PathBuf {


### PR DESCRIPTION
The iOS devs have noticed errors because this directory doesn't exist.

Removed code in `cli-support` to auto-create the directory.  In general, our components should be doing that.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
