### PR TITLE
Revert "Rename kotlin namespaces to match mozilla-central"

### DIFF
--- a/build-scripts/component-common.gradle
+++ b/build-scripts/component-common.gradle
@@ -43,12 +43,12 @@ kotlin {
 }
 
 dependencies {
-    testImplementation libs.junit.vintage
-    testImplementation libs.testing.mockito
-    testImplementation libs.testing.robolectric
+    testImplementation libs.junit
+    testImplementation libs.mockito
+    testImplementation libs.robolectric
 
-    androidTestImplementation libs.androidx.espresso.core
-    androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.test.espresso.core
+    androidTestImplementation libs.test.runner
 }
 
 // Shared logic for projects that depend on libmegazord

--- a/build.gradle
+++ b/build.gradle
@@ -9,10 +9,6 @@ buildscript {
         jvmTargetCompatibility: 17,
     ]
 
-    ext {
-        protobuf_plugin = libs.versions.protobuf.plugin.get()
-    }
-
     repositories {
         mavenCentral()
         google()
@@ -47,6 +43,7 @@ buildscript {
 plugins {
     alias libs.plugins.detekt
     alias libs.plugins.gradle.download.task  // Downloading libs/archives from Taskcluster.
+    alias libs.plugins.protobuf.gradle apply false
 }
 
 allprojects {

--- a/components/autofill/android/build.gradle
+++ b/components/autofill/android/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     // Part of the public API.
     api project(':sync15')
 
-    testImplementation libs.androidx.test.core
-    testImplementation libs.androidx.work.testing
+    testImplementation libs.test.core
+    testImplementation libs.test.work
     testImplementation project(":syncmanager")
 }
 

--- a/components/fxa-client/android/build.gradle
+++ b/components/fxa-client/android/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    alias libs.plugins.python.envs.plugin
+    alias libs.plugins.gradle.python.envs
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
@@ -17,7 +17,7 @@ dependencies {
 
     implementation libs.mozilla.glean
 
-    testImplementation libs.mozilla.glean.forUnitTests
+    testImplementation libs.mozilla.glean.native.tests
 }
 
 ext.configureUniFFIBindgen("fxa_client")

--- a/components/logins/android/build.gradle
+++ b/components/logins/android/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    alias libs.plugins.python.envs.plugin
+    alias libs.plugins.gradle.python.envs
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
@@ -22,9 +22,9 @@ dependencies {
     implementation libs.mozilla.glean
     implementation project(':init_rust_components')
 
-    testImplementation libs.mozilla.glean.forUnitTests
-    testImplementation libs.androidx.test.core
-    testImplementation libs.androidx.work.testing
+    testImplementation libs.mozilla.glean.native.tests
+    testImplementation libs.test.core
+    testImplementation libs.test.work
     testImplementation project(":syncmanager")
 }
 

--- a/components/nimbus/android/build.gradle
+++ b/components/nimbus/android/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    alias libs.plugins.python.envs.plugin
+    alias libs.plugins.gradle.python.envs
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
@@ -18,13 +18,13 @@ dependencies {
 
     implementation libs.androidx.core
     implementation libs.androidx.annotation
-    implementation libs.kotlin.coroutines
+    implementation libs.kotlinx.coroutines
     implementation libs.mozilla.glean
 
-    testImplementation libs.mozilla.glean.forUnitTests
-    testImplementation libs.androidx.test.core
-    testImplementation libs.androidx.test.junit
-    testImplementation libs.androidx.work.testing
+    testImplementation libs.mozilla.glean.native.tests
+    testImplementation libs.test.core
+    testImplementation libs.test.junit.ext
+    testImplementation libs.test.work
 }
 
 ext.configureUniFFIBindgen("nimbus")

--- a/components/places/android/build.gradle
+++ b/components/places/android/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    alias libs.plugins.python.envs.plugin
+    alias libs.plugins.gradle.python.envs
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
@@ -18,9 +18,9 @@ dependencies {
 
     implementation libs.mozilla.glean
 
-    testImplementation libs.mozilla.glean.forUnitTests
-    testImplementation libs.androidx.test.core
-    testImplementation libs.androidx.work.testing
+    testImplementation libs.mozilla.glean.native.tests
+    testImplementation libs.test.core
+    testImplementation libs.test.work
     testImplementation project(':syncmanager')
 }
 

--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -10,10 +10,6 @@ ext.dependsOnTheMegazord()
 ext.configurePublish()
 
 dependencies {
-    if (gradle.hasProperty("mozconfig")) {
-        api project(':concept-fetch')
-    } else {
-        api libs.mozilla.concept.fetch
-    }
+    testImplementation libs.mozilla.concept.fetch
     testImplementation project(":httpconfig")
 }

--- a/components/sync_manager/android/build.gradle
+++ b/components/sync_manager/android/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    alias libs.plugins.python.envs.plugin
+    alias libs.plugins.gradle.python.envs
 }
 
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
@@ -22,10 +22,10 @@ dependencies {
     implementation libs.androidx.core
     implementation libs.mozilla.glean
 
-    testImplementation libs.mozilla.glean.forUnitTests
-    testImplementation libs.androidx.test.core
-    testImplementation libs.androidx.test.junit
-    testImplementation libs.androidx.work.testing
+    testImplementation libs.mozilla.glean.native.tests
+    testImplementation libs.test.core
+    testImplementation libs.test.junit.ext
+    testImplementation libs.test.work
 }
 
 ext.configureUniFFIBindgen("sync_manager")

--- a/components/viaduct/android/build.gradle
+++ b/components/viaduct/android/build.gradle
@@ -1,7 +1,3 @@
-plugins {
-    alias libs.plugins.protobuf.plugin
-}
-
 apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
 apply from: "$appServicesRootDir/publish.gradle"
 
@@ -20,7 +16,7 @@ android {
 
 protobuf {
     protoc {
-        artifact = libs.protobuf.compiler.get().toString() // https://github.com/google/protobuf-gradle-plugin/issues/563
+        artifact = libs.protoc.get().toString() // https://github.com/google/protobuf-gradle-plugin/issues/563
     }
     generateProtoTasks {
         all().each { task ->
@@ -34,12 +30,8 @@ protobuf {
 }
 
 dependencies {
-    implementation libs.protobuf.javalite
-    if (gradle.hasProperty("mozconfig")) {
-        api project(':concept-fetch')
-    } else {
-        api libs.mozilla.concept.fetch
-    }
+    implementation libs.protobuf
+    api libs.mozilla.concept.fetch
 }
 
 ext.dependsOnTheMegazord()

--- a/components/webext-storage/android/build.gradle
+++ b/components/webext-storage/android/build.gradle
@@ -1,1 +1,22 @@
-// TODO: Add a build.gradle (copying from other components) when webext-storage component is integrated in android
+// TODO: Uncomment this code when webext-storage component is integrated in android
+
+// apply from: "$appServicesRootDir/build-scripts/component-common.gradle"
+// apply from: "$appServicesRootDir/publish.gradle"
+
+// dependencies {
+//     // Part of the public API.
+//     api project(':sync15')
+
+//     implementation libs.androidx.core
+//     implementation libs.mozilla.glean
+
+//     testImplementation libs.mozilla.glean.native.tests
+//     testImplementation libs.test.core
+//     testImplementation libs.test.junit.ext
+//     testImplementation libs.test.work
+// }
+
+
+// ext.configureUniFFIBindgen("../src/webext-storage.udl")
+// ext.dependsOnTheMegazord()
+// ext.configurePublish()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,11 +9,10 @@ android-plugin = "8.9.1"
 
 # Google
 protobuf = "4.30.2"
-protobuf-plugin = "0.9.5"
 
 # Kotlin
 kotlin-compiler = "2.1.20"
-kotlin-coroutines = "1.10.2"
+kotlinx-coroutines = "1.10.2"
 
 # Mozilla
 android-components = "135.0.1"
@@ -32,11 +31,11 @@ detekt = "1.23.8"
 ktlint = "0.50.0"
 
 # AndroidX Testing
-androidx-test = "1.6.1"
+androidx-test-core = "1.6.1"
 androidx-test-espresso = "3.6.1"
 androidx-test-junit = "1.2.1"
 androidx-test-runner = "1.6.2"
-androidx-work = "2.10.0"
+androidx-test-work = "2.10.0"
 
 # Third Party Testing
 junit = "5.12.0"
@@ -45,25 +44,26 @@ robolectric = "4.14.1"
 
 # Miscellaneous Gradle plugins
 gradle-download-task = "5.6.0"
-python-envs-plugin = "0.0.31"
+protobuf-gradle = "0.9.5"
+python-envs = "0.0.31"
 
 [libraries]
 # AGP
 tools-android-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-plugin" }
 
 # Google
-protobuf-javalite = { group = "com.google.protobuf", name = "protobuf-javalite", version.ref = "protobuf" }
-protobuf-compiler = { group = "com.google.protobuf", name = "protoc", version.ref = "protobuf" }
+protobuf = { group = "com.google.protobuf", name = "protobuf-javalite", version.ref = "protobuf" }
+protoc = { group = "com.google.protobuf", name = "protoc", version.ref = "protobuf" }
 
 # Kotlin
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin-compiler" }
-kotlin-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlin-coroutines" }
+kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 
 # Mozilla
 mozilla-concept-fetch = { group = "org.mozilla.components", name = "concept-fetch", version.ref = "android-components" }
 mozilla-glean = { group = "org.mozilla.telemetry", name = "glean", version.ref = "glean" }
 mozilla-glean-gradle-plugin = { group = "org.mozilla.telemetry", name = "glean-gradle-plugin", version.ref = "glean" }
-mozilla-glean-forUnitTests = { group = "org.mozilla.telemetry", name = "glean-native-forUnitTests", version.ref = "glean" }
+mozilla-glean-native-tests = { group = "org.mozilla.telemetry", name = "glean-native-forUnitTests", version.ref = "glean" }
 mozilla-rust-android-gradle = { group = "org.mozilla.rust-android-gradle", name = "plugin", version.ref = "rust-android-gradle" }
 
 # AndroidX
@@ -77,22 +77,19 @@ jna = { group = "net.java.dev.jna", name = "jna", version.ref = "jna" }
 ktlint = { module = "com.pinterest:ktlint", version.ref = "ktlint" }
 
 # AndroidX Testing
-androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-test-espresso" }
-androidx-test-core = { group = "androidx.test", name = "core-ktx", version.ref = "androidx-test" }
-androidx-test-junit = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-test-junit" }
-androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
-androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "androidx-work" }
-
+test-core = { group = "androidx.test", name = "core-ktx", version.ref = "androidx-test-core" }
 test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidx-test-espresso" }
-
+test-junit-ext = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidx-test-junit" }
+test-runner = { group = "androidx.test", name = "runner", version.ref = "androidx-test-runner" }
+test-work = { group = "androidx.work", name = "work-testing", version.ref = "androidx-test-work" }
 
 # Third Party Testing
-junit-vintage = { group = "org.junit.vintage", name = "junit-vintage-engine", version.ref = "junit" }
-testing-mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
-testing-robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
+junit = { group = "org.junit.vintage", name = "junit-vintage-engine", version.ref = "junit" }
+mockito = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
+robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 gradle-download-task = { id = "de.undercouch.download", version.ref = "gradle-download-task" }
-python-envs-plugin = {id = "com.jetbrains.python.envs", version.ref = "python-envs-plugin"}
-protobuf-plugin = { id = "com.google.protobuf", version.ref = "protobuf-plugin" }
+gradle-python-envs = { id = "com.jetbrains.python.envs", version.ref = "python-envs" }
+protobuf-gradle = { id = "com.google.protobuf", version.ref = "protobuf-gradle" }

--- a/publish.gradle
+++ b/publish.gradle
@@ -21,12 +21,8 @@ ext.configurePublish = {
     publishing {
         publications {
             aar(MavenPublication) {
-                // This doesn't work in m-c, but the entire "publish" flow will almost certainly need rethinking there,
-                // so just paper over this for now.
-                if (!gradle.root.hasProperty("mozconfig")) {
-                    project.afterEvaluate {
-                        from components.release
-                    }
+                project.afterEvaluate {
+                    from components.release
                 }
 
                 if (isMegazord) {


### PR DESCRIPTION
This reverts commit 118211aed01755c8290e6c9225befff98059e500 in another attempt to fix the m-c nightly bump bustage.