### PR TITLE
Use latest version of Android Components concept-fetch [ci full] 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 🦊 What's Changed 🦊
 
+### Android
+- Updated to a newer version of Android Components (`139.0.20250417022706`).
+
 ### Glean
 - Updated to v64.0.0 ([#6649](https://github.com/mozilla/application-services/pull/6649))
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,14 @@ buildscript {
                 includeGroupByRegex "org\\.mozilla\\..*"
             }
         }
+        maven {
+            name "Mozilla Nightly"
+            url "https://nightly.maven.mozilla.org/maven2"
+            content {
+                // Improve performance: only check moz maven for mozilla deps.
+                includeGroupByRegex "org\\.mozilla\\..*"
+            }
+        }
     }
 
     dependencies {
@@ -56,6 +64,14 @@ allprojects {
         maven {
             name "Mozilla"
             url "https://maven.mozilla.org/maven2"
+            content {
+                // Improve performance: only check moz maven for mozilla deps.
+                includeGroupByRegex "org\\.mozilla\\..*"
+            }
+        }
+        maven {
+            name "Mozilla Nightly"
+            url "https://nightly.maven.mozilla.org/maven2"
             content {
                 // Improve performance: only check moz maven for mozilla deps.
                 includeGroupByRegex "org\\.mozilla\\..*"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotlin-compiler = "2.1.20"
 kotlin-coroutines = "1.10.2"
 
 # Mozilla
-android-components = "135.0.1"
+android-components = "139.0.20250417022706"
 glean = "64.0.0"
 rust-android-gradle = "0.9.6"
 


### PR DESCRIPTION
There are [two][0] [patches][1] that need to land in mozilla-central which change the API of concept-fetch.

If those were to land today, it would then cause an incident where rust components are no longer able to communicate over viaduct on Android (via `RustHttpConfig`).

In order to break the cyclical dependency, we need to use a published verion of AC that is not published to Fenix, so that we can consume it in app services first.

I have tested this patch with a local app services that also includes the same patches in AC/Fenix. Without the patches in either project, leads to a signature mismatch.

**Dependencies:** For a version of app services to land in fenix that also includes this patch, it should also include the patches listed above.

[0]: https://phabricator.services.mozilla.com/D242856
[1]: https://phabricator.services.mozilla.com/D244926

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
