### PR TITLE
Bug 1957805 - Replace exposure suggestions with dynamic suggestions.

### DIFF
--- a/components/suggest/src/db.rs
+++ b/components/suggest/src/db.rs
@@ -23,9 +23,9 @@ use crate::{
     provider::{AmpMatchingStrategy, SuggestionProvider},
     query::{full_keywords_to_fts_content, FtsQuery},
     rs::{
-        DownloadedAmoSuggestion, DownloadedAmpSuggestion, DownloadedExposureSuggestion,
-        DownloadedFakespotSuggestion, DownloadedMdnSuggestion, DownloadedPocketSuggestion,
-        DownloadedWikipediaSuggestion, Record, SuggestRecordId,
+        DownloadedAmoSuggestion, DownloadedAmpSuggestion, DownloadedDynamicRecord,
+        DownloadedDynamicSuggestion, DownloadedFakespotSuggestion, DownloadedMdnSuggestion,
+        DownloadedPocketSuggestion, DownloadedWikipediaSuggestion, Record, SuggestRecordId,
     },
     schema::{clear_database, SuggestConnectionInitializer},
     suggestion::{cook_raw_suggestion_url, FtsMatchInfo, Suggestion},
@@ -927,68 +927,66 @@ impl<'a> SuggestDao<'a> {
         })
     }
 
