### PR TITLE
Revert "[DISCO-3212] Switch Relevancy to new remote settings API"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,7 +763,6 @@ dependencies = [
  "env_logger",
  "fxa-client",
  "log",
- "remote_settings",
  "sync15",
  "sync_manager",
  "url",

--- a/components/relevancy/src/ingest.rs
+++ b/components/relevancy/src/ingest.rs
@@ -39,10 +39,14 @@ pub fn ensure_interest_data_populated<C: RelevancyRemoteSettingsClient>(
 fn fetch_interest_data_inner<C: RelevancyRemoteSettingsClient>(
     client: C,
 ) -> Result<Vec<(Interest, UrlHash)>> {
+    let remote_settings_response = client.get_records()?;
     let mut result = vec![];
 
-    for record in client.get_records()? {
-        let attachment_data = client.get_attachment(&record)?;
+    for record in remote_settings_response.records {
+        let attachment_data = match &record.attachment {
+            None => return Err(Error::FetchInterestDataError),
+            Some(a) => client.get_attachment(&a.location)?,
+        };
         let interest = get_interest(&record)?;
         let urls = get_hash_urls(attachment_data)?;
         result.extend(std::iter::repeat(interest).zip(urls));
@@ -94,6 +98,7 @@ mod test {
     use std::{cell::RefCell, collections::HashMap};
 
     use anyhow::Context;
+    use remote_settings::RemoteSettingsResponse;
     use serde_json::json;
 
     use super::*;
@@ -155,12 +160,20 @@ mod test {
     }
 
     impl RelevancyRemoteSettingsClient for SnapshotSettingsClient {
-        fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
-            Ok(self.snapshot.borrow().records.clone())
+        fn get_records(&self) -> Result<RemoteSettingsResponse> {
+            let records = self.snapshot.borrow().records.clone();
+            let last_modified = records
+                .iter()
+                .map(|record: &RemoteSettingsRecord| record.last_modified)
+                .max()
+                .unwrap_or(0);
+            Ok(RemoteSettingsResponse {
+                records,
+                last_modified,
+            })
         }
 
-        fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
-            let location = record.attachment.as_ref().unwrap().location.as_str();
+        fn get_attachment(&self, location: &str) -> Result<Vec<u8>> {
             Ok(self
                 .snapshot
                 .borrow()

--- a/components/relevancy/src/lib.rs
+++ b/components/relevancy/src/lib.rs
@@ -20,25 +20,22 @@ pub mod url_hash;
 
 use rand_distr::{Beta, Distribution};
 
-use std::{collections::HashMap, sync::Arc};
-
-use parking_lot::Mutex;
-use remote_settings::{RemoteSettingsClient, RemoteSettingsService};
-
 pub use db::RelevancyDb;
 pub use error::{ApiResult, Error, RelevancyApiError, Result};
 pub use interest::{Interest, InterestVector};
+use parking_lot::Mutex;
 pub use ranker::score;
 
 use error_support::handle_error;
 
 use db::BanditData;
+use std::collections::HashMap;
 
 uniffi::setup_scaffolding!();
 
 #[derive(uniffi::Object)]
 pub struct RelevancyStore {
-    inner: RelevancyStoreInner<Arc<RemoteSettingsClient>>,
+    inner: RelevancyStoreInner<remote_settings::RemoteSettings>,
 }
 
 /// Top-level API for the Relevancy component
@@ -50,12 +47,9 @@ impl RelevancyStore {
     /// This is non-blocking since databases and other resources are lazily opened.
     #[uniffi::constructor]
     #[handle_error(Error)]
-    pub fn new(db_path: String, remote_settings: Arc<RemoteSettingsService>) -> ApiResult<Self> {
+    pub fn new(db_path: String) -> ApiResult<Self> {
         Ok(Self {
-            inner: RelevancyStoreInner::new(
-                db_path,
-                remote_settings.make_client(rs::REMOTE_SETTINGS_COLLECTION.to_string())?,
-            ),
+            inner: RelevancyStoreInner::new(db_path, rs::create_client()?),
         })
     }
 

--- a/components/relevancy/src/rs.rs
+++ b/components/relevancy/src/rs.rs
@@ -4,7 +4,9 @@
  */
 
 use crate::{Error, Result};
-use remote_settings::{RemoteSettingsClient, RemoteSettingsRecord};
+use remote_settings::{
+    RemoteSettings, RemoteSettingsConfig, RemoteSettingsResponse, RemoteSettingsServer,
+};
 use serde::Deserialize;
 /// The Remote Settings collection name.
 pub(crate) const REMOTE_SETTINGS_COLLECTION: &str = "content-relevance";
@@ -14,46 +16,45 @@ pub(crate) const REMOTE_SETTINGS_COLLECTION: &str = "content-relevance";
 /// This trait lets tests use a mock client.
 pub(crate) trait RelevancyRemoteSettingsClient {
     /// Fetches records from the Suggest Remote Settings collection.
-    fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>>;
+    fn get_records(&self) -> Result<RemoteSettingsResponse>;
 
     /// Fetches a record's attachment from the Suggest Remote Settings
     /// collection.
-    fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>>;
+    fn get_attachment(&self, location: &str) -> Result<Vec<u8>>;
 }
 
-impl RelevancyRemoteSettingsClient for RemoteSettingsClient {
-    fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
-        self.sync()?;
-        Ok(self
-            .get_records(false)
-            .expect("RemoteSettingsClient::get_records() returned None after `sync()` called"))
+impl RelevancyRemoteSettingsClient for remote_settings::RemoteSettings {
+    fn get_records(&self) -> Result<RemoteSettingsResponse> {
+        Ok(remote_settings::RemoteSettings::get_records(self)?)
     }
 
-    fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
-        Ok(self.get_attachment(record)?)
+    fn get_attachment(&self, location: &str) -> Result<Vec<u8>> {
+        Ok(remote_settings::RemoteSettings::get_attachment(
+            self, location,
+        )?)
     }
 }
 
 impl<T: RelevancyRemoteSettingsClient> RelevancyRemoteSettingsClient for &T {
-    fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
+    fn get_records(&self) -> Result<RemoteSettingsResponse> {
         (*self).get_records()
     }
 
-    fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
-        (*self).get_attachment(record)
+    fn get_attachment(&self, location: &str) -> Result<Vec<u8>> {
+        (*self).get_attachment(location)
     }
 }
 
-impl<T: RelevancyRemoteSettingsClient> RelevancyRemoteSettingsClient for std::sync::Arc<T> {
-    fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
-        (**self).get_records()
-    }
-
-    fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
-        (**self).get_attachment(record)
-    }
+pub fn create_client() -> Result<RemoteSettings> {
+    Ok(RemoteSettings::new(RemoteSettingsConfig {
+        collection_name: REMOTE_SETTINGS_COLLECTION.to_string(),
+        server: Some(RemoteSettingsServer::Prod),
+        server_url: None,
+        bucket_name: None,
+    })?)
 }
 
+/// A record in the Relevancy Remote Settings collection.
 #[derive(Clone, Debug, Deserialize)]
 pub struct RelevancyRecord {
     #[allow(dead_code)]
@@ -114,11 +115,11 @@ pub mod test {
     pub struct NullRelavancyRemoteSettingsClient;
 
     impl RelevancyRemoteSettingsClient for NullRelavancyRemoteSettingsClient {
-        fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
+        fn get_records(&self) -> Result<RemoteSettingsResponse> {
             panic!("NullRelavancyRemoteSettingsClient::get_records was called")
         }
 
-        fn get_attachment(&self, _record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
+        fn get_attachment(&self, _location: &str) -> Result<Vec<u8>> {
             panic!("NullRelavancyRemoteSettingsClient::get_records was called")
         }
     }

--- a/components/remote_settings/src/config.rs
+++ b/components/remote_settings/src/config.rs
@@ -17,7 +17,7 @@ use crate::{ApiResult, Error, RemoteSettingsContext, Result};
 /// This is the version used in the new API, hence the `2` at the end.  The plan is to move
 /// consumers to the new API, remove the RemoteSettingsConfig struct, then remove the `2` from this
 /// name.
-#[derive(Debug, Default, Clone, uniffi::Record)]
+#[derive(Debug, Clone, uniffi::Record)]
 pub struct RemoteSettingsConfig2 {
     /// The Remote Settings server to use. Defaults to [RemoteSettingsServer::Prod],
     #[uniffi(default = None)]

--- a/examples/cli-support/Cargo.toml
+++ b/examples/cli-support/Cargo.toml
@@ -8,7 +8,6 @@ license = "MPL-2.0"
 [dependencies]
 anyhow = "1.0"
 fxa-client = { path = "../../components/fxa-client" }
-remote_settings = { path = "../../components/remote_settings" }
 sync_manager = { path = "../../components/sync_manager" }
 log = "0.4"
 sync15 = { path = "../../components/sync15", features=["sync-client"] }

--- a/examples/cli-support/src/lib.rs
+++ b/examples/cli-support/src/lib.rs
@@ -5,12 +5,7 @@
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
-
-use remote_settings::{RemoteSettingsConfig2, RemoteSettingsService};
+use std::path::{Path, PathBuf};
 
 pub mod fxa_creds;
 pub mod prompt;
@@ -67,16 +62,4 @@ pub fn workspace_root_dir() -> PathBuf {
         .stdout;
     let cargo_toml_path = Path::new(std::str::from_utf8(&cargo_output).unwrap().trim());
     cargo_toml_path.parent().unwrap().to_path_buf()
-}
-
-pub fn remote_settings_service() -> Arc<RemoteSettingsService> {
-    Arc::new(
-        RemoteSettingsService::new(
-            data_path(Some("remote-settings"))
-                .to_string_lossy()
-                .to_string(),
-            RemoteSettingsConfig2::default(),
-        )
-        .expect("Error creating RemoteSettingsService"),
-    )
 }

--- a/examples/relevancy-cli/src/main.rs
+++ b/examples/relevancy-cli/src/main.rs
@@ -5,10 +5,7 @@
 use std::sync::Arc;
 
 use clap::Parser;
-use cli_support::{
-    fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE},
-    remote_settings_service,
-};
+use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
 use env_logger::Builder;
 use interrupt_support::NeverInterrupts;
 use places::{ConnectionType, PlacesApi};
@@ -47,10 +44,8 @@ fn main() -> Result<()> {
     }
     builder.init();
     println!("================== Initializing Relevancy ===================");
-    let relevancy_store = RelevancyStore::new(
-        "file:relevancy-cli-relevancy?mode=memory&cache=shared".to_owned(),
-        remote_settings_service(),
-    )?;
+    let relevancy_store =
+        RelevancyStore::new("file:relevancy-cli-relevancy?mode=memory&cache=shared".to_owned())?;
     relevancy_store.ensure_interest_data_populated()?;
 
     println!("==================== Downloading History ====================");


### PR DESCRIPTION
This reverts commit cec8e14773e5ee2498ef416945374e6891463d02.

The changed caused the UniFFI/Glean update to be backed out from moz-central because of `LateWriteObserver` failures.  The issue stems from the fact the new client has an SQLite connection which it uses for cached records and we're not closing that properly before shutdown.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
