### PR TITLE
Update protobuf and protobuf-gradle-plugin to the latest releases

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@
 android-plugin = "8.9.1"
 
 # Google
-protobuf = "4.29.0"
+protobuf = "4.30.2"
 
 # Kotlin
 kotlin-compiler = "2.1.20"
@@ -44,7 +44,7 @@ robolectric = "4.14.1"
 
 # Miscellaneous Gradle plugins
 gradle-download-task = "5.6.0"
-protobuf-gradle = "0.9.4"
+protobuf-gradle = "0.9.5"
 python-envs = "0.0.31"
 
 [libraries]


### PR DESCRIPTION
Release notes:
* https://github.com/google/protobuf-gradle-plugin/releases/tag/v0.9.5
* https://github.com/protocolbuffers/protobuf/releases/tag/v30.0
* https://github.com/protocolbuffers/protobuf/releases/tag/v30.1
* https://github.com/protocolbuffers/protobuf/releases/tag/v30.2