-    /// Fetches exposure suggestions
-    pub fn fetch_exposure_suggestions(&self, query: &SuggestionQuery) -> Result<Vec<Suggestion>> {
-        // A single exposure suggestion can be spread across multiple remote
-        // settings records, for example if it has very many keywords. On ingest
-        // we will insert one row in `exposure_custom_details` and one row in
-        // `suggestions` per record, but that's only an implementation detail.
-        // Logically, and for consumers, there's only ever at most one exposure
-        // suggestion with a given exposure suggestion type.
-        //
-        // Why do insertions this way? It's how other suggestions work, and it
-        // lets us perform relational operations on suggestions, records, and
-        // keywords. For example, when a record is deleted we can look up its ID
-        // in `suggestions`, join the keywords table on the suggestion ID, and
-        // delete the keywords that were added by that record.
-
+    /// Fetches dynamic suggestions
+    pub fn fetch_dynamic_suggestions(&self, query: &SuggestionQuery) -> Result<Vec<Suggestion>> {
         let Some(suggestion_types) = query
             .provider_constraints
             .as_ref()
-            .and_then(|c| c.exposure_suggestion_types.as_ref())
+            .and_then(|c| c.dynamic_suggestion_types.as_ref())
         else {
             return Ok(vec![]);
         };
 
         let keyword = query.keyword.to_lowercase();
         let params = rusqlite::params_from_iter(
-            std::iter::once(&SuggestionProvider::Exposure as &dyn ToSql)
+            std::iter::once(&SuggestionProvider::Dynamic as &dyn ToSql)
                 .chain(std::iter::once(&keyword as &dyn ToSql))
                 .chain(suggestion_types.iter().map(|t| t as &dyn ToSql)),
         );
         self.conn.query_rows_and_then_cached(
             &format!(
                 r#"
-                    SELECT DISTINCT
-                      d.type
-                    FROM
-                      suggestions s
-                    JOIN
-                      exposure_custom_details d
-                      ON d.suggestion_id = s.id
-                    JOIN
-                      keywords k
-                      ON k.suggestion_id = s.id
-                    WHERE
-                      s.provider = ?
-                      AND k.keyword = ?
-                      AND d.type IN ({})
-                    ORDER BY
-                      d.type
-                    "#,
+                SELECT
+                  s.url,
+                  s.score,
+                  d.suggestion_type,
+                  d.json_data
+                FROM
+                  suggestions s
+                JOIN
+                  dynamic_custom_details d
+                  ON d.suggestion_id = s.id
+                JOIN
+                  keywords k
+                  ON k.suggestion_id = s.id
+                WHERE
+                  s.provider = ?
+                  AND k.keyword = ?
+                  AND d.suggestion_type IN ({})
+                  AND NOT EXISTS (SELECT 1 FROM dismissed_suggestions WHERE url = s.url)
+                ORDER BY
+                  s.score ASC, d.suggestion_type ASC, s.id ASC
+                "#,
                 repeat_sql_vars(suggestion_types.len())
             ),
             params,
             |row| -> Result<Suggestion> {
-                Ok(Suggestion::Exposure {
-                    suggestion_type: row.get("type")?,
-                    score: 1.0,
+                let dismissal_key: String = row.get("url")?;
+                let json_data: Option<String> = row.get("json_data")?;
+                Ok(Suggestion::Dynamic {
+                    suggestion_type: row.get("suggestion_type")?,
+                    data: match json_data {
+                        None => None,
+                        Some(j) => serde_json::from_str(&j)?,
+                    },
+                    score: row.get("score")?,
+                    dismissal_key: (!dismissal_key.is_empty()).then_some(dismissal_key),
                 })
             },
         )
     }
 
-    pub fn is_exposure_suggestion_ingested(&self, record_id: &SuggestRecordId) -> Result<bool> {
+    pub fn are_suggestions_ingested_for_record(&self, record_id: &SuggestRecordId) -> Result<bool> {
         Ok(self.conn.exists(
             r#"
             SELECT
@@ -1229,31 +1227,34 @@ impl<'a> SuggestDao<'a> {
         Ok(())
     }
 
-    /// Inserts exposure suggestion records data into the database.
-    pub fn insert_exposure_suggestions(
+    /// Inserts dynamic suggestion records data into the database.
+    pub fn insert_dynamic_suggestions(
         &mut self,
         record_id: &SuggestRecordId,
-        suggestion_type: &str,
-        suggestions: &[DownloadedExposureSuggestion],
+        record: &DownloadedDynamicRecord,
+        suggestions: &[DownloadedDynamicSuggestion],
     ) -> Result<()> {
-        // `suggestion.keywords()` can yield duplicates for exposure
+        // `suggestion.keywords()` can yield duplicates for dynamic
         // suggestions, so ignore failures on insert in the uniqueness
         // constraint on `(suggestion_id, keyword)`.
         let mut keyword_insert = KeywordInsertStatement::new_with_or_ignore(self.conn)?;
         let mut suggestion_insert = SuggestionInsertStatement::new(self.conn)?;
-        let mut exposure_insert = ExposureInsertStatement::new(self.conn)?;
+        let mut dynamic_insert = DynamicInsertStatement::new(self.conn)?;
         for suggestion in suggestions {
             self.scope.err_if_interrupted()?;
             let suggestion_id = suggestion_insert.execute(
                 record_id,
-                "", // title, not used by exposure suggestions
-                "", // url, not used by exposure suggestions
-                DEFAULT_SUGGESTION_SCORE,
-                SuggestionProvider::Exposure,
+                // title - Not used by dynamic suggestions.
+                "",
+                // url - Dynamic suggestions store their dismissal key here
+                // instead.
+                suggestion.dismissal_key.as_deref().unwrap_or(""),
+                record.score.unwrap_or(DEFAULT_SUGGESTION_SCORE),
+                SuggestionProvider::Dynamic,
             )?;
-            exposure_insert.execute(suggestion_id, suggestion_type)?;
+            dynamic_insert.execute(suggestion_id, &record.suggestion_type, suggestion)?;
 
-            // Exposure suggestions don't use `rank` but `(suggestion_id, rank)`
+            // Dynamic suggestions don't use `rank` but `(suggestion_id, rank)`
             // must be unique since there's an index on that tuple.
             for (rank, keyword) in suggestion.keywords().enumerate() {
                 keyword_insert.execute(suggestion_id, &keyword, None, rank)?;
@@ -1726,24 +1727,37 @@ impl<'conn> FakespotInsertStatement<'conn> {
     }
 }
 
-struct ExposureInsertStatement<'conn>(rusqlite::Statement<'conn>);
+struct DynamicInsertStatement<'conn>(rusqlite::Statement<'conn>);
 
-impl<'conn> ExposureInsertStatement<'conn> {
+impl<'conn> DynamicInsertStatement<'conn> {
     fn new(conn: &'conn Connection) -> Result<Self> {
         Ok(Self(conn.prepare(
-            "INSERT INTO exposure_custom_details(
+            "INSERT INTO dynamic_custom_details(
                  suggestion_id,
-                 type
+                 suggestion_type,
+                 json_data
              )
-             VALUES(?, ?)
+             VALUES(?, ?, ?)
              ",
         )?))
     }
 
-    fn execute(&mut self, suggestion_id: i64, suggestion_type: &str) -> Result<()> {
+    fn execute(
+        &mut self,
+        suggestion_id: i64,
+        suggestion_type: &str,
+        suggestion: &DownloadedDynamicSuggestion,
+    ) -> Result<()> {
         self.0
-            .execute((suggestion_id, suggestion_type))
-            .with_context("exposure insert")?;
+            .execute((
+                suggestion_id,
+                suggestion_type,
+                match &suggestion.data {
+                    None => None,
+                    Some(d) => Some(serde_json::to_string(&d)?),
+                },
+            ))
+            .with_context("dynamic insert")?;
         Ok(())
     }
 }

--- a/components/suggest/src/lib.rs
+++ b/components/suggest/src/lib.rs
@@ -37,3 +37,11 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 pub type SuggestApiResult<T> = std::result::Result<T, SuggestApiError>;
 
 uniffi::setup_scaffolding!();
+
+use serde_json::Value as JsonValue;
+
+uniffi::custom_type!(JsonValue, String, {
+    remote,
+    try_lift: |val| serde_json::from_str(val.as_str()).map_err(Into::into),
+    lower: |obj| obj.to_string(),
+});

--- a/components/suggest/src/provider.rs
+++ b/components/suggest/src/provider.rs
@@ -43,7 +43,7 @@ pub enum SuggestionProvider {
     Mdn = 6,
     Weather = 7,
     Fakespot = 8,
-    Exposure = 9,
+    Dynamic = 9,
 }
 
 impl fmt::Display for SuggestionProvider {
@@ -57,7 +57,7 @@ impl fmt::Display for SuggestionProvider {
             Self::Mdn => write!(f, "mdn"),
             Self::Weather => write!(f, "weather"),
             Self::Fakespot => write!(f, "fakespot"),
-            Self::Exposure => write!(f, "exposure"),
+            Self::Dynamic => write!(f, "dynamic"),
         }
     }
 }
@@ -83,7 +83,7 @@ impl SuggestionProvider {
             Self::Mdn,
             Self::Weather,
             Self::Fakespot,
-            Self::Exposure,
+            Self::Dynamic,
         ]
     }
 
@@ -98,7 +98,7 @@ impl SuggestionProvider {
             6 => Some(Self::Mdn),
             7 => Some(Self::Weather),
             8 => Some(Self::Fakespot),
-            9 => Some(Self::Exposure),
+            9 => Some(Self::Dynamic),
             _ => None,
         }
     }
@@ -123,7 +123,7 @@ impl SuggestionProvider {
             Self::Mdn => SuggestRecordType::Mdn,
             Self::Weather => SuggestRecordType::Weather,
             Self::Fakespot => SuggestRecordType::Fakespot,
-            Self::Exposure => SuggestRecordType::Exposure,
+            Self::Dynamic => SuggestRecordType::Dynamic,
         }
     }
 
@@ -213,11 +213,10 @@ impl SuggestionProvider {
 /// other operations on those providers must be constrained to a desired subtype.
 #[derive(Clone, Default, Debug, uniffi::Record)]
 pub struct SuggestionProviderConstraints {
-    /// `Exposure` provider - For each desired exposure suggestion type, this
-    /// should contain the value of the `suggestion_type` field of its remote
-    /// settings record(s).
+    /// Which dynamic suggestions should we fetch or ingest? Corresponds to the
+    /// `suggestion_type` value in dynamic suggestions remote settings records.
     #[uniffi(default = None)]
-    pub exposure_suggestion_types: Option<Vec<String>>,
+    pub dynamic_suggestion_types: Option<Vec<String>>,
     /// Which strategy should we use for the AMP queries?
     /// Use None for the default strategy.
     #[uniffi(default = None)]

--- a/components/suggest/src/query.rs
+++ b/components/suggest/src/query.rs
@@ -117,12 +117,12 @@ impl SuggestionQuery {
         }
     }
 
-    pub fn exposure(keyword: &str, suggestion_types: &[&str]) -> Self {
+    pub fn dynamic(keyword: &str, suggestion_types: &[&str]) -> Self {
         Self {
             keyword: keyword.into(),
-            providers: vec![SuggestionProvider::Exposure],
+            providers: vec![SuggestionProvider::Dynamic],
             provider_constraints: Some(SuggestionProviderConstraints {
-                exposure_suggestion_types: Some(
+                dynamic_suggestion_types: Some(
                     suggestion_types.iter().map(|s| s.to_string()).collect(),
                 ),
                 ..SuggestionProviderConstraints::default()

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -24,7 +24,7 @@ use crate::{
     metrics::{MetricsContext, SuggestIngestionMetrics, SuggestQueryMetrics},
     provider::{SuggestionProvider, SuggestionProviderConstraints, DEFAULT_INGEST_PROVIDERS},
     rs::{
-        Client, Collection, DownloadedExposureRecord, Record, SuggestAttachment, SuggestRecord,
+        Client, Collection, DownloadedDynamicRecord, Record, SuggestAttachment, SuggestRecord,
         SuggestRecordId, SuggestRecordType, SuggestRemoteSettingsClient,
     },
     QueryWithMetricsResult, Result, SuggestApiResult, Suggestion, SuggestionQuery,
@@ -341,17 +341,17 @@ impl SuggestIngestionConstraints {
                 SuggestionProvider::Mdn,
                 SuggestionProvider::Weather,
                 SuggestionProvider::Fakespot,
-                SuggestionProvider::Exposure,
+                SuggestionProvider::Dynamic,
             ]),
             ..Self::default()
         }
     }
 
-    fn matches_exposure_record(&self, record: &DownloadedExposureRecord) -> bool {
+    fn matches_dynamic_record(&self, record: &DownloadedDynamicRecord) -> bool {
         match self
             .provider_constraints
             .as_ref()
-            .and_then(|c| c.exposure_suggestion_types.as_ref())
+            .and_then(|c| c.dynamic_suggestion_types.as_ref())
         {
             None => false,
             Some(suggestion_types) => suggestion_types
@@ -422,7 +422,7 @@ impl<S> SuggestStoreInner<S> {
                     SuggestionProvider::Mdn => dao.fetch_mdn_suggestions(&query),
                     SuggestionProvider::Weather => dao.fetch_weather_suggestions(&query),
                     SuggestionProvider::Fakespot => dao.fetch_fakespot_suggestions(&query),
-                    SuggestionProvider::Exposure => dao.fetch_exposure_suggestions(&query),
+                    SuggestionProvider::Dynamic => dao.fetch_dynamic_suggestions(&query),
                 })
             })?;
             suggestions.extend(new_suggestions);
@@ -693,18 +693,14 @@ where
                     dao.insert_fakespot_suggestions(record_id, suggestions)
                 })?;
             }
-            SuggestRecord::Exposure(r) => {
-                if constraints.matches_exposure_record(r) {
+            SuggestRecord::Dynamic(r) => {
+                if constraints.matches_dynamic_record(r) {
                     self.download_attachment(
                         dao,
                         record,
                         context,
                         |dao, record_id, suggestions| {
-                            dao.insert_exposure_suggestions(
-                                record_id,
-                                &r.suggestion_type,
-                                suggestions,
-                            )
+                            dao.insert_dynamic_suggestions(record_id, r, suggestions)
                         },
                     )?;
                 }
@@ -746,15 +742,9 @@ where
         constraints: &SuggestIngestionConstraints,
     ) -> Result<bool> {
         match &record.payload {
-            SuggestRecord::Exposure(r) => {
-                // Even though the record was previously ingested, its
-                // suggestion wouldn't have been if it never matched the
-                // provider constraints of any ingest. Return true if the
-                // suggestion is not ingested and the provider constraints of
-                // the current ingest do match the suggestion.
-                Ok(!dao.is_exposure_suggestion_ingested(&record.id)?
-                    && constraints.matches_exposure_record(r))
-            }
+            SuggestRecord::Dynamic(r) => Ok(!dao
+                .are_suggestions_ingested_for_record(&record.id)?
+                && constraints.matches_dynamic_record(r)),
             SuggestRecord::Amp => {
                 Ok(constraints.amp_matching_uses_fts()
                     && !dao.is_amp_fts_data_ingested(&record.id)?)
@@ -918,7 +908,8 @@ pub(crate) mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use crate::{
-        provider::AmpMatchingStrategy, suggestion::FtsMatchInfo, testing::*, SuggestionProvider,
+        db::DEFAULT_SUGGESTION_SCORE, provider::AmpMatchingStrategy, suggestion::FtsMatchInfo,
+        testing::*, SuggestionProvider,
     };
 
     // Extra methods for the tests
@@ -2708,74 +2699,112 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn exposure_basic() -> anyhow::Result<()> {
+    fn dynamic_basic() -> anyhow::Result<()> {
         before_each();
 
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(SuggestionProvider::Exposure.full_record(
-                    "exposure-0",
+                // A dynamic record whose attachment is a JSON object that only
+                // contains keywords
+                .with_record(SuggestionProvider::Dynamic.full_record(
+                    "dynamic-0",
                     Some(json!({
                         "suggestion_type": "aaa",
                     })),
                     Some(MockAttachment::Json(json!({
                         "keywords": [
                             "aaa keyword",
-                            "both keyword",
+                            "common keyword",
                             ["common prefix", [" aaa"]],
                             ["choco", ["bo", "late"]],
                             ["dup", ["licate 1", "licate 2"]],
                         ],
                     }))),
                 ))
-                .with_record(SuggestionProvider::Exposure.full_record(
-                    "exposure-1",
+                // A dynamic record with a score whose attachment is a JSON
+                // array with multiple suggestions with various properties
+                .with_record(SuggestionProvider::Dynamic.full_record(
+                    "dynamic-1",
                     Some(json!({
                         "suggestion_type": "bbb",
+                        "score": 1.0,
                     })),
-                    Some(MockAttachment::Json(json!({
-                        "keywords": [
-                            "bbb keyword",
-                            "both keyword",
-                            ["common prefix", [" bbb"]],
-                        ],
-                    }))),
+                    Some(MockAttachment::Json(json!([
+                        {
+                            "keywords": [
+                                "bbb keyword 0",
+                                "common keyword",
+                                "common bbb keyword",
+                                ["common prefix", [" bbb 0"]],
+                            ],
+                        },
+                        {
+                            "keywords": [
+                                "bbb keyword 1",
+                                "common keyword",
+                                "common bbb keyword",
+                                ["common prefix", [" bbb 1"]],
+                            ],
+                            "dismissal_key": "bbb-1-dismissal-key",
+                        },
+                        {
+                            "keywords": [
+                                "bbb keyword 2",
+                                "common keyword",
+                                "common bbb keyword",
+                                ["common prefix", [" bbb 2"]],
+                            ],
+                            "data": json!("bbb-2-data"),
+                            "dismissal_key": "bbb-2-dismissal-key",
+                        },
+                        {
+                            "keywords": [
+                                "bbb keyword 3",
+                                "common keyword",
+                                "common bbb keyword",
+                                ["common prefix", [" bbb 3"]],
+                            ],
+                            "data": json!("bbb-3-data"),
+                        },
+                    ]))),
                 )),
         );
         store.ingest(SuggestIngestionConstraints {
-            providers: Some(vec![SuggestionProvider::Exposure]),
+            providers: Some(vec![SuggestionProvider::Dynamic]),
             provider_constraints: Some(SuggestionProviderConstraints {
-                exposure_suggestion_types: Some(vec!["aaa".to_string(), "bbb".to_string()]),
+                dynamic_suggestion_types: Some(vec!["aaa".to_string(), "bbb".to_string()]),
                 ..SuggestionProviderConstraints::default()
             }),
             ..SuggestIngestionConstraints::all_providers()
         });
 
-        let no_matches = vec!["aaa", "both", "common prefi", "choc", "chocolate extra"];
-        for query in &no_matches {
+        // queries that shouldn't match anything
+        let no_match_queries = vec!["aaa", "common", "common prefi", "choc", "chocolate extra"];
+        for query in &no_match_queries {
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
                 vec![],
             );
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["bbb"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["bbb"])),
                 vec![],
             );
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa", "bbb"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa", "bbb"])),
                 vec![],
             );
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa", "zzz"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa", "zzz"])),
                 vec![],
             );
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["zzz"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["zzz"])),
                 vec![],
             );
         }
 
-        let aaa_only_matches = vec![
+        // queries that should match only the "aaa" suggestion
+        let aaa_queries = [
             "aaa keyword",
             "common prefix a",
             "common prefix aa",
@@ -2792,301 +2821,614 @@ pub(crate) mod tests {
             "duplicate 1",
             "duplicate 2",
         ];
-        for query in &aaa_only_matches {
+        for query in aaa_queries {
+            for suggestion_types in [
+                ["aaa"].as_slice(),
+                &["aaa", "bbb"],
+                &["bbb", "aaa"],
+                &["aaa", "zzz"],
+                &["zzz", "aaa"],
+            ] {
+                assert_eq!(
+                    store.fetch_suggestions(SuggestionQuery::dynamic(query, suggestion_types)),
+                    vec![Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: None,
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    }],
+                );
+            }
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "aaa".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa", "bbb"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "aaa".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["bbb", "aaa"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "aaa".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa", "zzz"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "aaa".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["zzz", "aaa"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "aaa".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["bbb"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["bbb"])),
                 vec![],
             );
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["zzz"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["zzz"])),
                 vec![],
             );
         }
 
-        let bbb_only_matches = vec![
-            "bbb keyword",
+        // queries that should match only the "bbb 0" suggestion
+        let bbb_0_queries = ["bbb keyword 0", "common prefix bbb 0"];
+        for query in &bbb_0_queries {
+            for suggestion_types in [
+                ["bbb"].as_slice(),
+                &["bbb", "aaa"],
+                &["aaa", "bbb"],
+                &["bbb", "zzz"],
+                &["zzz", "bbb"],
+            ] {
+                assert_eq!(
+                    store.fetch_suggestions(SuggestionQuery::dynamic(query, suggestion_types)),
+                    vec![Suggestion::Dynamic {
+                        suggestion_type: "bbb".into(),
+                        data: None,
+                        dismissal_key: None,
+                        score: 1.0,
+                    }],
+                );
+            }
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![],
+            );
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["zzz"])),
+                vec![],
+            );
+        }
+
+        // queries that should match only the "bbb 1" suggestion
+        let bbb_1_queries = ["bbb keyword 1", "common prefix bbb 1"];
+        for query in &bbb_1_queries {
+            for suggestion_types in [
+                ["bbb"].as_slice(),
+                &["bbb", "aaa"],
+                &["aaa", "bbb"],
+                &["bbb", "zzz"],
+                &["zzz", "bbb"],
+            ] {
+                assert_eq!(
+                    store.fetch_suggestions(SuggestionQuery::dynamic(query, suggestion_types)),
+                    vec![Suggestion::Dynamic {
+                        suggestion_type: "bbb".into(),
+                        data: None,
+                        dismissal_key: Some("bbb-1-dismissal-key".to_string()),
+                        score: 1.0,
+                    }],
+                );
+            }
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![],
+            );
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["zzz"])),
+                vec![],
+            );
+        }
+
+        // queries that should match only the "bbb 2" suggestion
+        let bbb_2_queries = ["bbb keyword 2", "common prefix bbb 2"];
+        for query in &bbb_2_queries {
+            for suggestion_types in [
+                ["bbb"].as_slice(),
+                &["bbb", "aaa"],
+                &["aaa", "bbb"],
+                &["bbb", "zzz"],
+                &["zzz", "bbb"],
+            ] {
+                assert_eq!(
+                    store.fetch_suggestions(SuggestionQuery::dynamic(query, suggestion_types)),
+                    vec![Suggestion::Dynamic {
+                        suggestion_type: "bbb".into(),
+                        data: Some(json!("bbb-2-data")),
+                        dismissal_key: Some("bbb-2-dismissal-key".to_string()),
+                        score: 1.0,
+                    }],
+                );
+            }
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![],
+            );
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["zzz"])),
+                vec![],
+            );
+        }
+
+        // queries that should match only the "bbb 3" suggestion
+        let bbb_3_queries = ["bbb keyword 3", "common prefix bbb 3"];
+        for query in &bbb_3_queries {
+            for suggestion_types in [
+                ["bbb"].as_slice(),
+                &["bbb", "aaa"],
+                &["aaa", "bbb"],
+                &["bbb", "zzz"],
+                &["zzz", "bbb"],
+            ] {
+                assert_eq!(
+                    store.fetch_suggestions(SuggestionQuery::dynamic(query, suggestion_types)),
+                    vec![Suggestion::Dynamic {
+                        suggestion_type: "bbb".into(),
+                        data: Some(json!("bbb-3-data")),
+                        dismissal_key: None,
+                        score: 1.0,
+                    }],
+                );
+            }
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![],
+            );
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["zzz"])),
+                vec![],
+            );
+        }
+
+        // queries that should match only the "bbb" suggestions
+        let bbb_queries = [
+            "common bbb keyword",
             "common prefix b",
             "common prefix bb",
             "common prefix bbb",
+            "common prefix bbb ",
         ];
