### PR TITLE
Remote settings storage directory handling fixes

### DIFF
--- a/examples/cli-support/src/lib.rs
+++ b/examples/cli-support/src/lib.rs
@@ -34,6 +34,13 @@ pub fn cli_data_dir() -> String {
     data_path(None).to_string_lossy().to_string()
 }
 
+pub fn ensure_cli_data_dir_exists() {
+    let dir = data_path(None);
+    if !dir.exists() {
+        std::fs::create_dir(&dir).unwrap_or_else(|_| panic!("Error creating dir: {dir:?}"))
+    }
+}
+
 pub fn cli_data_subdir(relative_path: &str) -> String {
     data_path(Some(relative_path)).to_string_lossy().to_string()
 }

--- a/examples/remote-settings-cli/src/main.rs
+++ b/examples/remote-settings-cli/src/main.rs
@@ -118,6 +118,7 @@ fn build_service(cli: &Cli) -> Result<RemoteSettingsService> {
         bucket_name: cli.bucket.clone(),
         app_context: None,
     };
+    cli_support::ensure_cli_data_dir_exists();
     let storage_dir = cli
         .storage_dir
         .clone()


### PR DESCRIPTION
- Fixed code in `components/remote_settings/src/storage.rs` that creates the remote settings data directory.  The old code was mixing up the path with the parent directory.
- Create the `.cli_data` dir in the remote-settings example CLI code. The remote settings service expects consumers to create at least the parent directory of the the data directory.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
