### PR TITLE
Bug 1962283 - Make AmpMatchingStrategy discriminants start at 1

### DIFF
--- a/components/suggest/src/provider.rs
+++ b/components/suggest/src/provider.rs
@@ -228,7 +228,7 @@ pub enum AmpMatchingStrategy {
     /// Disable keywords added via keyword expansion.
     /// This eliminates keywords that for terms related to the "real" keywords, for example
     /// misspellings like "underarmor" instead of "under armor"'.
-    NoKeywordExpansion,
+    NoKeywordExpansion = 1, // The desktop consumer assumes this starts at `1`
     /// Use FTS matching against the full keywords, joined together.
     FtsAgainstFullKeywords,
     /// Use FTS matching against the title field


### PR DESCRIPTION
### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