-        for query in &bbb_only_matches {
+        for query in &bbb_queries {
+            for suggestion_types in [
+                ["bbb"].as_slice(),
+                &["bbb", "aaa"],
+                &["aaa", "bbb"],
+                &["bbb", "zzz"],
+                &["zzz", "bbb"],
+            ] {
+                assert_eq!(
+                    store.fetch_suggestions(SuggestionQuery::dynamic(query, suggestion_types)),
+                    vec![
+                        Suggestion::Dynamic {
+                            suggestion_type: "bbb".into(),
+                            data: None,
+                            dismissal_key: None,
+                            score: 1.0,
+                        },
+                        Suggestion::Dynamic {
+                            suggestion_type: "bbb".into(),
+                            data: None,
+                            dismissal_key: Some("bbb-1-dismissal-key".to_string()),
+                            score: 1.0,
+                        },
+                        Suggestion::Dynamic {
+                            suggestion_type: "bbb".into(),
+                            data: Some(json!("bbb-2-data")),
+                            dismissal_key: Some("bbb-2-dismissal-key".to_string()),
+                            score: 1.0,
+                        },
+                        Suggestion::Dynamic {
+                            suggestion_type: "bbb".into(),
+                            data: Some(json!("bbb-3-data")),
+                            dismissal_key: None,
+                            score: 1.0,
+                        }
+                    ],
+                );
+            }
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["bbb"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "bbb".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["bbb", "aaa"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "bbb".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa", "bbb"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "bbb".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["bbb", "zzz"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "bbb".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["zzz", "bbb"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "bbb".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
                 vec![],
             );
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["zzz"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["zzz"])),
                 vec![],
             );
         }
 
