### PR TITLE
Bug 1955387 - Add locale fallback handling to the Rust based search engine selector.

### DIFF
--- a/components/search/src/configuration_types.rs
+++ b/components/search/src/configuration_types.rs
@@ -277,6 +277,14 @@ pub(crate) struct JSONEngineOrdersRecord {
     pub orders: Vec<JSONEngineOrder>,
 }
 
+/// Represents the available locales record.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct JSONAvailableLocalesRecord {
+    /// The available locales in the search config v2.
+    pub locales: Vec<String>,
+}
+
 /// Represents an individual record in the raw search configuration.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "recordType", rename_all = "camelCase")]
@@ -284,6 +292,7 @@ pub(crate) enum JSONSearchConfigurationRecords {
     DefaultEngines(JSONDefaultEnginesRecord),
     Engine(Box<JSONEngineRecord>),
     EngineOrders(JSONEngineOrdersRecord),
+    AvailableLocales(JSONAvailableLocalesRecord),
     // Include some flexibilty if we choose to add new record types in future.
     // Current versions of the application receiving the configuration will
     // ignore the new record types.


### PR DESCRIPTION


- Introduce a new record type for a list of availablelocales in the search configuration
- Implement logic to use the user's locale directly, or strip the regional part for fallback
- Map unsupported English locales to en-US

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
