### PR TITLE
Switch relevancy to the new remote settings API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ text, the list view has been slimmed down and a detail view has been added.
 
 ### Remote Settings
 - Several methods `RemoteSettingsService` are now infallible, which is a breaking change for Swift code.
+    - `RelevancyStore` constructor
     - `RemoteSettingsService` constructor
     - `RemoteSettingsService::make_client()`
     - `SearchEngineSelector::use_remote_settings_server()`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,11 @@ text, the list view has been slimmed down and a detail view has been added.
 ## ⚠️ Breaking Changes ⚠️
 
 ### Remote Settings
-- The `RemoteSettingsService` constructor is now infallible, which is a breaking change for Swift code.
+- Several methods `RemoteSettingsService` are now infallible, which is a breaking change for Swift code.
+    - `RemoteSettingsService` constructor
+    - `RemoteSettingsService::make_client()`
+    - `SearchEngineSelector::use_remote_settings_server()`
+    - `SuggestStore` constructor
 
 ### OHTTP Client
 - The now-unused `as-ohttp-client` component is now removed. It was previously

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ dependencies = [
  "env_logger",
  "fxa-client",
  "log",
+ "remote_settings",
  "rpassword",
  "sync15",
  "sync_manager",

--- a/components/relevancy/src/ingest.rs
+++ b/components/relevancy/src/ingest.rs
@@ -42,11 +42,8 @@ fn fetch_interest_data_inner<C: RelevancyRemoteSettingsClient>(
     let remote_settings_response = client.get_records()?;
     let mut result = vec![];
 
-    for record in remote_settings_response.records {
-        let attachment_data = match &record.attachment {
-            None => return Err(Error::FetchInterestDataError),
-            Some(a) => client.get_attachment(&a.location)?,
-        };
+    for record in remote_settings_response {
+        let attachment_data = client.get_attachment(&record)?;
         let interest = get_interest(&record)?;
         let urls = get_hash_urls(attachment_data)?;
         result.extend(std::iter::repeat(interest).zip(urls));
@@ -98,7 +95,6 @@ mod test {
     use std::{cell::RefCell, collections::HashMap};
 
     use anyhow::Context;
-    use remote_settings::RemoteSettingsResponse;
     use serde_json::json;
 
     use super::*;
@@ -160,20 +156,12 @@ mod test {
     }
 
     impl RelevancyRemoteSettingsClient for SnapshotSettingsClient {
-        fn get_records(&self) -> Result<RemoteSettingsResponse> {
-            let records = self.snapshot.borrow().records.clone();
-            let last_modified = records
-                .iter()
-                .map(|record: &RemoteSettingsRecord| record.last_modified)
-                .max()
-                .unwrap_or(0);
-            Ok(RemoteSettingsResponse {
-                records,
-                last_modified,
-            })
+        fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
+            Ok(self.snapshot.borrow().records.clone())
         }
 
-        fn get_attachment(&self, location: &str) -> Result<Vec<u8>> {
+        fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
+            let location = record.attachment.as_ref().unwrap().location.as_str();
             Ok(self
                 .snapshot
                 .borrow()

--- a/components/relevancy/src/ingest.rs
+++ b/components/relevancy/src/ingest.rs
@@ -170,6 +170,8 @@ mod test {
                 .unwrap_or_else(|| unreachable!("Unexpected request for attachment `{}`", location))
                 .clone())
         }
+
+        fn close(&self) {}
     }
 
     #[test]

--- a/components/relevancy/src/lib.rs
+++ b/components/relevancy/src/lib.rs
@@ -20,22 +20,25 @@ pub mod url_hash;
 
 use rand_distr::{Beta, Distribution};
 
+use std::{collections::HashMap, sync::Arc};
+
+use parking_lot::Mutex;
+use remote_settings::{RemoteSettingsClient, RemoteSettingsService};
+
 pub use db::RelevancyDb;
 pub use error::{ApiResult, Error, RelevancyApiError, Result};
 pub use interest::{Interest, InterestVector};
-use parking_lot::Mutex;
 pub use ranker::score;
 
 use error_support::handle_error;
 
 use db::BanditData;
-use std::collections::HashMap;
 
 uniffi::setup_scaffolding!();
 
 #[derive(uniffi::Object)]
 pub struct RelevancyStore {
-    inner: RelevancyStoreInner<remote_settings::RemoteSettings>,
+    inner: RelevancyStoreInner<Arc<RemoteSettingsClient>>,
 }
 
 /// Top-level API for the Relevancy component
@@ -46,11 +49,13 @@ impl RelevancyStore {
     ///
     /// This is non-blocking since databases and other resources are lazily opened.
     #[uniffi::constructor]
-    #[handle_error(Error)]
-    pub fn new(db_path: String) -> ApiResult<Self> {
-        Ok(Self {
-            inner: RelevancyStoreInner::new(db_path, rs::create_client()?),
-        })
+    pub fn new(db_path: String, remote_settings: Arc<RemoteSettingsService>) -> Self {
+        Self {
+            inner: RelevancyStoreInner::new(
+                db_path,
+                remote_settings.make_client(rs::REMOTE_SETTINGS_COLLECTION.to_string()),
+            ),
+        }
     }
 
     /// Close any open resources (for example databases)

--- a/components/relevancy/src/lib.rs
+++ b/components/relevancy/src/lib.rs
@@ -164,7 +164,8 @@ impl<C: rs::RelevancyRemoteSettingsClient> RelevancyStoreInner<C> {
     ///
     /// Calling `close` will interrupt any in-progress queries on other threads.
     pub fn close(&self) {
-        self.db.close()
+        self.db.close();
+        self.client.close();
     }
 
     /// Interrupt any current database queries

--- a/components/relevancy/src/rs.rs
+++ b/components/relevancy/src/rs.rs
@@ -4,9 +4,7 @@
  */
 
 use crate::{Error, Result};
-use remote_settings::{
-    RemoteSettings, RemoteSettingsConfig, RemoteSettingsResponse, RemoteSettingsServer,
-};
+use remote_settings::{RemoteSettingsClient, RemoteSettingsRecord};
 use serde::Deserialize;
 /// The Remote Settings collection name.
 pub(crate) const REMOTE_SETTINGS_COLLECTION: &str = "content-relevance";
@@ -16,45 +14,46 @@ pub(crate) const REMOTE_SETTINGS_COLLECTION: &str = "content-relevance";
 /// This trait lets tests use a mock client.
 pub(crate) trait RelevancyRemoteSettingsClient {
     /// Fetches records from the Suggest Remote Settings collection.
-    fn get_records(&self) -> Result<RemoteSettingsResponse>;
+    fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>>;
 
     /// Fetches a record's attachment from the Suggest Remote Settings
     /// collection.
-    fn get_attachment(&self, location: &str) -> Result<Vec<u8>>;
+    fn get_attachment(&self, location: &RemoteSettingsRecord) -> Result<Vec<u8>>;
 }
 
-impl RelevancyRemoteSettingsClient for remote_settings::RemoteSettings {
-    fn get_records(&self) -> Result<RemoteSettingsResponse> {
-        Ok(remote_settings::RemoteSettings::get_records(self)?)
+impl RelevancyRemoteSettingsClient for RemoteSettingsClient {
+    fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
+        self.sync()?;
+        Ok(self
+            .get_records(false)
+            .expect("RemoteSettingsClient::get_records() returned None after `sync()` called"))
     }
 
-    fn get_attachment(&self, location: &str) -> Result<Vec<u8>> {
-        Ok(remote_settings::RemoteSettings::get_attachment(
-            self, location,
-        )?)
+    fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
+        Ok(self.get_attachment(record)?)
     }
 }
 
 impl<T: RelevancyRemoteSettingsClient> RelevancyRemoteSettingsClient for &T {
-    fn get_records(&self) -> Result<RemoteSettingsResponse> {
+    fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
         (*self).get_records()
     }
 
-    fn get_attachment(&self, location: &str) -> Result<Vec<u8>> {
-        (*self).get_attachment(location)
+    fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
+        (*self).get_attachment(record)
     }
 }
 
-pub fn create_client() -> Result<RemoteSettings> {
-    Ok(RemoteSettings::new(RemoteSettingsConfig {
-        collection_name: REMOTE_SETTINGS_COLLECTION.to_string(),
-        server: Some(RemoteSettingsServer::Prod),
-        server_url: None,
-        bucket_name: None,
-    })?)
+impl<T: RelevancyRemoteSettingsClient> RelevancyRemoteSettingsClient for std::sync::Arc<T> {
+    fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
+        (**self).get_records()
+    }
+
+    fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
+        (**self).get_attachment(record)
+    }
 }
 
-/// A record in the Relevancy Remote Settings collection.
 #[derive(Clone, Debug, Deserialize)]
 pub struct RelevancyRecord {
     #[allow(dead_code)]
@@ -115,11 +114,11 @@ pub mod test {
     pub struct NullRelavancyRemoteSettingsClient;
 
     impl RelevancyRemoteSettingsClient for NullRelavancyRemoteSettingsClient {
-        fn get_records(&self) -> Result<RemoteSettingsResponse> {
+        fn get_records(&self) -> Result<Vec<RemoteSettingsRecord>> {
             panic!("NullRelavancyRemoteSettingsClient::get_records was called")
         }
 
-        fn get_attachment(&self, _location: &str) -> Result<Vec<u8>> {
+        fn get_attachment(&self, _record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
             panic!("NullRelavancyRemoteSettingsClient::get_records was called")
         }
     }

--- a/components/relevancy/src/rs.rs
+++ b/components/relevancy/src/rs.rs
@@ -19,6 +19,9 @@ pub(crate) trait RelevancyRemoteSettingsClient {
     /// Fetches a record's attachment from the Suggest Remote Settings
     /// collection.
     fn get_attachment(&self, location: &RemoteSettingsRecord) -> Result<Vec<u8>>;
+
+    /// Close any open resources
+    fn close(&self);
 }
 
 impl RelevancyRemoteSettingsClient for RemoteSettingsClient {
@@ -32,6 +35,10 @@ impl RelevancyRemoteSettingsClient for RemoteSettingsClient {
     fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
         Ok(self.get_attachment(record)?)
     }
+
+    fn close(&self) {
+        self.shutdown()
+    }
 }
 
 impl<T: RelevancyRemoteSettingsClient> RelevancyRemoteSettingsClient for &T {
@@ -42,6 +49,10 @@ impl<T: RelevancyRemoteSettingsClient> RelevancyRemoteSettingsClient for &T {
     fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
         (*self).get_attachment(record)
     }
+
+    fn close(&self) {
+        (*self).close();
+    }
 }
 
 impl<T: RelevancyRemoteSettingsClient> RelevancyRemoteSettingsClient for std::sync::Arc<T> {
@@ -51,6 +62,10 @@ impl<T: RelevancyRemoteSettingsClient> RelevancyRemoteSettingsClient for std::sy
 
     fn get_attachment(&self, record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
         (**self).get_attachment(record)
+    }
+
+    fn close(&self) {
+        (**self).close()
     }
 }
 
@@ -121,5 +136,7 @@ pub mod test {
         fn get_attachment(&self, _record: &RemoteSettingsRecord) -> Result<Vec<u8>> {
             panic!("NullRelavancyRemoteSettingsClient::get_records was called")
         }
+
+        fn close(&self) {}
     }
 }

--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use crate::config::RemoteSettingsConfig;
+use crate::config::{BaseUrl, RemoteSettingsConfig};
 use crate::error::{Error, Result};
 use crate::jexl_filter::JexlFilter;
 #[cfg(feature = "signatures")]
@@ -499,26 +499,21 @@ impl<C: ApiClient> RemoteSettingsClient<C> {
 
 impl RemoteSettingsClient<ViaductApiClient> {
     pub fn new(
-        server_url: Url,
+        server_url: BaseUrl,
         bucket_name: String,
         collection_name: String,
         context: Option<RemoteSettingsContext>,
         storage: Storage,
-    ) -> Result<Self> {
-        let api_client = ViaductApiClient::new(server_url, &bucket_name, &collection_name)?;
+    ) -> Self {
+        let api_client = ViaductApiClient::new(server_url, &bucket_name, &collection_name);
         let jexl_filter = JexlFilter::new(context);
 
-        Ok(Self::new_from_parts(
-            collection_name,
-            storage,
-            jexl_filter,
-            api_client,
-        ))
+        Self::new_from_parts(collection_name, storage, jexl_filter, api_client)
     }
 
-    pub fn update_config(&self, server_url: Url, bucket_name: String) -> Result<()> {
+    pub fn update_config(&self, server_url: BaseUrl, bucket_name: String) -> Result<()> {
         let mut inner = self.inner.lock();
-        inner.api_client = ViaductApiClient::new(server_url, &bucket_name, &self.collection_name)?;
+        inner.api_client = ViaductApiClient::new(server_url, &bucket_name, &self.collection_name);
         inner.storage.empty()
     }
 }
@@ -554,11 +549,11 @@ pub struct ViaductApiClient {
 }
 
 impl ViaductApiClient {
-    fn new(base_url: Url, bucket_name: &str, collection_name: &str) -> Result<Self> {
-        Ok(Self {
-            endpoints: RemoteSettingsEndpoints::new(&base_url, bucket_name, collection_name)?,
+    fn new(base_url: BaseUrl, bucket_name: &str, collection_name: &str) -> Self {
+        Self {
+            endpoints: RemoteSettingsEndpoints::new(&base_url, bucket_name, collection_name),
             remote_state: RemoteState::default(),
-        })
+        }
     }
 
     fn make_request(&mut self, url: Url) -> Result<Response> {
@@ -707,10 +702,10 @@ impl Client {
 
         let bucket_name = config.bucket_name.unwrap_or_else(|| String::from("main"));
         let endpoints = RemoteSettingsEndpoints::new(
-            &server.get_url()?,
+            &server.get_base_url()?,
             &bucket_name,
             &config.collection_name,
-        )?;
+        );
 
         Ok(Self {
             endpoints,
@@ -914,41 +909,31 @@ impl RemoteSettingsEndpoints {
     /// Construct a new RemoteSettingsEndpoints
     ///
     /// `base_url` should have the form `https://[domain]/v1` (no trailing slash).
-    fn new(base_url: &Url, bucket_name: &str, collection_name: &str) -> Result<Self> {
+    fn new(base_url: &BaseUrl, bucket_name: &str, collection_name: &str) -> Self {
         let mut root_url = base_url.clone();
         // Push the empty string to add the trailing slash.
-        Self::path_segments_mut(&mut root_url)?.push("");
+        root_url.path_segments_mut().push("");
 
         let mut collection_url = base_url.clone();
-        Self::path_segments_mut(&mut collection_url)?
+        collection_url
+            .path_segments_mut()
             .push("buckets")
             .push(bucket_name)
             .push("collections")
             .push(collection_name);
 
         let mut records_url = collection_url.clone();
-        Self::path_segments_mut(&mut records_url)?.push("records");
+        records_url.path_segments_mut().push("records");
 
         let mut changeset_url = collection_url.clone();
-        Self::path_segments_mut(&mut changeset_url)?.push("changeset");
+        changeset_url.path_segments_mut().push("changeset");
 
-        Ok(Self {
-            root_url,
-            collection_url,
-            records_url,
-            changeset_url,
-        })
-    }
-
-    /// Utility method for calling [Url::path_segments_mut]
-    ///
-    /// The issue we're working around is that path_segments_mut uses `()` as the error type, which
-    /// can't be converted into our `Error` type.
-    fn path_segments_mut(url: &mut Url) -> Result<url::PathSegmentsMut<'_>> {
-        url.path_segments_mut()
-            // path_segments_mut uses `()` as the error type, but the docs say that it only will
-            // error for cannot-be-a-base URLs.
-            .map_err(|_| Error::UrlParsingError(url::ParseError::RelativeUrlWithCannotBeABaseBase))
+        Self {
+            root_url: root_url.into_inner(),
+            collection_url: collection_url.into_inner(),
+            records_url: records_url.into_inner(),
+            changeset_url: changeset_url.into_inner(),
+        }
     }
 }
 
@@ -1920,11 +1905,10 @@ mod test_new_client {
     #[test]
     fn test_endpoints() {
         let endpoints = RemoteSettingsEndpoints::new(
-            &Url::parse("http://rs.example.com/v1").unwrap(),
+            &BaseUrl::parse("http://rs.example.com/v1").unwrap(),
             "main",
             "test-collection",
-        )
-        .unwrap();
+        );
         assert_eq!(endpoints.root_url.to_string(), "http://rs.example.com/v1/");
         assert_eq!(
             endpoints.collection_url.to_string(),
@@ -1982,7 +1966,7 @@ mod jexl_tests {
             ..Default::default()
         };
 
-        let mut storage = Storage::new(":memory:".into()).expect("Error creating storage");
+        let mut storage = Storage::new(":memory:".into());
         let _ = storage.insert_collection_content(
             "http://rs.example.com/v1/buckets/main/collections/test-collection",
             &records,
@@ -2040,7 +2024,7 @@ mod jexl_tests {
             ..Default::default()
         };
 
-        let mut storage = Storage::new(":memory:".into()).expect("Error creating storage");
+        let mut storage = Storage::new(":memory:".into());
         let _ = storage.insert_collection_content(
             "http://rs.example.com/v1/buckets/main/collections/test-collection",
             &records,
@@ -2221,7 +2205,7 @@ IKdcFKAt3fFrpyMhlfIKkLfmm0iDjmfmIXbDGBJw9SE=
             .expect_fetch_cert()
             .returning(move |_| Ok(certificate.clone().into_bytes()));
 
-        let storage = Storage::new(":memory:".into())?;
+        let storage = Storage::new(":memory:".into());
         let jexl_filter = JexlFilter::new(Some(RemoteSettingsContext::default()));
         let rs_client = RemoteSettingsClient::new_from_parts(
             collection_name.to_string(),

--- a/components/remote_settings/src/client.rs
+++ b/components/remote_settings/src/client.rs
@@ -360,11 +360,7 @@ impl<C: ApiClient> RemoteSettingsClient<C> {
         Ok(())
     }
 
-    /// Close the client
-    ///
-    /// This is typically used during shutdown.  It closes the underlying SQLite connection used to
-    /// cache records.
-    pub fn close(&self) {
+    pub fn shutdown(&self) {
         self.inner.lock().storage.close();
     }
 

--- a/components/remote_settings/src/config.rs
+++ b/components/remote_settings/src/config.rs
@@ -17,7 +17,7 @@ use crate::{ApiResult, Error, RemoteSettingsContext, Result};
 /// This is the version used in the new API, hence the `2` at the end.  The plan is to move
 /// consumers to the new API, remove the RemoteSettingsConfig struct, then remove the `2` from this
 /// name.
-#[derive(Debug, Clone, uniffi::Record)]
+#[derive(Debug, Default, Clone, uniffi::Record)]
 pub struct RemoteSettingsConfig2 {
     /// The Remote Settings server to use. Defaults to [RemoteSettingsServer::Prod],
     #[uniffi(default = None)]

--- a/components/remote_settings/src/config.rs
+++ b/components/remote_settings/src/config.rs
@@ -63,16 +63,31 @@ impl RemoteSettingsServer {
         self.get_url()
     }
 
+    /// Get a BaseUrl for this server
+    pub fn get_base_url(&self) -> Result<BaseUrl> {
+        let base_url = BaseUrl::parse(self.raw_url())?;
+        // Custom URLs are weird and require a couple tricks for backwards compatibility.
+        // Normally we append `v1/` to match how this has historically worked.  However,
+        // don't do this for file:// schemes which normally don't make any sense, but it's
+        // what Nimbus uses to indicate they want to use the file-based client, rather than
+        // a remote-settings based one.
+        if base_url.url().scheme() != "file" {
+            Ok(base_url.join("v1"))
+        } else {
+            Ok(base_url)
+        }
+    }
+
     /// get_url() that never fails
     ///
     /// If the URL is invalid, we'll log a warning and fall back to the production URL
-    pub fn get_url_with_prod_fallback(&self) -> Url {
-        match self.get_url() {
+    pub fn get_base_url_with_prod_fallback(&self) -> BaseUrl {
+        match self.get_base_url() {
             Ok(url) => url,
             // The unwrap below will never fail, since prod is a hard-coded/valid URL.
             Err(_) => {
                 log::warn!("Invalid Custom URL: {}", self.raw_url());
-                Self::Prod.get_url().unwrap()
+                BaseUrl::parse(Self::Prod.raw_url()).unwrap()
             }
         }
     }
@@ -108,5 +123,46 @@ impl RemoteSettingsServer {
                 url
             }
         })
+    }
+}
+
+/// Url that's guaranteed safe to use as a base
+#[derive(Debug, Clone)]
+pub struct BaseUrl {
+    url: Url,
+}
+
+impl BaseUrl {
+    pub fn parse(url: &str) -> Result<Self> {
+        let url = Url::parse(url)?;
+        if url.cannot_be_a_base() {
+            Err(Error::UrlParsingError(
+                url::ParseError::RelativeUrlWithCannotBeABaseBase,
+            ))
+        } else {
+            Ok(Self { url })
+        }
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    pub fn into_inner(self) -> Url {
+        self.url
+    }
+
+    pub fn join(&self, input: &str) -> BaseUrl {
+        Self {
+            // Unwrap is safe, because the join() docs say that it only will error for
+            // cannot-be-a-base URLs.
+            url: self.url.join(input).unwrap(),
+        }
+    }
+
+    pub fn path_segments_mut(&mut self) -> url::PathSegmentsMut<'_> {
+        // Unwrap is safe, because the path_segments_mut() docs say that it only will
+        // error for cannot-be-a-base URLs.
+        self.url.path_segments_mut().unwrap()
     }
 }

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -164,6 +164,11 @@ impl RemoteSettingsClient {
     pub fn sync(&self) -> ApiResult<()> {
         self.internal.sync()
     }
+
+    /// Shutdown the client, releasing the SQLite connection used to cache records.
+    pub fn shutdown(&self) {
+        self.internal.shutdown()
+    }
 }
 
 impl RemoteSettingsClient {

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -5,7 +5,6 @@
 use std::{collections::HashMap, fs::File, io::prelude::Write, sync::Arc};
 
 use error_support::{convert_log_report_error, handle_error};
-use url::Url;
 
 pub mod cache;
 pub mod client;
@@ -22,7 +21,7 @@ pub(crate) mod jexl_filter;
 mod macros;
 
 pub use client::{Attachment, RemoteSettingsRecord, RemoteSettingsResponse, RsJsonObject};
-pub use config::{RemoteSettingsConfig, RemoteSettingsConfig2, RemoteSettingsServer};
+pub use config::{BaseUrl, RemoteSettingsConfig, RemoteSettingsConfig2, RemoteSettingsServer};
 pub use context::RemoteSettingsContext;
 pub use error::{ApiResult, RemoteSettingsError, Result};
 
@@ -64,8 +63,7 @@ impl RemoteSettingsService {
     /// Create a new Remote Settings client
     ///
     /// This method performs no IO or network requests and is safe to run in a main thread that can't be blocked.
-    #[handle_error(Error)]
-    pub fn make_client(&self, collection_name: String) -> ApiResult<Arc<RemoteSettingsClient>> {
+    pub fn make_client(&self, collection_name: String) -> Arc<RemoteSettingsClient> {
         self.internal.make_client(collection_name)
     }
 
@@ -172,21 +170,21 @@ impl RemoteSettingsClient {
     /// Create a new client.  This is not exposed to foreign code, consumers need to call
     /// [RemoteSettingsService::make_client]
     fn new(
-        base_url: Url,
+        base_url: BaseUrl,
         bucket_name: String,
         collection_name: String,
         #[allow(unused)] context: Option<RemoteSettingsContext>,
         storage: Storage,
-    ) -> Result<Self> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             internal: client::RemoteSettingsClient::new(
                 base_url,
                 bucket_name,
                 collection_name,
                 context,
                 storage,
-            )?,
-        })
+            ),
+        }
     }
 }
 

--- a/components/remote_settings/src/storage.rs
+++ b/components/remote_settings/src/storage.rs
@@ -32,11 +32,11 @@ pub struct Storage {
 }
 
 impl Storage {
-    pub fn new(path: Utf8PathBuf) -> Result<Self> {
-        Ok(Self {
+    pub fn new(path: Utf8PathBuf) -> Self {
+        Self {
             path,
             conn: ConnectionCell::Uninitialized,
-        })
+        }
     }
 
     fn transaction(&mut self) -> Result<Transaction<'_>> {
@@ -324,7 +324,7 @@ mod tests {
 
     #[test]
     fn test_storage_set_and_get_records() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url = "https://example.com/api";
         let records = vec![
@@ -376,7 +376,7 @@ mod tests {
 
     #[test]
     fn test_storage_get_records_none() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url = "https://example.com/api";
 
@@ -393,7 +393,7 @@ mod tests {
 
     #[test]
     fn test_storage_get_records_empty() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url = "https://example.com/api";
 
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_storage_set_and_get_attachment() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let attachment = &[0x18, 0x64];
         let collection_url = "https://example.com/api";
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn test_storage_set_and_replace_attachment() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url = "https://example.com/api";
 
@@ -492,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_storage_set_attachment_delete_others() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url_1 = "https://example.com/api1";
         let collection_url_2 = "https://example.com/api2";
@@ -544,7 +544,7 @@ mod tests {
 
     #[test]
     fn test_storage_get_attachment_not_found() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url = "https://example.com/api";
         let metadata = Attachment::default();
@@ -558,7 +558,7 @@ mod tests {
 
     #[test]
     fn test_storage_empty() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url = "https://example.com/api";
         let attachment = &[0x18, 0x64];
@@ -626,7 +626,7 @@ mod tests {
 
     #[test]
     fn test_storage_collection_url_isolation() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url1 = "https://example.com/api1";
         let collection_url2 = "https://example.com/api2";
@@ -695,7 +695,7 @@ mod tests {
 
     #[test]
     fn test_storage_insert_collection_content() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url = "https://example.com/api";
         let initial_records = vec![RemoteSettingsRecord {
@@ -761,7 +761,7 @@ mod tests {
 
     #[test]
     fn test_storage_merge_records() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url = "https://example.com/api";
 
@@ -872,7 +872,7 @@ mod tests {
     }
     #[test]
     fn test_storage_get_collection_metadata() -> Result<()> {
-        let mut storage = Storage::new(":memory:".into())?;
+        let mut storage = Storage::new(":memory:".into());
 
         let collection_url = "https://example.com/api";
         let initial_records = vec![RemoteSettingsRecord {

--- a/components/search/src/selector.rs
+++ b/components/search/src/selector.rs
@@ -47,20 +47,18 @@ impl SearchEngineSelector {
     ///                               `search-config-v2-overrides` to the selected
     ///                               engines. Should be false unless the application
     ///                               supports the click URL feature.
-    #[handle_error(Error)]
     pub fn use_remote_settings_server(
         self: Arc<Self>,
         service: &Arc<RemoteSettingsService>,
         apply_engine_overrides: bool,
-    ) -> SearchApiResult<()> {
+    ) {
         let mut inner = self.0.lock();
-        inner.search_config_client = Some(service.make_client("search-config-v2".to_string())?);
+        inner.search_config_client = Some(service.make_client("search-config-v2".to_string()));
 
         if apply_engine_overrides {
             inner.search_config_overrides_client =
-                Some(service.make_client("search-config-overrides-v2".to_string())?);
+                Some(service.make_client("search-config-overrides-v2".to_string()));
         }
-        Ok(())
     }
 
     /// Sets the search configuration from the given string. If the configuration
@@ -1893,14 +1891,7 @@ mod tests {
 
         let selector = Arc::new(SearchEngineSelector::new());
 
-        let settings_result =
-            Arc::clone(&selector).use_remote_settings_server(&service, should_apply_overrides);
-        assert!(
-            settings_result.is_ok(),
-            "Should have set the client successfully. {:?}",
-            settings_result
-        );
-
+        Arc::clone(&selector).use_remote_settings_server(&service, should_apply_overrides);
         let sync_result = Arc::clone(&service).sync();
         assert!(
             if expect_sync_successful {

--- a/components/suggest/src/benchmarks/mod.rs
+++ b/components/suggest/src/benchmarks/mod.rs
@@ -67,6 +67,14 @@ fn unique_db_filename() -> String {
     format!("db{}.sqlite", COUNTER.fetch_add(1, Ordering::Relaxed))
 }
 
+fn unique_remote_settings_dir() -> String {
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+    format!(
+        "remote-settings-{}",
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
 // Create a "starter" store that will do an initial ingest, and then
 // initialize every returned store with a copy of its DB so that each one
 // doesn't need to reingest.
@@ -79,15 +87,17 @@ fn new_store() -> SuggestStore {
     let (starter_dir, starter_db_path) = starter.get_or_insert_with(|| {
         let temp_dir = tempfile::tempdir().unwrap();
         let db_path = temp_dir.path().join(unique_db_filename());
+        let remote_settings_dir = temp_dir.path().join(unique_remote_settings_dir());
         let rs_config = RemoteSettingsConfig2 {
             bucket_name: None,
             server: None,
             app_context: Some(RemoteSettingsContext::default()),
         };
-        let remote_settings_service =
-            Arc::new(RemoteSettingsService::new("".to_string(), rs_config));
-        let store = SuggestStore::new(&db_path.to_string_lossy(), remote_settings_service)
-            .expect("Error building store");
+        let remote_settings_service = Arc::new(RemoteSettingsService::new(
+            remote_settings_dir.to_string_lossy().to_string(),
+            rs_config,
+        ));
+        let store = SuggestStore::new(&db_path.to_string_lossy(), remote_settings_service);
         store
             .ingest(SuggestIngestionConstraints::all_providers())
             .expect("Error during ingestion");
@@ -104,7 +114,6 @@ fn new_store() -> SuggestStore {
     let remote_settings_service = Arc::new(RemoteSettingsService::new("".to_string(), rs_config));
     std::fs::copy(starter_db_path, &db_path).expect("Error copying starter DB file");
     SuggestStore::new(&db_path.to_string_lossy(), remote_settings_service)
-        .expect("Error building store")
 }
 
 /// Cleanup the temp directory created for SuggestStore instances used in the benchmarks.

--- a/components/suggest/src/rs.rs
+++ b/components/suggest/src/rs.rs
@@ -86,12 +86,12 @@ pub struct SuggestRemoteSettingsClient {
 }
 
 impl SuggestRemoteSettingsClient {
-    pub fn new(rs_service: &RemoteSettingsService) -> Result<Self> {
-        Ok(Self {
-            amp_client: rs_service.make_client(Collection::Amp.name().to_owned())?,
-            other_client: rs_service.make_client(Collection::Other.name().to_owned())?,
-            fakespot_client: rs_service.make_client(Collection::Fakespot.name().to_owned())?,
-        })
+    pub fn new(rs_service: &RemoteSettingsService) -> Self {
+        Self {
+            amp_client: rs_service.make_client(Collection::Amp.name().to_owned()),
+            other_client: rs_service.make_client(Collection::Other.name().to_owned()),
+            fakespot_client: rs_service.make_client(Collection::Fakespot.name().to_owned()),
+        }
     }
 
     fn client_for_collection(&self, collection: Collection) -> &RemoteSettingsClient {

--- a/components/suggest/src/store.rs
+++ b/components/suggest/src/store.rs
@@ -122,7 +122,7 @@ impl SuggestStoreBuilder {
             inner: SuggestStoreInner::new(
                 data_path,
                 extensions_to_load,
-                SuggestRemoteSettingsClient::new(&rs_service)?,
+                SuggestRemoteSettingsClient::new(&rs_service),
             ),
         }))
     }
@@ -176,16 +176,12 @@ pub struct SuggestStore {
 #[uniffi::export]
 impl SuggestStore {
     /// Creates a Suggest store.
-    #[handle_error(Error)]
     #[uniffi::constructor()]
-    pub fn new(
-        path: &str,
-        remote_settings_service: Arc<RemoteSettingsService>,
-    ) -> SuggestApiResult<Self> {
-        let client = SuggestRemoteSettingsClient::new(&remote_settings_service)?;
-        Ok(Self {
+    pub fn new(path: &str, remote_settings_service: Arc<RemoteSettingsService>) -> Self {
+        let client = SuggestRemoteSettingsClient::new(&remote_settings_service);
+        Self {
             inner: SuggestStoreInner::new(path.to_owned(), vec![], client),
-        })
+        }
     }
 
     /// Queries the database for suggestions.

--- a/examples/cli-support/Cargo.toml
+++ b/examples/cli-support/Cargo.toml
@@ -8,6 +8,7 @@ license = "MPL-2.0"
 [dependencies]
 anyhow = "1.0"
 fxa-client = { path = "../../components/fxa-client" }
+remote_settings = { path = "../../components/remote_settings" }
 sync_manager = { path = "../../components/sync_manager" }
 log = "0.4"
 sync15 = { path = "../../components/sync15", features=["sync-client"] }

--- a/examples/cli-support/src/lib.rs
+++ b/examples/cli-support/src/lib.rs
@@ -5,7 +5,12 @@
 #![allow(unknown_lints)]
 #![warn(rust_2018_idioms)]
 
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use remote_settings::{RemoteSettingsConfig2, RemoteSettingsService};
 
 pub mod fxa_creds;
 pub mod prompt;
@@ -67,4 +72,13 @@ pub fn workspace_root_dir() -> PathBuf {
         .stdout;
     let cargo_toml_path = Path::new(std::str::from_utf8(&cargo_output).unwrap().trim());
     cargo_toml_path.parent().unwrap().to_path_buf()
+}
+
+pub fn remote_settings_service() -> Arc<RemoteSettingsService> {
+    Arc::new(RemoteSettingsService::new(
+        data_path(Some("remote-settings"))
+            .to_string_lossy()
+            .to_string(),
+        RemoteSettingsConfig2::default(),
+    ))
 }

--- a/examples/relevancy-cli/src/main.rs
+++ b/examples/relevancy-cli/src/main.rs
@@ -5,7 +5,10 @@
 use std::sync::Arc;
 
 use clap::Parser;
-use cli_support::fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE};
+use cli_support::{
+    fxa_creds::{get_cli_fxa, get_default_fxa_config, SYNC_SCOPE},
+    remote_settings_service,
+};
 use env_logger::Builder;
 use interrupt_support::NeverInterrupts;
 use places::{ConnectionType, PlacesApi};
@@ -44,8 +47,10 @@ fn main() -> Result<()> {
     }
     builder.init();
     println!("================== Initializing Relevancy ===================");
-    let relevancy_store =
-        RelevancyStore::new("file:relevancy-cli-relevancy?mode=memory&cache=shared".to_owned())?;
+    let relevancy_store = RelevancyStore::new(
+        "file:relevancy-cli-relevancy?mode=memory&cache=shared".to_owned(),
+        remote_settings_service(),
+    );
     relevancy_store.ensure_interest_data_populated()?;
 
     println!("==================== Downloading History ====================");


### PR DESCRIPTION
I tried landing this before, alongside the UniFFI/Glean update but it didn't stick.  I'm going to try a second time, with some extra commits:

 - Close Remote settings DB connections: should make it easier to avoid the LateWriteErrors
 - Make creating remote settings clients infallible: not strictly needed, but it seems like a nice/simple improvement to me.  We can split this out if there are issues with review though.
 
Don't merge until the corresponding moz-central patch has been approved.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