-        let both_matches = vec!["both keyword", "common prefix", "common prefix "];
-        for query in &both_matches {
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "aaa".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["bbb"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "bbb".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa", "bbb"])),
-                vec![
-                    Suggestion::Exposure {
-                        suggestion_type: "aaa".into(),
-                        score: 1.0,
-                    },
-                    Suggestion::Exposure {
-                        suggestion_type: "bbb".into(),
-                        score: 1.0,
-                    },
-                ],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["bbb", "aaa"])),
-                vec![
-                    Suggestion::Exposure {
-                        suggestion_type: "aaa".into(),
-                        score: 1.0,
-                    },
-                    Suggestion::Exposure {
-                        suggestion_type: "bbb".into(),
-                        score: 1.0,
-                    },
-                ],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa", "zzz"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "aaa".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["zzz", "aaa"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "aaa".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["bbb", "zzz"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "bbb".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["zzz", "bbb"])),
-                vec![Suggestion::Exposure {
-                    suggestion_type: "bbb".into(),
-                    score: 1.0,
-                }],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa", "zzz", "bbb"])),
-                vec![
-                    Suggestion::Exposure {
-                        suggestion_type: "aaa".into(),
-                        score: 1.0,
-                    },
-                    Suggestion::Exposure {
-                        suggestion_type: "bbb".into(),
-                        score: 1.0,
-                    },
-                ],
-            );
-            assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["zzz"])),
-                vec![],
-            );
+        // queries that should match all suggestions
+        let common_queries = ["common keyword", "common prefix", "common prefix "];
+        for query in &common_queries {
+            for suggestion_types in [
+                ["aaa", "bbb"].as_slice(),
+                &["bbb", "aaa"],
+                &["zzz", "aaa", "bbb"],
+                &["aaa", "zzz", "bbb"],
+                &["aaa", "bbb", "zzz"],
+            ] {
+                assert_eq!(
+                    store.fetch_suggestions(SuggestionQuery::dynamic(query, suggestion_types)),
+                    vec![
+                        Suggestion::Dynamic {
+                            suggestion_type: "bbb".into(),
+                            data: None,
+                            dismissal_key: None,
+                            score: 1.0,
+                        },
+                        Suggestion::Dynamic {
+                            suggestion_type: "bbb".into(),
+                            data: None,
+                            dismissal_key: Some("bbb-1-dismissal-key".to_string()),
+                            score: 1.0,
+                        },
+                        Suggestion::Dynamic {
+                            suggestion_type: "bbb".into(),
+                            data: Some(json!("bbb-2-data")),
+                            dismissal_key: Some("bbb-2-dismissal-key".to_string()),
+                            score: 1.0,
+                        },
+                        Suggestion::Dynamic {
+                            suggestion_type: "bbb".into(),
+                            data: Some(json!("bbb-3-data")),
+                            dismissal_key: None,
+                            score: 1.0,
+                        },
+                        Suggestion::Dynamic {
+                            suggestion_type: "aaa".into(),
+                            data: None,
+                            dismissal_key: None,
+                            score: DEFAULT_SUGGESTION_SCORE,
+                        },
+                    ],
+                );
+                assert_eq!(
+                    store.fetch_suggestions(SuggestionQuery::dynamic(query, &["zzz"])),
+                    vec![],
+                );
+            }
         }
 
         Ok(())
     }
 
     #[test]
