### PR TITLE
[DISCO-3306] Refactor Curated Rec Client to use builder pattern

### DIFF
--- a/components/merino/src/curated_recommendations/error.rs
+++ b/components/merino/src/curated_recommendations/error.rs
@@ -50,32 +50,18 @@ impl GetErrorHandling for Error {
                 })
                 .log_warning()
             }
-            Self::Validation { code, message } => {
+
+            Self::Validation { code, .. }
+            | Self::Server { code, .. }
+            | Self::Unexpected { code, .. }
+            | Self::BadRequest { code, .. } => {
                 ErrorHandling::convert(CuratedRecommendationsApiError::Other {
                     code: Some(*code),
-                    reason: format!("Validation error: {}", message),
+                    reason: self.to_string(),
                 })
-                .report_error("merino-validation")
+                .report_error("merino-http-error")
             }
-            Self::Server { code, message } => {
-                ErrorHandling::convert(CuratedRecommendationsApiError::Other {
-                    code: Some(*code),
-                    reason: format!("Server error: {}", message),
-                })
-            }
-            Self::Unexpected { code, message } => {
-                ErrorHandling::convert(CuratedRecommendationsApiError::Other {
-                    code: Some(*code),
-                    reason: format!("Unexpected error: {}", message),
-                })
-                .report_error("merino-unexpected")
-            }
-            Self::BadRequest { code, message } => {
-                ErrorHandling::convert(CuratedRecommendationsApiError::Other {
-                    code: Some(*code),
-                    reason: format!("Bad request: {}", message),
-                })
-            }
+
             _ => ErrorHandling::convert(CuratedRecommendationsApiError::Other {
                 code: None,
                 reason: self.to_string(),

--- a/components/merino/src/curated_recommendations/mod.rs
+++ b/components/merino/src/curated_recommendations/mod.rs
@@ -27,15 +27,10 @@ struct CuratedRecommendationsClientInner<T: http::HttpClientTrait> {
     http_client: T,
 }
 
+#[derive(Default)]
 pub struct CuratedRecommendationsClientBuilder {
     base_host: Option<String>,
     user_agent_header: Option<String>,
-}
-
-impl Default for CuratedRecommendationsClientBuilder {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 impl CuratedRecommendationsClientBuilder {

--- a/components/merino/src/curated_recommendations/models.rs
+++ b/components/merino/src/curated_recommendations/models.rs
@@ -4,6 +4,13 @@
  */
 use serde::{Deserialize, Serialize};
 
+// Configuration options for initializing a `CuratedRecommendationsClient`
+#[derive(Debug, Serialize, PartialEq, Deserialize, uniffi::Record)]
+pub struct CuratedRecommendationsConfig {
+    pub base_host: Option<String>,
+    pub user_agent_header: String,
+}
+
 // Locales supported by Merino Curated Recommendations
 #[derive(Debug, Serialize, PartialEq, Deserialize, uniffi::Enum)]
 pub enum CuratedRecommendationLocale {

--- a/examples/merino-cli/src/main.rs
+++ b/examples/merino-cli/src/main.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use merino::curated_recommendations::{
-    CuratedRecommendationsClient, CuratedRecommendationsRequest,
+    CuratedRecommendationsClient, CuratedRecommendationsConfig, CuratedRecommendationsRequest,
 };
 
 #[derive(Debug, Parser)]
@@ -39,7 +39,12 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     viaduct_reqwest::use_reqwest_backend();
-    let client = CuratedRecommendationsClient::new(cli.base_host.clone(), cli.user_agent.clone())?;
+    let config = CuratedRecommendationsConfig {
+        base_host: cli.base_host.clone(),
+        user_agent_header: cli.user_agent.clone(),
+    };
+
+    let client = CuratedRecommendationsClient::new(config)?;
 
     match cli.command {
         Commands::Query { json, json_file } => {


### PR DESCRIPTION
What Changed
- Replaced the old constructor with a builder-based config: `CuratedRecommendationsConfig`
- Uniffi now exposes a single new(config) constructor for Swift/Kotlin
- CLI and tests updated to use the new config struct.
- Consolidated repetitive match arms in `get_error_handling`

To verify the client still works with these changes, test using the CLI:
sample command with json string:
`cargo run --bin merino-cli -- --user-agent "my-cli/1.0" query --json '{ "locale": "en", "region": "US", "count": 4, "topics": ["tech"], "feeds": ["sections"] }'
`

sample command with json file
`cargo run --bin merino-cli -- --user-agent "my-cli/1.0" query --json-file ./path-to-file.json
`
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
