### PR TITLE
Fix regression in #6647 in how concept-fetch is used

### DIFF
--- a/components/remote_settings/android/build.gradle
+++ b/components/remote_settings/android/build.gradle
@@ -11,9 +11,9 @@ ext.configurePublish()
 
 dependencies {
     if (gradle.hasProperty("mozconfig")) {
-        api project(':concept-fetch')
+        testImplementation project(':concept-fetch')
     } else {
-        api libs.mozilla.concept.fetch
+        testImplementation libs.mozilla.concept.fetch
     }
     testImplementation project(":httpconfig")
 }


### PR DESCRIPTION
This might have caused app-services nightlies to fail to build in m-c.