### PR TITLE
DO NOT MERGE - add logins store static key manager factory

### DIFF
--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -42,3 +42,13 @@ pub fn create_static_key_manager(key: String) -> Arc<StaticKeyManager> {
 pub fn create_managed_encdec(key_manager: Arc<dyn KeyManager>) -> Arc<ManagedEncryptorDecryptor> {
     Arc::new(ManagedEncryptorDecryptor::new(key_manager))
 }
+
+// Create a LoginStore by passing in a db path and a static key
+//
+// Note this is only temporarily needed until a bug with UniFFI and JavaScript is fixed, which
+// prevents passing around traits in JS
+pub fn create_login_store_with_static_key_manager(path: String, key: String) -> Arc<LoginStore> {
+    let encdec: ManagedEncryptorDecryptor =
+        ManagedEncryptorDecryptor::new(Arc::new(StaticKeyManager::new(key)));
+    Arc::new(LoginStore::new(path, Arc::new(encdec)).unwrap())
+}

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -28,6 +28,9 @@ namespace logins {
     /// Similar to create_static_key_manager above, create a
     /// ManagedEncryptorDecryptor by passing in a KeyManager
     EncryptorDecryptor create_managed_encdec(KeyManager key_manager);
+
+    /// Create a LoginStore by passing in a db path and a static key
+    LoginStore create_login_store_with_static_key_manager(string path, string key);
 };
 
 /// A login entry from the user, not linked to any database record.


### PR DESCRIPTION
This is for developing as logins for desktop, milestone 3. It is not intended to be merged.

### 1. Look at Cargo.toml, find revision for application-services, eg
```
interrupt-support = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
```
then rev is `8e84c588a5cc2686973c5026ecd240d6275d7e94`. This branch is branched from this rev, so no need for step 2 if above rev matches.

### 2. Rebase jo:as-logins-on-desktop-milestone-3 (https://github.com/mozilla/application-services/pull/6696) to that revision

### 3. replace the revision with above branch, and add logins

```
$ git diff --patch Cargo.toml 
diff --git a/Cargo.toml b/Cargo.toml
index aae4cc3f8adc2..76c3d0f7df119 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,14 +251,15 @@ malloc_size_of_derive = { path = "xpcom/rust/malloc_size_of_derive" }
 objc = { git = "https://github.com/glandium/rust-objc", rev = "4de89f5aa9851ceca4d40e7ac1e2759410c04324" }
 
 # application-services overrides to make updating them all simpler.
-interrupt-support = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
-relevancy = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
-search = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
-sql-support = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
-suggest = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
-sync15 = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
-tabs = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
-viaduct = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
-webext-storage = { git = "https://github.com/mozilla/application-services", rev = "8e84c588a5cc2686973c5026ecd240d6275d7e94" }
+interrupt-support = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
+relevancy = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
+search = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
+sql-support = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
+suggest = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
+sync15 = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
+tabs = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
+viaduct = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
+webext-storage = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
+logins = { git = "https://github.com/jo/application-services", branch = "as-logins-on-desktop-milestone-3" }
 
 allocator-api2 = { path = "third_party/rust/allocator-api2" }
```

### 4. Define dependencies for uniffi
```
$ git diff --patch toolkit/components/uniffi-bindgen-gecko-js/components/Cargo.toml 
diff --git a/toolkit/components/uniffi-bindgen-gecko-js/components/Cargo.toml b/toolkit/components/uniffi-bindgen-gecko-js/components/Cargo.toml
index 0c27a6747c37d..6c9f1ae2d125b 100644
--- a/toolkit/components/uniffi-bindgen-gecko-js/components/Cargo.toml
+++ b/toolkit/components/uniffi-bindgen-gecko-js/components/Cargo.toml
@@ -22,6 +22,11 @@ search = "0.1"
 suggest = "0.1"
 relevancy = "0.1"
 webext-storage = "0.1"
+logins = "0.1"
+# TODO: declaring these dependencies below should not be neccesary, but
+# currently they are for logins
+base16 = "0.2"
+hawk = { version = "5", default-features = false }
 
 [features]
 # Should we depend on xpcom crates?
```

(note 1: I haven't tested the need of declaring hawk and base16 deps with current code)
(note 2: we do not use the feature keydb because 8e84c588a5cc2686973c5026ecd240d6275d7e94 did not include it yet)

### 5. Ensure no commits
except the Cargo dep changes

```
$ git status 
On branch default
Your branch is up to date with 'central/default'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   Cargo.toml
	modified:   toolkit/components/uniffi-bindgen-gecko-js/components/Cargo.toml

no changes added to commit (use "git add" and/or "git commit -a")
```

### 6. Vendor Rust
```
$ ./mach vendor rust --force
```

### 7. Configure UniFFI exports
```
$ git diff --patch toolkit/components/uniffi-bindgen-gecko-js/components/lib.rs 
diff --git a/toolkit/components/uniffi-bindgen-gecko-js/components/lib.rs b/toolkit/components/uniffi-bindgen-gecko-js/components/lib.rs
index 29521a320d53a..eb38a73841bcc 100644
--- a/toolkit/components/uniffi-bindgen-gecko-js/components/lib.rs
+++ b/toolkit/components/uniffi-bindgen-gecko-js/components/lib.rs
@@ -8,6 +8,7 @@ mod reexport_appservices_uniffi_scaffolding {
     suggest::uniffi_reexport_scaffolding!();
     webext_storage::uniffi_reexport_scaffolding!();
     search::uniffi_reexport_scaffolding!();
+    logins::uniffi_reexport_scaffolding!();
 }
 
 // Define extern "C" versions of these UniFFI functions, so that they can be called from C++
```

and ensure they're sync:
```
$ git diff --patch toolkit/components/uniffi-bindgen-gecko-js/config.toml
diff --git a/toolkit/components/uniffi-bindgen-gecko-js/config.toml b/toolkit/components/uniffi-bindgen-gecko-js/config.toml
index 4bfe82e1376fc..df8959fcaf428 100644
--- a/toolkit/components/uniffi-bindgen-gecko-js/config.toml
+++ b/toolkit/components/uniffi-bindgen-gecko-js/config.toml
@@ -95,3 +95,7 @@ enable = true
 
 [uniffi_todolist.async_wrappers]
 enable = true
+
+[uniffi_logins.async_wrappers]
+# all on main thread
+enable = false
```

(note: to betested whether this needed at all, looks like its sync per default)

### 8. Generate JavaScript Bindings
```
$ ./mach uniffi generate
```

Sadly, this currentltly fails due to https://bugzilla.mozilla.org/show_bug.cgi?id=1959469

```
Building gkrust-uniffi-components
   Compiling hashbrown v0.14.999 (/home/jo/moz/mozilla-central/build/rust/hashbrown)
   Compiling hashlink v0.9.1
error[E0599]: no variant or associated item named `default` found for enum `DefaultHashBuilder` in the current scope
  --> /home/jo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashlink-0.9.1/src/linked_hash_map.rs:56:47
   |
56 |             hash_builder: DefaultHashBuilder::default(),
   |                                               ^^^^^^^ variant or associated item not found in `DefaultHashBuilder`

error[E0599]: no variant or associated item named `default` found for enum `DefaultHashBuilder` in the current scope
  --> /home/jo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hashlink-0.9.1/src/linked_hash_map.rs:66:47
   |
66 |             hash_builder: DefaultHashBuilder::default(),
   |                                               ^^^^^^^ variant or associated item not found in `DefaultHashBuilder`
```

Mark knows more.