### PR TITLE
Bug 1946621 - Implement `suggest` geo expansion and new collections.

### DIFF
--- a/components/suggest/src/benchmarks/client.rs
+++ b/components/suggest/src/benchmarks/client.rs
@@ -24,16 +24,25 @@ impl RemoteSettingsBenchmarkClient {
             remote_settings::RemoteSettings::new(remote_settings::RemoteSettingsConfig {
                 server: None,
                 bucket_name: None,
-                collection_name: "quicksuggest".to_owned(),
+                collection_name: rs::Collection::Amp.name().to_owned(),
                 server_url: None,
             })?,
-            rs::Collection::Quicksuggest,
+            rs::Collection::Amp,
         )?;
         new_benchmark_client.fetch_data_with_client(
             remote_settings::RemoteSettings::new(remote_settings::RemoteSettingsConfig {
                 server: None,
                 bucket_name: None,
-                collection_name: "fakespot-suggest-products".to_owned(),
+                collection_name: rs::Collection::Other.name().to_owned(),
+                server_url: None,
+            })?,
+            rs::Collection::Other,
+        )?;
+        new_benchmark_client.fetch_data_with_client(
+            remote_settings::RemoteSettings::new(remote_settings::RemoteSettingsConfig {
+                server: None,
+                bucket_name: None,
+                collection_name: rs::Collection::Fakespot.name().to_owned(),
                 server_url: None,
             })?,
             rs::Collection::Fakespot,

--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -23,12 +23,12 @@ use crate::{
     provider::{AmpMatchingStrategy, SuggestionProvider},
     query::{full_keywords_to_fts_content, FtsQuery},
     rs::{
-        DownloadedAmoSuggestion, DownloadedAmpSuggestion, DownloadedAmpWikipediaSuggestion,
-        DownloadedExposureSuggestion, DownloadedFakespotSuggestion, DownloadedMdnSuggestion,
-        DownloadedPocketSuggestion, DownloadedWikipediaSuggestion, Record, SuggestRecordId,
+        DownloadedAmoSuggestion, DownloadedAmpSuggestion, DownloadedExposureSuggestion,
+        DownloadedFakespotSuggestion, DownloadedMdnSuggestion, DownloadedPocketSuggestion,
+        DownloadedWikipediaSuggestion, Record, SuggestRecordId,
     },
     schema::{clear_database, SuggestConnectionInitializer},
-    suggestion::{cook_raw_suggestion_url, AmpSuggestionType, FtsMatchInfo, Suggestion},
+    suggestion::{cook_raw_suggestion_url, FtsMatchInfo, Suggestion},
     util::full_keyword,
     weather::WeatherCache,
     Result, SuggestionQuery,
@@ -255,25 +255,21 @@ impl<'a> SuggestDao<'a> {
     }
 
     /// Fetches Suggestions of type Amp provider that match the given query
-    pub fn fetch_amp_suggestions(
-        &self,
-        query: &SuggestionQuery,
-        suggestion_type: AmpSuggestionType,
-    ) -> Result<Vec<Suggestion>> {
+    pub fn fetch_amp_suggestions(&self, query: &SuggestionQuery) -> Result<Vec<Suggestion>> {
         let strategy = query
             .provider_constraints
             .as_ref()
             .and_then(|c| c.amp_alternative_matching.as_ref());
         match strategy {
-            None => self.fetch_amp_suggestions_using_keywords(query, suggestion_type, true),
+            None => self.fetch_amp_suggestions_using_keywords(query, true),
             Some(AmpMatchingStrategy::NoKeywordExpansion) => {
-                self.fetch_amp_suggestions_using_keywords(query, suggestion_type, false)
+                self.fetch_amp_suggestions_using_keywords(query, false)
             }
             Some(AmpMatchingStrategy::FtsAgainstFullKeywords) => {
-                self.fetch_amp_suggestions_using_fts(query, suggestion_type, "full_keywords")
+                self.fetch_amp_suggestions_using_fts(query, "full_keywords")
             }
             Some(AmpMatchingStrategy::FtsAgainstTitle) => {
-                self.fetch_amp_suggestions_using_fts(query, suggestion_type, "title")
+                self.fetch_amp_suggestions_using_fts(query, "title")
             }
         }
     }
@@ -281,14 +277,9 @@ impl<'a> SuggestDao<'a> {
     pub fn fetch_amp_suggestions_using_keywords(
         &self,
         query: &SuggestionQuery,
-        suggestion_type: AmpSuggestionType,
         allow_keyword_expansion: bool,
     ) -> Result<Vec<Suggestion>> {
         let keyword_lowercased = &query.keyword.to_lowercase();
-        let provider = match suggestion_type {
-            AmpSuggestionType::Mobile => SuggestionProvider::AmpMobile,
-            AmpSuggestionType::Desktop => SuggestionProvider::Amp,
-        };
         let where_extra = if allow_keyword_expansion {
             ""
         } else {
@@ -322,7 +313,7 @@ impl<'a> SuggestDao<'a> {
             ),
             named_params! {
                 ":keyword": keyword_lowercased,
-                ":provider": provider
+                ":provider": SuggestionProvider::Amp,
             },
             |row| -> Result<Suggestion> {
                 let suggestion_id: i64 = row.get("id")?;
@@ -401,15 +392,10 @@ impl<'a> SuggestDao<'a> {
     pub fn fetch_amp_suggestions_using_fts(
         &self,
         query: &SuggestionQuery,
-        suggestion_type: AmpSuggestionType,
         fts_column: &str,
     ) -> Result<Vec<Suggestion>> {
         let fts_query = query.fts_query();
         let match_arg = &fts_query.match_arg;
-        let provider = match suggestion_type {
-            AmpSuggestionType::Mobile => SuggestionProvider::AmpMobile,
-            AmpSuggestionType::Desktop => SuggestionProvider::Amp,
-        };
         let suggestions = self.conn.query_rows_and_then_cached(
             &format!(
                 r#"
@@ -433,7 +419,7 @@ impl<'a> SuggestDao<'a> {
                 "#
             ),
             named_params! {
-                ":provider": provider
+                ":provider": SuggestionProvider::Amp,
             },
             |row| -> Result<Suggestion> {
                 let suggestion_id: i64 = row.get("id")?;
@@ -1067,59 +1053,43 @@ impl<'a> SuggestDao<'a> {
         Ok(())
     }
 
-    /// Inserts all suggestions from a downloaded AMP-Wikipedia attachment into
-    /// the database.
-    pub fn insert_amp_wikipedia_suggestions(
+    /// Inserts suggestions from an AMP attachment into the database.
+    pub fn insert_amp_suggestions(
         &mut self,
         record_id: &SuggestRecordId,
-        suggestions: &[DownloadedAmpWikipediaSuggestion],
+        suggestions: &[DownloadedAmpSuggestion],
         enable_fts: bool,
     ) -> Result<()> {
         // Prepare statements outside of the loop.  This results in a large performance
         // improvement on a fresh ingest, since there are so many rows.
         let mut suggestion_insert = SuggestionInsertStatement::new(self.conn)?;
         let mut amp_insert = AmpInsertStatement::new(self.conn)?;
-        let mut wiki_insert = WikipediaInsertStatement::new(self.conn)?;
         let mut keyword_insert = KeywordInsertStatement::new(self.conn)?;
         let mut fts_insert = AmpFtsInsertStatement::new(self.conn)?;
         for suggestion in suggestions {
             self.scope.err_if_interrupted()?;
-            let common_details = suggestion.common_details();
-            let provider = suggestion.provider();
-
             let suggestion_id = suggestion_insert.execute(
                 record_id,
-                &common_details.title,
-                &common_details.url,
-                common_details.score.unwrap_or(DEFAULT_SUGGESTION_SCORE),
-                provider,
+                &suggestion.title,
+                &suggestion.url,
+                suggestion.score.unwrap_or(DEFAULT_SUGGESTION_SCORE),
+                SuggestionProvider::Amp,
             )?;
-            match suggestion {
-                DownloadedAmpWikipediaSuggestion::Amp(amp) => {
-                    amp_insert.execute(suggestion_id, amp)?;
-                }
-                DownloadedAmpWikipediaSuggestion::Wikipedia(wikipedia) => {
-                    wiki_insert.execute(suggestion_id, wikipedia)?;
-                }
-            }
+            amp_insert.execute(suggestion_id, suggestion)?;
             if enable_fts {
                 fts_insert.execute(
                     suggestion_id,
-                    &common_details.full_keywords_fts_column(),
-                    &common_details.title,
+                    &suggestion.full_keywords_fts_column(),
+                    &suggestion.title,
                 )?;
             }
             let mut full_keyword_inserter = FullKeywordInserter::new(self.conn, suggestion_id);
-            for keyword in common_details.keywords() {
-                let full_keyword_id = match (suggestion, keyword.full_keyword) {
-                    // Try to associate full keyword data.  Only do this for AMP, we decided to
-                    // skip it for Wikipedia in https://bugzilla.mozilla.org/show_bug.cgi?id=1876217
-                    (DownloadedAmpWikipediaSuggestion::Amp(_), Some(full_keyword)) => {
-                        Some(full_keyword_inserter.maybe_insert(full_keyword)?)
-                    }
-                    _ => None,
+            for keyword in suggestion.keywords() {
+                let full_keyword_id = if let Some(full_keyword) = keyword.full_keyword {
+                    Some(full_keyword_inserter.maybe_insert(full_keyword)?)
+                } else {
+                    None
                 };
-
                 keyword_insert.execute(
                     suggestion_id,
                     keyword.keyword,
@@ -1131,40 +1101,30 @@ impl<'a> SuggestDao<'a> {
         Ok(())
     }
 
-    /// Inserts all suggestions from a downloaded AMP-Mobile attachment into
-    /// the database.
-    pub fn insert_amp_mobile_suggestions(
+    /// Inserts suggestions from a Wikipedia attachment into the database.
+    pub fn insert_wikipedia_suggestions(
         &mut self,
         record_id: &SuggestRecordId,
-        suggestions: &[DownloadedAmpSuggestion],
+        suggestions: &[DownloadedWikipediaSuggestion],
     ) -> Result<()> {
+        // Prepare statements outside of the loop.  This results in a large performance
+        // improvement on a fresh ingest, since there are so many rows.
         let mut suggestion_insert = SuggestionInsertStatement::new(self.conn)?;
-        let mut amp_insert = AmpInsertStatement::new(self.conn)?;
+        let mut wiki_insert = WikipediaInsertStatement::new(self.conn)?;
         let mut keyword_insert = KeywordInsertStatement::new(self.conn)?;
         for suggestion in suggestions {
             self.scope.err_if_interrupted()?;
-            let common_details = &suggestion.common_details;
             let suggestion_id = suggestion_insert.execute(
                 record_id,
-                &common_details.title,
-                &common_details.url,
-                common_details.score.unwrap_or(DEFAULT_SUGGESTION_SCORE),
-                SuggestionProvider::AmpMobile,
+                &suggestion.title,
+                &suggestion.url,
+                suggestion.score.unwrap_or(DEFAULT_SUGGESTION_SCORE),
+                SuggestionProvider::Wikipedia,
             )?;
-            amp_insert.execute(suggestion_id, suggestion)?;
-
-            let mut full_keyword_inserter = FullKeywordInserter::new(self.conn, suggestion_id);
-            for keyword in common_details.keywords() {
-                let full_keyword_id = keyword
-                    .full_keyword
-                    .map(|full_keyword| full_keyword_inserter.maybe_insert(full_keyword))
-                    .transpose()?;
-                keyword_insert.execute(
-                    suggestion_id,
-                    keyword.keyword,
-                    full_keyword_id,
-                    keyword.rank,
-                )?;
+            wiki_insert.execute(suggestion_id, suggestion)?;
+            for keyword in suggestion.keywords() {
+                // Don't update `full_keywords`, see bug 1876217.
+                keyword_insert.execute(suggestion_id, keyword.keyword, None, keyword.rank)?;
             }
         }
         Ok(())

--- a/components/suggest/src/query.rs
+++ b/components/suggest/src/query.rs
@@ -69,14 +69,6 @@ impl SuggestionQuery {
         }
     }
 
-    pub fn amp_mobile(keyword: &str) -> Self {
-        Self {
-            keyword: keyword.into(),
-            providers: vec![SuggestionProvider::AmpMobile],
-            ..Self::default()
-        }
-    }
-
     pub fn amo(keyword: &str) -> Self {
         Self {
             keyword: keyword.into(),

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -40,21 +40,21 @@ use remote_settings::{
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 
-use crate::{
-    error::Error, provider::SuggestionProvider, query::full_keywords_to_fts_content, Result,
-};
+use crate::{error::Error, query::full_keywords_to_fts_content, Result};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Collection {
-    Quicksuggest,
+    Amp,
     Fakespot,
+    Other,
 }
 
 impl Collection {
     pub fn name(&self) -> &'static str {
         match self {
-            Self::Quicksuggest => "quicksuggest",
+            Self::Amp => "quicksuggest-amp",
             Self::Fakespot => "fakespot-suggest-products",
+            Self::Other => "quicksuggest-other",
         }
     }
 }
@@ -80,22 +80,25 @@ pub(crate) trait Client {
 /// Implements the [Client] trait using a real remote settings client
 pub struct SuggestRemoteSettingsClient {
     // Create a separate client for each collection name
-    quicksuggest_client: Arc<RemoteSettingsClient>,
+    amp_client: Arc<RemoteSettingsClient>,
+    other_client: Arc<RemoteSettingsClient>,
     fakespot_client: Arc<RemoteSettingsClient>,
 }
 
 impl SuggestRemoteSettingsClient {
     pub fn new(rs_service: &RemoteSettingsService) -> Result<Self> {
         Ok(Self {
-            quicksuggest_client: rs_service.make_client("quicksuggest".to_owned())?,
-            fakespot_client: rs_service.make_client("fakespot-suggest-products".to_owned())?,
+            amp_client: rs_service.make_client(Collection::Amp.name().to_owned())?,
+            other_client: rs_service.make_client(Collection::Other.name().to_owned())?,
+            fakespot_client: rs_service.make_client(Collection::Fakespot.name().to_owned())?,
         })
     }
 
     fn client_for_collection(&self, collection: Collection) -> &RemoteSettingsClient {
         match collection {
+            Collection::Amp => &self.amp_client,
+            Collection::Other => &self.other_client,
             Collection::Fakespot => &self.fakespot_client,
-            Collection::Quicksuggest => &self.quicksuggest_client,
         }
     }
 }
@@ -176,8 +179,10 @@ impl From<Record> for RemoteSettingsRecord {
 pub(crate) enum SuggestRecord {
     #[serde(rename = "icon")]
     Icon,
-    #[serde(rename = "data")]
-    AmpWikipedia,
+    #[serde(rename = "amp")]
+    Amp,
+    #[serde(rename = "wikipedia")]
+    Wikipedia,
     #[serde(rename = "amo-suggestions")]
     Amo,
     #[serde(rename = "pocket-suggestions")]
@@ -190,8 +195,6 @@ pub(crate) enum SuggestRecord {
     Weather,
     #[serde(rename = "configuration")]
     GlobalConfig(DownloadedGlobalConfig),
-    #[serde(rename = "amp-mobile-suggestions")]
-    AmpMobile,
     #[serde(rename = "fakespot-suggestions")]
     Fakespot,
     #[serde(rename = "exposure-suggestions")]
@@ -215,14 +218,14 @@ impl SuggestRecord {
 #[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum SuggestRecordType {
     Icon,
-    AmpWikipedia,
+    Amp,
+    Wikipedia,
     Amo,
     Pocket,
     Yelp,
     Mdn,
     Weather,
     GlobalConfig,
-    AmpMobile,
     Fakespot,
     Exposure,
     Geonames,
@@ -232,14 +235,14 @@ impl From<&SuggestRecord> for SuggestRecordType {
     fn from(suggest_record: &SuggestRecord) -> Self {
         match suggest_record {
             SuggestRecord::Amo => Self::Amo,
-            SuggestRecord::AmpWikipedia => Self::AmpWikipedia,
+            SuggestRecord::Amp => Self::Amp,
+            SuggestRecord::Wikipedia => Self::Wikipedia,
             SuggestRecord::Icon => Self::Icon,
             SuggestRecord::Mdn => Self::Mdn,
             SuggestRecord::Pocket => Self::Pocket,
             SuggestRecord::Weather => Self::Weather,
             SuggestRecord::Yelp => Self::Yelp,
             SuggestRecord::GlobalConfig(_) => Self::GlobalConfig,
-            SuggestRecord::AmpMobile => Self::AmpMobile,
             SuggestRecord::Fakespot => Self::Fakespot,
             SuggestRecord::Exposure(_) => Self::Exposure,
             SuggestRecord::Geonames => Self::Geonames,
@@ -261,14 +264,14 @@ impl SuggestRecordType {
     pub fn all() -> &'static [SuggestRecordType] {
         &[
             Self::Icon,
-            Self::AmpWikipedia,
+            Self::Amp,
+            Self::Wikipedia,
             Self::Amo,
             Self::Pocket,
             Self::Yelp,
             Self::Mdn,
             Self::Weather,
             Self::GlobalConfig,
-            Self::AmpMobile,
             Self::Fakespot,
             Self::Exposure,
             Self::Geonames,
@@ -278,24 +281,17 @@ impl SuggestRecordType {
     pub fn as_str(&self) -> &str {
         match self {
             Self::Icon => "icon",
-            Self::AmpWikipedia => "data",
+            Self::Amp => "amp",
+            Self::Wikipedia => "wikipedia",
             Self::Amo => "amo-suggestions",
             Self::Pocket => "pocket-suggestions",
             Self::Yelp => "yelp-suggestions",
             Self::Mdn => "mdn-suggestions",
             Self::Weather => "weather",
             Self::GlobalConfig => "configuration",
-            Self::AmpMobile => "amp-mobile-suggestions",
             Self::Fakespot => "fakespot-suggestions",
             Self::Exposure => "exposure-suggestions",
             Self::Geonames => "geonames",
-        }
-    }
-
-    pub fn collection(&self) -> Collection {
-        match self {
-            Self::Fakespot => Collection::Fakespot,
-            _ => Collection::Quicksuggest,
         }
     }
 }
@@ -354,22 +350,15 @@ impl fmt::Display for SuggestRecordId {
     }
 }
 
-/// Fields that are common to all downloaded suggestions.
+/// An AMP suggestion to ingest from an AMP attachment.
 #[derive(Clone, Debug, Default, Deserialize)]
-pub(crate) struct DownloadedSuggestionCommonDetails {
+pub(crate) struct DownloadedAmpSuggestion {
     pub keywords: Vec<String>,
     pub title: String,
     pub url: String,
     pub score: Option<f64>,
     #[serde(default)]
     pub full_keywords: Vec<(String, usize)>,
-}
-
-/// An AMP suggestion to ingest from an AMP-Wikipedia attachment.
-#[derive(Clone, Debug, Default, Deserialize)]
-pub(crate) struct DownloadedAmpSuggestion {
-    #[serde(flatten)]
-    pub common_details: DownloadedSuggestionCommonDetails,
     pub advertiser: String,
     #[serde(rename = "id")]
     pub block_id: i32,
@@ -380,63 +369,55 @@ pub(crate) struct DownloadedAmpSuggestion {
     pub icon_id: String,
 }
 
-/// A Wikipedia suggestion to ingest from an AMP-Wikipedia attachment.
+/// A Wikipedia suggestion to ingest from a Wikipedia attachment.
 #[derive(Clone, Debug, Default, Deserialize)]
 pub(crate) struct DownloadedWikipediaSuggestion {
-    #[serde(flatten)]
-    pub common_details: DownloadedSuggestionCommonDetails,
+    pub keywords: Vec<String>,
+    pub title: String,
+    pub url: String,
+    pub score: Option<f64>,
+    #[serde(default)]
+    pub full_keywords: Vec<(String, usize)>,
     #[serde(rename = "icon")]
     pub icon_id: String,
 }
 
-/// A suggestion to ingest from an AMP-Wikipedia attachment downloaded from
-/// Remote Settings.
-#[derive(Clone, Debug)]
-pub(crate) enum DownloadedAmpWikipediaSuggestion {
-    Amp(DownloadedAmpSuggestion),
-    Wikipedia(DownloadedWikipediaSuggestion),
+/// Iterate over all AMP/Wikipedia-style keywords.
+pub fn iterate_keywords<'a>(
+    keywords: &'a [String],
+    full_keywords: &'a [(String, usize)],
+) -> impl Iterator<Item = AmpKeyword<'a>> {
+    let full_keywords_iter = full_keywords
+        .iter()
+        .flat_map(|(full_keyword, repeat_for)| {
+            std::iter::repeat(Some(full_keyword.as_str())).take(*repeat_for)
+        })
+        .chain(std::iter::repeat(None)); // In case of insufficient full keywords, just fill in with infinite `None`s
+                                         //
+    keywords
+        .iter()
+        .zip(full_keywords_iter)
+        .enumerate()
+        .map(move |(i, (keyword, full_keyword))| AmpKeyword {
+            rank: i,
+            keyword,
+            full_keyword,
+        })
 }
 
-impl DownloadedAmpWikipediaSuggestion {
-    /// Returns the details that are common to AMP and Wikipedia suggestions.
-    pub fn common_details(&self) -> &DownloadedSuggestionCommonDetails {
-        match self {
-            Self::Amp(DownloadedAmpSuggestion { common_details, .. }) => common_details,
-            Self::Wikipedia(DownloadedWikipediaSuggestion { common_details, .. }) => common_details,
-        }
-    }
-
-    /// Returns the provider of this suggestion.
-    pub fn provider(&self) -> SuggestionProvider {
-        match self {
-            DownloadedAmpWikipediaSuggestion::Amp(_) => SuggestionProvider::Amp,
-            DownloadedAmpWikipediaSuggestion::Wikipedia(_) => SuggestionProvider::Wikipedia,
-        }
-    }
-}
-
-impl DownloadedSuggestionCommonDetails {
-    /// Iterate over all keywords for this suggestion
+impl DownloadedAmpSuggestion {
     pub fn keywords(&self) -> impl Iterator<Item = AmpKeyword<'_>> {
-        let full_keywords = self
-            .full_keywords
-            .iter()
-            .flat_map(|(full_keyword, repeat_for)| {
-                std::iter::repeat(Some(full_keyword.as_str())).take(*repeat_for)
-            })
-            .chain(std::iter::repeat(None)); // In case of insufficient full keywords, just fill in with infinite `None`s
-                                             //
-        self.keywords.iter().zip(full_keywords).enumerate().map(
-            move |(i, (keyword, full_keyword))| AmpKeyword {
-                rank: i,
-                keyword,
-                full_keyword,
-            },
-        )
+        iterate_keywords(&self.keywords, &self.full_keywords)
     }
 
     pub fn full_keywords_fts_column(&self) -> String {
         full_keywords_to_fts_content(self.full_keywords.iter().map(|(s, _)| s.as_str()))
+    }
+}
+
+impl DownloadedWikipediaSuggestion {
+    pub fn keywords(&self) -> impl Iterator<Item = AmpKeyword<'_>> {
+        iterate_keywords(&self.keywords, &self.full_keywords)
     }
 }
 
@@ -445,44 +426,6 @@ pub(crate) struct AmpKeyword<'a> {
     pub rank: usize,
     pub keyword: &'a str,
     pub full_keyword: Option<&'a str>,
-}
-
-impl<'de> Deserialize<'de> for DownloadedAmpWikipediaSuggestion {
-    fn deserialize<D>(
-        deserializer: D,
-    ) -> std::result::Result<DownloadedAmpWikipediaSuggestion, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        // AMP and Wikipedia suggestions use the same schema. To separate them,
-        // we use a "maybe tagged" outer enum with tagged and untagged variants,
-        // and a "tagged" inner enum.
-        //
-        // Wikipedia suggestions will deserialize successfully into the tagged
-        // variant. AMP suggestions will try the tagged variant, fail, and fall
-        // back to the untagged variant.
-        //
-        // This approach works around serde-rs/serde#912.
-
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum MaybeTagged {
-            Tagged(Tagged),
-            Untagged(DownloadedAmpSuggestion),
-        }
-
-        #[derive(Deserialize)]
-        #[serde(tag = "advertiser")]
-        enum Tagged {
-            #[serde(rename = "Wikipedia")]
-            Wikipedia(DownloadedWikipediaSuggestion),
-        }
-
-        Ok(match MaybeTagged::deserialize(deserializer)? {
-            MaybeTagged::Tagged(Tagged::Wikipedia(wikipedia)) => Self::Wikipedia(wikipedia),
-            MaybeTagged::Untagged(amp) => Self::Amp(amp),
-        })
-    }
 }
 
 /// An AMO suggestion to ingest from an attachment
@@ -665,24 +608,21 @@ mod test {
 
     #[test]
     fn test_full_keywords() {
-        let suggestion = DownloadedAmpWikipediaSuggestion::Amp(DownloadedAmpSuggestion {
-            common_details: DownloadedSuggestionCommonDetails {
-                keywords: vec![
-                    String::from("f"),
-                    String::from("fo"),
-                    String::from("foo"),
-                    String::from("foo b"),
-                    String::from("foo ba"),
-                    String::from("foo bar"),
-                ],
-                full_keywords: vec![(String::from("foo"), 3), (String::from("foo bar"), 3)],
-                ..DownloadedSuggestionCommonDetails::default()
-            },
+        let suggestion = DownloadedAmpSuggestion {
+            keywords: vec![
+                String::from("f"),
+                String::from("fo"),
+                String::from("foo"),
+                String::from("foo b"),
+                String::from("foo ba"),
+                String::from("foo bar"),
+            ],
+            full_keywords: vec![(String::from("foo"), 3), (String::from("foo bar"), 3)],
             ..DownloadedAmpSuggestion::default()
-        });
+        };
 
         assert_eq!(
-            Vec::from_iter(suggestion.common_details().keywords()),
+            Vec::from_iter(suggestion.keywords()),
             vec![
                 AmpKeyword {
                     rank: 0,
@@ -720,25 +660,22 @@ mod test {
 
     #[test]
     fn test_missing_full_keywords() {
-        let suggestion = DownloadedAmpWikipediaSuggestion::Amp(DownloadedAmpSuggestion {
-            common_details: DownloadedSuggestionCommonDetails {
-                keywords: vec![
-                    String::from("f"),
-                    String::from("fo"),
-                    String::from("foo"),
-                    String::from("foo b"),
-                    String::from("foo ba"),
-                    String::from("foo bar"),
-                ],
-                // Only the first 3 keywords have full keywords associated with them
-                full_keywords: vec![(String::from("foo"), 3)],
-                ..DownloadedSuggestionCommonDetails::default()
-            },
+        let suggestion = DownloadedAmpSuggestion {
+            keywords: vec![
+                String::from("f"),
+                String::from("fo"),
+                String::from("foo"),
+                String::from("foo b"),
+                String::from("foo ba"),
+                String::from("foo bar"),
+            ],
+            // Only the first 3 keywords have full keywords associated with them
+            full_keywords: vec![(String::from("foo"), 3)],
             ..DownloadedAmpSuggestion::default()
-        });
+        };
 
         assert_eq!(
-            Vec::from_iter(suggestion.common_details().keywords()),
+            Vec::from_iter(suggestion.keywords()),
             vec![
                 AmpKeyword {
                     rank: 0,

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -4,7 +4,7 @@
  */
 
 use std::{
-    collections::{hash_map::Entry, BTreeSet, HashMap, HashSet},
+    collections::{hash_map::Entry, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -27,7 +27,6 @@ use crate::{
         Client, Collection, DownloadedExposureRecord, Record, SuggestAttachment, SuggestRecord,
         SuggestRecordId, SuggestRecordType, SuggestRemoteSettingsClient,
     },
-    suggestion::AmpSuggestionType,
     QueryWithMetricsResult, Result, SuggestApiResult, Suggestion, SuggestionQuery,
 };
 
@@ -341,7 +340,6 @@ impl SuggestIngestionConstraints {
                 SuggestionProvider::Yelp,
                 SuggestionProvider::Mdn,
                 SuggestionProvider::Weather,
-                SuggestionProvider::AmpMobile,
                 SuggestionProvider::Fakespot,
                 SuggestionProvider::Exposure,
             ]),
@@ -416,12 +414,7 @@ impl<S> SuggestStoreInner<S> {
         for provider in unique_providers {
             let new_suggestions = metrics.measure_query(provider.to_string(), || {
                 reader.read(|dao| match provider {
-                    SuggestionProvider::Amp => {
-                        dao.fetch_amp_suggestions(&query, AmpSuggestionType::Desktop)
-                    }
-                    SuggestionProvider::AmpMobile => {
-                        dao.fetch_amp_suggestions(&query, AmpSuggestionType::Mobile)
-                    }
+                    SuggestionProvider::Amp => dao.fetch_amp_suggestions(&query),
                     SuggestionProvider::Wikipedia => dao.fetch_wikipedia_suggestions(&query),
                     SuggestionProvider::Amo => dao.fetch_amo_suggestions(&query),
                     SuggestionProvider::Pocket => dao.fetch_pocket_suggestions(&query),
@@ -536,28 +529,24 @@ where
 
         // Figure out which record types we're ingesting and group them by
         // collection. A record type may be used by multiple providers, but we
-        // want to ingest each one at most once.
-        let mut record_types_by_collection = HashMap::<Collection, BTreeSet<_>>::new();
-        for p in constraints
+        // want to ingest each one at most once. We always ingest some types
+        // like global config.
+        let mut record_types_by_collection = HashMap::from([(
+            Collection::Other,
+            HashSet::from([SuggestRecordType::GlobalConfig]),
+        )]);
+        for provider in constraints
             .providers
             .as_ref()
             .unwrap_or(&DEFAULT_INGEST_PROVIDERS.to_vec())
             .iter()
         {
-            for t in p.record_types() {
+            for (collection, provider_rts) in provider.record_types_by_collection() {
                 record_types_by_collection
-                    .entry(t.collection())
+                    .entry(collection)
                     .or_default()
-                    .insert(t);
+                    .extend(provider_rts.into_iter());
             }
-        }
-
-        // Always ingest these record types.
-        for rt in [SuggestRecordType::Icon, SuggestRecordType::GlobalConfig] {
-            record_types_by_collection
-                .entry(rt.collection())
-                .or_default()
-                .insert(rt);
         }
 
         // Create a single write scope for all DB operations
@@ -645,18 +634,18 @@ where
         context: &mut MetricsContext,
     ) -> Result<()> {
         match &record.payload {
-            SuggestRecord::AmpWikipedia => {
+            SuggestRecord::Amp => {
                 self.download_attachment(dao, record, context, |dao, record_id, suggestions| {
-                    dao.insert_amp_wikipedia_suggestions(
+                    dao.insert_amp_suggestions(
                         record_id,
                         suggestions,
                         constraints.amp_matching_uses_fts(),
                     )
                 })?;
             }
-            SuggestRecord::AmpMobile => {
+            SuggestRecord::Wikipedia => {
                 self.download_attachment(dao, record, context, |dao, record_id, suggestions| {
-                    dao.insert_amp_mobile_suggestions(record_id, suggestions)
+                    dao.insert_wikipedia_suggestions(record_id, suggestions)
                 })?;
             }
             SuggestRecord::Icon => {
@@ -766,7 +755,7 @@ where
                 Ok(!dao.is_exposure_suggestion_ingested(&record.id)?
                     && constraints.matches_exposure_record(r))
             }
-            SuggestRecord::AmpWikipedia => {
+            SuggestRecord::Amp => {
                 Ok(constraints.amp_matching_uses_fts()
                     && !dao.is_amp_fts_data_ingested(&record.id)?)
             }
@@ -837,14 +826,15 @@ where
             .expect("Error performing checkpoint");
     }
 
-    pub fn ingest_records_by_type(&self, ingest_record_type: SuggestRecordType) {
+    pub fn ingest_records_by_type(
+        &self,
+        collection: Collection,
+        ingest_record_type: SuggestRecordType,
+    ) {
         let writer = &self.dbs().unwrap().writer;
         let mut context = MetricsContext::default();
         let ingested_records = writer.read(|dao| dao.get_ingested_records()).unwrap();
-        let records = self
-            .settings_client
-            .get_records(ingest_record_type.collection())
-            .unwrap();
+        let records = self.settings_client.get_records(collection).unwrap();
 
         let changes = RecordChanges::new(
             records
@@ -858,7 +848,7 @@ where
             .write(|dao| {
                 self.process_changes(
                     dao,
-                    ingest_record_type.collection(),
+                    collection,
                     changes,
                     &SuggestIngestionConstraints::default(),
                     &mut context,
@@ -1035,8 +1025,8 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record("data", "1234", json![los_pollos_amp()])
-                .with_icon(los_pollos_icon()),
+                .with_record(SuggestionProvider::Amp.record("1234", json![los_pollos_amp()]))
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
@@ -1051,11 +1041,10 @@ pub(crate) mod tests {
     fn ingest_empty_only() -> anyhow::Result<()> {
         before_each();
 
-        let mut store = TestStore::new(MockRemoteSettingsClient::default().with_record(
-            "data",
-            "1234",
-            json![los_pollos_amp()],
-        ));
+        let mut store = TestStore::new(
+            MockRemoteSettingsClient::default()
+                .with_record(SuggestionProvider::Amp.record("1234", json![los_pollos_amp()])),
+        );
         // suggestions_table_empty returns true before the ingestion is complete
         assert!(store.read(|dao| dao.suggestions_table_empty())?);
         // This ingestion should run, since the DB is empty
@@ -1068,10 +1057,10 @@ pub(crate) mod tests {
 
         // This ingestion should not run since the DB is no longer empty
         store.client_mut().update_record(
-            "data",
-            "1234",
-            json!([los_pollos_amp(), good_place_eats_amp()]),
+            SuggestionProvider::Amp
+                .record("1234", json!([los_pollos_amp(), good_place_eats_amp()])),
         );
+
         store.ingest(SuggestIngestionConstraints {
             empty_only: true,
             ..SuggestIngestionConstraints::all_providers()
@@ -1091,12 +1080,11 @@ pub(crate) mod tests {
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
                 .with_record(
-                    "data",
-                    "1234",
-                    json!([los_pollos_amp(), good_place_eats_amp()]),
+                    SuggestionProvider::Amp
+                        .record("1234", json!([los_pollos_amp(), good_place_eats_amp()])),
                 )
-                .with_icon(los_pollos_icon())
-                .with_icon(good_place_eats_icon()),
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon()))
+                .with_record(SuggestionProvider::Amp.icon(good_place_eats_icon())),
         );
         // This ingestion should run, since the DB is empty
         store.ingest(SuggestIngestionConstraints::all_providers());
@@ -1114,11 +1102,12 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn ingest_full_keywords() -> anyhow::Result<()> {
+    fn ingest_amp_full_keywords() -> anyhow::Result<()> {
         before_each();
 
         let store = TestStore::new(MockRemoteSettingsClient::default()
-            .with_record("data", "1234", json!([
+            .with_record(
+                SuggestionProvider::Amp.record("1234", json!([
                 // AMP attachment with full keyword data
                 los_pollos_amp().merge(json!({
                     "keywords": ["lo", "los", "los p", "los pollos", "los pollos h", "los pollos hermanos"],
@@ -1131,27 +1120,9 @@ pub(crate) mod tests {
                 })),
                 // AMP attachment without full keyword data
                 good_place_eats_amp(),
-                // Wikipedia attachment with full keyword data.  We should ignore the full
-                // keyword data for Wikipedia suggestions
-                california_wiki(),
-                // california_wiki().merge(json!({
-                //     "keywords": ["cal", "cali", "california"],
-                //     "full_keywords": [("california institute of technology", 3)],
-                // })),
-            ]))
-            .with_record("amp-mobile-suggestions", "2468", json!([
-                // Amp mobile attachment with full keyword data
-                a1a_amp_mobile().merge(json!({
-                    "keywords": ["a1a", "ca", "car", "car wash"],
-                    "full_keywords": [
-                        ("A1A Car Wash", 1),
-                        ("car wash", 3),
-                    ],
-                })),
-            ]))
-            .with_icon(los_pollos_icon())
-            .with_icon(good_place_eats_icon())
-            .with_icon(california_icon())
+            ])))
+            .with_record(SuggestionProvider::Amp.icon(los_pollos_icon()))
+            .with_record(SuggestionProvider::Amp.icon(good_place_eats_icon()))
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
 
@@ -1163,22 +1134,41 @@ pub(crate) mod tests {
 
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::amp("la")),
-            // Good place eats did not have full keywords, so this one is calculated with the
-            // keywords.rs code
+            // Good place eats did not have full keywords, so this one is
+            // calculated at runtime
             vec![good_place_eats_suggestion("lasagna", None)],
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn ingest_wikipedia_full_keywords() -> anyhow::Result<()> {
+        before_each();
+
+        let store = TestStore::new(
+            MockRemoteSettingsClient::default()
+                .with_record(SuggestionProvider::Wikipedia.record(
+                    "1234",
+                    json!([
+                        // Wikipedia attachment with full keyword data.  We should ignore the full
+                        // keyword data for Wikipedia suggestions
+                        california_wiki(),
+                        // california_wiki().merge(json!({
+                        //     "keywords": ["cal", "cali", "california"],
+                        //     "full_keywords": [("california institute of technology", 3)],
+                        // })),
+                    ]),
+                ))
+                .with_record(SuggestionProvider::Wikipedia.icon(california_icon())),
+        );
+        store.ingest(SuggestIngestionConstraints::all_providers());
 
         assert_eq!(
             store.fetch_suggestions(SuggestionQuery::wikipedia("cal")),
             // Even though this had a full_keywords field, we should ignore it since it's a
             // wikipedia suggestion and use the keywords.rs code instead
             vec![california_suggestion("california")],
-        );
-
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::amp_mobile("a1a")),
-            // This keyword comes from the provided full_keywords list.
-            vec![a1a_suggestion("A1A Car Wash", None)],
         );
 
         Ok(())
@@ -1195,14 +1185,14 @@ pub(crate) mod tests {
                 //     keywords (i.e. it was the result of keyword expansion).
                 //   * There's a `los pollos ` keyword with an extra space
                 .with_record(
-                    "data",
+                    SuggestionProvider::Amp.record(
                     "1234",
                     los_pollos_amp().merge(json!({
                         "keywords": ["los", "los pollos", "los pollos ", "los pollos hermanos", "chicken"],
                         "full_keywords": [("los pollos", 3), ("los pollos hermanos", 2)],
                     }))
-                )
-                .with_icon(los_pollos_icon()),
+                ))
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
@@ -1241,15 +1231,14 @@ pub(crate) mod tests {
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
                 // Make sure there's full keywords to match against
-                .with_record(
-                    "data",
+                .with_record(SuggestionProvider::Amp.record(
                     "1234",
                     los_pollos_amp().merge(json!({
                         "keywords": ["los", "los pollos", "los pollos ", "los pollos hermanos"],
                         "full_keywords": [("los pollos", 3), ("los pollos hermanos", 1)],
                     })),
-                )
-                .with_icon(los_pollos_icon()),
+                ))
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon())),
         );
         store.ingest(SuggestIngestionConstraints::amp_with_fts());
         assert_eq!(
@@ -1279,8 +1268,8 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record("data", "1234", los_pollos_amp())
-                .with_icon(los_pollos_icon()),
+                .with_record(SuggestionProvider::Amp.record("1234", los_pollos_amp()))
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon())),
         );
         store.ingest(SuggestIngestionConstraints::amp_with_fts());
         assert_eq!(
@@ -1313,8 +1302,8 @@ pub(crate) mod tests {
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
                 // This record contains just one JSON object, rather than an array of them
-                .with_record("data", "1234", los_pollos_amp())
-                .with_icon(los_pollos_icon()),
+                .with_record(SuggestionProvider::Amp.record("1234", los_pollos_amp()))
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
@@ -1330,29 +1319,31 @@ pub(crate) mod tests {
     fn reingest_amp_suggestions() -> anyhow::Result<()> {
         before_each();
 
-        let mut store = TestStore::new(MockRemoteSettingsClient::default().with_record(
-            "data",
-            "1234",
-            json!([los_pollos_amp(), good_place_eats_amp()]),
-        ));
+        let mut store = TestStore::new(
+            MockRemoteSettingsClient::default().with_record(
+                SuggestionProvider::Amp
+                    .record("1234", json!([los_pollos_amp(), good_place_eats_amp()])),
+            ),
+        );
         // Ingest once
         store.ingest(SuggestIngestionConstraints::all_providers());
         // Update the snapshot with new suggestions: Los pollos has a new name and Good place eats
         // is now serving Penne
-        store.client_mut().update_record(
-            "data",
-            "1234",
-            json!([
-                los_pollos_amp().merge(json!({
-                    "title": "Los Pollos Hermanos - Now Serving at 14 Locations!",
-                })),
-                good_place_eats_amp().merge(json!({
-                    "keywords": ["pe", "pen", "penne", "penne for your thoughts"],
-                    "title": "Penne for Your Thoughts",
-                    "url": "https://penne.biz",
-                }))
-            ]),
-        );
+        store
+            .client_mut()
+            .update_record(SuggestionProvider::Amp.record(
+                "1234",
+                json!([
+                    los_pollos_amp().merge(json!({
+                        "title": "Los Pollos Hermanos - Now Serving at 14 Locations!",
+                    })),
+                    good_place_eats_amp().merge(json!({
+                        "keywords": ["pe", "pen", "penne", "penne for your thoughts"],
+                        "title": "Penne for Your Thoughts",
+                        "url": "https://penne.biz",
+                    }))
+                ]),
+            ));
         store.ingest(SuggestIngestionConstraints::all_providers());
 
         assert!(matches!(
@@ -1376,15 +1367,14 @@ pub(crate) mod tests {
         // Ingest with FTS enabled, this will populate the FTS table
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(
-                    "data",
+                .with_record(SuggestionProvider::Amp.record(
                     "data-1",
                     json!([los_pollos_amp().merge(json!({
                         "keywords": ["los", "los pollos", "los pollos ", "los pollos hermanos"],
                         "full_keywords": [("los pollos", 3), ("los pollos hermanos", 1)],
                     }))]),
-                )
-                .with_icon(los_pollos_icon()),
+                ))
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon())),
         );
         // Ingest without FTS
         store.ingest(SuggestIngestionConstraints::amp_without_fts());
@@ -1420,12 +1410,11 @@ pub(crate) mod tests {
         let mut store = TestStore::new(
             MockRemoteSettingsClient::default()
                 .with_record(
-                    "data",
-                    "1234",
-                    json!([los_pollos_amp(), good_place_eats_amp()]),
+                    SuggestionProvider::Amp
+                        .record("1234", json!([los_pollos_amp(), good_place_eats_amp()])),
                 )
-                .with_icon(los_pollos_icon())
-                .with_icon(good_place_eats_icon()),
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon()))
+                .with_record(SuggestionProvider::Amp.icon(good_place_eats_icon())),
         );
         // This ingestion should run, since the DB is empty
         store.ingest(SuggestIngestionConstraints::all_providers());
@@ -1435,24 +1424,23 @@ pub(crate) mod tests {
         //  - Good place eats gets new data only
         store
             .client_mut()
-            .update_record(
-                "data",
+            .update_record(SuggestionProvider::Amp.record(
                 "1234",
                 json!([
                     los_pollos_amp().merge(json!({"icon": "1000"})),
                     good_place_eats_amp()
                 ]),
-            )
-            .delete_icon(los_pollos_icon())
-            .add_icon(MockIcon {
+            ))
+            .delete_record(SuggestionProvider::Amp.icon(los_pollos_icon()))
+            .add_record(SuggestionProvider::Amp.icon(MockIcon {
                 id: "1000",
                 data: "new-los-pollos-icon",
                 ..los_pollos_icon()
-            })
-            .update_icon(MockIcon {
+            }))
+            .update_record(SuggestionProvider::Amp.icon(MockIcon {
                 data: "new-good-place-eats-icon",
                 ..good_place_eats_icon()
-            });
+            }));
         store.ingest(SuggestIngestionConstraints::all_providers());
 
         assert!(matches!(
@@ -1475,11 +1463,10 @@ pub(crate) mod tests {
 
         let mut store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record("amo-suggestions", "data-1", json!([relay_amo()]))
+                .with_record(SuggestionProvider::Amo.record("data-1", json!([relay_amo()])))
                 .with_record(
-                    "amo-suggestions",
-                    "data-2",
-                    json!([dark_mode_amo(), foxy_guestures_amo()]),
+                    SuggestionProvider::Amo
+                        .record("data-2", json!([dark_mode_amo(), foxy_guestures_amo()])),
                 ),
         );
 
@@ -1502,15 +1489,14 @@ pub(crate) mod tests {
         // third, and add the fourth.
         store
             .client_mut()
-            .update_record("amo-suggestions", "data-1", json!([relay_amo()]))
-            .update_record(
-                "amo-suggestions",
+            .update_record(SuggestionProvider::Amo.record("data-1", json!([relay_amo()])))
+            .update_record(SuggestionProvider::Amo.record(
                 "data-2",
                 json!([
                     dark_mode_amo().merge(json!({"title": "Updated second suggestion"})),
                     new_tab_override_amo(),
                 ]),
-            );
+            ));
         store.ingest(SuggestIngestionConstraints::all_providers());
 
         assert_eq!(
@@ -1540,10 +1526,12 @@ pub(crate) mod tests {
 
         let mut store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record("data", "data-1", json!([los_pollos_amp()]))
-                .with_record("data", "data-2", json!([good_place_eats_amp()]))
-                .with_icon(los_pollos_icon())
-                .with_icon(good_place_eats_icon()),
+                .with_record(SuggestionProvider::Amp.record("data-1", json!([los_pollos_amp()])))
+                .with_record(
+                    SuggestionProvider::Amp.record("data-2", json!([good_place_eats_amp()])),
+                )
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon()))
+                .with_record(SuggestionProvider::Amp.icon(good_place_eats_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
@@ -1558,8 +1546,8 @@ pub(crate) mod tests {
         // recognize that they're missing and delete them.
         store
             .client_mut()
-            .delete_record("quicksuggest", "data-1")
-            .delete_icon(good_place_eats_icon());
+            .delete_record(SuggestionProvider::Amp.empty_record("data-1"))
+            .delete_record(SuggestionProvider::Amp.icon(good_place_eats_icon()));
         store.ingest(SuggestIngestionConstraints::all_providers());
 
         assert_eq!(store.fetch_suggestions(SuggestionQuery::amp("lo")), vec![]);
@@ -1579,10 +1567,12 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record("data", "data-1", json!([los_pollos_amp()]))
-                .with_record("data", "data-2", json!([good_place_eats_amp()]))
-                .with_icon(los_pollos_icon())
-                .with_icon(good_place_eats_icon()),
+                .with_record(SuggestionProvider::Amp.record("data-1", json!([los_pollos_amp()])))
+                .with_record(
+                    SuggestionProvider::Amp.record("data-2", json!([good_place_eats_amp()])),
+                )
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon()))
+                .with_record(SuggestionProvider::Amp.icon(good_place_eats_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert!(store.count_rows("suggestions") > 0);
@@ -1605,32 +1595,27 @@ pub(crate) mod tests {
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
                 .with_record(
-                    "data",
-                    "data-1",
-                    json!([
-                        good_place_eats_amp(),
-                        california_wiki(),
-                        caltech_wiki(),
-                        multimatch_wiki(),
-                    ]),
+                    SuggestionProvider::Amp.record("data-1", json!([good_place_eats_amp(),])),
+                )
+                .with_record(SuggestionProvider::Wikipedia.record(
+                    "wikipedia-1",
+                    json!([california_wiki(), caltech_wiki(), multimatch_wiki(),]),
+                ))
+                .with_record(
+                    SuggestionProvider::Amo
+                        .record("data-2", json!([relay_amo(), multimatch_amo(),])),
                 )
                 .with_record(
-                    "amo-suggestions",
-                    "data-2",
-                    json!([relay_amo(), multimatch_amo(),]),
+                    SuggestionProvider::Pocket
+                        .record("data-3", json!([burnout_pocket(), multimatch_pocket(),])),
                 )
-                .with_record(
-                    "pocket-suggestions",
-                    "data-3",
-                    json!([burnout_pocket(), multimatch_pocket(),]),
-                )
-                .with_record("yelp-suggestions", "data-4", json!([ramen_yelp(),]))
-                .with_record("mdn-suggestions", "data-5", json!([array_mdn(),]))
-                .with_icon(good_place_eats_icon())
-                .with_icon(california_icon())
-                .with_icon(caltech_icon())
-                .with_icon(yelp_favicon())
-                .with_icon(multimatch_wiki_icon()),
+                .with_record(SuggestionProvider::Yelp.record("data-4", json!([ramen_yelp(),])))
+                .with_record(SuggestionProvider::Mdn.record("data-5", json!([array_mdn(),])))
+                .with_record(SuggestionProvider::Amp.icon(good_place_eats_icon()))
+                .with_record(SuggestionProvider::Wikipedia.icon(california_icon()))
+                .with_record(SuggestionProvider::Wikipedia.icon(caltech_icon()))
+                .with_record(SuggestionProvider::Yelp.icon(yelp_favicon()))
+                .with_record(SuggestionProvider::Wikipedia.icon(multimatch_wiki_icon())),
         );
 
         store.ingest(SuggestIngestionConstraints::all_providers());
@@ -2021,8 +2006,7 @@ pub(crate) mod tests {
             // where the scores are manually set.  We will test that the fetched suggestions are in
             // the correct order.
             MockRemoteSettingsClient::default()
-                .with_record(
-                    "data",
+                .with_record(SuggestionProvider::Amp.record(
                     "data-1",
                     json!([
                         los_pollos_amp().merge(json!({
@@ -2033,13 +2017,15 @@ pub(crate) mod tests {
                             "keywords": ["amp wiki match"],
                             "score": 0.1,
                         })),
-                        california_wiki().merge(json!({
-                            "keywords": ["amp wiki match", "pocket wiki match"],
-                        })),
                     ]),
-                )
-                .with_record(
-                    "pocket-suggestions",
+                ))
+                .with_record(SuggestionProvider::Wikipedia.record(
+                    "wikipedia-1",
+                    json!([california_wiki().merge(json!({
+                        "keywords": ["amp wiki match", "pocket wiki match"],
+                    })),]),
+                ))
+                .with_record(SuggestionProvider::Pocket.record(
                     "data-3",
                     json!([
                         burnout_pocket().merge(json!({
@@ -2051,10 +2037,10 @@ pub(crate) mod tests {
                             "score": 0.88,
                         })),
                     ]),
-                )
-                .with_icon(los_pollos_icon())
-                .with_icon(good_place_eats_icon())
-                .with_icon(california_icon()),
+                ))
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon()))
+                .with_record(SuggestionProvider::Amp.icon(good_place_eats_icon()))
+                .with_record(SuggestionProvider::Wikipedia.icon(california_icon())),
         );
 
         store.ingest(SuggestIngestionConstraints::all_providers());
@@ -2098,37 +2084,6 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    // Tests querying multiple suggestions with multiple keywords with same prefix keyword
-    #[test]
-    fn query_with_amp_mobile_provider() -> anyhow::Result<()> {
-        before_each();
-
-        // Use the exact same data for both the Amp and AmpMobile record
-        let store = TestStore::new(
-            MockRemoteSettingsClient::default()
-                .with_record(
-                    "amp-mobile-suggestions",
-                    "amp-mobile-1",
-                    json!([good_place_eats_amp()]),
-                )
-                .with_record("data", "data-1", json!([good_place_eats_amp()]))
-                // This icon is shared by both records which is kind of weird and probably not how
-                // things would work in practice, but it's okay for the tests.
-                .with_icon(good_place_eats_icon()),
-        );
-        store.ingest(SuggestIngestionConstraints::all_providers());
-        // The query results should be exactly the same for both the Amp and AmpMobile data
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::amp_mobile("las")),
-            vec![good_place_eats_suggestion("lasagna", None)]
-        );
-        assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::amp("las")),
-            vec![good_place_eats_suggestion("lasagna", None)]
-        );
-        Ok(())
-    }
-
     /// Tests ingesting malformed Remote Settings records that we understand,
     /// but that are missing fields, or aren't in the format we expect.
     #[test]
@@ -2137,13 +2092,31 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                // Amp/Wikipedia record without an attachment.
-                .with_record_but_no_attachment("data", "data-1")
+                // Amp record without an attachment.
+                .with_record(SuggestionProvider::Amp.empty_record("data-1"))
+                // Wikipedia record without an attachment.
+                .with_record(SuggestionProvider::Wikipedia.empty_record("wikipedia-1"))
                 // Icon record without an attachment.
-                .with_record_but_no_attachment("icon", "icon-1")
+                .with_record(MockRecord {
+                    collection: Collection::Amp,
+                    record_type: SuggestRecordType::Icon,
+                    id: "icon-1".to_string(),
+                    inline_data: None,
+                    attachment: None,
+                })
                 // Icon record with an ID that's not `icon-{id}`, so suggestions in
                 // the data attachment won't be able to reference it.
-                .with_record("icon", "bad-icon-id", json!("i-am-an-icon")),
+                .with_record(MockRecord {
+                    collection: Collection::Amp,
+                    record_type: SuggestRecordType::Icon,
+                    id: "bad-icon-id".to_string(),
+                    inline_data: None,
+                    attachment: Some(MockAttachment::Icon(MockIcon {
+                        id: "bad-icon-id",
+                        data: "",
+                        mimetype: "image/png",
+                    })),
+                }),
         );
 
         store.ingest(SuggestIngestionConstraints::all_providers());
@@ -2169,9 +2142,9 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record("data", "data-1", json!([los_pollos_amp()]))
-                .with_record("yelp-suggestions", "yelp-1", json!([ramen_yelp()]))
-                .with_icon(los_pollos_icon()),
+                .with_record(SuggestionProvider::Amp.record("data-1", json!([los_pollos_amp()])))
+                .with_record(SuggestionProvider::Yelp.record("yelp-1", json!([ramen_yelp()])))
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon())),
         );
 
         let constraints = SuggestIngestionConstraints {
@@ -2202,10 +2175,11 @@ pub(crate) mod tests {
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
                 // valid record
-                .with_record("data", "data-1", json!([good_place_eats_amp()]))
-                // This attachment is missing the `title` field and is invalid
                 .with_record(
-                    "data",
+                    SuggestionProvider::Amp.record("data-1", json!([good_place_eats_amp()])),
+                )
+                // This attachment is missing the `title` field and is invalid
+                .with_record(SuggestionProvider::Amp.record(
                     "data-2",
                     json!([{
                             "id": 1,
@@ -2218,8 +2192,8 @@ pub(crate) mod tests {
                             "click_url": "https://example.com/click_url",
                             "score": 0.3
                     }]),
-                )
-                .with_icon(good_place_eats_icon()),
+                ))
+                .with_record(SuggestionProvider::Amp.icon(good_place_eats_icon())),
         );
 
         store.ingest(SuggestIngestionConstraints::all_providers());
@@ -2239,11 +2213,10 @@ pub(crate) mod tests {
     fn query_mdn() -> anyhow::Result<()> {
         before_each();
 
-        let store = TestStore::new(MockRemoteSettingsClient::default().with_record(
-            "mdn-suggestions",
-            "mdn-1",
-            json!([array_mdn()]),
-        ));
+        let store = TestStore::new(
+            MockRemoteSettingsClient::default()
+                .with_record(SuggestionProvider::Mdn.record("mdn-1", json!([array_mdn()]))),
+        );
         store.ingest(SuggestIngestionConstraints::all_providers());
         // prefix
         assert_eq!(
@@ -2277,13 +2250,9 @@ pub(crate) mod tests {
     fn query_no_yelp_icon_data() -> anyhow::Result<()> {
         before_each();
 
-        let store = TestStore::new(
-            MockRemoteSettingsClient::default().with_record(
-                "yelp-suggestions",
-                "yelp-1",
-                json!([ramen_yelp()]),
-            ), // Note: yelp_favicon() is missing
-        );
+        let store = TestStore::new(MockRemoteSettingsClient::default().with_record(
+            SuggestionProvider::Yelp.record("yelp-1", json!([ramen_yelp()])), // Note: yelp_favicon() is missing
+        ));
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert!(matches!(
             store.fetch_suggestions(SuggestionQuery::yelp("ramen")).as_slice(),
@@ -2297,15 +2266,18 @@ pub(crate) mod tests {
     fn fetch_global_config() -> anyhow::Result<()> {
         before_each();
 
-        let store = TestStore::new(MockRemoteSettingsClient::default().with_inline_record(
-            "configuration",
-            "configuration-1",
-            json!({
+        let store = TestStore::new(MockRemoteSettingsClient::default().with_record(MockRecord {
+            collection: Collection::Other,
+            record_type: SuggestRecordType::GlobalConfig,
+            id: "configuration-1".to_string(),
+            inline_data: Some(json!({
                 "configuration": {
                     "show_less_frequently_cap": 3,
                 },
-            }),
-        ));
+            })),
+            attachment: None,
+        }));
+
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
             store.fetch_global_config(),
@@ -2353,15 +2325,16 @@ pub(crate) mod tests {
         before_each();
 
         let store = TestStore::new(MockRemoteSettingsClient::default().with_record(
-            "weather",
-            "weather-1",
-            json!({
-                "min_keyword_length": 3,
-                "score": 0.24,
-                "max_keyword_length": 1,
-                "max_keyword_word_count": 1,
-                "keywords": []
-            }),
+            SuggestionProvider::Weather.record(
+                "weather-1",
+                json!({
+                    "min_keyword_length": 3,
+                    "score": 0.24,
+                    "max_keyword_length": 1,
+                    "max_keyword_word_count": 1,
+                    "keywords": []
+                }),
+            ),
         ));
         store.ingest(SuggestIngestionConstraints::all_providers());
 
@@ -2386,45 +2359,37 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(
-                    "data",
+                .with_record(SuggestionProvider::Amp.record(
                     "data-1",
-                    json!([
-                        good_place_eats_amp().merge(json!({"keywords": ["cats"]})),
-                        california_wiki().merge(json!({"keywords": ["cats"]})),
-                    ]),
-                )
-                .with_record(
-                    "amo-suggestions",
+                    json!([good_place_eats_amp().merge(json!({"keywords": ["cats"]})),]),
+                ))
+                .with_record(SuggestionProvider::Wikipedia.record(
+                    "wikipedia-1",
+                    json!([california_wiki().merge(json!({"keywords": ["cats"]})),]),
+                ))
+                .with_record(SuggestionProvider::Amo.record(
                     "amo-1",
                     json!([relay_amo().merge(json!({"keywords": ["cats"]})),]),
-                )
-                .with_record(
-                    "pocket-suggestions",
+                ))
+                .with_record(SuggestionProvider::Pocket.record(
                     "pocket-1",
                     json!([burnout_pocket().merge(json!({
                         "lowConfidenceKeywords": ["cats"],
                     }))]),
-                )
-                .with_record(
-                    "mdn-suggestions",
+                ))
+                .with_record(SuggestionProvider::Mdn.record(
                     "mdn-1",
                     json!([array_mdn().merge(json!({"keywords": ["cats"]})),]),
-                )
-                .with_record(
-                    "amp-mobile-suggestions",
-                    "amp-mobile-1",
-                    json!([a1a_amp_mobile().merge(json!({"keywords": ["cats"]})),]),
-                )
-                .with_icon(good_place_eats_icon())
-                .with_icon(caltech_icon()),
+                ))
+                .with_record(SuggestionProvider::Amp.icon(good_place_eats_icon()))
+                .with_record(SuggestionProvider::Wikipedia.icon(caltech_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
 
         // A query for cats should return all suggestions
         let query = SuggestionQuery::all_providers("cats");
         let results = store.fetch_suggestions(query.clone());
-        assert_eq!(results.len(), 6);
+        assert_eq!(results.len(), 5);
 
         for result in results {
             store
@@ -2437,7 +2402,7 @@ pub(crate) mod tests {
 
         // Clearing the dismissals should cause them to be returned again
         store.inner.clear_dismissed_suggestions()?;
-        assert_eq!(store.fetch_suggestions(query.clone()).len(), 6);
+        assert_eq!(store.fetch_suggestions(query.clone()).len(), 5);
 
         Ok(())
     }
@@ -2448,12 +2413,11 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(
-                    "fakespot-suggestions",
+                .with_record(SuggestionProvider::Fakespot.record(
                     "fakespot-1",
                     json!([snowglobe_fakespot(), simpsons_fakespot()]),
-                )
-                .with_icon(fakespot_amazon_icon()),
+                ))
+                .with_record(SuggestionProvider::Fakespot.icon(fakespot_amazon_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
@@ -2512,8 +2476,7 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(
-                    "fakespot-suggestions",
+                .with_record(SuggestionProvider::Fakespot.record(
                     "fakespot-1",
                     json!([
                         // Snow normally returns the snowglobe first.  Test using the keyword field
@@ -2521,8 +2484,8 @@ pub(crate) mod tests {
                         snowglobe_fakespot(),
                         simpsons_fakespot().merge(json!({"keywords": "snow"})),
                     ]),
-                )
-                .with_icon(fakespot_amazon_icon()),
+                ))
+                .with_record(SuggestionProvider::Fakespot.icon(fakespot_amazon_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
@@ -2545,12 +2508,11 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(
-                    "fakespot-suggestions",
+                .with_record(SuggestionProvider::Fakespot.record(
                     "fakespot-1",
                     json!([snowglobe_fakespot(), simpsons_fakespot()]),
-                )
-                .with_icon(fakespot_amazon_icon()),
+                ))
+                .with_record(SuggestionProvider::Fakespot.icon(fakespot_amazon_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
@@ -2584,25 +2546,25 @@ pub(crate) mod tests {
 
         let mut store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(
-                    "fakespot-suggestions",
+                .with_record(SuggestionProvider::Fakespot.record(
                     "fakespot-1",
                     json!([snowglobe_fakespot(), simpsons_fakespot()]),
-                )
-                .with_icon(fakespot_amazon_icon()),
+                ))
+                .with_record(SuggestionProvider::Fakespot.icon(fakespot_amazon_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
 
         // Update the snapshot so that:
         //   - The Simpsons entry is deleted
         //   - Snow globes now use sea glass instead of glitter
-        store.client_mut().update_record(
-            "fakespot-suggestions",
-            "fakespot-1",
-            json!([
+        store
+            .client_mut()
+            .update_record(SuggestionProvider::Fakespot.record(
+                "fakespot-1",
+                json!([
                 snowglobe_fakespot().merge(json!({"title": "Make Your Own Sea Glass Snow Globes"}))
             ]),
-        );
+            ));
         store.ingest(SuggestIngestionConstraints::all_providers());
 
         assert_eq!(
@@ -2635,15 +2597,14 @@ pub(crate) mod tests {
             MockRemoteSettingsClient::default()
                 // This record is in the fakespot-suggest-products collection
                 .with_record(
-                    "fakespot-suggestions",
-                    "fakespot-1",
-                    json!([snowglobe_fakespot()]),
+                    SuggestionProvider::Fakespot
+                        .record("fakespot-1", json!([snowglobe_fakespot()])),
                 )
-                // This record is in the quicksuggest collection, but it has a fakespot record ID
+                // This record is in the Amp collection, but it has a fakespot record ID
                 // for some reason.
-                .with_record("data", "fakespot-1", json![los_pollos_amp()])
-                .with_icon(los_pollos_icon())
-                .with_icon(fakespot_amazon_icon()),
+                .with_record(SuggestionProvider::Amp.record("fakespot-1", json![los_pollos_amp()]))
+                .with_record(SuggestionProvider::Amp.icon(los_pollos_icon()))
+                .with_record(SuggestionProvider::Fakespot.icon(fakespot_amazon_icon())),
         );
         store.ingest(SuggestIngestionConstraints::all_providers());
         assert_eq!(
@@ -2661,8 +2622,8 @@ pub(crate) mod tests {
         // Test deleting one of the records
         store
             .client_mut()
-            .delete_record("quicksuggest", "fakespot-1")
-            .delete_icon(los_pollos_icon());
+            .delete_record(SuggestionProvider::Amp.empty_record("fakespot-1"))
+            .delete_record(SuggestionProvider::Amp.icon(los_pollos_icon()));
         store.ingest(SuggestIngestionConstraints::all_providers());
         // FIXME(Bug 1912283): this setup currently deletes both suggestions, since
         // `drop_suggestions` only checks against record ID.
@@ -2690,8 +2651,8 @@ pub(crate) mod tests {
                 .map(String::as_str)
                 .collect::<HashSet<_>>(),
             HashSet::from([
-                "quicksuggest:icon-fakespot-amazon",
-                "fakespot-suggest-products:fakespot-1"
+                "fakespot-suggest-products:fakespot-1",
+                "fakespot-suggest-products:icon-fakespot-amazon",
             ]),
         );
         Ok(())
@@ -2703,13 +2664,12 @@ pub(crate) mod tests {
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_full_record(
-                    "exposure-suggestions",
+                .with_record(SuggestionProvider::Exposure.full_record(
                     "exposure-0",
                     Some(json!({
                         "suggestion_type": "aaa",
                     })),
-                    Some(json!({
+                    Some(MockAttachment::Json(json!({
                         "keywords": [
                             "aaa keyword",
                             "both keyword",
@@ -2717,22 +2677,21 @@ pub(crate) mod tests {
                             ["choco", ["bo", "late"]],
                             ["dup", ["licate 1", "licate 2"]],
                         ],
-                    })),
-                )
-                .with_full_record(
-                    "exposure-suggestions",
+                    }))),
+                ))
+                .with_record(SuggestionProvider::Exposure.full_record(
                     "exposure-1",
                     Some(json!({
                         "suggestion_type": "bbb",
                     })),
-                    Some(json!({
+                    Some(MockAttachment::Json(json!({
                         "keywords": [
                             "bbb keyword",
                             "both keyword",
                             ["common prefix", [" bbb"]],
                         ],
-                    })),
-                ),
+                    }))),
+                )),
         );
         store.ingest(SuggestIngestionConstraints {
             providers: Some(vec![SuggestionProvider::Exposure]),
@@ -2980,32 +2939,30 @@ pub(crate) mod tests {
 
         let mut store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_full_record(
-                    "exposure-suggestions",
+                .with_record(SuggestionProvider::Exposure.full_record(
                     "exposure-0",
                     Some(json!({
                         "suggestion_type": "aaa",
                     })),
-                    Some(json!({
+                    Some(MockAttachment::Json(json!({
                         "keywords": [
                             "record 0 keyword",
                             ["sug", ["gest"]],
                         ],
-                    })),
-                )
-                .with_full_record(
-                    "exposure-suggestions",
+                    }))),
+                ))
+                .with_record(SuggestionProvider::Exposure.full_record(
                     "exposure-1",
                     Some(json!({
                         "suggestion_type": "aaa",
                     })),
-                    Some(json!({
+                    Some(MockAttachment::Json(json!({
                         "keywords": [
                             "record 1 keyword",
                             ["sug", ["arplum"]],
                         ],
-                    })),
-                ),
+                    }))),
+                )),
         );
         store.ingest(SuggestIngestionConstraints {
             providers: Some(vec![SuggestionProvider::Exposure]),
@@ -3044,7 +3001,7 @@ pub(crate) mod tests {
         // Delete the first record.
         store
             .client_mut()
-            .delete_record(Collection::Quicksuggest.name(), "exposure-0");
+            .delete_record(SuggestionProvider::Exposure.empty_record("exposure-0"));
         store.ingest(SuggestIngestionConstraints {
             providers: Some(vec![SuggestionProvider::Exposure]),
             provider_constraints: Some(SuggestionProviderConstraints {
@@ -3094,26 +3051,24 @@ pub(crate) mod tests {
         // Create suggestions with types "aaa" and "bbb".
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_full_record(
-                    "exposure-suggestions",
+                .with_record(SuggestionProvider::Exposure.full_record(
                     "exposure-0",
                     Some(json!({
                         "suggestion_type": "aaa",
                     })),
-                    Some(json!({
+                    Some(MockAttachment::Json(json!({
                         "keywords": ["aaa keyword", "both keyword"],
-                    })),
-                )
-                .with_full_record(
-                    "exposure-suggestions",
+                    }))),
+                ))
+                .with_record(SuggestionProvider::Exposure.full_record(
                     "exposure-1",
                     Some(json!({
                         "suggestion_type": "bbb",
                     })),
-                    Some(json!({
+                    Some(MockAttachment::Json(json!({
                         "keywords": ["bbb keyword", "both keyword"],
-                    })),
-                ),
+                    }))),
+                )),
         );
 
         // Ingest but don't pass in any provider constraints. The records will
@@ -3220,15 +3175,16 @@ pub(crate) mod tests {
         before_each();
 
         // Create an exposure suggestion and ingest it.
-        let mut store = TestStore::new(MockRemoteSettingsClient::default().with_full_record(
-            "exposure-suggestions",
-            "exposure-0",
-            Some(json!({
-                "suggestion_type": "aaa",
-            })),
-            Some(json!({
-                "keywords": ["old keyword"],
-            })),
+        let mut store = TestStore::new(MockRemoteSettingsClient::default().with_record(
+            SuggestionProvider::Exposure.full_record(
+                "exposure-0",
+                Some(json!({
+                    "suggestion_type": "aaa",
+                })),
+                Some(MockAttachment::Json(json!({
+                    "keywords": ["old keyword"],
+                }))),
+            ),
         ));
         store.ingest(SuggestIngestionConstraints {
             providers: Some(vec![SuggestionProvider::Exposure]),
@@ -3240,16 +3196,17 @@ pub(crate) mod tests {
         });
 
         // Add a new record of the same exposure type.
-        store.client_mut().add_full_record(
-            "exposure-suggestions",
-            "exposure-1",
-            Some(json!({
-                "suggestion_type": "aaa",
-            })),
-            Some(json!({
-                "keywords": ["new keyword"],
-            })),
-        );
+        store
+            .client_mut()
+            .add_record(SuggestionProvider::Exposure.full_record(
+                "exposure-1",
+                Some(json!({
+                    "suggestion_type": "aaa",
+                })),
+                Some(MockAttachment::Json(json!({
+                    "keywords": ["new keyword"],
+                }))),
+            ));
 
         // Ingest, but don't ingest the exposure type. The store will download
         // the new record but shouldn't ingest its attachment.

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -16,11 +16,6 @@ const TIMESTAMP_TEMPLATE: &str = "%YYYYMMDDHH%";
 /// 2 bytes shorter than [`TIMESTAMP_TEMPLATE`].
 const TIMESTAMP_LENGTH: usize = 10;
 
-/// Suggestion Types for Amp
-pub(crate) enum AmpSuggestionType {
-    Mobile,
-    Desktop,
-}
 /// A suggestion from the database to show in the address bar.
 #[derive(Clone, Debug, PartialEq, uniffi::Enum)]
 pub enum Suggestion {

--- a/components/suggest/src/testing/client.rs
+++ b/components/suggest/src/testing/client.rs
@@ -35,148 +35,19 @@ impl Default for MockRemoteSettingsClient {
     }
 }
 
-fn record_type_for_str(record_type_str: &str) -> SuggestRecordType {
-    for record_type in SuggestRecordType::all() {
-        if record_type.as_str() == record_type_str {
-            return *record_type;
-        }
-    }
-    panic!("Invalid record type string: {record_type_str}");
-}
-
 impl MockRemoteSettingsClient {
     // Consuming Builder API, this is best for constructing the initial client
-    pub fn with_record(mut self, record_type: &str, record_id: &str, items: JsonValue) -> Self {
-        self.add_record(record_type, record_id, items);
-        self
-    }
-
-    pub fn with_icon(mut self, icon: MockIcon) -> Self {
-        self.add_icon(icon);
-        self
-    }
-
-    pub fn with_record_but_no_attachment(mut self, record_type: &str, record_id: &str) -> Self {
-        self.add_record_but_no_attachment(record_type, record_id);
-        self
-    }
-
-    pub fn with_inline_record(
-        mut self,
-        record_type: &str,
-        record_id: &str,
-        inline_data: JsonValue,
-    ) -> Self {
-        self.add_inline_record(record_type, record_id, inline_data);
-        self
-    }
-
-    pub fn with_full_record(
-        mut self,
-        record_type: &str,
-        record_id: &str,
-        inline_data: Option<JsonValue>,
-        items: Option<JsonValue>,
-    ) -> Self {
-        self.add_full_record(record_type, record_id, inline_data, items);
+    pub fn with_record(mut self, record: MockRecord) -> Self {
+        self.add_record(record);
         self
     }
 
     // Non-Consuming Builder API, this is best for updating an existing client
 
     /// Add a record to the mock data
-    ///
-    /// A single record typically contains multiple items in the attachment data.  Pass all of them
-    /// as the `items` param.
-    pub fn add_record(
-        &mut self,
-        record_type: &str,
-        record_id: &str,
-        items: JsonValue,
-    ) -> &mut Self {
-        self.add_full_record(record_type, record_id, None, Some(items))
-    }
-
-    /// Add a record for an icon to the mock data
-    pub fn add_icon(&mut self, icon: MockIcon) -> &mut Self {
-        let icon_id = icon.id;
-        let record_id = format!("icon-{icon_id}");
-        let location = format!("icon-{icon_id}.png");
-        self.records.push(Record {
-            id: SuggestRecordId::new(record_id.to_string()),
-            last_modified: self.last_modified_timestamp,
-            collection: Collection::Quicksuggest,
-            attachment: Some(Attachment {
-                filename: location.clone(),
-                mimetype: icon.mimetype.into(),
-                hash: "".into(),
-                size: 0,
-                location: location.clone(),
-            }),
-            payload: serde_json::from_value(json!({"type": "icon"})).unwrap(),
-        });
-        self.attachments
-            .insert(location, icon.data.as_bytes().to_vec());
-        self
-    }
-
-    /// Add a record without attachment data
-    pub fn add_record_but_no_attachment(
-        &mut self,
-        record_type: &str,
-        record_id: &str,
-    ) -> &mut Self {
-        self.add_full_record(record_type, record_id, None, None)
-    }
-
-    /// Add a record to the mock data, with data stored inline rather than in an attachment
-    ///
-    /// Use this for record types like weather where the data it stored in the record itself rather
-    /// than in an attachment.
-    pub fn add_inline_record(
-        &mut self,
-        record_type: &str,
-        record_id: &str,
-        inline_data: JsonValue,
-    ) -> &mut Self {
-        self.add_full_record(record_type, record_id, Some(inline_data), None)
-    }
-
-    /// Add a record with optional extra fields stored inline and attachment
-    /// items
-    pub fn add_full_record(
-        &mut self,
-        record_type: &str,
-        record_id: &str,
-        inline_data: Option<JsonValue>,
-        items: Option<JsonValue>,
-    ) -> &mut Self {
-        let location = format!("{record_type}-{record_id}.json");
-        self.records.push(Record {
-            id: SuggestRecordId::new(record_id.to_string()),
-            collection: record_type_for_str(record_type).collection(),
-            last_modified: self.last_modified_timestamp,
-            payload: serde_json::from_value(
-                json!({
-                    "type": record_type,
-                })
-                .merge(inline_data.unwrap_or(json!({}))),
-            )
-            .unwrap(),
-            attachment: items.as_ref().map(|_| Attachment {
-                filename: location.clone(),
-                mimetype: "application/json".into(),
-                hash: "".into(),
-                size: 0,
-                location: location.clone(),
-            }),
-        });
-        if let Some(i) = items {
-            self.attachments.insert(
-                location,
-                serde_json::to_vec(&i).expect("error serializing attachment data"),
-            );
-        }
+    pub fn add_record(&mut self, mock_record: MockRecord) -> &mut Self {
+        self.insert_attachment(&mock_record);
+        self.records.push(self.record_from_mock(mock_record));
         self
     }
 
@@ -184,82 +55,53 @@ impl MockRemoteSettingsClient {
     // clients
 
     /// Update a record, storing a new payload and bumping the modified time
-    pub fn update_record(
-        &mut self,
-        record_type: &str,
-        record_id: &str,
-        items: JsonValue,
-    ) -> &mut Self {
-        let record = self
-            .records
-            .iter_mut()
-            .find(|r| r.id.as_str() == record_id)
-            .unwrap_or_else(|| panic!("update_record: {record_id} not found"));
-        let attachment_data = self
-            .attachments
-            .get_mut(
-                &record
-                    .attachment
-                    .as_ref()
-                    .expect("update_record: no attachment")
-                    .location,
-            )
-            .unwrap_or_else(|| panic!("update_record: attachment not found for {record_id}"));
-
-        record.last_modified += 1;
-        record.payload = serde_json::from_value(json!({"type": record_type})).unwrap();
-        *attachment_data = serde_json::to_vec(&items).expect("error serializing attachment data");
-        self
-    }
-
-    /// Update an icon record, storing a new payload and bumping the modified time
-    pub fn update_icon(&mut self, icon: MockIcon) -> &mut Self {
-        let icon_id = &icon.id;
-        let record_id = format!("icon-{icon_id}");
-        let record = self
-            .records
-            .iter_mut()
-            .find(|r| r.id.as_str() == record_id)
-            .unwrap_or_else(|| panic!("update_icon: {record_id} not found"));
-        let attachment_data = self
-            .attachments
-            .get_mut(
-                &record
-                    .attachment
-                    .as_ref()
-                    .expect("update_icon: no attachment")
-                    .location,
-            )
-            .unwrap_or_else(|| panic!("update_icon: attachment not found for {icon_id}"));
-
-        record.last_modified += 1;
-        *attachment_data = icon.data.as_bytes().to_vec();
-        self
-    }
-
-    /// Delete a record and it's attachment
-    pub fn delete_record(&mut self, collection: &str, record_id: &str) -> &mut Self {
-        let idx = self
+    pub fn update_record(&mut self, mock_record: MockRecord) -> &mut Self {
+        let index = self
             .records
             .iter()
-            .position(|r| r.id.as_str() == record_id && r.collection.name() == collection)
-            .unwrap_or_else(|| panic!("delete_record: {collection}:{record_id} not found"));
-        let deleted = self.records.remove(idx);
-        if let Some(a) = deleted.attachment {
-            self.attachments.remove(&a.location);
-        }
+            .position(|r| mock_record.matches_record(r))
+            .unwrap_or_else(|| panic!("update_record: {} not found", mock_record.qualified_id()));
+
+        self.insert_attachment(&mock_record);
+
+        let mut record = self.record_from_mock(mock_record);
+        record.last_modified += 1;
+        self.records.splice(index..=index, std::iter::once(record));
+
         self
     }
 
-    pub fn delete_icon(&mut self, icon: MockIcon) -> &mut Self {
-        self.delete_record("quicksuggest", &format!("icon-{}", icon.id))
+    /// Delete a record and its attachment
+    pub fn delete_record(&mut self, mock_record: MockRecord) -> &mut Self {
+        let index = self
+            .records
+            .iter()
+            .position(|r| mock_record.matches_record(r))
+            .unwrap_or_else(|| panic!("delete_record: {} not found", mock_record.qualified_id()));
+        self.records.remove(index);
+        self.attachments.remove(&mock_record.qualified_id());
+        self
     }
-}
 
-pub struct MockIcon {
-    pub id: &'static str,
-    pub data: &'static str,
-    pub mimetype: &'static str,
+    pub fn insert_attachment(&mut self, mock_record: &MockRecord) {
+        if let Some(bytes) = mock_record.attachment.as_ref().map(|a| match a {
+            MockAttachment::Json(items) => serde_json::to_vec(&items).unwrap_or_else(|_| {
+                panic!(
+                    "error serializing attachment data: {}",
+                    mock_record.qualified_id()
+                )
+            }),
+            MockAttachment::Icon(icon) => icon.data.as_bytes().to_vec(),
+        }) {
+            self.attachments.insert(mock_record.qualified_id(), bytes);
+        }
+    }
+
+    fn record_from_mock(&self, mock_record: MockRecord) -> Record {
+        let mut record: Record = mock_record.into();
+        record.last_modified = self.last_modified_timestamp;
+        record
+    }
 }
 
 impl Client for MockRemoteSettingsClient {
@@ -267,7 +109,7 @@ impl Client for MockRemoteSettingsClient {
         Ok(self
             .records
             .iter()
-            .filter(|r| collection == r.record_type().collection())
+            .filter(|r| collection == r.collection)
             .cloned()
             .collect())
     }
@@ -282,4 +124,68 @@ impl Client for MockRemoteSettingsClient {
                 .clone()),
         }
     }
+}
+
+pub struct MockRecord {
+    pub collection: Collection,
+    pub record_type: SuggestRecordType,
+    pub id: String,
+    pub inline_data: Option<JsonValue>,
+    pub attachment: Option<MockAttachment>,
+}
+
+impl MockRecord {
+    pub fn qualified_id(&self) -> String {
+        format!("{}:{}", self.collection.name(), self.id)
+    }
+
+    fn matches_record(&self, record: &Record) -> bool {
+        self.collection == record.collection && self.id.as_str() == record.id.as_str()
+    }
+}
+
+impl From<MockRecord> for Record {
+    fn from(mock_record: MockRecord) -> Self {
+        let attachment = mock_record.attachment.as_ref().map(|a| match a {
+            MockAttachment::Json(_) => Attachment {
+                filename: mock_record.id.to_string(),
+                location: mock_record.qualified_id(),
+                mimetype: "application/json".into(),
+                hash: "".into(),
+                size: 0,
+            },
+            MockAttachment::Icon(icon) => Attachment {
+                filename: mock_record.id.to_string(),
+                location: mock_record.qualified_id(),
+                mimetype: icon.mimetype.to_string(),
+                hash: "".into(),
+                size: 0,
+            },
+        });
+
+        Self {
+            id: SuggestRecordId::new(mock_record.id),
+            collection: mock_record.collection,
+            last_modified: 0,
+            payload: serde_json::from_value(
+                json!({
+                    "type": mock_record.record_type.as_str(),
+                })
+                .merge(mock_record.inline_data.unwrap_or(json!({}))),
+            )
+            .unwrap(),
+            attachment,
+        }
+    }
+}
+
+pub enum MockAttachment {
+    Json(JsonValue),
+    Icon(MockIcon),
+}
+
+pub struct MockIcon {
+    pub id: &'static str,
+    pub data: &'static str,
+    pub mimetype: &'static str,
 }

--- a/components/suggest/src/testing/data.rs
+++ b/components/suggest/src/testing/data.rs
@@ -157,40 +157,6 @@ pub fn caltech_suggestion(full_keyword: &str) -> Suggestion {
     }
 }
 
-pub fn a1a_amp_mobile() -> JsonValue {
-    json!({
-        "id": 300,
-        "advertiser": "A1A Car Wash",
-        "iab_category": "2 - Auto",
-        "keywords": ["a1a", "ca", "car", "car wash"],
-        "title": "A1A Car Wash",
-        "url": "https://www.a1a-wash.biz",
-        "icon": "200",
-        "impression_url": "https://example.com/impression_url",
-        "click_url": "https://example.com/click_url",
-        "score": 0.3
-    })
-}
-
-pub fn a1a_suggestion(full_keyword: &str, fts_match_info: Option<FtsMatchInfo>) -> Suggestion {
-    Suggestion::Amp {
-        title: "A1A Car Wash".into(),
-        url: "https://www.a1a-wash.biz".into(),
-        raw_url: "https://www.a1a-wash.biz".into(),
-        icon: None,
-        icon_mimetype: None,
-        block_id: 300,
-        advertiser: "A1A Car Wash".into(),
-        iab_category: "2 - Auto".into(),
-        impression_url: "https://example.com/impression_url".into(),
-        click_url: "https://example.com/click_url".into(),
-        raw_click_url: "https://example.com/click_url".into(),
-        score: 0.3,
-        full_keyword: full_keyword.to_string(),
-        fts_match_info,
-    }
-}
-
 pub fn relay_amo() -> JsonValue {
     json!({
         "title": "Firefox Relay",

--- a/components/suggest/src/testing/mod.rs
+++ b/components/suggest/src/testing/mod.rs
@@ -5,7 +5,7 @@
 mod client;
 mod data;
 
-pub use client::{MockIcon, MockRemoteSettingsClient};
+pub use client::{MockAttachment, MockIcon, MockRecord, MockRemoteSettingsClient};
 pub use data::*;
 
 use crate::Suggestion;

--- a/examples/suggest-cli/src/main.rs
+++ b/examples/suggest-cli/src/main.rs
@@ -90,7 +90,6 @@ enum SuggestionProviderArg {
     Yelp,
     Mdn,
     Weather,
-    AmpMobile,
     Fakespot,
 }
 
@@ -104,7 +103,6 @@ impl From<SuggestionProviderArg> for SuggestionProvider {
             SuggestionProviderArg::Yelp => Self::Yelp,
             SuggestionProviderArg::Mdn => Self::Mdn,
             SuggestionProviderArg::Weather => Self::Weather,
-            SuggestionProviderArg::AmpMobile => Self::AmpMobile,
             SuggestionProviderArg::Fakespot => Self::Fakespot,
         }
     }


### PR DESCRIPTION
This is based on https://github.com/mozilla/application-services/pull/6598

It uses the new remote settings collections and makes some other related changes. Sorry for how big this is but I think it makes sense to make these changes together. Details below.

## New RS collections

We're setting up two new RS collections for geo expansion: `quicksuggest-amp` and `quicksuggest-other`. The AMP collection will contain AMP suggestions and icons for all user segments. The other collection will contain everything else currently in the `quicksuggest` collection for all user segments. For both collections, the client will use RS filter expressions to download the right attachments for its user segment.

In the AMP collection, the record type will be `amp`, not `data` as it currently is. The AMP collection will be updated often compared to the other one.

After discussion with Nan and Ben, we think it makes sense to move the client over to the new collections. That's simpler than the alternative of hardcoding branching collection logic or adding a way for consumers to pass in collection overrides or something like that. We think it's unlikely we won't go forward with geo expansion in some capacity, and even if we don't, the new collections still have some benefits over the current single collection.

## The right collection depends on the provider

With the new collections, a record's collection isn't a function of its type anymore. AMP icons will be in the AMP collection, but other icons will be in the other collection. Currently Fakespot icons are in `quicksuggest` but this change would let us move them to the Fakespot collection if we wanted.

I replaced `SuggestRecordType::collection` with some methods on `SuggestionProvider`. There's a provider's primary collection and record type and then some possible secondary collections/types, like icons and geonames.

I added some test helpers to create mock records given a provider so that tests don't need to make assumptions about collections and record types. Most of the test changes in `store.rs` are due to that.

## `MockRemoteSettingsClient` simplifications

Related to the previous point, I simplified `MockRemoteSettingsClient` and introduced `MockRecord` and `MockAttachment` similar to the existing `MockIcon`. The test helpers I mentioned in the previous point create mock records, and the mock client interface is based on those.

## AMP and Wikipedia suggestions will live in different collections

I went ahead and replaced the `AmpWikipedia` record and type with separate `Amp` and `Wikipedia` values. This is a good opportunity to do that, and it simplifies `rs.rs`.

## AMP mobile suggestions don't need their own type anymore

Mobile and tablet suggestions are just AMP suggestions that will live in `quicksuggest-amp`, and consumers can ingest them by passing in an appropriate RS context/filter, so I removed the AMP mobile provider and record type.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
