### PR TITLE
Fixup localpublish workflows.

### DIFF
--- a/automation/publish_to_maven_local_if_modified.py
+++ b/automation/publish_to_maven_local_if_modified.py
@@ -12,6 +12,7 @@ import hashlib
 import os
 import sys
 import time
+import shutil
 
 from shared import fatal_err, find_app_services_root, run_cmd_checked
 
@@ -113,6 +114,9 @@ if contents_hash == last_contents_hash:
     print("Contents have not changed, no need to publish")
 else:
     print("Contents have changed, publishing")
+    # Ensure rust changes get picked up. No idea why, but stale .so files under `intermediates` end up published.
+    # Repro: 1) publish, 2) change rust, re-publish, 3) rust from first step is still in the artifacts; not all "dupe" .so files are identical.
+    shutil.rmtree("./megazords/full/android/build/intermediates", ignore_errors=True)
     run_cmd_checked(["./gradlew", "publishToMavenLocal", f"-Plocal={time.time_ns()}"])
     with open(LAST_CONTENTS_HASH_FILE, "w") as f:
         f.write(contents_hash)

--- a/docs/howtos/locally-published-components-in-fenix.md
+++ b/docs/howtos/locally-published-components-in-fenix.md
@@ -8,44 +8,69 @@ from there.
 With support from the upstream project, it's possible to do this in a single step using
 our auto-publishing workflow.
 
-## rust.targets
-
-Both the auto-publishing and manual workflows can be sped up significantly by
-using the `rust.targets` property which limits which architectures the Rust
-code gets build against.  You can set this property by creating/editing the
-`local.properties` file in the repository root and adding a line like
-`rust.targets=x86,linux-x86-64`.  The trick is knowing which targets to put in
-that comma separated list:
-
-  - Use `x86` for running the app on most emulators (in rare cases, when you have a 64-bit emulator, you'll want `x86_64`)
-  - If you're running the `android-components` or `fenix` unit tests, then you'll need the architecture of your machine:
-    - OSX running Intel chips: `darwin-x86-64`
-    - OSX running M1 chips: `darwin-aarch64`
-    - Linux: `linux-x86-64`
-
-## Using the auto-publishing workflow
+# Using the auto-publishing workflow
 
 mozilla-central has support for automatically publishing and including a local development version of application-services in the build.
 This is supported for most of the Android targets available in mozilla-central including Fenix - this
 doc will focus on Fenix, but the same general process is used for all. The workflow is:
 
-1. Ensure you have a regular build of Fenix working from mozilla-central and that you've done a `./mach build`
+## Pre-requisites:
 1. Ensure you have a regular [build of application-services working](../building.md).
-1. Edit (or create) the file `local.properties` - this can be in the root of the mozilla-central checkout,
-   or in the project specific directory (eg, `mobile/android/fenix`) and tell it where to
-   find your local checkout of application-services, by adding a line like:
+1. Disable the gradle cache in mozilla-central - edit `./gradle.properties`, comment out `org.gradle.configuration-cache=true`
+1. Ensure you have a regular build of Fenix from mozilla-central testable in Android Studio or an emulator.
 
-   `autoPublish.application-services.dir=path/to/your/checkout/of/application-services`
+## Setup 2 x `local.properties`
 
-   Note that the path can be absolute or relative from `local.properties`. For example, if `application-services`
-   and `mozilla-central` are at the same level, and you are using a `local.properties` in the root of mozilla-central,
-   the relative path would be `../application-services`
-1. Build your target normally - eg, in Android Studio. or using `gradle`
+Edit (or create) the file `local.properties` in each of the repos:
+
+### app-services
+
+In the root of the app-services repo:
+
+Please be sure you have read [our guide to building Fenix](../building.md#building-for-fenix) and successfully built
+using the instructions there. In particular, this may lead you to adding `sdk.dir` and `ndk.dir` properties, and/or
+set environment variables `ANDROID_SDK_ROOT` and `ANDROID_HOME`.
+
+In addition to those instructions, you will need:
+
+#### rust.targets
+
+Both the auto-publishing and manual workflows can be sped up significantly by
+using the `rust.targets` property which limits which architectures the Rust
+code gets build against.  Adding a line like
+`rust.targets=x86,linux-x86-64`.  The trick is knowing which targets to put in
+that comma separated list:
+
+  - Use `x86` for running the app on most emulators on Intel hardware (in rare cases, when you have a 64-bit emulator, you'll want `x86_64`).
+  - Use `arm64` for emulators running on Apple Silicon Macs.
+  - If you're running the `android-components` or `fenix` unit tests, then you'll need the architecture of your machine:
+    - OSX running Intel chips: `darwin-x86-64`
+    - OSX running M1 chips: `darwin-aarch64`
+    - Linux: `linux-x86-64`
+
+eg, on a Mac your `local.properties` file will have a single line, `rust.targets=darwin-aarch64,arm64`
+
+### mozilla-central
+
+`local.properties` can be in the root of the mozilla-central checkout,
+or in the project specific directory (eg, `mobile/android/fenix`) and you tell it where to
+find your local checkout of application-services by adding a line like:
+
+`autoPublish.application-services.dir=path/to/your/checkout/of/application-services`
+
+Note that the path can be absolute or relative from `local.properties`. For example, if `application-services`
+and `mozilla-central` are at the same level, and you are using a `local.properties` in the root of mozilla-central,
+the relative path would be `../application-services`
+
+## Build and test your Fenix again.
+
+After configuring as described above, build and test your Fenix again.
 
 If all goes well, this should automatically build your checkout of `application-services`, publish it
 to a local maven repository, and configure the consuming project to install it from there instead of
 from our published releases.
 
+# Other notes
 ### Using Windows/WSL
 
 Good luck! This implies you are also building mozilla-central in a Windows/WSL environment;


### PR DESCRIPTION
I updated the localpublish docs to reflect the fact the gradle cache must be disabled, and also to try and help clarify the fact we are talking about 2 different `local.properties` files and clarify which ones we are asking be modified.

 I also updated the script to delete possibly "stale" .so files, which caused re-publishes to not work.

Flagging @gruberb as I hope to walk him through this, and @badboy as I suspect all these changes apply to glean, so he may or may not want to apply this to the glean repo.