### PR TITLE
Update Kotlin to version 2.1.20 [ci full]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 🦊 What's Changed 🦊
 
 ### Android
-- Upgraded Kotlin compiler from 1.9.24 to 2.1.10 ([#6640](https://github.com/mozilla/application-services/pull/6640))
+- Upgraded Kotlin compiler from 1.9.24 to 2.1.20 ([#6640](https://github.com/mozilla/application-services/pull/6640))/([#6654](https://github.com/mozilla/application-services/pull/6654))
 
 ### `nss`
 - Initialize nss explicitly ([#6596](https://github.com/mozilla/application-services/pull/6596))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ android-plugin = "8.8.2"
 protobuf = "4.29.0"
 
 # Kotlin
-kotlin-compiler = "2.1.10"
+kotlin-compiler = "2.1.20"
 kotlinx-coroutines = "1.10.1"
 
 # Mozilla


### PR DESCRIPTION
Release notes: https://github.com/JetBrains/kotlin/releases/tag/v2.1.20