### PR TITLE
Fix remote settings IO errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,7 @@ dependencies = [
  "futures",
  "indicatif",
  "log",
+ "nss",
  "remote_settings",
  "reqwest 0.12.4",
  "serde",

--- a/components/remote_settings/src/error.rs
+++ b/components/remote_settings/src/error.rs
@@ -30,7 +30,9 @@ pub enum Error {
     #[error("JSON Error: {0}")]
     JSONError(#[from] serde_json::Error),
     #[error("Error writing downloaded attachment: {0}")]
-    FileError(#[from] std::io::Error),
+    AttachmentFileError(std::io::Error),
+    #[error("Error creating storage dir: {0}")]
+    CreateDirError(std::io::Error),
     /// An error has occurred while sending a request.
     #[error("Error sending request: {0}")]
     RequestError(#[from] viaduct::Error),

--- a/components/remote_settings/src/lib.rs
+++ b/components/remote_settings/src/lib.rs
@@ -234,8 +234,8 @@ impl RemoteSettings {
         path: String,
     ) -> ApiResult<()> {
         let resp = self.client.get_attachment(&attachment_id)?;
-        let mut file = File::create(path)?;
-        file.write_all(&resp)?;
+        let mut file = File::create(path).map_err(Error::AttachmentFileError)?;
+        file.write_all(&resp).map_err(Error::AttachmentFileError)?;
         Ok(())
     }
 }

--- a/examples/remote-settings-cli/Cargo.toml
+++ b/examples/remote-settings-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/dump/lib.rs"
 [dependencies]
 cli-support = { path = "../cli-support" }
 remote_settings = { features = ["signatures"], path = "../../components/remote_settings" }
+nss = { path = "../../components/support/rc_crypto/nss" }
 viaduct-reqwest = { path = "../../components/support/viaduct-reqwest" }
 log = "0.4"
 clap = {version = "4.2", features = ["derive"]}

--- a/examples/remote-settings-cli/src/main.rs
+++ b/examples/remote-settings-cli/src/main.rs
@@ -83,6 +83,7 @@ fn main() -> Result<()> {
             DEFAULT_LOG_FILTER
         },
     ));
+    nss::ensure_initialized();
     viaduct_reqwest::use_reqwest_backend();
     let service = build_service(&cli)?;
     match cli.command {


### PR DESCRIPTION
I've been seeing these in android (unfortunately with the wrong error type because of https://github.com/mozilla/application-services/pull/6731).  I'm not exactly sure why, but this is my best guess.  AFAICT, the only other source of these errors is in `download_attachment_to_path`, but that's not being called by anyone.

Updated the error enum so that we don't always assume IO errors happen because of writing attachments.  Instead, force the consumer to map the error type themselves, so we get more error details.

Also added a fix to the CLI.

### Pull Request checklist ###
<!-- Before submitting the PR, please address each item -->
- **Breaking changes**:  This PR follows our [breaking change policy](https://github.com/mozilla/application-services/blob/main/docs/howtos/breaking-changes.md)
  - [ ] This PR follows the breaking change policy:
     - This PR has no breaking API changes, or
     - There are corresponding PRs for our consumer applications that resolve the breaking changes and have been approved
- [ ] **Quality**: This PR builds and tests run cleanly
  - Note:
    - For changes that need extra cross-platform testing, consider adding `[ci full]` to the PR title.
    - If this pull request includes a breaking change, consider [cutting a new release](https://github.com/mozilla/application-services/blob/main/docs/howtos/cut-a-new-release.md) after merging.
- [ ] **Tests**: This PR includes thorough tests or an explanation of why it does not
- [ ] **Changelog**: This PR includes a changelog entry in [CHANGELOG.md](../CHANGELOG.md) or an explanation of why it does not need one
  - Any breaking changes to Swift or Kotlin binding APIs are noted explicitly
- [ ] **Dependencies**: This PR follows our [dependency management guidelines](https://github.com/mozilla/application-services/blob/main/docs/dependency-management.md)
  - Any new dependencies are accompanied by a summary of the due diligence applied in selecting them.

[Branch builds](https://github.com/mozilla/application-services/blob/main/docs/howtos/branch-builds.md): add `[firefox-android: branch-name]` to the PR title.