-    fn exposure_spread_across_multiple_records() -> anyhow::Result<()> {
+    fn dynamic_same_type_in_different_records() -> anyhow::Result<()> {
         before_each();
 
+        // Make a store with the same dynamic suggestion type in three different
+        // records.
         let mut store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(SuggestionProvider::Exposure.full_record(
-                    "exposure-0",
+                // A record whose attachment is a JSON object
+                .with_record(SuggestionProvider::Dynamic.full_record(
+                    "dynamic-0",
                     Some(json!({
                         "suggestion_type": "aaa",
                     })),
                     Some(MockAttachment::Json(json!({
                         "keywords": [
                             "record 0 keyword",
-                            ["sug", ["gest"]],
+                            "common keyword",
+                            ["common prefix", [" 0"]],
                         ],
+                        "data": json!("record-0-data"),
                     }))),
                 ))
-                .with_record(SuggestionProvider::Exposure.full_record(
-                    "exposure-1",
+                // Another record whose attachment is a JSON object
+                .with_record(SuggestionProvider::Dynamic.full_record(
+                    "dynamic-1",
                     Some(json!({
                         "suggestion_type": "aaa",
                     })),
                     Some(MockAttachment::Json(json!({
                         "keywords": [
                             "record 1 keyword",
-                            ["sug", ["arplum"]],
+                            "common keyword",
+                            ["common prefix", [" 1"]],
                         ],
+                        "data": json!("record-1-data"),
                     }))),
+                ))
+                // A record whose attachment is a JSON array with some
+                // suggestions
+                .with_record(SuggestionProvider::Dynamic.full_record(
+                    "dynamic-2",
+                    Some(json!({
+                        "suggestion_type": "aaa",
+                    })),
+                    Some(MockAttachment::Json(json!([
+                        {
+                            "keywords": [
+                                "record 2 keyword",
+                                "record 2 keyword 0",
+                                "common keyword",
+                                ["common prefix", [" 2-0"]],
+                            ],
+                            "data": json!("record-2-data-0"),
+                        },
+                        {
+                            "keywords": [
+                                "record 2 keyword",
+                                "record 2 keyword 1",
+                                "common keyword",
+                                ["common prefix", [" 2-1"]],
+                            ],
+                            "data": json!("record-2-data-1"),
+                        },
+                    ]))),
                 )),
         );
         store.ingest(SuggestIngestionConstraints {
-            providers: Some(vec![SuggestionProvider::Exposure]),
+            providers: Some(vec![SuggestionProvider::Dynamic]),
             provider_constraints: Some(SuggestionProviderConstraints {
-                exposure_suggestion_types: Some(vec!["aaa".to_string()]),
+                dynamic_suggestion_types: Some(vec!["aaa".to_string()]),
                 ..SuggestionProviderConstraints::default()
             }),
             ..SuggestIngestionConstraints::all_providers()
         });
 
-        let matches = vec![
-            "record 0 keyword",
-            "sug",
-            "sugg",
-            "sugge",
-            "sugges",
-            "suggest",
-            "record 1 keyword",
-            "suga",
-            "sugar",
-            "sugarp",
-            "sugarpl",
-            "sugarplu",
-            "sugarplum",
-        ];
-        for query in &matches {
+        // queries that should match only the suggestion in record 0
+        let record_0_queries = ["record 0 keyword", "common prefix 0"];
+        for query in record_0_queries {
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa"])),
-                vec![Suggestion::Exposure {
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![Suggestion::Dynamic {
                     suggestion_type: "aaa".into(),
-                    score: 1.0,
+                    data: Some(json!("record-0-data")),
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
                 }],
             );
         }
 
-        // Delete the first record.
+        // queries that should match only the suggestion in record 1
+        let record_1_queries = ["record 1 keyword", "common prefix 1"];
+        for query in record_1_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![Suggestion::Dynamic {
+                    suggestion_type: "aaa".into(),
+                    data: Some(json!("record-1-data")),
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                }],
+            );
+        }
+
+        // queries that should match only the suggestions in record 2
+        let record_2_queries = ["record 2 keyword", "common prefix 2", "common prefix 2-"];
+        for query in record_2_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-2-data-0")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-2-data-1")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                ],
+            );
+        }
+
+        // queries that should match only record 2 suggestion 0
+        let record_2_0_queries = ["record 2 keyword 0", "common prefix 2-0"];
+        for query in record_2_0_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![Suggestion::Dynamic {
+                    suggestion_type: "aaa".into(),
+                    data: Some(json!("record-2-data-0")),
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                }],
+            );
+        }
+
+        // queries that should match only record 2 suggestion 1
+        let record_2_1_queries = ["record 2 keyword 1", "common prefix 2-1"];
+        for query in record_2_1_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![Suggestion::Dynamic {
+                    suggestion_type: "aaa".into(),
+                    data: Some(json!("record-2-data-1")),
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                }],
+            );
+        }
+
+        // queries that should match all suggestions
+        let common_queries = ["common keyword", "common prefix", "common prefix "];
+        for query in common_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-0-data")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-1-data")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-2-data-0")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-2-data-1")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                ],
+            );
+        }
+
+        // Delete record 0.
         store
             .client_mut()
