### PR TITLE
Add function to locally remove corrupted logins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ logins.jwk
 *.db-wal
 *~
 .vscode/
+credentials.json
 
 # Android stuff.
 *.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ text, the list view has been slimmed down and a detail view has been added.
 ### Android
 - Upgraded Kotlin compiler from 1.9.24 to 2.1.20 ([#6640](https://github.com/mozilla/application-services/pull/6640))/([#6654](https://github.com/mozilla/application-services/pull/6654))
 
-
 ## ⚠️ Breaking Changes ⚠️
 
 ### `nss`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ And it has been polished up a bit: passwords are no longer displayed in plain
 text, the list view has been slimmed down and a detail view has been added.
 ([#6685](https://github.com/mozilla/application-services/pull/6685c))
 
+- Added a function to locally remove corrupted logins. ([#6667](https://github.com/mozilla/application-services/pull/6667))
+
 ### Android
 - Upgraded the JNA dependency version to 5.17.0. ([#6649](https://github.com/mozilla/application-services/pull/6649))
 
@@ -40,8 +42,6 @@ text, the list view has been slimmed down and a detail view has been added.
 
 ### Android
 - Upgraded Kotlin compiler from 1.9.24 to 2.1.20 ([#6640](https://github.com/mozilla/application-services/pull/6640))/([#6654](https://github.com/mozilla/application-services/pull/6654))
-
-## ⚠️ Breaking Changes ⚠️
 
 ### `nss`
 - Initialize nss explicitly ([#6596](https://github.com/mozilla/application-services/pull/6596))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Updated to v64.0.0 ([#6649](https://github.com/mozilla/application-services/pull/6649))
 
 ### Logins
-New `NSSKeyManager`, which provides an NSS-backed key manager implementation.
+- New `NSSKeyManager`, which provides an NSS-backed key manager implementation.
 Given a `PrimaryPasswordAuthenticator` implementation, the NSS keystore is used
 to store and retrieve the login encryption key. These features are only
 available when the Logins component is compiled with the `keydb` feature.
@@ -41,6 +41,8 @@ text, the list view has been slimmed down and a detail view has been added.
 ### Android
 - Upgraded Kotlin compiler from 1.9.24 to 2.1.20 ([#6640](https://github.com/mozilla/application-services/pull/6640))/([#6654](https://github.com/mozilla/application-services/pull/6654))
 
+
+## ⚠️ Breaking Changes ⚠️
 
 ### `nss`
 - Initialize nss explicitly ([#6596](https://github.com/mozilla/application-services/pull/6596))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3542,9 +3542,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if 1.0.0",
@@ -3583,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -347,17 +341,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.5.3",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -638,7 +632,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1719,7 +1713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1987,14 +1981,14 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.26.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -3071,15 +3065,6 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
@@ -3508,9 +3493,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -4507,9 +4492,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.21"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -6278,7 +6263,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6298,17 +6283,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -6325,9 +6311,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6349,9 +6335,9 @@ checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6373,9 +6359,15 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6397,9 +6389,9 @@ checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6421,9 +6413,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6439,9 +6431,9 @@ checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6463,9 +6455,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5075,6 +5075,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync-test"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "autofill",
+ "base64 0.21.2",
+ "cli-support",
+ "env_logger",
+ "fxa-client",
+ "interrupt-support",
+ "lazy_static",
+ "log",
+ "logins",
+ "nss",
+ "rand",
+ "restmail-client",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "structopt",
+ "sync-guid",
+ "sync15",
+ "sync_manager",
+ "tabs",
+ "url",
+ "viaduct",
+ "viaduct-reqwest",
+]
+
+[[package]]
 name = "sync15"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ members = [
 
     "examples/*/",
     "testing/separated/*/",
+    "testing/sync-test",
     "components/support/firefox-versioning",
 ]
 

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -645,7 +645,10 @@ impl LoginDb {
         Ok(exists)
     }
 
-    pub fn verify_logins(&self, encdec: &dyn EncryptorDecryptor) -> Result<bool> {
+    pub fn delete_undecryptable_records_for_remote_replacement(
+        &self,
+        encdec: &dyn EncryptorDecryptor,
+    ) -> Result<()> {
         // Retrieve a list of guids for logins that cannot be decrypted
         let corrupted_logins = self
             .get_all()?
@@ -657,9 +660,7 @@ impl LoginDb {
             .map(|login| login.guid_str())
             .collect::<Vec<_>>();
 
-        Ok(self
-            .delete_local_records_for_remote_replacement(ids)
-            .is_ok())
+        self.delete_local_records_for_remote_replacement(ids)
     }
 
     pub fn delete_local_records_for_remote_replacement(&self, ids: Vec<&str>) -> Result<()> {

--- a/components/logins/src/db.rs
+++ b/components/logins/src/db.rs
@@ -645,7 +645,7 @@ impl LoginDb {
         Ok(exists)
     }
 
-    pub fn delete_local(&self, id: &str) -> Result<bool> {
+    pub fn delete_local_for_remote_replacement(&self, id: &str) -> Result<bool> {
         let tx = self.unchecked_transaction_imm()?;
         let exists = self.exists(id)?;
 
@@ -1240,8 +1240,7 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_local() {
-        ensure_initialized();
+    fn test_delete_local_for_remote_replacement() {
         let db = LoginDb::open_in_memory().unwrap();
         let login = db
             .add(
@@ -1256,7 +1255,9 @@ mod tests {
             )
             .unwrap();
 
-        assert!(db.delete_local(login.guid_str()).unwrap());
+        assert!(db
+            .delete_local_for_remote_replacement(login.guid_str())
+            .unwrap());
 
         let local_guids = get_local_guids(&db);
         assert_eq!(local_guids.len(), 0);

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -19,10 +19,23 @@ mod util;
 use crate::encryption::{
     EncryptorDecryptor, KeyManager, ManagedEncryptorDecryptor, StaticKeyManager,
 };
+use sync15::ServerTimestamp;
 uniffi::include_scaffolding!("logins");
 
 #[cfg(feature = "keydb")]
 pub use crate::encryption::{NSSKeyManager, PrimaryPasswordAuthenticator};
+// for the UDL
+impl UniffiCustomTypeConverter for ServerTimestamp {
+    type Builtin = i64;
+
+    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+        Ok(Self(val as i64))
+    }
+
+    fn from_custom(obj: Self) -> Self::Builtin {
+        obj.as_millis()
+    }
+}
 
 pub use crate::db::LoginDb;
 use crate::encryption::{check_canary, create_canary, create_key};

--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -19,23 +19,10 @@ mod util;
 use crate::encryption::{
     EncryptorDecryptor, KeyManager, ManagedEncryptorDecryptor, StaticKeyManager,
 };
-use sync15::ServerTimestamp;
 uniffi::include_scaffolding!("logins");
 
 #[cfg(feature = "keydb")]
 pub use crate::encryption::{NSSKeyManager, PrimaryPasswordAuthenticator};
-// for the UDL
-impl UniffiCustomTypeConverter for ServerTimestamp {
-    type Builtin = i64;
-
-    fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
-        Ok(Self(val as i64))
-    }
-
-    fn from_custom(obj: Self) -> Self::Builtin {
-        obj.as_millis()
-    }
-}
 
 pub use crate::db::LoginDb;
 use crate::encryption::{check_canary, create_canary, create_key};

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -158,6 +158,14 @@ interface LoginStore {
     [Throws=LoginsApiError, Self=ByArc]
     void reset();
 
+    /// The `verify_logins` function locally deletes stored logins that cannot be decrypted and sets the last sync
+    /// time to 0 so any existing server records can be downloaded and overwrite the locally deleted records.
+    ///
+    /// NB: This function was created to unblock iOS logins users who are unable to sync logins and should not be used
+    /// outside of this use case.
+    [Throws=LoginsApiError, Self=ByArc]
+    boolean verify_logins();
+
     [Throws=LoginsApiError]
     void touch([ByRef] string id);
 

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -2,6 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+[Custom]
+typedef i64 ServerTimestamp;
+
 namespace logins {
     /// We expose the crypto primitives on the namespace
 
@@ -153,10 +156,16 @@ interface LoginStore {
     boolean delete([ByRef] string id);
 
     [Throws=LoginsApiError]
+    boolean delete_local([ByRef] string id);
+
+    [Throws=LoginsApiError]
     void wipe_local();
 
     [Throws=LoginsApiError, Self=ByArc]
     void reset();
+
+    [Throws=LoginsApiError, Self=ByArc]
+    void set_last_sync(ServerTimestamp last_sync);
 
     [Throws=LoginsApiError]
     void touch([ByRef] string id);

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -158,13 +158,14 @@ interface LoginStore {
     [Throws=LoginsApiError, Self=ByArc]
     void reset();
 
-    /// The `verify_logins` function locally deletes stored logins that cannot be decrypted and sets the last sync
-    /// time to 0 so any existing server records can be downloaded and overwrite the locally deleted records.
+    /// The `delete_undecryptable_records_for_remote_replacement` function locally deletes stored logins
+    /// that cannot be decrypted and sets the last sync time to 0 so any existing server records can be downloaded
+    /// and overwrite the locally deleted records.
     ///
     /// NB: This function was created to unblock iOS logins users who are unable to sync logins and should not be used
     /// outside of this use case.
     [Throws=LoginsApiError, Self=ByArc]
-    boolean verify_logins();
+    void delete_undecryptable_records_for_remote_replacement();
 
     [Throws=LoginsApiError]
     void touch([ByRef] string id);

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -2,9 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-[Custom]
-typedef i64 ServerTimestamp;
-
 namespace logins {
     /// We expose the crypto primitives on the namespace
 
@@ -156,16 +153,10 @@ interface LoginStore {
     boolean delete([ByRef] string id);
 
     [Throws=LoginsApiError]
-    boolean delete_local([ByRef] string id);
-
-    [Throws=LoginsApiError]
     void wipe_local();
 
     [Throws=LoginsApiError, Self=ByArc]
     void reset();
-
-    [Throws=LoginsApiError, Self=ByArc]
-    void set_last_sync(ServerTimestamp last_sync);
 
     [Throws=LoginsApiError]
     void touch([ByRef] string id);

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -139,8 +139,10 @@ impl LoginStore {
     }
 
     #[handle_error(Error)]
-    pub fn delete_local_for_remote_replacement(&self, id: &str) -> ApiResult<bool> {
-        self.db.lock().delete_local_for_remote_replacement(id)
+    pub fn verify_logins(self: Arc<Self>) -> ApiResult<bool> {
+        self.db.lock().verify_logins(self.encdec.as_ref())?;
+
+        Ok(self.set_last_sync(ServerTimestamp(0)).is_ok())
     }
 
     #[handle_error(Error)]

--- a/components/logins/src/store.rs
+++ b/components/logins/src/store.rs
@@ -139,8 +139,8 @@ impl LoginStore {
     }
 
     #[handle_error(Error)]
-    pub fn delete_local(&self, id: &str) -> ApiResult<bool> {
-        self.db.lock().delete_local(id)
+    pub fn delete_local_for_remote_replacement(&self, id: &str) -> ApiResult<bool> {
+        self.db.lock().delete_local_for_remote_replacement(id)
     }
 
     #[handle_error(Error)]

--- a/components/logins/src/sync/engine.rs
+++ b/components/logins/src/sync/engine.rs
@@ -279,7 +279,7 @@ impl LoginsSyncEngine {
         self.fetch_outgoing()
     }
 
-    fn set_last_sync(&self, db: &LoginDb, last_sync: ServerTimestamp) -> Result<()> {
+    pub fn set_last_sync(&self, db: &LoginDb, last_sync: ServerTimestamp) -> Result<()> {
         log::debug!("Updating last sync to {}", last_sync);
         let last_sync_millis = last_sync.as_millis();
         db.put_meta(schema::LAST_SYNC_META_KEY, &last_sync_millis)

--- a/testing/sync-test/Cargo.toml
+++ b/testing/sync-test/Cargo.toml
@@ -29,3 +29,4 @@ serde_derive = "1.0"
 serde_json = "1.0"
 base64 = "0.21"
 cli-support = { path = "../../examples/cli-support" }
+nss = { path = "../../components/support/rc_crypto/nss" }

--- a/testing/sync-test/src/logins.rs
+++ b/testing/sync-test/src/logins.rs
@@ -4,8 +4,12 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 use crate::auth::TestClient;
 use crate::testing::TestGroup;
 use anyhow::Result;
-use logins::{ApiResult as LoginResult, Login, LoginEntry, LoginStore};
-use std::collections::HashMap;
+use logins::{
+    encryption::{create_key, ManagedEncryptorDecryptor, StaticKeyManager},
+    ApiResult as LoginResult, Login, LoginEntry, LoginStore,
+};
+use std::sync::Arc;
+use std::{collections::hash_map::RandomState, collections::HashMap};
 use sync15::ServerTimestamp;
 
 // helpers...
@@ -73,6 +77,13 @@ pub fn touch_login(s: &LoginStore, id: &str, times: usize) -> LoginResult<Login>
 pub fn sync_logins(client: &mut TestClient) -> Result<()> {
     let local_encryption_keys = HashMap::new();
     client.sync(&["passwords".to_string()], local_encryption_keys)
+}
+
+pub fn sync_logins_with_failure(
+    client: &mut TestClient,
+) -> Result<HashMap<String, String, RandomState>> {
+    let local_encryption_keys = HashMap::new();
+    client.sync_with_failure(&["passwords".to_string()], local_encryption_keys)
 }
 
 // Actual tests.
@@ -331,7 +342,7 @@ fn test_login_deletes(c0: &mut TestClient, c1: &mut TestClient) {
 // This test verifies that the delete_local function deletes a login without propogating the
 // deletion to the server
 fn test_login_local_delete(c0: &mut TestClient, c1: &mut TestClient) {
-    log::info!("Add some logins to client0");
+    log::info!("Add a login to client0");
 
     // Add a login
     let login0 = add_login(
@@ -364,10 +375,11 @@ fn test_login_local_delete(c0: &mut TestClient, c1: &mut TestClient) {
 
     // Delete the login on the first device
     log::info!("Performing local delete {} from c0", l0id);
-    assert!(c0
-        .logins_store
-        .delete_local_for_remote_replacement(&l0id)
-        .expect("Local delete should work"));
+    c0.logins_store
+        .db
+        .lock()
+        .delete_local_records_for_remote_replacement(vec![&l0id])
+        .expect("Local delete should work");
 
     // Verify that the login no longer exists on the first device
     verify_missing_login(&c0.logins_store, &l0id);
@@ -399,13 +411,119 @@ fn test_login_local_delete(c0: &mut TestClient, c1: &mut TestClient) {
 
     // Sync the first device
     log::info!("Syncing client0 -- post c0 reset");
-    sync_logins(c0).expect("c0 sync to work");
+    sync_logins(c0).expect("c0 sync to work");
 
     // Sync the second device
     log::info!("Syncing client1 -- post c0 reset");
-    sync_logins(c1).expect("c1 sync to work");
+    sync_logins(c1).expect("c1 sync to work");
 
     // Verify that the login exists on both devices
+    verify_login(&c0.logins_store, &login0);
+    verify_login(&c1.logins_store, &login0);
+
+    // Clear the stores
+    _ = c0.logins_store.wipe_local();
+    _ = c1.logins_store.wipe_local();
+}
+
+fn test_verify_logins_unblocks_syncing(c0: &mut TestClient, c1: &mut TestClient) {
+    log::info!("Add a login to client0");
+
+    // Add a login
+    let login0 = add_login(
+        &c0.logins_store,
+        LoginEntry {
+            origin: "http://www.example2.com".into(),
+            form_action_origin: Some("http://login.example2.com".into()),
+            username_field: "uname".into(),
+            password_field: "pword".into(),
+            username: "cool_username".into(),
+            password: "hunter2".into(),
+            ..Default::default()
+        },
+    )
+    .expect("add login0");
+
+    // Sync the first device where the login was added
+    log::info!("Syncing client0 -- inital sync");
+    sync_logins(c0).expect("c0 sync to work");
+
+    // Sync the second device
+    log::info!("Syncing client1 -- inital sync");
+    sync_logins(c1).expect("c0 sync to work");
+
+    // Verify that the login exists on both devices
+    verify_login(&c0.logins_store, &login0);
+    verify_login(&c1.logins_store, &login0);
+
+    // Add a login with a different EncryptorDecryptor to replicate having a stored login that cannot be decrypted
+    // with the EncryptorDecryptor property of the store
+    let key = create_key().unwrap();
+    let new_encdec = Arc::new(ManagedEncryptorDecryptor::new(Arc::new(
+        StaticKeyManager::new(key.clone()),
+    )));
+
+    log::info!("Add another login to client0");
+
+    let login1 = c0
+        .logins_store
+        .db
+        .lock()
+        .add(
+            LoginEntry {
+                origin: "http://www.example3.com".into(),
+                form_action_origin: Some("http://login.example3.com".into()),
+                username_field: "uname".into(),
+                password_field: "pword".into(),
+                username: "cool_username".into(),
+                password: "hunter2".into(),
+                ..Default::default()
+            },
+            &*new_encdec,
+        )
+        .expect("add login1");
+    let l1id = login1.guid();
+
+    // Check that the corrupted login exists on first device
+    // The db retrieval function is being used instead of the store function so that we
+    // can provided our own EncryptorDecryptor.
+    let retrieved_login = c0
+        .logins_store
+        .db
+        .lock()
+        .get_by_id(&l1id)
+        .expect("get_by_id returns successfully")
+        .expect("login to be retrieved")
+        .decrypt(&*new_encdec)
+        .expect("decryption to succeed");
+    assert_eq!(retrieved_login.guid(), l1id);
+
+    // Check that syncing after adding a corrupted login fails with a decryption error
+    let failures = sync_logins_with_failure(c0).expect("sync to complete with failures");
+    let login_failures = failures.get("passwords");
+    assert!(login_failures.is_some());
+    assert!(login_failures.unwrap().contains("decryption failed"));
+
+    // Execute the verification logic to remove the corrupted login
+    log::info!("Verify logins");
+    assert!(c0
+        .logins_store
+        .clone()
+        .verify_logins()
+        .expect("stored logins to be verified"));
+
+    // Verify that the corrupted login has been removed
+    verify_missing_login(&c0.logins_store, &l1id);
+
+    // Sync the first device after verification
+    log::info!("Syncing client0 -- after verification");
+    sync_logins(c0).expect("c0 sync to work");
+
+    // Sync the second device after verification
+    log::info!("Syncing client1 -- after verification");
+    sync_logins(c1).expect("c0 sync to work");
+
+    // Verify that the first login record still exists on both devices
     verify_login(&c0.logins_store, &login0);
     verify_login(&c1.logins_store, &login0);
 
@@ -421,6 +539,10 @@ pub fn get_test_group() -> TestGroup {
             ("test_login_general", test_login_general),
             ("test_login_deletes", test_login_deletes),
             ("test_login_local_delete", test_login_local_delete),
+            (
+                "test_verify_logins_unblocks_syncing",
+                test_verify_logins_unblocks_syncing,
+            ),
         ],
     )
 }

--- a/testing/sync-test/src/logins.rs
+++ b/testing/sync-test/src/logins.rs
@@ -366,7 +366,7 @@ fn test_login_local_delete(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Performing local delete {} from c0", l0id);
     assert!(c0
         .logins_store
-        .delete_local(&l0id)
+        .delete_local_for_remote_replacement(&l0id)
         .expect("Local delete should work"));
 
     // Verify that the login no longer exists on the first device
@@ -380,8 +380,9 @@ fn test_login_local_delete(c0: &mut TestClient, c1: &mut TestClient) {
     log::info!("Syncing client1 -- post local deletion");
     sync_logins(c1).expect("c1 sync to work");
 
-    // The following verification checks ensure that the delete_local call removed the login
-    // from the first device without propogating that change to the sync server.
+    // The following verification checks ensure that the delete_local_for_remote_replacement
+    // call removed the login from the first device without propogating that change to the
+    // sync server.
 
     // Verify that the login is missing from the first device.
     verify_missing_login(&c0.logins_store, &l0id);

--- a/testing/sync-test/src/main.rs
+++ b/testing/sync-test/src/main.rs
@@ -5,6 +5,7 @@ http://creativecommons.org/publicdomain/zero/1.0/ */
 #![warn(rust_2018_idioms)]
 
 use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
+use nss::ensure_initialized;
 use std::sync::Arc;
 use std::{collections::HashSet, process};
 use structopt::StructOpt;
@@ -28,6 +29,8 @@ macro_rules! cleanup_clients {
 
 pub fn init_testing() {
     viaduct_reqwest::use_reqwest_backend();
+    ensure_initialized();
+
     // Enable backtraces.
     std::env::set_var("RUST_BACKTRACE", "1");
     // Turn on trace logging for everything except for a few crates (mostly from

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -85,7 +85,6 @@ LICENSES_IN_PREFERENCE_ORDER = [
     # Special one-off licenses for particular projects.
     "EXT-OPENSSL",
     "EXT-SQLITE",
-    "OPENSSL-SSLeay"
 ]
 
 # Packages that get pulled into our dependency tree but we know we definitely don't
@@ -262,7 +261,7 @@ PACKAGE_METADATA_FIXUPS = {
         },
     },
     "openssl": {
-        "license": {"check": "Apache-2.0 OR OPENSSL-SSLeay"},
+        "license": {"check": "Apache-2.0"},
         "license_file": {
             "check": None,
             "fixup": "https://raw.githubusercontent.com/sfackler/rust-openssl/refs/heads/master/openssl/LICENSE-APACHE",

--- a/tools/dependency_summary.py
+++ b/tools/dependency_summary.py
@@ -85,6 +85,7 @@ LICENSES_IN_PREFERENCE_ORDER = [
     # Special one-off licenses for particular projects.
     "EXT-OPENSSL",
     "EXT-SQLITE",
+    "OPENSSL-SSLeay"
 ]
 
 # Packages that get pulled into our dependency tree but we know we definitely don't
@@ -258,6 +259,13 @@ PACKAGE_METADATA_FIXUPS = {
         "license_file": {
             "check": None,
             "fixup": "https://raw.githubusercontent.com/martinthomson/ohttp/main/LICENSE-APACHE",
+        },
+    },
+    "openssl": {
+        "license": {"check": "Apache-2.0 OR OPENSSL-SSLeay"},
+        "license_file": {
+            "check": None,
+            "fixup": "https://raw.githubusercontent.com/sfackler/rust-openssl/refs/heads/master/openssl/LICENSE-APACHE",
         },
     },
     "bhttp": {


### PR DESCRIPTION
This PR adds a function to locally delete logins that cannot be decrypted so the deletion won't be propagated to the sync server. It additionally includes the following changes:
- Adds NSS initialization for the sync integration tests.
- Adds unit and integration tests for the new function

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
