### PR TITLE
Add method to get subscriptions' fields used to register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [Full Changelog](In progress)
 
+### Push
+- Add `listSubscriptionReq` and `SubscriptionRequest` to list informations used to subscribe. May be used to subscribe to another pusher
+
 # v137.0 (_2025-03-03_)
 
 ## ✨ What's New ✨

--- a/components/push/src/internal/storage/db.rs
+++ b/components/push/src/internal/storage/db.rs
@@ -17,6 +17,8 @@ pub trait Storage: Sized {
 
     fn get_record_by_scope(&self, scope: &str) -> Result<Option<PushRecord>>;
 
+    fn get_record_list(&self) -> Result<Vec<PushRecord>>;
+
     fn put_record(&self, record: &PushRecord) -> Result<bool>;
 
     fn delete_record(&self, chid: &str) -> Result<bool>;
@@ -116,6 +118,19 @@ impl Storage for PushDb {
             common_cols = schema::COMMON_COLS,
         );
         self.try_query_row(&query, &[(":scope", scope)], PushRecord::from_row, false)
+    }
+
+    fn get_record_list(&self) -> Result<Vec<PushRecord>> {
+        let query = format!(
+            "SELECT {common_cols}
+             FROM push_record",
+            common_cols = schema::COMMON_COLS,
+        );
+        self.query_rows_and_then(
+            &query,
+            [],
+            |row| -> Result<PushRecord> { Ok(PushRecord::from_row(row)?) },
+        )
     }
 
     fn put_record(&self, record: &PushRecord) -> Result<bool> {

--- a/components/push/src/lib.rs
+++ b/components/push/src/lib.rs
@@ -281,6 +281,20 @@ impl PushManager {
         self.internal.lock().unwrap().get_subscription(scope)
     }
 
+    /// List existing subscription requests
+    /// Contains scope and application server key from existing subscriptions
+    ///
+    /// # Returns
+    /// The list of existing [`SubscriptionRequest`]
+    ///
+    /// # Errors
+    /// Returns an error if:
+    ///   - An error occurred accessing the PushManagers's persistent storage
+    #[handle_error(PushError)]
+    pub fn list_subscription_req(&self) -> ApiResult<Vec<SubscriptionRequest>> {
+        self.internal.lock().unwrap().list_subscription_req()
+    }
+
     /// Unsubscribe from given channelID, ending that subscription for the user.
     ///
     /// # Arguments
@@ -379,6 +393,13 @@ impl PushManager {
     pub fn decrypt(&self, payload: HashMap<String, String>) -> ApiResult<DecryptResponse> {
         self.internal.lock().unwrap().decrypt(payload)
     }
+}
+
+/// Fields needed to do a subscription request: the scope and the application server key
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SubscriptionRequest {
+    pub scope: String,
+    pub app_server_key: Option<String>,
 }
 
 /// Key Information that can be used to encrypt payloads. These are encoded as base64

--- a/components/push/src/push.udl
+++ b/components/push/src/push.udl
@@ -63,6 +63,27 @@ interface PushManager {
     [Throws=PushApiError]
     SubscriptionResponse? get_subscription([ByRef] string scope);
 
+    /// List existing scopes
+    ///
+    /// # Returns
+    /// The list of subscribed scopes
+    ///
+    /// # Errors
+    /// Returns an error if:
+    ///   - An error occurred accessing the PushManagers's persistent storage
+
+    /// List existing subscription requests
+    /// Contains scope and application server key from existing subscriptions
+    ///
+    /// # Returns
+    /// The list of existing [`SubscriptionRequest`]
+    ///
+    /// # Errors
+    /// Returns an error if:
+    ///   - An error occurred accessing the PushManagers's persistent storage
+    [Throws=PushApiError]
+    sequence<SubscriptionRequest> list_subscription_req();
+
     /// Unsubscribe from given scope, ending that subscription for the user.
     ///
     /// # Arguments
@@ -141,6 +162,11 @@ interface PushManager {
     DecryptResponse decrypt(record<DOMString, string> payload);
 };
 
+/// Fields needed to do a subscription request: the scope and the application server key
+dictionary SubscriptionRequest {
+    string scope;
+    string? app_server_key;
+};
 /// Key Information that can be used to encrypt payloads
 dictionary KeyInfo {
     string auth;


### PR DESCRIPTION
This PR adds a method for the push manager, to be able to migrate from autopush to another pusher.

This is useful when migrating from AutoPush/FCM to UnifiedPush on Android ([Bug1802846](https://bugzilla.mozilla.org/show_bug.cgi?id=1802846))

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