-            .delete_record(SuggestionProvider::Exposure.empty_record("exposure-0"));
+            .delete_record(SuggestionProvider::Dynamic.empty_record("dynamic-0"));
         store.ingest(SuggestIngestionConstraints {
-            providers: Some(vec![SuggestionProvider::Exposure]),
+            providers: Some(vec![SuggestionProvider::Dynamic]),
             provider_constraints: Some(SuggestionProviderConstraints {
-                exposure_suggestion_types: Some(vec!["aaa".to_string()]),
+                dynamic_suggestion_types: Some(vec!["aaa".to_string()]),
                 ..SuggestionProviderConstraints::default()
             }),
             ..SuggestIngestionConstraints::all_providers()
         });
 
-        // Keywords from the second record should still return the suggestion.
-        let record_1_matches = vec![
-            "record 1 keyword",
-            "sug",
-            "suga",
-            "sugar",
-            "sugarp",
-            "sugarpl",
-            "sugarplu",
-            "sugarplum",
-        ];
-        for query in &record_1_matches {
+        // Keywords from record 0 should not match anything.
+        for query in record_0_queries {
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["aaa"])),
-                vec![Suggestion::Exposure {
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![],
+            );
+        }
+
+        // The suggestion in record 1 should remain fetchable.
+        for query in record_1_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![Suggestion::Dynamic {
                     suggestion_type: "aaa".into(),
-                    score: 1.0,
+                    data: Some(json!("record-1-data")),
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
                 }],
             );
         }
 
-        // Keywords from the first record should not return the suggestion.
-        let record_0_matches = vec!["record 0 keyword", "sugg", "sugge", "sugges", "suggest"];
-        for query in &record_0_matches {
+        // The suggestions in record 2 should remain fetchable.
+        for query in record_2_queries {
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, &["exposure-test"])),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-2-data-0")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-2-data-1")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                ],
+            );
+        }
+        for query in record_2_0_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![Suggestion::Dynamic {
+                    suggestion_type: "aaa".into(),
+                    data: Some(json!("record-2-data-0")),
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                }],
+            );
+        }
+        for query in record_2_1_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![Suggestion::Dynamic {
+                    suggestion_type: "aaa".into(),
+                    data: Some(json!("record-2-data-1")),
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                }],
+            );
+        }
+
+        // All remaining suggestions should remain fetchable via the common
+        // keywords.
+        for query in common_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-1-data")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-2-data-0")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                    Suggestion::Dynamic {
+                        suggestion_type: "aaa".into(),
+                        data: Some(json!("record-2-data-1")),
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
+                    },
+                ],
+            );
+        }
+
+        // Delete record 2.
+        store
+            .client_mut()
+            .delete_record(SuggestionProvider::Dynamic.empty_record("dynamic-2"));
+        store.ingest(SuggestIngestionConstraints {
+            providers: Some(vec![SuggestionProvider::Dynamic]),
+            provider_constraints: Some(SuggestionProviderConstraints {
+                dynamic_suggestion_types: Some(vec!["aaa".to_string()]),
+                ..SuggestionProviderConstraints::default()
+            }),
+            ..SuggestIngestionConstraints::all_providers()
+        });
+
+        // Keywords from record 0 still should not match anything.
+        for query in record_0_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![],
+            );
+        }
+
+        // The suggestion in record 1 should remain fetchable.
+        for query in record_1_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![Suggestion::Dynamic {
+                    suggestion_type: "aaa".into(),
+                    data: Some(json!("record-1-data")),
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                }],
+            );
+        }
+
+        // The suggestions in record 2 should not be fetchable.
+        for query in record_2_queries
+            .iter()
+            .chain(record_2_0_queries.iter().chain(record_2_1_queries.iter()))
+        {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
                 vec![]
+            );
+        }
+
+        // The one remaining suggestion, from record 1, should remain fetchable
+        // via the common keywords.
+        for query in common_queries {
+            assert_eq!(
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, &["aaa"])),
+                vec![Suggestion::Dynamic {
+                    suggestion_type: "aaa".into(),
+                    data: Some(json!("record-1-data")),
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                },],
             );
         }
 
