### PR TITLE
Add get_visit_count_for_host function

### DIFF
--- a/components/places/src/ffi.rs
+++ b/components/places/src/ffi.rs
@@ -298,6 +298,18 @@ impl PlacesConnection {
     }
 
     #[handle_error(crate::Error)]
+    pub fn get_visit_count_for_host(
+        &self,
+        host: String,
+        before: PlacesTimestamp,
+        exclude_types: VisitTransitionSet,
+    ) -> ApiResult<i64> {
+        self.with_conn(|conn| {
+            history::get_visit_count_for_host(conn, host.as_str(), before, exclude_types)
+        })
+    }
+
+    #[handle_error(crate::Error)]
     pub fn get_visit_page(
         &self,
         offset: i64,

--- a/components/places/src/places.udl
+++ b/components/places/src/places.udl
@@ -98,6 +98,9 @@ interface PlacesConnection {
     i64 get_visit_count(VisitTransitionSet exclude_types);
 
     [Throws=PlacesApiError]
+    i64 get_visit_count_for_host(string host, PlacesTimestamp before, VisitTransitionSet exclude_types);
+
+    [Throws=PlacesApiError]
     sequence<HistoryVisitInfo> get_visit_page(i64 offset, i64 count, VisitTransitionSet exclude_types);
     // TODO: bound should be a `PlacesTimestamp`?
     [Throws=PlacesApiError]


### PR DESCRIPTION
Adds a function getting the visit count for a host before a specified time. This is needed for https://bugzilla.mozilla.org/show_bug.cgi?id=1955414

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.
