### PR TITLE
Make AmpMatchingStrategyArg discriminents start at 1

### DIFF
--- a/examples/suggest-cli/src/main.rs
+++ b/examples/suggest-cli/src/main.rs
@@ -64,7 +64,7 @@ enum Commands {
 #[derive(Clone, Debug, ValueEnum)]
 enum AmpMatchingStrategyArg {
     /// Use keyword matching, without keyword expansion
-    NoKeyword,
+    NoKeyword = 1, // Use `1` as the starting discriminant, since the JS code assumes this.
     /// Use FTS matching
     Fts,
     /// Use FTS matching against the title


### PR DESCRIPTION
This is the easiest way to land https://bugzilla.mozilla.org/show_bug.cgi?id=1924764.

The Desktop code for this currently assumes that discrimenents start at one.  That's how it's worked historically, but that behavior was never correct.  This allows us to fix the bug but not have to update the suggest desktop code.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