@@ -3094,14 +3436,14 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn exposure_ingest() -> anyhow::Result<()> {
+    fn dynamic_ingest_provider_constraints() -> anyhow::Result<()> {
         before_each();
 
         // Create suggestions with types "aaa" and "bbb".
         let store = TestStore::new(
             MockRemoteSettingsClient::default()
-                .with_record(SuggestionProvider::Exposure.full_record(
-                    "exposure-0",
+                .with_record(SuggestionProvider::Dynamic.full_record(
+                    "dynamic-0",
                     Some(json!({
                         "suggestion_type": "aaa",
                     })),
@@ -3109,8 +3451,8 @@ pub(crate) mod tests {
                         "keywords": ["aaa keyword", "both keyword"],
                     }))),
                 ))
-                .with_record(SuggestionProvider::Exposure.full_record(
-                    "exposure-1",
+                .with_record(SuggestionProvider::Dynamic.full_record(
+                    "dynamic-1",
                     Some(json!({
                         "suggestion_type": "bbb",
                     })),
@@ -3124,7 +3466,7 @@ pub(crate) mod tests {
         // be ingested but their attachments won't be, so fetches shouldn't
         // return any suggestions.
         store.ingest(SuggestIngestionConstraints {
-            providers: Some(vec![SuggestionProvider::Exposure]),
+            providers: Some(vec![SuggestionProvider::Dynamic]),
             provider_constraints: None,
             ..SuggestIngestionConstraints::all_providers()
         });
@@ -3142,7 +3484,7 @@ pub(crate) mod tests {
         ];
         for (query, types) in &ingest_1_queries {
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, types)),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, types)),
                 vec![],
             );
         }
@@ -3150,9 +3492,9 @@ pub(crate) mod tests {
         // Ingest only the "bbb" suggestion. The "bbb" attachment should be
         // ingested, so "bbb" fetches should return the "bbb" suggestion.
         store.ingest(SuggestIngestionConstraints {
-            providers: Some(vec![SuggestionProvider::Exposure]),
+            providers: Some(vec![SuggestionProvider::Dynamic]),
             provider_constraints: Some(SuggestionProviderConstraints {
-                exposure_suggestion_types: Some(vec!["bbb".to_string()]),
+                dynamic_suggestion_types: Some(vec!["bbb".to_string()]),
                 ..SuggestionProviderConstraints::default()
             }),
             ..SuggestIngestionConstraints::all_providers()
@@ -3171,12 +3513,14 @@ pub(crate) mod tests {
         ];
         for (query, types, expected_types) in &ingest_2_queries {
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, types)),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, types)),
                 expected_types
                     .iter()
-                    .map(|t| Suggestion::Exposure {
+                    .map(|t| Suggestion::Dynamic {
                         suggestion_type: t.to_string(),
-                        score: 1.0,
+                        data: None,
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
                     })
                     .collect::<Vec<Suggestion>>(),
             );
@@ -3184,9 +3528,9 @@ pub(crate) mod tests {
 
         // Now ingest the "aaa" suggestion.
         store.ingest(SuggestIngestionConstraints {
-            providers: Some(vec![SuggestionProvider::Exposure]),
+            providers: Some(vec![SuggestionProvider::Dynamic]),
             provider_constraints: Some(SuggestionProviderConstraints {
-                exposure_suggestion_types: Some(vec!["aaa".to_string()]),
+                dynamic_suggestion_types: Some(vec!["aaa".to_string()]),
                 ..SuggestionProviderConstraints::default()
             }),
             ..SuggestIngestionConstraints::all_providers()
@@ -3205,12 +3549,14 @@ pub(crate) mod tests {
         ];
         for (query, types, expected_types) in &ingest_3_queries {
             assert_eq!(
-                store.fetch_suggestions(SuggestionQuery::exposure(query, types)),
+                store.fetch_suggestions(SuggestionQuery::dynamic(query, types)),
                 expected_types
                     .iter()
-                    .map(|t| Suggestion::Exposure {
+                    .map(|t| Suggestion::Dynamic {
                         suggestion_type: t.to_string(),
-                        score: 1.0,
+                        data: None,
+                        dismissal_key: None,
+                        score: DEFAULT_SUGGESTION_SCORE,
                     })
                     .collect::<Vec<Suggestion>>(),
             );
@@ -3220,13 +3566,13 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn exposure_ingest_new_record() -> anyhow::Result<()> {
+    fn dynamic_ingest_new_record() -> anyhow::Result<()> {
         before_each();
 
-        // Create an exposure suggestion and ingest it.
+        // Create a dynamic suggestion and ingest it.
         let mut store = TestStore::new(MockRemoteSettingsClient::default().with_record(
-            SuggestionProvider::Exposure.full_record(
-                "exposure-0",
+            SuggestionProvider::Dynamic.full_record(
+                "dynamic-0",
                 Some(json!({
                     "suggestion_type": "aaa",
                 })),
@@ -3236,19 +3582,19 @@ pub(crate) mod tests {
             ),
         ));
         store.ingest(SuggestIngestionConstraints {
-            providers: Some(vec![SuggestionProvider::Exposure]),
+            providers: Some(vec![SuggestionProvider::Dynamic]),
             provider_constraints: Some(SuggestionProviderConstraints {
-                exposure_suggestion_types: Some(vec!["aaa".to_string()]),
+                dynamic_suggestion_types: Some(vec!["aaa".to_string()]),
                 ..SuggestionProviderConstraints::default()
             }),
             ..SuggestIngestionConstraints::all_providers()
         });
 
-        // Add a new record of the same exposure type.
+        // Add a new record of the same dynamic type.
         store
             .client_mut()
-            .add_record(SuggestionProvider::Exposure.full_record(
-                "exposure-1",
+            .add_record(SuggestionProvider::Dynamic.full_record(
+                "dynamic-1",
                 Some(json!({
                     "suggestion_type": "aaa",
                 })),
@@ -3257,24 +3603,24 @@ pub(crate) mod tests {
                 }))),
             ));
 
-        // Ingest, but don't ingest the exposure type. The store will download
+        // Ingest, but don't ingest the dynamic type. The store will download
         // the new record but shouldn't ingest its attachment.
         store.ingest(SuggestIngestionConstraints {
-            providers: Some(vec![SuggestionProvider::Exposure]),
+            providers: Some(vec![SuggestionProvider::Dynamic]),
             provider_constraints: None,
             ..SuggestIngestionConstraints::all_providers()
         });
         assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::exposure("new keyword", &["aaa"])),
+            store.fetch_suggestions(SuggestionQuery::dynamic("new keyword", &["aaa"])),
             vec![],
         );
 
-        // Ingest again with the exposure type. The new record will be
+        // Ingest again with the dynamic type. The new record will be
         // unchanged, but the store should now ingest its attachment.
         store.ingest(SuggestIngestionConstraints {
-            providers: Some(vec![SuggestionProvider::Exposure]),
+            providers: Some(vec![SuggestionProvider::Dynamic]),
             provider_constraints: Some(SuggestionProviderConstraints {
-                exposure_suggestion_types: Some(vec!["aaa".to_string()]),
+                dynamic_suggestion_types: Some(vec!["aaa".to_string()]),
                 ..SuggestionProviderConstraints::default()
             }),
             ..SuggestIngestionConstraints::all_providers()
@@ -3283,11 +3629,133 @@ pub(crate) mod tests {
         // The keyword in the new attachment should match the suggestion,
         // confirming that the new record's attachment was ingested.
         assert_eq!(
-            store.fetch_suggestions(SuggestionQuery::exposure("new keyword", &["aaa"])),
-            vec![Suggestion::Exposure {
+            store.fetch_suggestions(SuggestionQuery::dynamic("new keyword", &["aaa"])),
+            vec![Suggestion::Dynamic {
                 suggestion_type: "aaa".to_string(),
-                score: 1.0,
+                data: None,
+                dismissal_key: None,
+                score: DEFAULT_SUGGESTION_SCORE,
             }]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn dynamic_dismissal() -> anyhow::Result<()> {
+        before_each();
+
+        let store = TestStore::new(MockRemoteSettingsClient::default().with_record(
+            SuggestionProvider::Dynamic.full_record(
+                "dynamic-0",
+                Some(json!({
+                    "suggestion_type": "aaa",
+                })),
+                Some(MockAttachment::Json(json!([
+                    {
+                        "keywords": ["aaa"],
+                        "dismissal_key": "dk0",
+                    },
+                    {
+                        "keywords": ["aaa"],
+                        "dismissal_key": "dk1",
+                    },
+                    {
+                        "keywords": ["aaa"],
+                    },
+                ]))),
+            ),
+        ));
+        store.ingest(SuggestIngestionConstraints {
+            providers: Some(vec![SuggestionProvider::Dynamic]),
+            provider_constraints: Some(SuggestionProviderConstraints {
+                dynamic_suggestion_types: Some(vec!["aaa".to_string()]),
+                ..SuggestionProviderConstraints::default()
+            }),
+            ..SuggestIngestionConstraints::all_providers()
+        });
+
+        // Make sure the suggestions are initially fetchable.
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::dynamic("aaa", &["aaa"])),
+            vec![
+                Suggestion::Dynamic {
+                    suggestion_type: "aaa".to_string(),
+                    data: None,
+                    dismissal_key: Some("dk0".to_string()),
+                    score: DEFAULT_SUGGESTION_SCORE,
+                },
+                Suggestion::Dynamic {
+                    suggestion_type: "aaa".to_string(),
+                    data: None,
+                    dismissal_key: Some("dk1".to_string()),
+                    score: DEFAULT_SUGGESTION_SCORE,
+                },
+                Suggestion::Dynamic {
+                    suggestion_type: "aaa".to_string(),
+                    data: None,
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                },
+            ],
+        );
+
+        // Dismiss the first suggestion.
+        store.inner.dismiss_suggestion("dk0".to_string())?;
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::dynamic("aaa", &["aaa"])),
+            vec![
+                Suggestion::Dynamic {
+                    suggestion_type: "aaa".to_string(),
+                    data: None,
+                    dismissal_key: Some("dk1".to_string()),
+                    score: DEFAULT_SUGGESTION_SCORE,
+                },
+                Suggestion::Dynamic {
+                    suggestion_type: "aaa".to_string(),
+                    data: None,
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                },
+            ],
+        );
+
+        // Dismiss the second suggestion.
+        store.inner.dismiss_suggestion("dk1".to_string())?;
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::dynamic("aaa", &["aaa"])),
+            vec![Suggestion::Dynamic {
+                suggestion_type: "aaa".to_string(),
+                data: None,
+                dismissal_key: None,
+                score: DEFAULT_SUGGESTION_SCORE,
+            },],
+        );
+
+        // Clear dismissals. All suggestions should be fetchable again.
+        store.inner.clear_dismissed_suggestions()?;
+        assert_eq!(
+            store.fetch_suggestions(SuggestionQuery::dynamic("aaa", &["aaa"])),
+            vec![
+                Suggestion::Dynamic {
+                    suggestion_type: "aaa".to_string(),
+                    data: None,
+                    dismissal_key: Some("dk0".to_string()),
+                    score: DEFAULT_SUGGESTION_SCORE,
+                },
+                Suggestion::Dynamic {
+                    suggestion_type: "aaa".to_string(),
+                    data: None,
+                    dismissal_key: Some("dk1".to_string()),
+                    score: DEFAULT_SUGGESTION_SCORE,
+                },
+                Suggestion::Dynamic {
+                    suggestion_type: "aaa".to_string(),
+                    data: None,
+                    dismissal_key: None,
+                    score: DEFAULT_SUGGESTION_SCORE,
+                },
+            ],
         );
 
         Ok(())

--- a/components/suggest/src/suggestion.rs
+++ b/components/suggest/src/suggestion.rs
@@ -97,8 +97,14 @@ pub enum Suggestion {
         // and therefore the only one we'll collect metrics for.
         match_info: Option<FtsMatchInfo>,
     },
-    Exposure {
+    Dynamic {
         suggestion_type: String,
+        data: Option<serde_json::Value>,
+        /// This value is optionally defined in the suggestion's remote settings
+        /// data and is an opaque token used for dismissing the suggestion in
+        /// lieu of a URL. If `Some`, the suggestion can be dismissed by passing
+        /// the wrapped string to [crate::SuggestStore::dismiss_suggestion].
+        dismissal_key: Option<String>,
         score: f64,
     },
 }
@@ -190,7 +196,7 @@ impl Suggestion {
             | Self::Mdn { score, .. }
             | Self::Weather { score, .. }
             | Self::Fakespot { score, .. }
-            | Self::Exposure { score, .. } => *score,
+            | Self::Dynamic { score, .. } => *score,
             Self::Wikipedia { .. } => DEFAULT_SUGGESTION_SCORE,
         }
     }

--- a/components/suggest/src/testing/mod.rs
+++ b/components/suggest/src/testing/mod.rs
@@ -47,7 +47,7 @@ impl Suggestion {
             Self::Weather { score, .. } => score,
             Self::Wikipedia { .. } => panic!("with_score not valid for wikipedia suggestions"),
             Self::Fakespot { score, .. } => score,
-            Self::Exposure { score, .. } => score,
+            Self::Dynamic { score, .. } => score,
         };
         *current_score = score;
         self


### PR DESCRIPTION
This replaces the exposure-suggestion type with a more general dynamic-suggestion type. The key differences between the two are:

* Dynamic suggestions are intended to be shown to the user unlike exposure suggestions -- but they don't have to be
* They can have an arbitrary JSON payload
* They can have an opaque dismissal key so they can be dismissed
* They can have a non-default score

Dynamic suggestions can be used to do exposure suggestions, so they're a superset basically.

Not sure if "dynamic" is a great name, I'm open to alternatives. I'm trying to convey that they can carry arbitrary payloads and don't require code changes.

My motivation is that we have a bunch of new suggestion types planned, and I don't want to have to keep making similar additions over and over. And more generally I'd like to move offline Suggest more in the direction of an Elasticsearch or generalized search engine that doesn't need to know every detail about the suggestions it serves.

This PR keeps the keyword-matching strategy of exposure suggestions: exact keyword matching, which should be sufficient for now. It's not hard to imagine supporting different strategies in the future and letting each dynamic suggestion type choose one (as we talked about for [exposure suggestions][1], e.g.: FTS, first word + prefix of remaining words, etc.) In the future I want to explore more sophisticated query parsing and matching like a real search engine would do (as we kind of talked about in [the weather-suggestions PR][2]).

[1]: https://github.com/mozilla/application-services/pull/6343
[2]: https://github.com/mozilla/application-services/pull/6406

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
