### PR TITLE
Bug 1955892 - Allow suggestions to be dismissed by dismissal/block keys and not only URLs

### DIFF
--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -367,6 +367,8 @@ pub(crate) struct DownloadedAmpSuggestion {
     pub impression_url: String,
     #[serde(rename = "icon")]
     pub icon_id: String,
+    /// The first key is the primary dismissal key.
+    pub dismissal_keys: Option<Vec<String>>,
 }
 
 /// A Wikipedia suggestion to ingest from a Wikipedia attachment.
@@ -380,6 +382,8 @@ pub(crate) struct DownloadedWikipediaSuggestion {
     pub full_keywords: Vec<(String, usize)>,
     #[serde(rename = "icon")]
     pub icon_id: String,
+    /// The first key is the primary dismissal key.
+    pub dismissal_keys: Option<Vec<String>>,
 }
 
 /// Iterate over all AMP/Wikipedia-style keywords.

--- a/components/suggest/src/testing/client.rs
+++ b/components/suggest/src/testing/client.rs
@@ -46,6 +46,7 @@ impl MockRemoteSettingsClient {
 
     /// Add a record to the mock data
     pub fn add_record(&mut self, mock_record: MockRecord) -> &mut Self {
+        self.last_modified_timestamp += 1;
         self.insert_attachment(&mock_record);
         self.records.push(self.record_from_mock(mock_record));
         self
@@ -61,13 +62,12 @@ impl MockRemoteSettingsClient {
             .iter()
             .position(|r| mock_record.matches_record(r))
             .unwrap_or_else(|| panic!("update_record: {} not found", mock_record.qualified_id()));
-
+        self.last_modified_timestamp += 1;
         self.insert_attachment(&mock_record);
-
-        let mut record = self.record_from_mock(mock_record);
-        record.last_modified += 1;
-        self.records.splice(index..=index, std::iter::once(record));
-
+        self.records.splice(
+            index..=index,
+            std::iter::once(self.record_from_mock(mock_record)),
+        );
         self
     }
 
@@ -78,6 +78,7 @@ impl MockRemoteSettingsClient {
             .iter()
             .position(|r| mock_record.matches_record(r))
             .unwrap_or_else(|| panic!("delete_record: {} not found", mock_record.qualified_id()));
+        self.last_modified_timestamp += 1;
         self.records.remove(index);
         self.attachments.remove(&mock_record.qualified_id());
         self

--- a/components/suggest/src/testing/data.rs
+++ b/components/suggest/src/testing/data.rs
@@ -8,6 +8,87 @@ use crate::{suggestion::FtsMatchInfo, testing::MockIcon, Suggestion};
 use serde_json::json;
 use serde_json::Value as JsonValue;
 
+pub fn amp_json(keywords: &[&str]) -> JsonValue {
+    let kws_str = keywords.join(",");
+    json!({
+        "id": 0,
+        "advertiser": "AMP Advertiser",
+        "iab_category": "5 - Shopping",
+        "keywords": keywords,
+        "title": format!("AMP suggestion - {}", kws_str),
+        "url": format!("https://example.com/amp/{}", kws_str),
+        "icon": "",
+        "impression_url": format!("https://example.com/amp/impression/{}", kws_str),
+        "click_url": format!("https://example.com/amp/click/{}", kws_str),
+        "full_keywords": [["amp full keyword", 1]],
+        "score": 0.3
+    })
+}
+
+pub fn amp_suggestion(keywords: &[&str]) -> Suggestion {
+    amp_suggestion_full(None, keywords)
+}
+
+pub fn amp_suggestion_with_dismissal_key(dismissal_key: &str, keywords: &[&str]) -> Suggestion {
+    amp_suggestion_full(Some(dismissal_key.to_string()), keywords)
+}
+
+pub fn amp_suggestion_full(dismissal_key: Option<String>, keywords: &[&str]) -> Suggestion {
+    let kws_str = keywords.join(",");
+    Suggestion::Amp {
+        title: format!("AMP suggestion - {}", kws_str),
+        url: format!("https://example.com/amp/{}", kws_str),
+        raw_url: format!("https://example.com/amp/{}", kws_str),
+        icon: None,
+        icon_mimetype: None,
+        block_id: 0,
+        advertiser: "AMP Advertiser".into(),
+        iab_category: "5 - Shopping".into(),
+        impression_url: format!("https://example.com/amp/impression/{}", kws_str),
+        click_url: format!("https://example.com/amp/click/{}", kws_str),
+        raw_click_url: format!("https://example.com/amp/click/{}", kws_str),
+        score: 0.3,
+        full_keyword: "amp full keyword".into(),
+        fts_match_info: None,
+        dismissal_key,
+    }
+}
+
+pub fn wikipedia_json(keywords: &[&str]) -> JsonValue {
+    let kws_str = keywords.join(",");
+    json!({
+        "keywords": keywords,
+        "title": format!("Wikipedia suggestion - {}", kws_str),
+        "url": format!("https://example.com/wikipedia/{}", kws_str),
+        "full_keywords": [],
+        "icon": "",
+        "score": 0.3
+    })
+}
+
+pub fn wikipedia_suggestion(keywords: &[&str]) -> Suggestion {
+    wikipedia_suggestion_full(None, keywords)
+}
+
+pub fn wikipedia_suggestion_with_dismissal_key(
+    dismissal_key: &str,
+    keywords: &[&str],
+) -> Suggestion {
+    wikipedia_suggestion_full(Some(dismissal_key.to_string()), keywords)
+}
+
+pub fn wikipedia_suggestion_full(dismissal_key: Option<String>, keywords: &[&str]) -> Suggestion {
+    let kws_str = keywords.join(",");
+    Suggestion::Wikipedia {
+        title: format!("Wikipedia suggestion - {}", kws_str),
+        url: format!("https://example.com/wikipedia/{}", kws_str),
+        icon: None,
+        icon_mimetype: None,
+        full_keyword: keywords[0].into(),
+        dismissal_key,
+    }
+}
+
 pub fn los_pollos_amp() -> JsonValue {
     json!({
         "id": 100,
@@ -50,6 +131,7 @@ pub fn los_pollos_suggestion(
         score: 0.3,
         full_keyword: full_keyword.to_string(),
         fts_match_info,
+        dismissal_key: None,
     }
 }
 
@@ -94,6 +176,7 @@ pub fn good_place_eats_suggestion(
         raw_click_url: "https://example.com/click_url".into(),
         score: 0.2,
         fts_match_info,
+        dismissal_key: None,
     }
 }
 
@@ -124,6 +207,7 @@ pub fn california_suggestion(full_keyword: &str) -> Suggestion {
         icon: Some("california-icon-data".as_bytes().to_vec()),
         icon_mimetype: Some("image/png".into()),
         full_keyword: full_keyword.into(),
+        dismissal_key: None,
     }
 }
 
@@ -154,6 +238,7 @@ pub fn caltech_suggestion(full_keyword: &str) -> Suggestion {
         icon: Some("caltech-icon-data".as_bytes().to_vec()),
         icon_mimetype: Some("image/png".into()),
         full_keyword: full_keyword.into(),
+        dismissal_key: None,
     }
 }
 
@@ -422,6 +507,7 @@ pub fn multimatch_wiki_suggestion() -> Suggestion {
         icon: Some("multimatch-wiki-icon-data".as_bytes().to_vec()),
         icon_mimetype: Some("image/png".into()),
         full_keyword: "multimatch".into(),
+        dismissal_key: None,
     }
 }
 

--- a/components/suggest/src/weather.rs
+++ b/components/suggest/src/weather.rs
@@ -337,6 +337,7 @@ impl SuggestDao<'_> {
                 "",
                 "",
                 attach.score.unwrap_or(DEFAULT_SUGGESTION_SCORE),
+                None,
                 SuggestionProvider::Weather,
             )?;
             for (i, keyword) in attach.keywords.iter().enumerate() {


### PR DESCRIPTION
This replaces dismissal-by-URL with dismissal-by-arbitrary-key.

AMP and Wikipedia suggestions can include a `dismissal_keys` array in their RS data. The first item in the array is the "primary" dismissal key, meaning the key that we store in the DB when the suggestion is dismissed. The remaining items in the array, if any, are "secondary" dismissal keys, the idea being that if we need to change a suggestion's dismissal key, we can include the old key(s) as secondary keys, and if the client dismissed the suggestion using an old key, it will know it should continue to hide it.

If a suggestion doesn't have any `dismissal_keys`, then dismissal falls back to its raw URL, so the dismissal key ends up being the raw URL like before.

Dismissed suggestions are now stored per provider and dismissal key. That way we don't need to worry about name clashes for keys in different providers. Due to that, I added a new `SuggestStore::dismiss()` method that takes a `Suggestion` instead of simply a URL/dismissal key.

The SQL for the schema migration is more complex than I would like due to recreating the `suggestions` table because of the new `dismissal_key` column. I tried adding the column by altering the table instead, but that causes `assert_schema_matches_new_database()` to fail for a really dumb reason: There's extra whitespace in the table's new SQL schema vs. the SQL that's hardcoded in the `SQL` const. Apparently Sqlite appends the new column like this when altering a table:

```
existing_col_foo TEXT , new_col_bar TEXT);
```

Whereas our `SQL` ends up being this (after converting line feeds to spaces and collapsing whitespace):

```
existing_col_foo TEXT, new_col_bar TEXT );
```

It's possible to tweak the `SQL` const so it ends up matching, but it's ugly and brittle, so I think that's worse. Ideally there would be a Sqlite function that normalizes SQL strings, and then `assert_schema_matches_new_database()` would compare normalized strings. There is [a normalization function](https://www.sqlite.org/c3ref/expanded_sql.html) but it takes a prepared statement and not just a string, which makes it impractical to use here (I tried). And I don't want to go down the path of modifying the `sql-support` crate so it tries to solve this by removing whitespace or things like that.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
