### PR TITLE
add logins store static key manager factory

### DIFF
--- a/components/logins/src/lib.rs
+++ b/components/logins/src/lib.rs
@@ -45,3 +45,13 @@ pub fn create_static_key_manager(key: String) -> Arc<StaticKeyManager> {
 pub fn create_managed_encdec(key_manager: Arc<dyn KeyManager>) -> Arc<ManagedEncryptorDecryptor> {
     Arc::new(ManagedEncryptorDecryptor::new(key_manager))
 }
+
+// Create a LoginStore by passing in a db path and a static key
+//
+// Note this is only temporarily needed until a bug with UniFFI and JavaScript is fixed, which
+// prevents passing around traits in JS
+pub fn create_login_store_with_static_key_manager(path: String, key: String) -> Arc<LoginStore> {
+    let encdec: ManagedEncryptorDecryptor =
+        ManagedEncryptorDecryptor::new(Arc::new(StaticKeyManager::new(key)));
+    Arc::new(LoginStore::new(path, Arc::new(encdec)).unwrap())
+}

--- a/components/logins/src/logins.udl
+++ b/components/logins/src/logins.udl
@@ -28,6 +28,9 @@ namespace logins {
     /// Similar to create_static_key_manager above, create a
     /// ManagedEncryptorDecryptor by passing in a KeyManager
     EncryptorDecryptor create_managed_encdec(KeyManager key_manager);
+
+    /// Create a LoginStore by passing in a db path and a static key
+    LoginStore create_login_store_with_static_key_manager(string path, string key);
 };
 
 /// A login entry from the user, not linked to any database record.


### PR DESCRIPTION
This is for developing as logins for desktop to work around a UniFFI bug preventing us to construct the login manager from Rust-provided structs on JavaScript side.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [x] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [x] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [x] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [x] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [x] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
